### PR TITLE
chore: update tools/pkgs/extras to 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/siderolabs/tools:v1.1.0-alpha.0-17-g967ebd9
-PKGS ?= v1.1.0-alpha.0-47-g9b70e9f
-EXTRAS ?= v1.1.0-alpha.0-3-ge2bb56e
+TOOLS ?= ghcr.io/siderolabs/tools:v1.1.0
+PKGS ?= v1.1.0
+EXTRAS ?= v1.1.0
 GO_VERSION ?= 1.18
 GOIMPORTS_VERSION ?= v0.1.10
 GOFUMPT_VERSION ?= v0.3.0


### PR DESCRIPTION
In preparation for Talos 1.1.0-beta, update all dependencies to release
versions.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
