### PR TITLE
feat: include azure public IPs from standard LB SKU into extips

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure_test.go
@@ -19,6 +19,9 @@ import (
 //go:embed testdata/metadata.json
 var rawMetadata []byte
 
+//go:embed testdata/loadbalancer.json
+var rawLoadBalancerMetadata []byte
+
 //go:embed testdata/expected.yaml
 var expectedNetworkConfig string
 
@@ -30,6 +33,13 @@ func TestParseMetadata(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rawMetadata, &m))
 
 	networkConfig, err := a.ParseMetadata(m, []byte("some.fqdn"))
+	require.NoError(t, err)
+
+	var lb azure.LoadBalancerMetadata
+
+	require.NoError(t, json.Unmarshal(rawLoadBalancerMetadata, &lb))
+
+	networkConfig.ExternalIPs, err = a.ParseLoadBalancerIP(lb, networkConfig.ExternalIPs)
 	require.NoError(t, err)
 
 	marshaled, err := yaml.Marshal(networkConfig)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
@@ -16,3 +16,5 @@ operators:
       layer: default
 externalIPs:
     - 1.2.3.4
+    - 2603:1020:10:5::34
+    - 20.10.5.34

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/loadbalancer.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/loadbalancer.json
@@ -1,0 +1,31 @@
+{
+    "loadbalancer": {
+        "publicIpAddresses": [
+            {
+                "frontendIpAddress": "[2603:1020:10:5::34]",
+                "privateIpAddress": "[fd00::10]"
+            },
+            {
+                "frontendIpAddress": "20.10.5.34",
+                "privateIpAddress": "172.18.1.10"
+            }
+        ],
+        "inboundRules": [
+            {
+                "frontendIpAddress": "[fd60:172:16:88::5]",
+                "protocol": "Tcp",
+                "frontendPort": 6443,
+                "backendPort": 6443,
+                "privateIpAddress": "[fd00::10]"
+            },
+            {
+                "frontendIpAddress": "172.16.136.5",
+                "protocol": "Tcp",
+                "frontendPort": 6443,
+                "backendPort": 6443,
+                "privateIpAddress": "172.18.1.10"
+            }
+        ],
+        "outboundRules": []
+    }
+}


### PR DESCRIPTION
Add public IP from Azure Standard SKU LB to the list of external IP (for
proper certificate generation).

part of #4150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5638)
<!-- Reviewable:end -->
