### PR TITLE
docs: fix the docs reference to star registry redirects

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1284,7 +1284,6 @@ type RegistriesConfig struct {
 	//
 	//     Registry name is the first segment of image identifier, with 'docker.io'
 	//     being default one.
-	//     To catch any registry names not specified explicitly, use '*'.
 	//   examples:
 	//     - value: machineConfigRegistryMirrorsExample
 	RegistryMirrors map[string]*RegistryMirrorConfig `yaml:"mirrors,omitempty"`

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -891,7 +891,7 @@ func init() {
 	RegistriesConfigDoc.Fields[0].Name = "mirrors"
 	RegistriesConfigDoc.Fields[0].Type = "map[string]RegistryMirrorConfig"
 	RegistriesConfigDoc.Fields[0].Note = ""
-	RegistriesConfigDoc.Fields[0].Description = "Specifies mirror configuration for each registry.\nThis setting allows to use local pull-through caching registires,\nair-gapped installations, etc.\n\nRegistry name is the first segment of image identifier, with 'docker.io'\nbeing default one.\nTo catch any registry names not specified explicitly, use '*'."
+	RegistriesConfigDoc.Fields[0].Description = "Specifies mirror configuration for each registry.\nThis setting allows to use local pull-through caching registires,\nair-gapped installations, etc.\n\nRegistry name is the first segment of image identifier, with 'docker.io'\nbeing default one."
 	RegistriesConfigDoc.Fields[0].Comments[encoder.LineComment] = "Specifies mirror configuration for each registry."
 
 	RegistriesConfigDoc.Fields[0].AddExample("", machineConfigRegistryMirrorsExample)

--- a/website/content/v1.1/reference/configuration.md
+++ b/website/content/v1.1/reference/configuration.md
@@ -2684,7 +2684,6 @@ air-gapped installations, etc.
 
 Registry name is the first segment of image identifier, with 'docker.io'
 being default one.
-To catch any registry names not specified explicitly, use '*'.
 
 
 


### PR DESCRIPTION
Since Talos moved to new registry redirect CRI plugin format, start
redirects are no longer supported in the CRI plugin (see
https://github.com/containerd/containerd/blob/main/docs/hosts.md).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5396)
<!-- Reviewable:end -->
