### PR TITLE
fix: properly handle omitempty fields in the validator

### DIFF
--- a/pkg/machinery/config/decoder/decoder.go
+++ b/pkg/machinery/config/decoder/decoder.go
@@ -178,7 +178,7 @@ func decode(manifest *yaml.Node) (target interface{}, err error) {
 
 //nolint:gocyclo
 func validate(target interface{}, spec *yaml.Node) error {
-	node, err := encoder.NewEncoder(target).Marshal()
+	node, err := encoder.NewEncoder(target, encoder.WithOmitEmpty(false)).Marshal()
 	if err != nil {
 		return err
 	}

--- a/pkg/machinery/config/decoder/decoder_test.go
+++ b/pkg/machinery/config/decoder/decoder_test.go
@@ -23,10 +23,17 @@ type MockV2 struct {
 	Map   map[string]Mock `yaml:"map"`
 }
 
+type MockV3 struct {
+	Omit bool `yaml:"omit,omitempty"`
+}
+
 func init() {
 	config.Register("mock", func(version string) interface{} {
-		if version == "v1alpha2" {
+		switch version {
+		case "v1alpha2":
 			return &MockV2{}
+		case "v1alpha3":
+			return &MockV3{}
 		}
 
 		return &Mock{}
@@ -199,6 +206,22 @@ spec:
 			wantErr: true,
 		},
 		{
+			name: "extra zero fields in map",
+			fields: fields{
+				source: []byte(`---
+kind: mock
+version: v1alpha2
+spec:
+  map:
+    second:
+      a:
+        b: {}
+`),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "valid nested",
 			fields: fields{
 				source: []byte(`---
@@ -244,6 +267,17 @@ spec:
        - rshared
        - rw
      source: /var/local
+`),
+			},
+		},
+		{
+			name: "omit empty test",
+			fields: fields{
+				source: []byte(`---
+kind: mock
+version: v1alpha3
+spec:
+  omit: false
 `),
 			},
 		},

--- a/pkg/machinery/config/encoder/documentation.go
+++ b/pkg/machinery/config/encoder/documentation.go
@@ -194,7 +194,7 @@ func addComments(node *yaml.Node, doc *Doc, comments ...int) {
 }
 
 //nolint:gocyclo
-func renderExample(key string, doc *Doc, flags CommentsFlags) string {
+func renderExample(key string, doc *Doc, options *Options) string {
 	if doc == nil {
 		return ""
 	}
@@ -216,7 +216,7 @@ func renderExample(key string, doc *Doc, flags CommentsFlags) string {
 
 		e.Populate(i)
 
-		node, err := toYamlNode(defaultValue, flags)
+		node, err := toYamlNode(defaultValue, options)
 		if err != nil {
 			continue
 		}
@@ -224,13 +224,13 @@ func renderExample(key string, doc *Doc, flags CommentsFlags) string {
 		if key != "" {
 			node, err = toYamlNode(map[string]*yaml.Node{
 				key: node,
-			}, flags)
+			}, options)
 			if err != nil {
 				continue
 			}
 		}
 
-		if i == 0 && flags.enabled(CommentsDocs) {
+		if i == 0 && options.Comments.enabled(CommentsDocs) {
 			addComments(node, doc, HeadComment, LineComment)
 		}
 

--- a/pkg/machinery/config/encoder/markdown.go
+++ b/pkg/machinery/config/encoder/markdown.go
@@ -180,7 +180,7 @@ func encodeYaml(in interface{}, name string) string {
 		}
 	}
 
-	node, err := toYamlNode(in, CommentsAll)
+	node, err := toYamlNode(in, newOptions(WithComments(CommentsAll)))
 	if err != nil {
 		return fmt.Sprintf("yaml encoding failed %s", err)
 	}

--- a/pkg/machinery/config/encoder/options.go
+++ b/pkg/machinery/config/encoder/options.go
@@ -24,12 +24,14 @@ const (
 
 // Options defines encoder config.
 type Options struct {
-	Comments CommentsFlags
+	Comments  CommentsFlags
+	OmitEmpty bool
 }
 
 func newOptions(opts ...Option) *Options {
 	res := &Options{
-		Comments: CommentsAll,
+		Comments:  CommentsAll,
+		OmitEmpty: true,
 	}
 
 	for _, o := range opts {
@@ -46,5 +48,12 @@ type Option func(*Options)
 func WithComments(flags CommentsFlags) Option {
 	return func(o *Options) {
 		o.Comments = flags
+	}
+}
+
+// WithOmitEmpty toggles omitempty handling.
+func WithOmitEmpty(value bool) Option {
+	return func(o *Options) {
+		o.OmitEmpty = value
 	}
 }


### PR DESCRIPTION
Add a new option to our custom YAML encoder to disable `omitempty` tags
completely.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>