### PR TITLE
test: use use correct method to generate Wireguard private key

### DIFF
--- a/cmd/talosctl/pkg/mgmt/helpers/wireguard.go
+++ b/cmd/talosctl/pkg/mgmt/helpers/wireguard.go
@@ -24,7 +24,7 @@ func NewWireguardConfigBundle(ips []net.IP, wireguardCidr string, listenPort, ma
 	peers := make([]*v1alpha1.DeviceWireguardPeer, len(ips))
 
 	for i, ip := range ips {
-		key, err := wgtypes.GenerateKey()
+		key, err := wgtypes.GeneratePrivateKey()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`GenerateKey` generates random 32 bytes vs. the key suitable for
Wireguard endpoint key.

This is the only place in code with this bug, and it is only used in
test code (`talosctl cluster create` with fixed Wireguard
configuration).

SideroLink and Kubespan are not affected.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5630)
<!-- Reviewable:end -->
