### PR TITLE
fix: treat literal 'unknown' as a valid machine type

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/machine/machine.go
+++ b/pkg/machinery/config/types/v1alpha1/machine/machine.go
@@ -39,6 +39,8 @@ func ParseType(s string) (Type, error) {
 		return TypeControlPlane, nil
 	case "worker", "join", "":
 		return TypeWorker, nil
+	case "unknown":
+		return TypeUnknown, nil
 	default:
 		return TypeUnknown, fmt.Errorf("invalid machine type: %q", s)
 	}

--- a/pkg/machinery/config/types/v1alpha1/machine/machine_test.go
+++ b/pkg/machinery/config/types/v1alpha1/machine/machine_test.go
@@ -36,6 +36,7 @@ func TestParseType(t *testing.T) {
 		{"worker", machine.TypeWorker},
 		{"join", machine.TypeWorker},
 		{"", machine.TypeWorker},
+		{"unknown", machine.TypeUnknown},
 	}
 
 	for _, tt := range validTests {
@@ -56,7 +57,6 @@ func TestParseType(t *testing.T) {
 
 	for _, s := range []string{
 		"foo",
-		machine.TypeUnknown.String(),
 	} {
 		s := s
 		t.Run(s, func(t *testing.T) {


### PR DESCRIPTION
We use `unknown` in the machine state file for PXE booted VMs in the
provisioning library.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4404)
<!-- Reviewable:end -->
