### PR TITLE
chore: run `xfs_repair` on xfs filesystem returing `EUCLEAN`

### DIFF
--- a/cmd/installer/pkg/install/manifest_test.go
+++ b/cmd/installer/pkg/install/manifest_test.go
@@ -27,7 +27,7 @@ import (
 // Some tests in this package cannot be run under buildkit, as buildkit doesn't propagate partition devices
 // like /dev/loopXpY into the sandbox. To run the tests on your local computer, do the following:
 //
-//	 sudo go test -v --count 1 ./cmd/installer/pkg/install/
+//	 go test -exec sudo -v --count 1 ./cmd/installer/pkg/install/
 
 type manifestSuite struct {
 	suite.Suite

--- a/internal/pkg/mount/mount_test.go
+++ b/internal/pkg/mount/mount_test.go
@@ -4,11 +4,123 @@
 
 package mount_test
 
-import "testing"
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-blockdevice/blockdevice/loopback"
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/pkg/makefs"
+)
+
+// Some tests in this package cannot be run under buildkit, as buildkit doesn't propagate partition devices
+// like /dev/loopXpY into the sandbox. To run the tests on your local computer, do the following:
+//
+//  go test -exec sudo -v --count 1 github.com/talos-systems/talos/internal/pkg/mount
+
+type manifestSuite struct {
+	suite.Suite
+
+	disk           *os.File
+	loopbackDevice *os.File
+}
+
+const (
+	diskSize = 4 * 1024 * 1024 * 1024 // 4 GiB
+)
+
+func TestManifestSuite(t *testing.T) {
+	suite.Run(t, new(manifestSuite))
+}
+
+func (suite *manifestSuite) SetupTest() {
+	suite.skipIfNotRoot()
+
+	var err error
+
+	suite.disk, err = ioutil.TempFile("", "talos")
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.disk.Truncate(diskSize))
+
+	suite.loopbackDevice, err = loopback.NextLoopDevice()
+	suite.Require().NoError(err)
+
+	suite.T().Logf("Using %s", suite.loopbackDevice.Name())
+
+	suite.Require().NoError(loopback.Loop(suite.loopbackDevice, suite.disk))
+
+	suite.Require().NoError(loopback.LoopSetReadWrite(suite.loopbackDevice))
+}
+
+func (suite *manifestSuite) TearDownTest() {
+	if suite.loopbackDevice != nil {
+		suite.Assert().NoError(loopback.Unloop(suite.loopbackDevice))
+	}
+
+	if suite.disk != nil {
+		suite.Assert().NoError(os.Remove(suite.disk.Name()))
+		suite.Assert().NoError(suite.disk.Close())
+	}
+}
+
+func (suite *manifestSuite) skipIfNotRoot() {
+	if os.Getuid() != 0 {
+		suite.T().Skip("can't run the test as non-root")
+	}
+}
+
+func (suite *manifestSuite) skipUnderBuildkit() {
+	hostname, _ := os.Hostname() //nolint:errcheck
+
+	if hostname == "buildkitsandbox" {
+		suite.T().Skip("test not supported under buildkit as partition devices are not propagated from /dev")
+	}
+}
+
+func (suite *manifestSuite) TestCleanCorrupedXFSFileSystem() {
+	suite.skipUnderBuildkit()
+
+	tempDir, err := ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	defer func() {
+		suite.Assert().NoError(os.RemoveAll(tempDir))
+	}()
+
+	mountDir := filepath.Join(tempDir, "var")
+
+	suite.Assert().NoError(os.MkdirAll(mountDir, 0o700))
+	suite.Require().NoError(makefs.XFS(suite.loopbackDevice.Name()))
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	mountpoint := mount.NewMountPoint(suite.loopbackDevice.Name(), mountDir, "xfs", unix.MS_NOATIME, "", mount.WithLogger(logger))
+
+	suite.Assert().NoError(mountpoint.Mount())
+
+	defer func() {
+		suite.Assert().NoError(mountpoint.Unmount())
+	}()
+
+	suite.Assert().NoError(mountpoint.Unmount())
+
+	// // now corrupt the disk
+	cmd := exec.Command("xfs_db", []string{
+		"-x",
+		"-c blockget",
+		"-c blocktrash -s 512109 -n 1000",
+		suite.loopbackDevice.Name(),
+	}...)
+
+	suite.Assert().NoError(cmd.Run())
+
+	suite.Assert().NoError(mountpoint.Mount())
 }

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -4,7 +4,11 @@
 
 package mount
 
-import "github.com/talos-systems/talos/pkg/machinery/config"
+import (
+	"log"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+)
 
 const (
 	// ReadOnly is a flag for setting the mount point as readonly.
@@ -41,6 +45,7 @@ type Options struct {
 	PreMountHooks    []Hook
 	PostUnmountHooks []Hook
 	Encryption       config.Encryption
+	Logger           *log.Logger
 }
 
 // Option is the functional option func.
@@ -88,6 +93,13 @@ func WithPostUnmountHooks(hooks ...Hook) Option {
 func WithEncryptionConfig(cfg config.Encryption) Option {
 	return func(args *Options) {
 		args.Encryption = cfg
+	}
+}
+
+// WithLogger sets the logger.
+func WithLogger(logger *log.Logger) Option {
+	return func(args *Options) {
+		args.Logger = logger
 	}
 }
 

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -198,6 +198,8 @@ func SystemPartitionMount(r runtime.Runtime, logger *log.Logger, label string, o
 		opts = append(opts, WithEncryptionConfig(encryptionConfig))
 	}
 
+	opts = append(opts, WithLogger(logger))
+
 	mountpoint, err := SystemMountPointForLabel(device.BlockDevice, label, opts...)
 	if err != nil {
 		return err

--- a/pkg/makefs/xfs.go
+++ b/pkg/makefs/xfs.go
@@ -10,10 +10,26 @@ import (
 	"github.com/talos-systems/go-cmd/pkg/cmd"
 )
 
+const (
+	// FilesystemTypeXFS is the filesystem type for XFS.
+	FilesystemTypeXFS = "xfs"
+)
+
 // XFSGrow expands a XFS filesystem to the maximum possible. The partition
 // MUST be mounted, or this will fail.
 func XFSGrow(partname string) error {
 	_, err := cmd.Run("xfs_growfs", "-d", partname)
+
+	return err
+}
+
+// XFSRepair repairs a XFS filesystem on the specified partition.
+func XFSRepair(partname, fsType string) error {
+	if fsType != FilesystemTypeXFS {
+		return fmt.Errorf("unsupported filesystem type: %s", fsType)
+	}
+
+	_, err := cmd.Run("xfs_repair", partname)
 
 	return err
 }


### PR DESCRIPTION
Run `xfs_repair` on XFS filesystems that needs repairing indicated by
the `unix.EUCLEAN` error when mounting

Fixes #5319
Fixes #5437

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5716)
<!-- Reviewable:end -->
