### PR TITLE
feat: enable cluster discovery by default

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -105,6 +105,7 @@ var (
 	encryptEphemeralPartition bool
 	useVIP                    bool
 	enableKubeSpan            bool
+	enableClusterDiscovery    bool
 	configPatch               string
 	configPatchControlPlane   string
 	configPatchWorker         string
@@ -276,6 +277,7 @@ func create(ctx context.Context) (err error) {
 			generate.WithInstallImage(nodeInstallImage),
 			generate.WithDebug(configDebug),
 			generate.WithDNSDomain(dnsDomain),
+			generate.WithClusterDiscovery(enableClusterDiscovery),
 		}
 
 		for _, registryMirror := range registryMirrors {
@@ -379,7 +381,6 @@ func create(ctx context.Context) (err error) {
 				generate.WithNetworkOptions(
 					v1alpha1.WithKubeSpan(),
 				),
-				generate.WithClusterDiscovery(),
 			)
 		}
 
@@ -830,6 +831,7 @@ func init() {
 	createCmd.Flags().BoolVar(&encryptEphemeralPartition, "encrypt-ephemeral", false, "enable ephemeral partition encryption")
 	createCmd.Flags().StringVar(&talosVersion, "talos-version", "", "the desired Talos version to generate config for (if not set, defaults to image version)")
 	createCmd.Flags().BoolVar(&useVIP, "use-vip", false, "use a virtual IP for the controlplane endpoint instead of the loadbalancer")
+	createCmd.Flags().BoolVar(&enableClusterDiscovery, "with-cluster-discovery", true, "enable cluster discovery")
 	createCmd.Flags().BoolVar(&enableKubeSpan, "with-kubespan", false, "enable KubeSpan system")
 	createCmd.Flags().StringVar(&configPatch, "config-patch", "", "patch generated machineconfigs (applied to all node types)")
 	createCmd.Flags().StringVar(&configPatchControlPlane, "config-patch-control-plane", "", "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -45,6 +45,7 @@ var genConfigCmdFlags struct {
 	persistConfig           bool
 	withExamples            bool
 	withDocs                bool
+	withClusterDiscovery    bool
 	withKubeSpan            bool
 }
 
@@ -214,7 +215,6 @@ func writeV1Alpha1Config(args []string) error {
 			generate.WithNetworkOptions(
 				v1alpha1.WithKubeSpan(),
 			),
-			generate.WithClusterDiscovery(),
 		)
 	}
 
@@ -224,6 +224,7 @@ func writeV1Alpha1Config(args []string) error {
 		generate.WithAdditionalSubjectAltNames(genConfigCmdFlags.additionalSANs),
 		generate.WithDNSDomain(genConfigCmdFlags.dnsDomain),
 		generate.WithPersist(genConfigCmdFlags.persistConfig),
+		generate.WithClusterDiscovery(genConfigCmdFlags.withClusterDiscovery),
 	)
 
 	commentsFlags := encoder.CommentsDisabled
@@ -283,6 +284,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.persistConfig, "persist", "p", true, "the desired persist value for configs")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withExamples, "with-examples", "", true, "renders all machine configs with the commented examples")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withDocs, "with-docs", "", true, "renders all machine configs adding the documentation for each field")
+	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withClusterDiscovery, "with-cluster-discovery", "", true, "enable cluster discovery feature")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withKubeSpan, "with-kubespan", "", false, "enable KubeSpan feature")
 
 	gen.Cmd.AddCommand(genConfigCmd)

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,7 +22,14 @@ preface = """\
 
 So there is no need to update CoreDNS, Flannel container manually after running `upgrade-k8s` anymore.
 """
-      
+
+    [notes.discovery]
+        title = "Cluster Discovery"
+        description="""\
+Cluster Discovery is enabled by default for Talos 0.14.
+Cluster Discovery can be disabled with `talosctl gen config --with-cluster-discovery=false`.
+"""
+
 
 [make_deps]
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -41,6 +41,18 @@ case "${WITH_VIRTUAL_IP:-false}" in
     ;;
 esac
 
+case "${WITH_CLUSTER_DISCOVERY:-true}" in
+  false)
+    QEMU_FLAGS="${QEMU_FLAGS} --with-cluster-discovery=false"
+    ;;
+esac
+
+case "${WITH_KUBESPAN:-false}" in
+  true)
+    QEMU_FLAGS="${QEMU_FLAGS} --with-kubespan"
+    ;;
+esac
+
 case "${USE_DISK_IMAGE:-false}" in
   false)
     DISK_IMAGE_FLAG=

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion0_14    = &VersionContract{0, 14}
 	TalosVersion0_13    = &VersionContract{0, 13}
 	TalosVersion0_12    = &VersionContract{0, 12}
 	TalosVersion0_11    = &VersionContract{0, 11}
@@ -90,4 +91,9 @@ func (contract *VersionContract) SupportsDynamicCertSANs() bool {
 // SupportsECDSASHA256 returns true if version of Talos supports ECDSA-SHA256 for Kubernetes certificates.
 func (contract *VersionContract) SupportsECDSASHA256() bool {
 	return contract.Greater(TalosVersion0_12)
+}
+
+// ClusterDiscoveryEnabled returns true if cluster discovery should be enabled by default.
+func (contract *VersionContract) ClusterDiscoveryEnabled() bool {
+	return contract.Greater(TalosVersion0_13)
 }

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -44,64 +44,97 @@ func TestContractParseVersion(t *testing.T) {
 }
 
 func TestContractCurrent(t *testing.T) {
-	assert.True(t, config.TalosVersionCurrent.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersionCurrent.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersionCurrent.SupportsServiceAccount())
-	assert.True(t, config.TalosVersionCurrent.SupportsRBACFeature())
-	assert.True(t, config.TalosVersionCurrent.SupportsDynamicCertSANs())
-	assert.True(t, config.TalosVersionCurrent.SupportsECDSASHA256())
+	contract := config.TalosVersionCurrent
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
+}
+
+func TestContract0_14(t *testing.T) {
+	contract := config.TalosVersion0_14
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_13(t *testing.T) {
-	assert.True(t, config.TalosVersion0_13.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersion0_13.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersion0_13.SupportsServiceAccount())
-	assert.True(t, config.TalosVersion0_13.SupportsRBACFeature())
-	assert.True(t, config.TalosVersion0_13.SupportsDynamicCertSANs())
-	assert.True(t, config.TalosVersion0_13.SupportsECDSASHA256())
+	contract := config.TalosVersion0_13
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_12(t *testing.T) {
-	assert.True(t, config.TalosVersion0_12.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersion0_12.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersion0_12.SupportsServiceAccount())
-	assert.True(t, config.TalosVersion0_12.SupportsRBACFeature())
-	assert.False(t, config.TalosVersion0_12.SupportsDynamicCertSANs())
-	assert.False(t, config.TalosVersion0_12.SupportsECDSASHA256())
+	contract := config.TalosVersion0_12
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.False(t, contract.SupportsDynamicCertSANs())
+	assert.False(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_11(t *testing.T) {
-	assert.True(t, config.TalosVersion0_11.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersion0_11.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersion0_11.SupportsServiceAccount())
-	assert.True(t, config.TalosVersion0_11.SupportsRBACFeature())
-	assert.False(t, config.TalosVersion0_11.SupportsDynamicCertSANs())
-	assert.False(t, config.TalosVersion0_11.SupportsECDSASHA256())
+	contract := config.TalosVersion0_11
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.False(t, contract.SupportsDynamicCertSANs())
+	assert.False(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_10(t *testing.T) {
-	assert.True(t, config.TalosVersion0_10.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersion0_10.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersion0_10.SupportsServiceAccount())
-	assert.False(t, config.TalosVersion0_10.SupportsRBACFeature())
-	assert.False(t, config.TalosVersion0_10.SupportsDynamicCertSANs())
-	assert.False(t, config.TalosVersion0_10.SupportsECDSASHA256())
+	contract := config.TalosVersion0_10
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.False(t, contract.SupportsRBACFeature())
+	assert.False(t, contract.SupportsDynamicCertSANs())
+	assert.False(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_9(t *testing.T) {
-	assert.True(t, config.TalosVersion0_9.SupportsAggregatorCA())
-	assert.True(t, config.TalosVersion0_9.SupportsECDSAKeys())
-	assert.True(t, config.TalosVersion0_9.SupportsServiceAccount())
-	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
-	assert.False(t, config.TalosVersion0_9.SupportsDynamicCertSANs())
-	assert.False(t, config.TalosVersion0_9.SupportsECDSASHA256())
+	contract := config.TalosVersion0_9
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.False(t, contract.SupportsRBACFeature())
+	assert.False(t, contract.SupportsDynamicCertSANs())
+	assert.False(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }
 
 func TestContract0_8(t *testing.T) {
-	assert.False(t, config.TalosVersion0_8.SupportsAggregatorCA())
-	assert.False(t, config.TalosVersion0_8.SupportsECDSAKeys())
-	assert.False(t, config.TalosVersion0_8.SupportsServiceAccount())
-	assert.False(t, config.TalosVersion0_8.SupportsRBACFeature())
-	assert.False(t, config.TalosVersion0_8.SupportsDynamicCertSANs())
-	assert.False(t, config.TalosVersion0_8.SupportsECDSASHA256())
+	contract := config.TalosVersion0_8
+
+	assert.False(t, contract.SupportsAggregatorCA())
+	assert.False(t, contract.SupportsECDSAKeys())
+	assert.False(t, contract.SupportsServiceAccount())
+	assert.False(t, contract.SupportsRBACFeature())
+	assert.False(t, contract.SupportsDynamicCertSANs())
+	assert.False(t, contract.SupportsECDSASHA256())
+	assert.False(t, contract.ClusterDiscoveryEnabled())
 }

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -481,6 +481,12 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		additionalSubjectAltNames = append(additionalSubjectAltNames, options.EndpointList...)
 	}
 
+	discoveryEnabled := options.VersionContract.ClusterDiscoveryEnabled()
+
+	if options.DiscoveryEnabled != nil {
+		discoveryEnabled = *options.DiscoveryEnabled
+	}
+
 	input = &Input{
 		Certs:                      secrets.Certs,
 		VersionContract:            options.VersionContract,
@@ -509,7 +515,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		AllowSchedulingOnMasters:   options.AllowSchedulingOnMasters,
 		MachineDisks:               options.MachineDisks,
 		SystemDiskEncryptionConfig: options.SystemDiskEncryptionConfig,
-		DiscoveryEnabled:           options.DiscoveryEnabled,
+		DiscoveryEnabled:           discoveryEnabled,
 	}
 
 	return input, nil

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -5,6 +5,8 @@
 package generate
 
 import (
+	"github.com/AlekSi/pointer"
+
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/role"
@@ -204,9 +206,9 @@ func WithRoles(roles role.Set) GenOption {
 }
 
 // WithClusterDiscovery enables cluster discovery feature.
-func WithClusterDiscovery() GenOption {
+func WithClusterDiscovery(enabled bool) GenOption {
 	return func(o *GenOptions) error {
-		o.DiscoveryEnabled = true
+		o.DiscoveryEnabled = pointer.ToBool(enabled)
 
 		return nil
 	}
@@ -247,7 +249,7 @@ type GenOptions struct {
 	VersionContract            *config.VersionContract
 	SystemDiskEncryptionConfig *v1alpha1.SystemDiskEncryptionConfig
 	Roles                      role.Set
-	DiscoveryEnabled           bool
+	DiscoveryEnabled           *bool
 }
 
 // DefaultGenOptions returns default options.

--- a/website/content/docs/v0.14/Reference/cli.md
+++ b/website/content/docs/v0.14/Reference/cli.md
@@ -137,6 +137,7 @@ talosctl cluster create [flags]
       --wireguard-cidr string                   CIDR of the wireguard network
       --with-apply-config                       enable apply config when the VM is starting in maintenance mode
       --with-bootloader                         enable bootloader to load kernel and initramfs from disk image after install (default true)
+      --with-cluster-discovery                  enable cluster discovery (default true)
       --with-debug                              enable debug in Talos config to send service logs to the console
       --with-init-node                          create the cluster with an init node
       --with-kubespan                           enable KubeSpan system
@@ -1120,6 +1121,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --registry-mirror strings             list of registry mirrors to use in format: <registry host>=<mirror URL>
       --talos-version string                the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
       --version string                      the desired machine config version to generate (default "v1alpha1")
+      --with-cluster-discovery              enable cluster discovery feature (default true)
       --with-docs                           renders all machine configs adding the documentation for each field (default true)
       --with-examples                       renders all machine configs with the commented examples (default true)
       --with-kubespan                       enable KubeSpan feature


### PR DESCRIPTION
This enables cluster discovery by default for Talos 0.14. KubeSpan is
not enabled by default.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4376)
<!-- Reviewable:end -->
