### PR TITLE
chore: bump kernel to 5.15.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.1.0-alpha.0-9-g533d5c9
-PKGS ?= v1.1.0-alpha.0-22-g8b48af6
+PKGS ?= v1.1.0-alpha.0-23-g9cda5c0
 EXTRAS ?= v1.1.0-alpha.0-1-gac3b9a4
 GO_VERSION ?= 1.18
 GOIMPORTS_VERSION ?= v0.1.10

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -18,7 +18,7 @@ preface = """\
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.33
+* Linux: 5.15.34
 * Kubernetes: 1.24.0-beta.0
 * Flannel: 0.17.0
 * runc: 1.1.1

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.33-talos"
+	DefaultKernelVersion = "5.15.34-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.1.0-alpha.0-22-g8b48af6
+v1.1.0-alpha.0-23-g9cda5c0


### PR DESCRIPTION
Bump kernel to 5.15.34

Ref: https://github.com/siderolabs/pkgs/pull/448

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5346)
<!-- Reviewable:end -->
