### PR TITLE
fix: remove listening socket to fix Talos in a container restart

### DIFF
--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -72,6 +72,11 @@ func (o *APID) PreFunc(ctx context.Context, r runtime.Runtime) error {
 		return err
 	}
 
+	// clean up the socket if it already exists (important for Talos in a container)
+	if err := os.RemoveAll(constants.APIRuntimeSocketPath); err != nil {
+		return err
+	}
+
 	listener, err := net.Listen("unix", constants.APIRuntimeSocketPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #4462

As `/system` volumes survives restarts in a container mode, we need to
make sure listening file socket is removed before creating a listener.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4465)
<!-- Reviewable:end -->
