### PR TITLE
fix: detect lingering mounts in the installer correctly

### DIFF
--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -227,7 +227,7 @@ func (m *Manifest) checkMounts(device Device) error {
 					}
 				}
 
-				if fields[len(fields)-2] == device.Device {
+				if strings.HasPrefix(fields[len(fields)-2], device.Device) {
 					return fmt.Errorf("found active mount in %q for %q: %s", path, device.Device, scanner.Text())
 				}
 			}


### PR DESCRIPTION
Not sure how and when it got broken, but we're looking for mounts for
the blockdevice (like `/dev/vda`), while the actual mount info contains
the partition device (like `/dev/vda6`).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5384)
<!-- Reviewable:end -->
