### PR TITLE
feat: update CoreDNS version 1.8.6

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -227,7 +227,7 @@ const (
 	CoreDNSImage = "docker.io/coredns/coredns"
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
-	DefaultCoreDNSVersion = "1.8.4"
+	DefaultCoreDNSVersion = "1.8.6"
 
 	// LabelNodeRoleMaster is the node label required by a control plane node.
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"

--- a/website/content/docs/v0.14/Reference/configuration.md
+++ b/website/content/docs/v0.14/Reference/configuration.md
@@ -1195,7 +1195,7 @@ Examples:
 
 ``` yaml
 coreDNS:
-    image: docker.io/coredns/coredns:1.8.4 # The `image` field is an override to the default coredns image.
+    image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
 ```
 
 
@@ -2392,7 +2392,7 @@ Appears in:
 
 
 ``` yaml
-image: docker.io/coredns/coredns:1.8.4 # The `image` field is an override to the default coredns image.
+image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
 ```
 
 <hr />


### PR DESCRIPTION
This updages CoreDNS from 1.8.4 which includes many fixes from upstream.

Also this seems to fix timeouts introduced in the change which added
`rewrite stop type AAAA A` rule to the `Corefile`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4401)
<!-- Reviewable:end -->
