### PR TITLE
docs: improve latest-version banner

### DIFF
--- a/website/assets/scss/_styles_project.scss
+++ b/website/assets/scss/_styles_project.scss
@@ -1,0 +1,5 @@
+.version-banner {
+    position: sticky;
+    top: 5rem;
+    z-index: 1;
+}

--- a/website/layouts/partials/doc_latest_version.html
+++ b/website/layouts/partials/doc_latest_version.html
@@ -1,0 +1,10 @@
+{{ $page := .Site.Params.url_latest_version }}
+{{ $doc_latest_version := replaceRE (.Section | printf "^/%s") .Site.Params.url_latest_version .Page.RelPermalink | path.Clean }}
+{{ range $p := (where .Site.Pages "Section" (.Site.Params.url_latest_version | strings.TrimPrefix "/")) }}
+{{ $page = cond (eq $doc_latest_version ($p.RelPermalink | path.Clean)) $p.RelPermalink $page }}
+{{ range .Aliases }}
+{{ $alias := cond (hasPrefix . "/") . (path.Join $p.RelPermalink ".." .) }}
+{{ $page = cond (eq $alias $doc_latest_version) $p.RelPermalink $page}}
+{{ end }}
+{{ end }}
+{{ return $page }}

--- a/website/layouts/partials/version-banner.html
+++ b/website/layouts/partials/version-banner.html
@@ -1,0 +1,28 @@
+<!-- Check the variable that indicates whether this is an archived doc set.
+  If yes, display a banner. -->
+{{ $latest_version := .Site.Params.url_latest_version }}
+{{ $current_version := .Section | printf "/%s" }}
+{{ $latest_doc := partial "doc_latest_version.html" . }}
+
+{{ if .FirstSection.Params.prerelease }}
+  {{ $color := "info" }}
+  <div class="version-banner pageinfo pageinfo-{{ $color }}">
+    {{ with $current_version }}<p>Version {{ trim . "/" | markdownify }} of the
+      documentation is for the Talos version being developed.
+      {{ with $latest_version }}For the latest stable version of Talos, see the
+        <a href="{{ $latest_doc | safeURL }}">latest version</a>.</p>
+      {{ end }}
+    {{ end }}
+  </div>
+{{ else if ne $latest_version $current_version }}
+  {{ $color := "warning" }}
+  <div class="version-banner pageinfo pageinfo-{{ $color }}">
+    {{ with $current_version }}<p>Version {{ trim . "/" | markdownify }} of the
+      documentation is no longer actively maintained. The site that you are
+      currently viewing is an archived snapshot.
+      {{ with $latest_version }}For up-to-date documentation, see the
+        <a href="{{ $latest_doc | safeURL }}">latest version</a>.</p>
+      {{ end }}
+    {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
Make the latest-version banner sticky and
more noticable, and ensure the link to the
latest version links to the current document
if possible.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5389)
<!-- Reviewable:end -->
