### PR TITLE
fix: give up virtual IPs before the kubelet workloads are shut down

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -91,6 +91,7 @@ func NewState() (*State, error) {
 		&k8s.ConfigStatus{},
 		&k8s.Endpoint{},
 		&k8s.KubeletConfig{},
+		&k8s.KubeletLifecycle{},
 		&k8s.KubeletSpec{},
 		&k8s.Manifest{},
 		&k8s.ManifestStatus{},

--- a/pkg/machinery/resources/k8s/k8s_test.go
+++ b/pkg/machinery/resources/k8s/k8s_test.go
@@ -28,6 +28,7 @@ func TestRegisterResource(t *testing.T) {
 		&k8s.ConfigStatus{},
 		&k8s.Endpoint{},
 		&k8s.KubeletConfig{},
+		&k8s.KubeletLifecycle{},
 		&k8s.KubeletSpec{},
 		&k8s.ManifestStatus{},
 		&k8s.Manifest{},

--- a/pkg/machinery/resources/k8s/kubelet_lifecycle.go
+++ b/pkg/machinery/resources/k8s/kubelet_lifecycle.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+)
+
+// KubeletLifecycleType is type of KubeletLifecycle resource.
+const KubeletLifecycleType = resource.Type("KubeletLifecycles.kubernetes.talos.dev")
+
+// KubeletLifecycleID is the singleton ID of the resource.
+const KubeletLifecycleID = resource.ID("kubelet")
+
+// KubeletLifecycle resource exists to signal that the kubelet pods are running.
+//
+// Components might put finalizers on the KubeletLifecycle resource to signal that additional
+// actions should be taken before the kubelet is about to be shut down.
+//
+// KubeletLifecycle is mostly about status of the workloads kubelet is running vs.
+// the actual status of the kubelet service itself.
+type KubeletLifecycle struct {
+	md   resource.Metadata
+	spec KubeletLifecycleSpec
+}
+
+// KubeletLifecycleSpec is empty.
+type KubeletLifecycleSpec struct{}
+
+// NewKubeletLifecycle initializes an empty KubeletLifecycle resource.
+func NewKubeletLifecycle(namespace resource.Namespace, id resource.ID) *KubeletLifecycle {
+	r := &KubeletLifecycle{
+		md:   resource.NewMetadata(namespace, KubeletLifecycleType, id, resource.VersionUndefined),
+		spec: KubeletLifecycleSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *KubeletLifecycle) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *KubeletLifecycle) Spec() interface{} {
+	return r.spec
+}
+
+func (r *KubeletLifecycle) String() string {
+	return fmt.Sprintf("k8s.KubeletLifecycle(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *KubeletLifecycle) DeepCopy() resource.Resource {
+	return &KubeletLifecycle{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *KubeletLifecycle) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             KubeletLifecycleType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+	}
+}


### PR DESCRIPTION
This introduces a shutdown lock basically which makes sure that whatever
needs to be terminated before kubelet shutdown sequence is initiated has
a chance to do so.

With the VIP, as the kubelet graceful shutdown terminates the API server
static pod, the VIP might be still on the node while the API server is
down. With this fix, VIP gets moved away from the node before the
kubelet graceful shutdown sequence starts.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5213)
<!-- Reviewable:end -->
