### PR TITLE
fix: allow SideroLink IPs in NodeAddresses

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
@@ -53,7 +53,11 @@ func (suite *LocalAffiliateSuite) TestGeneration() {
 	suite.Require().NoError(suite.state.Create(suite.ctx, nodename))
 
 	nonK8sAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s))
-	nonK8sAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("172.20.0.2/24"), netaddr.MustParseIPPrefix("10.5.0.1/32")}
+	nonK8sAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{
+		netaddr.MustParseIPPrefix("172.20.0.2/24"),
+		netaddr.MustParseIPPrefix("10.5.0.1/32"),
+		netaddr.MustParseIPPrefix("fdae:41e4:649b:9303:60be:7e36:c270:3238/128"), // SideroLink, should be ignored
+	}
 	suite.Require().NoError(suite.state.Create(suite.ctx, nonK8sAddresses))
 
 	machineType := config.NewMachineType()

--- a/internal/app/machined/pkg/controllers/network/node_address.go
+++ b/internal/app/machined/pkg/controllers/network/node_address.go
@@ -123,11 +123,6 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 				continue
 			}
 
-			if network.IsULA(ip.IP(), network.ULASideroLink) {
-				// ignore SideroLink addresses, as they are point-to-point addresses
-				continue
-			}
-
 			// set defaultAddress to the smallest IP from the alphabetically first link
 			// ignore address which are not assigned from the physical links
 			if addr.Metadata().Owner() == addressStatusControllerName {


### PR DESCRIPTION
Fixes #5588

This fixes `apid` certificate generation for SideroLink IPs, so that
Talos API can be accessed over SideroLink connection.

We also drop SideroLink addresses from cluster discovery, as these
addresses don't work across nodes, so that they are not used for
KubeSpan, endpoints, etc.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5589)
<!-- Reviewable:end -->
