### PR TITLE
docs: add enterprise link to docs header

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -210,6 +210,11 @@ name = "GitHub"
 url = "https://github.com/talos-systems/talos"
 
 [[menu.main]]
+name = "Sidero Labs"
+url = "https://www.siderolabs.com"
+weight = 100
+
+[[menu.main]]
 name = "GitHub"
 url = "https://github.com/talos-systems/talos"
 weight = 99
@@ -218,3 +223,4 @@ weight = 99
 name = "Sidero Metal"
 url = "https://sidero.dev"
 weight = 98
+


### PR DESCRIPTION
Adds a link to the enterprise site.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5185)
<!-- Reviewable:end -->
