### PR TITLE
Change command for cluster create to keep $HOME with sudo

### DIFF
--- a/website/content/v1.0/advanced/air-gapped.md
+++ b/website/content/v1.0/advanced/air-gapped.md
@@ -112,7 +112,7 @@ needs to be repeated for each of the identified registry prefixes above.
 The endpoint being used is `10.5.0.1`, as this is the default bridge interface address which will be routable from the QEMU VMs (`127.0.0.1` IP will be pointing to the VM itself).
 
 ```bash
-$ sudo -E talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
+$ sudo --preserve-env=HOME talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
   --registry-mirror docker.io=http://10.5.0.1:6000 \
   --registry-mirror gcr.io=http://10.5.0.1:6000 \
   --registry-mirror ghcr.io=http://10.5.0.1:6000 \

--- a/website/content/v1.0/advanced/developing-talos.md
+++ b/website/content/v1.0/advanced/developing-talos.md
@@ -62,7 +62,7 @@ bash hack/start-registry-proxies.sh
 Start your local cluster with:
 
 ```bash
-sudo -E _out/talosctl-linux-amd64 cluster create \
+sudo --preserve-env=HOME _out/talosctl-linux-amd64 cluster create \
     --provisioner=qemu \
     --cidr=172.20.0.0/24 \
     --registry-mirror docker.io=http://172.20.0.1:5000 \
@@ -181,7 +181,7 @@ Specfic tests can be run with `-test.run=TestIntegration/api.ResetSuite`.
 ## Destroying Cluster
 
 ```bash
-sudo -E ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
+sudo --preserve-env=HOME ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
 ```
 
 This command stops QEMU and helper processes, tears down bridged network on the host, and cleans up

--- a/website/content/v1.0/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.0/talos-guides/install/local-platforms/qemu.md
@@ -1,7 +1,7 @@
 ---
 title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
-aliases: 
+aliases:
   - ../../../local-platforms/qemu
 ---
 
@@ -85,7 +85,7 @@ mkdir -p ~/.talos/clusters
 Create the cluster:
 
 ```bash
-sudo -E talosctl cluster create --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster create --provisioner qemu
 ```
 
 Before the first cluster is created, `talosctl` will download the CNI bundle for the VM provisioning and install it to `~/.talos/cni` directory.
@@ -130,7 +130,7 @@ talos-default-worker-1   Worker         10.5.0.5   1.00   1.6 GB   4.3 GB
 To cleanup, run:
 
 ```bash
-sudo -E talosctl cluster destroy --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster destroy --provisioner qemu
 ```
 
 > Note: In that case that the host machine is rebooted before destroying the cluster, you may need to manually remove `~/.talos/clusters/talos-default`.

--- a/website/content/v1.1/advanced/air-gapped.md
+++ b/website/content/v1.1/advanced/air-gapped.md
@@ -112,7 +112,7 @@ needs to be repeated for each of the identified registry prefixes above.
 The endpoint being used is `10.5.0.1`, as this is the default bridge interface address which will be routable from the QEMU VMs (`127.0.0.1` IP will be pointing to the VM itself).
 
 ```bash
-$ sudo -E talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
+$ sudo --preserve-env=HOME talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
   --registry-mirror docker.io=http://10.5.0.1:6000 \
   --registry-mirror gcr.io=http://10.5.0.1:6000 \
   --registry-mirror ghcr.io=http://10.5.0.1:6000 \

--- a/website/content/v1.1/advanced/developing-talos.md
+++ b/website/content/v1.1/advanced/developing-talos.md
@@ -62,7 +62,7 @@ bash hack/start-registry-proxies.sh
 Start your local cluster with:
 
 ```bash
-sudo -E _out/talosctl-linux-amd64 cluster create \
+sudo --preserve-env=HOME _out/talosctl-linux-amd64 cluster create \
     --provisioner=qemu \
     --cidr=172.20.0.0/24 \
     --registry-mirror docker.io=http://172.20.0.1:5000 \
@@ -181,7 +181,7 @@ Specfic tests can be run with `-test.run=TestIntegration/api.ResetSuite`.
 ## Destroying Cluster
 
 ```bash
-sudo -E ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
+sudo --preserve-env=HOME ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
 ```
 
 This command stops QEMU and helper processes, tears down bridged network on the host, and cleans up

--- a/website/content/v1.1/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.1/talos-guides/install/local-platforms/qemu.md
@@ -1,7 +1,7 @@
 ---
 title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
-aliases: 
+aliases:
   - ../../../local-platforms/qemu
 ---
 
@@ -85,7 +85,7 @@ mkdir -p ~/.talos/clusters
 Create the cluster:
 
 ```bash
-sudo -E talosctl cluster create --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster create --provisioner qemu
 ```
 
 Before the first cluster is created, `talosctl` will download the CNI bundle for the VM provisioning and install it to `~/.talos/cni` directory.
@@ -130,7 +130,7 @@ talos-default-worker-1   Worker         10.5.0.5   1.00   1.6 GB   4.3 GB
 To cleanup, run:
 
 ```bash
-sudo -E talosctl cluster destroy --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster destroy --provisioner qemu
 ```
 
 > Note: In that case that the host machine is rebooted before destroying the cluster, you may need to manually remove `~/.talos/clusters/talos-default`.

--- a/website/content/v1.2/advanced/air-gapped.md
+++ b/website/content/v1.2/advanced/air-gapped.md
@@ -112,7 +112,7 @@ needs to be repeated for each of the identified registry prefixes above.
 The endpoint being used is `10.5.0.1`, as this is the default bridge interface address which will be routable from the QEMU VMs (`127.0.0.1` IP will be pointing to the VM itself).
 
 ```bash
-$ sudo -E talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
+$ sudo --preserve-env=HOME talosctl cluster create --provisioner=qemu --install-image=ghcr.io/siderolabs/installer:{{< release >}} \
   --registry-mirror docker.io=http://10.5.0.1:6000 \
   --registry-mirror gcr.io=http://10.5.0.1:6000 \
   --registry-mirror ghcr.io=http://10.5.0.1:6000 \

--- a/website/content/v1.2/advanced/developing-talos.md
+++ b/website/content/v1.2/advanced/developing-talos.md
@@ -62,7 +62,7 @@ bash hack/start-registry-proxies.sh
 Start your local cluster with:
 
 ```bash
-sudo -E _out/talosctl-linux-amd64 cluster create \
+sudo --preserve-env=HOME _out/talosctl-linux-amd64 cluster create \
     --provisioner=qemu \
     --cidr=172.20.0.0/24 \
     --registry-mirror docker.io=http://172.20.0.1:5000 \
@@ -181,7 +181,7 @@ Specfic tests can be run with `-test.run=TestIntegration/api.ResetSuite`.
 ## Destroying Cluster
 
 ```bash
-sudo -E ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
+sudo --preserve-env=HOME ../talos/_out/talosctl-linux-amd64 cluster destroy --provisioner=qemu
 ```
 
 This command stops QEMU and helper processes, tears down bridged network on the host, and cleans up

--- a/website/content/v1.2/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.2/talos-guides/install/local-platforms/qemu.md
@@ -1,7 +1,7 @@
 ---
 title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
-aliases: 
+aliases:
   - ../../../local-platforms/qemu
 ---
 
@@ -85,7 +85,7 @@ mkdir -p ~/.talos/clusters
 Create the cluster:
 
 ```bash
-sudo -E talosctl cluster create --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster create --provisioner qemu
 ```
 
 Before the first cluster is created, `talosctl` will download the CNI bundle for the VM provisioning and install it to `~/.talos/cni` directory.
@@ -130,7 +130,7 @@ talos-default-worker-1   Worker         10.5.0.5   1.00   1.6 GB   4.3 GB
 To cleanup, run:
 
 ```bash
-sudo -E talosctl cluster destroy --provisioner qemu
+sudo --preserve-env=HOME talosctl cluster destroy --provisioner qemu
 ```
 
 > Note: In that case that the host machine is rebooted before destroying the cluster, you may need to manually remove `~/.talos/clusters/talos-default`.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

chane `sudo` parameter from `-E` to `--preserve-enf=HOME` to enforce the config is created in users home and not in */root/.talos* when creating cluster with `talosctl cluster create --provisionber=qemu`

## Why? (reasoning)

On fedora and opensuse, `sudo -E talosctl cluster create --provisioner=qemu` doesn't keep the home variable, so talos uses */root/.talos*. See #5467 

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5801)
<!-- Reviewable:end -->
