### PR TITLE
docs: fix typo in main page

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -76,7 +76,7 @@ title = "Talos Linux?"
           <div class="col-12 col-lg-4">
             <h3 class="display-4 text-center mb-3">Evolvability</h3>
             <p class="">
-              Talos simplifies your architecture, increases your agility, and makes
+              Talos simplifies your architecture, increases your agility, and
               always delivers current stable Kubernetes and Linux versions.
             </p>
           </div>


### PR DESCRIPTION
This PR fixes a typo that a kubecon attendee noticed :)

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5601)
<!-- Reviewable:end -->
