### PR TITLE
chore: fix rook-ceph resource use

### DIFF
--- a/hack/test/day-two/ceph-values.yaml
+++ b/hack/test/day-two/ceph-values.yaml
@@ -1,0 +1,8 @@
+cephClusterSpec:
+  resources:
+    mgr:
+      limits: {}
+      requests: {}
+    osd:
+      limits: {}
+      requests: {}

--- a/hack/test/day-two/config.yaml
+++ b/hack/test/day-two/config.yaml
@@ -31,5 +31,6 @@ charts:
     podSecurityLevel: privileged
     repo: https://charts.rook.io/release
     chart: rook-ceph-cluster
+    valuesPath: hack/test/day-two/ceph-values.yaml
     depends:
       - rook


### PR DESCRIPTION
Reduce Rook-Ceph cluster resource use to something more
fitting a simple set of integration tests.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5701)
<!-- Reviewable:end -->
