### PR TITLE
chore: add cloud-image-uploader to go workspace

### DIFF
--- a/go.work
+++ b/go.work
@@ -2,5 +2,6 @@ go 1.18
 
 use (
 	.
+	./hack/cloud-image-uploader
 	./pkg/machinery
 )


### PR DESCRIPTION
Add cloud-image-uploader to go workspace

Signed-off-by: Noel Georgi <git@frezbo.dev>