### PR TITLE
chore: refactor remaining resources into typed.Resource

### DIFF
--- a/pkg/machinery/resources/files/etcfile_spec.go
+++ b/pkg/machinery/resources/files/etcfile_spec.go
@@ -9,16 +9,14 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // EtcFileSpecType is type of EtcFile resource.
 const EtcFileSpecType = resource.Type("EtcFileSpecs.files.talos.dev")
 
 // EtcFileSpec resource holds contents of the file which should be put to `/etc` directory.
-type EtcFileSpec struct {
-	md   resource.Metadata
-	spec EtcFileSpecSpec
-}
+type EtcFileSpec = typed.Resource[EtcFileSpecSpec, EtcFileSpecMD]
 
 // EtcFileSpecSpec describes status of rendered secrets.
 type EtcFileSpecSpec struct {
@@ -26,50 +24,31 @@ type EtcFileSpecSpec struct {
 	Mode     fs.FileMode `yaml:"mode"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (e EtcFileSpecSpec) DeepCopy() EtcFileSpecSpec {
+	return EtcFileSpecSpec{
+		Contents: append([]byte(nil), e.Contents...),
+		Mode:     e.Mode,
+	}
+}
+
 // NewEtcFileSpec initializes a EtcFileSpec resource.
 func NewEtcFileSpec(namespace resource.Namespace, id resource.ID) *EtcFileSpec {
-	r := &EtcFileSpec{
-		md:   resource.NewMetadata(namespace, EtcFileSpecType, id, resource.VersionUndefined),
-		spec: EtcFileSpecSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[EtcFileSpecSpec, EtcFileSpecMD](
+		resource.NewMetadata(namespace, EtcFileSpecType, id, resource.VersionUndefined),
+		EtcFileSpecSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *EtcFileSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *EtcFileSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *EtcFileSpec) DeepCopy() resource.Resource {
-	return &EtcFileSpec{
-		md: r.md,
-		spec: EtcFileSpecSpec{
-			Contents: append([]byte(nil), r.spec.Contents...),
-			Mode:     r.spec.Mode,
-		},
-	}
-}
+// EtcFileSpecMD provides auxiliary methods for EtcFileSpec.
+type EtcFileSpecMD struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *EtcFileSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+func (EtcFileSpecMD) ResourceDefinition(resource.Metadata, EtcFileSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             EtcFileSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *EtcFileSpec) TypedSpec() *EtcFileSpecSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/files/etcfile_status.go
+++ b/pkg/machinery/resources/files/etcfile_status.go
@@ -7,63 +7,42 @@ package files
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // EtcFileStatusType is type of EtcFile resource.
 const EtcFileStatusType = resource.Type("EtcFileStatuses.files.talos.dev")
 
 // EtcFileStatus resource holds contents of the file which should be put to `/etc` directory.
-type EtcFileStatus struct {
-	md   resource.Metadata
-	spec EtcFileStatusSpec
-}
+type EtcFileStatus = typed.Resource[EtcFileStatusSpec, EtcFileStatusMD]
 
 // EtcFileStatusSpec describes status of rendered secrets.
 type EtcFileStatusSpec struct {
 	SpecVersion string `yaml:"specVersion"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (e EtcFileStatusSpec) DeepCopy() EtcFileStatusSpec {
+	return e
+}
+
 // NewEtcFileStatus initializes a EtcFileStatus resource.
 func NewEtcFileStatus(namespace resource.Namespace, id resource.ID) *EtcFileStatus {
-	r := &EtcFileStatus{
-		md:   resource.NewMetadata(namespace, EtcFileStatusType, id, resource.VersionUndefined),
-		spec: EtcFileStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[EtcFileStatusSpec, EtcFileStatusMD](
+		resource.NewMetadata(namespace, EtcFileStatusType, id, resource.VersionUndefined),
+		EtcFileStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *EtcFileStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// EtcFileStatusMD provides auxiliary methods for EtcFileStatus.
+type EtcFileStatusMD struct{}
 
-// Spec implements resource.Resource.
-func (r *EtcFileStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *EtcFileStatus) DeepCopy() resource.Resource {
-	return &EtcFileStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *EtcFileStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (EtcFileStatusMD) ResourceDefinition(resource.Metadata, EtcFileStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             EtcFileStatusType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *EtcFileStatus) TypedSpec() *EtcFileStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/k8s/endpoint.go
+++ b/pkg/machinery/resources/k8s/endpoint.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -22,50 +23,33 @@ const ControlPlaneAPIServerEndpointsID = resource.ID("kube-apiserver")
 const ControlPlaneDiscoveredEndpointsID = resource.ID("discovery")
 
 // Endpoint resource holds definition of rendered secrets.
-type Endpoint struct {
-	md   resource.Metadata
-	spec EndpointSpec
-}
+type Endpoint = typed.Resource[EndpointSpec, EndpointRD]
 
 // EndpointSpec describes status of rendered secrets.
 type EndpointSpec struct {
 	Addresses []netaddr.IP `yaml:"addresses"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec EndpointSpec) DeepCopy() EndpointSpec {
+	return EndpointSpec{
+		Addresses: append([]netaddr.IP(nil), spec.Addresses...),
+	}
+}
+
 // NewEndpoint initializes a Endpoint resource.
 func NewEndpoint(namespace resource.Namespace, id resource.ID) *Endpoint {
-	r := &Endpoint{
-		md:   resource.NewMetadata(namespace, EndpointType, id, resource.VersionUndefined),
-		spec: EndpointSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[EndpointSpec, EndpointRD](
+		resource.NewMetadata(namespace, EndpointType, id, resource.VersionUndefined),
+		EndpointSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Endpoint) Metadata() *resource.Metadata {
-	return &r.md
-}
+// EndpointRD provides auxiliary methods for Endpoint.
+type EndpointRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Endpoint) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Endpoint) DeepCopy() resource.Resource {
-	return &Endpoint{
-		md: r.md,
-		spec: EndpointSpec{
-			Addresses: append([]netaddr.IP(nil), r.spec.Addresses...),
-		},
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Endpoint) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (EndpointRD) ResourceDefinition(resource.Metadata, EndpointSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             EndpointType,
 		Aliases:          []resource.Type{},
@@ -79,17 +63,12 @@ func (r *Endpoint) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Endpoint) TypedSpec() *EndpointSpec {
-	return &r.spec
-}
-
 // EndpointList is a flattened list of endpoints.
 type EndpointList []netaddr.IP
 
 // Merge endpoints from multiple Endpoint resources into a single list.
 func (l EndpointList) Merge(endpoint *Endpoint) EndpointList {
-	for _, ip := range endpoint.spec.Addresses {
+	for _, ip := range endpoint.TypedSpec().Addresses {
 		ip := ip
 
 		idx := sort.Search(len(l), func(i int) bool { return !l[i].Less(ip) })

--- a/pkg/machinery/resources/k8s/kubelet_lifecycle.go
+++ b/pkg/machinery/resources/k8s/kubelet_lifecycle.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // KubeletLifecycleType is type of KubeletLifecycle resource.
@@ -22,46 +23,27 @@ const KubeletLifecycleID = resource.ID("kubelet")
 //
 // KubeletLifecycle is mostly about status of the workloads kubelet is running vs.
 // the actual status of the kubelet service itself.
-type KubeletLifecycle struct {
-	md   resource.Metadata
-	spec KubeletLifecycleSpec
-}
+type KubeletLifecycle = typed.Resource[KubeletLifecycleSpec, KubeletLifecycleRD]
 
 // KubeletLifecycleSpec is empty.
 type KubeletLifecycleSpec struct{}
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec KubeletLifecycleSpec) DeepCopy() KubeletLifecycleSpec { return spec }
+
 // NewKubeletLifecycle initializes an empty KubeletLifecycle resource.
 func NewKubeletLifecycle(namespace resource.Namespace, id resource.ID) *KubeletLifecycle {
-	r := &KubeletLifecycle{
-		md:   resource.NewMetadata(namespace, KubeletLifecycleType, id, resource.VersionUndefined),
-		spec: KubeletLifecycleSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[KubeletLifecycleSpec, KubeletLifecycleRD](
+		resource.NewMetadata(namespace, KubeletLifecycleType, id, resource.VersionUndefined),
+		KubeletLifecycleSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *KubeletLifecycle) Metadata() *resource.Metadata {
-	return &r.md
-}
+// KubeletLifecycleRD provides auxiliary methods for KubeletLifecycle.
+type KubeletLifecycleRD struct{}
 
-// Spec implements resource.Resource.
-func (r *KubeletLifecycle) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KubeletLifecycle) DeepCopy() resource.Resource {
-	return &KubeletLifecycle{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KubeletLifecycle) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (KubeletLifecycleRD) ResourceDefinition(resource.Metadata, KubeletLifecycleSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KubeletLifecycleType,
 		Aliases:          []resource.Type{},

--- a/pkg/machinery/resources/k8s/kubelet_spec.go
+++ b/pkg/machinery/resources/k8s/kubelet_spec.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -14,10 +15,7 @@ import (
 const KubeletSpecType = resource.Type("KubeletSpecs.kubernetes.talos.dev")
 
 // KubeletSpec resource holds final definition of kubelet runtime configuration.
-type KubeletSpec struct {
-	md   resource.Metadata
-	spec *KubeletSpecSpec
-}
+type KubeletSpec = typed.Resource[KubeletSpecSpec, KubeletSpecRD]
 
 // KubeletSpecSpec holds the source of kubelet configuration.
 type KubeletSpecSpec struct {
@@ -27,57 +25,38 @@ type KubeletSpecSpec struct {
 	Config      map[string]interface{} `yaml:"config"`
 }
 
-// NewKubeletSpec initializes an empty KubeletSpec resource.
-func NewKubeletSpec(namespace resource.Namespace, id resource.ID) *KubeletSpec {
-	r := &KubeletSpec{
-		md:   resource.NewMetadata(namespace, KubeletSpecType, id, resource.VersionUndefined),
-		spec: &KubeletSpecSpec{},
-	}
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec KubeletSpecSpec) DeepCopy() KubeletSpecSpec {
+	config := make(map[string]interface{}, len(spec.Config))
 
-	r.md.BumpVersion()
-
-	return r
-}
-
-// Metadata implements resource.Resource.
-func (r *KubeletSpec) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *KubeletSpec) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *KubeletSpec) DeepCopy() resource.Resource {
-	config := make(map[string]interface{}, len(r.spec.Config))
-
-	for k, v := range r.spec.Config {
+	for k, v := range spec.Config {
 		config[k] = v
 	}
 
-	return &KubeletSpec{
-		md: r.md,
-		spec: &KubeletSpecSpec{
-			Image:       r.spec.Image,
-			Args:        append([]string(nil), r.spec.Args...),
-			ExtraMounts: append([]specs.Mount(nil), r.spec.ExtraMounts...),
-			Config:      config,
-		},
+	return KubeletSpecSpec{
+		Image:       spec.Image,
+		Args:        append([]string(nil), spec.Args...),
+		ExtraMounts: append([]specs.Mount(nil), spec.ExtraMounts...),
+		Config:      config,
 	}
 }
 
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *KubeletSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+// NewKubeletSpec initializes an empty KubeletSpec resource.
+func NewKubeletSpec(namespace resource.Namespace, id resource.ID) *KubeletSpec {
+	return typed.NewResource[KubeletSpecSpec, KubeletSpecRD](
+		resource.NewMetadata(namespace, KubeletSpecType, id, resource.VersionUndefined),
+		KubeletSpecSpec{},
+	)
+}
+
+// KubeletSpecRD provides auxiliary methods for KubeletSpec.
+type KubeletSpecRD struct{}
+
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (KubeletSpecRD) ResourceDefinition(resource.Metadata, KubeletSpecSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KubeletSpecType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 	}
-}
-
-// TypedSpec returns .spec.
-func (r *KubeletSpec) TypedSpec() *KubeletSpecSpec {
-	return r.spec
 }

--- a/pkg/machinery/resources/k8s/manifest_status.go
+++ b/pkg/machinery/resources/k8s/manifest_status.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // ManifestStatusType is type of ManifestStatus resource.
@@ -16,53 +17,29 @@ const ManifestStatusType = resource.Type("ManifestStatuses.kubernetes.talos.dev"
 const ManifestStatusID = resource.ID("manifests")
 
 // ManifestStatus resource holds definition of kubelet static pod.
-type ManifestStatus struct {
-	md   resource.Metadata
-	spec ManifestStatusSpec
-}
+type ManifestStatus = typed.Resource[ManifestStatusSpec, ManifestStatusRD]
 
 // ManifestStatusSpec describes manifest application status.
 type ManifestStatusSpec struct {
 	ManifestsApplied []string `yaml:"manifestsApplied"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec ManifestStatusSpec) DeepCopy() ManifestStatusSpec { return spec }
+
 // NewManifestStatus initializes an empty ManifestStatus resource.
 func NewManifestStatus(namespace resource.Namespace) *ManifestStatus {
-	r := &ManifestStatus{
-		md:   resource.NewMetadata(namespace, ManifestStatusType, ManifestStatusID, resource.VersionUndefined),
-		spec: ManifestStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[ManifestStatusSpec, ManifestStatusRD](
+		resource.NewMetadata(namespace, ManifestStatusType, ManifestStatusID, resource.VersionUndefined),
+		ManifestStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *ManifestStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// ManifestStatusRD provides auxiliary methods for ManifestStatus.
+type ManifestStatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *ManifestStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *ManifestStatus) DeepCopy() resource.Resource {
-	return &ManifestStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// TypedSpec returns ManifestStatusSpec.
-func (r *ManifestStatus) TypedSpec() *ManifestStatusSpec {
-	return &r.spec
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *ManifestStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (ManifestStatusRD) ResourceDefinition(resource.Metadata, ManifestStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             ManifestStatusType,
 		Aliases:          []resource.Type{},

--- a/pkg/machinery/resources/k8s/nodeip.go
+++ b/pkg/machinery/resources/k8s/nodeip.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -14,58 +15,36 @@ import (
 const NodeIPType = resource.Type("NodeIPs.kubernetes.talos.dev")
 
 // NodeIP resource holds definition of Node IP specification.
-type NodeIP struct {
-	md   resource.Metadata
-	spec *NodeIPSpec
-}
+type NodeIP = typed.Resource[NodeIPSpec, NodeIPRD]
 
 // NodeIPSpec holds the Node IP specification.
 type NodeIPSpec struct {
 	Addresses []netaddr.IP `yaml:"addresses"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec NodeIPSpec) DeepCopy() NodeIPSpec {
+	return NodeIPSpec{
+		Addresses: append([]netaddr.IP(nil), spec.Addresses...),
+	}
+}
+
 // NewNodeIP initializes an empty NodeIP resource.
 func NewNodeIP(namespace resource.Namespace, id resource.ID) *NodeIP {
-	r := &NodeIP{
-		md:   resource.NewMetadata(namespace, NodeIPType, id, resource.VersionUndefined),
-		spec: &NodeIPSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[NodeIPSpec, NodeIPRD](
+		resource.NewMetadata(namespace, NodeIPType, id, resource.VersionUndefined),
+		NodeIPSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *NodeIP) Metadata() *resource.Metadata {
-	return &r.md
-}
+// NodeIPRD provides auxiliary methods for NodeIP.
+type NodeIPRD struct{}
 
-// Spec implements resource.Resource.
-func (r *NodeIP) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *NodeIP) DeepCopy() resource.Resource {
-	return &NodeIP{
-		md: r.md,
-		spec: &NodeIPSpec{
-			Addresses: append([]netaddr.IP(nil), r.spec.Addresses...),
-		},
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *NodeIP) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (NodeIPRD) ResourceDefinition(resource.Metadata, NodeIPSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             NodeIPType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 	}
-}
-
-// TypedSpec returns .spec.
-func (r *NodeIP) TypedSpec() *NodeIPSpec {
-	return r.spec
 }

--- a/pkg/machinery/resources/k8s/nodeip_config.go
+++ b/pkg/machinery/resources/k8s/nodeip_config.go
@@ -7,16 +7,14 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // NodeIPConfigType is type of NodeIPConfig resource.
 const NodeIPConfigType = resource.Type("NodeIPConfigs.kubernetes.talos.dev")
 
 // NodeIPConfig resource holds definition of Node IP specification.
-type NodeIPConfig struct {
-	md   resource.Metadata
-	spec *NodeIPConfigSpec
-}
+type NodeIPConfig = typed.Resource[NodeIPConfigSpec, NodeIPConfigRD]
 
 // NodeIPConfigSpec holds the Node IP specification.
 type NodeIPConfigSpec struct {
@@ -24,49 +22,30 @@ type NodeIPConfigSpec struct {
 	ExcludeSubnets []string `yaml:"excludeSubnets"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec NodeIPConfigSpec) DeepCopy() NodeIPConfigSpec {
+	return NodeIPConfigSpec{
+		ValidSubnets:   append([]string(nil), spec.ValidSubnets...),
+		ExcludeSubnets: append([]string(nil), spec.ExcludeSubnets...),
+	}
+}
+
 // NewNodeIPConfig initializes an empty NodeIPConfig resource.
 func NewNodeIPConfig(namespace resource.Namespace, id resource.ID) *NodeIPConfig {
-	r := &NodeIPConfig{
-		md:   resource.NewMetadata(namespace, NodeIPConfigType, id, resource.VersionUndefined),
-		spec: &NodeIPConfigSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[NodeIPConfigSpec, NodeIPConfigRD](
+		resource.NewMetadata(namespace, NodeIPConfigType, id, resource.VersionUndefined),
+		NodeIPConfigSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *NodeIPConfig) Metadata() *resource.Metadata {
-	return &r.md
-}
+// NodeIPConfigRD provides auxiliary methods for NodeIPConfig.
+type NodeIPConfigRD struct{}
 
-// Spec implements resource.Resource.
-func (r *NodeIPConfig) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *NodeIPConfig) DeepCopy() resource.Resource {
-	return &NodeIPConfig{
-		md: r.md,
-		spec: &NodeIPConfigSpec{
-			ValidSubnets:   append([]string(nil), r.spec.ValidSubnets...),
-			ExcludeSubnets: append([]string(nil), r.spec.ExcludeSubnets...),
-		},
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *NodeIPConfig) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (NodeIPConfigRD) ResourceDefinition(resource.Metadata, NodeIPConfigSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             NodeIPConfigType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 	}
-}
-
-// TypedSpec returns .spec.
-func (r *NodeIPConfig) TypedSpec() *NodeIPConfigSpec {
-	return r.spec
 }

--- a/pkg/machinery/resources/k8s/nodename.go
+++ b/pkg/machinery/resources/k8s/nodename.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // NodenameType is type of Nodename resource.
@@ -16,10 +17,7 @@ const NodenameType = resource.Type("Nodenames.kubernetes.talos.dev")
 const NodenameID = resource.ID("nodename")
 
 // Nodename resource holds Kubernetes nodename.
-type Nodename struct {
-	md   resource.Metadata
-	spec NodenameSpec
-}
+type Nodename = typed.Resource[NodenameSpec, NodenameRD]
 
 // NodenameSpec describes Kubernetes nodename.
 type NodenameSpec struct {
@@ -27,38 +25,22 @@ type NodenameSpec struct {
 	HostnameVersion string `yaml:"hostnameVersion"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec NodenameSpec) DeepCopy() NodenameSpec { return spec }
+
 // NewNodename initializes a Nodename resource.
 func NewNodename(namespace resource.Namespace, id resource.ID) *Nodename {
-	r := &Nodename{
-		md:   resource.NewMetadata(namespace, NodenameType, id, resource.VersionUndefined),
-		spec: NodenameSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[NodenameSpec, NodenameRD](
+		resource.NewMetadata(namespace, NodenameType, id, resource.VersionUndefined),
+		NodenameSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Nodename) Metadata() *resource.Metadata {
-	return &r.md
-}
+// NodenameRD provides auxiliary methods for Nodename.
+type NodenameRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Nodename) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Nodename) DeepCopy() resource.Resource {
-	return &Nodename{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Nodename) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (NodenameRD) ResourceDefinition(resource.Metadata, NodenameSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             NodenameType,
 		Aliases:          []resource.Type{},
@@ -70,9 +52,4 @@ func (r *Nodename) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Nodename) TypedSpec() *NodenameSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/k8s/secrets_status.go
+++ b/pkg/machinery/resources/k8s/secrets_status.go
@@ -10,6 +10,7 @@ package k8s
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // SecretsStatusType is type of SecretsStatus resource.
@@ -19,10 +20,7 @@ const SecretsStatusType = resource.Type("SecretStatuses.kubernetes.talos.dev")
 const StaticPodSecretsStaticPodID = resource.ID("static-pods")
 
 // SecretsStatus resource holds definition of rendered secrets.
-type SecretsStatus struct {
-	md   resource.Metadata
-	spec SecretsStatusSpec
-}
+type SecretsStatus = typed.Resource[SecretsStatusSpec, SecretsStatusRD]
 
 // SecretsStatusSpec describes status of rendered secrets.
 type SecretsStatusSpec struct {
@@ -30,38 +28,22 @@ type SecretsStatusSpec struct {
 	Version string `yaml:"version"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec SecretsStatusSpec) DeepCopy() SecretsStatusSpec { return spec }
+
 // NewSecretsStatus initializes a SecretsStatus resource.
 func NewSecretsStatus(namespace resource.Namespace, id resource.ID) *SecretsStatus {
-	r := &SecretsStatus{
-		md:   resource.NewMetadata(namespace, SecretsStatusType, id, resource.VersionUndefined),
-		spec: SecretsStatusSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[SecretsStatusSpec, SecretsStatusRD](
+		resource.NewMetadata(namespace, SecretsStatusType, id, resource.VersionUndefined),
+		SecretsStatusSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *SecretsStatus) Metadata() *resource.Metadata {
-	return &r.md
-}
+// SecretsStatusRD provides auxiliary methods for SecretsStatus.
+type SecretsStatusRD struct{}
 
-// Spec implements resource.Resource.
-func (r *SecretsStatus) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *SecretsStatus) DeepCopy() resource.Resource {
-	return &SecretsStatus{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *SecretsStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (SecretsStatusRD) ResourceDefinition(resource.Metadata, SecretsStatusSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             SecretsStatusType,
 		Aliases:          []resource.Type{},
@@ -77,9 +59,4 @@ func (r *SecretsStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *SecretsStatus) TypedSpec() *SecretsStatusSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/kubespan/config.go
+++ b/pkg/machinery/resources/kubespan/config.go
@@ -7,6 +7,7 @@ package kubespan
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 
 	"github.com/talos-systems/talos/pkg/machinery/resources/config"
 )
@@ -18,10 +19,7 @@ const ConfigType = resource.Type("KubeSpanConfigs.kubespan.talos.dev")
 const ConfigID = resource.ID("kubespan")
 
 // Config resource holds KubeSpan configuration.
-type Config struct {
-	md   resource.Metadata
-	spec ConfigSpec
-}
+type Config = typed.Resource[ConfigSpec, ConfigRD]
 
 // ConfigSpec describes KubeSpan configuration..
 type ConfigSpec struct {
@@ -32,38 +30,22 @@ type ConfigSpec struct {
 	ForceRouting bool `yaml:"forceRouting"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec ConfigSpec) DeepCopy() ConfigSpec { return spec }
+
 // NewConfig initializes a Config resource.
 func NewConfig(namespace resource.Namespace, id resource.ID) *Config {
-	r := &Config{
-		md:   resource.NewMetadata(namespace, ConfigType, id, resource.VersionUndefined),
-		spec: ConfigSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[ConfigSpec, ConfigRD](
+		resource.NewMetadata(namespace, ConfigType, id, resource.VersionUndefined),
+		ConfigSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Config) Metadata() *resource.Metadata {
-	return &r.md
-}
+// ConfigRD provides auxiliary methods for Config.
+type ConfigRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Config) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Config) DeepCopy() resource.Resource {
-	return &Config{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Config) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (ConfigRD) ResourceDefinition(resource.Metadata, ConfigSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             ConfigType,
 		Aliases:          []resource.Type{},
@@ -71,9 +53,4 @@ func (r *Config) ResourceDefinition() meta.ResourceDefinitionSpec {
 		PrintColumns:     []meta.PrintColumn{},
 		Sensitivity:      meta.Sensitive,
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Config) TypedSpec() *ConfigSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/kubespan/endpoint.go
+++ b/pkg/machinery/resources/kubespan/endpoint.go
@@ -7,6 +7,7 @@ package kubespan
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -16,10 +17,7 @@ const EndpointType = resource.Type("KubeSpanEndpoints.kubespan.talos.dev")
 // Endpoint is produced from KubeSpanPeerStatuses by mapping back discovered endpoints to the affiliates.
 //
 // Endpoint is identified by the public key of the peer.
-type Endpoint struct {
-	md   resource.Metadata
-	spec EndpointSpec
-}
+type Endpoint = typed.Resource[EndpointSpec, EndpointRD]
 
 // EndpointSpec describes Endpoint state.
 type EndpointSpec struct {
@@ -27,38 +25,22 @@ type EndpointSpec struct {
 	Endpoint    netaddr.IPPort `yaml:"endpoint"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec EndpointSpec) DeepCopy() EndpointSpec { return spec }
+
 // NewEndpoint initializes a Endpoint resource.
 func NewEndpoint(namespace resource.Namespace, id resource.ID) *Endpoint {
-	r := &Endpoint{
-		md:   resource.NewMetadata(namespace, EndpointType, id, resource.VersionUndefined),
-		spec: EndpointSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[EndpointSpec, EndpointRD](
+		resource.NewMetadata(namespace, EndpointType, id, resource.VersionUndefined),
+		EndpointSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Endpoint) Metadata() *resource.Metadata {
-	return &r.md
-}
+// EndpointRD provides auxiliary methods for Endpoint.
+type EndpointRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Endpoint) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Endpoint) DeepCopy() resource.Resource {
-	return &Endpoint{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Endpoint) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (EndpointRD) ResourceDefinition(resource.Metadata, EndpointSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             EndpointType,
 		Aliases:          []resource.Type{},
@@ -74,9 +56,4 @@ func (r *Endpoint) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Endpoint) TypedSpec() *EndpointSpec {
-	return &r.spec
 }

--- a/pkg/machinery/resources/kubespan/identity.go
+++ b/pkg/machinery/resources/kubespan/identity.go
@@ -7,6 +7,7 @@ package kubespan
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"inet.af/netaddr"
 )
 
@@ -17,10 +18,7 @@ const IdentityType = resource.Type("KubeSpanIdentities.kubespan.talos.dev")
 const LocalIdentity = resource.ID("local")
 
 // Identity resource holds node identity (as a member of the cluster).
-type Identity struct {
-	md   resource.Metadata
-	spec IdentitySpec
-}
+type Identity = typed.Resource[IdentitySpec, IdentityRD]
 
 // IdentitySpec describes KubeSpan keys and address.
 //
@@ -35,38 +33,22 @@ type IdentitySpec struct {
 	PublicKey  string `yaml:"publicKey"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (spec IdentitySpec) DeepCopy() IdentitySpec { return spec }
+
 // NewIdentity initializes a Identity resource.
 func NewIdentity(namespace resource.Namespace, id resource.ID) *Identity {
-	r := &Identity{
-		md:   resource.NewMetadata(namespace, IdentityType, id, resource.VersionUndefined),
-		spec: IdentitySpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[IdentitySpec, IdentityRD](
+		resource.NewMetadata(namespace, IdentityType, id, resource.VersionUndefined),
+		IdentitySpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *Identity) Metadata() *resource.Metadata {
-	return &r.md
-}
+// IdentityRD provides auxiliary methods for Identity.
+type IdentityRD struct{}
 
-// Spec implements resource.Resource.
-func (r *Identity) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Identity) DeepCopy() resource.Resource {
-	return &Identity{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *Identity) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (IdentityRD) ResourceDefinition(resource.Metadata, IdentitySpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             IdentityType,
 		Aliases:          []resource.Type{},
@@ -83,9 +65,4 @@ func (r *Identity) ResourceDefinition() meta.ResourceDefinitionSpec {
 		},
 		Sensitivity: meta.Sensitive,
 	}
-}
-
-// TypedSpec allows to access the Spec with the proper type.
-func (r *Identity) TypedSpec() *IdentitySpec {
-	return &r.spec
 }


### PR DESCRIPTION
Refactor remaining resources into typed.Resource. Exceptions are:
- MachineConfig
- MachineType
- LinkRefresh
- LinkStatus
all of which contain additional methods, and cannot be simply reworked into new resource framework.

StaticPod and StaticPodStatus are also absent from this PR, because they result in e2e errors which are going to be resolved in the next PR.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5472)
<!-- Reviewable:end -->
