### PR TITLE
fix: append hostname to cluster SANs when port is not specified

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -116,10 +116,7 @@ func (i *Input) GetAPIServerSANs() []string {
 
 	endpointURL, err := url.Parse(i.ControlPlaneEndpoint)
 	if err == nil {
-		host, _, err := net.SplitHostPort(endpointURL.Host)
-		if err == nil {
-			list = append(list, host)
-		}
+		list = append(list, endpointURL.Hostname())
 	}
 
 	list = append(list, i.AdditionalSubjectAltNames...)


### PR DESCRIPTION
This fixes an issue with `talosctl gen config` not appending API server
cert SANs if the endpoint doesn't contain a port.

In fact this shouldn't be ever needed, as Talos automatically injects
SANs form the endpoint URL on the fly, but good to fix for consistency.

Fixes #5536

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5543)
<!-- Reviewable:end -->
