### PR TITLE
chore: output top header in all caps

### DIFF
--- a/cmd/osctl/cmd/top.go
+++ b/cmd/osctl/cmd/top.go
@@ -190,7 +190,7 @@ func topOutput(ctx context.Context, c *client.Client) (output string, err error)
 	}
 
 	s := make([]string, 0, len(procs))
-	s = append(s, "PID | State | Threads | CPU Time | VirtMem | ResMem | Command")
+	s = append(s, "PID | STATE | THREADS | CPU-TIME | VIRTMEM | RESMEM | COMMAND")
 	var cmdline string
 	for _, p := range procs {
 		switch {


### PR DESCRIPTION
This changes the top output to be consistent with the rest of the CLI
output.