### PR TITLE
test: fix e2e k8s version

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -30,7 +30,7 @@ export TALOS_VERSION=v0.14
 # Kubernetes
 
 export KUBECONFIG="${TMP}/kubeconfig"
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.23.0-alpha.3}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.23.0-alpha.3}
 
 export NAME_PREFIX="talos-e2e-${SHA}-${PLATFORM}"
 export TIMEOUT=1200


### PR DESCRIPTION
Prefix `v` shouldn't be there.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4415)
<!-- Reviewable:end -->
