### PR TITLE
docs: snippets for logging api server audit logs

### DIFF
--- a/website/content/v1.0/learn-more/knowledge-base.md
+++ b/website/content/v1.0/learn-more/knowledge-base.md
@@ -19,3 +19,37 @@ machine:
       shutdownGracePeriod: 0s
       shutdownGracePeriodCriticalPods: 0s
 ```
+
+## Logging Kubernetes audit logs with loki
+
+If using loki-stack helm chart to gather logs from the Kubernetes cluster, you can use the helm values to configure loki-stack to log Kubernetes API server audit logs:
+
+```yaml
+promtail:
+  extraArgs:
+    - -config.expand-env
+  # // this is required so that the promtail process can read the kube-apiserver audit logs written as `nobody` user
+  containerSecurityContext:
+    capabilities:
+      add:
+        - DAC_READ_SEARCH
+  extraVolumes:
+    - name: audit-logs
+      hostPath:
+        path: /var/log/audit/kube
+  extraVolumeMounts:
+    - name: audit-logs
+      mountPath: /var/log/audit/kube
+      readOnly: true
+  config:
+    snippets:
+      extraScrapeConfigs: |
+        - job_name: auditlogs
+          static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: auditlogs
+                host: ${HOSTNAME}
+                __path__: /var/log/audit/kube/*.log
+```

--- a/website/content/v1.1/learn-more/knowledge-base.md
+++ b/website/content/v1.1/learn-more/knowledge-base.md
@@ -33,3 +33,37 @@ $ docker run --rm -i ghcr.io/siderolabs/imager:{{< release >}} iso --arch amd64 
 ```
 
 ISO will be output to the file `talos-<arch>.iso` in the current directory.
+
+## Logging Kubernetes audit logs with loki
+
+If using loki-stack helm chart to gather logs from the Kubernetes cluster, you can use the helm values to configure loki-stack to log Kubernetes API server audit logs:
+
+```yaml
+promtail:
+  extraArgs:
+    - -config.expand-env
+  # // this is required so that the promtail process can read the kube-apiserver audit logs written as `nobody` user
+  containerSecurityContext:
+    capabilities:
+      add:
+        - DAC_READ_SEARCH
+  extraVolumes:
+    - name: audit-logs
+      hostPath:
+        path: /var/log/audit/kube
+  extraVolumeMounts:
+    - name: audit-logs
+      mountPath: /var/log/audit/kube
+      readOnly: true
+  config:
+    snippets:
+      extraScrapeConfigs: |
+        - job_name: auditlogs
+          static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: auditlogs
+                host: ${HOSTNAME}
+                __path__: /var/log/audit/kube/*.log
+```

--- a/website/content/v1.2/learn-more/knowledge-base.md
+++ b/website/content/v1.2/learn-more/knowledge-base.md
@@ -33,3 +33,37 @@ $ docker run --rm -i ghcr.io/siderolabs/imager:{{< release >}} iso --arch amd64 
 ```
 
 ISO will be output to the file `talos-<arch>.iso` in the current directory.
+
+## Logging Kubernetes audit logs with loki
+
+If using loki-stack helm chart to gather logs from the Kubernetes cluster, you can use the helm values to configure loki-stack to log Kubernetes API server audit logs:
+
+```yaml
+promtail:
+  extraArgs:
+    - -config.expand-env
+  # this is required so that the promtail process can read the kube-apiserver audit logs written as `nobody` user
+  containerSecurityContext:
+    capabilities:
+      add:
+        - DAC_READ_SEARCH
+  extraVolumes:
+    - name: audit-logs
+      hostPath:
+        path: /var/log/audit/kube
+  extraVolumeMounts:
+    - name: audit-logs
+      mountPath: /var/log/audit/kube
+      readOnly: true
+  config:
+    snippets:
+      extraScrapeConfigs: |
+        - job_name: auditlogs
+          static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: auditlogs
+                host: ${HOSTNAME}
+                __path__: /var/log/audit/kube/*.log
+```


### PR DESCRIPTION
Add snippets for logging kube-apiserver audit logs from Talos

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5753)
<!-- Reviewable:end -->
