### PR TITLE
feat: dhcpv4: send current hostname, fix spec compliance of renewals

### DIFF
--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -96,14 +96,14 @@ message HardwareAddrSpec {
   bytes hardware_addr = 2;
 }
 
-// HostnameSpecSpec describes node nostname.
+// HostnameSpecSpec describes node hostname.
 message HostnameSpecSpec {
   string hostname = 1;
   string domainname = 2;
   talos.resource.definitions.enums.NetworkConfigLayer config_layer = 3;
 }
 
-// HostnameStatusSpec describes node nostname.
+// HostnameStatusSpec describes node hostname.
 message HostnameStatusSpec {
   string hostname = 1;
   string domainname = 2;

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hetznercloud/hcloud-go v1.41.0
-	github.com/insomniacslk/dhcp v0.0.0-20230307103557-e252950ab961
+	github.com/insomniacslk/dhcp v0.0.0-20230327135226-74ae03f2425e
 	github.com/jsimonetti/rtnetlink v1.3.1
 	github.com/jxskiss/base62 v1.1.0
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/insomniacslk/dhcp v0.0.0-20230307103557-e252950ab961 h1:x/YtdDlmypenG1te/FfH6LVM+3krhXk5CFV8VYNNX5M=
-github.com/insomniacslk/dhcp v0.0.0-20230307103557-e252950ab961/go.mod h1:IKrnDWs3/Mqq5n0lI+RxA2sB7MvN/vbMBP3ehXg65UI=
+github.com/insomniacslk/dhcp v0.0.0-20230327135226-74ae03f2425e h1:8ChxkWKTVYg7LKBvYNLNRnlobgbPrzzossZUoST2T7o=
+github.com/insomniacslk/dhcp v0.0.0-20230327135226-74ae03f2425e/go.mod h1:IKrnDWs3/Mqq5n0lI+RxA2sB7MvN/vbMBP3ehXg65UI=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/internal/app/machined/pkg/controllers/network/operator_spec.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec.go
@@ -234,7 +234,7 @@ func (ctrl *OperatorSpecController) reconcileOperators(ctx context.Context, r co
 			// stop operator
 			ctrl.operators[id].Stop()
 			delete(ctrl.operators, id)
-		} else if *shouldRun[id] != ctrl.operators[id].Spec {
+		} else if !ctrl.operators[id].Spec.Equal(*shouldRun[id]) {
 			logger.Debug("replacing operator", zap.String("operator", id))
 
 			// stop operator
@@ -423,7 +423,7 @@ func (ctrl *OperatorSpecController) newOperator(logger *zap.Logger, spec *networ
 	case network.OperatorDHCP4:
 		logger = logger.With(zap.String("operator", "dhcp4"))
 
-		return operator.NewDHCP4(logger, spec.LinkName, spec.DHCP4, ctrl.V1alpha1Platform)
+		return operator.NewDHCP4(logger, spec.LinkName, spec.DHCP4, ctrl.V1alpha1Platform, ctrl.State)
 	case network.OperatorDHCP6:
 		logger = logger.With(zap.String("operator", "dhcp6"))
 

--- a/pkg/machinery/api/resource/definitions/network/network.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network.pb.go
@@ -801,7 +801,7 @@ func (x *HardwareAddrSpec) GetHardwareAddr() []byte {
 	return nil
 }
 
-// HostnameSpecSpec describes node nostname.
+// HostnameSpecSpec describes node hostname.
 type HostnameSpecSpec struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -865,7 +865,7 @@ func (x *HostnameSpecSpec) GetConfigLayer() enums.NetworkConfigLayer {
 	return enums.NetworkConfigLayer(0)
 }
 
-// HostnameStatusSpec describes node nostname.
+// HostnameStatusSpec describes node hostname.
 type HostnameStatusSpec struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/machinery/resources/network/condition.go
+++ b/pkg/machinery/resources/network/condition.go
@@ -19,7 +19,7 @@ type ReadyCondition struct {
 	checks []StatusCheck
 }
 
-// NewReadyCondition builds a coondition which waits for the network to be ready.
+// NewReadyCondition builds a condition which waits for the network to be ready.
 func NewReadyCondition(state state.State, checks ...StatusCheck) *ReadyCondition {
 	return &ReadyCondition{
 		state:  state,

--- a/pkg/machinery/resources/network/hostname_spec.go
+++ b/pkg/machinery/resources/network/hostname_spec.go
@@ -25,7 +25,7 @@ type HostnameSpec = typed.Resource[HostnameSpecSpec, HostnameSpecExtension]
 // HostnameID is the ID of the singleton instance.
 const HostnameID resource.ID = "hostname"
 
-// HostnameSpecSpec describes node nostname.
+// HostnameSpecSpec describes node hostname.
 //
 //gotagsrewrite:gen
 type HostnameSpecSpec struct {

--- a/pkg/machinery/resources/network/hostname_status.go
+++ b/pkg/machinery/resources/network/hostname_status.go
@@ -19,7 +19,7 @@ const HostnameStatusType = resource.Type("HostnameStatuses.net.talos.dev")
 // HostnameStatus resource holds node hostname.
 type HostnameStatus = typed.Resource[HostnameStatusSpec, HostnameStatusExtension]
 
-// HostnameStatusSpec describes node nostname.
+// HostnameStatusSpec describes node hostname.
 //
 //gotagsrewrite:gen
 type HostnameStatusSpec struct {

--- a/pkg/machinery/resources/network/operator_spec.go
+++ b/pkg/machinery/resources/network/operator_spec.go
@@ -36,6 +36,14 @@ type OperatorSpecSpec struct {
 	ConfigLayer ConfigLayer `yaml:"layer" protobuf:"7"`
 }
 
+// Equal implements equality check for OperatorSpecSpec.
+func (spec OperatorSpecSpec) Equal(other OperatorSpecSpec) bool {
+	// config layer is not important for equality check
+	spec.ConfigLayer = other.ConfigLayer
+
+	return spec == other
+}
+
 // DHCP4OperatorSpec describes DHCP4 operator options.
 //
 //gotagsrewrite:gen

--- a/website/content/v1.4/reference/api.md
+++ b/website/content/v1.4/reference/api.md
@@ -2567,7 +2567,7 @@ HardwareAddrSpec describes spec for the link.
 <a name="talos.resource.definitions.network.HostnameSpecSpec"></a>
 
 ### HostnameSpecSpec
-HostnameSpecSpec describes node nostname.
+HostnameSpecSpec describes node hostname.
 
 
 | Field | Type | Label | Description |
@@ -2584,7 +2584,7 @@ HostnameSpecSpec describes node nostname.
 <a name="talos.resource.definitions.network.HostnameStatusSpec"></a>
 
 ### HostnameStatusSpec
-HostnameStatusSpec describes node nostname.
+HostnameStatusSpec describes node hostname.
 
 
 | Field | Type | Label | Description |


### PR DESCRIPTION
This adds support for automatically registering node hostnames in DNS by
sending the current hostname to DHCP via option 12. If the current hostname is
updated, issue a new DISCOVER to propagate the update to DHCP (updating the
hostname on lease renewals is not universally supported by DHCP servers). This
addition maintains the previous functionality where the node can also request
its hostname from the DHCP server. The received hostname will be processed and
prioritized as usual by the `network.HostnameSpecController`.

This change set also contains fixes to make DHCP renewals compliant with RFC
2131, specifically avoiding sending the server identifier and requested IP
address when issuing renewals using a previous offer. This also uncovered an
issue in the upstream `insomniacslk/dhcp` library, for which a fix is now
pending at https://github.com/insomniacslk/dhcp/pull/469. As upstream
contributions seem to have stalled, I have temporarily added a replacement for
the library to my own fork that carries the fix.

Sending hostname updates have been tested against `dnsmasq` and the built-in
DHCP + DNS services in Windows Server. Hostname retrieval from DHCP and edge
cases with overridden hostnames from different configuration layers have been
extensively tested against `dnsmasq`.

Fixes https://github.com/siderolabs/talos/issues/4536.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
