### PR TITLE
chore: bump kernel to 5.15.37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-3-ga8fb702
-PKGS ?= v1.0.0-10-gbf81bd2
+PKGS ?= v1.0.0-13-gb4a98c4
 EXTRAS ?= v1.0.0-2-gc5d3ab0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -373,7 +373,7 @@ const (
 	TrustdUserID = 51
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.6.2"
+	DefaultContainerdVersion = "1.6.4"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
Bump kernel to 5.15.37

Ref: https://github.com/siderolabs/pkgs/pull/464

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5483)
<!-- Reviewable:end -->
