### PR TITLE
refactor: rewrite runtime resources to use typed.Resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/containernetworking/plugins v1.1.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63
+	github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.14+incompatible
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63 h1:z8IOq3C2m8V37jOOmRrON0I/5Mut7Ji/WNcfEO0/lbY=
-github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63/go.mod h1:CyH8WYzYaPNiLW7phc0VgYn/WxPPBlD4G6XGmO9BPbY=
+github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81 h1:qB3TKLl82/F8zHyPngGFPG4J/h26qrN0DxEJccPT+x4=
+github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81/go.mod h1:CyH8WYzYaPNiLW7phc0VgYn/WxPPBlD4G6XGmO9BPbY=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/pkg/machinery/extensions/config.go
+++ b/pkg/machinery/extensions/config.go
@@ -44,3 +44,8 @@ func (cfg *Config) Write(path string) error {
 
 	return yaml.NewEncoder(f).Encode(cfg)
 }
+
+// DeepCopy implements DeepCopyable.
+func (layer Layer) DeepCopy() Layer {
+	return layer
+}

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -9,7 +9,7 @@ replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20210315173758-8fb3
 require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/containerd/go-cni v1.1.4
-	github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63
+	github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -21,8 +21,8 @@ github.com/containerd/go-cni v1.1.4 h1:Mv3XkOjVsjTJHMpSi+dKZQPQGXEMpmXWs8oYZDaCK
 github.com/containerd/go-cni v1.1.4/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containernetworking/cni v1.0.1 h1:9OIL/sZmMYDBe+G8svzILAlulUpaDTUjeAbtH/JNLBo=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63 h1:z8IOq3C2m8V37jOOmRrON0I/5Mut7Ji/WNcfEO0/lbY=
-github.com/cosi-project/runtime v0.0.0-20220426085650-bb78834e8c63/go.mod h1:CyH8WYzYaPNiLW7phc0VgYn/WxPPBlD4G6XGmO9BPbY=
+github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81 h1:qB3TKLl82/F8zHyPngGFPG4J/h26qrN0DxEJccPT+x4=
+github.com/cosi-project/runtime v0.0.0-20220426184241-e22a85955e81/go.mod h1:CyH8WYzYaPNiLW7phc0VgYn/WxPPBlD4G6XGmO9BPbY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/machinery/resources/runtime/extension_status.go
+++ b/pkg/machinery/resources/runtime/extension_status.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 
 	"github.com/talos-systems/talos/pkg/machinery/extensions"
 )
@@ -15,46 +16,24 @@ import (
 const ExtensionStatusType = resource.Type("ExtensionStatuses.runtime.talos.dev")
 
 // ExtensionStatus resource holds status of installed system extensions.
-type ExtensionStatus struct {
-	md   resource.Metadata
-	spec ExtensionStatusSpec
-}
+type ExtensionStatus = typed.Resource[ExtensionStatusSpec, ExtensionStatusRD]
 
 // ExtensionStatusSpec is the spec for system extensions.
 type ExtensionStatusSpec = extensions.Layer
 
 // NewExtensionStatus initializes a ExtensionStatus resource.
 func NewExtensionStatus(namespace resource.Namespace, id resource.ID) *ExtensionStatus {
-	r := &ExtensionStatus{
-		md:   resource.NewMetadata(namespace, ExtensionStatusType, id, resource.VersionUndefined),
-		spec: ExtensionStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[ExtensionStatusSpec, ExtensionStatusRD](
+		resource.NewMetadata(namespace, ExtensionStatusType, id, resource.VersionUndefined),
+		ExtensionStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *ExtensionStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *ExtensionStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *ExtensionStatus) DeepCopy() resource.Resource {
-	return &ExtensionStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// ExtensionStatusRD is auxiliary resource data for ExtensionStatus.
+type ExtensionStatusRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *ExtensionStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (ExtensionStatusRD) ResourceDefinition(resource.Metadata, ExtensionStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             ExtensionStatusType,
 		Aliases:          []resource.Type{"extensions"},
@@ -70,9 +49,4 @@ func (r *ExtensionStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the ExtensionStatusSpec with the proper type.
-func (r *ExtensionStatus) TypedSpec() *ExtensionStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/runtime/kernel_module_spec.go
+++ b/pkg/machinery/resources/runtime/kernel_module_spec.go
@@ -7,16 +7,14 @@ package runtime
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // KernelModuleSpecType is type of KernelModuleSpec resource.
 const KernelModuleSpecType = resource.Type("KernelModuleSpecs.runtime.talos.dev")
 
 // KernelModuleSpec resource holds information about Linux kernel module to load.
-type KernelModuleSpec struct {
-	md   resource.Metadata
-	spec KernelModuleSpecSpec
-}
+type KernelModuleSpec = typed.Resource[KernelModuleSpecSpec, KernelModuleSpecRD]
 
 // KernelModuleSpecSpec describes Linux kernel module to load.
 type KernelModuleSpecSpec struct {
@@ -26,44 +24,25 @@ type KernelModuleSpecSpec struct {
 
 // NewKernelModuleSpec initializes a KernelModuleSpec resource.
 func NewKernelModuleSpec(namespace resource.Namespace, id resource.ID) *KernelModuleSpec {
-	r := &KernelModuleSpec{
-		md:   resource.NewMetadata(namespace, KernelModuleSpecType, id, resource.VersionUndefined),
-		spec: KernelModuleSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[KernelModuleSpecSpec, KernelModuleSpecRD](
+		resource.NewMetadata(namespace, KernelModuleSpecType, id, resource.VersionUndefined),
+		KernelModuleSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *KernelModuleSpec) Metadata() *resource.Metadata {
-	return &r.md
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec KernelModuleSpecSpec) DeepCopy() KernelModuleSpecSpec {
+	return spec
 }
 
-// Spec implements resource.Resource.
-func (r *KernelModuleSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KernelModuleSpec) DeepCopy() resource.Resource {
-	return &KernelModuleSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// KernelModuleSpecRD is auxiliary resource data for KernelModuleSpec.
+type KernelModuleSpecRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KernelModuleSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (KernelModuleSpecRD) ResourceDefinition(resource.Metadata, KernelModuleSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KernelModuleSpecType,
 		Aliases:          []resource.Type{"modules"},
 		DefaultNamespace: NamespaceName,
 	}
-}
-
-// TypedSpec allows to access the KernelModuleSpecSpec with the proper type.
-func (r *KernelModuleSpec) TypedSpec() *KernelModuleSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/runtime/kernel_params_spec.go
+++ b/pkg/machinery/resources/runtime/kernel_params_spec.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 
 	"github.com/talos-systems/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -26,10 +27,7 @@ type KernelParam interface {
 }
 
 // KernelParamSpec resource holds sysctl flags to define.
-type KernelParamSpec struct {
-	md   resource.Metadata
-	spec KernelParamSpecSpec
-}
+type KernelParamSpec = typed.Resource[KernelParamSpecSpec, KernelParamSpecRD]
 
 // KernelParamSpecSpec describes status of the defined sysctls.
 type KernelParamSpecSpec struct {
@@ -37,38 +35,24 @@ type KernelParamSpecSpec struct {
 	IgnoreErrors bool   `yaml:"ignoreErrors"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec KernelParamSpecSpec) DeepCopy() KernelParamSpecSpec {
+	return spec
+}
+
 // NewKernelParamSpec initializes a KernelParamSpec resource.
 func NewKernelParamSpec(namespace resource.Namespace, id resource.ID) *KernelParamSpec {
-	r := &KernelParamSpec{
-		md:   resource.NewMetadata(namespace, KernelParamSpecType, id, resource.VersionUndefined),
-		spec: KernelParamSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[KernelParamSpecSpec, KernelParamSpecRD](
+		resource.NewMetadata(namespace, KernelParamSpecType, id, resource.VersionUndefined),
+		KernelParamSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *KernelParamSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *KernelParamSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KernelParamSpec) DeepCopy() resource.Resource {
-	return &KernelParamSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// KernelParamSpecRD is the ResourceDefinition for KernelParamSpec.
+type KernelParamSpecRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KernelParamSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (KernelParamSpecRD) ResourceDefinition(resource.Metadata, KernelParamSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KernelParamSpecType,
 		Aliases:          []resource.Type{},
@@ -77,58 +61,29 @@ func (r *KernelParamSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// TypedSpec allows to access the KernelParamSpecSpec with the proper type.
-func (r *KernelParamSpec) TypedSpec() *KernelParamSpecSpec {
-	return &r.spec
-}
-
-// NewKernelParamDefaultSpec initializes a KernelParamSpec resource.
-func NewKernelParamDefaultSpec(namespace resource.Namespace, id resource.ID) *KernelParamDefaultSpec {
-	r := &KernelParamDefaultSpec{
-		md:   resource.NewMetadata(namespace, KernelParamDefaultSpecType, id, resource.VersionUndefined),
-		spec: KernelParamSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
-}
-
 // KernelParamDefaultSpec implements meta.ResourceDefinitionProvider interface.
-type KernelParamDefaultSpec struct {
-	md   resource.Metadata
-	spec KernelParamSpecSpec
+type KernelParamDefaultSpec = typed.Resource[KernelParamDefaultSpecSpec, KernelParamDefaultSpecRD]
+
+// KernelParamDefaultSpecSpec is same as KernelParamSpecSpec.
+type KernelParamDefaultSpecSpec = KernelParamSpecSpec
+
+// NewKernelParamDefaultSpec initializes a KernelParamDefaultSpec resource.
+func NewKernelParamDefaultSpec(namespace resource.Namespace, id resource.ID) *KernelParamDefaultSpec {
+	return typed.NewResource[KernelParamDefaultSpecSpec, KernelParamDefaultSpecRD](
+		resource.NewMetadata(namespace, KernelParamDefaultSpecType, id, resource.VersionUndefined),
+		KernelParamSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *KernelParamDefaultSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *KernelParamDefaultSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KernelParamDefaultSpec) DeepCopy() resource.Resource {
-	return &KernelParamDefaultSpec{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// KernelParamDefaultSpecRD is the ResourceDefinition for KernelParamDefaultSpec.
+type KernelParamDefaultSpecRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KernelParamDefaultSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (KernelParamDefaultSpecRD) ResourceDefinition(resource.Metadata, KernelParamDefaultSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KernelParamDefaultSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the KernelParamSpecSpec with the proper type.
-func (r *KernelParamDefaultSpec) TypedSpec() *KernelParamSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/runtime/kernel_params_status.go
+++ b/pkg/machinery/resources/runtime/kernel_params_status.go
@@ -7,16 +7,14 @@ package runtime
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // KernelParamStatusType is type of KernelParam resource.
 const KernelParamStatusType = resource.Type("KernelParamStatuses.runtime.talos.dev")
 
 // KernelParamStatus resource holds defined sysctl flags status.
-type KernelParamStatus struct {
-	md   resource.Metadata
-	spec KernelParamStatusSpec
-}
+type KernelParamStatus = typed.Resource[KernelParamStatusSpec, KernelParamStatusRD]
 
 // KernelParamStatusSpec describes status of the defined sysctls.
 type KernelParamStatusSpec struct {
@@ -27,36 +25,22 @@ type KernelParamStatusSpec struct {
 
 // NewKernelParamStatus initializes a KernelParamStatus resource.
 func NewKernelParamStatus(namespace resource.Namespace, id resource.ID) *KernelParamStatus {
-	r := &KernelParamStatus{
-		md:   resource.NewMetadata(namespace, KernelParamStatusType, id, resource.VersionUndefined),
-		spec: KernelParamStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[KernelParamStatusSpec, KernelParamStatusRD](
+		resource.NewMetadata(namespace, KernelParamStatusType, id, resource.VersionUndefined),
+		KernelParamStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *KernelParamStatus) Metadata() *resource.Metadata {
-	return &r.md
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec KernelParamStatusSpec) DeepCopy() KernelParamStatusSpec {
+	return spec
 }
 
-// Spec implements resource.Resource.
-func (r *KernelParamStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KernelParamStatus) DeepCopy() resource.Resource {
-	return &KernelParamStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// KernelParamStatusRD is auxiliary resource data for KernelParamStatus.
+type KernelParamStatusRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KernelParamStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (KernelParamStatusRD) ResourceDefinition(resource.Metadata, KernelParamStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KernelParamStatusType,
 		Aliases:          []resource.Type{"sysctls", "kernelparameters", "kernelparams"},
@@ -76,9 +60,4 @@ func (r *KernelParamStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the KernelParamStatusSpec with the proper type.
-func (r *KernelParamStatus) TypedSpec() *KernelParamStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/runtime/mount_status.go
+++ b/pkg/machinery/resources/runtime/mount_status.go
@@ -7,16 +7,14 @@ package runtime
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // MountStatusType is type of Mount resource.
 const MountStatusType = resource.Type("MountStatuses.runtime.talos.dev")
 
 // MountStatus resource holds defined sysctl flags status.
-type MountStatus struct {
-	md   resource.Metadata
-	spec MountStatusSpec
-}
+type MountStatus = typed.Resource[MountStatusSpec, MountStatusRD]
 
 // MountStatusSpec describes status of the defined sysctls.
 type MountStatusSpec struct {
@@ -28,36 +26,22 @@ type MountStatusSpec struct {
 
 // NewMountStatus initializes a MountStatus resource.
 func NewMountStatus(namespace resource.Namespace, id resource.ID) *MountStatus {
-	r := &MountStatus{
-		md:   resource.NewMetadata(namespace, MountStatusType, id, resource.VersionUndefined),
-		spec: MountStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[MountStatusSpec, MountStatusRD](
+		resource.NewMetadata(namespace, MountStatusType, id, resource.VersionUndefined),
+		MountStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *MountStatus) Metadata() *resource.Metadata {
-	return &r.md
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec MountStatusSpec) DeepCopy() MountStatusSpec {
+	return spec
 }
 
-// Spec implements resource.Resource.
-func (r *MountStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *MountStatus) DeepCopy() resource.Resource {
-	return &MountStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// MountStatusRD is auxiliary resource data for MountStatus.
+type MountStatusRD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *MountStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (MountStatusRD) ResourceDefinition(resource.Metadata, MountStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             MountStatusType,
 		Aliases:          []resource.Type{"mounts"},
@@ -77,9 +61,4 @@ func (r *MountStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the MountStatusSpec with the proper type.
-func (r *MountStatus) TypedSpec() *MountStatusSpec {
-	return &r.spec
 }


### PR DESCRIPTION
No functional changes.

Also bump bumped cosi-runtime with the fix for the UnmarshalProto.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5447)
<!-- Reviewable:end -->
