### PR TITLE
feat: enable version API in maintenance mode

### DIFF
--- a/website/content/v1.1/reference/cli.md
+++ b/website/content/v1.1/reference/cli.md
@@ -2094,9 +2094,10 @@ talosctl version [flags]
 ### Options
 
 ```
-      --client   Print client version only
-  -h, --help     help for version
-      --short    Print the short version
+      --client     Print client version only
+  -h, --help       help for version
+  -i, --insecure   use Talos maintenance mode API
+      --short      Print the short version
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This is useful to find Talos version as it got booted (e.g. to generate
proper machine configuration).

There's a security concern that version API might return sensitive
information via public API. At the same time Talos version can be
guessed by looking at the output of other APIs, e.g. resource type list
(`talosctl get rd`), which changes with every minor version.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5645)
<!-- Reviewable:end -->
