### PR TITLE
feat: add mdadm pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ FROM --platform=arm64 ghcr.io/talos-systems/libseccomp:${PKGS} AS pkg-libseccomp
 FROM --platform=amd64 ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware-amd64
 FROM --platform=arm64 ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware-arm64
 
+FROM --platform=amd64 ghcr.io/talos-systems/mdadm:${PKGS} AS pkg-mdadm-amd64
+FROM --platform=arm64 ghcr.io/talos-systems/mdadm:${PKGS} AS pkg-mdadm-arm64
+
 FROM --platform=amd64 ghcr.io/talos-systems/lvm2:${PKGS} AS pkg-lvm2-amd64
 FROM --platform=arm64 ghcr.io/talos-systems/lvm2:${PKGS} AS pkg-lvm2-arm64
 
@@ -335,6 +338,7 @@ COPY --from=pkg-libressl-amd64 / /rootfs
 COPY --from=pkg-libseccomp-amd64 / /rootfs
 COPY --from=pkg-linux-firmware-amd64 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
 COPY --from=pkg-linux-firmware-amd64 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=pkg-mdadm-amd64 / /rootfs
 COPY --from=pkg-lvm2-amd64 / /rootfs
 COPY --from=pkg-libaio-amd64 / /rootfs
 COPY --from=pkg-musl-amd64 / /rootfs
@@ -379,6 +383,7 @@ COPY --from=pkg-libressl-arm64 / /rootfs
 COPY --from=pkg-libseccomp-arm64 / /rootfs
 COPY --from=pkg-linux-firmware-arm64 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
 COPY --from=pkg-linux-firmware-arm64 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=pkg-mdadm-arm64 / /rootfs
 COPY --from=pkg-lvm2-arm64 / /rootfs
 COPY --from=pkg-libaio-arm64 / /rootfs
 COPY --from=pkg-musl-arm64 / /rootfs


### PR DESCRIPTION
Add mdadm package to root filesystem.
Which automatically activate healthy softraid.

PR: https://github.com/talos-systems/pkgs/pull/315

Soft raid has to be created before

```shell
mdadm --create --verbose --level=1 --metadata=1.2 --raid-devices=2 --homehost=any /dev/md/RAID1Array /dev/sdb /dev/sdc
mkfs.xfs -L data /dev/md/RAID1Array
```

Result of command ```blkid``` will be like

```shell
/dev/sdb: UUID="a6a859b8-0d42-090d-8269-e9d55e5875b4" UUID_SUB="788bcff8-8486-5829-815c-7dd634af8a02" LABEL="any:RAID1Array" TYPE="linux_raid_member"
/dev/sdc: UUID="a6a859b8-0d42-090d-8269-e9d55e5875b4" UUID_SUB="5dfb68d1-c5e6-623f-7c83-c02ea4af2e35" LABEL="any:RAID1Array" TYPE="linux_raid_member"
/dev/md127: LABEL="data" UUID="facbfa7a-45a1-4659-ba85-b689a3c1a2b3" TYPE="xfs"
```

You can add those yaml lines to mount the softraid at boot time

```yaml
machine:
  disks:
    - device: /dev/md/RAID1Array
      partitions:
        - mountpoint: /var/mnt/extra
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/4579)
<!-- Reviewable:end -->
