### PR TITLE
fix: improve error message when creating cluster

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -698,7 +698,7 @@ func postCreate(ctx context.Context, clusterAccess *access.Adapter) error {
 func saveConfig(talosConfigObj *clientconfig.Config) (err error) {
 	c, err := clientconfig.Open(talosconfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening talos config: %s", err)
 	}
 
 	renames := c.Merge(talosConfigObj)


### PR DESCRIPTION
Add extra context to error message when unable to properly
open the talos config file when creating a cluster.

Closes #5625 

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5626)
<!-- Reviewable:end -->
