### PR TITLE
chore: refactor network resources to use typed resource

### DIFF
--- a/pkg/machinery/resources/network/address_spec.go
+++ b/pkg/machinery/resources/network/address_spec.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
@@ -16,10 +17,7 @@ import (
 const AddressSpecType = resource.Type("AddressSpecs.net.talos.dev")
 
 // AddressSpec resource holds physical network link status.
-type AddressSpec struct {
-	md   resource.Metadata
-	spec AddressSpecSpec
-}
+type AddressSpec = typed.Resource[AddressSpecSpec, AddressSpecRD]
 
 // AddressSpecSpec describes status of rendered secrets.
 type AddressSpecSpec struct {
@@ -32,47 +30,28 @@ type AddressSpecSpec struct {
 	ConfigLayer     ConfigLayer             `yaml:"layer"`
 }
 
+// DeepCopy generates a deep copy of AddressSpecSpec.
+func (spec AddressSpecSpec) DeepCopy() AddressSpecSpec {
+	return spec
+}
+
 // NewAddressSpec initializes a AddressSpec resource.
 func NewAddressSpec(namespace resource.Namespace, id resource.ID) *AddressSpec {
-	r := &AddressSpec{
-		md:   resource.NewMetadata(namespace, AddressSpecType, id, resource.VersionUndefined),
-		spec: AddressSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[AddressSpecSpec, AddressSpecRD](
+		resource.NewMetadata(namespace, AddressSpecType, id, resource.VersionUndefined),
+		AddressSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *AddressSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
+// AddressSpecRD provides auxiliary methods for AddressSpec.
+type AddressSpecRD struct{}
 
-// Spec implements resource.Resource.
-func (r *AddressSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *AddressSpec) DeepCopy() resource.Resource {
-	return &AddressSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *AddressSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (AddressSpecRD) ResourceDefinition(resource.Metadata, AddressSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             AddressSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *AddressSpec) TypedSpec() *AddressSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/address_status.go
+++ b/pkg/machinery/resources/network/address_status.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
@@ -16,10 +17,7 @@ import (
 const AddressStatusType = resource.Type("AddressStatuses.net.talos.dev")
 
 // AddressStatus resource holds physical network link status.
-type AddressStatus struct {
-	md   resource.Metadata
-	spec AddressStatusSpec
-}
+type AddressStatus = typed.Resource[AddressStatusSpec, AddressStatusRD]
 
 // AddressStatusSpec describes status of rendered secrets.
 type AddressStatusSpec struct {
@@ -35,38 +33,24 @@ type AddressStatusSpec struct {
 	Flags     nethelpers.AddressFlags `yaml:"flags"`
 }
 
+// DeepCopy generates a deep copy of AddressStatusSpec.
+func (spec AddressStatusSpec) DeepCopy() AddressStatusSpec {
+	return spec
+}
+
 // NewAddressStatus initializes a AddressStatus resource.
 func NewAddressStatus(namespace resource.Namespace, id resource.ID) *AddressStatus {
-	r := &AddressStatus{
-		md:   resource.NewMetadata(namespace, AddressStatusType, id, resource.VersionUndefined),
-		spec: AddressStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[AddressStatusSpec, AddressStatusRD](
+		resource.NewMetadata(namespace, AddressStatusType, id, resource.VersionUndefined),
+		AddressStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *AddressStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// AddressStatusRD provides auxiliary methods for AddressStatus.
+type AddressStatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *AddressStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *AddressStatus) DeepCopy() resource.Resource {
-	return &AddressStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *AddressStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (AddressStatusRD) ResourceDefinition(resource.Metadata, AddressStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             AddressStatusType,
 		Aliases:          []resource.Type{"address", "addresses"},
@@ -82,9 +66,4 @@ func (r *AddressStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *AddressStatus) TypedSpec() *AddressStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/hardrware_addr.go
+++ b/pkg/machinery/resources/network/hardrware_addr.go
@@ -5,10 +5,9 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 )
@@ -20,10 +19,7 @@ const HardwareAddrType = resource.Type("HardwareAddresses.net.talos.dev")
 const FirstHardwareAddr = resource.ID("first")
 
 // HardwareAddr resource describes hardware address of the physical links.
-type HardwareAddr struct {
-	md   resource.Metadata
-	spec HardwareAddrSpec
-}
+type HardwareAddr = typed.Resource[HardwareAddrSpec, HardwareAddrRD]
 
 // HardwareAddrSpec describes spec for the link.
 type HardwareAddrSpec struct {
@@ -34,51 +30,34 @@ type HardwareAddrSpec struct {
 	HardwareAddr nethelpers.HardwareAddr `yaml:"hardwareAddr"`
 }
 
+// DeepCopy generates a deep copy of HardwareAddrSpec.
+func (spec HardwareAddrSpec) DeepCopy() HardwareAddrSpec {
+	cp := spec
+	if spec.HardwareAddr != nil {
+		cp.HardwareAddr = make([]byte, len(spec.HardwareAddr))
+		copy(cp.HardwareAddr, spec.HardwareAddr)
+	}
+
+	return cp
+}
+
 // NewHardwareAddr initializes a HardwareAddr resource.
 func NewHardwareAddr(namespace resource.Namespace, id resource.ID) *HardwareAddr {
-	r := &HardwareAddr{
-		md:   resource.NewMetadata(namespace, HardwareAddrType, id, resource.VersionUndefined),
-		spec: HardwareAddrSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[HardwareAddrSpec, HardwareAddrRD](
+		resource.NewMetadata(namespace, HardwareAddrType, id, resource.VersionUndefined),
+		HardwareAddrSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *HardwareAddr) Metadata() *resource.Metadata {
-	return &r.md
-}
+// HardwareAddrRD provides auxiliary methods for HardwareAddr.
+type HardwareAddrRD struct{}
 
-// Spec implements resource.Resource.
-func (r *HardwareAddr) Spec() interface{} {
-	return r.spec
-}
-
-func (r *HardwareAddr) String() string {
-	return fmt.Sprintf("network.HardwareAddr(%q)", r.md.ID())
-}
-
-// DeepCopy implements resource.Resource.
-func (r *HardwareAddr) DeepCopy() resource.Resource {
-	return &HardwareAddr{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *HardwareAddr) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (HardwareAddrRD) ResourceDefinition(resource.Metadata, HardwareAddrSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             HardwareAddrType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *HardwareAddr) TypedSpec() *HardwareAddrSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/hostname_spec.go
+++ b/pkg/machinery/resources/network/hostname_spec.go
@@ -10,16 +10,14 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // HostnameSpecType is type of HostnameSpec resource.
 const HostnameSpecType = resource.Type("HostnameSpecs.net.talos.dev")
 
 // HostnameSpec resource holds node hostname.
-type HostnameSpec struct {
-	md   resource.Metadata
-	spec HostnameSpecSpec
-}
+type HostnameSpec = typed.Resource[HostnameSpecSpec, HostnameSpecRD]
 
 // HostnameID is the ID of the singleton instance.
 const HostnameID resource.ID = "hostname"
@@ -29,6 +27,11 @@ type HostnameSpecSpec struct {
 	Hostname    string      `yaml:"hostname"`
 	Domainname  string      `yaml:"domainname"`
 	ConfigLayer ConfigLayer `yaml:"layer"`
+}
+
+// DeepCopy generates a deep copy of HostnameSpecSpec.
+func (spec HostnameSpecSpec) DeepCopy() HostnameSpecSpec {
+	return spec
 }
 
 // Validate the hostname.
@@ -70,45 +73,21 @@ func (spec *HostnameSpecSpec) ParseFQDN(fqdn string) error {
 
 // NewHostnameSpec initializes a HostnameSpec resource.
 func NewHostnameSpec(namespace resource.Namespace, id resource.ID) *HostnameSpec {
-	r := &HostnameSpec{
-		md:   resource.NewMetadata(namespace, HostnameSpecType, id, resource.VersionUndefined),
-		spec: HostnameSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[HostnameSpecSpec, HostnameSpecRD](
+		resource.NewMetadata(namespace, HostnameSpecType, id, resource.VersionUndefined),
+		HostnameSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *HostnameSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
+// HostnameSpecRD provides auxiliary methods for HostnameSpec.
+type HostnameSpecRD struct{}
 
-// Spec implements resource.Resource.
-func (r *HostnameSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *HostnameSpec) DeepCopy() resource.Resource {
-	return &HostnameSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *HostnameSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (HostnameSpecRD) ResourceDefinition(resource.Metadata, HostnameSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             HostnameSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *HostnameSpec) TypedSpec() *HostnameSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/hostname_status.go
+++ b/pkg/machinery/resources/network/hostname_status.go
@@ -7,21 +7,24 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // HostnameStatusType is type of HostnameStatus resource.
 const HostnameStatusType = resource.Type("HostnameStatuses.net.talos.dev")
 
 // HostnameStatus resource holds node hostname.
-type HostnameStatus struct {
-	md   resource.Metadata
-	spec HostnameStatusSpec
-}
+type HostnameStatus = typed.Resource[HostnameStatusSpec, HostnameStatusRD]
 
 // HostnameStatusSpec describes node nostname.
 type HostnameStatusSpec struct {
 	Hostname   string `yaml:"hostname"`
 	Domainname string `yaml:"domainname"`
+}
+
+// DeepCopy generates a deep copy of HostnameSpecSpec.
+func (spec HostnameStatusSpec) DeepCopy() HostnameStatusSpec {
+	return spec
 }
 
 // FQDN returns the fully-qualified domain name.
@@ -46,36 +49,17 @@ func (spec *HostnameStatusSpec) DNSNames() []string {
 
 // NewHostnameStatus initializes a HostnameStatus resource.
 func NewHostnameStatus(namespace resource.Namespace, id resource.ID) *HostnameStatus {
-	r := &HostnameStatus{
-		md:   resource.NewMetadata(namespace, HostnameStatusType, id, resource.VersionUndefined),
-		spec: HostnameStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[HostnameStatusSpec, HostnameStatusRD](
+		resource.NewMetadata(namespace, HostnameStatusType, id, resource.VersionUndefined),
+		HostnameStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *HostnameStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// HostnameStatusRD provides auxiliary methods for HostnameStatus.
+type HostnameStatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *HostnameStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *HostnameStatus) DeepCopy() resource.Resource {
-	return &HostnameStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *HostnameStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (HostnameStatusRD) ResourceDefinition(resource.Metadata, HostnameStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             HostnameStatusType,
 		Aliases:          []resource.Type{"hostname"},
@@ -91,9 +75,4 @@ func (r *HostnameStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *HostnameStatus) TypedSpec() *HostnameStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/operator_spec.go
+++ b/pkg/machinery/resources/network/operator_spec.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -14,10 +15,7 @@ import (
 const OperatorSpecType = resource.Type("OperatorSpecs.net.talos.dev")
 
 // OperatorSpec resource holds DNS resolver info.
-type OperatorSpec struct {
-	md   resource.Metadata
-	spec OperatorSpecSpec
-}
+type OperatorSpec = typed.Resource[OperatorSpecSpec, OperatorSpecRD]
 
 // OperatorSpecSpec describes DNS resolvers.
 type OperatorSpecSpec struct {
@@ -30,6 +28,11 @@ type OperatorSpecSpec struct {
 	VIP   VIPOperatorSpec   `yaml:"vip,omitempty"`
 
 	ConfigLayer ConfigLayer `yaml:"layer"`
+}
+
+// DeepCopy generates a deep copy of OperatorSpecSpec.
+func (spec OperatorSpecSpec) DeepCopy() OperatorSpecSpec {
+	return spec
 }
 
 // DHCP4OperatorSpec describes DHCP4 operator options.
@@ -68,36 +71,17 @@ type VIPHCloudSpec struct {
 
 // NewOperatorSpec initializes a OperatorSpec resource.
 func NewOperatorSpec(namespace resource.Namespace, id resource.ID) *OperatorSpec {
-	r := &OperatorSpec{
-		md:   resource.NewMetadata(namespace, OperatorSpecType, id, resource.VersionUndefined),
-		spec: OperatorSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[OperatorSpecSpec, OperatorSpecRD](
+		resource.NewMetadata(namespace, OperatorSpecType, id, resource.VersionUndefined),
+		OperatorSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *OperatorSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
+// OperatorSpecRD provides auxiliary methods for OperatorSpec.
+type OperatorSpecRD struct{}
 
-// Spec implements resource.Resource.
-func (r *OperatorSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *OperatorSpec) DeepCopy() resource.Resource {
-	return &OperatorSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *OperatorSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (OperatorSpecRD) ResourceDefinition(resource.Metadata, OperatorSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             OperatorSpecType,
 		Aliases:          []resource.Type{},
@@ -105,9 +89,4 @@ func (r *OperatorSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 		PrintColumns:     []meta.PrintColumn{},
 		Sensitivity:      meta.Sensitive,
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *OperatorSpec) TypedSpec() *OperatorSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/resolver_spec.go
+++ b/pkg/machinery/resources/network/resolver_spec.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -14,10 +15,7 @@ import (
 const ResolverSpecType = resource.Type("ResolverSpecs.net.talos.dev")
 
 // ResolverSpec resource holds DNS resolver info.
-type ResolverSpec struct {
-	md   resource.Metadata
-	spec ResolverSpecSpec
-}
+type ResolverSpec = typed.Resource[ResolverSpecSpec, ResolverSpecRD]
 
 // ResolverID is the ID of the singleton instance.
 const ResolverID resource.ID = "resolvers"
@@ -28,50 +26,34 @@ type ResolverSpecSpec struct {
 	ConfigLayer ConfigLayer  `yaml:"layer"`
 }
 
+// DeepCopy generates a deep copy of ResolverSpecSpec.
+func (spec ResolverSpecSpec) DeepCopy() ResolverSpecSpec {
+	cp := spec
+	if spec.DNSServers != nil {
+		cp.DNSServers = make([]netaddr.IP, len(spec.DNSServers))
+		copy(cp.DNSServers, spec.DNSServers)
+	}
+
+	return cp
+}
+
 // NewResolverSpec initializes a ResolverSpec resource.
 func NewResolverSpec(namespace resource.Namespace, id resource.ID) *ResolverSpec {
-	r := &ResolverSpec{
-		md:   resource.NewMetadata(namespace, ResolverSpecType, id, resource.VersionUndefined),
-		spec: ResolverSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[ResolverSpecSpec, ResolverSpecRD](
+		resource.NewMetadata(namespace, ResolverSpecType, id, resource.VersionUndefined),
+		ResolverSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *ResolverSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
+// ResolverSpecRD provides auxiliary methods for ResolverSpec.
+type ResolverSpecRD struct{}
 
-// Spec implements resource.Resource.
-func (r *ResolverSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *ResolverSpec) DeepCopy() resource.Resource {
-	return &ResolverSpec{
-		md: r.md,
-		spec: ResolverSpecSpec{
-			DNSServers:  append([]netaddr.IP(nil), r.spec.DNSServers...),
-			ConfigLayer: r.spec.ConfigLayer,
-		},
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *ResolverSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (ResolverSpecRD) ResourceDefinition(resource.Metadata, ResolverSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             ResolverSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *ResolverSpec) TypedSpec() *ResolverSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/route_status.go
+++ b/pkg/machinery/resources/network/route_status.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
@@ -16,10 +17,7 @@ import (
 const RouteStatusType = resource.Type("RouteStatuses.net.talos.dev")
 
 // RouteStatus resource holds physical network link status.
-type RouteStatus struct {
-	md   resource.Metadata
-	spec RouteStatusSpec
-}
+type RouteStatus = typed.Resource[RouteStatusSpec, RouteStatusRD]
 
 // RouteStatusSpec describes status of rendered secrets.
 type RouteStatusSpec struct {
@@ -37,38 +35,24 @@ type RouteStatusSpec struct {
 	Protocol     nethelpers.RouteProtocol `yaml:"protocol"`
 }
 
+// DeepCopy generates a deep copy of RouteStatusSpec.
+func (spec RouteStatusSpec) DeepCopy() RouteStatusSpec {
+	return spec
+}
+
 // NewRouteStatus initializes a RouteStatus resource.
 func NewRouteStatus(namespace resource.Namespace, id resource.ID) *RouteStatus {
-	r := &RouteStatus{
-		md:   resource.NewMetadata(namespace, RouteStatusType, id, resource.VersionUndefined),
-		spec: RouteStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[RouteStatusSpec, RouteStatusRD](
+		resource.NewMetadata(namespace, RouteStatusType, id, resource.VersionUndefined),
+		RouteStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *RouteStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// RouteStatusRD provides auxiliary methods for RouteStatus.
+type RouteStatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *RouteStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *RouteStatus) DeepCopy() resource.Resource {
-	return &RouteStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *RouteStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (RouteStatusRD) ResourceDefinition(resource.Metadata, RouteStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             RouteStatusType,
 		Aliases:          []resource.Type{"route", "routes"},
@@ -92,9 +76,4 @@ func (r *RouteStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *RouteStatus) TypedSpec() *RouteStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/network/status.go
+++ b/pkg/machinery/resources/network/status.go
@@ -7,16 +7,14 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // StatusType is type of Status resource.
 const StatusType = resource.Type("NetworkStatuses.net.talos.dev")
 
 // Status resource holds status of networking setup.
-type Status struct {
-	md   resource.Metadata
-	spec StatusSpec
-}
+type Status = typed.Resource[StatusSpec, StatusRD]
 
 // StatusSpec describes network state.
 type StatusSpec struct {
@@ -26,50 +24,31 @@ type StatusSpec struct {
 	EtcFilesReady     bool `yaml:"etcFilesReady"`
 }
 
+// DeepCopy generates a deep copy of StatusSpec.
+func (spec StatusSpec) DeepCopy() StatusSpec {
+	return spec
+}
+
 // StatusID is the resource ID of the singleton instance.
 const StatusID resource.ID = "status"
 
 // NewStatus initializes a Status resource.
 func NewStatus(namespace resource.Namespace, id resource.ID) *Status {
-	r := &Status{
-		md:   resource.NewMetadata(namespace, StatusType, id, resource.VersionUndefined),
-		spec: StatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[StatusSpec, StatusRD](
+		resource.NewMetadata(namespace, StatusType, id, resource.VersionUndefined),
+		StatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Status) Metadata() *resource.Metadata {
-	return &r.md
-}
+// StatusRD provides auxiliary methods for Status.
+type StatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Status) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Status) DeepCopy() resource.Resource {
-	return &Status{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Status) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (StatusRD) ResourceDefinition(resource.Metadata, StatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             StatusType,
 		Aliases:          []resource.Type{"netstatus", "netstatuses"},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Status) TypedSpec() *StatusSpec {
-	return &r.spec
 }


### PR DESCRIPTION
Refactor all types except LinkStatus and LinkRefresh to use typed.Resource.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5379)
<!-- Reviewable:end -->
