### PR TITLE
docs: tag latest docs for search

### DIFF
--- a/website/layouts/partials/hooks/body-end.html
+++ b/website/layouts/partials/hooks/body-end.html
@@ -1,11 +1,17 @@
+{{ $currentVersionDir := index (split .Page.File.Dir "/" ) 0 | printf "/%s"}}
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 
 <script>
-docsearch({
-  appId: "D72DGJBSSA",
-  apiKey: "49ca9541d72f7814b88a3a9204988360",
-  indexName: "talos",
-  container: '#algolia-search',
-  debug: true
-});
+  docsearch({
+    appId: "D72DGJBSSA",
+    apiKey: "49ca9541d72f7814b88a3a9204988360",
+    indexName: "talos",
+    container: '#algolia-search',
+    debug: true,
+  });
 </script>
+
+
+{{ if eq $currentVersionDir site.Params.url_latest_version }}
+<meta name="docsearch:version" content="latest" />
+{{ end }}


### PR DESCRIPTION
This PR adds to our templates to inject a "latest" version metadata if
the doc is indeed our latest version. This will be coupled with an algolia
facet filter to only return "latest" version results in a separate PR
after I kick a recrawl of the site once this is merged.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5194)
<!-- Reviewable:end -->
