### PR TITLE
feat: update Linux to 5.10.75

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.9.0-alpha.0
-PKGS ?= v0.9.0-alpha.0-1-gb88127a
+PKGS ?= v0.9.0-alpha.0-7-g80a63d4
 EXTRAS ?= v0.7.0-alpha.0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.69-talos"
+	DefaultKernelVersion = "5.10.75-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This also brings many drivers added recently via pkgs PRs:

* QLogic QED 25/40/100Gb Ethernet NIC driver
* SuperMicro raid controller
* Intel VMD driver
* smarpqi driver

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4411)
<!-- Reviewable:end -->
