### PR TITLE
chore: bump kernel to 5.15.43

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-4-g943b5d0
-PKGS ?= v1.0.0-19-g33d694c
+PKGS ?= v1.0.0-20-g7e779c7
 EXTRAS ?= v1.0.0-3-g6327c36
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -17,7 +17,7 @@ preface = """\
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.41
+* Linux: 5.15.43
 * Containerd: v1.6.4
 * Runc: 1.1.2
 * CoreDNS: v1.9.2

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.41-talos"
+	DefaultKernelVersion = "5.15.43-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to [5.15.43](https://github.com/siderolabs/pkgs/pull/491)

Signed-off-by: Noel Georgi <git@frezbo.dev>