### PR TITLE
Update VMware documentation to correct links

### DIFF
--- a/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
@@ -23,8 +23,8 @@ Using the VIP chosen in the prereq steps, we will now generate the base configur
 This can be done with the `talosctl gen config ...` command.
 Take note that we will also use a JSON6902 patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
 
-First, download `the cp.patch` to your local machine and edit the VIP to match your chosen IP.
-You can do this by issuing `https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/virtualized-platforms/vmware/cp.patch.yaml`.
+First, download `cp.patch.yaml` to your local machine and edit the VIP to match your chosen IP.
+You can do this by issuing: `curl -fsSLO https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml`.
 It's contents should look like the following:
 
 ```yaml
@@ -93,7 +93,7 @@ If you wish to carry out the manual approach, simply skip ahead to the "Manual A
 ### Scripted Install
 
 Download the `vmware.sh` script to your local machine.
-You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/virtualized-platforms/vmware/vmware.sh"`.
+You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/vmware.sh"`.
 This script has default variables for things like Talos version and cluster name that may be interesting to tweak before deploying.
 
 #### Import OVA


### PR DESCRIPTION
# Pull Request

## What? (description)
Fixed broken links and command in VMware documentation.

## Why? (reasoning)
The examples didn't work.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5470)
<!-- Reviewable:end -->
