### PR TITLE
docs: enable nested arrow

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -180,6 +180,8 @@ navbar_logo = true
 navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = true
+# Enables the arrow for content to show there's nested stuff
+sidebar_menu_foldable = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = true
 


### PR DESCRIPTION
This PR enables the little arrow that shows there's stuff underneath a
header on the sidebar.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5309)
<!-- Reviewable:end -->
