### PR TITLE
test: add a test for version of Go Talos was built with

### DIFF
--- a/internal/integration/api/version.go
+++ b/internal/integration/api/version.go
@@ -50,6 +50,7 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(suite.Version, v.Messages[0].Version.Tag)
+	suite.Assert().Equal(suite.GoVersion, v.Messages[0].Version.GoVersion)
 }
 
 // TestSameVersionCluster verifies that all the nodes are on the same version.

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -28,6 +28,8 @@ type TalosSuite struct {
 	TalosConfig string
 	// Version is the (expected) version of Talos tests are running against
 	Version string
+	// GoVersion is the (expected) version of Go compiler.
+	GoVersion string
 	// TalosctlPath is a path to talosctl binary
 	TalosctlPath string
 	// KubectlPath is a path to kubectl binary

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/internal/integration/k8s"
 	provision_test "github.com/talos-systems/talos/internal/integration/provision"
 	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers"
 	"github.com/talos-systems/talos/pkg/version"
@@ -33,17 +34,18 @@ var allSuites []suite.TestingSuite
 
 // Flag values.
 var (
-	failFast         bool
-	crashdumpEnabled bool
-	talosConfig      string
-	endpoint         string
-	k8sEndpoint      string
-	expectedVersion  string
-	talosctlPath     string
-	kubectlPath      string
-	provisionerName  string
-	clusterName      string
-	stateDir         string
+	failFast          bool
+	crashdumpEnabled  bool
+	talosConfig       string
+	endpoint          string
+	k8sEndpoint       string
+	expectedVersion   string
+	expectedGoVersion string
+	talosctlPath      string
+	kubectlPath       string
+	provisionerName   string
+	clusterName       string
+	stateDir          string
 )
 
 // TestIntegration ...
@@ -88,6 +90,7 @@ func TestIntegration(t *testing.T) {
 				Cluster:      cluster,
 				TalosConfig:  talosConfig,
 				Version:      expectedVersion,
+				GoVersion:    expectedGoVersion,
 				TalosctlPath: talosctlPath,
 				KubectlPath:  kubectlPath,
 			})
@@ -134,6 +137,7 @@ func init() {
 	flag.StringVar(&stateDir, "talos.state", defaultStateDir, "directory path to store cluster state")
 	flag.StringVar(&clusterName, "talos.name", "talos-default", "the name of the cluster")
 	flag.StringVar(&expectedVersion, "talos.version", version.Tag, "expected Talos version")
+	flag.StringVar(&expectedGoVersion, "talos.go.version", constants.GoVersion, "expected Talos version")
 	flag.StringVar(&talosctlPath, "talos.talosctlpath", "talosctl", "The path to 'talosctl' binary")
 	flag.StringVar(&kubectlPath, "talos.kubectlpath", "kubectl", "The path to 'kubectl' binary")
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -659,6 +659,9 @@ const (
 
 	// DBusClientSocketPath is the path to the D-Bus socket for the kubelet to connect to.
 	DBusClientSocketPath = "/run/dbus/system_bus_socket"
+
+	// GoVersion is the version of Go compiler this release was built with.
+	GoVersion = "go1.18.1"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
This is to ensure that in fact Talos is built with Go version we expect.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5541)
<!-- Reviewable:end -->
