### PR TITLE
fix: allow overriding `audit-policy-file` in `kube-apiserver` static pod

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -262,7 +262,6 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"proxy-client-cert-file":           argsbuilder.MergeDenied,
 		"proxy-client-key-file":            argsbuilder.MergeDenied,
 		"encryption-provider-config":       argsbuilder.MergeDenied,
-		"audit-policy-file":                argsbuilder.MergeDenied,
 		"etcd-cafile":                      argsbuilder.MergeDenied,
 		"etcd-certfile":                    argsbuilder.MergeDenied,
 		"etcd-keyfile":                     argsbuilder.MergeDenied,


### PR DESCRIPTION
Otherwise we lock it with our default config.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4353)
<!-- Reviewable:end -->
