### PR TITLE
fix: look for qemu-kvm binary

### DIFF
--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -5,7 +5,7 @@
 package qemu
 
 import (
-	"fmt"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -111,5 +111,17 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 
 // QemuExecutable returns name of qemu executable for the arch.
 func (arch Arch) QemuExecutable() string {
-	return fmt.Sprintf("qemu-system-%s", arch.QemuArch())
+	binaries := []string{
+		"qemu-system-" + arch.QemuArch(),
+		"qemu-kvm",
+		"/usr/libexec/qemu-kvm",
+	}
+
+	for _, binary := range binaries {
+		if path, err := exec.LookPath(binary); err == nil {
+			return path
+		}
+	}
+
+	return ""
 }

--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/hashicorp/go-getter"
-	"github.com/talos-systems/go-cmd/pkg/cmd"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/provision"
@@ -68,8 +67,8 @@ func (check *preflightCheckContext) checkKVM(ctx context.Context) error {
 }
 
 func (check *preflightCheckContext) qemuExecutable(ctx context.Context) error {
-	if _, err := cmd.Run(check.arch.QemuExecutable(), "--version"); err != nil {
-		return fmt.Errorf("error running QEMU %q, please install QEMU with package manager: %w", check.arch.QemuExecutable(), err)
+	if check.arch.QemuExecutable() == "" {
+		return fmt.Errorf("QEMU executable (qemu-system-%s or qemu-kvm) not found, please install QEMU with package manager", check.arch.QemuArch())
 	}
 
 	return nil


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Find additional qemu binaries.
Default binary location on rhel is `/usr/libexec/qemu-kvm`.
By default, this location is not in the PATH, therefore we look both for the explicit path, and for just the `qemu-kvm` binary

## Why? (reasoning)
Fix https://github.com/siderolabs/talos/issues/5761

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5795)
<!-- Reviewable:end -->
