### PR TITLE
chore: drop dirty from abbreviated tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]\*)
-ABBREV_TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]\* --abbrev=0 )
+ABBREV_TAG ?= $(shell git describe --tag --always --match v[0-9]\* --abbrev=0 )
 TAG_SUFFIX ?=
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 IMAGE_REGISTRY ?= $(REGISTRY)


### PR DESCRIPTION
Otherwise `make generate` updates embeddable data file with `-dirty`
stuffix which we don't want.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5256)
<!-- Reviewable:end -->
