### PR TITLE
fix: use unique variables for CLI flags

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	clusterName   string
+	nodeImage     string
 	networkMTU    string
 	workers       int
 	masters       int
@@ -90,7 +91,7 @@ func create() (err error) {
 
 	// Ensure the image is present.
 
-	if err = ensureImageExists(ctx, cli, image); err != nil {
+	if err = ensureImageExists(ctx, cli, nodeImage); err != nil {
 		return err
 	}
 
@@ -122,7 +123,7 @@ func create() (err error) {
 	for i := range requests {
 		requests[i] = &node.Request{
 			Input:    *input,
-			Image:    image,
+			Image:    nodeImage,
 			Name:     fmt.Sprintf("master-%d", i+1),
 			IP:       net.ParseIP(ips[i]),
 			Memory:   memory,
@@ -147,7 +148,7 @@ func create() (err error) {
 		r := &node.Request{
 			Type:     generate.TypeJoin,
 			Input:    *input,
-			Image:    image,
+			Image:    nodeImage,
 			Name:     fmt.Sprintf("worker-%d", i),
 			Memory:   memory,
 			NanoCPUs: nanoCPUs,
@@ -354,7 +355,7 @@ func parseCPUShare() (int64, error) {
 }
 
 func init() {
-	clusterUpCmd.Flags().StringVar(&image, "image", "docker.io/autonomy/talos:"+version.Tag, "the image to use")
+	clusterUpCmd.Flags().StringVar(&nodeImage, "image", "docker.io/autonomy/talos:"+version.Tag, "the image to use")
 	clusterUpCmd.Flags().StringVar(&networkMTU, "mtu", "1500", "MTU of the docker bridge network")
 	clusterUpCmd.Flags().IntVar(&workers, "workers", 1, "the number of workers to create")
 	clusterUpCmd.Flags().IntVar(&masters, "masters", 3, "the number of masters to create")

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	image string
+	upgradeImage string
 )
 
 // upgradeCmd represents the processes command
@@ -31,7 +31,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 func init() {
-	upgradeCmd.Flags().StringVarP(&image, "image", "u", "", "the container image to use for performing the install")
+	upgradeCmd.Flags().StringVarP(&upgradeImage, "image", "u", "", "the container image to use for performing the install")
 	rootCmd.AddCommand(upgradeCmd)
 }
 
@@ -44,7 +44,7 @@ func upgrade() error {
 	setupClient(func(c *client.Client) {
 		// TODO: See if we can validate version and prevent starting upgrades to
 		// an unknown version
-		ack, err = c.Upgrade(globalCtx, image)
+		ack, err = c.Upgrade(globalCtx, upgradeImage)
 	})
 
 	if err == nil {


### PR DESCRIPTION
Since the cluster create command and the upgrade command shared a common
variable, and the upgrade defaults to an empty string, we get an invalid
reference format error when attempting to create a cluster. This makes
the variables unique to avoid that.

Fixes #1079.