### PR TITLE
feat: add bond slaves ordering

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/ordered"
 	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
 
@@ -244,13 +245,13 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 
 		linkSpecSpecs = append(linkSpecSpecs, bondLinkSpec)
 
-		for _, slave := range bondSlaves {
+		for idx, slave := range bondSlaves {
 			slaveLinkSpec := network.LinkSpecSpec{
 				Name:        slave,
 				Up:          true,
 				ConfigLayer: network.ConfigCmdline,
 			}
-			SetBondSlave(&slaveLinkSpec, bondName)
+			SetBondSlave(&slaveLinkSpec, ordered.MakePair(bondName, idx))
 			linkSpecSpecs = append(linkSpecSpecs, slaveLinkSpec)
 		}
 	}

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -63,14 +63,20 @@ func (suite *CmdlineSuite) TestParse() {
 				Up:          true,
 				Logical:     false,
 				ConfigLayer: netconfig.ConfigCmdline,
-				MasterName:  "bond0",
+				BondSlave: netconfig.BondSlave{
+					MasterName: "bond0",
+					SlaveIndex: 0,
+				},
 			},
 			{
 				Name:        "eth1",
 				Up:          true,
 				Logical:     false,
 				ConfigLayer: netconfig.ConfigCmdline,
-				MasterName:  "bond0",
+				BondSlave: netconfig.BondSlave{
+					MasterName: "bond0",
+					SlaveIndex: 1,
+				},
 			},
 		},
 	}
@@ -233,14 +239,20 @@ func (suite *CmdlineSuite) TestParse() {
 						Up:          true,
 						Logical:     false,
 						ConfigLayer: netconfig.ConfigCmdline,
-						MasterName:  "bond1",
+						BondSlave: netconfig.BondSlave{
+							MasterName: "bond1",
+							SlaveIndex: 0,
+						},
 					},
 					{
 						Name:        "eth4",
 						Up:          true,
 						Logical:     false,
 						ConfigLayer: netconfig.ConfigCmdline,
-						MasterName:  "bond1",
+						BondSlave: netconfig.BondSlave{
+							MasterName: "bond1",
+							SlaveIndex: 1,
+						},
 					},
 				},
 			},
@@ -275,14 +287,20 @@ func (suite *CmdlineSuite) TestParse() {
 						Up:          true,
 						Logical:     false,
 						ConfigLayer: netconfig.ConfigCmdline,
-						MasterName:  "bond1",
+						BondSlave: netconfig.BondSlave{
+							MasterName: "bond1",
+							SlaveIndex: 0,
+						},
 					},
 					{
 						Name:        "eth4",
 						Up:          true,
 						Logical:     false,
 						ConfigLayer: netconfig.ConfigCmdline,
-						MasterName:  "bond1",
+						BondSlave: netconfig.BondSlave{
+							MasterName: "bond1",
+							SlaveIndex: 1,
+						},
 					},
 				},
 			},

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -316,7 +316,7 @@ func (suite *LinkConfigSuite) TestMachineConfiguration() {
 						case "eth2", "eth3":
 							suite.Assert().True(r.TypedSpec().Up)
 							suite.Assert().False(r.TypedSpec().Logical)
-							suite.Assert().Equal("bond0", r.TypedSpec().MasterName)
+							suite.Assert().Equal("bond0", r.TypedSpec().BondSlave.MasterName)
 						case "bond0":
 							suite.Assert().True(r.TypedSpec().Up)
 							suite.Assert().True(r.TypedSpec().Logical)

--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -11,6 +11,7 @@ import (
 	networkadapter "github.com/talos-systems/talos/internal/app/machined/pkg/adapters/network"
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/machinery/ordered"
 	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
 
@@ -18,8 +19,11 @@ import (
 const DefaultRouteMetric = 1024
 
 // SetBondSlave sets the bond slave spec.
-func SetBondSlave(link *network.LinkSpecSpec, bondName string) {
-	link.MasterName = bondName
+func SetBondSlave(link *network.LinkSpecSpec, bond ordered.Pair[string, int]) {
+	link.BondSlave = network.BondSlave{
+		MasterName: bond.F1,
+		SlaveIndex: bond.F2,
+	}
 }
 
 // SetBondMaster sets the bond master spec.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -117,6 +117,8 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 		return nil, fmt.Errorf("error listing host interfaces: %w", err)
 	}
 
+	slaveIndex := 0
+
 	for _, iface := range equinixMetadata.Network.Interfaces {
 		if iface.Bond == "" {
 			continue
@@ -136,11 +138,15 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 
 				networkConfig.Links = append(networkConfig.Links,
 					network.LinkSpecSpec{
+						Name: hostIf.Name,
+						Up:   true,
+						BondSlave: network.BondSlave{
+							MasterName: bondName,
+							SlaveIndex: slaveIndex,
+						},
 						ConfigLayer: network.ConfigPlatform,
-						Name:        hostIf.Name,
-						Up:          true,
-						MasterName:  bondName,
 					})
+				slaveIndex++
 
 				break
 			}
@@ -154,8 +160,12 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 					ConfigLayer: network.ConfigPlatform,
 					Name:        iface.Name,
 					Up:          true,
-					MasterName:  bondName,
+					BondSlave: network.BondSlave{
+						MasterName: bondName,
+						SlaveIndex: slaveIndex,
+					},
 				})
+			slaveIndex++
 		}
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
@@ -33,6 +33,7 @@ links:
       kind: ""
       type: netrom
       masterName: bond0
+      slaveIndex: 1
       layer: platform
     - name: bond0
       logical: true

--- a/pkg/machinery/ordered/ordered.go
+++ b/pkg/machinery/ordered/ordered.go
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ordered
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+}
+
+// Pair is two element tuple of ordered values.
+type Pair[T1, T2 Ordered] struct {
+	F1 T1
+	F2 T2
+}
+
+// MakePair creates a new Pair.
+func MakePair[T1, T2 Ordered](v1 T1, v2 T2) Pair[T1, T2] {
+	return Pair[T1, T2]{
+		F1: v1,
+		F2: v2,
+	}
+}
+
+// Compare returns an integer comparing two pairs in natural order.
+// The result will be 0 if p == other, -1 if p < other, and +1 if p > other.
+func (p Pair[T1, T2]) Compare(other Pair[T1, T2]) int {
+	if result := cmp(p.F1, other.F1); result != 0 {
+		return result
+	}
+
+	return cmp(p.F2, other.F2)
+}
+
+// MoreThan checks if current pair is bigger than the other.
+func (p Pair[T1, T2]) MoreThan(other Pair[T1, T2]) bool {
+	return p.Compare(other) == 1
+}
+
+// LessThan checks if current pair is lesser than the other.
+func (p Pair[T1, T2]) LessThan(other Pair[T1, T2]) bool {
+	return p.Compare(other) == -1
+}
+
+// Equal checks if current pair is equal to the other.
+func (p Pair[T1, T2]) Equal(other Pair[T1, T2]) bool {
+	return p.Compare(other) == 0
+}
+
+func cmp[T Ordered](a, b T) int {
+	switch {
+	case a == b:
+		return 0
+	case a < b:
+		return -1
+	default:
+		return +1
+	}
+}

--- a/pkg/machinery/ordered/ordered_test.go
+++ b/pkg/machinery/ordered/ordered_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ordered_test
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/pkg/machinery/ordered"
+)
+
+func TestTriple(t *testing.T) {
+	t.Parallel()
+
+	expectedSlice := []ordered.Triple[int, string, float64]{
+		ordered.MakeTriple(math.MinInt64, "Alpha", 69.0),
+		ordered.MakeTriple(-200, "Alpha", 69.0),
+		ordered.MakeTriple(-200, "Beta", -69.0),
+		ordered.MakeTriple(-200, "Beta", 69.0),
+		ordered.MakeTriple(1, "", 69.0),
+		ordered.MakeTriple(1, "Alpha", 67.0),
+		ordered.MakeTriple(1, "Alpha", 68.0),
+		ordered.MakeTriple(10, "Alpha", 68.0),
+		ordered.MakeTriple(10, "Beta", 68.0),
+		ordered.MakeTriple(math.MaxInt64, "", 69.0),
+	}
+
+	seed := time.Now().Unix()
+	rnd := rand.New(rand.NewSource(seed))
+
+	for i := 0; i < 1000; i++ {
+		a := append([]ordered.Triple[int, string, float64](nil), expectedSlice...)
+		rnd.Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i] })
+		sort.Slice(a, func(i, j int) bool {
+			return a[i].LessThan(a[j])
+		})
+		require.Equal(t, expectedSlice, a, "failed with seed %d iteration %d", seed, i)
+	}
+}

--- a/pkg/machinery/ordered/triple.go
+++ b/pkg/machinery/ordered/triple.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ordered
+
+// Triple is three element tuple of ordered values.
+type Triple[T1, T2, T3 Ordered] struct {
+	V1 T1
+	V2 T2
+	V3 T3
+}
+
+// MakeTriple creates a new Triple.
+func MakeTriple[T1, T2, T3 Ordered](v1 T1, v2 T2, v3 T3) Triple[T1, T2, T3] {
+	return Triple[T1, T2, T3]{
+		V1: v1,
+		V2: v2,
+		V3: v3,
+	}
+}
+
+// Compare returns an integer comparing two triples in natural order.
+// The result will be 0 if t == other, -1 if t < other, and +1 if t > other.
+func (t Triple[T1, T2, T3]) Compare(other Triple[T1, T2, T3]) int {
+	if result := cmp(t.V1, other.V1); result != 0 {
+		return result
+	} else if result := cmp(t.V2, other.V2); result != 0 {
+		return result
+	}
+
+	return cmp(t.V3, other.V3)
+}
+
+// MoreThan checks if current triple is bigger than the other.
+func (t Triple[T1, T2, T3]) MoreThan(other Triple[T1, T2, T3]) bool {
+	return t.Compare(other) == 1
+}
+
+// LessThan checks if current triple is lesser than the other.
+func (t Triple[T1, T2, T3]) LessThan(other Triple[T1, T2, T3]) bool {
+	return t.Compare(other) == -1
+}
+
+// Equal checks if current triple is equal to the other.
+func (t Triple[T1, T2, T3]) Equal(other Triple[T1, T2, T3]) bool {
+	return t.Compare(other) == 0
+}

--- a/pkg/machinery/resources/network/link_spec_test.go
+++ b/pkg/machinery/resources/network/link_spec_test.go
@@ -26,7 +26,10 @@ func TestLinkSpecMarshalYAML(t *testing.T) {
 		Kind:       "eth",
 		Type:       nethelpers.LinkEther,
 		ParentName: "eth1",
-		MasterName: "bond0",
+		BondSlave: network.BondSlave{
+			MasterName: "bond0",
+			SlaveIndex: 0,
+		},
 		VLAN: network.VLANSpec{
 			VID:      25,
 			Protocol: nethelpers.VLANProtocol8021AD,


### PR DESCRIPTION
Before this change, we didn't preserve bonded interfaces ordering, which caused problems in some scenarios. Fix this by remembering their position in the original config.

Fixes #5207.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5455)
<!-- Reviewable:end -->
