### PR TITLE
feat: expose strategic merge config patches

### DIFF
--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -100,7 +100,7 @@ func V1Alpha1Config(genOptions []generate.GenOption,
 	configPatch []string,
 	configPatchControlPlane []string,
 	configPatchWorker []string,
-) (*v1alpha1.ConfigBundle, error) {
+) (*bundle.ConfigBundle, error) {
 	configBundleOpts := []bundle.Option{
 		bundle.WithInputOptions(
 			&bundle.InputOptions{

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -227,7 +227,7 @@ type UpgradeSuite struct {
 
 	provisioner provision.Provisioner
 
-	configBundle *v1alpha1.ConfigBundle
+	configBundle *bundle.ConfigBundle
 
 	clusterAccess        *access.Adapter
 	controlPlaneEndpoint string

--- a/pkg/machinery/config/configpatcher/apply.go
+++ b/pkg/machinery/config/configpatcher/apply.go
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher
+
+import (
+	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
+)
+
+// configOrBytes encapsulates either unmarshaled config or raw byte representation.
+type configOrBytes struct {
+	marshaled []byte
+	config    config.Provider
+}
+
+func (cb *configOrBytes) Bytes() ([]byte, error) {
+	if cb.marshaled != nil {
+		return cb.marshaled, nil
+	}
+
+	var err error
+
+	cb.marshaled, err = cb.config.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+	if err != nil {
+		return nil, err
+	}
+
+	cb.config = nil
+
+	return cb.marshaled, nil
+}
+
+func (cb *configOrBytes) Config() (config.Provider, error) {
+	if cb.config != nil {
+		return cb.config, nil
+	}
+
+	var err error
+
+	cb.config, err = configloader.NewFromBytes(cb.marshaled)
+	if err != nil {
+		return nil, err
+	}
+
+	cb.marshaled = nil
+
+	return cb.config, nil
+}
+
+// Input to the patch application process.
+type Input interface {
+	Config() (config.Provider, error)
+	Bytes() ([]byte, error)
+}
+
+// WithConfig returns a new Input that wraps the given config.
+func WithConfig(config config.Provider) Input {
+	return &configOrBytes{config: config}
+}
+
+// WithBytes returns a new Input that wraps the given bytes.
+func WithBytes(bytes []byte) Input {
+	return &configOrBytes{marshaled: bytes}
+}
+
+// Output of patch application process.
+type Output = Input
+
+// Apply config patches to Talos machine config.
+//
+// Apply either JSON6902 or StrategicMergePatch.
+//
+// This method tries to minimize conversion between byte and unmarshalled
+// config representation as much as possible.
+func Apply(in Input, patches []Patch) (Output, error) {
+	for _, patch := range patches {
+		switch p := patch.(type) {
+		case jsonpatch.Patch:
+			bytes, err := in.Bytes()
+			if err != nil {
+				return nil, err
+			}
+
+			patched, err := JSON6902(bytes, p)
+			if err != nil {
+				return nil, err
+			}
+
+			in = WithBytes(patched)
+		case StrategicMergePatch:
+			cfg, err := in.Config()
+			if err != nil {
+				return nil, err
+			}
+
+			patched, err := StrategicMerge(cfg, p)
+			if err != nil {
+				return nil, err
+			}
+
+			in = WithConfig(patched)
+		}
+	}
+
+	return in, nil
+}

--- a/pkg/machinery/config/configpatcher/apply_test.go
+++ b/pkg/machinery/config/configpatcher/apply_test.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher_test
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+	"github.com/talos-systems/talos/pkg/machinery/config/configpatcher"
+)
+
+//go:embed testdata/apply/config.yaml
+var config []byte
+
+//go:embed testdata/apply/expected.yaml
+var expected []byte
+
+func TestApply(t *testing.T) {
+	patches, err := configpatcher.LoadPatches([]string{
+		"@testdata/apply/strategic1.yaml",
+		"@testdata/apply/jsonpatch1.yaml",
+		"@testdata/apply/jsonpatch2.yaml",
+		"@testdata/apply/strategic2.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := configloader.NewFromBytes(config)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		input configpatcher.Input
+	}{
+		{
+			name:  "WithConfig",
+			input: configpatcher.WithConfig(cfg),
+		},
+		{
+			name:  "WithBytes",
+			input: configpatcher.WithBytes(config),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := configpatcher.Apply(tt.input, patches)
+			require.NoError(t, err)
+
+			bytes, err := out.Bytes()
+			require.NoError(t, err)
+
+			assert.Equal(t, expected, bytes)
+		})
+	}
+}

--- a/pkg/machinery/config/configpatcher/configpatcher.go
+++ b/pkg/machinery/config/configpatcher/configpatcher.go
@@ -5,29 +5,5 @@
 // Package configpatcher provides methods to patch Talos config.
 package configpatcher
 
-import (
-	"fmt"
-
-	jsonpatch "github.com/evanphx/json-patch"
-	ghodssyaml "github.com/ghodss/yaml"
-)
-
-// JSON6902 is responsible for applying a JSON 6902 patch to the bootstrap data.
-func JSON6902(talosMachineConfig []byte, patch jsonpatch.Patch) ([]byte, error) {
-	jsonDecodedData, err := ghodssyaml.YAMLToJSON(talosMachineConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failure converting talos machine config to json: %s", err)
-	}
-
-	jsonDecodedData, err = patch.Apply(jsonDecodedData)
-	if err != nil {
-		return nil, fmt.Errorf("failure applying rfc6902 patches to talos machine config: %s", err)
-	}
-
-	talosMachineConfig, err = ghodssyaml.JSONToYAML(jsonDecodedData)
-	if err != nil {
-		return nil, fmt.Errorf("failure converting talos machine config from json to yaml: %s", err)
-	}
-
-	return talosMachineConfig, nil
-}
+// Patch is either JSON patch or strategic merge patch.
+type Patch any

--- a/pkg/machinery/config/configpatcher/json6902.go
+++ b/pkg/machinery/config/configpatcher/json6902.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	ghodssyaml "github.com/ghodss/yaml"
+)
+
+// JSON6902 is responsible for applying a JSON 6902 patch to the bootstrap data.
+func JSON6902(talosMachineConfig []byte, patch jsonpatch.Patch) ([]byte, error) {
+	jsonDecodedData, err := ghodssyaml.YAMLToJSON(talosMachineConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failure converting talos machine config to json: %s", err)
+	}
+
+	jsonDecodedData, err = patch.Apply(jsonDecodedData)
+	if err != nil {
+		return nil, fmt.Errorf("failure applying rfc6902 patches to talos machine config: %s", err)
+	}
+
+	talosMachineConfig, err = ghodssyaml.JSONToYAML(jsonDecodedData)
+	if err != nil {
+		return nil, fmt.Errorf("failure converting talos machine config from json to yaml: %s", err)
+	}
+
+	return talosMachineConfig, nil
+}

--- a/pkg/machinery/config/configpatcher/strategic.go
+++ b/pkg/machinery/config/configpatcher/strategic.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/merge"
+)
+
+// StrategicMergePatch is a strategic merge config patch.
+type StrategicMergePatch struct {
+	config.Provider
+}
+
+// StrategicMerge performs strategic merge config patching.
+func StrategicMerge(cfg config.Provider, patch StrategicMergePatch) (config.Provider, error) {
+	left := cfg.Raw()
+	right := patch.Raw()
+
+	if err := merge.Merge(left, right); err != nil {
+		return nil, err
+	}
+
+	result, ok := left.(config.Provider)
+	if !ok {
+		return nil, fmt.Errorf("strategic left is not config.Provider %T", left)
+	}
+
+	return result, nil
+}

--- a/pkg/machinery/config/configpatcher/testdata/apply/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/config.yaml
@@ -1,0 +1,7 @@
+version: v1alpha1
+machine:
+  network:
+    hostname: hostname1
+    interfaces:
+      - interface: eth0
+        dhcp: true

--- a/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
@@ -1,0 +1,16 @@
+version: v1alpha1
+machine:
+    type: ""
+    token: ""
+    certSANs: []
+    network:
+        hostname: foo
+        interfaces:
+            - interface: eth0
+              addresses:
+                - 10.1.2.3/24
+              mtu: 0
+              dhcp: false
+              vip:
+                ip: 10.3.5.6
+cluster: null

--- a/pkg/machinery/config/configpatcher/testdata/apply/jsonpatch1.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/jsonpatch1.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /machine/network/interfaces/0/addresses
+  value:
+     - 10.1.2.3/24

--- a/pkg/machinery/config/configpatcher/testdata/apply/jsonpatch2.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/jsonpatch2.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /machine/network/hostname
+  value: foo

--- a/pkg/machinery/config/configpatcher/testdata/apply/strategic1.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/strategic1.yaml
@@ -1,0 +1,5 @@
+machine:
+  network:
+    interfaces:
+      - interface: eth0
+        dhcp: false

--- a/pkg/machinery/config/configpatcher/testdata/apply/strategic2.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/strategic2.yaml
@@ -1,0 +1,6 @@
+machine:
+  network:
+    interfaces:
+      - interface: eth0
+        vip:
+          ip: 10.3.5.6

--- a/pkg/machinery/config/configpatcher/testdata/strategic.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/strategic.yaml
@@ -1,0 +1,3 @@
+machine:
+  network:
+    hostname: foo.bar

--- a/pkg/machinery/config/decoder/decoder.go
+++ b/pkg/machinery/config/decoder/decoder.go
@@ -31,10 +31,16 @@ const (
 	ManifestVersionKey = "version"
 	// ManifestKindKey is the string indicating a manifest's kind.
 	ManifestKindKey = "kind"
-	// ManifestSpecKey is represents a manifest's spec.
+	// ManifestSpecKey represents a manifest's spec.
 	ManifestSpecKey = "spec"
-	// ManifestDeprecatedKey is represents the deprected v1alpha1 manifest.
-	ManifestDeprecatedKey = "machine"
+	// ManifestDeprecatedKeyMachine represents the deprecated v1alpha1 manifest.
+	ManifestDeprecatedKeyMachine = "machine"
+	// ManifestDeprecatedKeyCluster represents the deprecated v1alpha1 manifest.
+	ManifestDeprecatedKeyCluster = "cluster"
+	// ManifestDeprecatedKeyDebug represents the deprecated v1alpha1 manifest.
+	ManifestDeprecatedKeyDebug = "debug"
+	// ManifestDeprecatedKeyPersist represents the deprecated v1alpha1 manifest.
+	ManifestDeprecatedKeyPersist = "persist"
 )
 
 // Decoder represents a multi-doc YAML decoder.
@@ -134,7 +140,11 @@ func decode(manifest *yaml.Node) (target interface{}, err error) {
 			}
 
 			spec = manifest.Content[i+1]
-		case ManifestDeprecatedKey:
+		case
+			ManifestDeprecatedKeyMachine,
+			ManifestDeprecatedKeyCluster,
+			ManifestDeprecatedKeyDebug,
+			ManifestDeprecatedKeyPersist:
 			if target, err = config.New("v1alpha1", ""); err != nil {
 				return nil, fmt.Errorf("new deprecated config: %w", err)
 			}

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -21,7 +21,7 @@ import (
 
 // NewConfigBundle returns a new bundle.
 //nolint:gocyclo,cyclop
-func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
+func NewConfigBundle(opts ...Option) (*ConfigBundle, error) {
 	options := DefaultOptions()
 
 	for _, opt := range opts {
@@ -30,7 +30,7 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		}
 	}
 
-	bundle := &v1alpha1.ConfigBundle{}
+	bundle := &ConfigBundle{}
 
 	// Configs already exist, we'll pull them in.
 	if options.ExistingConfigs != "" {
@@ -148,7 +148,7 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 	return bundle, nil
 }
 
-func applyJSONPatches(bundle *v1alpha1.ConfigBundle, options Options) error {
+func applyJSONPatches(bundle *ConfigBundle, options Options) error {
 	if err := bundle.ApplyJSONPatch(options.JSONPatch, true, true); err != nil {
 		return fmt.Errorf("error patching configs: %w", err)
 	}

--- a/pkg/machinery/config/types/v1alpha1/bundle/v1alpha1_configurator_bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/v1alpha1_configurator_bundle.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package v1alpha1
+package bundle
 
 import (
 	"fmt"
@@ -17,6 +17,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/configpatcher"
 	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
@@ -24,9 +25,9 @@ import (
 // docgen: nodoc
 // +k8s:deepcopy-gen=false
 type ConfigBundle struct {
-	InitCfg         *Config
-	ControlPlaneCfg *Config
-	WorkerCfg       *Config
+	InitCfg         *v1alpha1.Config
+	ControlPlaneCfg *v1alpha1.Config
+	WorkerCfg       *v1alpha1.Config
 	TalosCfg        *clientconfig.Config
 }
 
@@ -99,7 +100,7 @@ func (c *ConfigBundle) ApplyJSONPatch(patch jsonpatch.Patch, patchControlPlane, 
 		return nil
 	}
 
-	apply := func(in *Config) (out *Config, err error) {
+	apply := func(in *v1alpha1.Config) (out *v1alpha1.Config, err error) {
 		var marshaled []byte
 
 		marshaled, err = in.Bytes()
@@ -114,7 +115,7 @@ func (c *ConfigBundle) ApplyJSONPatch(patch jsonpatch.Patch, patchControlPlane, 
 			return nil, err
 		}
 
-		out = &Config{}
+		out = &v1alpha1.Config{}
 		err = yaml.Unmarshal(patched, out)
 
 		return out, err

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -499,7 +499,7 @@ metadata:
 		},
 	}
 
-	kubeletNodeIPExample = KubeletNodeIPConfig{
+	kubeletNodeIPExample = &KubeletNodeIPConfig{
 		KubeletNodeIPValidSubnets: []string{
 			"10.0.0.0/8",
 			"!10.0.0.3/32",
@@ -582,6 +582,12 @@ metadata:
 			},
 		},
 	}
+
+	installExtensionsExample = []InstallExtensionConfig{
+		{
+			ExtensionImage: "ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0",
+		},
+	}
 )
 
 // Config defines the v1alpha1 configuration file.
@@ -604,7 +610,7 @@ type Config struct {
 	//     - yes
 	//     - false
 	//     - no
-	ConfigDebug *bool `yaml:"debug"`
+	ConfigDebug *bool `yaml:"debug,omitempty"`
 	//   description: |
 	//     Indicates whether to pull the machine config upon every boot.
 	//   values:
@@ -612,7 +618,7 @@ type Config struct {
 	//     - yes
 	//     - false
 	//     - no
-	ConfigPersist *bool `yaml:"persist"`
+	ConfigPersist *bool `yaml:"persist,omitempty"`
 	//   description: |
 	//     Provides machine specific configuration options.
 	MachineConfig *MachineConfig `yaml:"machine"`
@@ -1167,7 +1173,7 @@ type InstallConfig struct {
 	//   description: |
 	//     Allows for supplying additional system extension images to install on top of base Talos image.
 	//   examples:
-	//     - value: '"ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0"'
+	//     - value: installExtensionsExample
 	InstallExtensions []InstallExtensionConfig `yaml:"extensions,omitempty"`
 	//   description: |
 	//     Indicates if a bootloader should be installed.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -742,7 +742,7 @@ func init() {
 	InstallConfigDoc.Fields[4].Description = "Allows for supplying additional system extension images to install on top of base Talos image."
 	InstallConfigDoc.Fields[4].Comments[encoder.LineComment] = "Allows for supplying additional system extension images to install on top of base Talos image."
 
-	InstallConfigDoc.Fields[4].AddExample("", "ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0")
+	InstallConfigDoc.Fields[4].AddExample("", installExtensionsExample)
 	InstallConfigDoc.Fields[5].Name = "bootloader"
 	InstallConfigDoc.Fields[5].Type = "bool"
 	InstallConfigDoc.Fields[5].Note = ""
@@ -849,7 +849,7 @@ func init() {
 	InstallExtensionConfigDoc.Comments[encoder.LineComment] = "InstallExtensionConfig represents a configuration for a system extension."
 	InstallExtensionConfigDoc.Description = "InstallExtensionConfig represents a configuration for a system extension."
 
-	InstallExtensionConfigDoc.AddExample("", "ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0")
+	InstallExtensionConfigDoc.AddExample("", installExtensionsExample)
 	InstallExtensionConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "InstallConfig",


### PR DESCRIPTION
The end result is that every Talos CLI accepts both JSON and strategic
patches to patch machine configuration.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
