### PR TITLE
fix: use json.Unmarshal instead of yaml.Unmarshal

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -7,6 +7,7 @@ package openstack
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"net"
@@ -14,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/talos-systems/go-procfs/procfs"
-	yaml "gopkg.in/yaml.v3"
 	"inet.af/netaddr"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -299,8 +299,8 @@ func (o *Openstack) NetworkConfiguration(ctx context.Context, ch chan<- *runtime
 	)
 
 	// ignore errors unmarshaling, empty configs work just fine as empty default
-	_ = yaml.Unmarshal(metadataConfigDl, &unmarshalledMetadataConfig)       //nolint:errcheck
-	_ = yaml.Unmarshal(metadataNetworkConfigDl, &unmarshalledNetworkConfig) //nolint:errcheck
+	_ = json.Unmarshal(metadataConfigDl, &unmarshalledMetadataConfig)       //nolint:errcheck
+	_ = json.Unmarshal(metadataNetworkConfigDl, &unmarshalledNetworkConfig) //nolint:errcheck
 
 	networkConfig, err := o.ParseMetadata(&unmarshalledMetadataConfig, &unmarshalledNetworkConfig, string(hostname), extIPs)
 	if err != nil {


### PR DESCRIPTION
Fixes #5510

JSON is a subset of YAML, but struct tags are declared for `json:""`, so
we need to use proper function call.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5530)
<!-- Reviewable:end -->
