### PR TITLE
fix: unmarshal HardwareAddr without stdlib help

### DIFF
--- a/pkg/machinery/nethelpers/hwaddr.go
+++ b/pkg/machinery/nethelpers/hwaddr.go
@@ -4,7 +4,11 @@
 
 package nethelpers
 
-import "net"
+import (
+	"bytes"
+	"encoding/hex"
+	"net"
+)
 
 // HardwareAddr wraps net.HardwareAddr for YAML marshaling.
 type HardwareAddr net.HardwareAddr
@@ -16,12 +20,17 @@ func (addr HardwareAddr) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements text.Unmarshaler interface.
 func (addr *HardwareAddr) UnmarshalText(b []byte) error {
-	mac, err := net.ParseMAC(string(b))
+	rawHex := bytes.ReplaceAll(b, []byte(":"), []byte(""))
+	dstLen := hex.DecodedLen(len(rawHex))
+
+	dst := make([]byte, dstLen)
+
+	n, err := hex.Decode(dst, rawHex)
 	if err != nil {
 		return err
 	}
 
-	*addr = HardwareAddr(mac)
+	*addr = HardwareAddr(dst[:n])
 
 	return nil
 }


### PR DESCRIPTION
Stdlib `net.ParseMAC` does lots of validations, but some hardware addrs
we can see (on logical interfaces) are not valid, so parse MACs in a
simple way.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5651)
<!-- Reviewable:end -->
