### PR TITLE
chore: fix incorrect ManifestSpec.MarshalYAML signature

### DIFF
--- a/pkg/machinery/resources/k8s/manifest.go
+++ b/pkg/machinery/resources/k8s/manifest.go
@@ -29,7 +29,7 @@ func (spec ManifestSpec) DeepCopy() ManifestSpec {
 }
 
 // MarshalYAML implements yaml.Marshaler.
-func (spec *ManifestSpec) MarshalYAML() (interface{}, error) {
+func (spec ManifestSpec) MarshalYAML() (interface{}, error) {
 	return spec.Items, nil
 }
 


### PR DESCRIPTION
Remove pointer from method, because otherwise MarshalYAML doesn't work when called from type asserted empty interface.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5502)
<!-- Reviewable:end -->
