### PR TITLE
fix: filter static pods correctly and optimize fetching

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
@@ -317,13 +317,13 @@ func (ctrl *KubeletStaticPodController) refreshPodStatus(ctx context.Context, r 
 	podsSeen := map[string]struct{}{}
 
 	for _, pod := range podList.Items {
-		if pod.OwnerReferences != nil {
+		if pod.Metadata.Annotations.ConfigSource != "file" {
 			continue
 		}
 
 		pod := pod
 
-		statusID := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		statusID := fmt.Sprintf("%s/%s", pod.Metadata.Namespace, pod.Metadata.Name)
 
 		podsSeen[statusID] = struct{}{}
 


### PR DESCRIPTION
When we query kubelet API to populate the StaticPodStatuses, instead of checking for ownerReferences to be empty, we check the annotation "kubernetes.io/config.source" value so we avoid including standalone pods (that are regular pods but not part of a replicaset).

We also optimize their fetching by avoiding to unmarshal the fields we do not need.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5819)
<!-- Reviewable:end -->
