### PR TITLE
docs: fix redirects for /docs URLs

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -3,8 +3,7 @@
 ## See https://dev.to/faraixyz/setting-a-custom-output-format-in-hugo-for-netlify-or-gitlab-page-s-redirects-file-4dcf
 ## for what I'm talking about
 /docs     /v0.14  302
-/docs/latest    /v0.14  302
-/docs/latest/*     /v0.14/:splat  302
+/docs/*  /:splat 302
 
 /latest     /v0.14  302
-/latest/*     /v0.14/:splat  302
+/latest/*   /v0.14/:splat  302


### PR DESCRIPTION
We should support old links with `/docs`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5190)
<!-- Reviewable:end -->
