### PR TITLE
fix: enable IPv6 in Docker-based Talos clusters

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -118,6 +118,7 @@ var (
 	configPatchWorker         []string
 	badRTC                    bool
 	extraBootKernelArgs       string
+	dockerDisableIPv6         bool
 )
 
 // createCmd represents the cluster up command.
@@ -250,6 +251,7 @@ func create(ctx context.Context) (err error) {
 
 				BundleURL: cniBundleURL,
 			},
+			DockerDisableIPv6: dockerDisableIPv6,
 		},
 
 		Image:         nodeImage,
@@ -869,6 +871,7 @@ func init() {
 	createCmd.Flags().StringArrayVar(&configPatchWorker, "config-patch-worker", nil, "patch generated machineconfigs (applied to 'worker' type)")
 	createCmd.Flags().BoolVar(&badRTC, "bad-rtc", false, "launch VM with bad RTC state (QEMU only)")
 	createCmd.Flags().StringVar(&extraBootKernelArgs, "extra-boot-kernel-args", "", "add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)")
+	createCmd.Flags().BoolVar(&dockerDisableIPv6, "docker-disable-ipv6", false, "skip enabling IPv6 in containers (Docker only)")
 
 	Cmd.AddCommand(createCmd)
 }

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,6 +23,16 @@ preface = """\
 * runc: 1.1.1
 """
 
+    [notes.dockeripv6]
+        title = "IPv6 in Docker-based Talos Clusters"
+        description="""\
+The command `talosctl cluster create` now enables IPv6 by default for the Docker containers
+created for Talos nodes. This allows to use IPv6 addresses in Kubernetes networking.
+
+If `talosctl cluster create` fails to work on Linux due to the lack of IPv6 support,
+please use the flag `--disable-docker-ipv6` to revert the change.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/provision/providers/docker/node.go
+++ b/pkg/provision/providers/docker/node.go
@@ -104,6 +104,13 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 		},
 	}
 
+	if !clusterReq.Network.DockerDisableIPv6 {
+		// enable IPv6
+		hostConfig.Sysctls = map[string]string{
+			"net.ipv6.conf.all.disable_ipv6": "0",
+		}
+	}
+
 	// Ensure that the container is created in the talos network.
 
 	networkConfig := &network.NetworkingConfig{

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -54,6 +54,9 @@ type NetworkRequest struct {
 
 	// CNI-specific parameters.
 	CNI CNIConfig
+
+	// Docker-specific parameters.
+	DockerDisableIPv6 bool
 }
 
 // NodeRequests is a list of NodeRequest.

--- a/website/content/v1.1/reference/cli.md
+++ b/website/content/v1.1/reference/cli.md
@@ -104,6 +104,7 @@ talosctl cluster create [flags]
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
       --disk-image-path string                   disk image to use
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
+      --docker-disable-ipv6                      skip enabling IPv6 in containers (Docker only)
       --docker-host-ip string                    Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
       --encrypt-ephemeral                        enable ephemeral partition encryption
       --encrypt-state                            enable state partition encryption


### PR DESCRIPTION
Docker by default disable IPv6 completely in the containers which breaks
SideroLink on Docker-based clusters, as SideroLink is using IPv6
addresses for the Wiregurard tunnel.

This change might break `talosctl cluster create` on host systems which
have IPv6 disabled completely, so provide a flag to revert this
behavior.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5279)
<!-- Reviewable:end -->
