### PR TITLE
docs: fix disk encryption params

### DIFF
--- a/website/content/v1.0/talos-guides/configuration/disk-encryption.md
+++ b/website/content/v1.0/talos-guides/configuration/disk-encryption.md
@@ -36,10 +36,12 @@ machine:
   ...
   systemDiskEncryption:
     ephemeral:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0
     state:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0

--- a/website/content/v1.1/talos-guides/configuration/disk-encryption.md
+++ b/website/content/v1.1/talos-guides/configuration/disk-encryption.md
@@ -36,10 +36,12 @@ machine:
   ...
   systemDiskEncryption:
     ephemeral:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0
     state:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0

--- a/website/content/v1.2/talos-guides/configuration/disk-encryption.md
+++ b/website/content/v1.2/talos-guides/configuration/disk-encryption.md
@@ -36,10 +36,12 @@ machine:
   ...
   systemDiskEncryption:
     ephemeral:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0
     state:
+      provider: luks2
       keys:
         - nodeID: {}
           slot: 0


### PR DESCRIPTION
# Pull Request

## What? (description)

Disk encryption documentation is currently missing the `provider` key. This PR adds it.

## Why? (reasoning)

Following the configuration in the current docs results in a reboot loop.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
