### PR TITLE
feat: support join token as part of siderolink kernel parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/talos-systems/go-smbios v0.2.0
 	github.com/talos-systems/grpc-proxy v0.3.0
 	github.com/talos-systems/net v0.3.2
-	github.com/talos-systems/siderolink v0.1.1
+	github.com/talos-systems/siderolink v0.1.2-0.20220524191358-3a5be65da5bb
 	github.com/talos-systems/talos/pkg/machinery v1.1.0-alpha.2
 	github.com/u-root/u-root v0.8.0
 	github.com/vishvananda/netlink v1.2.0-beta

--- a/go.sum
+++ b/go.sum
@@ -1159,6 +1159,8 @@ github.com/talos-systems/net v0.3.2 h1:IMseRyuha8fNsv/3FbQPRE9hLVRBEFR+9sxcoETQ5
 github.com/talos-systems/net v0.3.2/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
 github.com/talos-systems/siderolink v0.1.1 h1:Jsgx2CQ8OslDu4DzsGBTecj/bdxDm2fKfTIU8eee2Es=
 github.com/talos-systems/siderolink v0.1.1/go.mod h1:1PLRyKRx+MAkz1vWJXIP19p5wChF0TejbIbX/CQMWuw=
+github.com/talos-systems/siderolink v0.1.2-0.20220524191358-3a5be65da5bb h1:VZwe9q3fjBMtRcwwvLv05YmvVgiSGsLq17U7rxThlwk=
+github.com/talos-systems/siderolink v0.1.2-0.20220524191358-3a5be65da5bb/go.mod h1:1PLRyKRx+MAkz1vWJXIP19p5wChF0TejbIbX/CQMWuw=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/app/machined/pkg/controllers/siderolink/export_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/export_test.go
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package siderolink
+
+var ParseJoinToken = parseJoinToken

--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
+	"regexp"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -63,6 +65,30 @@ func (ctrl *ManagerController) Outputs() []controller.Output {
 			Kind: controller.OutputShared,
 		},
 	}
+}
+
+var urlSchemeMatcher = regexp.MustCompile(`[a-zA-z]+\://`)
+
+// parseJoinToken parses the jointoken from the sidero link kernel parameter
+// and returns nil if no joinToken was specified.
+func parseJoinToken(sideroLinkParam string) (joinToken *string, err error) {
+	if !urlSchemeMatcher.Match([]byte(sideroLinkParam)) {
+		sideroLinkParam = "grpc://" + sideroLinkParam
+	}
+
+	u, err := url.Parse(sideroLinkParam)
+	if err != nil {
+		return nil, err
+	}
+
+	params := u.Query()
+
+	joinTokenStr, ok := params["jointoken"]
+	if !ok || len(joinTokenStr) < 1 {
+		return nil, nil
+	}
+
+	return &joinTokenStr[0], nil
 }
 
 // Run implements controller.Controller interface.
@@ -121,9 +147,15 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 			continue
 		}
 
+		joinToken, err := parseJoinToken(apiEndpoint)
+		if err != nil {
+			logger.Warn("failed to parse join token from sidero link kernel parameter: %w", zap.Error(err))
+		}
+
 		resp, err := sideroLinkClient.Provision(ctx, &pb.ProvisionRequest{
 			NodeUuid:      nodeUUID,
 			NodePublicKey: ctrl.nodeKey.PublicKey().String(),
+			JoinToken:     joinToken,
 		})
 		if err != nil {
 			return fmt.Errorf("error accessing SideroLink API: %w", err)

--- a/internal/app/machined/pkg/controllers/siderolink/manager_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
@@ -201,4 +202,42 @@ func (suite *ManagerSuite) TearDownTest() {
 
 func TestManagerSuite(t *testing.T) {
 	suite.Run(t, new(ManagerSuite))
+}
+
+func TestParseJoinToken(t *testing.T) {
+	t.Run("parses a join token from a complete URL without error", func(t *testing.T) {
+		// when
+		joinToken, err := siderolinkctrl.ParseJoinToken("grpc://10.5.0.2:3445?jointoken=ttt")
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "ttt", *joinToken)
+	})
+
+	t.Run("parses a join token from an URL without a scheme", func(t *testing.T) {
+		// when
+		joinToken, err := siderolinkctrl.ParseJoinToken("10.5.0.2:3445?jointoken=ttt")
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "ttt", *joinToken)
+	})
+
+	t.Run("does not error if there is no join token in a complete URL", func(t *testing.T) {
+		// when
+		joinToken, err := siderolinkctrl.ParseJoinToken("grpc://10.5.0.2:3445")
+
+		// then
+		assert.NoError(t, err)
+		assert.Nil(t, joinToken)
+	})
+
+	t.Run("does not error if there is no join token in an URL without a scheme", func(t *testing.T) {
+		// when
+		joinToken, err := siderolinkctrl.ParseJoinToken("10.5.0.2:3445")
+
+		// then
+		assert.NoError(t, err)
+		assert.Nil(t, joinToken)
+	})
 }


### PR DESCRIPTION
# Pull Request

To enable authorization to services via siderolink on startup we extend
the kernel parameter siderolink.api to accept an optional join token as
a parameter as in grpc://<host>:<port>?jointoken=1234

Fixes #5592 

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5623)
<!-- Reviewable:end -->
