### PR TITLE
fix: introduce more route protocols as constants

### DIFF
--- a/pkg/machinery/nethelpers/routeprotocol.go
+++ b/pkg/machinery/nethelpers/routeprotocol.go
@@ -11,9 +11,26 @@ type RouteProtocol uint8
 
 // RouteType constants.
 const (
-	ProtocolUnspec   RouteProtocol = iota // unspec
-	ProtocolRedirect                      // redirect
-	ProtocolKernel                        // kernel
-	ProtocolBoot                          // boot
-	ProtocolStatic                        // static
+	ProtocolUnspec     RouteProtocol = 0   // unspec
+	ProtocolRedirect   RouteProtocol = 1   // redirect
+	ProtocolKernel     RouteProtocol = 2   // kernel
+	ProtocolBoot       RouteProtocol = 3   // boot
+	ProtocolStatic     RouteProtocol = 4   // static
+	ProtocolRA         RouteProtocol = 9   // ra
+	ProtocolMRT        RouteProtocol = 10  // mrt
+	ProtocolZebra      RouteProtocol = 11  // zebra
+	ProtocolBird       RouteProtocol = 12  // bird
+	ProtocolDnrouted   RouteProtocol = 13  // dnrouted
+	ProtocolXorp       RouteProtocol = 14  // xorp
+	ProtocolNTK        RouteProtocol = 15  // ntk
+	ProtocolDHCP       RouteProtocol = 16  // dhcp
+	ProtocolMRTD       RouteProtocol = 17  // mrtd
+	ProtocolKeepalived RouteProtocol = 18  // keepalived
+	ProtocolBabel      RouteProtocol = 42  // babel
+	ProtocolOpenr      RouteProtocol = 99  // openr
+	ProtocolBGP        RouteProtocol = 186 // bgp
+	ProtocolISIS       RouteProtocol = 187 // isis
+	ProtocolOSPF       RouteProtocol = 188 // ospf
+	ProtocolRIP        RouteProtocol = 189 // rip
+	ProtocolEIGRP      RouteProtocol = 192 // eigrp
 )

--- a/pkg/machinery/nethelpers/routeprotocol_enumer.go
+++ b/pkg/machinery/nethelpers/routeprotocol_enumer.go
@@ -7,25 +7,70 @@ import (
 	"fmt"
 )
 
-const _RouteProtocolName = "unspecredirectkernelbootstatic"
+const (
+	_RouteProtocolName_0 = "unspecredirectkernelbootstatic"
+	_RouteProtocolName_1 = "ramrtzebrabirddnroutedxorpntkdhcpmrtdkeepalived"
+	_RouteProtocolName_2 = "babel"
+	_RouteProtocolName_3 = "openr"
+	_RouteProtocolName_4 = "bgpisisospfrip"
+	_RouteProtocolName_5 = "eigrp"
+)
 
-var _RouteProtocolIndex = [...]uint8{0, 6, 14, 20, 24, 30}
+var (
+	_RouteProtocolIndex_0 = [...]uint8{0, 6, 14, 20, 24, 30}
+	_RouteProtocolIndex_1 = [...]uint8{0, 2, 5, 10, 14, 22, 26, 29, 33, 37, 47}
+	_RouteProtocolIndex_2 = [...]uint8{0, 5}
+	_RouteProtocolIndex_3 = [...]uint8{0, 5}
+	_RouteProtocolIndex_4 = [...]uint8{0, 3, 7, 11, 14}
+	_RouteProtocolIndex_5 = [...]uint8{0, 5}
+)
 
 func (i RouteProtocol) String() string {
-	if i >= RouteProtocol(len(_RouteProtocolIndex)-1) {
+	switch {
+	case 0 <= i && i <= 4:
+		return _RouteProtocolName_0[_RouteProtocolIndex_0[i]:_RouteProtocolIndex_0[i+1]]
+	case 9 <= i && i <= 18:
+		i -= 9
+		return _RouteProtocolName_1[_RouteProtocolIndex_1[i]:_RouteProtocolIndex_1[i+1]]
+	case i == 42:
+		return _RouteProtocolName_2
+	case i == 99:
+		return _RouteProtocolName_3
+	case 186 <= i && i <= 189:
+		i -= 186
+		return _RouteProtocolName_4[_RouteProtocolIndex_4[i]:_RouteProtocolIndex_4[i+1]]
+	case i == 192:
+		return _RouteProtocolName_5
+	default:
 		return fmt.Sprintf("RouteProtocol(%d)", i)
 	}
-	return _RouteProtocolName[_RouteProtocolIndex[i]:_RouteProtocolIndex[i+1]]
 }
 
-var _RouteProtocolValues = []RouteProtocol{0, 1, 2, 3, 4}
+var _RouteProtocolValues = []RouteProtocol{0, 1, 2, 3, 4, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 42, 99, 186, 187, 188, 189, 192}
 
 var _RouteProtocolNameToValueMap = map[string]RouteProtocol{
-	_RouteProtocolName[0:6]:   0,
-	_RouteProtocolName[6:14]:  1,
-	_RouteProtocolName[14:20]: 2,
-	_RouteProtocolName[20:24]: 3,
-	_RouteProtocolName[24:30]: 4,
+	_RouteProtocolName_0[0:6]:   0,
+	_RouteProtocolName_0[6:14]:  1,
+	_RouteProtocolName_0[14:20]: 2,
+	_RouteProtocolName_0[20:24]: 3,
+	_RouteProtocolName_0[24:30]: 4,
+	_RouteProtocolName_1[0:2]:   9,
+	_RouteProtocolName_1[2:5]:   10,
+	_RouteProtocolName_1[5:10]:  11,
+	_RouteProtocolName_1[10:14]: 12,
+	_RouteProtocolName_1[14:22]: 13,
+	_RouteProtocolName_1[22:26]: 14,
+	_RouteProtocolName_1[26:29]: 15,
+	_RouteProtocolName_1[29:33]: 16,
+	_RouteProtocolName_1[33:37]: 17,
+	_RouteProtocolName_1[37:47]: 18,
+	_RouteProtocolName_2[0:5]:   42,
+	_RouteProtocolName_3[0:5]:   99,
+	_RouteProtocolName_4[0:3]:   186,
+	_RouteProtocolName_4[3:7]:   187,
+	_RouteProtocolName_4[7:11]:  188,
+	_RouteProtocolName_4[11:14]: 189,
+	_RouteProtocolName_5[0:5]:   192,
 }
 
 // RouteProtocolString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This fixes marshaling of route information.

Taken from `/etc/iproute2/rt_protos`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5656)
<!-- Reviewable:end -->
