### PR TITLE
fix: attempt to clean up tasks in containerd runner

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -125,7 +125,7 @@ func (c *containerdRunner) Close() error {
 
 // Run implements runner.Runner interface
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (c *containerdRunner) Run(eventSink events.Recorder) error {
 	defer close(c.stopped)
 
@@ -134,6 +134,14 @@ func (c *containerdRunner) Run(eventSink events.Recorder) error {
 		logW io.WriteCloser
 		err  error
 	)
+
+	// attempt to clean up a task if it already exists
+	task, err = c.container.Task(c.ctx, nil)
+	if err == nil {
+		if _, err = task.Delete(c.ctx); err != nil {
+			return fmt.Errorf("failed to clean up task %q: %w", c.args.ID, err)
+		}
+	}
 
 	logW, err = c.opts.LoggingManager.ServiceLog(c.args.ID).Writer()
 	if err != nil {


### PR DESCRIPTION
I was not able to reproduce the issue fully, but community bug report
contained the following log lines:

```
192.168.81.122: [talos] service[kubelet](Waiting): Error running Containerd(kubelet), going to restart forever: failed to create task: "kubelet": task kubelet already exists: unknown
```

This fix should clean up any leftover tasks before attempting to create
a new one.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4373)
<!-- Reviewable:end -->
