### PR TITLE
feat(apiserver): disallow anonymous requests by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -120,6 +120,21 @@ Talos machine configuration supports specifying network interfaces by selectors 
 See [documentation](https://www.talos.dev/v1.1/talos-guides/network/device-selector/) for more details.
 """
 
+    [notes.anonymous]
+        title = "Kubernetes API Server Anonymous Auth"
+        description="""\
+Anonymous authentication is now disabled by default for the `kube-apiserver` (CIS compliance).
+
+To enable anonymous authentication, update the machine config with:
+
+```yaml
+cluster:
+    apiServer:
+        extraArgs:
+            anonymous-auth: true
+```
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -300,9 +300,11 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 	}
 
 	builder := argsbuilder.Args{
-		"admission-control-config-file":      filepath.Join(constants.KubernetesAPIServerConfigDir, "admission-control-config.yaml"),
-		"advertise-address":                  "$(POD_IP)",
-		"allow-privileged":                   "true",
+		"admission-control-config-file": filepath.Join(constants.KubernetesAPIServerConfigDir, "admission-control-config.yaml"),
+		"advertise-address":             "$(POD_IP)",
+		"allow-privileged":              "true",
+		// Do not accept anonymous requests by default. Otherwise the kube-apiserver will set the request's group to system:unauthenticated exposing endpoints like /version etc.
+		"anonymous-auth":                     "false",
 		"api-audiences":                      cfg.ControlPlaneEndpoint,
 		"authorization-mode":                 "Node,RBAC",
 		"bind-address":                       "0.0.0.0",


### PR DESCRIPTION
This is inline with CIS guidelines. Otherwise the kube-apiserver will pass along the request with the group
set to `system:unauthenticated`. This will expose anything that is allowed by the `system:public-info-viewer`
and `system:discovery` cluster roles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5713)
<!-- Reviewable:end -->
