### PR TITLE
docs: fix pod security talos resource name

### DIFF
--- a/website/content/v1.1/kubernetes-guides/configuration/pod-security.md
+++ b/website/content/v1.1/kubernetes-guides/configuration/pod-security.md
@@ -42,12 +42,12 @@ This default policy can be modified by updating the generated machine configurat
 Verify current admission plugin configuration with:
 
 ```shell
-$ talosctl get kubernetescontrolplaneconfigs apiserver-admission-control -o yaml
+$ talosctl get admissioncontrolconfigs.kubernetes.talos.dev admission-control -o yaml
 node: 172.20.0.2
 metadata:
-    namespace: config
-    type: KubernetesControlPlaneConfigs.config.talos.dev
-    id: apiserver-admission-control
+    namespace: controlplane
+    type: AdmissionControlConfigs.kubernetes.talos.dev
+    id: admission-control
     version: 1
     owner: config.K8sControlPlaneController
     phase: running

--- a/website/content/v1.2/kubernetes-guides/configuration/pod-security.md
+++ b/website/content/v1.2/kubernetes-guides/configuration/pod-security.md
@@ -42,12 +42,12 @@ This default policy can be modified by updating the generated machine configurat
 Verify current admission plugin configuration with:
 
 ```shell
-$ talosctl get kubernetescontrolplaneconfigs apiserver-admission-control -o yaml
+$ talosctl get admissioncontrolconfigs.kubernetes.talos.dev admission-control -o yaml
 node: 172.20.0.2
 metadata:
-    namespace: config
-    type: KubernetesControlPlaneConfigs.config.talos.dev
-    id: apiserver-admission-control
+    namespace: controlplane
+    type: AdmissionControlConfigs.kubernetes.talos.dev
+    id: admission-control
     version: 1
     owner: config.K8sControlPlaneController
     phase: running


### PR DESCRIPTION
Fix the resource name for admissionconfig

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5826)
<!-- Reviewable:end -->
