### PR TITLE
feat: add support for equinix metal events

### DIFF
--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -159,6 +159,10 @@ func RunInstallerContainer(disk, platform, ref string, cfg config.Provider, opts
 		args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", constants.KernelParamLoggingKernel, *c))
 	}
 
+	if c := procfs.ProcCmdline().Get(constants.KernelParamEquinixMetalEvents).First(); c != nil {
+		args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", constants.KernelParamEquinixMetalEvents, *c))
+	}
+
 	specOpts := []oci.SpecOpts{
 		oci.WithImageConfig(img),
 		oci.WithProcessArgs(args...),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -5,13 +5,17 @@
 package equinixmetal
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net"
+	"net/http"
+	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
+	"github.com/talos-systems/go-retry/retry"
 	"inet.af/netaddr"
 
 	networkadapter "github.com/talos-systems/talos/internal/app/machined/pkg/adapters/network"
@@ -19,9 +23,26 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/download"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
+
+const (
+	EventTypeActivate     = "activate"
+	EventTypeFailure      = "failure"
+	EventTypeInfo         = "info"
+	EventTypeConfigLoaded = "talos.prov.config.loaded"
+	EventTypeRebooted     = "talos.prov.host.rebooted"
+	EventTypeInstalled    = "talos.prov.os.installed"
+	EventTypeUpgraded     = "talos.prov.os.upgraded"
+)
+
+// Event holds data to pass to the Equinix Metal event URL
+type Event struct {
+	Type    string `json:"type"`
+	Message string `json:"msg"`
+}
 
 // Metadata holds equinixmetal metadata info.
 type Metadata struct {
@@ -324,4 +345,32 @@ func (p *EquinixMetal) NetworkConfiguration(ctx context.Context, ch chan<- *runt
 	}
 
 	return nil
+}
+
+// FireEvent will take an event and pass it to an events server.
+// nb: This is currently only used with Equinix Metal but we may find interesting ways
+// to extend it for other event servers (Azure may have something similar?)
+func (p *EquinixMetal) FireEvent(ctx context.Context, event Event) error {
+	var eventURL *string
+	if eventURL = procfs.ProcCmdline().Get(constants.KernelParamEquinixMetalEvents).First(); eventURL == nil {
+		return errors.ErrNoEventURL
+	}
+
+	eventData, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	err = retry.Constant(5*time.Minute,
+		retry.WithUnits(time.Second),
+		retry.WithErrorLogging(true)).RetryWithContext(
+		ctx,
+		func(ctx context.Context) error {
+			_, err = http.Post(*eventURL, "application/json", bytes.NewBuffer(eventData))
+
+			return retry.ExpectedError(err)
+		},
+	)
+
+	return err
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
@@ -14,3 +14,6 @@ var ErrNoHostname = errors.New("failed to fetch hostname from metadata service")
 
 // ErrNoExternalIPs indicates that the meta server does not have a external addresses.
 var ErrNoExternalIPs = errors.New("failed to fetch external addresses from metadata service")
+
+// ErrNoEventURL indicates that the platform does not have an expected events URL in the kernel params.
+var ErrNoEventURL = errors.New("no event URL")

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -86,8 +86,12 @@ const (
 	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
 	KernelParamPanic = "panic"
 
-	// KernelParamSideroLink is the kernel paramater name to specify SideroLink API endpoint.
+	// KernelParamSideroLink is the kernel parameter name to specify SideroLink API endpoint.
 	KernelParamSideroLink = "siderolink.api"
+
+	// KernelParamEquinixMetalEvents is the kernel parameter name to specify the Equinix Metal phone home endpoint.
+	// This param is injected by Equinix Metal and depends on the device ID and datacenter.
+	KernelParamEquinixMetalEvents = "em.events_url"
 
 	// NewRoot is the path where the switchroot target is mounted.
 	NewRoot = "/root"

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -80,7 +80,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	cmdline.Append("talos.shutdown", "halt")
 
 	// Talos config
-	cmdline.Append("talos.platform", "metal")
+	cmdline.Append("talos.platform", "packet")
 
 	// add overrides
 	if nodeReq.ExtraKernelArgs != nil {


### PR DESCRIPTION
This PR gets us closer to being a supported option on Equinix Metal. We
now look for a new kernel arg `em.events_url` and will send events there
based on the state of our install. These events are then presented to
the user in the GUI or via calls to the EM API.

*** Note: this is currently a WIP as the EM folks aren't yet ready to
test this out ***

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5380)
<!-- Reviewable:end -->
