### PR TITLE
feat: add vlan support to cmdline

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -36,6 +36,19 @@ spec:
 See [documentation](https://www.talos.dev/v1.2/reference/configuration/#bridge) for more details.
 """
 
+    [notes.network-vlan-cmdline]
+        title = "VLAN support in cmdline arguments"
+        description = """\
+Talos now supports dracut-style `vlan` kernel argument to allow
+installing Talos Linux in networks where ports are not tagged
+with a default VLAN:
+
+```
+vlan=eth1.5:eth1 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1.5:::::
+```
+
+"""
+
     [notes.updates]
         title = "Component Updates"
         description="""\

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -311,6 +311,51 @@ func (suite *CmdlineSuite) TestParse() {
 
 			expectedError: "unknown bond option: mod",
 		},
+		{
+			name:    "vlan configuration",
+			cmdline: "vlan=eth1.5:eth1 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1.5:::::",
+			expectedSettings: network.CmdlineNetworking{
+				Address:  netaddr.MustParseIPPrefix("172.20.0.2/24"),
+				Gateway:  netaddr.MustParseIP("172.20.0.1"),
+				LinkName: "eth1.5",
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth1.5",
+						Logical:     true,
+						Up:          true,
+						Kind:        netconfig.LinkKindVLAN,
+						Type:        nethelpers.LinkEther,
+						ParentName:  "eth1",
+						ConfigLayer: netconfig.ConfigCmdline,
+						VLAN: netconfig.VLANSpec{
+							VID:      5,
+							Protocol: nethelpers.VLANProtocol8021Q,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "vlan configuration without ip configuration",
+			cmdline: "vlan=eth1.5:eth1",
+			expectedSettings: network.CmdlineNetworking{
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth1.5",
+						Logical:     true,
+						Up:          true,
+						Kind:        netconfig.LinkKindVLAN,
+						Type:        nethelpers.LinkEther,
+						ParentName:  "eth1",
+						ConfigLayer: netconfig.ConfigCmdline,
+						VLAN: netconfig.VLANSpec{
+							VID:      5,
+							Protocol: nethelpers.VLANProtocol8021Q,
+						},
+					},
+				},
+			},
+		},
 	} {
 		test := test
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -80,6 +80,9 @@ const (
 	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos.
 	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
 
+	// KernelParamVlan is the kernel parameter for specifying vlan for the interface.
+	KernelParamVlan = "vlan"
+
 	// KernelParamBonding is the kernel parameter for specifying bonded network interfaces.
 	KernelParamBonding = "bond"
 

--- a/pkg/machinery/resources/network/link.go
+++ b/pkg/machinery/resources/network/link.go
@@ -80,6 +80,16 @@ type WireguardPeer struct {
 	AllowedIPs                  []netaddr.IPPrefix `yaml:"allowedIPs"`
 }
 
+// ID Returns the VID for type VLANSpec.
+func (vlan VLANSpec) ID() uint16 {
+	return vlan.VID
+}
+
+// MTU Returns MTU=0 for type VLANSpec.
+func (vlan VLANSpec) MTU() uint32 {
+	return 0
+}
+
 // Equal checks two WireguardPeer structs for equality.
 //
 // `spec` is considered to be the result of getting current Wireguard configuration,

--- a/website/content/v1.2/reference/kernel.md
+++ b/website/content/v1.2/reference/kernel.md
@@ -68,6 +68,23 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 
   This will create a bond interface named `bond1` with `eth3` and `eth4` as slaves and set the bond mode to `802.3ad`, the transmit hash policy to `layer2+3` and bond interface MTU to 1450.
 
+#### `vlan`
+
+  The interface vlan configuration.
+
+  Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
+
+  Talos will use the `vlan=` kernel parameter if supplied to set the initial vlan configuration.
+  This parameter is useful in environments where the switch ports are VLAN tagged with no native VLAN.
+
+  Only one vlan can be configured at this stage.
+
+  An example of a vlan configuration including static ip configuration:
+
+  `vlan=eth0.100:eth0 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth0.100:::::`
+
+  This will create a vlan interface named `eth0.100` with `eth0` as the underlying interface and set the vlan id to 100 with static IP 172.20.0.2/24 and 172.20.0.1 as default gateway.
+
 #### `panic`
 
   The amount of time to wait after a panic before a reboot is issued.


### PR DESCRIPTION
this commits adds dracut style vlan support to allow
installing talos in networks where ports is not tagged
with a default vlan.

Signed-off-by: Eirik Askheim <eirik@x13.no>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
dracut style vlan= cmdline support solving https://github.com/siderolabs/talos/issues/5755

Fixes #5755 

## Why? (reasoning)
allow installation of Talos in environments without default vlan.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5851)
<!-- Reviewable:end -->
