### PR TITLE
docs: fix non-latest download links

### DIFF
--- a/website/content/v1.0/cloud-platforms/aws.md
+++ b/website/content/v1.0/cloud-platforms/aws.md
@@ -53,7 +53,7 @@ Note that the role should be associated with the S3 bucket we created above.
 First, download the AWS image from a Talos release:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/aws-amd64.tar.gz | tar -xv
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/aws-amd64.tar.gz | tar -xv
 ```
 
 Copy the RAW disk to S3 and import it as a snapshot:

--- a/website/content/v1.0/introduction/getting-started.md
+++ b/website/content/v1.0/introduction/getting-started.md
@@ -29,7 +29,7 @@ You should install `talosctl` before continuing:
 #### `amd64`
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -38,7 +38,7 @@ chmod +x /usr/local/bin/talosctl
 For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/v1.0/introduction/quickstart.md
+++ b/website/content/v1.0/introduction/quickstart.md
@@ -26,7 +26,7 @@ Download `talosctl`:
 ##### `amd64`
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -35,7 +35,7 @@ chmod +x /usr/local/bin/talosctl
 For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/v1.0/local-platforms/qemu.md
+++ b/website/content/v1.0/local-platforms/qemu.md
@@ -49,7 +49,7 @@ curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<p
 For example version `{{< release >}}` for `linux` platform:
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-linux-amd64 -L -o talosctl
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
 sudo cp talosctl /usr/local/bin
 sudo chmod +x /usr/local/bin/talosctl
 ```

--- a/website/content/v1.0/local-platforms/virtualbox.md
+++ b/website/content/v1.0/local-platforms/virtualbox.md
@@ -34,7 +34,7 @@ curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<p
 For example version `{{< release >}}` for `linux` platform:
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-linux-amd64 -L -o talosctl
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
 sudo cp talosctl /usr/local/bin
 sudo chmod +x /usr/local/bin/talosctl
 ```
@@ -54,7 +54,7 @@ For example version `{{< release >}}` for `linux` platform:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talos-amd64.iso -L -o _out/talos-amd64.iso
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talos-amd64.iso -L -o _out/talos-amd64.iso
 ```
 
 ## Create VMs

--- a/website/content/v1.0/single-board-computers/bananapi_m64.md
+++ b/website/content/v1.0/single-board-computers/bananapi_m64.md
@@ -13,7 +13,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-bananapi_m64-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-bananapi_m64-arm64.img.xz
 xz -d metal-bananapi_m64-arm64.img.xz
 ```
 

--- a/website/content/v1.0/single-board-computers/jetson_nano.md
+++ b/website/content/v1.0/single-board-computers/jetson_nano.md
@@ -14,7 +14,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -83,7 +83,7 @@ Once the flashing is done you can disconnect the USB cable and power off the Jet
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-jetson_nano-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-jetson_nano-arm64.img.xz
 xz -d metal-jetson_nano-arm64.img.xz
 ```
 

--- a/website/content/v1.0/single-board-computers/libretech_all_h3_cc_h5.md
+++ b/website/content/v1.0/single-board-computers/libretech_all_h3_cc_h5.md
@@ -13,7 +13,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-libretech_all_h3_cc_h5-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-libretech_all_h3_cc_h5-arm64.img.xz
 xz -d metal-libretech_all_h3_cc_h5-arm64.img.xz
 ```
 

--- a/website/content/v1.0/single-board-computers/pine64.md
+++ b/website/content/v1.0/single-board-computers/pine64.md
@@ -13,7 +13,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-pine64-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-pine64-arm64.img.xz
 xz -d metal-pine64-arm64.img.xz
 ```
 

--- a/website/content/v1.0/single-board-computers/rock64.md
+++ b/website/content/v1.0/single-board-computers/rock64.md
@@ -13,7 +13,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-rock64-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-rock64-arm64.img.xz
 xz -d metal-rock64-arm64.img.xz
 ```
 

--- a/website/content/v1.0/single-board-computers/rockpi_4.md
+++ b/website/content/v1.0/single-board-computers/rockpi_4.md
@@ -13,7 +13,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-rockpi_4-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-rockpi_4-arm64.img.xz
 xz -d metal-rockpi_4-arm64.img.xz
 ```
 
@@ -81,7 +81,7 @@ sudo dd if=rkspi_loader-v20.11.2-trunk-v2.img of=/dev/mtdblock0 bs=4K
 - Optionally, you can also write Talos image to the SSD drive right from your Rock PI board:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-rockpi_4-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-rockpi_4-arm64.img.xz
 xz -d metal-rockpi_4-arm64.img.xz
 sudo dd if=metal-rockpi_4-arm64.img.xz of=/dev/nvme0n1
 ```

--- a/website/content/v1.0/single-board-computers/rpi_4.md
+++ b/website/content/v1.0/single-board-computers/rpi_4.md
@@ -18,7 +18,7 @@ You will need
 Download the latest `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -53,7 +53,7 @@ Power off the Raspberry Pi and remove the SD card from it.
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/{{< release >}}/download/metal-rpi_4-arm64.img.xz
+curl -LO https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-rpi_4-arm64.img.xz
 xz -d metal-rpi_4-arm64.img.xz
 ```
 

--- a/website/content/v1.0/virtualized-platforms/proxmox.md
+++ b/website/content/v1.0/virtualized-platforms/proxmox.md
@@ -30,7 +30,7 @@ curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<p
 For example version `{{< release >}}` for `linux` platform:
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talosctl-linux-amd64 -L -o talosctl
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
 sudo cp talosctl /usr/local/bin
 sudo chmod +x /usr/local/bin/talosctl
 ```
@@ -50,7 +50,7 @@ For example version `{{< release >}}` for `linux` platform:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/siderolabs/talos/releases/{{< release >}}/download/talos-amd64.iso -L -o _out/talos-amd64.iso
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talos-amd64.iso -L -o _out/talos-amd64.iso
 ```
 
 ## Upload ISO


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

GitHub download links

## Why? (reasoning)

The path order of the `/download/` element is different for non-`latest` links, this was overlooked when replacing `latest` with `{{< release >}}` in c5da386092185fe4ed4173b08f95eac4e435ff99.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5229)
<!-- Reviewable:end -->
