### PR TITLE
docs: remove second search bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ sha512sum.txt
 *.lock
 package-lock.json
 node_modules
+website/resources

--- a/website/config.toml
+++ b/website/config.toml
@@ -116,7 +116,7 @@ url_latest_version = "/v0.14"
 # gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
-algolia_docsearch = true
+algolia_docsearch = false
 
 # Enable Lunr.js offline search
 offlineSearch = false
@@ -223,4 +223,3 @@ weight = 99
 name = "Sidero Metal"
 url = "https://sidero.dev"
 weight = 98
-


### PR DESCRIPTION
The config.toml for algolia doesn't do what it says on the tin. The
algolia search bar shows up without this option and enabling it somehow
adds a second search bar.

Also added the `resources/` subdir to our gitignore. This dir is
generated when doing local hugo dev.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5191)
<!-- Reviewable:end -->
