### PR TITLE
chore: allow mounting files from the host

### DIFF
--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -6,6 +6,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -102,6 +103,13 @@ func (svc *Extension) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	for _, mount := range svc.Spec.Container.Mounts {
+		if _, err := os.Stat(mount.Source); err == nil {
+			// already exists, skip
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+
 		if err := os.MkdirAll(mount.Source, 0o700); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow mounting files from host into extension services as per the [OCI
spec](https://github.com/opencontainers/runtime-spec/blob/main/config.md#mounts)

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5403)
<!-- Reviewable:end -->
