### PR TITLE
fix: properly set `allowSchedulingOnMasters` in the interactive install

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -136,6 +136,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		ClusterDiscoveryConfig: v1alpha1.ClusterDiscoveryConfig{
 			DiscoveryEnabled: in.DiscoveryEnabled,
 		},
+		AllowSchedulingOnMasters: in.AllowSchedulingOnMasters,
 	}
 
 	config.MachineConfig = machine


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/talos/issues/5507

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5537)
<!-- Reviewable:end -->
