### PR TITLE
docs: update search settings and redirects

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -116,7 +116,7 @@ url_latest_version = "/v0.14"
 # gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
-algolia_docsearch = false
+algolia_docsearch = true
 
 # Enable Lunr.js offline search
 offlineSearch = false

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,0 +1,10 @@
+## TODO: we should templatize this so hugo spits it out and it always points to latest from config.toml.
+## There's a way to do it, but I couldn't get it to work quickly.
+## See https://dev.to/faraixyz/setting-a-custom-output-format-in-hugo-for-netlify-or-gitlab-page-s-redirects-file-4dcf
+## for what I'm talking about
+/docs     /v0.14  302
+/docs/latest    /v0.14  302
+/docs/latest/*     /v0.14/:splat  302
+
+/latest     /v0.14  302
+/latest/*     /v0.14/:splat  302


### PR DESCRIPTION
This gives us doc searches, as well as redirects for latest and
docs/latest to the actual v0.14 version (until we cut 1.0).

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5173)
<!-- Reviewable:end -->
