### PR TITLE
chore: bump kernel to 5.15.38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-3-ga8fb702
-PKGS ?= v1.0.0-13-gb4a98c4
+PKGS ?= v1.0.0-14-gde04341
 EXTRAS ?= v1.0.0-2-gc5d3ab0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -17,7 +17,7 @@ preface = """\
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.37
+* Linux: 5.15.38
 * Containerd: v1.6.4
 """
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.37-talos"
+	DefaultKernelVersion = "5.15.38-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to 5.15.38 LTS

Ref: https://github.com/siderolabs/pkgs/pull/469

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5532)
<!-- Reviewable:end -->
