### PR TITLE
fix: handle skipped mounts correctly

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -252,12 +252,12 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 	}
 
 	if err := func() error {
-		if err := mount.SystemPartitionMount(s.Controller.Runtime(), constants.BootPartitionLabel); err != nil {
+		if err := mount.SystemPartitionMount(s.Controller.Runtime(), nil, constants.BootPartitionLabel); err != nil {
 			return fmt.Errorf("error mounting boot partition: %w", err)
 		}
 
 		defer func() {
-			if err := mount.SystemPartitionUnmount(s.Controller.Runtime(), constants.BootPartitionLabel); err != nil {
+			if err := mount.SystemPartitionUnmount(s.Controller.Runtime(), nil, constants.BootPartitionLabel); err != nil {
 				log.Printf("failed unmounting boot partition: %s", err)
 			}
 		}()

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1524,28 +1524,28 @@ func SaveStateEncryptionConfig(seq runtime.Sequence, data interface{}) (runtime.
 // MountBootPartition mounts the boot partition.
 func MountBootPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mount.SystemPartitionMount(r, constants.BootPartitionLabel)
+		return mount.SystemPartitionMount(r, logger, constants.BootPartitionLabel)
 	}, "mountBootPartition"
 }
 
 // UnmountBootPartition unmounts the boot partition.
 func UnmountBootPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionUnmount(r, constants.BootPartitionLabel)
+		return mount.SystemPartitionUnmount(r, logger, constants.BootPartitionLabel)
 	}, "unmountBootPartition"
 }
 
 // MountEFIPartition mounts the EFI partition.
 func MountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mount.SystemPartitionMount(r, constants.EFIPartitionLabel)
+		return mount.SystemPartitionMount(r, logger, constants.EFIPartitionLabel)
 	}, "mountEFIPartition"
 }
 
 // UnmountEFIPartition unmounts the EFI partition.
 func UnmountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionUnmount(r, constants.EFIPartitionLabel)
+		return mount.SystemPartitionUnmount(r, logger, constants.EFIPartitionLabel)
 	}, "unmountEFIPartition"
 }
 
@@ -1592,28 +1592,28 @@ func MountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 			opts = append(opts, mount.WithEncryptionConfig(encryption))
 		}
 
-		return mount.SystemPartitionMount(r, constants.StatePartitionLabel, opts...)
+		return mount.SystemPartitionMount(r, logger, constants.StatePartitionLabel, opts...)
 	}, "mountStatePartition"
 }
 
 // UnmountStatePartition unmounts the system partition.
 func UnmountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionUnmount(r, constants.StatePartitionLabel)
+		return mount.SystemPartitionUnmount(r, logger, constants.StatePartitionLabel)
 	}, "unmountStatePartition"
 }
 
 // MountEphemeralPartition mounts the ephemeral partition.
 func MountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionMount(r, constants.EphemeralPartitionLabel, mount.WithFlags(mount.Resize))
+		return mount.SystemPartitionMount(r, logger, constants.EphemeralPartitionLabel, mount.WithFlags(mount.Resize))
 	}, "mountEphemeralPartition"
 }
 
 // UnmountEphemeralPartition unmounts the ephemeral partition.
 func UnmountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mount.SystemPartitionUnmount(r, constants.EphemeralPartitionLabel)
+		return mount.SystemPartitionUnmount(r, logger, constants.EphemeralPartitionLabel)
 	}, "unmountEphemeralPartition"
 }
 


### PR DESCRIPTION
If the mount is skipped, we shouldn't record it and create a matching
resource.

This fixes a problem discovered by cluster discovery tests when node
establishes more than a single identity on initial boot with first one
being lost, but still exists in the discovery service.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4436)
<!-- Reviewable:end -->
