### PR TITLE
docs: improve vip caveats documentation

### DIFF
--- a/website/content/v1.0/introduction/getting-started.md
+++ b/website/content/v1.0/introduction/getting-started.md
@@ -116,7 +116,7 @@ Once chosen, form the full HTTPS URL from this IP:
 https://192.168.0.15:6443
 ```
 
-You are free to set a DNS record to this IP address to identify the endpoint, but you will need to use the IP address itself, not the DNS name, to configure the shared IP (`machine.network.interfaces[].vip.ip`) in the Talos configuration.
+You are free to set a DNS record to this IP address to identify the Kubernetes API endpoint, but you will need to use the IP address itself, not the DNS name, to configure the shared IP (`machine.network.interfaces[].vip.ip`) in the Talos configuration.
 
 For more information about using a shared IP, see the related
 [Guide]({{< relref "../talos-guides/network/vip" >}})
@@ -164,6 +164,10 @@ The difference is that the Talos API listens on port `50000/tcp`.
 
 Whichever way you wish to access the Talos API, be sure to note the IP(s) or
 hostname(s) so that you can configure your `talosctl` tool's `endpoints` below.
+
+**NOTE**: The [Virtual IP]({{< relref "../talos-guides/network/vip.md" >}}) method is not recommended when accessing the Talos API as it requires etcd to be bootstrapped and functional.
+This can make debugging any issues via the Talos API more difficult as issues with Talos configuration may result in etcd not achieving quorum, and therefore the Virtual IP not being available.
+In this case setting the endpoints to the IP or hostnames of the control plane nodes themselves is preferred.
 
 ## Configure Talos
 

--- a/website/content/v1.0/talos-guides/network/vip.md
+++ b/website/content/v1.0/talos-guides/network/vip.md
@@ -19,7 +19,7 @@ router in between them.
 The term "virtual" is misleading here.
 The IP address is real, and it is assigned to an interface.
 Instead, what actually happens is that the controlplane machines vie for
-control of the shared IP address.
+control of the shared IP address using etcd elections.
 There can be only one owner of the IP address at any given time, but if that
 owner disappears or becomes non-responsive, another owner will be chosen,
 and it will take up the mantle: the IP address.
@@ -27,6 +27,8 @@ and it will take up the mantle: the IP address.
 Talos has (as of version 0.9) built-in support for this form of shared IP address,
 and it can utilize this for both the Kubernetes API server and the Talos endpoint set.
 Talos uses `etcd` for elections and leadership (control) of the IP address.
+It is not reccomended to use a virtual IP to access the API of Talos itself, since the
+node using the shared IP is not deterministic and could change.
 
 ## Video Walkthrough
 
@@ -93,9 +95,9 @@ You are free to use static addressing (`cidr`) instead of DHCP.
 ## Caveats
 
 In general, the shared IP should just work.
-However, since it relies on `etcd` for elections, the shared IP will not come
-alive until after you have bootstrapped Kubernetes.
+However, since it relies on `etcd` for elections, the shared IP will not be
+available until after you have bootstrapped Kubernetes.
 In general, this is not a problem, but it does mean that you cannot use the
 shared IP when issuing the `talosctl bootstrap` command.
 Instead, that command will need to target one of the controlplane nodes
-discretely.
+directly.

--- a/website/content/v1.1/introduction/getting-started.md
+++ b/website/content/v1.1/introduction/getting-started.md
@@ -116,7 +116,7 @@ Once chosen, form the full HTTPS URL from this IP:
 https://192.168.0.15:6443
 ```
 
-You are free to set a DNS record to this IP address to identify the endpoint, but you will need to use the IP address itself, not the DNS name, to configure the shared IP (`machine.network.interfaces[].vip.ip`) in the Talos configuration.
+You are free to set a DNS record to this IP address to identify the Kubernetes API endpoint, but you will need to use the IP address itself, not the DNS name, to configure the shared IP (`machine.network.interfaces[].vip.ip`) in the Talos configuration.
 
 For more information about using a shared IP, see the related
 [Guide]({{< relref "../talos-guides/network/vip" >}})
@@ -164,6 +164,10 @@ The difference is that the Talos API listens on port `50000/tcp`.
 
 Whichever way you wish to access the Talos API, be sure to note the IP(s) or
 hostname(s) so that you can configure your `talosctl` tool's `endpoints` below.
+
+**NOTE**: The [Virtual IP]({{< relref "../talos-guides/network/vip.md" >}}) method is not recommended when accessing the Talos API as it requires etcd to be bootstrapped and functional.
+This can make debugging any issues via the Talos API more difficult as issues with Talos configuration may result in etcd not achieving quorum, and therefore the Virtual IP not being available.
+In this case setting the endpoints to the IP or hostnames of the control plane nodes themselves is preferred.
 
 ## Configure Talos
 

--- a/website/content/v1.1/talos-guides/network/vip.md
+++ b/website/content/v1.1/talos-guides/network/vip.md
@@ -19,7 +19,7 @@ router in between them.
 The term "virtual" is misleading here.
 The IP address is real, and it is assigned to an interface.
 Instead, what actually happens is that the controlplane machines vie for
-control of the shared IP address.
+control of the shared IP address using etcd elections.
 There can be only one owner of the IP address at any given time, but if that
 owner disappears or becomes non-responsive, another owner will be chosen,
 and it will take up the mantle: the IP address.
@@ -27,6 +27,8 @@ and it will take up the mantle: the IP address.
 Talos has (as of version 0.9) built-in support for this form of shared IP address,
 and it can utilize this for both the Kubernetes API server and the Talos endpoint set.
 Talos uses `etcd` for elections and leadership (control) of the IP address.
+It is not reccomended to use a virtual IP to access the API of Talos itself, since the
+node using the shared IP is not deterministic and could change.
 
 ## Video Walkthrough
 


### PR DESCRIPTION
Many users have been using the VIP functionality to configure
endpoints in Talos config. Documentation to clarify the possible
issues with that option and that it should be avoided.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5365)
<!-- Reviewable:end -->
