### PR TITLE
chore: re-enable containerd related tests

### DIFF
--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -14,9 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/suite"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -59,10 +56,6 @@ type CRISuite struct {
 }
 
 func (suite *CRISuite) SetupSuite() {
-	if cgroups.Mode() == cgroups.Unified {
-		suite.T().Skip("test doesn't pass under cgroupsv2")
-	}
-
 	var err error
 
 	suite.tmpDir, err = ioutil.TempDir("", "talos")
@@ -73,28 +66,6 @@ func (suite *CRISuite) SetupSuite() {
 	suite.Require().NoError(os.Mkdir(rootDir, 0o777))
 
 	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
-
-	if cgroups.Mode() == cgroups.Unified {
-		var (
-			groupPath string
-			manager   *cgroupsv2.Manager
-		)
-
-		groupPath, err = cgroupsv2.NestedGroupPath(suite.tmpDir)
-		suite.Require().NoError(err)
-
-		manager, err = cgroupsv2.NewManager(constants.CgroupMountPath, groupPath, &cgroupsv2.Resources{})
-		suite.Require().NoError(err)
-
-		defer manager.Delete() //nolint:errcheck
-	} else {
-		var manager cgroups.Cgroup
-
-		manager, err = cgroups.New(cgroups.V1, cgroups.NestedPath(suite.tmpDir), &specs.LinuxResources{})
-		suite.Require().NoError(err)
-
-		defer manager.Delete() //nolint:errcheck
-	}
 
 	args := &runner.Args{
 		ID: "containerd",
@@ -112,7 +83,6 @@ func (suite *CRISuite) SetupSuite() {
 		args,
 		runner.WithLoggingManager(logging.NewFileLoggingManager(suite.tmpDir)),
 		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
-		runner.WithCgroupPath(suite.tmpDir),
 	)
 	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
 	suite.containerdWg.Add(1)


### PR DESCRIPTION
Stop moving containerd process into any cgroup.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/4126)
<!-- Reviewable:end -->
