### PR TITLE
chore: disable systeminfo controller in container

### DIFF
--- a/internal/app/machined/pkg/controllers/hardware/system.go
+++ b/internal/app/machined/pkg/controllers/hardware/system.go
@@ -15,13 +15,15 @@ import (
 	"go.uber.org/zap"
 
 	hwadapter "github.com/talos-systems/talos/internal/app/machined/pkg/adapters/hardware"
+	runtimetalos "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	pkgSMBIOS "github.com/talos-systems/talos/internal/pkg/smbios"
 	"github.com/talos-systems/talos/pkg/machinery/resources/hardware"
 )
 
 // SystemInfoController populates CPU information of the underlying hardware.
 type SystemInfoController struct {
-	SMBIOS *smbios.SMBIOS
+	V1Alpha1Mode runtimetalos.Mode
+	SMBIOS       *smbios.SMBIOS
 }
 
 // Name implements controller.Controller interface.
@@ -62,6 +64,10 @@ func (ctrl *SystemInfoController) Run(ctx context.Context, r controller.Runtime,
 	case <-r.EventCh():
 	}
 
+	// smbios info is not available inside container, so skip the controller
+	if ctrl.V1Alpha1Mode == runtimetalos.ModeContainer {
+		return nil
+	}
 	// controller runs only once
 	if ctrl.SMBIOS == nil {
 		s, err := pkgSMBIOS.GetSMBIOSInfo()

--- a/internal/app/machined/pkg/controllers/hardware/system_test.go
+++ b/internal/app/machined/pkg/controllers/hardware/system_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/talos-systems/go-smbios/smbios"
 
 	hardwarectrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/hardware"
+	runtimetalos "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/resources/hardware"
 )
 
@@ -122,6 +123,20 @@ func (suite *SystemInfoSuite) TestPopulateSystemInformation() {
 			),
 		)
 	}
+}
+
+func (suite *SystemInfoSuite) TestPopulateSystemInformationIsDisabledInContainerMode() {
+	suite.Require().NoError(
+		suite.runtime.RegisterController(
+			&hardwarectrl.SystemInfoController{
+				V1Alpha1Mode: runtimetalos.ModeContainer,
+			},
+		),
+	)
+
+	suite.startRuntime()
+
+	suite.Assert().NoError(retry.Constant(1*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(suite.assertNoResource(*hardware.NewSystemInformation("systeminformation").Metadata())))
 }
 
 func TestSystemInfoSyncSuite(t *testing.T) {

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -109,7 +109,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			EtcPath:    "/etc",
 			ShadowPath: constants.SystemEtcPath,
 		},
-		&hardware.SystemInfoController{},
+		&hardware.SystemInfoController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&k8s.ControlPlaneStaticPodController{},
 		&k8s.EndpointController{},
 		&k8s.ExtraManifestController{},


### PR DESCRIPTION
Disable systeminfo controller in container mode

Fixes: #5849

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5850)
<!-- Reviewable:end -->
