### PR TITLE
feat: use kubeconfig env var

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -670,7 +670,7 @@ func saveConfig(talosConfigObj *clientconfig.Config) (err error) {
 }
 
 func mergeKubeconfig(ctx context.Context, clusterAccess *access.Adapter) error {
-	kubeconfigPath, err := kubeconfig.DefaultPath()
+	kubeconfigPath, err := kubeconfig.SinglePath()
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -50,7 +50,7 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				var err error
 
 				if merge {
-					localPath, err = kubeconfig.DefaultPath()
+					localPath, err = kubeconfig.SinglePath()
 					if err != nil {
 						return err
 					}

--- a/internal/pkg/kubeconfig/kubeconfig.go
+++ b/internal/pkg/kubeconfig/kubeconfig.go
@@ -6,6 +6,7 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -18,4 +19,18 @@ func DefaultPath() (string, error) {
 	}
 
 	return filepath.Join(home, ".kube/config"), nil
+}
+
+// SinglePath parses KUBECONFIG and the default kubeconfig file location
+// and ensures there is only one to return.
+func SinglePath() (string, error) {
+	envVarFilePaths := filepath.SplitList(os.Getenv("KUBECONFIG"))
+	switch len(envVarFilePaths) {
+	case 0:
+		return DefaultPath()
+	case 1:
+		return envVarFilePaths[0], nil
+	default:
+		return "", fmt.Errorf("multiple kubeconfig files defined")
+	}
 }

--- a/internal/pkg/kubeconfig/kubeconfig_test.go
+++ b/internal/pkg/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubeconfig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
+)
+
+func TestSinglePath(t *testing.T) {
+	expectedDefaultPath, err := kubeconfig.DefaultPath()
+	assert.NoError(t, err)
+
+	for _, tt := range []struct {
+		name      string
+		envVar    string
+		shouldErr bool
+		expected  string
+	}{
+		{
+			name:      "NoKUBECONFIGSet",
+			shouldErr: false,
+			expected:  expectedDefaultPath,
+		},
+		{
+			name:      "UseKUBECONFIGSet",
+			envVar:    "/my/custom/path/to/kubeconfig",
+			shouldErr: false,
+			expected:  "/my/custom/path/to/kubeconfig",
+		},
+		{
+			name:      "MultiKUBECONFIGSet",
+			envVar:    "/my/custom/path/to/kubeconfig:/another/path/to/kubeconfig:/foo/bar/kubeconfig",
+			shouldErr: true,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv("KUBECONFIG", tt.envVar)
+			}
+			result, err := kubeconfig.SinglePath()
+
+			if tt.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When interating with the kubeconfig it can be
expected that a user may have the KUBECONFIG
environment variable set, so we need to use
it when appropriate.
Closes #5091

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5265)
<!-- Reviewable:end -->
