### PR TITLE
Docs get machine config

### DIFF
--- a/website/content/v1.0/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.0/talos-guides/configuration/editing-machine-configuration.md
@@ -28,6 +28,9 @@ Each of these commands can operate in one of four modes:
 > Note: applying change on next reboot (`--mode=staged`) doesn't modify current node configuration, so next call to
 > `talosctl edit machineconfig --mode=staged` will not see changes
 
+Additionally, there is also `talosctl get machineconfig`, which retrieves the current node configuration API resource and contains the machine configuration in the `.spec` field.
+It can be used to modify the configuration locally before being applied to the node.
+
 The list of config changes allowed to be applied immediately in Talos {{< release >}}:
 
 * `.debug`

--- a/website/content/v1.1/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.1/talos-guides/configuration/editing-machine-configuration.md
@@ -28,6 +28,9 @@ Each of these commands can operate in one of four modes:
 > Note: applying change on next reboot (`--mode=staged`) doesn't modify current node configuration, so next call to
 > `talosctl edit machineconfig --mode=staged` will not see changes
 
+Additionally, there is also `talosctl get machineconfig`, which retrieves the current node configuration API resource and contains the machine configuration in the `.spec` field.
+It can be used to modify the configuration locally before being applied to the node.
+
 The list of config changes allowed to be applied immediately in Talos {{< release >}}:
 
 * `.debug`


### PR DESCRIPTION
Add a note on how machine configuration can be retrieved
from the node, after e.g. interactive setup.

Closes #5296

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5378)
<!-- Reviewable:end -->
