### PR TITLE
chore: bump kernel to 5.15.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.1.0-alpha.0-1-g99be089
-PKGS ?= v1.1.0-alpha.0-9-ga76edfd
+PKGS ?= v1.1.0-alpha.0-10-gba98e20
 EXTRAS ?= v1.0.0
 GO_VERSION ?= 1.17
 GOIMPORTS_VERSION ?= v0.1.10

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -71,7 +71,7 @@ Previously, the audit logs were sent to `kube-apiserver`'s `stdout`, along with 
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.31
+* Linux: 5.15.32
 * Kubernetes: 1.23.5
 * CoreDNS: 1.9.1
 * etcd: 3.5.2

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.31-talos"
+	DefaultKernelVersion = "5.15.32-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to 5.15.32

Ref: https://github.com/siderolabs/pkgs/pull/432

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5226)
<!-- Reviewable:end -->
