### PR TITLE
docs: add adopters file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,17 @@
+# Adopters
+
+A list of adopters of Talos Linux, and the use
+
+## Adopters (listed alphabetically)
+
+* **[Sidero Labs](https://www.siderolanbs.com)**  
+  Sidero Labs uses Talos to build & test Talos! All the unit and end-to-end testing happens on our CI platform running in Talos-backed Kubernetes clusters.
+
+## Contributing
+
+If you use Talos Linux and want to add your organization to this list, simply [edit](https://github.com/siderolabs/talos/edit/master/ADOPTERS.md) this file using the template below, then submit the changes in a pull request!
+
+### Template
+
+* **[ORG NAME](ORG URL)**  
+  ORG DESCRIPTION & TALOS USE


### PR DESCRIPTION
Adds an ADOPTERS markdown to the repo to allow users to show
they have adopted using Talos Linux in their organization.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5496)
<!-- Reviewable:end -->
