### PR TITLE
fix: etcd peer sans list

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -129,7 +129,7 @@ func (ctrl *APIController) Run(ctx context.Context, r controller.Runtime, logger
 	}
 }
 
-//nolint:gocyclo,cyclop
+//nolint:gocyclo,cyclop,dupl
 func (ctrl *APIController) reconcile(ctx context.Context, r controller.Runtime, logger *zap.Logger, isControlplane bool) error {
 	inputs := []controller.Input{
 		{

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -242,12 +242,6 @@ func (e *Etcd) HealthSettings(runtime.Runtime) *health.Settings {
 
 //nolint:gocyclo
 func generatePKI(ctx context.Context, r runtime.Runtime) (err error) {
-	// remove legacy etcd PKI directory to handle upgrades with `--preserve` to Talos 0.12
-	// TODO: remove me in Talos 0.13
-	if err = os.RemoveAll("/etc/kubernetes/pki/etcd"); err != nil {
-		return err
-	}
-
 	if err = os.MkdirAll(constants.EtcdPKIPath, 0o700); err != nil {
 		return err
 	}
@@ -574,8 +568,8 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime) error
 		"listen-peer-urls":                   "https://" + net.FormatAddress(listenAddress) + ":2380",
 		"listen-client-urls":                 "https://" + net.FormatAddress(listenAddress) + ":2379",
 		"client-cert-auth":                   "true",
-		"cert-file":                          constants.KubernetesEtcdPeerCert,
-		"key-file":                           constants.KubernetesEtcdPeerKey,
+		"cert-file":                          constants.KubernetesEtcdCert,
+		"key-file":                           constants.KubernetesEtcdKey,
 		"trusted-ca-file":                    constants.KubernetesEtcdCACert,
 		"peer-client-cert-auth":              "true",
 		"peer-cert-file":                     constants.KubernetesEtcdPeerCert,


### PR DESCRIPTION
Before generate the peer certificate, we will check IP existence on the node.

## Why? (reasoning)

The node does not have all IP addresses when we create Etcd certificate. In this case, peer cert does not have an advertised IP.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5806)
<!-- Reviewable:end -->
