### PR TITLE
Fix for etcd snapshot on windows

### DIFF
--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -187,6 +187,10 @@ var etcdSnapshotCmd = &cobra.Command{
 				return fmt.Errorf("sha256 checksum not found (size %d)", size)
 			}
 
+			if err = dest.Close(); err != nil {
+				return fmt.Errorf("failed to close: %w", err)
+			}
+
 			if err = os.Rename(partPath, dbPath); err != nil {
 				return fmt.Errorf("error renaming to final location: %w", err)
 			}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Fix `talosctl etcd snapshot` on windows.  Before PR change, executing `./talosctl.exe etcd snapshot ./etcd.db` on windows would give me:
> error renaming to final location: rename ./etcd.db.part ./etcd.db: The process cannot access the file because it is being used by another process.

## Why? (reasoning)
Standard windows file locking issue, dest not being closed before trying to re-open it for the `os.Rename()`.

## Acceptance
I didn't quite get my environment all the way set up, make conformance and make unit-tests isn't running locally, but I did build talosctl with my change and verify it fixed my issue and generated an etcd snapshot.

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5800)
<!-- Reviewable:end -->
