### PR TITLE
fix: don't drop ability to use ambient capabilities

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -248,15 +248,6 @@ func DropCapabilities(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 			return nil
 		}
 
-		// Disallow raising ambient capabilities (ever).
-		secbits := cap.GetSecbits()
-		secbits |=
-			cap.SecbitNoCapAmbientRaise | cap.SecbitNoCapAmbientRaiseLocked
-
-		if err := secbits.Set(); err != nil {
-			return fmt.Errorf("error setting secbits: %w", err)
-		}
-
 		// Drop capabilities from the bounding set effectively disabling it for all forked processes,
 		// but keep them for PID 1.
 		droppedCapabilities := []cap.Value{


### PR DESCRIPTION
This fixes KubeVirt on Talos in default mode.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4441)
<!-- Reviewable:end -->
