### PR TITLE
feat: resubstitute talos.config url variables on retry

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -54,20 +54,22 @@ func (m *Metal) Configuration(ctx context.Context, r state.State) ([]byte, error
 		return nil, errors.ErrNoConfigSource
 	}
 
-	downloadURL, err := PopulateURLParameters(ctx, *option, r)
-	if err != nil {
-		log.Fatalf("failed to populate talos.config fetch URL: %q ; %s", *option, err.Error())
+	getURL := func() string {
+		downloadEndpoint, err := PopulateURLParameters(ctx, *option, r)
+		if err != nil {
+			log.Fatalf("failed to populate talos.config fetch URL: %q ; %s", *option, err.Error())
+		}
 
-		return nil, err
+		log.Printf("fetching machine config from: %q", downloadEndpoint)
+
+		return downloadEndpoint
 	}
 
-	log.Printf("fetching machine config from: %q", downloadURL)
-
-	switch downloadURL {
+	switch *option {
 	case constants.MetalConfigISOLabel:
 		return readConfigFromISO()
 	default:
-		return download.Download(ctx, downloadURL)
+		return download.Download(ctx, *option, download.WithEndpointFunc(getURL))
 	}
 }
 


### PR DESCRIPTION
The download of the talos configuration may fail because the substituted
information like the hostname may not be initialized yet. Therefore we
retry the download and resubstitute the variables each time.

Fixes #3272

Signed-off-by: Philipp Sauter <philipp.sauter@siderolabs.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
