### PR TITLE
chore: Increase timers for healthchecks

### DIFF
--- a/internal/app/machined/pkg/system/health/settings.go
+++ b/internal/app/machined/pkg/system/health/settings.go
@@ -17,7 +17,7 @@ type Settings struct {
 
 // DefaultSettings provides some default health check settings
 var DefaultSettings = Settings{
-	InitialDelay: 200 * time.Millisecond,
-	Period:       time.Second,
+	InitialDelay: time.Second,
+	Period:       5 * time.Second,
 	Timeout:      500 * time.Millisecond,
 }


### PR DESCRIPTION
We've seen some instances where the initial delay is not long enough (containerd)
as well as a period of every second increases the log size for services like
proxyd which log incoming connections.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>