### PR TITLE
docs: update docker guide for MacOS and Windows

### DIFF
--- a/website/content/v1.0/local-platforms/docker.md
+++ b/website/content/v1.0/local-platforms/docker.md
@@ -26,7 +26,13 @@ Further, when running on a Mac in docker,  due to networking limitations, VIPs a
 Creating a local cluster is as simple as:
 
 ```bash
-talosctl cluster create --wait
+talosctl cluster create
+```
+
+Note that if you are on MacOS or Windows you will need to add `--endpoint 127.0.0.1`:
+
+```bash
+talosctl cluster create --endpoint 127.0.0.1
 ```
 
 Once the above finishes successfully, your talosconfig(`~/.talos/config`) will be configured to point to the new cluster.


### PR DESCRIPTION
Adds a note to use the `--endpoint` flag on MacOS and Windows when using
`talosctl cluster create`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5202)
<!-- Reviewable:end -->
