### PR TITLE
chore: tune QEMU disk provisioner options

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -253,7 +253,7 @@ func launchVM(config *LaunchConfig) error {
 	}
 
 	for _, disk := range config.DiskPaths {
-		args = append(args, "-drive", fmt.Sprintf("format=raw,if=virtio,file=%s", disk))
+		args = append(args, "-drive", fmt.Sprintf("format=raw,if=virtio,file=%s,cache=unsafe", disk))
 	}
 
 	machineArg := config.MachineType


### PR DESCRIPTION
As QEMU clusters are used for testing, use unsafe cache options to
reduce amount of fsyncs going to the host blockdevice.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5407)
<!-- Reviewable:end -->
