### PR TITLE
add variable substitution to config URLs

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -189,9 +189,9 @@ func readConfigFromISO() (b []byte, err error) {
 		return nil, fmt.Errorf("failed to get filesystem type")
 	}
 
-	//if err = unix.Mount(dev.Device().Name(), mnt, sb.Type(), unix.MS_RDONLY, ""); err != nil {
-	//	return nil, fmt.Errorf("failed to mount iso: %w", err)
-	//}
+	if err = unix.Mount(dev.Device().Name(), mnt, sb.Type(), unix.MS_RDONLY, ""); err != nil {
+		return nil, fmt.Errorf("failed to mount iso: %w", err)
+	}
 
 	b, err = ioutil.ReadFile(filepath.Join(mnt, filepath.Base(constants.ConfigPath)))
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal_test.go
@@ -48,6 +48,11 @@ func TestPopulateURLParameters(t *testing.T) {
 			url:         "http://example.com/metadata?uuid=xyz&uuid=foo",
 			expectedURL: fmt.Sprintf("http://example.com/metadata?uuid=%s", mockUUID),
 		},
+		{
+			name:        "uuid in path",
+			url:         "http://example.com/{{.UUID}}/metadata",
+			expectedURL: fmt.Sprintf("http://example.com/%s/metadata", mockUUID),
+		},
 	} {
 		tt := tt
 

--- a/website/content/v1.1/reference/kernel.md
+++ b/website/content/v1.1/reference/kernel.md
@@ -84,6 +84,13 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 
   The URL at which the machine configuration data may be found.
 
+  Supports `text/template` style replacements for:
+    - `{{.UUID}}`
+    - `{{.MAC}}`
+    - `{{.Hostname}}`
+
+  Example: `https://config.example.com/machines/{{.UUID}}/bootstrap/config?mac={{.MAC}}`
+
 #### `talos.platform`
 
   The platform name on which Talos will run.


### PR DESCRIPTION
# Pull Request

Passing the `talos.config` url through a templating engine.

## What? (description)

Implementing #3272 

## Why? (reasoning)

By doing token substitution on the `talos.config` downloadUrl with [text/template](https://pkg.go.dev/text/template), talos can provide can provide mode runtime information to a machine config serving endpoint, like a MAC address in a querystring or URL path part to check against a pre-approved list of interfaces.  As @Ulexus put it, "This would allow more dynamic deployments with simpler bootloader requirements."

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5660)
<!-- Reviewable:end -->
