### PR TITLE
fix: generate correct bootstrap manifests when only IPv6 CIDR is used

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -241,17 +241,13 @@ func (ctrl *K8sControlPlaneController) manageManifestsConfig(ctx context.Context
 	dnsServiceIP := ""
 	dnsServiceIPv6 := ""
 
-	if len(dnsServiceIPs) == 1 {
-		dnsServiceIP = dnsServiceIPs[0].String()
-	} else {
-		for _, ip := range dnsServiceIPs {
-			if dnsServiceIP == "" && ip.To4().Equal(ip) {
-				dnsServiceIP = ip.String()
-			}
+	for _, ip := range dnsServiceIPs {
+		if dnsServiceIP == "" && ip.To4().Equal(ip) {
+			dnsServiceIP = ip.String()
+		}
 
-			if dnsServiceIPv6 == "" && talosnet.IsNonLocalIPv6(ip) {
-				dnsServiceIPv6 = ip.String()
-			}
+		if dnsServiceIPv6 == "" && talosnet.IsNonLocalIPv6(ip) {
+			dnsServiceIPv6 = ip.String()
 		}
 	}
 


### PR DESCRIPTION
`DNSServiceIP` was assumed to be IPv4 when only one CIDR is specified
which was leading to a malformed CoreDNS manifest.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5798)
<!-- Reviewable:end -->
