### PR TITLE
feat: use discovery information for etcd join (and other etcd calls)

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -496,7 +496,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 	}
 
 	if s.Controller.Runtime().Config().Machine().Type() != machinetype.TypeWorker && !in.GetForce() {
-		client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().Config().Cluster().CA(), s.Controller.Runtime().Config().Cluster().Endpoint())
+		client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create etcd client: %w", err)
 		}
@@ -1782,7 +1782,7 @@ func (s *Server) EtcdMemberList(ctx context.Context, in *machine.EtcdMemberListR
 	if in.QueryLocal {
 		client, err = etcd.NewLocalClient()
 	} else {
-		client, err = etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().Config().Cluster().CA(), s.Controller.Runtime().Config().Cluster().Endpoint())
+		client, err = etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 	}
 
 	if err != nil {
@@ -1834,7 +1834,7 @@ func (s *Server) EtcdRemoveMember(ctx context.Context, in *machine.EtcdRemoveMem
 		return nil, err
 	}
 
-	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().Config().Cluster().CA(), s.Controller.Runtime().Config().Cluster().Endpoint())
+	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %w", err)
 	}
@@ -1863,7 +1863,7 @@ func (s *Server) EtcdLeaveCluster(ctx context.Context, in *machine.EtcdLeaveClus
 		return nil, err
 	}
 
-	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().Config().Cluster().CA(), s.Controller.Runtime().Config().Cluster().Endpoint())
+	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %w", err)
 	}
@@ -1892,7 +1892,7 @@ func (s *Server) EtcdForfeitLeadership(ctx context.Context, in *machine.EtcdForf
 		return nil, err
 	}
 
-	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().Config().Cluster().CA(), s.Controller.Runtime().Config().Cluster().Endpoint())
+	client, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %w", err)
 	}

--- a/internal/app/machined/pkg/controllers/k8s/endpoint.go
+++ b/internal/app/machined/pkg/controllers/k8s/endpoint.go
@@ -19,6 +19,12 @@ import (
 	"inet.af/netaddr"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/kubernetes"
@@ -26,6 +32,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/machinery/resources/config"
 	"github.com/talos-systems/talos/pkg/machinery/resources/k8s"
+	"github.com/talos-systems/talos/pkg/machinery/resources/secrets"
 )
 
 // EndpointController looks up control plane endpoints.
@@ -38,14 +45,7 @@ func (ctrl *EndpointController) Name() string {
 
 // Inputs implements controller.Controller interface.
 func (ctrl *EndpointController) Inputs() []controller.Input {
-	return []controller.Input{
-		{
-			Namespace: config.NamespaceName,
-			Type:      config.MachineTypeType,
-			ID:        pointer.ToString(config.MachineTypeID),
-			Kind:      controller.InputWeak,
-		},
-	}
+	return nil
 }
 
 // Outputs implements controller.Controller interface.
@@ -59,7 +59,20 @@ func (ctrl *EndpointController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
+//
+//nolint:gocyclo
 func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if err := r.UpdateInputs([]controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineTypeType,
+			ID:        pointer.ToString(config.MachineTypeID),
+			Kind:      controller.InputWeak,
+		},
+	}); err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -78,25 +91,27 @@ func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, l
 
 		machineType := machineTypeRes.(*config.MachineType).MachineType()
 
-		if machineType != machine.TypeWorker {
-			// TODO: implemented only for machine.TypeWorker for now, should be extended to support control plane machines (for etcd join).
-			continue
-		}
-
-		logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
-
-		if err = conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
-			return err
-		}
-
-		if err = ctrl.watchEndpoints(ctx, r, logger); err != nil {
-			return err
+		switch machineType { //nolint:exhaustive
+		case machine.TypeWorker:
+			if err = ctrl.watchEndpointsOnWorker(ctx, r, logger); err != nil {
+				return err
+			}
+		case machine.TypeControlPlane, machine.TypeInit:
+			if err = ctrl.watchEndpointsOnControlPlane(ctx, r, logger); err != nil {
+				return err
+			}
 		}
 	}
 }
 
 //nolint:gocyclo
-func (ctrl *EndpointController) watchEndpoints(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *EndpointController) watchEndpointsOnWorker(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
+
+	if err := conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+		return err
+	}
+
 	client, err := kubernetes.NewClientFromKubeletKubeconfig()
 	if err != nil {
 		return fmt.Errorf("error building Kubernetes client: %w", err)
@@ -114,38 +129,157 @@ func (ctrl *EndpointController) watchEndpoints(ctx context.Context, r controller
 			return fmt.Errorf("error getting endpoints: %w", err)
 		}
 
-		addrs := []netaddr.IP{}
-
-		for _, endpoint := range endpoints.Subsets {
-			for _, addr := range endpoint.Addresses {
-				ip, err := netaddr.ParseIP(addr.IP)
-				if err == nil {
-					addrs = append(addrs, ip)
-				}
-			}
-		}
-
-		sort.Slice(addrs, func(i, j int) bool { return addrs[i].Compare(addrs[j]) < 0 })
-
-		if err := r.Modify(ctx,
-			k8s.NewEndpoint(k8s.ControlPlaneNamespaceName, k8s.ControlPlaneAPIServerEndpointsID),
-			func(r resource.Resource) error {
-				if !reflect.DeepEqual(r.(*k8s.Endpoint).TypedSpec().Addresses, addrs) {
-					logger.Debug("updated controlplane endpoints", zap.Any("endpoints", addrs))
-				}
-
-				r.(*k8s.Endpoint).TypedSpec().Addresses = addrs
-
-				return nil
-			},
-		); err != nil {
-			return fmt.Errorf("error updating endpoints: %w", err)
+		if err = ctrl.updateEndpointsResource(ctx, r, logger, endpoints); err != nil {
+			return err
 		}
 
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+		case <-r.EventCh():
 		}
 	}
+}
+
+//nolint:gocyclo
+func (ctrl *EndpointController) watchEndpointsOnControlPlane(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if err := r.UpdateInputs([]controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineTypeType,
+			ID:        pointer.ToString(config.MachineTypeID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: secrets.NamespaceName,
+			Type:      secrets.KubernetesType,
+			ID:        pointer.ToString(secrets.KubernetesID),
+			Kind:      controller.InputWeak,
+		},
+	}); err != nil {
+		return err
+	}
+
+	r.QueueReconcile()
+
+	for {
+		select {
+		case <-r.EventCh():
+		case <-ctx.Done():
+			return nil
+		}
+
+		secretsResources, err := r.Get(ctx, resource.NewMetadata(secrets.NamespaceName, secrets.KubernetesType, secrets.KubernetesID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		secrets := secretsResources.(*secrets.Kubernetes).Certs()
+
+		kubeconfig, err := clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+			// using here kubeconfig with cluster control plane endpoint, as endpoint discovery should work before local API server is ready
+			return clientcmd.Load([]byte(secrets.AdminKubeconfig))
+		})
+		if err != nil {
+			return fmt.Errorf("error loading kubeconfig: %w", err)
+		}
+
+		if err = ctrl.watchKubernetesEndpoint(ctx, r, logger, kubeconfig); err != nil {
+			return err
+		}
+	}
+}
+
+func (ctrl *EndpointController) updateEndpointsResource(ctx context.Context, r controller.Runtime, logger *zap.Logger, endpoints *corev1.Endpoints) error {
+	addrs := []netaddr.IP{}
+
+	for _, endpoint := range endpoints.Subsets {
+		for _, addr := range endpoint.Addresses {
+			ip, err := netaddr.ParseIP(addr.IP)
+			if err == nil {
+				addrs = append(addrs, ip)
+			}
+		}
+	}
+
+	sort.Slice(addrs, func(i, j int) bool { return addrs[i].Compare(addrs[j]) < 0 })
+
+	if err := r.Modify(ctx,
+		k8s.NewEndpoint(k8s.ControlPlaneNamespaceName, k8s.ControlPlaneAPIServerEndpointsID),
+		func(r resource.Resource) error {
+			if !reflect.DeepEqual(r.(*k8s.Endpoint).TypedSpec().Addresses, addrs) {
+				logger.Debug("updated controlplane endpoints", zap.Any("endpoints", addrs))
+			}
+
+			r.(*k8s.Endpoint).TypedSpec().Addresses = addrs
+
+			return nil
+		},
+	); err != nil {
+		return fmt.Errorf("error updating endpoints: %w", err)
+	}
+
+	return nil
+}
+
+func (ctrl *EndpointController) watchKubernetesEndpoint(ctx context.Context, r controller.Runtime, logger *zap.Logger, kubeconfig *rest.Config) error {
+	client, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("error building Kubernetes client: %w", err)
+	}
+
+	defer client.Close() //nolint:errcheck
+
+	// abort the watch on any return from this function
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	notifyCh := kubernetesEndpointWatcher(ctx, logger, client)
+
+	for {
+		select {
+		case endpoints := <-notifyCh:
+			if err = ctrl.updateEndpointsResource(ctx, r, logger, endpoints); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+			// something got updated, probably kubeconfig, restart the watch
+			r.QueueReconcile()
+
+			return nil
+		}
+	}
+}
+
+func kubernetesEndpointWatcher(ctx context.Context, logger *zap.Logger, client *kubernetes.Client) chan *corev1.Endpoints {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		client.Clientset, 30*time.Second,
+		informers.WithNamespace(corev1.NamespaceDefault),
+		informers.WithTweakListOptions(func(options *v1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", "kubernetes").String()
+		}),
+	)
+
+	notifyCh := make(chan *corev1.Endpoints, 1)
+
+	informer := informerFactory.Core().V1().Endpoints().Informer()
+	informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) { //nolint:errcheck
+		logger.Error("kubernetes endpoint watch error", zap.Error(err))
+	})
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { notifyCh <- obj.(*corev1.Endpoints) },
+		DeleteFunc: func(_ interface{}) { notifyCh <- &corev1.Endpoints{} },
+		UpdateFunc: func(_, obj interface{}) { notifyCh <- obj.(*corev1.Endpoints) },
+	})
+
+	informerFactory.Start(ctx.Done())
+
+	return notifyCh
 }

--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -132,7 +132,7 @@ func (ctrl *ManifestApplyController) Run(ctx context.Context, r controller.Runti
 			)
 
 			kubeconfig, err = clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
-				return clientcmd.Load([]byte(secrets.AdminKubeconfig))
+				return clientcmd.Load([]byte(secrets.LocalhostAdminKubeconfig))
 			})
 			if err != nil {
 				return fmt.Errorf("error loading kubeconfig: %w", err)

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
@@ -236,6 +236,7 @@ func (suite *KubernetesSuite) TestReconcile() {
 				for _, kubeconfig := range []string{
 					kubernetesCerts.ControllerManagerKubeconfig,
 					kubernetesCerts.SchedulerKubeconfig,
+					kubernetesCerts.LocalhostAdminKubeconfig,
 					kubernetesCerts.AdminKubeconfig,
 				} {
 					config, err := clientcmd.Load([]byte(kubeconfig))

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1206,7 +1206,7 @@ func UncordonNode(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 // LeaveEtcd represents the task for removing a control plane node from etcd.
 func LeaveEtcd(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
+		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.State().V1Alpha2().Resources())
 		if err != nil {
 			return fmt.Errorf("failed to create etcd client: %w", err)
 		}

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -343,7 +343,7 @@ func addMember(ctx context.Context, r runtime.Runtime, addrs []string, name stri
 		return nil, 0, fmt.Errorf("failed to generate etcd PKI: %w", err)
 	}
 
-	client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
+	client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.State().V1Alpha2().Resources())
 	if err != nil {
 		return nil, 0, err
 	}
@@ -691,7 +691,7 @@ func promoteMember(ctx context.Context, r runtime.Runtime, memberID uint64) erro
 		retry.WithJitter(time.Second),
 		retry.WithErrorLogging(true),
 	).RetryWithContext(ctx, func(ctx context.Context) error {
-		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
+		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.State().V1Alpha2().Resources())
 		if err != nil {
 			return retry.ExpectedError(err)
 		}

--- a/pkg/kubernetes/klog.go
+++ b/pkg/kubernetes/klog.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"io"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	// Kubernetes client likes to do calls to `klog` in random places which are not configurable.
+	// For Talos this means those logs are going to the console which doesn't look good.
+	klog.SetOutput(io.Discard)
+	klog.LogToStderr(false)
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -170,24 +170,6 @@ func (h *Client) Close() error {
 	return nil
 }
 
-// MasterIPs returns a list of control plane endpoints (IP addresses).
-func (h *Client) MasterIPs(ctx context.Context) (addrs []string, err error) {
-	endpoints, err := h.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	addrs = []string{}
-
-	for _, endpoint := range endpoints.Subsets {
-		for _, addr := range endpoint.Addresses {
-			addrs = append(addrs, addr.IP)
-		}
-	}
-
-	return addrs, nil
-}
-
 // NodeIPs returns list of node IP addresses by machine type.
 //
 //nolint:gocyclo

--- a/pkg/machinery/resources/secrets/kubernetes.go
+++ b/pkg/machinery/resources/secrets/kubernetes.go
@@ -30,7 +30,10 @@ type KubernetesCertsSpec struct {
 
 	SchedulerKubeconfig         string `yaml:"schedulerKubeconfig"`
 	ControllerManagerKubeconfig string `yaml:"controllerManagerKubeconfig"`
-	AdminKubeconfig             string `yaml:"adminKubeconfig"`
+
+	// Admin-level kubeconfig with access through the localhost endpoint and cluster endpoints.
+	LocalhostAdminKubeconfig string `yaml:"localhostAdminKubeconfig"`
+	AdminKubeconfig          string `yaml:"adminKubeconfig"`
 }
 
 // NewKubernetes initializes a Kubernetes resource.


### PR DESCRIPTION
Talos historically relied on `kubernetes` `Endpoints` resource (which
specifies `kube-apiserver` endpoints) to find other controlplane members
of the cluster to connect to the `etcd` nodes for the cluster (when node
local etcd instance is not up, for example). This method works great,
but it relies on Kubernetes endpoint being up. If the Kubernetes API is
down for whatever reason, or if the loadbalancer malfunctions, endpoints
are not available and join/leave operations don't work.

This PR replaces the endpoints lookup to use the `Endpoints` COSI
resource which is filled in using two methods:

* from the discovery data (if discovery is enabled, default to enabled)
* from the Kubernetes `Endpoints` resource

If the discovery is disabled (or not available), this change does almost
nothing: still Kubernetes is used to discover control plane endpoints,
but as the data persists in memory, even if the Kubernetes control plane
endpoint went down, cached copy will be used to connect to the endpoint.

If the discovery is enabled, Talos can join the etcd cluster immediately
on boot without waiting for Kubernetes to be up on the bootstrap node
which means that Talos cluster initial bootstrap runs in parallel on all
control plane nodes, while previously nodes were waiting for the first
node to finish bootstrap enough to fill in the endpoints data.

As the `etcd` communication is anyways protected with mutual TLS,
there's no risk even if the discovery data is stale or poisoned, as etcd
operations would fail on TLS mismatch.

Most of the changes in this PR actually enable populating Talos
`Endpoints` resource based on the `Kubernetes` `endpoints` resource
using the watch API.

Fixes #5343 

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5406)
<!-- Reviewable:end -->
