### PR TITLE
docs: fix analytics and sitemap

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,7 @@
 [build]
+command = "hugo --source website --gc --minify"
 publish = "website/public"
 
 [build.environment]
-BUILD_COMMAND = "hugo --source website --gc --minify"
 HUGO_VERSION = "0.95.0"
 NODE_VERSION = "16.13.2"
-
-[context.production]
-command = "$BUILD_COMMAND --baseURL $URL"
-
-[context.deploy-preview]
-command = "$BUILD_COMMAND --baseURL $DEPLOY_PRIME_URL"

--- a/website/config.toml
+++ b/website/config.toml
@@ -56,7 +56,7 @@ resampleFilter = "CatmullRom"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-141692582-2"
+id = "G-F7TDNSY952"
 
 [markup]
 [markup.goldmark]

--- a/website/layouts/partials/hooks/head-end.html
+++ b/website/layouts/partials/hooks/head-end.html
@@ -12,7 +12,7 @@
   {{ if ne $latest_version $current_version }}
     {{ $latest_doc := partial "doc_latest_version.html" . }}
     {{ if ne $latest_doc $latest_version }}
-      <link rel="canonical" href="{{ $latest_doc | safeURL | absURL }}" />
+      <link rel="canonical" href="https://www.talos.dev{{ $latest_doc | safeURL }}" />
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes the Google Analytics tracking ID and
restores the production sitemap.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5415)
<!-- Reviewable:end -->
