### PR TITLE
fix: enable long timestamps for xfs

### DIFF
--- a/pkg/makefs/xfs.go
+++ b/pkg/makefs/xfs.go
@@ -27,7 +27,8 @@ func XFS(partname string, setters ...Option) error {
 	opts := NewDefaultOptions(setters...)
 
 	// The ftype=1 naming option is required by overlayfs.
-	args := []string{"-n", "ftype=1"}
+	// The bigtime=1 metadata option enables timestamps beyond 2038.
+	args := []string{"-n", "ftype=1", "-m", "bigtime=1"}
 
 	if opts.Force {
 		args = append(args, "-f")


### PR DESCRIPTION
This "fixes" the message like:

```
xfs filesystem being mounted at /var supports timestamps until 2038 (0x7fffffff)
```

We should support Talos beyond 2038, even if we switch to a different
filesystem type by 2038 :)

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5356)
<!-- Reviewable:end -->
