### PR TITLE
fix: load kubelet system service in StartAllServices task

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -672,6 +672,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 
 		svcs.Load(
 			&services.CRI{},
+			&services.Kubelet{},
 		)
 
 		switch t := r.Config().Machine().Type(); t {


### PR DESCRIPTION
# Pull Request

## Description

We found a race condition in the StartAllServices task, where the task
would start, before kubelet was loaded as a system service. It's
possible that the task completes without the kubelet service becoming "up". As a fix
we load the kubelet service again in StartAllServices.

Fixes #5527

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5535)
<!-- Reviewable:end -->
