### PR TITLE
docs: remove old docs from site

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -167,22 +167,6 @@ version = "v0.11"
 url = "/v0.10/"
 version = "v0.10"
 
-[[params.versions]]
-url = "/v0.9/"
-version = "v0.9"
-
-[[params.versions]]
-url = "/v0.8/"
-version = "v0.8"
-
-[[params.versions]]
-url = "/v0.7/"
-version = "v0.7"
-
-[[params.versions]]
-url = "/v0.6/"
-version = "v0.6"
-
 # User interface configuration
 [params.ui]
 #  Set to true to disable breadcrumb navigation.


### PR DESCRIPTION
This PR removes pre-v0.10 docs from the drop down. They will remain in
the content so folks can still read them if needed.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>