### PR TITLE
test: use clusterctl.yaml overrides after org rename

### DIFF
--- a/hack/test/clusterctl.yaml
+++ b/hack/test/clusterctl.yaml
@@ -1,0 +1,7 @@
+providers:
+  - name: "talos"
+    url: "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml"
+    type: "BootstrapProvider"
+  - name: "talos"
+    url: "https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml"
+    type: "ControlPlaneProvider"

--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -24,6 +24,7 @@ export AWS_B64ENCODED_CREDENTIALS=${AWS_SVC_ACCT}
 set -x
 
 ${CLUSTERCTL} init \
+    --config hack/test/clusterctl.yaml \
     --core "cluster-api:v${CAPI_VERSION}" \
     --control-plane "talos" \
     --infrastructure "aws:v${CAPA_VERSION},gcp:v${CAPG_VERSION}" \


### PR DESCRIPTION
`clusterctl init` can't follow redirects.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5184)
<!-- Reviewable:end -->
