### PR TITLE
fix: flannel ipv6 compatibility

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -216,8 +216,9 @@ func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scr
 	for i := range defaultManifests {
 		tmpl, err := template.New(defaultManifests[i].name).
 			Funcs(template.FuncMap{
-				"json": jsonify,
-				"join": strings.Join,
+				"json":     jsonify,
+				"join":     strings.Join,
+				"contains": strings.Contains,
 			}).
 			Parse(string(defaultManifests[i].template))
 		if err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -534,7 +534,14 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "{{ index .PodCIDRs 0 }}",
+      {{- range $cidr := .PodCIDRs }}
+        {{- if contains $cidr "." }}
+      "Network": "{{ $cidr }}",
+        {{- else }}
+      "IPv6Network" : "{{ $cidr }}",
+      "EnableIPv6" : true,
+        {{- end }}
+      {{- end }}
       "Backend": {
         "Type": "vxlan",
         "Port": 4789


### PR DESCRIPTION
Flannel v0.18.0 requares ipv6-cidr in the config file if node.spec.PodCIDRs
has IPv6 subnet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5662)
<!-- Reviewable:end -->
