### PR TITLE
fix: use ECDSA-SHA512 when generating certs for Talos < 0.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/smira/go-xz v0.0.0-20201019130106-9921ed7a9935
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/crypto v0.3.3
+	github.com/talos-systems/crypto v0.3.4
 	github.com/talos-systems/discovery-service v0.1.0
 	github.com/talos-systems/go-blockdevice v0.2.4
 	github.com/talos-systems/go-cmd v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1040,8 +1040,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/crypto v0.3.3 h1:MvYJY0Tg8+/QDfRj2JJ/m54INsi1ZXbwyc6H+7ea/v8=
-github.com/talos-systems/crypto v0.3.3/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
+github.com/talos-systems/crypto v0.3.4 h1:bg4N27CH1MvUBasr70BlZObPXQYEhUTwOOm/jhCRFxg=
+github.com/talos-systems/crypto v0.3.4/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/discovery-service v0.1.0 h1:mfFElRIetj6+rit+WnrKjSZMA0CTzUesSVJhqLSnddk=
 github.com/talos-systems/discovery-service v0.1.0/go.mod h1:+9VWFbTcUChtlE0qc2fQ3Lyj1kj2AakFQ/ITnaB8Pd0=
 github.com/talos-systems/go-blockdevice v0.2.4 h1:/E5I95byCxfdmQIiBEyWgdUo+6vPBbbOJQIF9+yeysU=

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -86,3 +86,8 @@ func (contract *VersionContract) SupportsRBACFeature() bool {
 func (contract *VersionContract) SupportsDynamicCertSANs() bool {
 	return contract.Greater(TalosVersion0_12)
 }
+
+// SupportsECDSASHA256 returns true if version of Talos supports ECDSA-SHA256 for Kubernetes certificates.
+func (contract *VersionContract) SupportsECDSASHA256() bool {
+	return contract.Greater(TalosVersion0_12)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -49,6 +49,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, config.TalosVersionCurrent.SupportsServiceAccount())
 	assert.True(t, config.TalosVersionCurrent.SupportsRBACFeature())
 	assert.True(t, config.TalosVersionCurrent.SupportsDynamicCertSANs())
+	assert.True(t, config.TalosVersionCurrent.SupportsECDSASHA256())
 }
 
 func TestContract0_13(t *testing.T) {
@@ -57,6 +58,7 @@ func TestContract0_13(t *testing.T) {
 	assert.True(t, config.TalosVersion0_13.SupportsServiceAccount())
 	assert.True(t, config.TalosVersion0_13.SupportsRBACFeature())
 	assert.True(t, config.TalosVersion0_13.SupportsDynamicCertSANs())
+	assert.True(t, config.TalosVersion0_13.SupportsECDSASHA256())
 }
 
 func TestContract0_12(t *testing.T) {
@@ -65,6 +67,7 @@ func TestContract0_12(t *testing.T) {
 	assert.True(t, config.TalosVersion0_12.SupportsServiceAccount())
 	assert.True(t, config.TalosVersion0_12.SupportsRBACFeature())
 	assert.False(t, config.TalosVersion0_12.SupportsDynamicCertSANs())
+	assert.False(t, config.TalosVersion0_12.SupportsECDSASHA256())
 }
 
 func TestContract0_11(t *testing.T) {
@@ -73,6 +76,7 @@ func TestContract0_11(t *testing.T) {
 	assert.True(t, config.TalosVersion0_11.SupportsServiceAccount())
 	assert.True(t, config.TalosVersion0_11.SupportsRBACFeature())
 	assert.False(t, config.TalosVersion0_11.SupportsDynamicCertSANs())
+	assert.False(t, config.TalosVersion0_11.SupportsECDSASHA256())
 }
 
 func TestContract0_10(t *testing.T) {
@@ -81,6 +85,7 @@ func TestContract0_10(t *testing.T) {
 	assert.True(t, config.TalosVersion0_10.SupportsServiceAccount())
 	assert.False(t, config.TalosVersion0_10.SupportsRBACFeature())
 	assert.False(t, config.TalosVersion0_10.SupportsDynamicCertSANs())
+	assert.False(t, config.TalosVersion0_10.SupportsECDSASHA256())
 }
 
 func TestContract0_9(t *testing.T) {
@@ -89,6 +94,7 @@ func TestContract0_9(t *testing.T) {
 	assert.True(t, config.TalosVersion0_9.SupportsServiceAccount())
 	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
 	assert.False(t, config.TalosVersion0_9.SupportsDynamicCertSANs())
+	assert.False(t, config.TalosVersion0_9.SupportsECDSASHA256())
 }
 
 func TestContract0_8(t *testing.T) {
@@ -97,4 +103,5 @@ func TestContract0_8(t *testing.T) {
 	assert.False(t, config.TalosVersion0_8.SupportsServiceAccount())
 	assert.False(t, config.TalosVersion0_8.SupportsRBACFeature())
 	assert.False(t, config.TalosVersion0_8.SupportsDynamicCertSANs())
+	assert.False(t, config.TalosVersion0_8.SupportsECDSASHA256())
 }

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/crypto v0.3.3
+	github.com/talos-systems/crypto v0.3.4
 	github.com/talos-systems/go-blockdevice v0.2.4
 	github.com/talos-systems/go-debug v0.2.1
 	github.com/talos-systems/net v0.3.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -154,8 +154,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/talos-systems/crypto v0.3.3 h1:MvYJY0Tg8+/QDfRj2JJ/m54INsi1ZXbwyc6H+7ea/v8=
-github.com/talos-systems/crypto v0.3.3/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
+github.com/talos-systems/crypto v0.3.4 h1:bg4N27CH1MvUBasr70BlZObPXQYEhUTwOOm/jhCRFxg=
+github.com/talos-systems/crypto v0.3.4/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/go-blockdevice v0.2.4 h1:/E5I95byCxfdmQIiBEyWgdUo+6vPBbbOJQIF9+yeysU=
 github.com/talos-systems/go-blockdevice v0.2.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=


### PR DESCRIPTION
Due to the way our crypto library is implemented, it can't generate a
key from CA with ECDSA-SHA256 on older versions of Talos.

Talos >= 0.13: ECDSA-SHA256 with P-256
Talos < 0.13: ECDSA-SHA512 with P-256

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4346)
<!-- Reviewable:end -->
