### PR TITLE
fix: provide logger to the etcd snapshot restore

### DIFF
--- a/cmd/talosctl/cmd/talos/bootstrap.go
+++ b/cmd/talosctl/cmd/talos/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	snapshot "go.etcd.io/etcd/etcdutl/v3/snapshot"
 
+	"github.com/talos-systems/talos/pkg/logging"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
@@ -37,7 +38,7 @@ Talos etcd cluster can be recovered from a known snapshot with '--recover-from='
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			if bootstrapCmdFlags.recoverFrom != "" {
-				manager := snapshot.NewV3(nil)
+				manager := snapshot.NewV3(logging.Wrap(os.Stderr))
 
 				status, err := manager.Status(bootstrapCmdFlags.recoverFrom)
 				if err != nil {

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/talos-systems/talos/pkg/cli"
+	"github.com/talos-systems/talos/pkg/logging"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
@@ -192,7 +193,7 @@ var etcdSnapshotCmd = &cobra.Command{
 
 			fmt.Printf("etcd snapshot saved to %q (%d bytes)\n", dbPath, size)
 
-			manager := snapshot.NewV3(nil)
+			manager := snapshot.NewV3(logging.Wrap(os.Stderr))
 
 			status, err := manager.Status(dbPath)
 			if err != nil {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/etcd"
 	"github.com/talos-systems/talos/pkg/argsbuilder"
 	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/logging"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/machinery/resources/network"
@@ -650,7 +651,7 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime) error
 
 // recoverFromSnapshot recovers etcd data directory from the snapshot uploaded previously.
 func (e *Etcd) recoverFromSnapshot(hostname, primaryAddr string) error {
-	manager := snapshot.NewV3(nil)
+	manager := snapshot.NewV3(logging.Wrap(log.Writer()))
 
 	status, err := manager.Status(constants.EtcdRecoverySnapshotPath)
 	if err != nil {


### PR DESCRIPTION
With update of the client library to 3.5.3, etcd library started using
the logger, so using `nil` isn't fine anymore.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit 68dfdd3311c602faaeb5e5f7970c0e7d13a32600)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5383)
<!-- Reviewable:end -->
