### PR TITLE
chore: rename github organization to siderolabs

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -5,7 +5,7 @@ policies:
       gpg:
         required: true
         identity:
-          gitHubOrganization: talos-systems
+          gitHubOrganization: siderolabs
       spellcheck:
         locale: US
       maximumOfOneCommit: true

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -360,7 +360,7 @@ local integration_provision_tests_track_2 = Step("provision-tests-track-2", priv
 
 local integration_extensions = Step("e2e-extensions", target="e2e-qemu", privileged=true, depends_on=[load_artifacts], environment={
         "SHORT_INTEGRATION_TEST": "yes",
-        "WITH_CONFIG_PATCH": '[{"op":"add","path":"/machine/install/extensions","value":[{"image":"ghcr.io/talos-systems/gvisor:54b831d"},{"image":"ghcr.io/talos-systems/intel-ucode:54b831d"},{"image":"ghcr.io/talos-systems/hello-world-service:a05f558"}]},{"op":"add","path":"/machine/sysctls","value":{"user.max_user_namespaces": "11255"}}]',
+        "WITH_CONFIG_PATCH": '[{"op":"add","path":"/machine/install/extensions","value":[{"image":"ghcr.io/siderolabs/gvisor:54b831d"},{"image":"ghcr.io/siderolabs/intel-ucode:54b831d"},{"image":"ghcr.io/siderolabs/hello-world-service:a05f558"}]},{"op":"add","path":"/machine/sysctls","value":{"user.max_user_namespaces": "11255"}}]',
         "WITH_TEST": "run_extensions_test",
         "IMAGE_REGISTRY": local_registry,
 });

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,80 +10,80 @@ ARG INSTALLER_ARCH
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
-FROM ghcr.io/talos-systems/fhs:${PKGS} AS pkg-fhs
-FROM ghcr.io/talos-systems/ca-certificates:${PKGS} AS pkg-ca-certificates
+FROM ghcr.io/siderolabs/fhs:${PKGS} AS pkg-fhs
+FROM ghcr.io/siderolabs/ca-certificates:${PKGS} AS pkg-ca-certificates
 
-FROM --platform=amd64 ghcr.io/talos-systems/cryptsetup:${PKGS} AS pkg-cryptsetup-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/cryptsetup:${PKGS} AS pkg-cryptsetup-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/cryptsetup:${PKGS} AS pkg-cryptsetup-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/cryptsetup:${PKGS} AS pkg-cryptsetup-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/containerd:${PKGS} AS pkg-containerd-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/containerd:${PKGS} AS pkg-containerd-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/containerd:${PKGS} AS pkg-containerd-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/containerd:${PKGS} AS pkg-containerd-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/dosfstools:${PKGS} AS pkg-dosfstools-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/dosfstools:${PKGS} AS pkg-dosfstools-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/dosfstools:${PKGS} AS pkg-dosfstools-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/dosfstools:${PKGS} AS pkg-dosfstools-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/eudev:${PKGS} AS pkg-eudev-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/eudev:${PKGS} AS pkg-eudev-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/eudev:${PKGS} AS pkg-eudev-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/eudev:${PKGS} AS pkg-eudev-arm64
 
-FROM ghcr.io/talos-systems/grub:${PKGS} AS pkg-grub
-FROM --platform=amd64 ghcr.io/talos-systems/grub:${PKGS} AS pkg-grub-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/grub:${PKGS} AS pkg-grub-arm64
+FROM ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub
+FROM --platform=amd64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/iptables:${PKGS} AS pkg-iptables-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/iptables:${PKGS} AS pkg-iptables-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/iptables:${PKGS} AS pkg-iptables-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/iptables:${PKGS} AS pkg-iptables-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/libinih:${PKGS} AS pkg-libinih-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libinih:${PKGS} AS pkg-libinih-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/libinih:${PKGS} AS pkg-libinih-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libinih:${PKGS} AS pkg-libinih-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/libjson-c:${PKGS} AS pkg-libjson-c-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libjson-c:${PKGS} AS pkg-libjson-c-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/libjson-c:${PKGS} AS pkg-libjson-c-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libjson-c:${PKGS} AS pkg-libjson-c-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/libpopt:${PKGS} AS pkg-libpopt-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libpopt:${PKGS} AS pkg-libpopt-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/libpopt:${PKGS} AS pkg-libpopt-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libpopt:${PKGS} AS pkg-libpopt-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/liburcu:${PKGS} AS pkg-liburcu-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/liburcu:${PKGS} AS pkg-liburcu-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/liburcu:${PKGS} AS pkg-liburcu-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/liburcu:${PKGS} AS pkg-liburcu-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/openssl:${PKGS} AS pkg-openssl-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/openssl:${PKGS} AS pkg-openssl-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/openssl:${PKGS} AS pkg-openssl-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/openssl:${PKGS} AS pkg-openssl-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/libseccomp:${PKGS} AS pkg-libseccomp-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libseccomp:${PKGS} AS pkg-libseccomp-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/libseccomp:${PKGS} AS pkg-libseccomp-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libseccomp:${PKGS} AS pkg-libseccomp-arm64
 
 # linux-firmware is not arch-specific
-FROM --platform=amd64 ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware
+FROM --platform=amd64 ghcr.io/siderolabs/linux-firmware:${PKGS} AS pkg-linux-firmware
 
-FROM --platform=amd64 ghcr.io/talos-systems/lvm2:${PKGS} AS pkg-lvm2-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/lvm2:${PKGS} AS pkg-lvm2-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/lvm2:${PKGS} AS pkg-lvm2-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/lvm2:${PKGS} AS pkg-lvm2-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/libaio:${PKGS} AS pkg-libaio-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libaio:${PKGS} AS pkg-libaio-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/libaio:${PKGS} AS pkg-libaio-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libaio:${PKGS} AS pkg-libaio-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/runc:${PKGS} AS pkg-runc-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/runc:${PKGS} AS pkg-runc-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/runc:${PKGS} AS pkg-runc-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/runc:${PKGS} AS pkg-runc-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/xfsprogs:${PKGS} AS pkg-xfsprogs-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/xfsprogs:${PKGS} AS pkg-xfsprogs-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/xfsprogs:${PKGS} AS pkg-xfsprogs-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/xfsprogs:${PKGS} AS pkg-xfsprogs-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/util-linux:${PKGS} AS pkg-util-linux-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/util-linux:${PKGS} AS pkg-util-linux-arm64
 
-FROM --platform=amd64 ghcr.io/talos-systems/kmod:${PKGS} AS pkg-kmod-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/kmod:${PKGS} AS pkg-kmod-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/kmod:${PKGS} AS pkg-kmod-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/kmod:${PKGS} AS pkg-kmod-arm64
 
-FROM ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel
-FROM --platform=amd64 ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel-arm64
+FROM ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel
+FROM --platform=amd64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-arm64
 
-FROM --platform=arm64 ghcr.io/talos-systems/u-boot:${PKGS} AS pkg-u-boot-arm64
-FROM --platform=arm64 ghcr.io/talos-systems/raspberrypi-firmware:${PKGS} AS pkg-raspberrypi-firmware-arm64
+FROM --platform=arm64 ghcr.io/siderolabs/u-boot:${PKGS} AS pkg-u-boot-arm64
+FROM --platform=arm64 ghcr.io/siderolabs/raspberrypi-firmware:${PKGS} AS pkg-raspberrypi-firmware-arm64
 
 # Resolve package images using ${EXTRAS} to be used later in COPY --from=.
 
-FROM ghcr.io/talos-systems/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
+FROM ghcr.io/siderolabs/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
 
 # The tools target provides base toolchain for the build.
 
@@ -310,7 +310,7 @@ COPY --from=talosctl-linux /talosctl-linux-${TARGETARCH} /talosctl
 ARG TAG
 ENV VERSION ${TAG}
 LABEL "alpha.talos.dev/version"="${VERSION}"
-LABEL org.opencontainers.image.source https://github.com/talos-systems/talos
+LABEL org.opencontainers.image.source https://github.com/siderolabs/talos
 ENTRYPOINT ["/talosctl"]
 
 FROM base AS talosctl-darwin-amd64-build
@@ -500,7 +500,7 @@ COPY --from=initramfs-archive /initramfs.xz /initramfs-${TARGETARCH}.xz
 
 FROM scratch AS talos
 COPY --from=rootfs / /
-LABEL org.opencontainers.image.source https://github.com/talos-systems/talos
+LABEL org.opencontainers.image.source https://github.com/siderolabs/talos
 ENTRYPOINT ["/sbin/init"]
 
 # The installer target generates an image that can be used to install Talos to
@@ -561,7 +561,7 @@ RUN ln -s /bin/installer /bin/talosctl
 ARG TAG
 ENV VERSION ${TAG}
 LABEL "alpha.talos.dev/version"="${VERSION}"
-LABEL org.opencontainers.image.source https://github.com/talos-systems/talos
+LABEL org.opencontainers.image.source https://github.com/siderolabs/talos
 ENTRYPOINT ["/bin/installer"]
 ONBUILD RUN apk add --no-cache --update \
     cpio \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]\*)
 TAG_SUFFIX ?=
@@ -12,7 +12,7 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v1.1.0-alpha.0-1-g99be089
+TOOLS ?= ghcr.io/siderolabs/tools:v1.1.0-alpha.0-1-g99be089
 PKGS ?= v1.1.0-alpha.0-5-g58603ba
 EXTRAS ?= v1.0.0
 GO_VERSION ?= 1.17
@@ -22,7 +22,7 @@ STRINGER_VERSION ?= v0.1.5
 ENUMER_VERSION ?= v1.1.2
 DEEPCOPY_GEN_VERSION ?= v0.21.3
 VTPROTOBUF_VERSION ?= v0.2.0
-IMPORTVET ?= ghcr.io/talos-systems/importvet:c9424fe
+IMPORTVET ?= ghcr.io/siderolabs/importvet:c9424fe
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_DEFAULT_TARGET := integration-test-$(OPERATING_SYSTEM)
@@ -31,7 +31,7 @@ KUBECTL_URL ?= https://storage.googleapis.com/kubernetes-release/release/v1.23.5
 KUBESTR_URL ?= https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_amd64.tar.gz
 CLUSTERCTL_VERSION ?= 1.0.4
 CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/download/v$(CLUSTERCTL_VERSION)/clusterctl-$(OPERATING_SYSTEM)-amd64
-D2CTL_URL ?= https://github.com/talos-systems/day-two/releases/download/v0.1.0-alpha.1/d2ctl-$(OPERATING_SYSTEM)-amd64
+D2CTL_URL ?= https://github.com/siderolabs/day-two/releases/download/v0.1.0-alpha.1/d2ctl-$(OPERATING_SYSTEM)-amd64
 PULUMI_URL ?= https://get.pulumi.com/releases/sdk/pulumi-v3.26.1-$(OPERATING_SYSTEM)-x64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
 RELEASES ?= v0.13.4 v0.14.1
@@ -377,10 +377,10 @@ $(ARTIFACTS)/$(TALOS_RELEASE)/%:
 	@mkdir -p $(ARTIFACTS)/$(TALOS_RELEASE)/
 	@case "$*" in \
 		vmlinuz) \
-			curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/talos-systems/talos/releases/download/$(TALOS_RELEASE)/vmlinuz-amd64" \
+			curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/siderolabs/talos/releases/download/$(TALOS_RELEASE)/vmlinuz-amd64" \
 			;; \
 		initramfs.xz) \
-			curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/talos-systems/talos/releases/download/$(TALOS_RELEASE)/initramfs-amd64.xz" \
+			curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/siderolabs/talos/releases/download/$(TALOS_RELEASE)/initramfs-amd64.xz" \
 			;; \
 	esac
 
@@ -394,7 +394,7 @@ release-artifacts:
 
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
-	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/talos-systems/conform:v0.1.0-alpha.22 enforce
+	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/siderolabs/conform:v0.1.0-alpha.22 enforce
 
 .PHONY: release-notes
 release-notes:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+RELEASE_TOOL_IMAGE="ghcr.io/siderolabs/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -2,8 +2,8 @@
 commit = "HEAD"
 
 project_name = "Talos"
-github_repo = "talos-systems/talos"
-match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
+github_repo = "siderolabs/talos"
+match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 # previous release
 previous = "v0.14.0"
@@ -180,12 +180,12 @@ Use machine configuration field `.machine.sysfs` to set `sysfs` kernel parameter
 
     [make_deps.tools]
         variable = "TOOLS"
-        repository = "github.com/talos-systems/tools"
+        repository = "github.com/siderolabs/tools"
 
     [make_deps.pkgs]
         variable = "PKGS"
-        repository = "github.com/talos-systems/pkgs"
+        repository = "github.com/siderolabs/pkgs"
 
     [make_deps.extras]
         variable = "EXTRAS"
-        repository = "github.com/talos-systems/extras"
+        repository = "github.com/siderolabs/extras"

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -24,8 +24,9 @@ function create_cluster {
     --cpus=2.0 \
     --cidr=172.20.2.0/24 \
     --with-apply-config \
-    --install-image=${REGISTRY:-ghcr.io}/talos-systems/installer:${TAG} \
+    --install-image=${REGISTRY:-ghcr.io}/siderolabs/installer:${TAG} \
     --cni-bundle-url=${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+    --crashdump \
     ${REGISTRY_MIRROR_FLAGS}
 
   "${TALOSCTL}" config node "${NODE}"

--- a/hack/test/libvirt/libvirt.sh
+++ b/hack/test/libvirt/libvirt.sh
@@ -29,7 +29,7 @@ function usage {
 
 NODES=(control-plane-1 control-plane-2 control-plane-3 worker-1)
 
-INSTALLER=${INSTALLER:-ghcr.io/talos-systems/installer:latest}
+INSTALLER=${INSTALLER:-ghcr.io/siderolabs/installer:latest}
 
 VM_MEMORY=${VM_MEMORY:-2048}
 VM_DISK=${VM_DISK:-10}

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -89,11 +89,11 @@ func upgradePreviousToStable() upgradeSpec {
 
 		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(previousRelease), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(previousRelease), constants.InitramfsAsset)),
-		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", previousRelease),
+		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/siderolabs/installer", previousRelease),
 		SourceVersion:        previousRelease,
 		SourceK8sVersion:     previousK8sVersion,
 
-		TargetInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
+		TargetInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/siderolabs/installer", stableRelease),
 		TargetVersion:        stableRelease,
 		TargetK8sVersion:     stableK8sVersion,
 
@@ -112,7 +112,7 @@ func upgradeStableToCurrent() upgradeSpec {
 
 		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.InitramfsAsset)),
-		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
+		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/siderolabs/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
 
@@ -156,7 +156,7 @@ func upgradeStableToCurrentPreserve() upgradeSpec {
 
 		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.InitramfsAsset)),
-		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
+		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/siderolabs/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
 
@@ -177,7 +177,7 @@ func upgradeStableToCurrentPreserveStage() upgradeSpec {
 
 		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(stableRelease), constants.InitramfsAsset)),
-		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
+		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/siderolabs/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
 

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -38,7 +38,7 @@ func List(config config.Provider) Versions {
 	images.Etcd = config.Cluster().Etcd().Image()
 	images.CoreDNS = config.Cluster().CoreDNS().Image()
 	images.Flannel = "quay.io/coreos/flannel:v0.15.1"
-	images.FlannelCNI = fmt.Sprintf("ghcr.io/talos-systems/install-cni:%s", version.ExtrasVersion)
+	images.FlannelCNI = fmt.Sprintf("ghcr.io/siderolabs/install-cni:%s", version.ExtrasVersion)
 	images.Kubelet = config.Machine().Kubelet().Image()
 	images.KubeAPIServer = config.Cluster().APIServer().Image()
 	images.KubeControllerManager = config.Cluster().ControllerManager().Image()

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -181,7 +181,7 @@ var (
 	machineInstallExample = &InstallConfig{
 		InstallDisk:            "/dev/sda",
 		InstallExtraKernelArgs: []string{"console=ttyS1", "panic=10"},
-		InstallImage:           "ghcr.io/talos-systems/installer:latest",
+		InstallImage:           "ghcr.io/siderolabs/installer:latest",
 		InstallBootloader:      true,
 		InstallWipe:            false,
 	}
@@ -1084,12 +1084,12 @@ type InstallConfig struct {
 	//     Image reference for each Talos release can be found on
 	//     [GitHub releases page](https://github.com/talos-systems/talos/releases).
 	//   examples:
-	//     - value: '"ghcr.io/talos-systems/installer:latest"'
+	//     - value: '"ghcr.io/siderolabs/installer:latest"'
 	InstallImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     Allows for supplying additional system extension images to install on top of base Talos image.
 	//   examples:
-	//     - value: '"ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0"'
+	//     - value: '"ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0"'
 	InstallExtensions []InstallExtensionConfig `yaml:"extensions,omitempty"`
 	//   description: |
 	//     Indicates if a bootloader should be installed.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -720,14 +720,14 @@ func init() {
 	InstallConfigDoc.Fields[3].Description = "Allows for supplying the image used to perform the installation.\nImage reference for each Talos release can be found on\n[GitHub releases page](https://github.com/talos-systems/talos/releases)."
 	InstallConfigDoc.Fields[3].Comments[encoder.LineComment] = "Allows for supplying the image used to perform the installation."
 
-	InstallConfigDoc.Fields[3].AddExample("", "ghcr.io/talos-systems/installer:latest")
+	InstallConfigDoc.Fields[3].AddExample("", "ghcr.io/siderolabs/installer:latest")
 	InstallConfigDoc.Fields[4].Name = "extensions"
 	InstallConfigDoc.Fields[4].Type = "[]InstallExtensionConfig"
 	InstallConfigDoc.Fields[4].Note = ""
 	InstallConfigDoc.Fields[4].Description = "Allows for supplying additional system extension images to install on top of base Talos image."
 	InstallConfigDoc.Fields[4].Comments[encoder.LineComment] = "Allows for supplying additional system extension images to install on top of base Talos image."
 
-	InstallConfigDoc.Fields[4].AddExample("", "ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0")
+	InstallConfigDoc.Fields[4].AddExample("", "ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0")
 	InstallConfigDoc.Fields[5].Name = "bootloader"
 	InstallConfigDoc.Fields[5].Type = "bool"
 	InstallConfigDoc.Fields[5].Note = ""
@@ -834,7 +834,7 @@ func init() {
 	InstallExtensionConfigDoc.Comments[encoder.LineComment] = "InstallExtensionConfig represents a configuration for a system extension."
 	InstallExtensionConfigDoc.Description = "InstallExtensionConfig represents a configuration for a system extension."
 
-	InstallExtensionConfigDoc.AddExample("", "ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0")
+	InstallExtensionConfigDoc.AddExample("", "ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0")
 	InstallExtensionConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "InstallConfig",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -166,10 +166,10 @@ func TestValidate(t *testing.T) {
 						InstallDisk: "/dev/vda",
 						InstallExtensions: []v1alpha1.InstallExtensionConfig{
 							{
-								ExtensionImage: "ghcr.io/talos-systems/gvisor:v0.1.0",
+								ExtensionImage: "ghcr.io/siderolabs/gvisor:v0.1.0",
 							},
 							{
-								ExtensionImage: "ghcr.io/talos-systems/gvisor:v0.1.0",
+								ExtensionImage: "ghcr.io/siderolabs/gvisor:v0.1.0",
 							},
 						},
 					},
@@ -183,7 +183,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			requiresInstall: true,
-			expectedError:   "1 error occurred:\n\t* duplicate system extension \"ghcr.io/talos-systems/gvisor:v0.1.0\"\n\n",
+			expectedError:   "1 error occurred:\n\t* duplicate system extension \"ghcr.io/siderolabs/gvisor:v0.1.0\"\n\n",
 		},
 		{
 			name: "ExternalCloudProviderEnabled",

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -256,7 +256,7 @@ const (
 	DefaultControlPlanePort = 6443
 
 	// KubeletImage is the enforced kubelet image to use.
-	KubeletImage = "ghcr.io/talos-systems/kubelet"
+	KubeletImage = "ghcr.io/siderolabs/kubelet"
 
 	// KubeProxyImage is the enforced kube-proxy image to use for the control plane.
 	KubeProxyImage = "k8s.gcr.io/kube-proxy"

--- a/website/content/v1.0/guides/adding-a-proprietary-kernel-module.md
+++ b/website/content/v1.0/guides/adding-a-proprietary-kernel-module.md
@@ -44,7 +44,7 @@ description: ""
         FROM scratch AS customization
         COPY --from=ghcr.io/your-username/kernel:<kernel version> /lib/modules /lib/modules
 
-        FROM ghcr.io/talos-systems/installer:<talos version>
+        FROM ghcr.io/siderolabs/installer:<talos version>
         COPY --from=ghcr.io/your-username/kernel:<kernel version> /boot/vmlinuz /usr/install/${TARGETARCH}/vmlinuz
         ```
 

--- a/website/content/v1.0/guides/air-gapped.md
+++ b/website/content/v1.0/guides/air-gapped.md
@@ -55,7 +55,7 @@ All images are now stored in the Docker daemon store:
 
 ```bash
 $ docker images
-ghcr.io/talos-systems/install-cni    v0.3.0-12-g90722c3      980d36ee2ee1        5 days ago          79.7MB
+ghcr.io/siderolabs/install-cni    v0.3.0-12-g90722c3      980d36ee2ee1        5 days ago          79.7MB
 k8s.gcr.io/kube-proxy-amd64          v1.20.0                 33c60812eab8        2 weeks ago         118MB
 ...
 ```
@@ -99,7 +99,7 @@ The only required flag for this guide is `--registry-mirror '*'=http://10.5.0.1:
 The endpoint being used is `10.5.0.1`, as this is the default bridge interface address which will be routable from the QEMU VMs (`127.0.0.1` IP will be pointing to the VM itself).
 
 ```bash
-$ sudo -E talosctl cluster create --provisioner=qemu --registry-mirror '*'=http://10.5.0.1:6000 --install-image=ghcr.io/talos-systems/installer:v1.0.0
+$ sudo -E talosctl cluster create --provisioner=qemu --registry-mirror '*'=http://10.5.0.1:6000 --install-image=ghcr.io/siderolabs/installer:v1.0.0
 validating CIDR and reserving IPs
 generating PKI and tokens
 creating state directory in "/home/smira/.talos/clusters/talos-default"

--- a/website/content/v1.0/guides/customizing-the-kernel.md
+++ b/website/content/v1.0/guides/customizing-the-kernel.md
@@ -30,7 +30,7 @@ Using a multi-stage `Dockerfile` we can define the `customization` stage and bui
 FROM scratch AS customization
 COPY --from=<custom kernel image> /lib/modules /lib/modules
 
-FROM ghcr.io/talos-systems/installer:latest
+FROM ghcr.io/siderolabs/installer:latest
 COPY --from=<custom kernel image> /boot/vmlinuz /usr/install/${TARGETARCH}/vmlinuz
 ```
 

--- a/website/content/v1.0/guides/customizing-the-root-filesystem.md
+++ b/website/content/v1.0/guides/customizing-the-root-filesystem.md
@@ -27,7 +27,7 @@ Using a multi-stage `Dockerfile` we can define the `customization` stage and bui
 FROM scratch AS customization
 COPY --from=<name|index> <src> <dest>
 
-FROM ghcr.io/talos-systems/installer:latest
+FROM ghcr.io/siderolabs/installer:latest
 ```
 
 When building the image, the `customization` stage will automatically be copied into the rootfs.

--- a/website/content/v1.0/guides/editing-machine-configuration.md
+++ b/website/content/v1.0/guides/editing-machine-configuration.md
@@ -107,7 +107,7 @@ Command `talosctl patch` works similar to `talosctl edit` command - it loads cur
 Example, updating kubelet version (in auto mode):
 
 ```bash
-$ talosctl -n <IP> patch machineconfig -p '[{"op": "replace", "path": "/machine/kubelet/image", "value": "ghcr.io/talos-systems/kubelet:v1.20.5"}]'
+$ talosctl -n <IP> patch machineconfig -p '[{"op": "replace", "path": "/machine/kubelet/image", "value": "ghcr.io/siderolabs/kubelet:v1.20.5"}]'
 patched mc at the node <IP>
 ```
 
@@ -137,7 +137,7 @@ Talos can detect file format automatically:
 # kubelet-patch.yaml
 - op: replace
   path: /machine/kubelet/image
-  value: ghcr.io/talos-systems/kubelet:v1.23.3
+  value: ghcr.io/siderolabs/kubelet:v1.23.3
 ```
 
 ```bash

--- a/website/content/v1.0/guides/logging.md
+++ b/website/content/v1.0/guides/logging.md
@@ -41,7 +41,7 @@ Container logs for Kubernetes pods can be retrieved with `talosctl logs -k` comm
 $ talosctl -n 172.20.1.2 containers -k
 NODE         NAMESPACE   ID                                                 IMAGE                                                         PID    STATUS
 172.20.1.2   k8s.io      kube-system/kube-flannel-dk6d5                     k8s.gcr.io/pause:3.5                                          1329   SANDBOX_READY
-172.20.1.2   k8s.io      └─ kube-system/kube-flannel-dk6d5:install-cni      ghcr.io/talos-systems/install-cni:v0.7.0-alpha.0-1-g2bb2efc   0      CONTAINER_EXITED
+172.20.1.2   k8s.io      └─ kube-system/kube-flannel-dk6d5:install-cni      ghcr.io/siderolabs/install-cni:v0.7.0-alpha.0-1-g2bb2efc      0      CONTAINER_EXITED
 172.20.1.2   k8s.io      └─ kube-system/kube-flannel-dk6d5:install-config   quay.io/coreos/flannel:v0.13.0                                0      CONTAINER_EXITED
 172.20.1.2   k8s.io      └─ kube-system/kube-flannel-dk6d5:kube-flannel     quay.io/coreos/flannel:v0.13.0                                1610   CONTAINER_RUNNING
 172.20.1.2   k8s.io      kube-system/kube-proxy-gfkqj                       k8s.gcr.io/pause:3.5                                          1311   SANDBOX_READY

--- a/website/content/v1.0/guides/system-extensions.md
+++ b/website/content/v1.0/guides/system-extensions.md
@@ -16,7 +16,7 @@ System extensions are configured in the `.machine.install` section:
 machine:
   install:
     extensions:
-      - image: ghcr.io/talos-systems/gvisor:33f613e
+      - image: ghcr.io/siderolabs/gvisor:33f613e
 ```
 
 During the initial install (e.g. when PXE booting or booting from an ISO), Talos will pull down container images for system extensions,

--- a/website/content/v1.0/guides/upgrading-kubernetes.md
+++ b/website/content/v1.0/guides/upgrading-kubernetes.md
@@ -333,7 +333,7 @@ kubectl apply -f manifests.yaml
 For every node, patch machine configuration with new kubelet version, wait for the kubelet to restart with new version:
 
 ```bash
-$ talosctl -n <IP> patch mc --mode=no-reboot -p '[{"op": "replace", "path": "/machine/kubelet/image", "value": "ghcr.io/talos-systems/kubelet:v1.23.0"}]'
+$ talosctl -n <IP> patch mc --mode=no-reboot -p '[{"op": "replace", "path": "/machine/kubelet/image", "value": "ghcr.io/siderolabs/kubelet:v1.23.0"}]'
 patched mc at the node 172.20.0.2
 ```
 

--- a/website/content/v1.0/guides/upgrading-talos.md
+++ b/website/content/v1.0/guides/upgrading-talos.md
@@ -41,7 +41,7 @@ as:
 
 ```sh
   $ talosctl upgrade --nodes 10.20.30.40 \
-      --image ghcr.io/talos-systems/installer:v1.0.0
+      --image ghcr.io/siderolabs/installer:v1.0.0
 ```
 
 There is an option to this command: `--preserve`, which will explicitly tell Talos to keep ephemeral data intact.

--- a/website/content/v1.0/reference/cli.md
+++ b/website/content/v1.0/reference/cli.md
@@ -114,11 +114,11 @@ talosctl cluster create [flags]
       --extra-disks-size int                     default limit on disk size in MB (each VM) (default 5120)
       --extra-uefi-search-paths strings          additional search paths for UEFI firmware (only applies when UEFI is enabled)
   -h, --help                                     help for create
-      --image string                             the image to use (default "ghcr.io/talos-systems/talos:latest")
+      --image string                             the image to use (default "ghcr.io/siderolabs/talos:latest")
       --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
       --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
   -i, --input-dir string                         location of pre-generated config files
-      --install-image string                     the installer image to use (default "ghcr.io/talos-systems/installer:latest")
+      --install-image string                     the installer image to use (default "ghcr.io/siderolabs/installer:latest")
       --ipv4                                     enable IPv4 network in the cluster (default true)
       --ipv6                                     enable IPv6 network in the cluster (QEMU provisioner only)
       --iso-path string                          the ISO path to use for the initial boot (VM only)
@@ -1091,7 +1091,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
-      --install-image string                     the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
+      --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")
       --kubernetes-version string                desired kubernetes version to run (default "1.23.5")
   -o, --output-dir string                        destination to output generated files
   -p, --persist                                  the desired persist value for configs (default true)

--- a/website/content/v1.0/reference/configuration.md
+++ b/website/content/v1.0/reference/configuration.md
@@ -140,7 +140,7 @@ install:
     extraKernelArgs:
         - console=ttyS1
         - panic=10
-    image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
+    image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
     bootloader: true # Indicates if a bootloader should be installed.
     wipe: false # Indicates if the installation disk should be wiped at installation time.
 
@@ -151,7 +151,7 @@ install:
     #     busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0 # Disk bus path.
 
     # # Allows for supplying additional system extension images to install on top of base Talos image.
-    # extensions: ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0
+    # extensions: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0
 ```
 
 <hr />
@@ -316,7 +316,7 @@ Examples:
 
 ``` yaml
 kubelet:
-    image: ghcr.io/talos-systems/kubelet:v1.23.5 # The `image` field is an optional reference to an alternative kubelet image.
+    image: ghcr.io/siderolabs/kubelet:v1.23.5 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -545,7 +545,7 @@ install:
     extraKernelArgs:
         - console=ttyS1
         - panic=10
-    image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
+    image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
     bootloader: true # Indicates if a bootloader should be installed.
     wipe: false # Indicates if the installation disk should be wiped at installation time.
 
@@ -556,7 +556,7 @@ install:
     #     busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0 # Disk bus path.
 
     # # Allows for supplying additional system extension images to install on top of base Talos image.
-    # extensions: ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0
+    # extensions: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0
 ```
 
 
@@ -1656,7 +1656,7 @@ Appears in:
 
 
 ``` yaml
-image: ghcr.io/talos-systems/kubelet:v1.23.5 # The `image` field is an optional reference to an alternative kubelet image.
+image: ghcr.io/siderolabs/kubelet:v1.23.5 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -1706,7 +1706,7 @@ Examples:
 
 
 ``` yaml
-image: ghcr.io/talos-systems/kubelet:v1.23.5
+image: ghcr.io/siderolabs/kubelet:v1.23.5
 ```
 
 
@@ -2178,7 +2178,7 @@ disk: /dev/sda # The disk used for installations.
 extraKernelArgs:
     - console=ttyS1
     - panic=10
-image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
+image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
 bootloader: true # Indicates if a bootloader should be installed.
 wipe: false # Indicates if the installation disk should be wiped at installation time.
 
@@ -2189,7 +2189,7 @@ wipe: false # Indicates if the installation disk should be wiped at installation
 #     busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0 # Disk bus path.
 
 # # Allows for supplying additional system extension images to install on top of base Talos image.
-# extensions: ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0
+# extensions: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0
 ```
 
 <hr />
@@ -2287,7 +2287,7 @@ Examples:
 
 
 ``` yaml
-image: ghcr.io/talos-systems/installer:latest
+image: ghcr.io/siderolabs/installer:latest
 ```
 
 
@@ -2309,7 +2309,7 @@ Examples:
 
 
 ``` yaml
-extensions: ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0
+extensions: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0
 ```
 
 
@@ -2558,7 +2558,7 @@ Appears in:
 
 
 ``` yaml
-ghcr.io/talos-systems/gvisor:20220117.0-v1.0.0
+ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0
 ```
 
 <hr />

--- a/website/content/v1.0/single-board-computers/jetson_nano.md
+++ b/website/content/v1.0/single-board-computers/jetson_nano.md
@@ -46,7 +46,7 @@ Next we will extract the L4T release and replace the `u-boot` binary with the pa
 ```bash
 tar xf jetson-210_linux_r32.6.1_aarch64.tbz2
 cd Linux_for_Tegra
-crane --platform=linux/arm64 export ghcr.io/talos-systems/u-boot:v0.10.0-alpha.0-11-g5dd08a7 - | tar xf - --strip-components=1 -C bootloader/t210ref/p3450-0000/ jetson_nano/u-boot.bin
+crane --platform=linux/arm64 export ghcr.io/siderolabs/u-boot:v0.10.0-alpha.0-11-g5dd08a7 - | tar xf - --strip-components=1 -C bootloader/t210ref/p3450-0000/ jetson_nano/u-boot.bin
 ```
 
 Next we will flash the firmware to the Jetson Nano SPI flash.


### PR DESCRIPTION
Go module import paths still use talos-systems, packages use new
siderolabs name.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5183)
<!-- Reviewable:end -->
