### PR TITLE
chore: bump kernel to 5.15.50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.2.0-alpha.0
-PKGS ?= v1.2.0-alpha.0-13-ged75c50
+PKGS ?= v1.2.0-alpha.0-16-g6fedbdc
 EXTRAS ?= v1.2.0-alpha.0
 GO_VERSION ?= 1.18
 GOIMPORTS_VERSION ?= v0.1.10

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -39,7 +39,7 @@ See [documentation](https://www.talos.dev/v1.1/reference/configuration/#bridge) 
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.49
+* Linux: 5.15.50
 """
 
     [notes.talos-config-kernel-param-variable-substitution]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.49-talos"
+	DefaultKernelVersion = "5.15.50-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.2.0-alpha.0-13-ged75c50
+v1.2.0-alpha.0-16-g6fedbdc


### PR DESCRIPTION
Bump kernel to [5.15.50](https://github.com/siderolabs/pkgs/pull/524)
Also pulls in https://github.com/siderolabs/pkgs/pull/526

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5820)
<!-- Reviewable:end -->
