### PR TITLE
fix: return an error if there is no byte slice in ReadonlyProvider

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_readonly_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_readonly_provider.go
@@ -5,6 +5,8 @@
 package v1alpha1
 
 import (
+	"errors"
+
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 )
@@ -57,15 +59,11 @@ func (r *ReadonlyProvider) Validate(mode config.RuntimeMode, opts ...config.Vali
 
 // Bytes returns source YAML representation (if available) or does default encoding.
 func (r *ReadonlyProvider) Bytes() ([]byte, error) {
-	if r.bytes != nil {
-		return r.bytes, nil
+	if r.bytes == nil {
+		return r.bytes, errors.New("incorrect provider state: bytes is nil")
 	}
 
-	var err error
-
-	r.bytes, err = r.EncodeBytes()
-
-	return r.bytes, err
+	return r.bytes, nil
 }
 
 // EncodeString implements the config.Provider interface.


### PR DESCRIPTION
Current code contains a data race, since access to r.bytes in Bytes() is unguarded and can be called from several goroutines. There is no need for it anyway, since WrapReadonly always gets a full slice. Refactor code to reflect that.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5457)
<!-- Reviewable:end -->
