### PR TITLE
test: fix csi tests

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -231,6 +231,8 @@ function run_csi_tests {
   pushd "${TMP}/rook/deploy/examples"
   ${KUBECTL} apply -f crds.yaml -f common.yaml -f operator.yaml
   ${KUBECTL} apply -f cluster.yaml
+  # mark namespace as privileged for Pod Security
+  ${KUBECTL} label ns rook-ceph pod-security.kubernetes.io/enforce=privileged
   # wait for the controller to populate the status field
   sleep 30
   ${KUBECTL} --namespace rook-ceph wait --timeout=900s --for=jsonpath='{.status.phase}=Ready' cephclusters.ceph.rook.io/rook-ceph


### PR DESCRIPTION
With Pod Security, we need to allow priveleged for rook-ceph.

This fix was lost when reverting day-two.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5730)
<!-- Reviewable:end -->
