### PR TITLE
docs: fix a typo in QEMU VM setup guide

### DIFF
--- a/website/content/v0.10/local-platforms/qemu.md
+++ b/website/content/v0.10/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.11/local-platforms/qemu.md
+++ b/website/content/v0.11/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.12/local-platforms/qemu.md
+++ b/website/content/v0.12/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.13/local-platforms/qemu.md
+++ b/website/content/v0.13/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.14/local-platforms/qemu.md
+++ b/website/content/v0.14/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.7/local-platforms/qemu.md
+++ b/website/content/v0.7/local-platforms/qemu.md
@@ -90,7 +90,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.8/local-platforms/qemu.md
+++ b/website/content/v0.8/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v0.9/local-platforms/qemu.md
+++ b/website/content/v0.9/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v1.0/local-platforms/qemu.md
+++ b/website/content/v1.0/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 

--- a/website/content/v1.1/local-platforms/qemu.md
+++ b/website/content/v1.1/local-platforms/qemu.md
@@ -91,7 +91,7 @@ Before the first cluster is created, `talosctl` will download the CNI bundle for
 Once the above finishes successfully, your talosconfig (`~/.talos/config`) will be configured to point to the new cluster, and `kubeconfig` will be
 downloaded and merged into default kubectl config location (`~/.kube/config`).
 
-Cluster provisioning process can be optimized with [registry pull-through cahces](../../guides/configuring-pull-through-cache/).
+Cluster provisioning process can be optimized with [registry pull-through caches](../../guides/configuring-pull-through-cache/).
 
 ## Using the Cluster
 


### PR DESCRIPTION
Fix a typo in the QEMU VM install docs.

Signed-off-by: Andrei Dobre <andreidobre.web@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5288)
<!-- Reviewable:end -->
