### PR TITLE
chore: use discovery-client and discovery-api modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,8 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.3.4
-	github.com/talos-systems/discovery-service v0.1.1
+	github.com/talos-systems/discovery-api v0.1.0
+	github.com/talos-systems/discovery-client v0.1.0
 	github.com/talos-systems/go-blockdevice v0.2.4
 	github.com/talos-systems/go-cmd v0.1.0
 	github.com/talos-systems/go-debug v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1044,8 +1044,10 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.3.4 h1:bg4N27CH1MvUBasr70BlZObPXQYEhUTwOOm/jhCRFxg=
 github.com/talos-systems/crypto v0.3.4/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
-github.com/talos-systems/discovery-service v0.1.1 h1:GCCRnLT0GzJiU1l55WsiaNHDc88+wi7YZMsLaOT7uhY=
-github.com/talos-systems/discovery-service v0.1.1/go.mod h1:7o4Fo240P3e2Bo7vZZ+4d/sykqPYI8LTtXCgjKgbqo4=
+github.com/talos-systems/discovery-api v0.1.0 h1:aKod6uqakH6VfeQ6HaxPF7obqFAL1QTJe4HHTb2mVKk=
+github.com/talos-systems/discovery-api v0.1.0/go.mod h1:ZsbzzOC5bzToaF3+YvUXDf9paeWV5bedpDu5RPXrglM=
+github.com/talos-systems/discovery-client v0.1.0 h1:m+f96TKGFckMWrhDI+o9+QhcGn8f1A61Jp6YYVwiulI=
+github.com/talos-systems/discovery-client v0.1.0/go.mod h1:LxqCv16VBB68MgaMnV8jXujYd3Q097DAn22U5gaHmkU=
 github.com/talos-systems/go-blockdevice v0.2.4 h1:/E5I95byCxfdmQIiBEyWgdUo+6vPBbbOJQIF9+yeysU=
 github.com/talos-systems/go-blockdevice v0.2.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=

--- a/internal/app/machined/pkg/controllers/cluster/discovery_service.go
+++ b/internal/app/machined/pkg/controllers/cluster/discovery_service.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/talos-systems/discovery-service/api/v1alpha1/client/pb"
-	discoveryclient "github.com/talos-systems/discovery-service/pkg/client"
+	"github.com/talos-systems/discovery-api/api/v1alpha1/client/pb"
+	discoveryclient "github.com/talos-systems/discovery-client/pkg/client"
 	"go.uber.org/zap"
 	"inet.af/netaddr"
 


### PR DESCRIPTION
This stops using `discovery-service` module which contained both client
and server code. The tests were reworked to use the public discovery
service endpoint.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4367)
<!-- Reviewable:end -->
