### PR TITLE
docs: fix extension services alias

### DIFF
--- a/website/content/v1.0/advanced/extension-services.md
+++ b/website/content/v1.0/advanced/extension-services.md
@@ -2,7 +2,7 @@
 title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
-  - ../learn-more/extention-services
+  - ../learn-more/extension-services
 ---
 
 Talos provides a way to run additional system services early in the Talos boot process.

--- a/website/content/v1.1/advanced/extension-services.md
+++ b/website/content/v1.1/advanced/extension-services.md
@@ -2,7 +2,7 @@
 title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
-  - ../learn-more/extention-services
+  - ../learn-more/extension-services
 ---
 
 Talos provides a way to run additional system services early in the Talos boot process.


### PR DESCRIPTION
Fixes a typo in the Extension Services document alias
which serves as the redirect from the old location.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5355)
<!-- Reviewable:end -->
