### PR TITLE
docs: update docs with emmc boot guide

### DIFF
--- a/website/content/docs/v0.13/Single Board Computers/rockpi_4.md
+++ b/website/content/docs/v0.13/Single Board Computers/rockpi_4.md
@@ -56,22 +56,21 @@ Retrieve the admin `kubeconfig` by running:
 talosctl kubeconfig
 ```
 
-## Boot Talos from an SSD Drive
+## Boot Talos from an eMMC or SSD Drive
 
 > Note: this is only tested on Rock PI 4c
 
-Rock PI 4 has an M2 slot which supports NVMe disks.
-It is possible to run Talos without any SD cards right from that SSD disk.
+It is possible to run Talos without any SD cards right from either an eMMC or SSD disk.
 
-The pre-installed SPI loader won't be able to chain Talos u-boot on the SSD drive because it's too outdated.
-The official docs on booting from the SSD also propose using an outdated SPI to flash u-boot.
+The pre-installed SPI loader won't be able to chain Talos u-boot on the device because it's too outdated.
 
 Instead, it is necessary to update u-boot to a more recent version for this process to work.
 The Armbian u-boot build for Rock PI 4c has been proved to work: [https://users.armbian.com/piter75/](https://users.armbian.com/piter75/).
 
 ### Steps
 
-- Flash any OS to the SD card (can be Armbian for example).
+- Flash the Rock PI 4c variant of [Debian](https://wiki.radxa.com/Rockpi4/downloads) to the SD card.
+- Check that /dev/mtdblock0 exists otherwise the command will silently fail; e.g. `lsblk`.
 - Download Armbian u-boot and update SPI flash:
 
 ```bash

--- a/website/content/docs/v0.14/Single Board Computers/rockpi_4.md
+++ b/website/content/docs/v0.14/Single Board Computers/rockpi_4.md
@@ -56,22 +56,21 @@ Retrieve the admin `kubeconfig` by running:
 talosctl kubeconfig
 ```
 
-## Boot Talos from an SSD Drive
+## Boot Talos from an eMMC or SSD Drive
 
 > Note: this is only tested on Rock PI 4c
 
-Rock PI 4 has an M2 slot which supports NVMe disks.
-It is possible to run Talos without any SD cards right from that SSD disk.
+It is possible to run Talos without any SD cards right from either an eMMC or SSD disk.
 
-The pre-installed SPI loader won't be able to chain Talos u-boot on the SSD drive because it's too outdated.
-The official docs on booting from the SSD also propose using an outdated SPI to flash u-boot.
+The pre-installed SPI loader won't be able to chain Talos u-boot on the device because it's too outdated.
 
 Instead, it is necessary to update u-boot to a more recent version for this process to work.
 The Armbian u-boot build for Rock PI 4c has been proved to work: [https://users.armbian.com/piter75/](https://users.armbian.com/piter75/).
 
 ### Steps
 
-- Flash any OS to the SD card (can be Armbian for example).
+- Flash the Rock PI 4c variant of [Debian](https://wiki.radxa.com/Rockpi4/downloads) to the SD card.
+- Check that /dev/mtdblock0 exists otherwise the command will silently fail; e.g. `lsblk`.
 - Download Armbian u-boot and update SPI flash:
 
 ```bash


### PR DESCRIPTION
eMMC needs Armbian SPI as well as NVMe drive.

Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>
Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

# Pull Request

## What? (description)

Update docs to include eMMC as a usecase for the RockPi 4c - Additionally make a few slight adjustments to fill a few caveats that weren't immediately obvious previously.

## Why? (reasoning)

Booting from eMMC required a very similar approach to the SSD setup; Once I connected a UART serial to TTL cable we discovered the following error:

```
U-Boot TPL 2021.10-rc3 (Sep 30 2021 - 16:37:58)
Channel 0: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
Channel 1: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
256B stride
lpddr4_set_rate: change freq to 400000000 mhz 0, 1
lpddr4_set_rate: change freq to 800000000 mhz 1, 0
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2021.10-rc3 (Sep 30 2021 - 16:37:58 +0000)
Trying to boot from MMC1
Card did not respond to voltage select! : -110
spl: mmc init failed with error: -95
SPL: failed to boot from all boot devices
### ERROR ### Please RESET the board ###
```

@Unix4ever and I tried several approach to solve this including; 
- shorting pins 23 + 25 to disable SPI
- following several other guides here: https://wiki.radxa.com/Rockpi4/dev/spi-install

However, we then made the discovery that using armbian didn't contain the device `/dev/mtdblock0` so when we initially tried this and didn't validate it the `dd` completed without error despite it not existing; We then attempted the official Debian Rock Pi 4c variant and this indeed had the device and worked as expected once we completed the SPI update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4464)
<!-- Reviewable:end -->
