### PR TITLE
feat: use kexec when resetting a node

### DIFF
--- a/cmd/installer/pkg/install/target.go
+++ b/cmd/installer/pkg/install/target.go
@@ -289,6 +289,11 @@ func (t *Target) Save() (err error) {
 	return nil
 }
 
+// GetLabel returns the underlaying partition label.
+func (t *Target) GetLabel() string {
+	return t.Label
+}
+
 func withTemporaryMounted(partPath string, flags uintptr, fileSystemType partition.FileSystemType, label string, f func(mountPath string) error) error {
 	mountPath := filepath.Join(constants.SystemPath, "mnt")
 

--- a/internal/app/machined/pkg/runtime/sequencer.go
+++ b/internal/app/machined/pkg/runtime/sequencer.go
@@ -97,6 +97,7 @@ type ResetOptions interface {
 type PartitionTarget interface {
 	fmt.Stringer
 	Format() error
+	GetLabel() string
 }
 
 // Sequencer describes the set of sequences required for the lifecycle


### PR DESCRIPTION
In the case of a node being reset, using kexec greatly
speeds up the process. However, in the event the boot
partition is wiped, a full reboot is required.
Closes #4670

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5273)
<!-- Reviewable:end -->
