### PR TITLE
fix: skip generating empty `.machine.logging`

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -481,6 +481,15 @@ metadata:
 	loggingEndpointExample2 = &Endpoint{
 		mustParseURL("tcp://1.2.3.4:12345"),
 	}
+
+	machineLoggingExample = LoggingConfig{
+		LoggingDestinations: []LoggingDestination{
+			{
+				LoggingEndpoint: loggingEndpointExample2,
+				LoggingFormat:   constants.LoggingFormatJSONLines,
+			},
+		},
+	}
 )
 
 // Config defines the v1alpha1 configuration file.
@@ -670,7 +679,9 @@ type MachineConfig struct {
 	MachineUdev *UdevConfig `yaml:"udev,omitempty"`
 	//   description: |
 	//     Configures the logging system.
-	MachineLogging *LoggingConfig `yaml:"logging"`
+	//   examples:
+	//     - value: machineLoggingExample
+	MachineLogging *LoggingConfig `yaml:"logging,omitempty"`
 }
 
 // ClusterConfig represents the cluster-wide config values.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -264,6 +264,8 @@ func init() {
 	MachineConfigDoc.Fields[16].Description = "Configures the logging system."
 	MachineConfigDoc.Fields[16].Comments[encoder.LineComment] = "Configures the logging system."
 
+	MachineConfigDoc.Fields[16].AddExample("", machineLoggingExample)
+
 	ClusterConfigDoc.Type = "ClusterConfig"
 	ClusterConfigDoc.Comments[encoder.LineComment] = "ClusterConfig represents the cluster-wide config values."
 	ClusterConfigDoc.Description = "ClusterConfig represents the cluster-wide config values."
@@ -2176,6 +2178,8 @@ func init() {
 	LoggingConfigDoc.Type = "LoggingConfig"
 	LoggingConfigDoc.Comments[encoder.LineComment] = "LoggingConfig struct configures Talos logging."
 	LoggingConfigDoc.Description = "LoggingConfig struct configures Talos logging."
+
+	LoggingConfigDoc.AddExample("", machineLoggingExample)
 	LoggingConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "MachineConfig",

--- a/website/content/docs/v0.14/Reference/configuration.md
+++ b/website/content/docs/v0.14/Reference/configuration.md
@@ -772,6 +772,20 @@ udev:
 
 Configures the logging system.
 
+
+
+Examples:
+
+
+``` yaml
+logging:
+    # Logging destination.
+    destinations:
+        - endpoint: tcp://1.2.3.4:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+          format: json_lines # Logs format.
+```
+
+
 </div>
 
 <hr />
@@ -5600,6 +5614,12 @@ Appears in:
 - <code><a href="#machineconfig">MachineConfig</a>.logging</code>
 
 
+``` yaml
+# Logging destination.
+destinations:
+    - endpoint: tcp://1.2.3.4:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+      format: json_lines # Logs format.
+```
 
 <hr />
 


### PR DESCRIPTION
This fixes backwards compatibility with previous versions of Talos.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4442)
<!-- Reviewable:end -->
