### PR TITLE
fix: allow graceful node shutdown to be overridden

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
@@ -294,11 +294,11 @@ func NewKubeletConfiguration(clusterDNS []string, dnsDomain string, extraConfig 
 		config.Logging.Format = "json"
 	}
 
-	if config.ShutdownGracePeriod.Duration == 0 {
+	if _, overridden := extraConfig["shutdownGracePeriod"]; !overridden && config.ShutdownGracePeriod.Duration == 0 {
 		config.ShutdownGracePeriod = metav1.Duration{Duration: constants.KubeletShutdownGracePeriod}
 	}
 
-	if config.ShutdownGracePeriodCriticalPods.Duration == 0 {
+	if _, overridden := extraConfig["shutdownGracePeriodCriticalPods"]; !overridden && config.ShutdownGracePeriodCriticalPods.Duration == 0 {
 		config.ShutdownGracePeriodCriticalPods = metav1.Duration{Duration: constants.KubeletShutdownGracePeriodCriticalPods}
 	}
 

--- a/website/content/v1.1/learn-more/knowledge-base.md
+++ b/website/content/v1.1/learn-more/knowledge-base.md
@@ -1,0 +1,21 @@
+---
+title: "Knowledge Base"
+weight: 1999
+description: "Recipes for common configuration tasks with Talos Linux."
+---
+
+## Disabling `GracefulNodeShutdown` on a node
+
+Talos Linux enables [Graceful Node Shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) Kubernetes feature by default.
+
+If this feature should be disabled, modify the `kubelet` part of the machine configuration with:
+
+```yaml
+machine:
+  kubelet:
+    extraArgs:
+      feature-gates: GracefulNodeShutdown=false
+    extraConfig:
+      shutdownGracePeriod: 0s
+      shutdownGracePeriodCriticalPods: 0s
+```


### PR DESCRIPTION
The problem is that these values needs to be set to zero if the kubelet
feature gate is disabled, so we can't assume that we can override zero
value with the proper config, so we have to do an extra check on the
supplied configuration.

Also creates KB article on disabling this feature gate.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5456)
<!-- Reviewable:end -->
