### PR TITLE
docs: re-add GA token

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -56,7 +56,7 @@ resampleFilter = "CatmullRom"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-141692582-2"
 
 [markup]
 [markup.goldmark]


### PR DESCRIPTION
This PR adds the Google Analytics token back. This _should_ ensure the
script is injected if the environment is "production". Once published,
if this doesn't work I'll troubleshoot further.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5246)
<!-- Reviewable:end -->
