### PR TITLE
fix: dhcpv6 leasetime segfault loop

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
@@ -145,7 +145,7 @@ func (d *DHCP6) TimeServerSpecs() []network.TimeServerSpecSpec {
 	return d.timeservers
 }
 
-func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
+func (d *DHCP6) parseReply(reply *dhcpv6.Message) (leaseTime time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -165,6 +165,8 @@ func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
 				ConfigLayer: network.ConfigOperator,
 			},
 		}
+
+		leaseTime = reply.Options.OneIANA().Options.OneAddress().ValidLifetime
 	} else {
 		d.addresses = nil
 	}
@@ -215,6 +217,8 @@ func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
 	} else {
 		d.timeservers = nil
 	}
+
+	return leaseTime
 }
 
 func (d *DHCP6) renew(ctx context.Context) (time.Duration, error) {
@@ -243,9 +247,7 @@ func (d *DHCP6) renew(ctx context.Context) (time.Duration, error) {
 
 	d.logger.Debug("DHCP6 REPLY", zap.String("link", d.linkName), zap.String("dhcp", collapseSummary(reply.Summary())))
 
-	d.parseReply(reply)
-
-	return reply.Options.OneIANA().Options.OneAddress().ValidLifetime, nil
+	return d.parseReply(reply), nil
 }
 
 func (d *DHCP6) waitIPv6LinkReady(ctx context.Context, iface *net.Interface) error {


### PR DESCRIPTION
We are trying to get an IP-address lifetime, but we do not have it yet.

```
kern:    info: [2022-05-12T06:40:28.25916042Z]: init[663]: segfault at 20 ip 000000000201d2b1 sp 000000c00148b930 error 4 in init[400000+20ae000]
kern:    info: [2022-05-12T06:40:28.26453742Z]: Code: db 75 04 31 d2 eb 03 48 8b 10 48 8b 42 18 48 8b 5a 20 48 8b 4a 28 0f 1f 00 e8 3b a6 f7 ff 48 85 db 75 04 31 c0 eb 03 48 8b 00 <48> 8b 40 20 48 89 44 24 78 44 0f 11 bc 24 a8 00 00 00 c6 44 24 77
user: warning: [2022-05-12T06:40:28.27713142Z]: [talos] operator panicked {"component": "controller-runtime", "controller": "network.OperatorSpecController", "stack": "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network.(*operatorRunState).runWithPanicHandler.func1\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator_spec.go:137\x5cnruntime.gopanic\x5cn\x5ct/toolchain/go/src/runtime/panic.go:838\x5cnruntime.panicmem\x5cn\x5ct/toolchain/go/src/runtime/panic.go:220\x5cnruntime.sigpanic\x5cn\x5ct/toolchain/go/src/runtime/signal_unix.go:818\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator.(*DHCP6).renew\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator/dhcp6.go:248\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator.(*DHCP6).Run\x5cn\x5ct/src/internal/app/machined/pkg/controllers/network/operator/dhcp6.go:75\x5cngithub.com/talos-systems/talos/internal/app/machined/pkg/controllers/network.(*operatorRunState).runWithPanicHandle...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5547)
<!-- Reviewable:end -->
