### PR TITLE
fix: stabilize etcd join and promote sequences

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -336,7 +336,7 @@ func addMember(ctx context.Context, r runtime.Runtime, addrs []string, name stri
 		return nil, 0, fmt.Errorf("failed to generate etcd PKI: %w", err)
 	}
 
-	client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.State().V1Alpha2().Resources())
+	client, err := etcd.NewClientFromControlPlaneIPsNoDiscovery(ctx, r.State().V1Alpha2().Resources())
 	if err != nil {
 		return nil, 0, err
 	}
@@ -675,11 +675,11 @@ func promoteMember(ctx context.Context, r runtime.Runtime, memberID uint64) erro
 	// try to promote a member until it succeeds (call might fail until the member catches up with the leader)
 	// promote member call will fail until member catches up with the master
 	return retry.Constant(10*time.Minute,
-		retry.WithUnits(10*time.Second),
+		retry.WithUnits(15*time.Second),
 		retry.WithJitter(time.Second),
 		retry.WithErrorLogging(true),
 	).RetryWithContext(ctx, func(ctx context.Context) error {
-		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.State().V1Alpha2().Resources())
+		client, err := etcd.NewClientFromControlPlaneIPsNoDiscovery(ctx, r.State().V1Alpha2().Resources())
 		if err != nil {
 			return retry.ExpectedError(err)
 		}


### PR DESCRIPTION
There were two issues with using discovery service for join and promote:

* on join, that resulted in joining too fast which triggers race bugs in
  etcd cert generation (to be fixed as separate PR)
* on promote, Talos has to connect to non-learner member of the cluster
  which is somehow "automatic" with Kuberentes discovery, as it only
  lists `kube-apiserver` running which is up only when etcd on the same
  node is healthy. etcd client doesn't allow to avoid learner members,
  as even getting a member list from a learner doesn't work (to be fixed
  as a separate PR)

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siderolabs/talos/5876)
<!-- Reviewable:end -->
