### PR TITLE
feat: add ability to pass data on event bus

### DIFF
--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -56,7 +56,7 @@ func (r *Registrator) Reboot(ctx context.Context, in *empty.Empty) (reply *proto
 	reply = &proto.RebootReply{}
 
 	log.Printf("reboot via API received")
-	event.Bus().Publish(event.Reboot)
+	event.Bus().Notify(event.Event{Type: event.Reboot})
 
 	return
 }
@@ -66,7 +66,7 @@ func (r *Registrator) Shutdown(ctx context.Context, in *empty.Empty) (reply *pro
 	reply = &proto.ShutdownReply{}
 
 	log.Printf("shutdown via API received")
-	event.Bus().Publish(event.Shutdown)
+	event.Bus().Notify(event.Event{Type: event.Shutdown})
 
 	return
 }

--- a/internal/app/machined/internal/event/event.go
+++ b/internal/app/machined/internal/event/event.go
@@ -2,14 +2,72 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Package event implements an embeddable type that uses the observation
+// pattern to facilitate an event bus.
 package event
 
-// Type is event kind
+// Type is event type.
 type Type int
 
-// Registered events
 const (
+	// Shutdown is the shutdown event.
 	Shutdown = Type(iota)
+	// Reboot is the reboot event.
 	Reboot
+	// Upgrade is the upgrade event.
 	Upgrade
 )
+
+// Event represents an event in the observer pattern.
+type Event struct {
+	Type Type
+	Data interface{}
+}
+
+// Channel is a channel for sending events.
+type Channel chan Event
+
+// Listeners is a slice of listeners to send events to.
+type Listeners []Channel
+
+// Observer is a component of the observer design pattern.
+type Observer interface {
+	Channel() Channel
+	Types() []Type
+}
+
+// Notifier is a component of the observer design pattern.
+type Notifier interface {
+	Notify(Event)
+	Register(Observer, ...Type)
+	Unregister(Observer)
+}
+
+// ObserveNotifier is a composite interface consisting of the Observer, and
+// Notifier interfaces.
+type ObserveNotifier interface {
+	Observer
+	Notifier
+}
+
+// Embeddable is a type that implements sane defaults as an observer.
+type Embeddable struct {
+	channel Channel
+	types   []Type
+}
+
+// Channel implements the Observer interface.
+func (e *Embeddable) Channel() Channel {
+	if cap(e.channel) == 0 {
+		e.channel = make(Channel, 20)
+	}
+	return e.channel
+}
+
+// Types implements the Observer interface.
+func (e *Embeddable) Types() []Type {
+	if e.types == nil {
+		e.types = []Type{Shutdown, Reboot, Upgrade}
+	}
+	return e.types
+}

--- a/internal/app/machined/internal/phase/acpi/acpi.go
+++ b/internal/app/machined/internal/phase/acpi/acpi.go
@@ -89,7 +89,7 @@ func listenForPowerButton() (err error) {
 			}
 			if len(msgs) > 0 {
 				log.Printf("shutdown via ACPI received")
-				event.Bus().Publish(event.Shutdown)
+				event.Bus().Notify(event.Event{Type: event.Shutdown})
 				return
 			}
 		}

--- a/internal/app/machined/internal/phase/signal/signal.go
+++ b/internal/app/machined/internal/phase/signal/signal.go
@@ -44,7 +44,7 @@ func (task *Handler) container(platform platform.Platform, data *userdata.UserDa
 		signal.Stop(termCh)
 
 		log.Printf("shutdown via SIGTERM received")
-		event.Bus().Publish(event.Shutdown)
+		event.Bus().Notify(event.Event{Type: event.Shutdown})
 	}()
 
 	return nil

--- a/internal/app/machined/internal/sequencer/sequencer.go
+++ b/internal/app/machined/internal/sequencer/sequencer.go
@@ -6,13 +6,14 @@ package sequencer
 
 import (
 	"github.com/talos-systems/talos/internal/app/machined/internal/sequencer/v1alpha1"
+	"github.com/talos-systems/talos/internal/app/machined/proto"
 )
 
 // Sequencer describes the boot, shutdown, and upgrade events.
 type Sequencer interface {
 	Boot() error
 	Shutdown() error
-	Upgrade() error
+	Upgrade(*proto.UpgradeRequest) error
 }
 
 // Version represents the sequencer version.

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/signal"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/sysctls"
 	userdatatask "github.com/talos-systems/talos/internal/app/machined/internal/phase/userdata"
+	"github.com/talos-systems/talos/internal/app/machined/proto"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -112,6 +113,6 @@ func (d *Sequencer) Shutdown() error {
 }
 
 // Upgrade implements the Sequencer interface.
-func (d *Sequencer) Upgrade() error {
+func (d *Sequencer) Upgrade(req *proto.UpgradeRequest) error {
 	return nil
 }


### PR DESCRIPTION
We need to support eventing with associated data. This moves the event
bus to an observer design pattern that allows observers to register for
specific events, and to receive the associated data.