### PR TITLE
fix: add source path for ovmf flash image

### DIFF
--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -93,7 +93,7 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			return nil
 		}
 
-		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd"}
+		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd", "/usr/share/OVMF/OVMF_CODE.fd"}
 		for _, p := range extraUEFISearchPaths {
 			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "OVMF.fd"))
 		}


### PR DESCRIPTION
# Pull Request


## What? (description)
talosctl could not find the ovmf flash image to provision a local qemu
on Fedora. We added the source path where the dnf package manager will
place the image.

Fixes #5517
Fixes #5466 

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5518)
<!-- Reviewable:end -->
