### PR TITLE
fix: use correct sha256sum of go-blockdevice@v0.3.2

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1144,7 +1144,7 @@ github.com/talos-systems/discovery-api v0.1.0 h1:aKod6uqakH6VfeQ6HaxPF7obqFAL1QT
 github.com/talos-systems/discovery-api v0.1.0/go.mod h1:ZsbzzOC5bzToaF3+YvUXDf9paeWV5bedpDu5RPXrglM=
 github.com/talos-systems/discovery-client v0.1.0 h1:m+f96TKGFckMWrhDI+o9+QhcGn8f1A61Jp6YYVwiulI=
 github.com/talos-systems/discovery-client v0.1.0/go.mod h1:LxqCv16VBB68MgaMnV8jXujYd3Q097DAn22U5gaHmkU=
-github.com/talos-systems/go-blockdevice v0.3.2 h1:qa966a7JH6ORv7xUFb1JyBjXAEHqTxhfCzU0ARzUKek=
+github.com/talos-systems/go-blockdevice v0.3.2 h1:uzPwAxb+4RZIoDGlGMeUBqRd9++Z2IGLGwnxAh8atS0=
 github.com/talos-systems/go-blockdevice v0.3.2/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-cmd v0.1.0 h1:bqPeL0ksproFyTOlvMisdUXc7uAf0aqJ5Q6waSGv32s=

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -136,7 +136,7 @@ github.com/stretchr/testify v1.7.3 h1:dAm0YRdRQlWojc3CrCRgPBzG5f941d0zvAKu7qY4e+
 github.com/stretchr/testify v1.7.3/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/talos-systems/crypto v0.3.6-0.20220622130438-e9df1b8ca74c h1:JoZa0ZQlzm1RzxLMkM6Ak668qVmOTGR4l1kMFeSXTwc=
 github.com/talos-systems/crypto v0.3.6-0.20220622130438-e9df1b8ca74c/go.mod h1:jbt9CspHnhdwyKmXQQEIiFSHz1cfsCJjsd0iNat1wEA=
-github.com/talos-systems/go-blockdevice v0.3.2 h1:qa966a7JH6ORv7xUFb1JyBjXAEHqTxhfCzU0ARzUKek=
+github.com/talos-systems/go-blockdevice v0.3.2 h1:uzPwAxb+4RZIoDGlGMeUBqRd9++Z2IGLGwnxAh8atS0=
 github.com/talos-systems/go-blockdevice v0.3.2/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-debug v0.2.1 h1:VSN8P1zXWeHWgUBZn4cVT3keBcecCAJBG9Up+F6N2KM=


### PR DESCRIPTION
# Pull Request

Fixes siderolabs/talos#5807


## What? (description)
The tag for go-blockdevice of version `v0.3.2` is incorrect in `go.sum`. This makes old systems still build as they have the old tag still in cache, but breaks systems that pull fresh source code.

## Why? (reasoning)
The tag of go-blockdevice was probably retagged.

NOTE:
The CI build will probably fail as it still has the cache of go-blockdevice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5808)
<!-- Reviewable:end -->
