### PR TITLE
fix: use 'localhost' endpoint in docker provisioner on Windows

### DIFF
--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -80,7 +80,7 @@ func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (int
 	// docker doesn't provide internal LB, so return empty string
 	// external LB is always localhost for OS X where docker exposes ports
 	switch runtime.GOOS {
-	case "darwin":
+	case "darwin", "windows":
 		return "", "127.0.0.1"
 	default:
 		return "", ""


### PR DESCRIPTION
Same as OS X, we need to force endpoint to the localhost/exposed port of
the apid.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5212)
<!-- Reviewable:end -->
