### PR TITLE
fix: validate IP address returned as HTTP response in platform code

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -202,7 +202,9 @@ func (a *AWS) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 		return
 	}
 
-	addrs = append(addrs, net.ParseIP(string(body)))
+	if addr := net.ParseIP(string(body)); addr != nil {
+		addrs = append(addrs, addr)
+	}
 
 	return addrs, err
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -99,7 +99,9 @@ func (d *DigitalOcean) ExternalIPs(ctx context.Context) (addrs []net.IP, err err
 		return
 	}
 
-	addrs = append(addrs, net.ParseIP(string(body)))
+	if addr := net.ParseIP(string(body)); addr != nil {
+		addrs = append(addrs, addr)
+	}
 
 	return addrs, err
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -101,7 +101,9 @@ func (a *Openstack) ExternalIPs(ctx context.Context) (addrs []net.IP, err error)
 		return
 	}
 
-	addrs = append(addrs, net.ParseIP(string(body)))
+	if addr := net.ParseIP(string(body)); addr != nil {
+		addrs = append(addrs, addr)
+	}
 
 	return addrs, err
 }


### PR DESCRIPTION
If provider returns empty response, it is parsed as `nil` IP address and
included in the response which leads to `<nil>` entries in the machine
configuration after applying dynamic config.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
