### PR TITLE
test: workaround EventsWatch test flakiness

### DIFF
--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -57,6 +57,9 @@ func (suite *EventsSuite) TestEventsWatch() {
 		suite.Assert().NoError(suite.Client.EventsWatch(watchCtx, func(ch <-chan client.Event) {
 			defer watchCtxCancel()
 
+			timer := time.NewTimer(500 * time.Millisecond)
+			defer timer.Stop()
+
 			for {
 				select {
 				case event, ok := <-ch:
@@ -65,7 +68,7 @@ func (suite *EventsSuite) TestEventsWatch() {
 					}
 
 					result = append(result, event)
-				case <-time.After(100 * time.Millisecond):
+				case <-timer.C:
 					return
 				}
 			}


### PR DESCRIPTION
This test sometimes fails with a message like:

```
=== RUN   TestIntegration/api.EventsSuite/TestEventsWatch
    assertion_compare.go:323:
        	Error Trace:	events.go:88
        	Error:      	"0" is not greater than or equal to "14"
        	Test:       	TestIntegration/api.EventsSuite/TestEventsWatch
        	Messages:   	[]
```

I believe the root cause is that the initial (first event) delivery
might be more than 100ms, so instead of waiting for 100ms for each
event, block for 500ms for all events to arrive.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4381)
<!-- Reviewable:end -->
