### PR TITLE
chore: bump kernel to 5.15.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-3-ga8fb702
-PKGS ?= v1.0.0-7-ge6eb485
+PKGS ?= v1.0.0-8-g76f8c5b
 EXTRAS ?= v1.0.0-2-gc5d3ab0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -17,6 +17,8 @@ preface = """\
     [notes.updates]
         title = "Component Updates"
         description="""\
+* Linux: 5.15.34
+
 Talos is built with [Go 1.17.9](https://go.dev/doc/devel/release#go1.17.minor).
 """
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.32-talos"
+	DefaultKernelVersion = "5.15.34-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to 5.15.34 LTS

Ref: https://github.com/siderolabs/pkgs/pull/452

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5353)
<!-- Reviewable:end -->
