### PR TITLE
fix: siderlink api assume port 443 with https schema

### DIFF
--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -93,6 +93,10 @@ func parseAPIEndpoint(sideroLinkParam string) (apiEndpoint, error) {
 		Insecure: u.Scheme == "grpc",
 	}
 
+	if u.Port() == "" && u.Scheme == "https" {
+		result.Host += ":443"
+	}
+
 	params := u.Query()
 
 	joinTokenStr, ok := params["jointoken"]

--- a/internal/app/machined/pkg/controllers/siderolink/manager_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager_test.go
@@ -182,6 +182,19 @@ func TestParseJoinToken(t *testing.T) {
 		}, endpoint)
 	})
 
+	t.Run("parses a join token from a secure URL without port", func(t *testing.T) {
+		// when
+		endpoint, err := siderolinkctrl.ParseAPIEndpoint("https://10.5.0.2?jointoken=ttt&jointoken=xxx")
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, siderolinkctrl.APIEndpoint{
+			Host:      "10.5.0.2:443",
+			Insecure:  false,
+			JoinToken: pointer.To("ttt"),
+		}, endpoint)
+	})
+
 	t.Run("parses a join token from an URL without a scheme", func(t *testing.T) {
 		// when
 		endpoint, err := siderolinkctrl.ParseAPIEndpoint("10.5.0.2:3445?jointoken=ttt")


### PR DESCRIPTION
If no port is supplied for the SideroLink API endpoint and the https
schema is used, then assume port 443 is wanted.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5792)
<!-- Reviewable:end -->
