### PR TITLE
docs: fix code fence formatting

### DIFF
--- a/website/content/v1.0/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.0/virtualized-platforms/hyper-v.md
@@ -22,7 +22,7 @@ For example, if VMs `talos-cp01` and `talos-cp02` exist, this will create VMs st
 
 Use the following command to create a single control plane node:
 
-````powershell
+```powershell
 New-TalosVM -VMNamePrefix talos-cp -CPUCount 2 -StartupMemory 4GB -SwitchName LAB -TalosISOPath C:\ISO\talos-amd64.iso -NumberOfVMs 1 -VMDestinationBasePath 'D:\Virtual Machines\Test VMs\Talos'
 ```
 

--- a/website/content/v1.1/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.1/virtualized-platforms/hyper-v.md
@@ -22,7 +22,7 @@ For example, if VMs `talos-cp01` and `talos-cp02` exist, this will create VMs st
 
 Use the following command to create a single control plane node:
 
-````powershell
+```powershell
 New-TalosVM -VMNamePrefix talos-cp -CPUCount 2 -StartupMemory 4GB -SwitchName LAB -TalosISOPath C:\ISO\talos-amd64.iso -NumberOfVMs 1 -VMDestinationBasePath 'D:\Virtual Machines\Test VMs\Talos'
 ```
 


### PR DESCRIPTION
Signed-off-by: William Ashton <William@AshtonFam.org>

# Pull Request

## What? (description)

This PR fixes a formatting issue on the Hyper-V docs page, where a code fence included more than intended.

Before:

![Before](https://user-images.githubusercontent.com/3431482/161824547-0d913982-24b9-46b5-b6b6-85e35de3e2d6.png)

After:

![After](https://user-images.githubusercontent.com/3431482/161824562-7873b09f-3e27-4fd8-90e9-588a85225e5b.png)


## Why? (reasoning)

This change makes the Hyper-V docs page a little easier to read.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5300)
<!-- Reviewable:end -->
