### PR TITLE
feat: provide talosctl.exe for Windows

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -191,7 +191,7 @@ local Pipeline(name, steps=[], depends_on=[], with_docker=true, disable_clone=fa
 
 local generate = Step("generate", target="generate docs", depends_on=[setup_ci]);
 local check_dirty = Step("check-dirty", depends_on=[generate]);
-local build = Step("build", target="talosctl-linux talosctl-darwin kernel initramfs installer talos", depends_on=[check_dirty], environment={"IMAGE_REGISTRY": local_registry, "PUSH": true});
+local build = Step("build", target="talosctl-linux talosctl-darwin talosctl-windows kernel initramfs installer talos", depends_on=[check_dirty], environment={"IMAGE_REGISTRY": local_registry, "PUSH": true});
 local lint = Step("lint", depends_on=[build]);
 local talosctl_cni_bundle = Step('talosctl-cni-bundle', depends_on=[build, lint]);
 local iso = Step("iso", target="iso", depends_on=[build], environment={"IMAGE_REGISTRY": local_registry});
@@ -549,6 +549,7 @@ local release = {
       '_out/talosctl-linux-amd64',
       '_out/talosctl-linux-arm64',
       '_out/talosctl-linux-armv7',
+      '_out/talosctl-windows-amd64.exe',
       '_out/vmware-amd64.ova',
       '_out/vmware-arm64.ova',
       '_out/vmlinuz-amd64',

--- a/Dockerfile
+++ b/Dockerfile
@@ -303,6 +303,15 @@ FROM scratch AS talosctl-darwin
 COPY --from=talosctl-darwin-amd64-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 COPY --from=talosctl-darwin-arm64-build /talosctl-darwin-arm64 /talosctl-darwin-arm64
 
+FROM base AS talosctl-windows-amd64-build
+WORKDIR /src/cmd/talosctl
+ARG GO_BUILDFLAGS
+ARG GO_LDFLAGS
+RUN --mount=type=cache,target=/.cache GOOS=windows GOARCH=amd64 go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /talosctl-windows-amd64.exe
+
+FROM scratch AS talosctl-windows
+COPY --from=talosctl-windows-amd64-build /talosctl-windows-amd64.exe /talosctl-windows-amd64.exe
+
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.3.2
-	github.com/talos-systems/go-blockdevice v0.2.3
+	github.com/talos-systems/go-blockdevice v0.2.4-0.20210825155946-d9811569588b
 	github.com/talos-systems/go-cmd v0.1.0
 	github.com/talos-systems/go-debug v0.2.1
 	github.com/talos-systems/go-kmsg v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1134,8 +1134,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.3.2 h1:I+MC9ql6K29EMlbPzdSeHZInSRWdze1FX1qGGrlom8Q=
 github.com/talos-systems/crypto v0.3.2/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
-github.com/talos-systems/go-blockdevice v0.2.3 h1:THqjUboZfTVth3R9+75vtBXYWollr5bVg3wLGpB4C6I=
 github.com/talos-systems/go-blockdevice v0.2.3/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.4-0.20210825155946-d9811569588b h1:/Tlvc7iho7Q4pHR6CAbtnLNx/SSkvUqMqARYAe4Jllk=
+github.com/talos-systems/go-blockdevice v0.2.4-0.20210825155946-d9811569588b/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-cmd v0.1.0 h1:bqPeL0ksproFyTOlvMisdUXc7uAf0aqJ5Q6waSGv32s=
 github.com/talos-systems/go-cmd v0.1.0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=


### PR DESCRIPTION
Provide talosctl.exe for Windows users.

Marked as draft because need Go mod update which bring https://github.com/talos-systems/go-blockdevice/pull/43 to here (and new version of it need to be released first)