### PR TITLE
fix: respect local API server port

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -381,13 +381,12 @@ local integration_disk_image = Step("e2e-disk-image", target="e2e-qemu", privile
         "IMAGE_REGISTRY": local_registry,
         "WITH_DISK_ENCRYPTION": "true",
 });
-local integration_canal_reset = Step("e2e-canal-disabled-reset", target="e2e-qemu", privileged=true, depends_on=[integration_disk_image], environment={
-        "INTEGRATION_TEST_RUN": "TestIntegration/api.ResetSuite/TestResetWithSpec",
-        // TODO: re-enable when https://github.com/projectcalico/cni-plugin/issues/1214 is fixed
-        // "CUSTOM_CNI_URL": "https://docs.projectcalico.org/manifests/canal.yaml",
+local integration_control_plane_port = Step("e2e-cp-port", target="e2e-qemu", privileged=true, depends_on=[integration_disk_image], environment={
+        "SHORT_INTEGRATION_TEST": "yes",
         "REGISTRY": local_registry,
+        "WITH_CONTROL_PLANE_PORT": "443",
 });
-local integration_no_cluster_discovery = Step("e2e-no-cluster-discovery", target="e2e-qemu", privileged=true, depends_on=[integration_canal_reset], environment={
+local integration_no_cluster_discovery = Step("e2e-no-cluster-discovery", target="e2e-qemu", privileged=true, depends_on=[integration_control_plane_port], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "WITH_CLUSTER_DISCOVERY": "false",
         "IMAGE_REGISTRY": local_registry,
@@ -452,7 +451,7 @@ local integration_pipelines = [
   Pipeline('integration-provision-1', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_1]) + integration_trigger(['integration-provision', 'integration-provision-1']),
   Pipeline('integration-provision-2', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_2]) + integration_trigger(['integration-provision', 'integration-provision-2']),
   Pipeline('integration-misc', default_pipeline_steps + [integration_extensions
-, integration_cilium, integration_bios, integration_disk_image, integration_canal_reset, integration_no_cluster_discovery, integration_kubespan]) + integration_trigger(['integration-misc']),
+, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan]) + integration_trigger(['integration-misc']),
   Pipeline('integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip]) + integration_trigger(['integration-qemu-encrypted-vip']),
   Pipeline('integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race]) + integration_trigger(['integration-qemu-race']),
   Pipeline('integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi]) + integration_trigger(['integration-qemu-csi']),
@@ -464,7 +463,7 @@ local integration_pipelines = [
   Pipeline('cron-integration-provision-1', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_1], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-provision-2', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_2], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-misc', default_pipeline_steps + [integration_extensions
-, integration_cilium, integration_bios, integration_disk_image, integration_canal_reset, integration_no_cluster_discovery, integration_kubespan], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
+, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race], [default_cron_pipeline]) + cron_trigger(['nightly']),
   Pipeline('cron-integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi], [default_cron_pipeline]) + cron_trigger(['nightly']),

--- a/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
+++ b/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
@@ -16,6 +16,7 @@ import (
 
 var loadbalancerLaunchCmdFlags struct {
 	addr             string
+	ports            []int
 	upstreams        []string
 	apidOnlyInitNode bool
 }
@@ -30,7 +31,7 @@ var loadbalancerLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var lb loadbalancer.TCP
 
-		for _, port := range []int{constants.DefaultControlPlanePort} {
+		for _, port := range loadbalancerLaunchCmdFlags.ports {
 			upstreams := slices.Map(loadbalancerLaunchCmdFlags.upstreams, func(upstream string) string {
 				return fmt.Sprintf("%s:%d", upstream, port)
 			})
@@ -46,6 +47,7 @@ var loadbalancerLaunchCmd = &cobra.Command{
 
 func init() {
 	loadbalancerLaunchCmd.Flags().StringVar(&loadbalancerLaunchCmdFlags.addr, "loadbalancer-addr", "localhost", "load balancer listen address (IP or host)")
+	loadbalancerLaunchCmd.Flags().IntSliceVar(&loadbalancerLaunchCmdFlags.ports, "loadbalancer-ports", []int{constants.DefaultControlPlanePort}, "load balancer ports")
 	loadbalancerLaunchCmd.Flags().StringSliceVar(&loadbalancerLaunchCmdFlags.upstreams, "loadbalancer-upstreams", []string{}, "load balancer upstreams (nodes to proxy to)")
 	addCommand(loadbalancerLaunchCmd)
 }

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -55,6 +55,14 @@ case "${WITH_KUBESPAN:-false}" in
     ;;
 esac
 
+case "${WITH_CONTROL_PLANE_PORT:-false}" in
+  false)
+    ;;
+  *)
+    QEMU_FLAGS="${QEMU_FLAGS} --control-plane-port=${WITH_CONTROL_PLANE_PORT}"
+    ;;
+esac
+
 case "${USE_DISK_IMAGE:-false}" in
   false)
     DISK_IMAGE_FLAG=

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -246,7 +246,7 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.KubernetesRootS
 		CommonName:   constants.KubernetesControllerManagerOrganization,
 		Organization: constants.KubernetesControllerManagerOrganization,
 
-		Endpoint:    "https://localhost:6443/",
+		Endpoint:    k8sRoot.LocalEndpoint.String(),
 		Username:    constants.KubernetesControllerManagerOrganization,
 		ContextName: "default",
 	}, &buf); err != nil {
@@ -266,7 +266,7 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.KubernetesRootS
 		CommonName:   constants.KubernetesSchedulerOrganization,
 		Organization: constants.KubernetesSchedulerOrganization,
 
-		Endpoint:    "https://localhost:6443/",
+		Endpoint:    k8sRoot.LocalEndpoint.String(),
 		Username:    constants.KubernetesSchedulerOrganization,
 		ContextName: "default",
 	}, &buf); err != nil {
@@ -288,11 +288,9 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.KubernetesRootS
 
 	buf.Reset()
 
-	localhost, _ := url.Parse("https://localhost:6443/") //nolint:errcheck
-
 	if err = kubeconfig.GenerateAdmin(&generateAdminAdapter{
 		k8sRoot:  k8sRoot,
-		endpoint: localhost,
+		endpoint: k8sRoot.LocalEndpoint,
 	}, &buf); err != nil {
 		return fmt.Errorf("failed to generate admin kubeconfig: %w", err)
 	}

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
@@ -79,6 +79,8 @@ func (suite *KubernetesCertSANsSuite) TestReconcile() {
 	rootSecrets.TypedSpec().DNSDomain = "cluster.remote"
 	rootSecrets.TypedSpec().Endpoint, err = url.Parse("https://some.url:6443/")
 	suite.Require().NoError(err)
+	rootSecrets.TypedSpec().LocalEndpoint, err = url.Parse("https://localhost:6443/")
+	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
@@ -94,6 +94,8 @@ func (suite *KubernetesSuite) TestReconcile() {
 	rootSecrets.TypedSpec().Name = "cluster1"
 	rootSecrets.TypedSpec().Endpoint, err = url.Parse("https://some.url:6443/")
 	suite.Require().NoError(err)
+	rootSecrets.TypedSpec().LocalEndpoint, err = url.Parse("https://localhost:6443/")
+	suite.Require().NoError(err)
 
 	rootSecrets.TypedSpec().CA = &x509.PEMEncodedCertificateAndKey{
 		Crt: k8sCA.CrtPEM,

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -161,12 +162,16 @@ func (ctrl *RootController) updateEtcdSecrets(cfgProvider talosconfig.Provider, 
 }
 
 func (ctrl *RootController) updateK8sSecrets(cfgProvider talosconfig.Provider, k8sSecrets *secrets.KubernetesRootSpec) error {
+	localEndpoint, err := url.Parse(fmt.Sprintf("https://localhost:%d", cfgProvider.Cluster().LocalAPIServerPort()))
+	if err != nil {
+		return err
+	}
+
 	k8sSecrets.Name = cfgProvider.Cluster().Name()
 	k8sSecrets.Endpoint = cfgProvider.Cluster().Endpoint()
+	k8sSecrets.LocalEndpoint = localEndpoint
 	k8sSecrets.CertSANs = cfgProvider.Cluster().CertSANs()
 	k8sSecrets.DNSDomain = cfgProvider.Cluster().Network().DNSDomain()
-
-	var err error
 
 	k8sSecrets.APIServerIPs, err = cfgProvider.Cluster().Network().APIServerIPs()
 	if err != nil {

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -58,6 +58,8 @@ type Input struct {
 	// multi-valued.  It may optionally specify the port.
 	ControlPlaneEndpoint string
 
+	LocalAPIServerPort int
+
 	AdditionalSubjectAltNames []string
 	AdditionalMachineCertSANs []string
 
@@ -491,6 +493,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		Certs:                      secrets.Certs,
 		VersionContract:            options.VersionContract,
 		ControlPlaneEndpoint:       endpoint,
+		LocalAPIServerPort:         options.LocalAPIServerPort,
 		PodNet:                     []string{podNet},
 		ServiceNet:                 []string{serviceNet},
 		ServiceDomain:              options.DNSDomain,

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -100,7 +100,8 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		ClusterName:   in.ClusterName,
 		ClusterSecret: in.ClusterSecret,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
+			Endpoint:           &v1alpha1.Endpoint{URL: controlPlaneURL},
+			LocalAPIServerPort: in.LocalAPIServerPort,
 		},
 		APIServerConfig: &v1alpha1.APIServerConfig{
 			CertSANs:                       certSANs,

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -24,6 +24,15 @@ func WithEndpointList(endpoints []string) GenOption {
 	}
 }
 
+// WithLocalAPIServerPort specifies the local API server port for the cluster.
+func WithLocalAPIServerPort(port int) GenOption {
+	return func(o *GenOptions) error {
+		o.LocalAPIServerPort = port
+
+		return nil
+	}
+}
+
 // WithInstallDisk specifies install disk to use in Talos cluster.
 func WithInstallDisk(disk string) GenOption {
 	return func(o *GenOptions) error {
@@ -250,6 +259,7 @@ type GenOptions struct {
 	SystemDiskEncryptionConfig *v1alpha1.SystemDiskEncryptionConfig
 	Roles                      role.Set
 	DiscoveryEnabled           *bool
+	LocalAPIServerPort         int
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/machinery/resources/secrets/kubernetes_root.go
+++ b/pkg/machinery/resources/secrets/kubernetes_root.go
@@ -25,11 +25,12 @@ type KubernetesRoot = typed.Resource[KubernetesRootSpec, KubernetesRootRD]
 
 // KubernetesRootSpec describes root Kubernetes secrets.
 type KubernetesRootSpec struct {
-	Name         string   `yaml:"name"`
-	Endpoint     *url.URL `yaml:"endpoint"`
-	CertSANs     []string `yaml:"certSANs"`
-	APIServerIPs []net.IP `yaml:"apiServerIPs"`
-	DNSDomain    string   `yaml:"dnsDomain"`
+	Name          string   `yaml:"name"`
+	Endpoint      *url.URL `yaml:"endpoint"`
+	LocalEndpoint *url.URL `yaml:"local_endpoint"`
+	CertSANs      []string `yaml:"certSANs"`
+	APIServerIPs  []net.IP `yaml:"apiServerIPs"`
+	DNSDomain     string   `yaml:"dnsDomain"`
 
 	CA             *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
 	ServiceAccount *x509.PEMEncodedKey               `yaml:"serviceAccount"`

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -52,6 +52,8 @@ type NetworkRequest struct {
 	MTU          int
 	Nameservers  []net.IP
 
+	LoadBalancerPorts []int
+
 	// CNI-specific parameters.
 	CNI CNIConfig
 

--- a/website/content/v1.1/reference/cli.md
+++ b/website/content/v1.1/reference/cli.md
@@ -99,6 +99,7 @@ talosctl cluster create [flags]
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
       --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
+      --control-plane-port int                   control plane port (load balancer and local API port) (default 6443)
       --cpus string                              the share of CPUs as fraction (each control plane/VM) (default "2.0")
       --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
       --crashdump                                print debug crashdump to stderr when cluster startup fails


### PR DESCRIPTION
It wasn't used when building an endpoint to the local API server, so
Talos couldn't talk to the local API server when port was changed from
the default one.

Fixes #5706

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5715)
<!-- Reviewable:end -->
