### PR TITLE
docs: copy knowledge base to v1.0 docs

### DIFF
--- a/website/content/v1.0/learn-more/knowledge-base.md
+++ b/website/content/v1.0/learn-more/knowledge-base.md
@@ -1,0 +1,21 @@
+---
+title: "Knowledge Base"
+weight: 1999
+description: "Recipes for common configuration tasks with Talos Linux."
+---
+
+## Disabling `GracefulNodeShutdown` on a node
+
+Talos Linux enables [Graceful Node Shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) Kubernetes feature by default.
+
+If this feature should be disabled, modify the `kubelet` part of the machine configuration with:
+
+```yaml
+machine:
+  kubelet:
+    extraArgs:
+      feature-gates: GracefulNodeShutdown=false
+    extraConfig:
+      shutdownGracePeriod: 0s
+      shutdownGracePeriodCriticalPods: 0s
+```


### PR DESCRIPTION
As Talos v1.0.4 now supports kubelet with graceful shutdown disabled,
update the docs.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5464)
<!-- Reviewable:end -->
