### PR TITLE
chore: move from gofumpt to gofumports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.18.0
 RUN cd $(mktemp -d) \
     && go mod init tmp \
-    && go get mvdan.cc/gofumpt \
-    && mv /go/bin/gofumpt /toolchain/go/bin/gofumpt
+    && go get mvdan.cc/gofumpt/gofumports \
+    && mv /go/bin/gofumports /toolchain/go/bin/gofumports
 RUN curl -sfL https://github.com/uber/prototool/releases/download/v1.8.0/prototool-Linux-x86_64.tar.gz | tar -xz --strip-components=2 -C /toolchain/bin prototool/bin/prototool
 
 # The build target creates a container that will be used to build Talos source
@@ -321,7 +321,7 @@ COPY hack/golang/golangci-lint.yaml .
 ENV GOGC=50
 RUN --mount=type=cache,target=/.cache/go-build golangci-lint run --config golangci-lint.yaml
 RUN find . -name '*.pb.go' | xargs rm
-RUN FILES="$(gofumpt -l .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumpt -s -w':\n${FILES}"; exit 1)
+RUN FILES="$(gofumports -l -local github.com/talos-systems/talos .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local github.com/talos-systems/talos .':\n${FILES}"; exit 1)
 
 # The protolint target performs linting on Markdown files.
 

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ unit-tests-race: buildkitd
 
 .PHONY: fmt
 fmt:
-	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt && cd - && gofumpt -s -w ."
+	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports && cd - && gofumports -w -local github.com/talos-systems/talos ."
 
 .PHONY: lint
 lint: buildkitd

--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/cmd/cluster/pkg/node"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"

--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+
 	"github.com/talos-systems/talos/pkg/userdata/v1alpha1/generate"
 )
 

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	udv0 "github.com/talos-systems/talos/pkg/userdata"

--- a/cmd/osctl/cmd/df.go
+++ b/cmd/osctl/cmd/df.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/machined/proto"

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/gen.go
+++ b/cmd/osctl/cmd/gen.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )

--- a/cmd/osctl/cmd/inject.go
+++ b/cmd/osctl/cmd/inject.go
@@ -9,10 +9,11 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/userdata"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // injectCmd represents the inject command

--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	localud "github.com/talos-systems/talos/cmd/osctl/internal/userdata"
 	"github.com/talos-systems/talos/internal/pkg/installer"
 	"github.com/talos-systems/talos/internal/pkg/kernel"

--- a/cmd/osctl/cmd/interfaces.go
+++ b/cmd/osctl/cmd/interfaces.go
@@ -11,6 +11,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/networkd/proto"

--- a/cmd/osctl/cmd/kubeconfig.go
+++ b/cmd/osctl/cmd/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -14,6 +14,7 @@ import (
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/osd/proto"

--- a/cmd/osctl/cmd/reboot.go
+++ b/cmd/osctl/cmd/reboot.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/reset.go
+++ b/cmd/osctl/cmd/reset.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/restart.go
+++ b/cmd/osctl/cmd/restart.go
@@ -10,6 +10,7 @@ import (
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/osd/proto"

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/constants"

--- a/cmd/osctl/cmd/routes.go
+++ b/cmd/osctl/cmd/routes.go
@@ -11,6 +11,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/networkd/proto"

--- a/cmd/osctl/cmd/shutdown.go
+++ b/cmd/osctl/cmd/shutdown.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -14,6 +14,7 @@ import (
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/app/osd/proto"

--- a/cmd/osctl/cmd/top.go
+++ b/cmd/osctl/cmd/top.go
@@ -19,10 +19,11 @@ import (
 	"github.com/gizak/termui/v3/widgets"
 	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/proc"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // versionCmd represents the version command

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )

--- a/cmd/osctl/cmd/validate.go
+++ b/cmd/osctl/cmd/validate.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/internal/userdata"
 )
 

--- a/cmd/osctl/cmd/version.go
+++ b/cmd/osctl/cmd/version.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/version"

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -9,13 +9,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/squashfs"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/virtual"
 	"github.com/talos-systems/talos/internal/pkg/mount/switchroot"
 	"github.com/talos-systems/talos/pkg/constants"
-	"golang.org/x/sys/unix"
 )
 
 // nolint: gocyclo

--- a/internal/app/machined/internal/cni/cni.go
+++ b/internal/app/machined/internal/cni/cni.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"
 )

--- a/internal/app/machined/internal/phase/disk/reset.go
+++ b/internal/app/machined/internal/phase/disk/reset.go
@@ -6,6 +6,7 @@ package disk
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/kubernetes/tasks.go
+++ b/internal/app/machined/internal/phase/kubernetes/tasks.go
@@ -13,13 +13,14 @@ import (
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sync/errgroup"
 )
 
 // KillKubernetesTasks represents the task for stop all containerd tasks in the

--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"

--- a/internal/app/machined/internal/phase/rootfs/etc/etc.go
+++ b/internal/app/machined/internal/phase/rootfs/etc/etc.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/version"
 
 	"golang.org/x/sys/unix"

--- a/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/rootfs/mount_shared.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_shared.go
@@ -5,11 +5,12 @@
 package rootfs
 
 import (
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sys/unix"
 )
 
 // MountShared represents the MountShared task.

--- a/internal/app/machined/internal/phase/rootfs/unmount_pod_mounts.go
+++ b/internal/app/machined/internal/phase/rootfs/unmount_pod_mounts.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sys/unix"
 )
 
 // UnmountPodMounts represents the UnmountPodMounts task.

--- a/internal/app/machined/internal/phase/services/stop_non_crucial_services.go
+++ b/internal/app/machined/internal/phase/services/stop_non_crucial_services.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/namespaces"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/sysctls/sysctls.go
+++ b/internal/app/machined/internal/phase/sysctls/sysctls.go
@@ -7,6 +7,7 @@ package sysctls
 import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/upgrade/leave_etcd.go
+++ b/internal/app/machined/internal/phase/upgrade/leave_etcd.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/install"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"

--- a/internal/app/machined/internal/phase/userdata/extra_devices.go
+++ b/internal/app/machined/internal/phase/userdata/extra_devices.go
@@ -7,13 +7,14 @@ package userdata
 import (
 	"fmt"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sys/unix"
 )
 
 // ExtraDevices represents the ExtraDevices task.

--- a/internal/app/machined/internal/phase/userdata/extra_files.go
+++ b/internal/app/machined/internal/phase/userdata/extra_files.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/userdata/pki.go
+++ b/internal/app/machined/internal/phase/userdata/pki.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"

--- a/internal/app/machined/internal/phase/userdata/save_userdata.go
+++ b/internal/app/machined/internal/phase/userdata/save_userdata.go
@@ -9,12 +9,13 @@ import (
 	"log"
 	"os"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"gopkg.in/yaml.v2"
 )
 
 // SaveUserData represents the SaveUserData task.

--- a/internal/app/machined/internal/phase/userdata/userdata.go
+++ b/internal/app/machined/internal/phase/userdata/userdata.go
@@ -8,14 +8,15 @@ import (
 	"errors"
 	"log"
 
+	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
-	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 )
 
 // UserData represents the UserData task.

--- a/internal/app/machined/internal/platform/aws/aws.go
+++ b/internal/app/machined/internal/platform/aws/aws.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/fullsailor/pkcs7"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/download"

--- a/internal/app/machined/internal/platform/container/container.go
+++ b/internal/app/machined/internal/platform/container/container.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/translate"

--- a/internal/app/machined/internal/platform/metal/metal.go
+++ b/internal/app/machined/internal/platform/metal/metal.go
@@ -10,6 +10,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"

--- a/internal/app/machined/internal/platform/platform.go
+++ b/internal/app/machined/internal/platform/platform.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform/aws"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform/azure"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform/container"

--- a/internal/app/machined/internal/platform/vmware/vmware.go
+++ b/internal/app/machined/internal/platform/vmware/vmware.go
@@ -8,12 +8,13 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/vmware/vmw-guestinfo/rpcvmx"
+	"github.com/vmware/vmw-guestinfo/vmcheck"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"github.com/vmware/vmw-guestinfo/rpcvmx"
-	"github.com/vmware/vmw-guestinfo/vmcheck"
 
 	yaml "gopkg.in/yaml.v2"
 )

--- a/internal/app/machined/internal/runtime/initializer/interactive/interactive.go
+++ b/internal/app/machined/internal/runtime/initializer/interactive/interactive.go
@@ -13,13 +13,14 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/pkg/installer"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sys/unix"
 )
 
 // Interactive is an initializer that performs an installation by prompting the

--- a/internal/app/machined/internal/runtime/initializer/metal/metal.go
+++ b/internal/app/machined/internal/runtime/initializer/metal/metal.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/internal/event"
 	"github.com/talos-systems/talos/internal/app/machined/internal/install"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"

--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"

--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/pkg/userdata"

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	containerdrunner "github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"

--- a/internal/app/machined/pkg/system/runner/containerd/import.go
+++ b/internal/app/machined/pkg/system/runner/containerd/import.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/pkg/constants"
 )

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/goroutine"

--- a/internal/app/machined/pkg/system/runner/process/process.go
+++ b/internal/app/machined/pkg/system/runner/process/process.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	processlogger "github.com/talos-systems/talos/internal/app/machined/pkg/system/log"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"

--- a/internal/app/machined/pkg/system/runner/process/process_test.go
+++ b/internal/app/machined/pkg/system/runner/process/process_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"

--- a/internal/app/machined/pkg/system/service_events.go
+++ b/internal/app/machined/pkg/system/service_events.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 )
 

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"

--- a/internal/app/machined/pkg/system/service_runner_test.go
+++ b/internal/app/machined/pkg/system/service_runner_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/machined/pkg/system/services/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm.go
@@ -18,6 +18,7 @@ import (
 	criconstants "github.com/containerd/cri/pkg/constants"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"

--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
@@ -17,6 +17,11 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	kubeadmv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+
 	"github.com/talos-systems/talos/internal/app/trustd/proto"
 	"github.com/talos-systems/talos/internal/pkg/cis"
 	"github.com/talos-systems/talos/pkg/cmd"
@@ -24,10 +29,6 @@ import (
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	kubeadmv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 )
 
 const dirPerm os.FileMode = 0700

--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
@@ -11,11 +11,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/talos/internal/app/trustd/proto"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"gopkg.in/yaml.v2"
 )
 
 type KubeadmSuite struct {

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -14,6 +14,7 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -14,6 +14,7 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -13,6 +13,7 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"

--- a/internal/app/machined/pkg/system/services/proxyd.go
+++ b/internal/app/machined/pkg/system/services/proxyd.go
@@ -13,6 +13,7 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -13,6 +13,7 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"

--- a/internal/app/machined/pkg/system/system_test.go
+++ b/internal/app/machined/pkg/system/system_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 )
 

--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -13,9 +13,10 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"
-	"golang.org/x/sys/unix"
 )
 
 // DHCP implements the Addressing interface

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -9,8 +9,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/talos-systems/talos/pkg/userdata"
 	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/pkg/userdata"
 )
 
 // Static implements the Addressing interface

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -17,9 +17,10 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/jsimonetti/rtnetlink/rtnl"
 	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
-	"golang.org/x/sys/unix"
 )
 
 // Set up default nameservers

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
-	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
-	"github.com/talos-systems/talos/internal/app/networkd/proto"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
+	"github.com/talos-systems/talos/internal/app/networkd/proto"
 )
 
 // Registrator is the concrete type that implements the factory.Registrator and

--- a/internal/app/networkd/pkg/reg/reg_test.go
+++ b/internal/app/networkd/pkg/reg/reg_test.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
 	"github.com/talos-systems/talos/internal/app/networkd/proto"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
-	"golang.org/x/sys/unix"
-	"google.golang.org/grpc"
 )
 
 type NetworkdSuite struct {

--- a/internal/app/ntpd/pkg/reg/reg.go
+++ b/internal/app/ntpd/pkg/reg/reg.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/ntpd/pkg/ntp"
 	"github.com/talos-systems/talos/internal/app/ntpd/proto"
-	"google.golang.org/grpc"
 )
 
 // Registrator is the concrete type that implements the factory.Registrator and

--- a/internal/app/ntpd/pkg/reg/reg_test.go
+++ b/internal/app/ntpd/pkg/reg/reg_test.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/ntpd/pkg/ntp"
 	"github.com/talos-systems/talos/internal/app/ntpd/proto"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
-	"google.golang.org/grpc"
 )
 
 type NtpdSuite struct {

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -9,9 +9,10 @@ import (
 	"io"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/machined/proto"
 	"github.com/talos-systems/talos/pkg/constants"
-	"google.golang.org/grpc"
 )
 
 // InitServiceClient is a gRPC client for init service API

--- a/internal/app/osd/internal/reg/networkd_client.go
+++ b/internal/app/osd/internal/reg/networkd_client.go
@@ -8,9 +8,10 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/networkd/proto"
 	"github.com/talos-systems/talos/pkg/constants"
-	"google.golang.org/grpc"
 )
 
 // NetworkdClient is a gRPC client for init service API

--- a/internal/app/osd/internal/reg/ntp_client.go
+++ b/internal/app/osd/internal/reg/ntp_client.go
@@ -8,9 +8,10 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/ntpd/proto"
 	"github.com/talos-systems/talos/pkg/constants"
-	"google.golang.org/grpc"
 )
 
 // NtpdClient is a gRPC client for init service API

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -9,14 +9,15 @@ import (
 	"flag"
 	"log"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/talos-systems/talos/internal/app/osd/internal/reg"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/grpc/tls"
 	"github.com/talos-systems/talos/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var dataPath *string

--- a/internal/app/proxyd/internal/frontend/frontend.go
+++ b/internal/app/proxyd/internal/frontend/frontend.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
-	tnet "github.com/talos-systems/talos/pkg/net"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -24,6 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
+	tnet "github.com/talos-systems/talos/pkg/net"
 )
 
 // ReverseProxy represents a reverse proxy server.

--- a/internal/app/proxyd/internal/frontend/frontend_test.go
+++ b/internal/app/proxyd/internal/frontend/frontend_test.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
-	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
 
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/internal/app/proxyd/internal/reg/reg.go
+++ b/internal/app/proxyd/internal/reg/reg.go
@@ -8,9 +8,10 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
 	"github.com/talos-systems/talos/internal/app/proxyd/proto"
-	"google.golang.org/grpc"
 )
 
 // Registrator is the concrete type that implements the factory.Registrator and

--- a/internal/app/proxyd/internal/reg/reg_test.go
+++ b/internal/app/proxyd/internal/reg/reg_test.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
 	"github.com/talos-systems/talos/internal/app/proxyd/proto"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
-	"google.golang.org/grpc"
 )
 
 type ProxydSuite struct {

--- a/internal/app/proxyd/main.go
+++ b/internal/app/proxyd/main.go
@@ -9,6 +9,9 @@ import (
 	"flag"
 	"log"
 
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/reg"
@@ -16,8 +19,6 @@ import (
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	pkgnet "github.com/talos-systems/talos/pkg/net"
 )

--- a/internal/app/trustd/internal/reg/reg.go
+++ b/internal/app/trustd/internal/reg/reg.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"path"
 
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/trustd/proto"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"google.golang.org/grpc"
 )
 
 // Registrator is the concrete type that implements the factory.Registrator and

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -8,6 +8,9 @@ import (
 	"flag"
 	"log"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/talos-systems/talos/internal/app/trustd/internal/reg"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
@@ -15,8 +18,6 @@ import (
 	"github.com/talos-systems/talos/pkg/grpc/tls"
 	"github.com/talos-systems/talos/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var dataPath *string

--- a/internal/pkg/installer/bootloader/syslinux/syslinux.go
+++ b/internal/pkg/installer/bootloader/syslinux/syslinux.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/cmd"
 
 	"golang.org/x/sys/unix"

--- a/internal/pkg/installer/installer.go
+++ b/internal/pkg/installer/installer.go
@@ -12,6 +12,8 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/pkg/installer/bootloader/syslinux"
 	"github.com/talos-systems/talos/internal/pkg/installer/manifest"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
@@ -20,7 +22,6 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"golang.org/x/sys/unix"
 )
 
 // Installer represents the installer logic. It serves as the entrypoint to all

--- a/internal/pkg/installer/manifest/manifest.go
+++ b/internal/pkg/installer/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/blockdevice"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/vfat"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/xfs"

--- a/internal/pkg/installer/manifest/manifest_test.go
+++ b/internal/pkg/installer/manifest/manifest_test.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/talos-systems/talos/pkg/userdata"
 	"gopkg.in/yaml.v2"
+
+	"github.com/talos-systems/talos/pkg/userdata"
 )
 
 type manifestSuite struct {

--- a/internal/pkg/installer/manifest/verify.go
+++ b/internal/pkg/installer/manifest/verify.go
@@ -6,6 +6,7 @@ package manifest
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"

--- a/internal/pkg/installer/manifest/verify_test.go
+++ b/internal/pkg/installer/manifest/verify_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/talos-systems/talos/pkg/userdata"
 	"gopkg.in/yaml.v2"
+
+	"github.com/talos-systems/talos/pkg/userdata"
 )
 
 type validateSuite struct {

--- a/internal/pkg/kernel/kspp/kspp.go
+++ b/internal/pkg/kernel/kspp/kspp.go
@@ -7,6 +7,7 @@ package kspp
 import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/sysctl"
 )

--- a/internal/pkg/mount/manager/manager.go
+++ b/internal/pkg/mount/manager/manager.go
@@ -6,6 +6,7 @@ package manager
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/internal/pkg/mount"
 )
 

--- a/internal/pkg/mount/manager/owned/owned.go
+++ b/internal/pkg/mount/manager/owned/owned.go
@@ -8,10 +8,11 @@ import (
 	"log"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/constants"
-	"golang.org/x/sys/unix"
 )
 
 // MountPointsForDevice returns the mountpoints required to boot the system.

--- a/internal/pkg/mount/manager/squashfs/squashfs.go
+++ b/internal/pkg/mount/manager/squashfs/squashfs.go
@@ -5,10 +5,11 @@
 package squashfs
 
 import (
-	"github.com/talos-systems/talos/internal/pkg/mount"
-	"github.com/talos-systems/talos/pkg/constants"
 	"golang.org/x/sys/unix"
 	"gopkg.in/freddierice/go-losetup.v1"
+
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // MountPoints returns the mountpoints required to boot the system.

--- a/internal/pkg/mount/manager/virtual/virtual.go
+++ b/internal/pkg/mount/manager/virtual/virtual.go
@@ -5,8 +5,9 @@
 package virtual
 
 import (
-	"github.com/talos-systems/talos/internal/pkg/mount"
 	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/pkg/mount"
 )
 
 // MountPoints returns the mountpoints required to boot the system.

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -13,12 +13,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/pkg/blockdevice"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/xfs"
 	gptpartition "github.com/talos-systems/talos/pkg/blockdevice/table/gpt/partition"
 	"github.com/talos-systems/talos/pkg/blockdevice/util"
 	"github.com/talos-systems/talos/pkg/constants"
-	"golang.org/x/sys/unix"
 )
 
 // RetryFunc defines the requirements for retrying a mount point operation.

--- a/internal/pkg/mount/switchroot/switchroot.go
+++ b/internal/pkg/mount/switchroot/switchroot.go
@@ -9,8 +9,9 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 )
 
 // Switch moves the rootfs to a specified directory. See

--- a/pkg/archiver/tar_test.go
+++ b/pkg/archiver/tar_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/pkg/archiver"
 )
 

--- a/pkg/archiver/walker_test.go
+++ b/pkg/archiver/walker_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
 	"github.com/talos-systems/talos/pkg/archiver"
 )
 

--- a/pkg/blockdevice/blkpg/blkpg.go
+++ b/pkg/blockdevice/blkpg/blkpg.go
@@ -9,9 +9,10 @@ import (
 	"syscall"
 	"unsafe"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/pkg/blockdevice/lba"
 	"github.com/talos-systems/talos/pkg/blockdevice/table"
-	"golang.org/x/sys/unix"
 )
 
 // InformKernelOfAdd invokes the BLKPG_ADD_PARTITION ioctl.

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/blockdevice/table"
 	"github.com/talos-systems/talos/pkg/blockdevice/table/gpt"
 

--- a/pkg/blockdevice/probe/probe.go
+++ b/pkg/blockdevice/probe/probe.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/blockdevice"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/iso9660"

--- a/pkg/blockdevice/table/gpt/gpt.go
+++ b/pkg/blockdevice/table/gpt/gpt.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/blockdevice/blkpg"
 	"github.com/talos-systems/talos/pkg/blockdevice/lba"
 	"github.com/talos-systems/talos/pkg/blockdevice/table"

--- a/pkg/blockdevice/table/gpt/header/header.go
+++ b/pkg/blockdevice/table/gpt/header/header.go
@@ -12,6 +12,7 @@ import (
 	"hash/crc32"
 
 	"github.com/google/uuid"
+
 	"github.com/talos-systems/talos/pkg/blockdevice/lba"
 	"github.com/talos-systems/talos/pkg/serde"
 )

--- a/pkg/blockdevice/table/gpt/partition/partition.go
+++ b/pkg/blockdevice/table/gpt/partition/partition.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/talos-systems/talos/pkg/serde"
 	"golang.org/x/text/encoding/unicode"
+
+	"github.com/talos-systems/talos/pkg/serde"
 )
 
 // Partition represents a partition entry in a GUID partition table.

--- a/pkg/chunker/file/file.go
+++ b/pkg/chunker/file/file.go
@@ -11,8 +11,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/talos-systems/talos/pkg/chunker"
 	"gopkg.in/fsnotify.v1"
+
+	"github.com/talos-systems/talos/pkg/chunker"
 )
 
 // Options is the functional options struct.

--- a/pkg/grpc/gen/gen.go
+++ b/pkg/grpc/gen/gen.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc"
+
 	"github.com/talos-systems/talos/internal/app/trustd/proto"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"google.golang.org/grpc"
 )
 
 // Generator represents the OS identity generator.

--- a/pkg/grpc/middleware/auth/basic/basic.go
+++ b/pkg/grpc/middleware/auth/basic/basic.go
@@ -9,10 +9,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/talos-systems/talos/pkg/net"
-	"github.com/talos-systems/talos/pkg/userdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/talos-systems/talos/pkg/net"
+	"github.com/talos-systems/talos/pkg/userdata"
 )
 
 // Credentials describes an authorization method.

--- a/pkg/grpc/tls/cert.go
+++ b/pkg/grpc/tls/cert.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/gen"
 	"github.com/talos-systems/talos/pkg/userdata"

--- a/pkg/grpc/tls/tls.go
+++ b/pkg/grpc/tls/tls.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 

--- a/pkg/userdata/download/download.go
+++ b/pkg/userdata/download/download.go
@@ -14,9 +14,10 @@ import (
 	"net/url"
 	"time"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/translate"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const b64 = "base64"

--- a/pkg/userdata/generate/generate_test.go
+++ b/pkg/userdata/generate/generate_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/generate"
-	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/pkg/userdata/kubernetes_security.go
+++ b/pkg/userdata/kubernetes_security.go
@@ -6,6 +6,7 @@ package userdata
 
 import (
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 

--- a/pkg/userdata/kubernetes_security_test.go
+++ b/pkg/userdata/kubernetes_security_test.go
@@ -7,8 +7,9 @@ package userdata
 
 import (
 	"github.com/hashicorp/go-multierror"
-	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"golang.org/x/xerrors"
+
+	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
 func (suite *validateSuite) TestValidateKubernetesSecurity() {

--- a/pkg/userdata/os_security.go
+++ b/pkg/userdata/os_security.go
@@ -6,6 +6,7 @@ package userdata
 
 import (
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 

--- a/pkg/userdata/os_security_test.go
+++ b/pkg/userdata/os_security_test.go
@@ -7,8 +7,9 @@ package userdata
 
 import (
 	"github.com/hashicorp/go-multierror"
-	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"golang.org/x/xerrors"
+
+	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
 func (suite *validateSuite) TestValidateOSSecurity() {

--- a/pkg/userdata/translate/translate_v1alpha1.go
+++ b/pkg/userdata/translate/translate_v1alpha1.go
@@ -9,15 +9,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/talos-systems/talos/pkg/constants"
-	"github.com/talos-systems/talos/pkg/crypto/x509"
-	"github.com/talos-systems/talos/pkg/userdata"
-	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+	"github.com/talos-systems/talos/pkg/userdata"
+	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 )
 
 // V1Alpha1Translator holds info about a v1alpha1 machine config translation layer

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/net"
-	"golang.org/x/xerrors"
 
 	yaml "gopkg.in/yaml.v2"
 )

--- a/pkg/userdata/v1alpha1/generate/controlplane.go
+++ b/pkg/userdata/v1alpha1/generate/controlplane.go
@@ -5,8 +5,9 @@
 package generate
 
 import (
-	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 	yaml "gopkg.in/yaml.v2"
+
+	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 )
 
 func controlPlaneUd(in *Input) (string, error) {

--- a/pkg/userdata/v1alpha1/generate/generate_test.go
+++ b/pkg/userdata/v1alpha1/generate/generate_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+
 	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 	udgenv1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1/generate"
-	"gopkg.in/yaml.v2"
 )
 
 var input *udgenv1alpha1.Input

--- a/pkg/userdata/v1alpha1/generate/init.go
+++ b/pkg/userdata/v1alpha1/generate/init.go
@@ -5,8 +5,9 @@
 package generate
 
 import (
-	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 	yaml "gopkg.in/yaml.v2"
+
+	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 )
 
 func initUd(in *Input) (string, error) {

--- a/pkg/userdata/v1alpha1/generate/join.go
+++ b/pkg/userdata/v1alpha1/generate/join.go
@@ -5,8 +5,9 @@
 package generate
 
 import (
-	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 	yaml "gopkg.in/yaml.v2"
+
+	v1alpha1 "github.com/talos-systems/talos/pkg/userdata/v1alpha1"
 )
 
 func workerUd(in *Input) (string, error) {


### PR DESCRIPTION
The gofumports does everything that gofumpt does with the addition of
formatting imports. This change proposes the use of the `-local` flag so
that we can have imports separated in the following order:

- standard library
- third party
- Talos specific