### PR TITLE
feat: print the status of services during boot

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,7 +9,7 @@ A list of adopters of Talos Linux, and the use
 * **[Nedap Security Atlas](https://nedapsecurityatlas.com)**  
   Nedap Security Atlas does all on-premise development, unit and integration testing in Gitlab running on Talos clusters.
 
-* **[Sidero Labs](https://www.siderolanbs.com)**  
+* **[Sidero Labs](https://www.siderolabs.com)**  
   Sidero Labs uses Talos to build & test Talos! All the unit and end-to-end testing happens on our CI platform running in Talos-backed Kubernetes clusters.
 
 ## Contributing

--- a/website/content/v1.1/advanced/developing-talos.md
+++ b/website/content/v1.1/advanced/developing-talos.md
@@ -71,7 +71,7 @@ sudo -E _out/talosctl-linux-amd64 cluster create \
     --registry-mirror gcr.io=http://172.20.0.1:5003 \
     --registry-mirror ghcr.io=http://172.20.0.1:5004 \
     --registry-mirror 127.0.0.1:5005=http://172.20.0.1:5005 \
-    --install-image=127.0.0.1:5005/talos-systems/installer:<RECORDED HASH from the build step> \
+    --install-image=127.0.0.1:5005/siderolabs/installer:<RECORDED HASH from the build step> \
     --masters 3 \
     --workers 2 \
     --with-bootloader=false


### PR DESCRIPTION
If the a service hangs in the boot sequence will not finish. To inform
users we poll the collection of services in the StartAllServices task
regularly and log if their status has changed.

Fixes #5449

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
Signed-off-by: Philipp Sauter <philipp.sauter@siderolabs.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5529)
<!-- Reviewable:end -->
