### PR TITLE
fix: avoid panic in DHCPv6 operator on nil dereference

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
@@ -149,7 +149,7 @@ func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if reply.Options.OneIANA() != nil {
+	if reply.Options.OneIANA() != nil && reply.Options.OneIANA().Options.OneAddress() != nil {
 		addr, _ := netaddr.FromStdIPNet(&net.IPNet{
 			IP:   reply.Options.OneIANA().Options.OneAddress().IPv6Addr,
 			Mask: net.CIDRMask(128, 128),


### PR DESCRIPTION
Log (lines for Talos v1):

```
[talos] operator panicked {"component": "controller-runtime", "controller": "network.OperatorSpecController", "stack": "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network.(*operatorRunState).runWithPanicHandler.func1\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator_spec.go:137\x5cnruntime.gopanic\x5cn\x5ct/toolchain/go/src/runtime/panic.go:1038\x5cnruntime.panicmem\x5cn\x5ct/toolchain/go/src/runtime/panic.go:221\x5cnruntime.sigpanic\x5cn\x5ct/toolchain/go/src/runtime/signal_unix.go:735\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator.(*DHCP6).parseReply\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator/dhcp6.go:145\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator.(*DHCP6).renew\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator/dhcp6.go:208\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator.(*DHCP6).Run\x5cn\x5ct/src
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5301)
<!-- Reviewable:end -->
