### PR TITLE
feat: increase aio-max-nr and inotify.max_user_instances

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -139,7 +139,11 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 		// configs inotify.
 		{
 			Key:   "proc.sys.fs.inotify.max_user_instances",
-			Value: "512",
+			Value: "8192",
+		},
+		{
+			Key:   "proc.sys.fs.aio-max-nr",
+			Value: "1048576",
 		},
 	}...)
 


### PR DESCRIPTION
Increase values:
- fs.aio-max-nr to 1048576 (for Ceph\Veritas\other storages)
- fs.inotify.max_user_instances to 8192 (since the usual 512 is too small today's needs)

There is no need to adjust fs.inotify.max_user_watches since it's set dynamically during startup by kernel.

Closes #5175

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5408)
<!-- Reviewable:end -->
