### PR TITLE
doc: correct the install-image tag in the `Developing Talos` section

### DIFF
--- a/website/content/v1.0/advanced/developing-talos.md
+++ b/website/content/v1.0/advanced/developing-talos.md
@@ -71,7 +71,7 @@ sudo -E _out/talosctl-linux-amd64 cluster create \
     --registry-mirror gcr.io=http://172.20.0.1:5003 \
     --registry-mirror ghcr.io=http://172.20.0.1:5004 \
     --registry-mirror 127.0.0.1:5005=http://172.20.0.1:5005 \
-    --install-image=127.0.0.1:5005/talos-systems/installer:<RECORDED HASH from the build step> \
+    --install-image=127.0.0.1:5005/siderolabs/installer:<RECORDED HASH from the build step> \
     --masters 3 \
     --workers 2 \
     --with-bootloader=false


### PR DESCRIPTION
The tag was already corrected in v1.1 of the doc but we also need to
correct it for v1.0. When we check out git tag v1.0.5 and build the
installer it will create the image with `siderolabs` in the image tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5635)
<!-- Reviewable:end -->
