### PR TITLE
fix: correctly parse empty route flags from YAML

### DIFF
--- a/pkg/machinery/nethelpers/routeflags.go
+++ b/pkg/machinery/nethelpers/routeflags.go
@@ -29,6 +29,10 @@ func (flags RouteFlags) String() string {
 func RouteFlagsString(s string) (RouteFlags, error) {
 	flags := RouteFlags(0)
 
+	if s == "" {
+		return flags, nil
+	}
+
 	for _, p := range strings.Split(s, ",") {
 		flag, err := RouteFlagString(p)
 		if err != nil {

--- a/pkg/machinery/nethelpers/routeflags_test.go
+++ b/pkg/machinery/nethelpers/routeflags_test.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nethelpers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+)
+
+func TestRouteFlagsStrings(t *testing.T) {
+	for _, tt := range []struct {
+		routeFlagsString string
+		expected         nethelpers.RouteFlags
+	}{
+		{
+			routeFlagsString: "",
+			expected:         nethelpers.RouteFlags(0),
+		},
+		{
+			routeFlagsString: "cloned",
+			expected:         nethelpers.RouteFlags(nethelpers.RouteCloned),
+		},
+		{
+			routeFlagsString: "cloned,prefix",
+			expected:         nethelpers.RouteFlags(nethelpers.RouteCloned | nethelpers.RoutePrefix),
+		},
+	} {
+		routeFlags, err := nethelpers.RouteFlagsString(tt.routeFlagsString)
+
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expected, routeFlags)
+	}
+}


### PR DESCRIPTION
This fixes unmarshaling of resource spec for routes with empty flags.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5648)
<!-- Reviewable:end -->
