### PR TITLE
feat: build Talos images with system extensions included

### DIFF
--- a/hack/imager.sh
+++ b/hack/imager.sh
@@ -1,0 +1,19 @@
+# helper scripts for running imager functions
+
+prepare_extension_images() {
+    # first argument - image platform, e.g. linux/amd64
+    # other arguments - list of system extension images
+    local platform="$1"
+    shift
+
+	local extensions_dir=$(mktemp -d)
+
+	for ext_image in "$@"; do
+        echo "Extracting ${ext_image}..." >&2
+		local ext_dir="${extensions_dir}/$(basename `mktemp -u`)"
+		mkdir -p "${ext_dir}" && \
+			crane export --platform="${platform}" "${ext_image}" - | tar x -C "${ext_dir}"
+	done
+
+    echo "${extensions_dir}"
+}

--- a/website/content/v1.1/talos-guides/configuration/system-extensions.md
+++ b/website/content/v1.1/talos-guides/configuration/system-extensions.md
@@ -29,9 +29,16 @@ System extensions will be activated on boot and overlaid on top of the Talos roo
 In order to update the system extensions for a running instance, update `.machine.install.extensions` and upgrade Talos.
 (Note: upgrading to the same version of Talos is fine).
 
-> Note: in the next releases of Talos there will be a way to build a Talos image with system extensions included.
+## Building a Talos Image with System Extensions
 
-## Creating System Extensions
+System extensions can be installed into the Talos disk image (e.g. AWS AMI or VMWare OVF) by running the following command to generate the image
+from the Talos source tree:
+
+```sh
+make image-metal IMAGER_SYSTEM_EXTENSIONS="ghcr.io/siderolabs/amd-ucode:20220411 ghcr.io/siderolabs/gvisor:20220405.0-v1.0.0-10-g82b41ad"
+```
+
+## Authoring System Extensions
 
 A Talos system extension is a container image with the [specific folder structure](https://github.com/siderolabs/extensions#readme).
 System extensions can be built and managed using any tool that produces container images, e.g. `docker build`.


### PR DESCRIPTION
This allows to build a custom Talos image which comes with some system
extension bundled in. Sometimes we might need to have an extension in
the initial image, e.g. `vmtoolsd` for VMWare Talos image.

Syntax:

```
make image-aws \
  IMAGER_SYSTEM_EXTENSIONS="ghcr.io/siderolabs/amd-ucode:..."
```

System extensions are not supported for now for ISO images, as they
don't go through the common installer flow (https://github.com/siderolabs/talos/issues/5725).

Also it might be nice to add a simple way to generate just
`initramfs.xz` with system extensions bundled in (e.g. for PXE booting).
(https://github.com/siderolabs/talos/issues/5726)

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5707)
<!-- Reviewable:end -->
