### PR TITLE
feat: extend node definition used in health checks

### DIFF
--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -87,7 +87,7 @@ func (suite *ApplyConfigSuite) TestApply() {
 		suite.T().Skip("cluster doesn't support reboot")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeWorker)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)
 	suite.Require().NotEmpty(nodes)
 
 	suite.WaitForBootDone(suite.ctx)
@@ -160,7 +160,7 @@ func (suite *ApplyConfigSuite) TestApplyWithoutReboot() {
 	} {
 		suite.WaitForBootDone(suite.ctx)
 
-		node := suite.RandomDiscoveredNode()
+		node := suite.RandomDiscoveredNodeInternalIP()
 		suite.ClearConnectionRefused(suite.ctx, node)
 
 		nodeCtx := client.WithNodes(suite.ctx, node)
@@ -227,7 +227,7 @@ func (suite *ApplyConfigSuite) TestApplyConfigRotateEncryptionSecrets() {
 		suite.T().Skip("skipping in short mode")
 	}
 
-	node := suite.RandomDiscoveredNode(machine.TypeWorker)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 	suite.ClearConnectionRefused(suite.ctx, node)
 
 	nodeCtx := client.WithNodes(suite.ctx, node)
@@ -371,7 +371,7 @@ func (suite *ApplyConfigSuite) TestApplyConfigRotateEncryptionSecrets() {
 
 // TestApplyNoReboot verifies the apply config API fails if NoReboot mode is requested on a field that can not be applied immediately.
 func (suite *ApplyConfigSuite) TestApplyNoReboot() {
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeWorker)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)
 	suite.Require().NotEmpty(nodes)
 
 	suite.WaitForBootDone(suite.ctx)
@@ -414,7 +414,7 @@ func (suite *ApplyConfigSuite) TestApplyNoReboot() {
 
 // TestApplyDryRun verifies the apply config API with dry run enabled.
 func (suite *ApplyConfigSuite) TestApplyDryRun() {
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeWorker)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)
 	suite.Require().NotEmpty(nodes)
 
 	suite.WaitForBootDone(suite.ctx)
@@ -452,7 +452,7 @@ func (suite *ApplyConfigSuite) TestApplyDryRun() {
 // TestApplyTry applies the config in try mode with a short timeout.
 //nolint:gocyclo
 func (suite *ApplyConfigSuite) TestApplyTry() {
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeWorker)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)
 	suite.Require().NotEmpty(nodes)
 
 	suite.WaitForBootDone(suite.ctx)

--- a/internal/integration/api/discovery.go
+++ b/internal/integration/api/discovery.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -20,6 +21,8 @@ import (
 
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/generic/maps"
+	"github.com/talos-systems/talos/pkg/machinery/generic/slices"
 	"github.com/talos-systems/talos/pkg/machinery/resources/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/resources/kubespan"
 )
@@ -43,7 +46,7 @@ func (suite *DiscoverySuite) SetupTest() {
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 15*time.Second)
 
 	// check that cluster has discovery enabled
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 	suite.ClearConnectionRefused(suite.ctx, node)
 
 	nodeCtx := client.WithNodes(suite.ctx, node)
@@ -66,30 +69,34 @@ func (suite *DiscoverySuite) TearDownTest() {
 //
 //nolint:gocyclo
 func (suite *DiscoverySuite) TestMembers() {
-	nodes := suite.DiscoverNodes(suite.ctx)
+	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+
 	expectedTalosVersion := fmt.Sprintf("Talos (%s)", suite.Version)
 
-	for _, node := range nodes.Nodes() {
-		nodeCtx := client.WithNodes(suite.ctx, node)
+	for _, node := range nodes {
+		nodeCtx := client.WithNodes(suite.ctx, node.InternalIP.String())
 
 		members := suite.getMembers(nodeCtx)
 
-		suite.Assert().Len(members, len(nodes.Nodes()))
+		suite.Assert().Len(members, len(nodes))
 
 		// do basic check against discovered nodes
-		for _, expectedNode := range nodes.Nodes() {
-			addr, err := netaddr.ParseIP(expectedNode)
-			suite.Require().NoError(err)
+		for _, expectedNode := range nodes {
+			nodeAddresses := slices.Map(expectedNode.IPs, func(t netip.Addr) string {
+				return t.String()
+			})
 
 			found := false
 
 			for _, member := range members {
-				for _, memberAddr := range member.TypedSpec().Addresses {
-					if memberAddr.Compare(addr) == 0 {
-						found = true
+				memberAddresses := slices.Map(member.TypedSpec().Addresses, func(t netaddr.IP) string {
+					return t.String()
+				})
 
-						break
-					}
+				if maps.Contains(slices.ToSet(memberAddresses), nodeAddresses) {
+					found = true
+
+					break
 				}
 
 				if found {
@@ -97,10 +104,10 @@ func (suite *DiscoverySuite) TestMembers() {
 				}
 			}
 
-			suite.Assert().True(found, "addr %s", addr)
+			suite.Assert().True(found, "addr %q", nodeAddresses)
 		}
 
-		// if cluster informantion is available, perform additional checks
+		// if cluster information is available, perform additional checks
 		if suite.Cluster == nil {
 			continue
 		}
@@ -145,9 +152,9 @@ func (suite *DiscoverySuite) TestMembers() {
 func (suite *DiscoverySuite) TestRegistries() {
 	registries := []string{"k8s/", "service/"}
 
-	nodes := suite.DiscoverNodes(suite.ctx)
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 
-	for _, node := range nodes.Nodes() {
+	for _, node := range nodes {
 		nodeCtx := client.WithNodes(suite.ctx, node)
 
 		members := suite.getMembers(nodeCtx)
@@ -208,7 +215,7 @@ func (suite *DiscoverySuite) TestKubeSpanPeers() {
 	}
 
 	// check that cluster has KubeSpan enabled
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 	suite.ClearConnectionRefused(suite.ctx, node)
 
 	nodeCtx := client.WithNodes(suite.ctx, node)
@@ -219,7 +226,7 @@ func (suite *DiscoverySuite) TestKubeSpanPeers() {
 		suite.T().Skip("KubeSpan is disabled")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 
 	for _, node := range nodes {
 		nodeCtx := client.WithNodes(suite.ctx, node)

--- a/internal/integration/api/diskusage.go
+++ b/internal/integration/api/diskusage.go
@@ -39,7 +39,7 @@ func (suite *DiskUsageSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
-	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode())
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNodeInternalIP())
 }
 
 // TearDownTest ...

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -121,7 +121,7 @@ DrainLoop:
 
 // TestClusterHasDmesg verifies that all the cluster nodes have dmesg.
 func (suite *DmesgSuite) TestClusterHasDmesg() {
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 	suite.Require().NotEmpty(nodes)
 
 	ctx := client.WithNodes(suite.ctx, nodes...)

--- a/internal/integration/api/etcd-recover.go
+++ b/internal/integration/api/etcd-recover.go
@@ -69,13 +69,13 @@ func (suite *EtcdRecoverSuite) TestSnapshotRecover() {
 	}
 
 	// 'init' nodes are not compatible with etcd recovery
-	suite.Require().Empty(suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeInit))
+	suite.Require().Empty(suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeInit))
 
-	controlPlaneNodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeControlPlane)
+	controlPlaneNodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeControlPlane)
 	suite.Require().NotEmpty(controlPlaneNodes)
 
-	snapshotNode := suite.RandomDiscoveredNode(machine.TypeControlPlane)
-	recoverNode := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	snapshotNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	recoverNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	suite.WaitForBootDone(suite.ctx)
 

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -58,7 +58,7 @@ func (suite *EtcdSuite) TestEtcdForfeitLeadership() {
 		suite.T().Skip("without full cluster state etcd test is not reliable (can't wait for cluster readiness in between resets)")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeControlPlane)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeControlPlane)
 
 	if len(nodes) < 3 {
 		suite.T().Skip("test only can be run on HA etcd clusters")
@@ -93,7 +93,7 @@ func (suite *EtcdSuite) TestEtcdLeaveCluster() {
 		suite.T().Skip("without full cluster state reset test is not reliable (can't wait for cluster readiness in between resets)")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).NodesByType(machine.TypeControlPlane)
+	nodes := suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeControlPlane)
 
 	if len(nodes) < 3 {
 		suite.T().Skip("test only can be run on HA etcd clusters")

--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -36,7 +36,7 @@ func (suite *EventsSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Second)
 
-	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode(machinetype.TypeWorker))
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNodeInternalIP(machinetype.TypeWorker))
 }
 
 // TearDownTest ...

--- a/internal/integration/api/generate-config.go
+++ b/internal/integration/api/generate-config.go
@@ -80,7 +80,7 @@ func (suite *GenerateConfigSuite) TestGenerate() {
 		},
 	}
 
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 	ctx := client.WithNodes(suite.ctx, node)
 
 	reply, err := suite.Client.GenerateConfiguration(

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -41,7 +41,7 @@ func (suite *LogsSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
-	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode())
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNodeInternalIP())
 }
 
 // TearDownTest ...

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -56,7 +56,7 @@ func (suite *RebootSuite) TestRebootNodeByNode() {
 		suite.T().Skip("cluster doesn't support reboots")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 	suite.Require().NotEmpty(nodes)
 
 	for _, node := range nodes {
@@ -78,7 +78,7 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 		suite.T().Skip("cluster doesn't support reboots")
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 	suite.Require().NotEmpty(nodes)
 
 	errCh := make(chan error, len(nodes))

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -69,7 +69,7 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 		}
 	}
 
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 	suite.Require().NotEmpty(nodes)
 
 	sort.Strings(nodes)
@@ -113,7 +113,7 @@ func (suite *ResetSuite) testResetNoGraceful(nodeType machine.Type) {
 		suite.T().Skip("without full cluster state reset test is not reliable (can't wait for cluster readiness in between resets)")
 	}
 
-	node := suite.RandomDiscoveredNode(nodeType)
+	node := suite.RandomDiscoveredNodeInternalIP(nodeType)
 
 	suite.T().Logf("Resetting %s node !graceful %s", nodeType, node)
 
@@ -159,7 +159,7 @@ func (suite *ResetSuite) TestResetWithSpecEphemeral() {
 		suite.T().Skip("without full cluster state reset test is not reliable (can't wait for cluster readiness in between resets)")
 	}
 
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	suite.T().Log("Resetting node with spec=[EPHEMERAL]", node)
 
@@ -208,7 +208,7 @@ func (suite *ResetSuite) TestResetWithSpecState() {
 		suite.T().Skip("without full cluster state reset test is not reliable (can't wait for cluster readiness in between resets)")
 	}
 
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	suite.T().Log("Resetting node with spec=[STATE]", node)
 

--- a/internal/integration/api/version.go
+++ b/internal/integration/api/version.go
@@ -55,7 +55,7 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 
 // TestSameVersionCluster verifies that all the nodes are on the same version.
 func (suite *VersionSuite) TestSameVersionCluster() {
-	nodes := suite.DiscoverNodes(suite.ctx).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(suite.ctx)
 	suite.Require().NotEmpty(nodes)
 
 	ctx := client.WithNodes(suite.ctx, nodes...)

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -63,7 +63,7 @@ func (apiSuite *APISuite) SetupSuite() {
 	apiSuite.Require().NoError(err)
 
 	// clear any connection refused errors left after the previous tests
-	nodes := apiSuite.DiscoverNodes(context.TODO()).Nodes()
+	nodes := apiSuite.DiscoverNodeInternalIPs(context.TODO())
 
 	if len(nodes) > 0 {
 		// grpc might trigger backoff on reconnect attempts, so make sure we clear them
@@ -102,23 +102,43 @@ func (apiSuite *APISuite) DiscoverNodes(ctx context.Context) cluster.Info {
 	return apiSuite.discoveredNodes
 }
 
-// RandomDiscoveredNode returns a random node of the specified type (or any type if no types are specified).
-func (apiSuite *APISuite) RandomDiscoveredNode(types ...machine.Type) string {
+// DiscoverNodeInternalIPs provides list of Talos node internal IPs in the cluster.
+func (apiSuite *APISuite) DiscoverNodeInternalIPs(ctx context.Context) []string {
+	nodes := apiSuite.DiscoverNodes(ctx).Nodes()
+
+	return mapNodeInfosToInternalIPs(nodes)
+}
+
+// DiscoverNodeInternalIPsByType provides list of Talos node internal IPs in the cluster for given machine type.
+func (apiSuite *APISuite) DiscoverNodeInternalIPsByType(ctx context.Context, machineType machine.Type) []string {
+	nodesByType := apiSuite.DiscoverNodes(ctx).NodesByType(machineType)
+
+	return mapNodeInfosToInternalIPs(nodesByType)
+}
+
+// RandomDiscoveredNodeInternalIP returns the internal IP a random node of the specified type (or any type if no types are specified).
+//
+//nolint:dupl
+func (apiSuite *APISuite) RandomDiscoveredNodeInternalIP(types ...machine.Type) string {
 	nodeInfo := apiSuite.DiscoverNodes(context.TODO())
 
-	var nodes []string
+	var nodes []cluster.NodeInfo
 
 	if len(types) == 0 {
-		nodes = nodeInfo.Nodes()
+		nodeInfos := nodeInfo.Nodes()
+
+		nodes = nodeInfos
 	} else {
 		for _, t := range types {
-			nodes = append(nodes, nodeInfo.NodesByType(t)...)
+			nodeInfosByType := nodeInfo.NodesByType(t)
+
+			nodes = append(nodes, nodeInfosByType...)
 		}
 	}
 
 	apiSuite.Require().NotEmpty(nodes)
 
-	return nodes[rand.Intn(len(nodes))]
+	return nodes[rand.Intn(len(nodes))].InternalIP.String()
 }
 
 // Capabilities describes current cluster allowed actions.
@@ -245,7 +265,7 @@ func (apiSuite *APISuite) AssertRebooted(ctx context.Context, node string, reboo
 
 // WaitForBootDone waits for boot phase done event.
 func (apiSuite *APISuite) WaitForBootDone(ctx context.Context) {
-	nodes := apiSuite.DiscoverNodes(ctx).Nodes()
+	nodes := apiSuite.DiscoverNodeInternalIPs(ctx)
 
 	nodesNotDoneBooting := make(map[string]struct{})
 
@@ -280,7 +300,10 @@ func (apiSuite *APISuite) ClearConnectionRefused(ctx context.Context, nodes ...s
 	ctx, cancel := context.WithTimeout(ctx, backoff.DefaultConfig.MaxDelay)
 	defer cancel()
 
-	numMasterNodes := len(apiSuite.DiscoverNodes(ctx).NodesByType(machine.TypeControlPlane)) + len(apiSuite.DiscoverNodes(ctx).NodesByType(machine.TypeInit))
+	controlPlaneNodes := apiSuite.DiscoverNodes(ctx).NodesByType(machine.TypeControlPlane)
+	initNodes := apiSuite.DiscoverNodes(ctx).NodesByType(machine.TypeInit)
+
+	numMasterNodes := len(controlPlaneNodes) + len(initNodes)
 	if numMasterNodes == 0 {
 		numMasterNodes = 3
 	}
@@ -391,4 +414,14 @@ func (apiSuite *APISuite) TearDownSuite() {
 	if apiSuite.Client != nil {
 		apiSuite.Assert().NoError(apiSuite.Client.Close())
 	}
+}
+
+func mapNodeInfosToInternalIPs(nodes []cluster.NodeInfo) []string {
+	ips := make([]string, len(nodes))
+
+	for i, node := range nodes {
+		ips[i] = node.InternalIP.String()
+	}
+
+	return ips
 }

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -52,11 +52,20 @@ func (cliSuite *CLISuite) DiscoverNodes(ctx context.Context) cluster.Info {
 	return nil
 }
 
-// RandomDiscoveredNode returns a random node of the specified type (or any type if no types are specified).
-func (cliSuite *CLISuite) RandomDiscoveredNode(types ...machine.Type) string {
+// DiscoverNodeInternalIPs provides list of Talos node internal IPs in the cluster.
+func (cliSuite *CLISuite) DiscoverNodeInternalIPs(ctx context.Context) []string {
+	nodes := cliSuite.DiscoverNodes(ctx)
+
+	return mapNodeInfosToInternalIPs(nodes.Nodes())
+}
+
+// RandomDiscoveredNodeInternalIP returns the internal IP a random node of the specified type (or any type if no types are specified).
+//
+//nolint:dupl
+func (cliSuite *CLISuite) RandomDiscoveredNodeInternalIP(types ...machine.Type) string {
 	nodeInfo := cliSuite.DiscoverNodes(context.TODO())
 
-	var nodes []string
+	var nodes []cluster.NodeInfo
 
 	if len(types) == 0 {
 		nodes = nodeInfo.Nodes()
@@ -68,7 +77,7 @@ func (cliSuite *CLISuite) RandomDiscoveredNode(types ...machine.Type) string {
 
 	cliSuite.Require().NotEmpty(nodes)
 
-	return nodes[rand.Intn(len(nodes))]
+	return nodes[rand.Intn(len(nodes))].InternalIP.String()
 }
 
 func (cliSuite *CLISuite) discoverKubectl() cluster.Info {

--- a/internal/integration/base/cluster.go
+++ b/internal/integration/base/cluster.go
@@ -8,31 +8,22 @@
 package base
 
 import (
-	"fmt"
-
+	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
 type infoWrapper struct {
 	masterNodes []string
 	workerNodes []string
+
+	nodeInfos       []cluster.NodeInfo
+	nodeInfosByType map[machine.Type][]cluster.NodeInfo
 }
 
-func (wrapper *infoWrapper) Nodes() []string {
-	return append([]string(nil), append(wrapper.masterNodes, wrapper.workerNodes...)...)
+func (wrapper *infoWrapper) Nodes() []cluster.NodeInfo {
+	return wrapper.nodeInfos
 }
 
-func (wrapper *infoWrapper) NodesByType(t machine.Type) []string {
-	switch t {
-	case machine.TypeInit:
-		return nil
-	case machine.TypeControlPlane:
-		return append([]string(nil), wrapper.masterNodes...)
-	case machine.TypeWorker:
-		return append([]string(nil), wrapper.workerNodes...)
-	case machine.TypeUnknown:
-		fallthrough
-	default:
-		panic(fmt.Sprintf("unexpected machine type %v", t))
-	}
+func (wrapper *infoWrapper) NodesByType(t machine.Type) []cluster.NodeInfo {
+	return wrapper.nodeInfosByType[t]
 }

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -74,6 +75,26 @@ func discoverNodesK8s(ctx context.Context, client *client.Client, suite *TalosSu
 		} else {
 			result.workerNodes = append(result.workerNodes, address)
 		}
+	}
+
+	controlPlaneNodeInfos, err := cluster.IPsToNodeInfos(result.masterNodes)
+	if err != nil {
+		return nil, err
+	}
+
+	workerNodeInfos, err := cluster.IPsToNodeInfos(result.workerNodes)
+	if err != nil {
+		return nil, err
+	}
+
+	var allNodeInfos []cluster.NodeInfo
+	allNodeInfos = append(allNodeInfos, controlPlaneNodeInfos...)
+	allNodeInfos = append(allNodeInfos, workerNodeInfos...)
+
+	result.nodeInfos = allNodeInfos
+	result.nodeInfosByType = map[machine.Type][]cluster.NodeInfo{
+		machine.TypeControlPlane: controlPlaneNodeInfos,
+		machine.TypeWorker:       workerNodeInfos,
 	}
 
 	return result, nil

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -69,7 +69,7 @@ func (suite *TalosconfigSuite) TestMerge() {
 
 // TestNew checks `talosctl config new`.
 func (suite *TalosconfigSuite) TestNew() {
-	stdout := suite.RunCLI([]string{"version", "--json", "--nodes", suite.RandomDiscoveredNode()})
+	stdout := suite.RunCLI([]string{"version", "--json", "--nodes", suite.RandomDiscoveredNodeInternalIP()})
 
 	var v machineapi.Version
 	err := protojson.Unmarshal([]byte(stdout), &v)
@@ -79,7 +79,7 @@ func (suite *TalosconfigSuite) TestNew() {
 
 	tempDir := suite.T().TempDir()
 
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	readerConfig := filepath.Join(tempDir, "talosconfig")
 	suite.RunCLI([]string{"--nodes", node, "config", "new", "--roles", "os:reader", readerConfig},

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -26,7 +26,7 @@ func (suite *ContainersSuite) SuiteName() string {
 
 // TestContainerd inspects containers via containerd driver.
 func (suite *ContainersSuite) TestContainerd() {
-	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`IMAGE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 	)
@@ -34,7 +34,10 @@ func (suite *ContainersSuite) TestContainerd() {
 
 // TestCRI inspects containers via CRI driver.
 func (suite *ContainersSuite) TestCRI() {
-	suite.RunCLI([]string{"containers", "-k", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	suite.RunCLI([]string{
+		"containers", "-k", "--nodes",
+		suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane),
+	},
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 	)
 }

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -29,7 +29,7 @@ func (suite *CopySuite) SuiteName() string {
 func (suite *CopySuite) TestSuccess() {
 	tempDir := suite.T().TempDir()
 
-	suite.RunCLI([]string{"copy", "--nodes", suite.RandomDiscoveredNode(), "/etc/os-release", tempDir},
+	suite.RunCLI([]string{"copy", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/etc/os-release", tempDir},
 		base.StdoutEmpty())
 
 	_, err := os.Stat(filepath.Join(tempDir, "os-release"))

--- a/internal/integration/cli/disk.go
+++ b/internal/integration/cli/disk.go
@@ -23,7 +23,7 @@ func (suite *DisksSuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *DisksSuite) TestSuccess() {
-	suite.RunCLI([]string{"disks", "--nodes", suite.RandomDiscoveredNode()})
+	suite.RunCLI([]string{"disks", "--nodes", suite.RandomDiscoveredNodeInternalIP()})
 }
 
 func init() {

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -73,7 +73,7 @@ func parseLine(line string) (*duInfo, error) {
 // TestSuccess runs comand with success.
 func (suite *DiskUsageSuite) TestSuccess() {
 	folder := "/etc"
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	var folderSize int64 = 4096
 
@@ -129,7 +129,10 @@ func (suite *DiskUsageSuite) TestSuccess() {
 
 // TestError runs comand with error.
 func (suite *DiskUsageSuite) TestError() {
-	suite.RunCLI([]string{"usage", "--nodes", suite.RandomDiscoveredNode(), "/no/such/folder/here/just/for/sure"},
+	suite.RunCLI([]string{
+		"usage", "--nodes",
+		suite.RandomDiscoveredNodeInternalIP(), "/no/such/folder/here/just/for/sure",
+	},
 		base.StderrNotEmpty(),
 		base.StdoutEmpty())
 }

--- a/internal/integration/cli/dmesg.go
+++ b/internal/integration/cli/dmesg.go
@@ -29,12 +29,12 @@ func (suite *DmesgSuite) SuiteName() string {
 
 // TestHasOutput verifies that dmesg is displayed.
 func (suite *DmesgSuite) TestHasOutput() {
-	suite.RunCLI([]string{"dmesg", "--nodes", suite.RandomDiscoveredNode()}) // default checks for stdout not empty
+	suite.RunCLI([]string{"dmesg", "--nodes", suite.RandomDiscoveredNodeInternalIP()}) // default checks for stdout not empty
 }
 
 // TestClusterHasOutput verifies that each node in the cluster has some output.
 func (suite *DmesgSuite) TestClusterHasOutput() {
-	nodes := suite.DiscoverNodes(context.TODO()).Nodes()
+	nodes := suite.DiscoverNodeInternalIPs(context.TODO())
 	suite.Require().NotEmpty(nodes)
 
 	matchers := slices.Map(nodes, func(node string) base.RunOption {

--- a/internal/integration/cli/etcd.go
+++ b/internal/integration/cli/etcd.go
@@ -28,7 +28,7 @@ func (suite *EtcdSuite) SuiteName() string {
 
 // TestMembers etcd members should have some output.
 func (suite *EtcdSuite) TestMembers() {
-	suite.RunCLI([]string{"etcd", "members", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)}) // default checks for stdout not empty
+	suite.RunCLI([]string{"etcd", "members", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)}) // default checks for stdout not empty
 }
 
 // TestForfeitLeadership etcd forfeit-leadership check.
@@ -39,7 +39,7 @@ func (suite *EtcdSuite) TestForfeitLeadership() {
 		suite.T().Skip("test only can be run on HA etcd clusters")
 	}
 
-	suite.RunCLI([]string{"etcd", "forfeit-leadership", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	suite.RunCLI([]string{"etcd", "forfeit-leadership", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
 		base.StdoutEmpty(),
 	)
 }
@@ -50,7 +50,7 @@ func (suite *EtcdSuite) TestSnapshot() {
 
 	dbPath := filepath.Join(tempDir, "snapshot.db")
 
-	suite.RunCLI([]string{"etcd", "snapshot", dbPath, "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	suite.RunCLI([]string{"etcd", "snapshot", dbPath, "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`etcd snapshot saved to .+\d+ bytes.+`)),
 	)
 }

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -86,7 +86,8 @@ func (suite *HealthSuite) TestClientSide() {
 
 // TestServerSide does successful health check run from server-side.
 func (suite *HealthSuite) TestServerSide() {
-	suite.RunCLI([]string{"health", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	randomControlPlaneNodeInternalIP := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	suite.RunCLI([]string{"health", "--nodes", randomControlPlaneNodeInternalIP},
 		base.StdoutEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`waiting for all k8s nodes to report ready`)),
 	)

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -32,7 +32,7 @@ func (suite *KubeconfigSuite) SuiteName() string {
 func (suite *KubeconfigSuite) TestDirectory() {
 	tempDir := suite.T().TempDir()
 
-	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), tempDir},
+	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), tempDir},
 		base.StdoutEmpty())
 
 	path := filepath.Join(tempDir, "kubeconfig")
@@ -53,7 +53,7 @@ func (suite *KubeconfigSuite) TestCwd() {
 
 	suite.Require().NoError(os.Chdir(tempDir))
 
-	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
 		base.StdoutEmpty())
 
 	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
@@ -63,7 +63,7 @@ func (suite *KubeconfigSuite) TestCwd() {
 func (suite *KubeconfigSuite) TestCustomName() {
 	tempDir := suite.T().TempDir()
 
-	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), filepath.Join(tempDir, "k8sconfig")},
+	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), filepath.Join(tempDir, "k8sconfig")},
 		base.StdoutEmpty())
 
 	suite.Require().FileExists(filepath.Join(tempDir, "k8sconfig"))
@@ -83,9 +83,9 @@ func (suite *KubeconfigSuite) TestMergeRename() {
 
 	path := filepath.Join(tempDir, "config")
 
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), path},
 		base.StdoutEmpty())
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path})
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), path})
 
 	config, err := clientcmd.LoadFromFile(path)
 	suite.Require().NoError(err)
@@ -99,9 +99,9 @@ func (suite *KubeconfigSuite) TestMergeOverwrite() {
 
 	path := filepath.Join(tempDir, "config")
 
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), path},
 		base.StdoutEmpty())
-	suite.RunCLI([]string{"kubeconfig", "--force", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path},
+	suite.RunCLI([]string{"kubeconfig", "--force", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane), path},
 		base.StdoutEmpty())
 
 	config, err := clientcmd.LoadFromFile(path)

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -32,10 +32,10 @@ func (suite *ListSuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *ListSuite) TestSuccess() {
-	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNode(), "/etc"},
+	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/etc"},
 		base.StdoutShouldMatch(regexp.MustCompile(`os-release`)))
 
-	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNode(), "/"},
+	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/"},
 		base.StdoutShouldNotMatch(regexp.MustCompile(`os-release`)))
 }
 
@@ -43,7 +43,7 @@ func (suite *ListSuite) TestSuccess() {
 func (suite *ListSuite) TestDepth() {
 	suite.T().Parallel()
 
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	// checks that enough separators are encountered in the output
 	runAndCheck := func(t *testing.T, expectedSeparators int, flags ...string) {

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -27,12 +27,12 @@ func (suite *LogsSuite) SuiteName() string {
 
 // TestServiceLogs verifies that logs are displayed.
 func (suite *LogsSuite) TestServiceLogs() {
-	suite.RunCLI([]string{"logs", "kubelet", "--nodes", suite.RandomDiscoveredNode()}) // default checks for stdout not empty
+	suite.RunCLI([]string{"logs", "kubelet", "--nodes", suite.RandomDiscoveredNodeInternalIP()}) // default checks for stdout not empty
 }
 
 // TestTailLogs verifies that logs can be displayed with tail lines.
 func (suite *LogsSuite) TestTailLogs() {
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	// run some machined API calls to produce enough log lines
 	for i := 0; i < 10; i++ {
@@ -52,7 +52,7 @@ func (suite *LogsSuite) TestTailLogs() {
 
 // TestServiceNotFound verifies that logs displays an error if service is not found.
 func (suite *LogsSuite) TestServiceNotFound() {
-	suite.RunCLI([]string{"logs", "--nodes", suite.RandomDiscoveredNode(), "servicenotfound"},
+	suite.RunCLI([]string{"logs", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "servicenotfound"},
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`ERROR:.+ log "servicenotfound" was not registered`)),

--- a/internal/integration/cli/memory.go
+++ b/internal/integration/cli/memory.go
@@ -25,13 +25,13 @@ func (suite *MemorySuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *MemorySuite) TestSuccess() {
-	suite.RunCLI([]string{"memory", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"memory", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`FREE`)))
 }
 
 // TestVerbose verifies verbose mode.
 func (suite *MemorySuite) TestVerbose() {
-	suite.RunCLI([]string{"memory", "-v", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"memory", "-v", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`MemFree: \d+ kB`)))
 }
 

--- a/internal/integration/cli/mounts.go
+++ b/internal/integration/cli/mounts.go
@@ -27,7 +27,7 @@ func (suite *MountsSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *MountsSuite) TestSuccess() {
-	suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`(?s)FILESYSTEM.*`)))
 }
 
@@ -40,7 +40,7 @@ func (suite *MountsSuite) TestUserDisksMounted() {
 	}
 
 	for _, path := range strings.Split(paths, ",") {
-		suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNode()},
+		suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 			base.StdoutShouldMatch(regexp.MustCompile(path)))
 	}
 }

--- a/internal/integration/cli/patch.go
+++ b/internal/integration/cli/patch.go
@@ -28,7 +28,7 @@ func (suite *PatchSuite) SuiteName() string {
 
 // TestSuccess successful run.
 func (suite *PatchSuite) TestSuccess() {
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	patch := []map[string]interface{}{
 		{
@@ -49,7 +49,7 @@ func (suite *PatchSuite) TestSuccess() {
 
 // TestError runs comand with error.
 func (suite *PatchSuite) TestError() {
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	patch := []map[string]interface{}{
 		{

--- a/internal/integration/cli/processes.go
+++ b/internal/integration/cli/processes.go
@@ -25,7 +25,7 @@ func (suite *ProcessesSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *ProcessesSuite) TestSuccess() {
-	suite.RunCLI([]string{"processes", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"processes", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`PID`)))
 }
 

--- a/internal/integration/cli/read.go
+++ b/internal/integration/cli/read.go
@@ -25,7 +25,7 @@ func (suite *ReadSuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *ReadSuite) TestSuccess() {
-	suite.RunCLI([]string{"read", "--nodes", suite.RandomDiscoveredNode(), "/etc/os-release"},
+	suite.RunCLI([]string{"read", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/etc/os-release"},
 		base.StdoutShouldMatch(regexp.MustCompile(`ID=talos`)))
 }
 

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -33,7 +33,7 @@ func (suite *RestartSuite) TestSystem() {
 	}
 
 	// trustd only runs on control plane nodes
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	suite.RunCLI([]string{"restart", "-n", node, "trustd"},
 		base.StdoutEmpty())

--- a/internal/integration/cli/services.go
+++ b/internal/integration/cli/services.go
@@ -26,7 +26,7 @@ func (suite *ServicesSuite) SuiteName() string {
 
 // TestList verifies service list.
 func (suite *ServicesSuite) TestList() {
-	suite.RunCLI([]string{"services", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"services", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 	)
@@ -34,7 +34,7 @@ func (suite *ServicesSuite) TestList() {
 
 // TestStatus verifies service status.
 func (suite *ServicesSuite) TestStatus() {
-	suite.RunCLI([]string{"service", "apid", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"service", "apid", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`\[Running\]`)),
@@ -43,7 +43,7 @@ func (suite *ServicesSuite) TestStatus() {
 
 // TestRestart verifies kubelet restart.
 func (suite *ServicesSuite) TestRestart() {
-	node := suite.RandomDiscoveredNode()
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	suite.RunCLI([]string{"service", "kubelet", "restart", "--nodes", node})
 

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -26,7 +26,7 @@ func (suite *StatsSuite) SuiteName() string {
 
 // TestContainerd inspects stats via containerd driver.
 func (suite *StatsSuite) TestContainerd() {
-	suite.RunCLI([]string{"stats", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"stats", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 	)
@@ -34,7 +34,7 @@ func (suite *StatsSuite) TestContainerd() {
 
 // TestCRI inspects stats via CRI driver.
 func (suite *StatsSuite) TestCRI() {
-	suite.RunCLI([]string{"stats", "-k", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
+	suite.RunCLI([]string{"stats", "-k", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),

--- a/internal/integration/cli/support.go
+++ b/internal/integration/cli/support.go
@@ -33,7 +33,7 @@ func (suite *SupportSuite) TestSupport() {
 
 	output := filepath.Join(tempDir, "support.zip")
 
-	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	suite.RunCLI([]string{"support", "--nodes", node, "-w", "5", "-O", output})
 

--- a/internal/integration/cli/time.go
+++ b/internal/integration/cli/time.go
@@ -28,7 +28,7 @@ func (suite *TimeSuite) SuiteName() string {
 
 // TestDefault runs default time check.
 func (suite *TimeSuite) TestDefault() {
-	suite.RunCLI([]string{"time", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"time", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`NTP-SERVER`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`UTC`)),
 		base.WithRetry(retry.Constant(time.Minute, retry.WithUnits(time.Second))),

--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -25,7 +25,7 @@ func (suite *VersionSuite) SuiteName() string {
 
 // TestExpectedVersionMaster verifies master node version matches expected.
 func (suite *VersionSuite) TestExpectedVersionMaster() {
-	suite.RunCLI([]string{"version", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"version", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client:\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
 		base.StdoutShouldMatch(regexp.MustCompile(`Server:\n(\s*NODE:[^\n]+\n)?\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
 	)
@@ -33,7 +33,7 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 
 // TestShortVersion verifies short version output.
 func (suite *VersionSuite) TestShortVersion() {
-	suite.RunCLI([]string{"version", "--short", "--nodes", suite.RandomDiscoveredNode()},
+	suite.RunCLI([]string{"version", "--short", "--nodes", suite.RandomDiscoveredNodeInternalIP()},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client\s*`+regexp.QuoteMeta(suite.Version))),
 	)
 }

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -39,14 +39,17 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 	}
 
 	controlPlaneNodes := s.NodesByType(machine.TypeControlPlane)
+
 	if len(controlPlaneNodes) == 0 {
 		return fmt.Errorf("no control plane nodes to bootstrap")
 	}
 
-	sort.Strings(controlPlaneNodes)
+	sort.Slice(controlPlaneNodes, func(i, j int) bool {
+		return controlPlaneNodes[i].IPs[0].String() < controlPlaneNodes[j].IPs[0].String()
+	})
 
-	node := controlPlaneNodes[0]
-	nodeCtx := client.WithNodes(ctx, node)
+	nodeIP := controlPlaneNodes[0].IPs[0]
+	nodeCtx := client.WithNodes(ctx, nodeIP.String())
 
 	fmt.Fprintln(out, "waiting for API")
 

--- a/pkg/cluster/check/apid.go
+++ b/pkg/cluster/check/apid.go
@@ -18,7 +18,10 @@ func ApidReadyAssertion(ctx context.Context, cluster ClusterInfo) error {
 		return err
 	}
 
-	nodesCtx := client.WithNodes(ctx, cluster.Nodes()...)
+	nodes := cluster.Nodes()
+
+	nodeIPs := mapIPsToStrings(mapNodeInfosToInternalIPs(nodes))
+	nodesCtx := client.WithNodes(ctx, nodeIPs...)
 
 	_, err = cli.Version(nodesCtx)
 

--- a/pkg/cluster/check/check.go
+++ b/pkg/cluster/check/check.go
@@ -7,10 +7,12 @@ package check
 
 import (
 	"context"
+	"net/netip"
 	"time"
 
 	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/machinery/generic/slices"
 )
 
 const updateInterval = 100 * time.Millisecond
@@ -80,4 +82,16 @@ func Wait(ctx context.Context, cluster ClusterInfo, checks []ClusterCheck, repor
 	}
 
 	return nil
+}
+
+func flatMapNodeInfosToIPs(nodes []cluster.NodeInfo) []netip.Addr {
+	return slices.FlatMap(nodes, func(node cluster.NodeInfo) []netip.Addr { return node.IPs })
+}
+
+func mapNodeInfosToInternalIPs(nodes []cluster.NodeInfo) []netip.Addr {
+	return slices.Map(nodes, func(node cluster.NodeInfo) netip.Addr { return node.InternalIP })
+}
+
+func mapIPsToStrings(input []netip.Addr) []string {
+	return slices.Map(input, func(ip netip.Addr) string { return ip.String() })
 }

--- a/pkg/cluster/check/etcd.go
+++ b/pkg/cluster/check/etcd.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sort"
 
+	"github.com/talos-systems/talos/pkg/cluster"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
@@ -20,14 +21,21 @@ import (
 
 // EtcdConsistentAssertion checks that etcd membership is consistent across nodes.
 //nolint:gocyclo
-func EtcdConsistentAssertion(ctx context.Context, cluster ClusterInfo) error {
-	cli, err := cluster.Client()
+func EtcdConsistentAssertion(ctx context.Context, cl ClusterInfo) error {
+	cli, err := cl.Client()
 	if err != nil {
 		return err
 	}
 
-	nodes := append(cluster.NodesByType(machine.TypeInit), cluster.NodesByType(machine.TypeControlPlane)...)
-	nodesCtx := client.WithNodes(ctx, nodes...)
+	var nodes []cluster.NodeInfo
+
+	initNodes := cl.NodesByType(machine.TypeInit)
+	nodes = append(nodes, initNodes...)
+	controlPlaneNodes := cl.NodesByType(machine.TypeControlPlane)
+
+	nodes = append(nodes, controlPlaneNodes...)
+
+	nodesCtx := client.WithNodes(ctx, mapIPsToStrings(mapNodeInfosToInternalIPs(nodes))...)
 
 	resp, err := cli.EtcdMemberList(nodesCtx, &machineapi.EtcdMemberListRequest{})
 	if err != nil {
@@ -82,13 +90,13 @@ func EtcdConsistentAssertion(ctx context.Context, cluster ClusterInfo) error {
 }
 
 // EtcdControlPlaneNodesAssertion checks that etcd nodes are control plane nodes.
-func EtcdControlPlaneNodesAssertion(ctx context.Context, cluster ClusterInfo) error {
-	cli, err := cluster.Client()
+func EtcdControlPlaneNodesAssertion(ctx context.Context, cl ClusterInfo) error {
+	cli, err := cl.Client()
 	if err != nil {
 		return err
 	}
 
-	controlPlaneNodes := append(cluster.NodesByType(machine.TypeInit), cluster.NodesByType(machine.TypeControlPlane)...)
+	nodes := append(cl.NodesByType(machine.TypeInit), cl.NodesByType(machine.TypeControlPlane)...)
 
 	resp, err := cli.EtcdMemberList(ctx, &machineapi.EtcdMemberListRequest{})
 	if err != nil {
@@ -111,7 +119,8 @@ func EtcdControlPlaneNodesAssertion(ctx context.Context, cluster ClusterInfo) er
 		}
 	}
 
-	if !maps.Contains(slices.ToSet(controlPlaneNodes), memberIPs) {
+	controlPlaneNodeIPs := mapIPsToStrings(flatMapNodeInfosToIPs(nodes))
+	if !maps.Contains(slices.ToSet(controlPlaneNodeIPs), memberIPs) {
 		return errors.New("mismatch between etcd member and control plane nodes")
 	}
 

--- a/pkg/cluster/check/events.go
+++ b/pkg/cluster/check/events.go
@@ -27,8 +27,10 @@ func AllNodesBootedAssertion(ctx context.Context, cluster ClusterInfo) error {
 
 	nodes := cluster.Nodes()
 
+	nodeInternalIPs := mapIPsToStrings(mapNodeInfosToInternalIPs(nodes))
+
 	ctx, cancel := context.WithCancel(ctx)
-	nodesCtx := client.WithNodes(ctx, nodes...)
+	nodesCtx := client.WithNodes(ctx, nodeInternalIPs...)
 
 	nodesBootStarted := map[string]struct{}{}
 	nodesBootStopped := map[string]struct{}{}

--- a/pkg/cluster/check/service.go
+++ b/pkg/cluster/check/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
@@ -20,16 +21,17 @@ import (
 var ErrServiceNotFound = fmt.Errorf("service not found")
 
 // ServiceStateAssertion checks whether service reached some specified state.
-func ServiceStateAssertion(ctx context.Context, cluster ClusterInfo, service string, states ...string) error {
-	cli, err := cluster.Client()
+func ServiceStateAssertion(ctx context.Context, cl ClusterInfo, service string, states ...string) error {
+	cli, err := cl.Client()
 	if err != nil {
 		return err
 	}
 
 	// by default, we check all control plane nodes. if some nodes don't have that service running,
 	// it won't be returned in the response
-	nodes := append(cluster.NodesByType(machine.TypeInit), cluster.NodesByType(machine.TypeControlPlane)...)
-	nodesCtx := client.WithNodes(ctx, nodes...)
+	nodes := append(cl.NodesByType(machine.TypeInit), cl.NodesByType(machine.TypeControlPlane)...)
+
+	nodesCtx := client.WithNodes(ctx, mapIPsToStrings(mapNodeInfosToInternalIPs(nodes))...)
 
 	servicesInfo, err := cli.ServiceInfo(nodesCtx, service)
 	if err != nil {
@@ -67,7 +69,7 @@ func ServiceStateAssertion(ctx context.Context, cluster ClusterInfo, service str
 
 // ServiceHealthAssertion checks whether service reached some specified state.
 //nolint:gocyclo
-func ServiceHealthAssertion(ctx context.Context, cluster ClusterInfo, service string, setters ...Option) error {
+func ServiceHealthAssertion(ctx context.Context, cl ClusterInfo, service string, setters ...Option) error {
 	opts := DefaultOptions()
 
 	for _, setter := range setters {
@@ -76,24 +78,24 @@ func ServiceHealthAssertion(ctx context.Context, cluster ClusterInfo, service st
 		}
 	}
 
-	cli, err := cluster.Client()
+	cli, err := cl.Client()
 	if err != nil {
 		return err
 	}
 
-	var nodes []string
+	var nodes []cluster.NodeInfo
 
 	if len(opts.Types) > 0 {
 		for _, t := range opts.Types {
-			nodes = append(nodes, cluster.NodesByType(t)...)
+			nodes = append(nodes, cl.NodesByType(t)...)
 		}
 	} else {
-		nodes = cluster.Nodes()
+		nodes = cl.Nodes()
 	}
 
 	count := len(nodes)
 
-	nodesCtx := client.WithNodes(ctx, nodes...)
+	nodesCtx := client.WithNodes(ctx, mapIPsToStrings(mapNodeInfosToInternalIPs(nodes))...)
 
 	servicesInfo, err := cli.ServiceInfo(nodesCtx, service)
 	if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -8,6 +8,7 @@ package cluster
 import (
 	"context"
 	"io"
+	"net/netip"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -42,15 +43,50 @@ type CrashDumper interface {
 	CrashDump(ctx context.Context, out io.Writer)
 }
 
+// NodeInfo describes a Talos node.
+type NodeInfo struct {
+	InternalIP netip.Addr
+	IPs        []netip.Addr
+}
+
 // Info describes the Talos cluster.
 type Info interface {
-	// Nodes returns list of all node endpoints (IPs).
-	Nodes() []string
+	// Nodes returns list of all node infos.
+	Nodes() []NodeInfo
 	// NodesByType return list of node endpoints by type.
-	NodesByType(machine.Type) []string
+	NodesByType(machine.Type) []NodeInfo
 }
 
 // Bootstrapper performs Talos cluster bootstrap.
 type Bootstrapper interface {
 	Bootstrap(ctx context.Context, out io.Writer) error
+}
+
+// IPsToNodeInfos converts list of IPs to a list of NodeInfos.
+func IPsToNodeInfos(ips []string) ([]NodeInfo, error) {
+	result := make([]NodeInfo, len(ips))
+
+	for i, ip := range ips {
+		info, err := IPToNodeInfo(ip)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = *info
+	}
+
+	return result, nil
+}
+
+// IPToNodeInfo converts a node internal IP to a NodeInfo.
+func IPToNodeInfo(ip string) (*NodeInfo, error) {
+	parsed, err := netip.ParseAddr(ip)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NodeInfo{
+		InternalIP: parsed,
+		IPs:        []netip.Addr{parsed},
+	}, nil
 }

--- a/pkg/cluster/crashdump.go
+++ b/pkg/cluster/crashdump.go
@@ -43,12 +43,16 @@ func (s *APICrashDumper) CrashDump(ctx context.Context, out io.Writer) {
 		return
 	}
 
-	for _, node := range s.Nodes() {
-		func(node string) {
-			nodeCtx, nodeCtxCancel := context.WithTimeout(client.WithNodes(ctx, node), 30*time.Second)
+	nodes := s.Nodes()
+
+	for _, node := range nodes {
+		func(node NodeInfo) {
+			nodeIP := node.InternalIP.String()
+
+			nodeCtx, nodeCtxCancel := context.WithTimeout(client.WithNodes(ctx, nodeIP), 30*time.Second)
 			defer nodeCtxCancel()
 
-			fmt.Fprintf(out, "\n%s\n%s\n\n", node, strings.Repeat("=", len(node)))
+			fmt.Fprintf(out, "\n%s\n%s\n\n", node, strings.Repeat("=", len(nodeIP)))
 
 			services, err := cli.ServiceList(nodeCtx)
 			if err != nil {

--- a/pkg/cluster/provision.go
+++ b/pkg/cluster/provision.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"net/netip"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/provision"
+)
+
+// MapProvisionNodeInfosToClusterNodeInfos maps provision.NodeInfos to cluster.NodeInfos.
+func MapProvisionNodeInfosToClusterNodeInfos(nodes []provision.NodeInfo) ([]NodeInfo, error) {
+	result := make([]NodeInfo, len(nodes))
+
+	for i, info := range nodes {
+		clusterNodeInfo, err := toClusterNodeInfo(info)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = *clusterNodeInfo
+	}
+
+	return result, nil
+}
+
+// MapProvisionNodeInfosToNodeInfosByType maps provision.NodeInfos
+// to cluster.NodeInfos, grouping them by machine type.
+func MapProvisionNodeInfosToNodeInfosByType(nodes []provision.NodeInfo) (map[machine.Type][]NodeInfo, error) {
+	result := make(map[machine.Type][]NodeInfo)
+
+	for _, info := range nodes {
+		clusterNodeInfo, err := toClusterNodeInfo(info)
+		if err != nil {
+			return nil, err
+		}
+
+		result[info.Type] = append(result[info.Type], *clusterNodeInfo)
+	}
+
+	return result, nil
+}
+
+func toClusterNodeInfo(info provision.NodeInfo) (*NodeInfo, error) {
+	ips := make([]netip.Addr, len(info.IPs))
+
+	for i, ip := range info.IPs {
+		parsed, err := netip.ParseAddr(ip.String())
+		if err != nil {
+			return nil, err
+		}
+
+		ips[i] = parsed
+	}
+
+	return &NodeInfo{
+		InternalIP: ips[0],
+		IPs:        ips,
+	}, nil
+}

--- a/pkg/machinery/generic/slices/slices.go
+++ b/pkg/machinery/generic/slices/slices.go
@@ -4,7 +4,7 @@
 
 package slices
 
-// NOTE(DmitriyMV): I tried to implement this generic functions to be as perfomant as possible.
+// NOTE(DmitriyMV): I tried to implement this generic functions to be as performant as possible.
 // However, I couldn't find a way to do it, since Go (1.18 at the time of writing) cannot inline closures if (generic)
 // function, which accepts the closure, was not inlined itself.
 // And inlining budget of 80 is quite small, since most of it is going towards closure call.


### PR DESCRIPTION
Introduce `cluster.NodeInfo` to represent the basic info about a node which can be used in the health checks. This information, where possible, will be populated by the discovery service in following PRs. Part of siderolabs#5554.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5718)
<!-- Reviewable:end -->
