### PR TITLE
fix: reset certificate SANs on update

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api_cert_sans.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_cert_sans.go
@@ -115,6 +115,8 @@ func (ctrl *APICertSANsController) Run(ctx context.Context, r controller.Runtime
 		if err = r.Modify(ctx, secrets.NewCertSAN(secrets.NamespaceName, secrets.CertSANAPIID), func(r resource.Resource) error {
 			spec := r.(*secrets.CertSAN).TypedSpec()
 
+			spec.Reset()
+
 			spec.AppendIPs(apiRoot.CertSANIPs...)
 			spec.AppendIPs(nodeAddresses.IPs()...)
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans.go
@@ -115,6 +115,8 @@ func (ctrl *KubernetesCertSANsController) Run(ctx context.Context, r controller.
 		if err = r.Modify(ctx, secrets.NewCertSAN(secrets.NamespaceName, secrets.CertSANKubernetesID), func(r resource.Resource) error {
 			spec := r.(*secrets.CertSAN).TypedSpec()
 
+			spec.Reset()
+
 			spec.Append(k8sRoot.Endpoint.Hostname())
 			spec.Append(k8sRoot.CertSANs...)
 

--- a/pkg/machinery/resources/secrets/cert_sans.go
+++ b/pkg/machinery/resources/secrets/cert_sans.go
@@ -63,6 +63,13 @@ func (spec CertSANSpec) DeepCopy() CertSANSpec {
 	}
 }
 
+// Reset the list of SANs.
+func (spec *CertSANSpec) Reset() {
+	spec.DNSNames = nil
+	spec.IPs = nil
+	spec.FQDN = ""
+}
+
 // Append list of SANs splitting into IPs/DNS names.
 func (spec *CertSANSpec) Append(sans ...string) {
 	for _, san := range sans {


### PR DESCRIPTION
This affects both API server and Talos API cert SANs.

Before the fix, SANs accumulated changes over time, so even if the
hostname changes, old hostname is still kept in SANs. Even though it
shouldn't be a problem in general, it is confusing as after reboot list
will be reset back to expected value.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5544)
<!-- Reviewable:end -->
