### PR TITLE
Fixed download link in vmware docs. Added explicit config in talos-vm…

### DIFF
--- a/website/content/v1.1/virtualized-platforms/vmware.md
+++ b/website/content/v1.1/virtualized-platforms/vmware.md
@@ -118,12 +118,12 @@ You may now skip past the "Manual Approach" section down to "Bootstrap Cluster".
 
 #### Import the OVA into vCenter
 
-A `talos.ova` asset is published with each [release](https://github.com/siderolabs/talos/releases).
+A `vmware-amd64.ova` asset is published with each [release](https://github.com/siderolabs/talos/releases).
 We will refer to the version of the release as `$TALOS_VERSION` below.
 It can be easily exported with `export TALOS_VERSION="v0.3.0-alpha.10"` or similar.
 
 ```bash
-curl -LO https://github.com/siderolabs/talos/releases/download/$TALOS_VERSION/talos.ova
+curl -LO https://github.com/siderolabs/talos/releases/download/$TALOS_VERSION/vmware-amd64.ova
 ```
 
 Create a content library (if needed) with:
@@ -135,7 +135,7 @@ govc library.create <library name>
 Import the OVA to the library with:
 
 ```bash
-govc library.import -n talos-${TALOS_VERSION} <library name> /path/to/downloaded/talos.ova
+govc library.import -n talos-${TALOS_VERSION} <library name> /path/to/downloaded/vmware-amd64.ova
 ```
 
 #### Create the Bootstrap Node
@@ -294,7 +294,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:


### PR DESCRIPTION
…toolsd command

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Updated VMware documentation with correct download URL for the OVA. I also added the explicit talosconfig used in all the previous steps to the `talos-vmtoolsd` command used later.

## Why? (reasoning)
The URL in the documentation was not correct.

I ran into an issue not explicitly using that created talosconfig where it instead used an old `~/.talos/config` file I forgot about. This makes everything more consistent.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5307)
<!-- Reviewable:end -->
