### PR TITLE
chore: disable kexec on rpi4 and rockpi

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4/rockpi4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4/rockpi4.go
@@ -86,6 +86,7 @@ func (r *Rockpi4) Install(disk string) (err error) {
 func (r *Rockpi4) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty0").Append("ttyS2,1500000n8"),
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c/rockpi4c.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c/rockpi4c.go
@@ -85,6 +85,7 @@ func (r *Rockpi4c) Install(disk string) (err error) {
 func (r *Rockpi4c) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty0").Append("ttyS2,1500000n8"),
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -52,6 +52,7 @@ func (r *RPi4) Install(disk string) (err error) {
 func (r *RPi4) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty0").Append("ttyAMA0,115200"),
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 


### PR DESCRIPTION
Disable kexec on SBC's known to have issues when doing kexec

Fixes: https://github.com/siderolabs/talos/issues/5649

Raspberry Pi seems to have issues enabling secondary CPU's on subsequent
reboots. RockPi's doesn't seem to work at all with kexec.

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5670)
<!-- Reviewable:end -->
