### PR TITLE
fix: avoid double append of `talos.platform` kernel argument

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -54,7 +54,11 @@ func Install(p runtime.Platform, seq runtime.Sequence, opts *Options) (err error
 		return err
 	}
 
-	if err = cmdline.AppendAll(opts.ExtraKernelArgs, procfs.WithOverwriteArgs("console")); err != nil {
+	if err = cmdline.AppendAll(
+		opts.ExtraKernelArgs,
+		procfs.WithOverwriteArgs("console"),
+		procfs.WithOverwriteArgs(constants.KernelParamPlatform),
+	); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The example configuration generated by talosctl contains

```yaml
extraKernelArgs:
  - talos.platform=metal
```

in the install section, which, if uncommented, causes the installer to append the
`talos.platform` option twice. Thus, if the platform is set/changed here, it will
not be respected. This change allows the existing value to be overridden.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5867)
<!-- Reviewable:end -->
