### PR TITLE
fix: correct cri package import path

### DIFF
--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"sync"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/common"

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/crypto/x509"
 	"google.golang.org/grpc"

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/containerd/cgroups v1.0.4-0.20220301195952-2e502f6b9e43
 	github.com/containerd/containerd v1.6.2
-	github.com/containerd/cri v1.19.0
 	github.com/containerd/typeurl v1.0.2
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,6 @@ github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EX
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/continuity v0.2.2 h1:QSqfxcn8c+12slxwu00AtzXrsami0MJb/MQs9lOLHLA=
 github.com/containerd/continuity v0.2.2/go.mod h1:pWygW9u7LtS1o4N/Tn0FoCFDIXZ7rxcMX7HX1Dmibvk=
-github.com/containerd/cri v1.19.0 h1:+8hdV7HhI02iupp4XduAKcYJp0nEcaWSQn5pFDnttJ0=
-github.com/containerd/cri v1.19.0/go.mod h1:DavH5Qa8+6jOmeOMO3dhWoqksucZDe06LfuhBz/xPZs=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/prometheus/procfs"
 	"github.com/rs/xid"

--- a/pkg/cluster/support.go
+++ b/pkg/cluster/support.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/cri/pkg/constants"
+	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/dustin/go-humanize"

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -7,7 +7,7 @@ package images
 import (
 	"fmt"
 
-	criconfig "github.com/containerd/cri/pkg/config"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/version"


### PR DESCRIPTION
Containerd CRI plugin was merged into the main repo, but we were using
old import path, so our constants coming from the module were outdated.

This fixes the image version for the pause container.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5347)
<!-- Reviewable:end -->
