### PR TITLE
fix: make --target persistent across all commands

### DIFF
--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -140,6 +140,5 @@ captures ownership and permission bits.`,
 }
 
 func init() {
-	cpCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(cpCmd)
 }

--- a/cmd/osctl/cmd/df.go
+++ b/cmd/osctl/cmd/df.go
@@ -57,6 +57,5 @@ func dfRender(reply *proto.DFReply, err error) {
 }
 
 func init() {
-	dfCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(dfCmd)
 }

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -36,6 +36,5 @@ var dmesgCmd = &cobra.Command{
 }
 
 func init() {
-	dmesgCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(dmesgCmd)
 }

--- a/cmd/osctl/cmd/interfaces.go
+++ b/cmd/osctl/cmd/interfaces.go
@@ -50,6 +50,5 @@ func intersRender(reply *proto.InterfacesReply) {
 }
 
 func init() {
-	interfacesCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(interfacesCmd)
 }

--- a/cmd/osctl/cmd/logs.go
+++ b/cmd/osctl/cmd/logs.go
@@ -66,6 +66,5 @@ var logsCmd = &cobra.Command{
 func init() {
 	logsCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 	logsCmd.Flags().BoolVarP(&useCRI, "use-cri", "c", false, "use the CRI driver")
-	logsCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(logsCmd)
 }

--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -103,7 +103,6 @@ var lsCmd = &cobra.Command{
 }
 
 func init() {
-	lsCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	lsCmd.Flags().BoolP("long", "l", false, "display additional file details")
 	lsCmd.Flags().BoolP("recurse", "r", false, "recurse into subdirectories")
 	lsCmd.Flags().Int32P("depth", "d", 0, "maximum recursion depth")

--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -75,6 +75,5 @@ func processesRender(reply *proto.ProcessesReply) {
 func init() {
 	psCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 	psCmd.Flags().BoolVarP(&useCRI, "use-cri", "c", false, "use the CRI driver")
-	psCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(psCmd)
 }

--- a/cmd/osctl/cmd/reboot.go
+++ b/cmd/osctl/cmd/reboot.go
@@ -33,6 +33,5 @@ var rebootCmd = &cobra.Command{
 }
 
 func init() {
-	rebootCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(rebootCmd)
 }

--- a/cmd/osctl/cmd/reset.go
+++ b/cmd/osctl/cmd/reset.go
@@ -33,6 +33,5 @@ var resetCmd = &cobra.Command{
 }
 
 func init() {
-	resetCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(resetCmd)
 }

--- a/cmd/osctl/cmd/restart.go
+++ b/cmd/osctl/cmd/restart.go
@@ -48,7 +48,6 @@ var restartCmd = &cobra.Command{
 }
 
 func init() {
-	restartCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	restartCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 	restartCmd.Flags().BoolVarP(&useCRI, "use-cri", "c", false, "use the CRI driver")
 	rootCmd.AddCommand(restartCmd)

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -91,6 +91,7 @@ func Execute() {
 		defaultTalosConfig = path.Join(home, ".talos", "config")
 	}
 	rootCmd.PersistentFlags().StringVar(&talosconfig, "talosconfig", defaultTalosConfig, "The path to the Talos configuration file")
+	rootCmd.PersistentFlags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	if err := rootCmd.Execute(); err != nil {
 		helpers.Fatalf("%s", err)
 	}

--- a/cmd/osctl/cmd/routes.go
+++ b/cmd/osctl/cmd/routes.go
@@ -48,6 +48,5 @@ func routesRender(reply *proto.RoutesReply) {
 }
 
 func init() {
-	routesCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(routesCmd)
 }

--- a/cmd/osctl/cmd/service.go
+++ b/cmd/osctl/cmd/service.go
@@ -164,6 +164,5 @@ func (svc serviceInfoWrapper) HealthStatus() string {
 }
 
 func init() {
-	serviceCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(serviceCmd)
 }

--- a/cmd/osctl/cmd/shutdown.go
+++ b/cmd/osctl/cmd/shutdown.go
@@ -33,6 +33,5 @@ var shutdownCmd = &cobra.Command{
 }
 
 func init() {
-	shutdownCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(shutdownCmd)
 }

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -74,6 +74,5 @@ func statsRender(reply *proto.StatsReply) {
 func init() {
 	statsCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 	statsCmd.Flags().BoolVarP(&useCRI, "use-cri", "c", false, "use the CRI driver")
-	statsCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(statsCmd)
 }

--- a/cmd/osctl/cmd/time.go
+++ b/cmd/osctl/cmd/time.go
@@ -60,7 +60,6 @@ var timeCmd = &cobra.Command{
 }
 
 func init() {
-	timeCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	timeCmd.Flags().StringP("check", "c", "pool.ntp.org", "checks server time against specified ntp server")
 	rootCmd.AddCommand(timeCmd)
 }

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -32,7 +32,6 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	upgradeCmd.Flags().StringVarP(&image, "image", "u", "", "the container image to use for performing the install")
-	upgradeCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(upgradeCmd)
 }
 


### PR DESCRIPTION
We have this flag missing in a number of places. This ensures that all
commands in the future will have this flags. A potential cleanup would
be to hide this flag in commands where it does not make sense. For now I
think its best to have everywhere.