### PR TITLE
fix: add interface route if DHCP4 router is not directly routeable

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -222,6 +222,22 @@ func (d *DHCP4) parseAck(ack *dhcpv4.DHCPv4) {
 				Protocol:    nethelpers.ProtocolBoot,
 				ConfigLayer: network.ConfigOperator,
 			})
+
+			if !addr.Contains(gw) {
+				// add an interface route for the gateway if it's not in the same network
+				d.routes = append(d.routes, network.RouteSpecSpec{
+					Family:      nethelpers.FamilyInet4,
+					Destination: netaddr.IPPrefixFrom(gw, gw.BitLen()),
+					Source:      addr.IP(),
+					OutLinkName: d.linkName,
+					Table:       nethelpers.TableMain,
+					Priority:    d.routeMetric,
+					Scope:       nethelpers.ScopeLink,
+					Type:        nethelpers.TypeUnicast,
+					Protocol:    nethelpers.ProtocolBoot,
+					ConfigLayer: network.ConfigOperator,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #4320

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4332)
<!-- Reviewable:end -->
