### PR TITLE
chore: refactor LinkRefresh and LinkStatus into typed.Resource

### DIFF
--- a/internal/app/machined/pkg/controllers/network/hardware_addr.go
+++ b/internal/app/machined/pkg/controllers/network/hardware_addr.go
@@ -76,7 +76,7 @@ func (ctrl *HardwareAddrController) Run(ctx context.Context, r controller.Runtim
 		for _, res := range links.Items {
 			link := res.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
 
-			if !link.Physical() {
+			if !link.TypedSpec().Physical() {
 				continue
 			}
 

--- a/internal/app/machined/pkg/controllers/network/link_config.go
+++ b/internal/app/machined/pkg/controllers/network/link_config.go
@@ -184,7 +184,7 @@ func (ctrl *LinkConfigController) Run(ctx context.Context, r controller.Runtime,
 			linkStatus := item.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
 
 			if _, configured := configuredLinks[linkStatus.Metadata().ID()]; !configured {
-				if linkStatus.Physical() {
+				if linkStatus.TypedSpec().Physical() {
 					var ids []string
 
 					ids, err = ctrl.apply(ctx, r, []network.LinkSpecSpec{

--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -421,7 +421,7 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 
 				// notify link status controller, as wireguard updates can't be watched via netlink API
 				if err = r.Modify(ctx, network.NewLinkRefresh(network.NamespaceName, network.LinkKindWireguard), func(r resource.Resource) error {
-					r.(*network.LinkRefresh).Bump()
+					r.(*network.LinkRefresh).TypedSpec().Bump()
 
 					return nil
 				}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/node_address.go
+++ b/internal/app/machined/pkg/controllers/network/node_address.go
@@ -86,7 +86,7 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 
 			if link.TypedSpec().OperationalState == nethelpers.OperStateUp || link.TypedSpec().OperationalState == nethelpers.OperStateUnknown {
 				// skip physical interfaces without carrier
-				if !link.Physical() || link.TypedSpec().LinkState {
+				if !link.TypedSpec().Physical() || link.TypedSpec().LinkState {
 					linksUp[link.TypedSpec().Index] = struct{}{}
 				}
 			}

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -201,7 +201,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 		for _, item := range list.Items {
 			linkStatus := item.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
 
-			if linkStatus.Physical() {
+			if linkStatus.TypedSpec().Physical() {
 				if _, configured := configuredInterfaces[linkStatus.Metadata().ID()]; !configured {
 					if _, ignored := ignoredInterfaces[linkStatus.Metadata().ID()]; !ignored {
 						// enable DHCPv4 operator on physical interfaces which don't have any explicit configuration and are not ignored

--- a/pkg/machinery/resources/network/link_refresh.go
+++ b/pkg/machinery/resources/network/link_refresh.go
@@ -7,6 +7,7 @@ package network
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // LinkRefreshType is type of LinkRefresh resource.
@@ -19,57 +20,38 @@ const LinkRefreshType = resource.Type("LinkRefreshes.net.talos.dev")
 //
 // Whenever Wireguard interface is updated, LinkRefresh resource is modified to trigger a reconcile
 // loop in the LinkStatusController.
-type LinkRefresh struct {
-	md   resource.Metadata
-	spec LinkRefreshSpec
-}
+type LinkRefresh = typed.Resource[LinkRefreshSpec, LinkRefreshRD]
 
 // LinkRefreshSpec describes status of rendered secrets.
 type LinkRefreshSpec struct {
 	Generation int `yaml:"generation"`
 }
 
+// DeepCopy implements typed.DeepCopyable interface.
+func (s LinkRefreshSpec) DeepCopy() LinkRefreshSpec { return s }
+
+// Bump performs an update.
+func (s *LinkRefreshSpec) Bump() {
+	s.Generation++
+}
+
 // NewLinkRefresh initializes a LinkRefresh resource.
 func NewLinkRefresh(namespace resource.Namespace, id resource.ID) *LinkRefresh {
-	r := &LinkRefresh{
-		md:   resource.NewMetadata(namespace, LinkRefreshType, id, resource.VersionUndefined),
-		spec: LinkRefreshSpec{},
-	}
-
-	r.md.BumpVersion()
-
-	return r
+	return typed.NewResource[LinkRefreshSpec, LinkRefreshRD](
+		resource.NewMetadata(namespace, LinkRefreshType, id, resource.VersionUndefined),
+		LinkRefreshSpec{},
+	)
 }
 
-// Metadata implements resource.Resource.
-func (r *LinkRefresh) Metadata() *resource.Metadata {
-	return &r.md
-}
+// LinkRefreshRD provides auxiliary methods for LinkRefresh.
+type LinkRefreshRD struct{}
 
-// Spec implements resource.Resource.
-func (r *LinkRefresh) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *LinkRefresh) DeepCopy() resource.Resource {
-	return &LinkRefresh{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (r *LinkRefresh) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements typed.ResourceDefinition interface.
+func (LinkRefreshRD) ResourceDefinition(resource.Metadata, LinkRefreshSpec) meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             LinkRefreshType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
 	}
-}
-
-// Bump performs an update.
-func (r *LinkRefresh) Bump() {
-	r.spec.Generation++
 }


### PR DESCRIPTION
From #5472 Andrey comments, this commit changes LinkRefresh and LinkStatus into typed.Resource by moving Bump and Physical methods to *Spec types.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5489)
<!-- Reviewable:end -->
