### PR TITLE
feat: Add support for disabling search domains

### DIFF
--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -239,6 +239,24 @@ func (suite *EtcFileConfigSuite) TestNoExtraHosts() {
 	)
 }
 
+func (suite *EtcFileConfigSuite) TestNoSearchDomain() {
+	cfg := config.NewMachineConfig(
+		&v1alpha1.Config{
+			ConfigVersion: "v1alpha1",
+			MachineConfig: &v1alpha1.MachineConfig{
+				MachineNetwork: &v1alpha1.NetworkConfig{
+					NetworkDisableSearchDomain: true,
+				},
+			},
+		},
+	)
+	suite.testFiles(
+		[]resource.Resource{cfg, suite.defaultAddress, suite.hostnameStatus, suite.resolverStatus},
+		"nameserver 1.1.1.1\nnameserver 2.2.2.2\nnameserver 3.3.3.3\n",
+		"127.0.0.1       localhost\n33.11.22.44       foo.example.com foo\n::1             localhost ip6-localhost ip6-loopback\nff02::1         ip6-allnodes\nff02::2         ip6-allrouters", //nolint:lll
+	)
+}
+
 func (suite *EtcFileConfigSuite) TestNoDomainname() {
 	suite.hostnameStatus.TypedSpec().Domainname = ""
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -141,6 +141,7 @@ type MachineNetwork interface {
 	Devices() []Device
 	ExtraHosts() []ExtraHost
 	KubeSpan() KubeSpan
+	DisableSearchDomain() bool
 }
 
 // ExtraHost represents a host entry in /etc/hosts.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -469,6 +469,11 @@ func (n *NetworkConfig) Hostname() string {
 	return n.NetworkHostname
 }
 
+// DisableSearchDomain implements the config.Provider interface.
+func (n *NetworkConfig) DisableSearchDomain() bool {
+	return n.NetworkDisableSearchDomain
+}
+
 // Devices implements the config.Provider interface.
 func (n *NetworkConfig) Devices() []config.Device {
 	interfaces := make([]config.Device, len(n.NetworkInterfaces))

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -149,7 +149,8 @@ var (
 	kubeletImageExample = (&KubeletConfig{}).Image()
 
 	machineNetworkConfigExample = &NetworkConfig{
-		NetworkHostname: "worker-1",
+		NetworkHostname:            "worker-1",
+		NetworkDisableSearchDomain: false,
 		NetworkInterfaces: []*Device{
 			{
 				DeviceInterface: "eth0",
@@ -1061,6 +1062,16 @@ type NetworkConfig struct {
 	//   examples:
 	//     - value: networkKubeSpanExample
 	NetworkKubeSpan NetworkKubeSpan `yaml:"kubespan,omitempty"`
+	//   description: |
+	//     Disable generating a default search domain in /etc/resolv.conf
+	//     based on the machine hostname.
+	//     Defaults to `false`.
+	//   values:
+	//     - true
+	//     - yes
+	//     - false
+	//     - no
+	NetworkDisableSearchDomain bool `yaml:"disableSearchDomain,omitempty"`
 }
 
 // InstallConfig represents the installation options for preparing a node.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -644,7 +644,7 @@ func init() {
 			FieldName: "network",
 		},
 	}
-	NetworkConfigDoc.Fields = make([]encoder.Doc, 5)
+	NetworkConfigDoc.Fields = make([]encoder.Doc, 6)
 	NetworkConfigDoc.Fields[0].Name = "hostname"
 	NetworkConfigDoc.Fields[0].Type = "string"
 	NetworkConfigDoc.Fields[0].Note = ""
@@ -678,6 +678,17 @@ func init() {
 	NetworkConfigDoc.Fields[4].Comments[encoder.LineComment] = "Configures KubeSpan feature."
 
 	NetworkConfigDoc.Fields[4].AddExample("", networkKubeSpanExample)
+	NetworkConfigDoc.Fields[5].Name = "disableSearchDomain"
+	NetworkConfigDoc.Fields[5].Type = "bool"
+	NetworkConfigDoc.Fields[5].Note = ""
+	NetworkConfigDoc.Fields[5].Description = "Disable generating a default search domain in /etc/resolv.conf\nbased on the machine hostname.\nDefaults to `false`."
+	NetworkConfigDoc.Fields[5].Comments[encoder.LineComment] = "Disable generating a default search domain in /etc/resolv.conf"
+	NetworkConfigDoc.Fields[5].Values = []string{
+		"true",
+		"yes",
+		"false",
+		"no",
+	}
 
 	InstallConfigDoc.Type = "InstallConfig"
 	InstallConfigDoc.Comments[encoder.LineComment] = "InstallConfig represents the installation options for preparing a node."

--- a/website/content/v1.1/reference/configuration.md
+++ b/website/content/v1.1/reference/configuration.md
@@ -950,6 +950,7 @@ extraHostEntries:
 kubespan:
     enabled: true # Enable the KubeSpan feature.
 {{< /highlight >}}</details> | |
+|`disableSearchDomain` |bool |<details><summary>Disable generating a default search domain in /etc/resolv.conf</summary>based on the machine hostname.<br />Defaults to `false`.</details>  |`true`<br />`yes`<br />`false`<br />`no`<br /> |
 
 
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This PR adds the ability to disable the automatic setting of a search domain.

## Why? (reasoning)

This can (for example) be useful to prevent issues with Alpine-based containers. (https://stackoverflow.com/a/65593511)

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5605)
<!-- Reviewable:end -->
