### PR TITLE
feat: add Nedap Security Atlas as adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,6 +4,9 @@ A list of adopters of Talos Linux, and the use
 
 ## Adopters (listed alphabetically)
 
+* **[Nedap Security Atlas](https://nedapsecurityatlas.com)**  
+  Nedap Security Atlas does all on-premise development, unit and integration testing in Gitlab running on Talos clusters.
+
 * **[Sidero Labs](https://www.siderolanbs.com)**  
   Sidero Labs uses Talos to build & test Talos! All the unit and end-to-end testing happens on our CI platform running in Talos-backed Kubernetes clusters.
 


### PR DESCRIPTION
# Pull Request

## What? (description)

Upon your invitation via Slack we would like to add Nedap Security Atlas as a Talos adopter

## Why? (reasoning)

To show our ❤️ for Talos/k8s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5503)
<!-- Reviewable:end -->
