### PR TITLE
chore: bump kernel and runc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.2.0-alpha.0
-PKGS ?= v1.2.0-alpha.0-4-gb9c72a5
+PKGS ?= v1.2.0-alpha.0-6-g5bc7e34
 EXTRAS ?= v1.2.0-alpha.0
 GO_VERSION ?= 1.18
 GOIMPORTS_VERSION ?= v0.1.10

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -24,11 +24,11 @@ Talos now enables the Raspberry Pi PoE fan control by pulling in the poe overlay
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.45
+* Linux: 5.15.46
 * Containerd: v1.6.6
 * Kubernetes: 1.24.1
 * Flannel: 0.18.1
-* runc: 1.1.2
+* runc: 1.1.3
 * CoreDNS: v1.9.3
 
 Talos is built with Go 1.18.3

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.45-talos"
+	DefaultKernelVersion = "5.15.46-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.2.0-alpha.0-4-gb9c72a5
+v1.2.0-alpha.0-6-g5bc7e34


### PR DESCRIPTION
Bump kernel to [5.15.46](https://github.com/siderolabs/pkgs/pull/511)
Bump runc to [v1.1.3](https://github.com/siderolabs/pkgs/pull/513)

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5722)
<!-- Reviewable:end -->
