### PR TITLE
fix: support SideroLink "secure" gRPC connection

### DIFF
--- a/internal/app/machined/pkg/controllers/siderolink/export_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/export_test.go
@@ -4,4 +4,6 @@
 
 package siderolink
 
-var ParseJoinToken = parseJoinToken
+var ParseAPIEndpoint = parseAPIEndpoint
+
+type APIEndpoint = apiEndpoint


### PR DESCRIPTION
Keep using old defaults: if the scheme is not specified, assume
"insecure" gRPC.

If `https://` scheme is specified, use gRPC with default TLS config
(which assumes default trusted CAs, no client cert).

Also fixes a bug when gRPC endpoint was passed in raw form, this won't
work with actual scheme.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5724)
<!-- Reviewable:end -->
