### PR TITLE
fix: sort output of the argument builder

### DIFF
--- a/pkg/argsbuilder/argsbuilder_args.go
+++ b/pkg/argsbuilder/argsbuilder_args.go
@@ -6,6 +6,7 @@ package argsbuilder
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -87,10 +88,18 @@ func (a Args) Set(k, v Key) ArgsBuilder {
 
 // Args implements the ArgsBuilder interface.
 func (a Args) Args() []string {
+	keys := make([]string, 0, len(a))
+
+	for key := range a {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
 	args := []string{}
 
-	for key, val := range a {
-		args = append(args, fmt.Sprintf("--%s=%s", key, val))
+	for _, key := range keys {
+		args = append(args, fmt.Sprintf("--%s=%s", key, a[key]))
 	}
 
 	return args

--- a/pkg/argsbuilder/argsbuilder_test.go
+++ b/pkg/argsbuilder/argsbuilder_test.go
@@ -33,6 +33,7 @@ func (suite *ArgsbuilderSuite) TestMergeAdditive() {
 	)
 
 	suite.Require().Equal("value1,value2,value3,value10", args["param"])
+	suite.Assert().Equal([]string{"--param=value1,value2,value3,value10", "--param2="}, args.Args())
 
 	suite.Require().NoError(
 		args.Merge(argsbuilder.Args{
@@ -45,6 +46,7 @@ func (suite *ArgsbuilderSuite) TestMergeAdditive() {
 	)
 
 	suite.Require().Equal("value1,value5", args["param2"])
+	suite.Assert().Equal([]string{"--param=value1,value2,value3,value10", "--param2=value1,value5"}, args.Args())
 }
 
 func (suite *ArgsbuilderSuite) TestMergeOverwrite() {
@@ -63,6 +65,7 @@ func (suite *ArgsbuilderSuite) TestMergeOverwrite() {
 	)
 
 	suite.Require().Equal("value10", args["param"])
+	suite.Assert().Equal([]string{"--param=value10"}, args.Args())
 }
 
 func (suite *ArgsbuilderSuite) TestMergeDenied() {


### PR DESCRIPTION
This fixes the instabilitiy on some of the internal resources, as they
get regenerated as a result of machine config changes. As map iteration
order is not stable this might cause unexpected static pod defition
regeneration with the only difference is the flag order.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4340)
<!-- Reviewable:end -->
