### PR TITLE
test: fix openstack unit-test stability

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -223,8 +224,16 @@ func (o *Openstack) ConfigurationNetwork(metadataNetworkConfig []byte, metadataC
 			}
 		}
 
-		for _, iface := range ifaces {
-			machineConfig.MachineConfig.MachineNetwork.NetworkInterfaces = append(machineConfig.MachineConfig.MachineNetwork.NetworkInterfaces, iface)
+		ifaceNames := make([]string, 0, len(ifaces))
+
+		for ifaceName := range ifaces {
+			ifaceNames = append(ifaceNames, ifaceName)
+		}
+
+		sort.Strings(ifaceNames)
+
+		for _, ifaceName := range ifaceNames {
+			machineConfig.MachineConfig.MachineNetwork.NetworkInterfaces = append(machineConfig.MachineConfig.MachineNetwork.NetworkInterfaces, ifaces[ifaceName])
 		}
 
 		if machineConfig.MachineConfig.MachineNetwork.NameServers == nil && len(nameServers) > 0 {


### PR DESCRIPTION
Put interfaces in sorted order to avoid mismatch on expected results,
also makes machine config reproducible.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4433)
<!-- Reviewable:end -->
