### PR TITLE
docs: update releases shortcode in upgrade guide

### DIFF
--- a/website/content/v1.0/guides/upgrading-talos.md
+++ b/website/content/v1.0/guides/upgrading-talos.md
@@ -26,7 +26,7 @@ To see a live demo of an upgrade of Talos Linux, see the video below:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/AAF6WhX0USo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### After Upgrade to {{< release >}}
+## After Upgrade to {{% release %}}
 
 There are no specific actions to be taken after an upgrade.
 
@@ -108,7 +108,7 @@ We set the bootloader to boot _once_ with the new kernel and OS image, then we r
 After the node comes back up and Talos verifies itself, it will make
 the bootloader change permanent, rejoin the cluster, and finally uncordon itself to receive new workloads.
 
-### FAQs
+## FAQs
 
 **Q.** What happens if an upgrade fails?
 

--- a/website/content/v1.1/guides/upgrading-talos.md
+++ b/website/content/v1.1/guides/upgrading-talos.md
@@ -26,7 +26,7 @@ To see a live demo of an upgrade of Talos Linux, see the video below:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/AAF6WhX0USo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### After Upgrade to {{< release >}}
+## After Upgrade to {{% release %}}
 
 There are no specific actions to be taken after an upgrade.
 
@@ -100,7 +100,7 @@ We set the bootloader to boot _once_ with the new kernel and OS image, then we r
 After the node comes back up and Talos verifies itself, it will make
 the bootloader change permanent, rejoin the cluster, and finally uncordon itself to receive new workloads.
 
-### FAQs
+## FAQs
 
 **Q.** What happens if an upgrade fails?
 


### PR DESCRIPTION
This PR moves to using % instead of < for the release shortcode. As far
as I understand it, doing so tells hugo it's not raw html and thus the
headers get rendered to the sidebar properly. We may want to switch the
other uses as well, but I'm not sure it would make any difference one
way or another.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5258)
<!-- Reviewable:end -->
