### PR TITLE
fix: hcloud network config changes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -90,6 +90,10 @@ func (h *Hcloud) ConfigurationNetwork(metadataNetworkConfig []byte, confProvider
 	}
 
 	for _, network := range unmarshalledNetworkConfig.Config {
+		if network.Type != "physical" {
+			continue
+		}
+
 		iface := v1alpha1.Device{
 			DeviceInterface: network.Interfaces,
 			DeviceDHCP:      false,
@@ -184,12 +188,14 @@ func (h *Hcloud) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 		download.WithErrorOnNotFound(errors.ErrNoExternalIPs),
 		download.WithErrorOnEmptyResponse(errors.ErrNoExternalIPs))
 	if err != nil {
-		return addrs, err
+		return nil, err
 	}
 
-	addrs = append(addrs, net.ParseIP(string(exIP)))
+	if ip := net.ParseIP(string(exIP)); ip != nil {
+		addrs = append(addrs, ip)
+	}
 
-	return addrs, err
+	return addrs, nil
 }
 
 // KernelArgs implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud_test.go
@@ -23,17 +23,18 @@ config:
 - mac_address: 96:00:00:1:2:3
   name: eth0
   subnets:
-  - dns_nameservers:
-    - 213.133.100.100
-    - 213.133.99.99
-    - 213.133.98.98
-    ipv4: true
+  - ipv4: true
     type: dhcp
   - address: 2a01:4f8:1:2::1/64
     gateway: fe80::1
     ipv6: true
     type: static
   type: physical
+- address:
+  - 185.12.64.2
+  - 185.12.64.1
+  interface: eth0
+  type: nameserver
 version: 1
 `)
 	p := &hcloud.Hcloud{}
@@ -70,21 +71,3 @@ version: 1
 func TestConfigSuite(t *testing.T) {
 	suite.Run(t, new(ConfigSuite))
 }
-
-// http://169.254.169.254/hetzner/v1/metadata/network-config
-// config:
-// - mac_address: 96:00:00:72:a3:19
-//   name: eth0
-//   subnets:
-//   - dns_nameservers:
-//     - 213.133.100.100
-//     - 213.133.99.99
-//     - 213.133.98.98
-//     ipv4: true
-//     type: dhcp
-//   - address: 2a01:4f8:1:2::1/64
-//     gateway: fe80::1
-//     ipv6: true
-//     type: static
-//   type: physical
-// version: 1


### PR DESCRIPTION
* The format of network config has changed.
      Now it similar nocloud.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4424)
<!-- Reviewable:end -->
