### PR TITLE
docs: add algolia versions to all content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ sha512sum.txt
 package-lock.json
 node_modules
 website/resources
+website/public

--- a/website/layouts/partials/hooks/body-end.html
+++ b/website/layouts/partials/hooks/body-end.html
@@ -1,4 +1,6 @@
-{{ $currentVersionDir := index (split .Page.File.Dir "/" ) 0 | printf "/%s"}}
+{{ $currentVersion := index (split .Page.File.Dir "/" ) 0 }}
+{{ $currentVersionDir := $currentVersion | printf "/%s"}}
+
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 
 <script>
@@ -15,6 +17,15 @@
 </script>
 
 
+<!--
+tag all content with its corresponding version.
+the "not equal" handles the case where there is no version on the main landing page 
+the "equal" handles whether we also tag this content as "latest"
+-->
+{{ if ne $currentVersion "" }}
 {{ if eq $currentVersionDir site.Params.url_latest_version }}
-<meta name="docsearch:version" content="latest" />
+<meta name="docsearch:version" content="latest,{{ $currentVersion }}" />
+{{else}}
+<meta name="docsearch:version" content="{{ $currentVersion }}" />
+{{end}}
 {{ end }}


### PR DESCRIPTION
This PR makes sure all content gets tagged appropriately so we can be
smarter about showing relevant results.

Also added the `public` directory to the gitignore. This is created when
doing local hugo development and shouldn't be committed.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5208)
<!-- Reviewable:end -->
