### PR TITLE
fix: updating diskSelector option

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -115,7 +115,7 @@ func (r *Runtime) CanApplyImmediate(b []byte) error {
 	}
 
 	if !reflect.DeepEqual(currentConfig, newConfig) {
-		diff := cmp.Diff(currentConfig, newConfig)
+		diff := cmp.Diff(currentConfig, newConfig, cmp.AllowUnexported(v1alpha1.InstallDiskSizeMatcher{}))
 
 		return fmt.Errorf("this config change can't be applied in immediate mode\ndiff: %s", diff)
 	}


### PR DESCRIPTION
Looks like `cmp.Diff` needs to have `AllowUnexported` option for
types with unexported fields if you want to avoid panic when you compare them.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>