### PR TITLE
fix: match for WSL platform in case-insensitive way

### DIFF
--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -108,7 +108,7 @@ func (p *provisioner) GetFirstInterface() string {
 func detectWSL() bool {
 	// "Official" way of detecting WSL https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
 	contents, err := os.ReadFile("/proc/sys/kernel/osrelease")
-	if err == nil && (bytes.Contains(contents, []byte("Microsoft")) || bytes.Contains(contents, []byte("WSL"))) {
+	if err == nil && (bytes.Contains(bytes.ToLower(contents), []byte("microsoft")) || bytes.Contains(bytes.ToLower(contents), []byte("wsl"))) {
 		return true
 	}
 


### PR DESCRIPTION
```
$ cat /proc/sys/kernel/osrelease
4.19.128-microsoft-standard
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5593)
<!-- Reviewable:end -->
