### PR TITLE
fix: correctly escape '.' in volume names

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
@@ -172,6 +172,10 @@ func (suite *K8sControlPlaneSuite) TestReconcileExtraVolumes() {
 							VolumeHostPath:  "/var/lib",
 							VolumeMountPath: "/var/foo/",
 						},
+						{
+							VolumeHostPath:  "/var/lib/a.foo",
+							VolumeMountPath: "/var/foo/b.foo",
+						},
 					},
 				},
 			},
@@ -185,6 +189,12 @@ func (suite *K8sControlPlaneSuite) TestReconcileExtraVolumes() {
 				Name:      "var-foo",
 				HostPath:  "/var/lib",
 				MountPath: "/var/foo/",
+				ReadOnly:  false,
+			},
+			{
+				Name:      "var-foo-b-foo",
+				HostPath:  "/var/lib/a.foo",
+				MountPath: "/var/foo/b.foo",
 				ReadOnly:  false,
 			},
 		}, apiServerCfg.ExtraVolumes,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1252,9 +1252,11 @@ func (v VolumeMountConfig) MountPath() string {
 	return v.VolumeMountPath
 }
 
+var volumeNameSanitizer = strings.NewReplacer("/", "-", "_", "-", ".", "-")
+
 // Name implements the config.VolumeMount interface.
 func (v VolumeMountConfig) Name() string {
-	return strings.Trim(strings.ReplaceAll(strings.ReplaceAll(v.VolumeMountPath, "/", "-"), "_", "-"), "-")
+	return strings.Trim(volumeNameSanitizer.Replace(v.VolumeMountPath), "-")
 }
 
 // ReadOnly implements the config.VolumeMount interface.


### PR DESCRIPTION
Volume name is derived from the mount path.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5214)
<!-- Reviewable:end -->
