### PR TITLE
fix: strip 'v' prefix from versions on Kubernetes upgrade

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -66,6 +66,10 @@ var deprecations = map[string][]string{
 //
 //nolint:gocyclo,cyclop
 func UpgradeTalosManaged(ctx context.Context, cluster UpgradeProvider, options UpgradeOptions) error {
+	// strip leading `v` from Kubernetes version
+	options.FromVersion = strings.TrimLeft(options.FromVersion, "v")
+	options.ToVersion = strings.TrimLeft(options.ToVersion, "v")
+
 	switch path := options.Path(); path {
 	// nothing for all those
 	case "1.19->1.19":


### PR DESCRIPTION
This fixes an issue when `talosctl upgrade-k8s` fails with unhelpful
message if the version is specified as `v1.23.5` vs. `1.23.5`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5412)
<!-- Reviewable:end -->
