### PR TITLE
fix: trigger CRI config merge on correct resource update

### DIFF
--- a/internal/app/machined/pkg/controllers/files/cri_config_parts.go
+++ b/internal/app/machined/pkg/controllers/files/cri_config_parts.go
@@ -36,7 +36,7 @@ func (ctrl *CRIConfigPartsController) Inputs() []controller.Input {
 	return []controller.Input{
 		{
 			Namespace: files.NamespaceName,
-			Type:      files.EtcFileSpecType,
+			Type:      files.EtcFileStatusType,
 			ID:        pointer.ToString(constants.CRIRegistryConfigPart), // watch only registry configuration which might be updated
 			Kind:      controller.InputWeak,
 		},


### PR DESCRIPTION
When registry CRI config gets updated, contents of the file are written
to the `EtcFileSpec` resource, which gets rendered to disk and resource
`EtcFileStatus` is updated when the config is ready.

CRI config parts are merged from contents of `*.part` files which come
from system extensions and dynamic registry config which is written via
`EtcFileSpec` resource. As the controller was incorrectly triggered on
`EtcFileSpec` resource while reading files from disk, it might have read
stale contents of CRI config part (which hasn't been fully rendered to
disk), it might miss the latest content of the CRI config.

With the fix, controller is triggered on `EtcFileStatus` update, so when
the file is rendered to disk.

The symptom of the bug is the empty CRI registry config like:

```shell
$ talosctl read /etc/cri/conf.d/cri.toml

  ## /etc/cri/conf.d/00-base.part

version = 2

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
    runtime_type = "io.containerd.runc.v2"
    discard_unpacked_layers = true

  ## /etc/cri/conf.d/01-registries.part
```

Notice that the `01-registries.part` is empty.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5445)
<!-- Reviewable:end -->
