### PR TITLE
chore: azure platform refactoring

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure_test.go
@@ -4,11 +4,74 @@
 
 package azure_test
 
-import "testing"
+import (
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/AlekSi/pointer"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/azure"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+)
+
+type ConfigSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigSuite) TestNetworkConfig() {
+	cfg := []byte(`
+[
+  {
+    "ipv4": {
+      "ipAddress": [
+        {
+          "privateIpAddress": "172.18.1.10",
+          "publicIpAddress": "1.2.3.4"
+        }
+      ],
+      "subnet": [
+        {
+          "address": "172.18.1.0",
+          "prefix": "24"
+        }
+      ]
+    },
+    "ipv6": {
+      "ipAddress": [
+        {
+            "privateIpAddress": "fd00::10",
+            "publicIpAddress": ""
+        }
+       ]
+    },
+    "macAddress": "000D3AD631EE"
+  }
+]
+`)
+	a := &azure.Azure{}
+
+	defaultMachineConfig := &v1alpha1.Config{}
+
+	machineConfig := &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNetwork: &v1alpha1.NetworkConfig{
+				NetworkInterfaces: []*v1alpha1.Device{
+					{
+						DeviceInterface:   "eth0",
+						DeviceDHCP:        true,
+						DeviceDHCPOptions: &v1alpha1.DHCPOptions{DHCPIPv6: pointer.ToBool(true)},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := a.ConfigurationNetwork(cfg, defaultMachineConfig)
+
+	suite.Require().NoError(err)
+	suite.Assert().Equal(machineConfig, result)
+}
+
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigSuite))
 }

--- a/website/content/docs/v0.14/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.14/Cloud Platforms/azure.md
@@ -182,6 +182,10 @@ for i in $( seq 0 1 2 ); do
     --lb-name talos-lb \
     --lb-address-pools talos-be-pool
 done
+
+# NOTES:
+# Talos can detect PublicIPs automatically if PublicIP SKU is Basic.
+# Use `--sku Basic` to set SKU to Basic.
 ```
 
 ### Cluster Configuration
@@ -201,6 +205,10 @@ talosctl gen config talos-k8s-azure-tutorial https://${LB_PUBLIC_IP}:6443
 ### Compute Creation
 
 We are now ready to create our azure nodes.
+Azure allows you to pass Talos machine configuration to the virtual machine at bootstrap time via
+`user-data` or `custom-data` methods.
+
+Talos supports only `custom-data` method, machine configuration is available to the VM only on the first boot.
 
 ```bash
 # Create availability set


### PR DESCRIPTION
Use download.Download method to download meta configs from IMDS.
Set DHCP-v6 to true if IPv6 exists on VM and machineconfig does not define network parameters.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4357)
<!-- Reviewable:end -->
