### PR TITLE
chore: Clean up e2e scripts

### DIFF
--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -11,20 +11,20 @@ export KUBECONFIG="${TMP}/kubeconfig"
 export TIMEOUT=300
 
 ## Create tmp dir
-mkdir -p $TMP
+mkdir -p ${TMP}
 
 run() {
-	docker run \
-	 	--rm \
-	 	--interactive \
-	 	--net=integration \
-		--entrypoint=bash \
-		--mount type=bind,source=${TMP},target=${TMP} \
-		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
-	 	-v ${OSCTL}:/bin/osctl:ro \
-	 	-e KUBECONFIG=${KUBECONFIG} \
-	 	-e TALOSCONFIG=${TALOSCONFIG} \
-	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
+  docker run \
+         --rm \
+         --interactive \
+         --net=integration \
+         --entrypoint=bash \
+         --mount type=bind,source=${TMP},target=${TMP} \
+         --mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
+         -v ${OSCTL}:/bin/osctl:ro \
+         -e KUBECONFIG=${KUBECONFIG} \
+         -e TALOSCONFIG=${TALOSCONFIG} \
+         k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
 }
 
 ${OSCTL} cluster create --name integration --image ${TALOS_IMG} --mtu 1440 --cpus 4.0
@@ -32,44 +32,32 @@ ${OSCTL} config target 10.5.0.2
 
 ## Fetch kubeconfig
 run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-	 until osctl kubeconfig > ${KUBECONFIG}
-	 do
-	   if  [[ \$(date +%s) -gt \$timeout ]]
-	   then
-	     exit 1
-	   fi
-	   sleep 2
-	 done"
+     until osctl kubeconfig > ${KUBECONFIG}; do
+       [[ \$(date +%s) -gt \$timeout ]] && exit 1
+       sleep 2
+     done"
 
 ## Wait for the init node to report in
 run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-     until kubectl get node master-1 >/dev/null
-	 do
-	   if  [[ \$(date +%s) -gt \$timeout ]]
-	   then
-	     exit 1
-	   fi
-	   kubectl get nodes -o wide
-	   sleep 5
-	 done"
+     until kubectl get node master-1 >/dev/null; do
+       [[ \$(date +%s) -gt \$timeout ]] && exit 1
+       kubectl get nodes -o wide
+       sleep 5
+     done"
 
 ## Deploy needed manifests
 run "kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml -f /manifests/coredns.yaml"
 
 ## Wait for all nodes to report in
 run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-     until kubectl get nodes -o json | jq '.items | length' | grep 4 >/dev/null
-	 do
-	   if  [[ \$(date +%s) -gt \$timeout ]]
-	   then
-	     exit 1
-	   fi
-	   kubectl get nodes -o wide
-	   sleep 5
-	 done"
+     until kubectl get nodes -o go-template='{{ len .items }}' | grep 4 >/dev/null; do
+       [[ \$(date +%s) -gt \$timeout ]] && exit 1
+       kubectl get nodes -o wide
+       sleep 5
+     done"
 
 ## Wait for all nodes ready
 run "kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
 
 ##  Verify that we have an HA controlplane
-run "kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 >/dev/null"
+run "kubectl get nodes -l node-role.kubernetes.io/master='' -o go-template='{{ len .items }}' | grep 3 >/dev/null"

--- a/hack/test/capi.sh
+++ b/hack/test/capi.sh
@@ -4,22 +4,20 @@ set -eou pipefail
 source ./hack/test/e2e-runner.sh
 
 ## Create tmp dir
-mkdir -p $TMP
+mkdir -p ${TMP}
 
 ## Drop in capi stuff
 sed "s/{{PACKET_AUTH_TOKEN}}/${PACKET_AUTH_TOKEN}/" ${PWD}/hack/test/manifests/provider-components.yaml > ${TMP}/provider-components.yaml
 sed -e "s#{{GCE_SVC_ACCT}}#${GCE_SVC_ACCT}#" \
     -e "s#{{AZURE_SVC_ACCT}}#${AZURE_SVC_ACCT}#" ${PWD}/hack/test/manifests/capi-secrets.yaml > ${TMP}/capi-secrets.yaml
+
 e2e_run "kubectl apply -f ${TMP}/provider-components.yaml -f ${TMP}/capi-secrets.yaml"
 
 ## Wait for talosconfig in cm then dump it out
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until kubectl wait --timeout=1s --for=condition=Ready -n cluster-api-provider-talos-system pod/cluster-api-provider-talos-controller-manager-0
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-		     exit 1
-		   fi
-		   echo 'Waiting to CAPT pod to be available...'
-		   sleep 10
-		 done"
+         pod='pod/cluster-api-provider-talos-controller-manager-0'
+         until KUBECONFIG=${TMP}/kubeconfig kubectl wait --timeout=1s --for=condition=Ready -n ${CAPI_NS} ${pod}; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           echo 'Waiting to CAPT pod to be available...'
+           sleep 10
+         done"

--- a/hack/test/conformance.sh
+++ b/hack/test/conformance.sh
@@ -17,14 +17,15 @@ source ./hack/test/e2e-runner.sh
 #          kubectl logs job/kube-bench-node"
 
 # Download sonobuoy and run kubernetes conformance
-e2e_run "apt-get update && apt-get install wget
-		 wget --quiet -O /tmp/sonobuoy.tar.gz ${SONOBUOY_URL}
-		 tar -xf /tmp/sonobuoy.tar.gz -C /usr/local/bin
-		 sonobuoy run --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi \
-        --wait \
-        --skip-preflight \
-        --plugin e2e \
-        --plugin-env e2e.E2E_USE_GO_RUNNER=true \
-        --kube-conformance-image-version v1.16.0-beta.0
-		 results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi)
-		 sonobuoy e2e --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi \$results"
+e2e_run "set -eou pipefail
+         apt-get update && apt-get install wget
+         wget --quiet -O /tmp/sonobuoy.tar.gz ${SONOBUOY_URL}
+         tar -xf /tmp/sonobuoy.tar.gz -C /usr/local/bin
+         sonobuoy run --kubeconfig ${KUBECONFIG} \
+            --wait \
+            --skip-preflight \
+            --plugin e2e \
+            --plugin-env e2e.E2E_USE_GO_RUNNER=true \
+            --kube-conformance-image-version v1.16.0-beta.0
+         results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG})
+         sonobuoy e2e --kubeconfig ${KUBECONFIG} \$results"

--- a/hack/test/e2e-integration.sh
+++ b/hack/test/e2e-integration.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 source ./hack/test/e2e-runner.sh
 
 ## Create tmp dir
-mkdir -p $TMP
+mkdir -p ${TMPPLATFORM}
 
 NAME_PREFIX="talos-e2e-${TAG}-${PLATFORM}"
 
@@ -19,87 +19,63 @@ cleanup() {
 trap cleanup EXIT
 
 ## Setup the cluster YAML.
-sed "s/{{TAG}}/${TAG}/" ${PWD}/hack/test/manifests/${PLATFORM}-cluster.yaml > ${TMP}/${PLATFORM}-cluster.yaml
+sed "s/{{TAG}}/${TAG}/" ${PWD}/hack/test/manifests/${PLATFORM}-cluster.yaml > ${TMPPLATFORM}/cluster.yaml
 
 ## Download kustomize and template out capi cluster, then deploy it
-e2e_run "kubectl apply -f ${TMP}/${PLATFORM}-cluster.yaml"
+e2e_run "kubectl apply -f ${TMPPLATFORM}/cluster.yaml"
 
 ## Wait for talosconfig in cm then dump it out
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until kubectl get cm -n cluster-api-provider-talos-system ${NAME_PREFIX}-master-0
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-		     exit 1
-		   fi
-		   sleep 10
-		 done
-         kubectl get cm -n cluster-api-provider-talos-system ${NAME_PREFIX}-master-0 -o jsonpath='{.data.talosconfig}' > ${TALOSCONFIG}-${PLATFORM}-capi"
+         until KUBECONFIG=${TMP}/kubeconfig kubectl get cm -n ${CAPI_NS} ${NAME_PREFIX}-master-0; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           sleep 10
+         done
+         kubectl get cm -n ${CAPI_NS} ${NAME_PREFIX}-master-0 -o jsonpath='{.data.talosconfig}' > ${TALOSCONFIG}"
 
 ## Wait for kubeconfig from capi master-0
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until /bin/osctl --talosconfig ${TALOSCONFIG}-${PLATFORM}-capi kubeconfig > ${KUBECONFIG}-${PLATFORM}-capi
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-		     exit 1
-		   fi
-		   sleep 10
-		 done"
+         until /bin/osctl kubeconfig > ${KUBECONFIG}; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           sleep 10
+         done"
 
 ## Wait for the init node to report in
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-     until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 1 >/dev/null
-	 do
-	   if  [[ \$(date +%s) -gt \$timeout ]]
-	   then
-	     exit 1
-	   fi
-	   kubectl get nodes -o wide
-	   sleep 5
-	 done"
+         until kubectl get nodes -l node-role.kubernetes.io/master='' -o go-template='{{ len .items }}' | grep 1 >/dev/null; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           kubectl get nodes -o wide
+           sleep 5
+         done"
 
 ##  Apply psp and flannel
-e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
+e2e_run "kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
 
 ##  Wait for nodes to check in
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o json | jq '.items | length' | grep ${NUM_NODES} >/dev/null
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-			exit 1
-		   fi
-		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o wide
-		   sleep 10
-		 done"
+         until kubectl get nodes -o go-template='{{ len .items }}' | grep ${NUM_NODES} >/dev/null; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           kubectl get nodes -o wide
+           sleep 10
+         done"
 
 ## Wait for kube-proxy up
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get po -n kube-system -l k8s-app=kube-proxy -o json | jq '.items | length' | grep ${NUM_NODES} > /dev/null
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-			exit 1
-		   fi
-		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get po -n kube-system -l k8s-app=kube-proxy
-		   sleep 10
-		 done"
+         until kubectl get po -n kube-system -l k8s-app=kube-proxy -o go-template='{{ len .items }}' | grep ${NUM_NODES} > /dev/null; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           kubectl get po -n kube-system -l k8s-app=kube-proxy
+           sleep 10
+         done"
 
 ##  Wait for nodes ready
-e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
+e2e_run "kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
 
 ## Verify that we have an HA controlplane
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 > /dev/null
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-			exit 1
-		   fi
-		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length'
-		   sleep 10
-		 done"
+         until kubectl get nodes -l node-role.kubernetes.io/master='' -o go-template='{{ len .items }}' | grep 3 > /dev/null; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           kubectl get nodes -l node-role.kubernetes.io/master=''
+           sleep 10
+         done"
 
 ## Run conformance tests if var is not null
 if [ ${CONFORMANCE:-"dontrun"} == "run" ]; then

--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -1,9 +1,10 @@
 export KUBERNETES_VERSION=v1.14.5
 export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
 export TMP="/tmp/e2e"
+export TMPPLATFORM="${TMP}/${PLATFORM}"
 export OSCTL="${PWD}/build/osctl-linux-amd64"
-export TALOSCONFIG="${TMP}/talosconfig"
-export KUBECONFIG="${TMP}/kubeconfig"
+export TALOSCONFIG="${TMPPLATFORM}/talosconfig"
+export KUBECONFIG="${TMPPLATFORM}/kubeconfig"
 
 ## Long timeout due to provisioning times
 export TIMEOUT=9000
@@ -18,18 +19,19 @@ export KUSTOMIZE_VERSION="1.0.11"
 export KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64"
 export SONOBUOY_VERSION="0.15.1"
 export SONOBUOY_URL="https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
+export CAPI_NS="cluster-api-provider-talos-system"
 
 e2e_run() {
-	docker run \
-	 	--rm \
-		--interactive \
-	 	--net=integration \
-		--entrypoint=bash \
-		--mount type=bind,source=${TMP},target=${TMP} \
-		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
-		--mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
-	 	-v ${OSCTL}:/bin/osctl:ro \
-	 	-e KUBECONFIG=${KUBECONFIG} \
-	 	-e TALOSCONFIG=${TALOSCONFIG} \
-	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
+  docker run \
+         --rm \
+         --interactive \
+         --net=integration \
+         --entrypoint=bash \
+         --mount type=bind,source=${TMP},target=${TMP} \
+         --mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
+         --mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
+         -v ${OSCTL}:/bin/osctl:ro \
+         -e KUBECONFIG=${KUBECONFIG} \
+         -e TALOSCONFIG=${TALOSCONFIG} \
+         k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
 }

--- a/hack/test/gcp-setup.sh
+++ b/hack/test/gcp-setup.sh
@@ -4,15 +4,12 @@ set -eou pipefail
 
 ## Setup svc acct
 echo $GCE_SVC_ACCT | base64 -d > /tmp/svc-acct.json
-apk add --no-cache python
-curl -L -o /tmp/google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-253.0.0-linux-x86_64.tar.gz
-tar -xf /tmp/google-cloud-sdk.tar.gz -C /tmp
-/tmp/google-cloud-sdk/install.sh --disable-installation-options --quiet
-/tmp/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file /tmp/svc-acct.json
+
+gcloud auth activate-service-account --key-file /tmp/svc-acct.json
 
 ## Push talos-gcp to storage bucket
-/tmp/google-cloud-sdk/bin/gsutil cp ./build/gcp.tar.gz gs://talos-e2e/gcp-${TAG}.tar.gz
+gsutil cp ./build/gcp.tar.gz gs://talos-e2e/gcp-${TAG}.tar.gz
 
 ## Create image from talos-gcp
-/tmp/google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images delete talos-e2e-${TAG} || true ##Ignore error if image doesn't exist
-/tmp/google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images create talos-e2e-${TAG} --source-uri gs://talos-e2e/gcp-${TAG}.tar.gz
+gcloud --quiet --project talos-testbed compute images delete talos-e2e-${TAG} || true ##Ignore error if image doesn't exist
+gcloud --quiet --project talos-testbed compute images create talos-e2e-${TAG} --source-uri gs://talos-e2e/gcp-${TAG}.tar.gz


### PR DESCRIPTION
- Use az/gcloud cli bundled with container
- Use consistent spacing in scripts ( 2 spaces vs tab )
- Updated count functions to handle the count inline
- Made platform kubeconfig the default

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>