### PR TITLE
feat: add ethtool ioctl as additional source of information

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/ryanuber/go-glob v1.0.0
+	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1039,6 +1039,8 @@ github.com/ryanuber/columnize v2.1.2+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 h1:ZFfeKAhIQiiOrQaI3/znw0gOmYpO28Tcu1YaqMa/jtQ=
+github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/pkg/machinery/resources/network/link_status.go
+++ b/pkg/machinery/resources/network/link_status.go
@@ -36,6 +36,8 @@ type LinkStatusSpec struct {
 	BusPath          string                      `yaml:"busPath,omitempty"`
 	PCIID            string                      `yaml:"pciID,omitempty"`
 	Driver           string                      `yaml:"driver,omitempty"`
+	DriverVersion    string                      `yaml:"driverVersion,omitempty"`
+	FirmwareVersion  string                      `yaml:"firmwareVersion,omitempty"`
 	// Fields coming from ethtool API.
 	LinkState     bool              `yaml:"linkState"`
 	SpeedMegabits int               `yaml:"speedMbit,omitempty"`


### PR DESCRIPTION
This expands `LinkStatus` information when available.

Example, for QEMU:

```
$ talosctl -n 172.20.0.6 get links eth0 -o yaml
    busPath: "0000:00:02.0"
    driver: virtio_net
    driverVersion: "1.0.0\00-talos"
```

```
$ talosctl -n 172.20.0.6 get links bond0 -o yaml
    driver: bonding
    driverVersion: 5.15.40-talos
    firmwareVersion: "2"
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5600)
<!-- Reviewable:end -->
