### PR TITLE
docs: use template for netlify redirects

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -72,7 +72,18 @@ style = "solarized-dark"
 
 # Comment out if you don't want the "print entire section" link enabled.
 [outputs]
+home = ["HTML", "RSS", "netlify_redirect"]
 section = ["HTML", "print", "RSS"]
+
+[mediaTypes.'text/prs.netlify']
+suffixes = [""]
+delimiter = ""
+
+[outputFormats.netlify_redirect]
+baseName = "_redirects"
+isPlainText = true
+mediaType = "text/prs.netlify"
+notAlternative = true
 
 [params]
 copyright = "Sidero Labs, Inc."

--- a/website/layouts/index.netlify_redirect
+++ b/website/layouts/index.netlify_redirect
@@ -1,0 +1,5 @@
+# Set docs/latest to the release param
+/docs		{{ .Site.Params.url_latest_version }}		302
+/docs/*		/:splat	302
+/latest		{{ .Site.Params.url_latest_version }}		302
+/latest/*	{{ .Site.Params.url_latest_version }}/:splat	302

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,9 +1,0 @@
-## TODO: we should templatize this so hugo spits it out and it always points to latest from config.toml.
-## There's a way to do it, but I couldn't get it to work quickly.
-## See https://dev.to/faraixyz/setting-a-custom-output-format-in-hugo-for-netlify-or-gitlab-page-s-redirects-file-4dcf
-## for what I'm talking about
-/docs     /v1.0  302
-/docs/*  /:splat 302
-
-/latest     /v1.0  302
-/latest/*   /v1.0/:splat  302


### PR DESCRIPTION
Use a template for Netlify redirects so we
dont have to maintinan a static file manually.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>