### PR TITLE
docs: add canonical link ref

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "cd website && hugo --gc --minify"
+command = "cd website && hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"
 publish = "website/public"
 
 [build.environment]

--- a/website/layouts/partials/hooks/head-end.html
+++ b/website/layouts/partials/hooks/head-end.html
@@ -4,3 +4,15 @@
 {{ if (findRE "<pre" .Content 1) }}
     <link rel="stylesheet" href="/css/clipboard.css">
 {{ end }}
+
+<!--- https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls?hl=en#rel-canonical-link-method -->
+{{ if .Section }}
+  {{ $latest_version := .Site.Params.url_latest_version }}
+  {{ $current_version := .Section | printf "/%s" }}
+  {{ if ne $latest_version $current_version }}
+    {{ $latest_doc := partial "doc_latest_version.html" . }}
+    {{ if ne $latest_doc $latest_version }}
+      <link rel="canonical" href="{{ $latest_doc | safeURL | absURL }}" />
+    {{ end }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Adds a canonical link tag to doc pages
to help SEO find the current version of
documentation.

Closes #5336

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5391)
<!-- Reviewable:end -->
