### PR TITLE
chore: bump golang to 1.17.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-4-g943b5d0
-PKGS ?= v1.0.0-21-g80fca56
-EXTRAS ?= v1.0.0-3-g6327c36
+TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-5-g06e7ef3
+PKGS ?= v1.0.0-22-gb01e120
+EXTRAS ?= v1.0.0-4-g05b0920
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1
 GOLANGCILINT_VERSION ?= v1.43.0

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,7 +22,7 @@ preface = """\
 * Runc: 1.1.2
 * CoreDNS: v1.9.2
 
-Talos is built with Go 1.17.10
+Talos is built with Go 1.17.11
 """
 
 [make_deps]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -655,7 +655,7 @@ const (
 	DBusClientSocketPath = "/run/dbus/system_bus_socket"
 
 	// GoVersion is the version of Go compiler this release was built with.
-	GoVersion = "go1.17.10"
+	GoVersion = "go1.17.11"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Bump golang to 1.17.11

Ref:
 - https://github.com/siderolabs/pkgs/pull/500
 - https://github.com/siderolabs/extras/pull/53

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5685)
<!-- Reviewable:end -->
