### PR TITLE
fix: don't extract nil IPs in the GCP platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -100,7 +100,9 @@ func (g *GCP) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 
 	for _, networkInterface := range m {
 		for _, accessConfig := range networkInterface.AccessConfigs {
-			addrs = append(addrs, net.ParseIP(accessConfig.ExternalIP))
+			if addr := net.ParseIP(accessConfig.ExternalIP); addr != nil {
+				addrs = append(addrs, addr)
+			}
 		}
 	}
 


### PR DESCRIPTION
This fix is same as #4152.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
