### PR TITLE
test: fix health endpoint cli test when discovery is disabled

### DIFF
--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -12,8 +12,11 @@ import (
 	"regexp"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/resources/cluster"
 )
 
 // HealthSuite verifies health command.
@@ -79,6 +82,13 @@ func (suite *HealthSuite) TestClientSideWithExplicitNodes() {
 //
 //nolint:gocyclo
 func (suite *HealthSuite) TestClientSideWithDiscovery() {
+	discoveryEnabled, err := suite.isDiscoveryEnabled()
+	suite.Require().NoError(err)
+
+	if !discoveryEnabled {
+		suite.T().Skipf("skipping test: discovery is not enabled on the cluster")
+	}
+
 	suite.testClientSide()
 }
 
@@ -106,6 +116,22 @@ func (suite *HealthSuite) testClientSide(extraArgs ...string) {
 		base.StdoutEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`waiting for all k8s nodes to report ready`)),
 	)
+}
+
+func (suite *HealthSuite) isDiscoveryEnabled() (bool, error) {
+	temp := struct {
+		Spec cluster.ConfigSpec `yaml:"spec"`
+	}{}
+
+	randomControlPlaneNodeInternalIP := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	stdout, _ := suite.RunCLI([]string{"--nodes", randomControlPlaneNodeInternalIP, "get", "discoveryconfigs", "-oyaml"})
+
+	err := yaml.Unmarshal([]byte(stdout), &temp)
+	if err != nil {
+		return false, err
+	}
+
+	return temp.Spec.DiscoveryEnabled, nil
 }
 
 func init() {


### PR DESCRIPTION
We skip the client-side health endpoint test that relies on the discovery service if the discovery service is not enabled for the cluster. Related to siderolabs#5554.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5775)
<!-- Reviewable:end -->
