### PR TITLE
docs: update sitemap to point to direct url

### DIFF
--- a/website/layouts/sitemap.xml
+++ b/website/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{- range .Data.Pages -}}{{ $currentVersion := index (split .Permalink "/" ) 1 }}{{ $currentVersionDir := $currentVersion | printf "/%s"}}{{ if and .Permalink (ne .Params.sitemap_exclude true) (eq $currentVersionDir site.Params.url_latest_version)}}
   <url>
-    <loc>https://talos.dev{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>https://www.talos.dev{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}


### PR DESCRIPTION
`talos.dev` redirects to `www.talos.dev` so this fix to
the sitemap removes the redirect when scraping.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

Closes #5313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5314)
<!-- Reviewable:end -->
