### PR TITLE
fix: include Go primitive types into unstructured deepcopy

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_unstructured.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_unstructured.go
@@ -55,8 +55,10 @@ func deepCopyUnstructured(x interface{}) interface{} {
 		}
 
 		return clone
-	case string, int64, bool, float64, nil:
+	case string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, complex64, complex128, nil:
 		return x
+	case []byte:
+		return append([]byte(nil), x...)
 	default:
 		panic(fmt.Errorf("cannot deep copy %T", x))
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_unstructured_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_unstructured_test.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+)
+
+func TestUnstructuredDeepCopy(t *testing.T) {
+	u := v1alpha1.Unstructured{
+		Object: map[string]interface{}{
+			"strings": map[string]interface{}{
+				"foo": "bar",
+			},
+			"numbers": []interface{}{
+				map[string]interface{}{
+					"int":    32,
+					"int8":   int8(34),
+					"byte":   byte(35),
+					"int16":  int16(36),
+					"int32":  int32(37),
+					"int64":  int64(38),
+					"uint":   uint(39),
+					"uint8":  uint8(40),
+					"uint16": uint16(41),
+					"uint32": uint32(42),
+					"uint64": uint64(43),
+				},
+				float32(44.0),
+				float64(45.0),
+				complex64(complex(46.0, 47.0)),
+				complex128(complex(48.0, 49.0)),
+			},
+			"bytes": []byte("abc"),
+		},
+	}
+
+	assert.Equal(t, u.DeepCopy(), &u)
+}


### PR DESCRIPTION
This code was written from JSON point of view, but
when YAML is unmarshaled,  we get more primitive Go types
as values, so why not include all of them?

This was showing as an error when applying a machine config e.g. for
kubelet extraArgs like:

```
shutdownGracePeriod: 0
```

Changing this to string fixes the problem, but it's not the best UX.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5453)
<!-- Reviewable:end -->
