### PR TITLE
dhcp-v6 unique identifier/ntp from dhcp-v6

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
@@ -6,6 +6,7 @@ package operator
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -30,18 +31,23 @@ type DHCP6 struct {
 	logger *zap.Logger
 
 	linkName string
+	duid     []byte
 
-	mu        sync.Mutex
-	addresses []network.AddressSpecSpec
-	hostname  []network.HostnameSpecSpec
-	resolvers []network.ResolverSpecSpec
+	mu          sync.Mutex
+	addresses   []network.AddressSpecSpec
+	hostname    []network.HostnameSpecSpec
+	resolvers   []network.ResolverSpecSpec
+	timeservers []network.TimeServerSpecSpec
 }
 
 // NewDHCP6 creates DHCPv6 operator.
-func NewDHCP6(logger *zap.Logger, linkName string) *DHCP6 {
+func NewDHCP6(logger *zap.Logger, linkName string, duid string) *DHCP6 {
+	duidBin, _ := hex.DecodeString(duid) //nolint:errcheck
+
 	return &DHCP6{
 		logger:   logger,
 		linkName: linkName,
+		duid:     duidBin,
 	}
 }
 
@@ -133,7 +139,10 @@ func (d *DHCP6) ResolverSpecs() []network.ResolverSpecSpec {
 
 // TimeServerSpecs implements Operator interface.
 func (d *DHCP6) TimeServerSpecs() []network.TimeServerSpecSpec {
-	return nil
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.timeservers
 }
 
 func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
@@ -188,6 +197,24 @@ func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
 	} else {
 		d.hostname = nil
 	}
+
+	if len(reply.Options.NTPServers()) > 0 {
+		ntp := make([]string, len(reply.Options.NTPServers()))
+
+		for i := range ntp {
+			ip, _ := netaddr.FromStdIP(reply.Options.NTPServers()[i])
+			ntp[i] = ip.String()
+		}
+
+		d.timeservers = []network.TimeServerSpecSpec{
+			{
+				NTPServers:  ntp,
+				ConfigLayer: network.ConfigOperator,
+			},
+		}
+	} else {
+		d.timeservers = nil
+	}
 }
 
 func (d *DHCP6) renew(ctx context.Context) (time.Duration, error) {
@@ -198,7 +225,18 @@ func (d *DHCP6) renew(ctx context.Context) (time.Duration, error) {
 
 	defer cli.Close() //nolint:errcheck
 
-	reply, err := cli.RapidSolicit(ctx)
+	var modifiers []dhcpv6.Modifier
+
+	if len(d.duid) > 0 {
+		duid, derr := dhcpv6.DuidFromBytes(d.duid)
+		if derr != nil {
+			d.logger.Error("failed to parse DUID, ignored", zap.String("link", d.linkName))
+		} else {
+			modifiers = []dhcpv6.Modifier{dhcpv6.WithClientID(*duid)}
+		}
+	}
+
+	reply, err := cli.RapidSolicit(ctx, modifiers...)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -147,6 +147,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 						RequireUp: true,
 						DHCP6: network.DHCP6OperatorSpec{
 							RouteMetric: routeMetric,
+							DUID:        device.DHCPOptions().DUIDv6(),
 						},
 						ConfigLayer: network.ConfigMachineConfiguration,
 					})

--- a/internal/app/machined/pkg/controllers/network/operator_spec.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec.go
@@ -425,7 +425,7 @@ func (ctrl *OperatorSpecController) newOperator(logger *zap.Logger, spec *networ
 	case network.OperatorDHCP6:
 		logger = logger.With(zap.String("operator", "dhcp6"))
 
-		return operator.NewDHCP6(logger, spec.LinkName)
+		return operator.NewDHCP6(logger, spec.LinkName, spec.DHCP6.DUID)
 	case network.OperatorVIP:
 		logger = logger.With(zap.String("operator", "vip"))
 

--- a/internal/app/machined/pkg/controllers/network/timeserver_spec.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_spec.go
@@ -89,6 +89,14 @@ func (ctrl *TimeServerSpecController) Run(ctx context.Context, r controller.Runt
 					return fmt.Errorf("error removing finalizer: %w", err)
 				}
 			case resource.PhaseRunning:
+				ntps := make([]string, len(spec.TypedSpec().NTPServers))
+
+				for i := range ntps {
+					ntps[i] = spec.TypedSpec().NTPServers[i]
+				}
+
+				logger.Info("setting time servers", zap.Strings("addresses", ntps))
+
 				if err = r.Modify(ctx, network.NewTimeServerStatus(network.NamespaceName, spec.Metadata().ID()), func(r resource.Resource) error {
 					status := r.(*network.TimeServerStatus) //nolint:forcetypeassert,errcheck
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -170,6 +170,7 @@ type DHCPOptions interface {
 	RouteMetric() uint32
 	IPv4() bool
 	IPv6() bool
+	DUIDv6() string
 }
 
 // VIPConfig contains settings for the Virtual (shared) IP setup.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -684,6 +684,11 @@ func (d *DHCPOptions) IPv6() bool {
 	return *d.DHCPIPv6
 }
 
+// DUIDv6 implements the DHCPOptions interface.
+func (d *DHCPOptions) DUIDv6() string {
+	return d.DHCPDUIDv6
+}
+
 // PrivateKey implements the MachineNetwork interface.
 func (wc *DeviceWireguardConfig) PrivateKey() string {
 	return wc.WireguardPrivateKey

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1848,6 +1848,8 @@ type DHCPOptions struct {
 	DHCPIPv4 *bool `yaml:"ipv4,omitempty"`
 	//   description: Enables DHCPv6 protocol for the interface (default is disabled).
 	DHCPIPv6 *bool `yaml:"ipv6,omitempty"`
+	//   description: Set client DUID (hex string).
+	DHCPDUIDv6 string `yaml:"duidv6,omitempty"`
 }
 
 // DeviceWireguardConfig contains settings for configuring Wireguard network interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1656,7 +1656,7 @@ func init() {
 			FieldName: "dhcpOptions",
 		},
 	}
-	DHCPOptionsDoc.Fields = make([]encoder.Doc, 3)
+	DHCPOptionsDoc.Fields = make([]encoder.Doc, 4)
 	DHCPOptionsDoc.Fields[0].Name = "routeMetric"
 	DHCPOptionsDoc.Fields[0].Type = "uint32"
 	DHCPOptionsDoc.Fields[0].Note = ""
@@ -1672,6 +1672,11 @@ func init() {
 	DHCPOptionsDoc.Fields[2].Note = ""
 	DHCPOptionsDoc.Fields[2].Description = "Enables DHCPv6 protocol for the interface (default is disabled)."
 	DHCPOptionsDoc.Fields[2].Comments[encoder.LineComment] = "Enables DHCPv6 protocol for the interface (default is disabled)."
+	DHCPOptionsDoc.Fields[3].Name = "duidv6"
+	DHCPOptionsDoc.Fields[3].Type = "string"
+	DHCPOptionsDoc.Fields[3].Note = ""
+	DHCPOptionsDoc.Fields[3].Description = "Set client DUID (hex string)."
+	DHCPOptionsDoc.Fields[3].Comments[encoder.LineComment] = "Set client DUID (hex string)."
 
 	DeviceWireguardConfigDoc.Type = "DeviceWireguardConfig"
 	DeviceWireguardConfigDoc.Comments[encoder.LineComment] = "DeviceWireguardConfig contains settings for configuring Wireguard network interface."

--- a/pkg/machinery/resources/network/operator_spec.go
+++ b/pkg/machinery/resources/network/operator_spec.go
@@ -41,6 +41,7 @@ type DHCP4OperatorSpec struct {
 
 // DHCP6OperatorSpec describes DHCP6 operator options.
 type DHCP6OperatorSpec struct {
+	DUID        string `yaml:"DUID,omitempty"`
 	RouteMetric uint32 `yaml:"routeMetric"`
 }
 

--- a/website/content/v1.1/reference/configuration.md
+++ b/website/content/v1.1/reference/configuration.md
@@ -4622,6 +4622,18 @@ Enables DHCPv6 protocol for the interface (default is disabled).
 </div>
 
 <hr />
+<div class="dd">
+
+<code>duidv6</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Set client DUID (hex string).
+
+</div>
+
+<hr />
 
 
 


### PR DESCRIPTION
# Pull Request

I found a few cloud providers which wants to have DHCP-DUID identify to allocate the IPv6 address.
Some times DHCP-DUID uses as  stable_secret in SLAAC mode.

Also I've add the NTP server received from DHCPv6 server.

close #5018

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5086)
<!-- Reviewable:end -->
