### PR TITLE
docs: fix required ports

### DIFF
--- a/website/content/v1.0/learn-more/talos-network-connectivity.md
+++ b/website/content/v1.0/learn-more/talos-network-connectivity.md
@@ -63,8 +63,8 @@ This is not always possible, however, so this page lays out the minimal network 
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
-      <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="../../learn-more/components/#trustd">trustd</a></td>
+      <td class="border px-4 py-2">50000*</td>
+    <td class="border px-4 py-2"><a href="../../learn-more/components/#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/website/content/v1.1/learn-more/talos-network-connectivity.md
+++ b/website/content/v1.1/learn-more/talos-network-connectivity.md
@@ -63,8 +63,8 @@ This is not always possible, however, so this page lays out the minimal network 
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
-      <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="../../learn-more/components/#trustd">trustd</a></td>
+      <td class="border px-4 py-2">50000*</td>
+    <td class="border px-4 py-2"><a href="../../learn-more/components/#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Workers need port 50000 to be open for control plane nodes, not port
50001.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5687)
<!-- Reviewable:end -->
