### PR TITLE
chore: upgrade tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TOOLS ?= autonomy/tools:ea86807
+TOOLS ?= autonomy/tools:a9fa749
 
 # TODO(andrewrynhard): Move this logic to a shell script.
 BUILDKIT_VERSION ?= v0.6.0


### PR DESCRIPTION
This brings in Go v1.12.9 to address CVEs and bugs.