### PR TITLE
docs: add talos/kubernetes config faq

### DIFF
--- a/website/content/v1.0/learn-more/faqs.md
+++ b/website/content/v1.0/learn-more/faqs.md
@@ -30,3 +30,10 @@ We envision Talos being a great place for the application of [control theory](ht
 Talos was an automaton created by the Greek God of the forge to protect the island of Crete.
 He would patrol the coast and enforce laws throughout the land.
 We felt it was a fitting name for a security focused operating system designed to run Kubernetes.
+
+## Why does Talos rely on a separate configuration from Kubernetes?
+
+The `talosconfig` file contains client credentials to access the Talos Linux API.
+Sometimes Kubernetes might be down for a number of reasons (etcd issues, misconfiguration, etc.), while Talos API access will always be available.
+The Talos API is a way to access the operating system and fix issues, e.g. fixing access to Kubernetes.
+When Talos Linux is running fine, using the Kubernetes APIs (via `kubeconfig`) is all you should need to deploy and manage Kubernetes workloads.

--- a/website/content/v1.1/learn-more/faqs.md
+++ b/website/content/v1.1/learn-more/faqs.md
@@ -30,3 +30,10 @@ We envision Talos being a great place for the application of [control theory](ht
 Talos was an automaton created by the Greek God of the forge to protect the island of Crete.
 He would patrol the coast and enforce laws throughout the land.
 We felt it was a fitting name for a security focused operating system designed to run Kubernetes.
+
+## Why does Talos rely on a separate configuration from Kubernetes?
+
+The `talosconfig` file contains client credentials to access the Talos Linux API.
+Sometimes Kubernetes might be down for a number of reasons (etcd issues, misconfiguration, etc.), while Talos API access will always be available.
+The Talos API is a way to access the operating system and fix issues, e.g. fixing access to Kubernetes.
+When Talos Linux is running fine, using the Kubernetes APIs (via `kubeconfig`) is all you should need to deploy and manage Kubernetes workloads.


### PR DESCRIPTION
Add an entry to our FAQs on why separate configurations
are needed for Talos and Kubernetes.

Closes #5295

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5370)
<!-- Reviewable:end -->
