### PR TITLE
refactor: remove bootstrap sequence

### DIFF
--- a/internal/app/machined/pkg/runtime/sequencer.go
+++ b/internal/app/machined/pkg/runtime/sequencer.go
@@ -16,8 +16,6 @@ type Sequence int
 const (
 	// SequenceBoot is the boot sequence.
 	SequenceBoot Sequence = iota
-	// SequenceBootstrap is the boot sequence.
-	SequenceBootstrap
 	// SequenceInitialize is the initialize sequence.
 	SequenceInitialize
 	// SequenceInstall is the install sequence.
@@ -38,7 +36,6 @@ const (
 
 const (
 	boot         = "boot"
-	bootstrap    = "bootstrap"
 	initialize   = "initialize"
 	install      = "install"
 	shutdown     = "shutdown"
@@ -51,7 +48,7 @@ const (
 
 // String returns the string representation of a `Sequence`.
 func (s Sequence) String() string {
-	return [...]string{boot, bootstrap, initialize, install, shutdown, upgrade, stageUpgrade, reset, reboot, noop}[s]
+	return [...]string{boot, initialize, install, shutdown, upgrade, stageUpgrade, reset, reboot, noop}[s]
 }
 
 // ParseSequence returns a `Sequence` that matches the specified string.
@@ -61,8 +58,6 @@ func ParseSequence(s string) (seq Sequence, err error) {
 	switch s {
 	case boot:
 		seq = SequenceBoot
-	case bootstrap:
-		seq = SequenceBootstrap
 	case initialize:
 		seq = SequenceInitialize
 	case install:
@@ -104,7 +99,6 @@ type PartitionTarget interface {
 // management of the operating system.
 type Sequencer interface {
 	Boot(Runtime) []Phase
-	Bootstrap(Runtime) []Phase
 	Initialize(Runtime) []Phase
 	Install(Runtime) []Phase
 	Reboot(Runtime) []Phase

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -95,7 +95,7 @@ func (c *Controller) Run(ctx context.Context, seq runtime.Sequence, data interfa
 	// Allow only one sequence to run at a time with the exception of bootstrap
 	// and reset sequences.
 	switch seq { //nolint:exhaustive
-	case runtime.SequenceBootstrap, runtime.SequenceReset:
+	case runtime.SequenceReset:
 		// Do not attempt to lock.
 	default:
 		if opts.Force {
@@ -384,8 +384,6 @@ func (c *Controller) phases(seq runtime.Sequence, data interface{}) ([]runtime.P
 	switch seq {
 	case runtime.SequenceBoot:
 		phases = c.s.Boot(c.r)
-	case runtime.SequenceBootstrap:
-		phases = c.s.Bootstrap(c.r)
 	case runtime.SequenceInitialize:
 		phases = c.s.Initialize(c.r)
 	case runtime.SequenceInstall:

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -248,19 +248,6 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	return phases
 }
 
-// Bootstrap is the bootstrap sequence. This primary goal if this sequence is
-// to bootstrap Etcd and Kubernetes.
-func (*Sequencer) Bootstrap(r runtime.Runtime) []runtime.Phase {
-	phases := PhaseList{}
-
-	phases = phases.Append(
-		"etcd",
-		BootstrapEtcd,
-	)
-
-	return phases
-}
-
 // Reboot is the reboot sequence.
 func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}.Append(

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -101,6 +101,8 @@ func (s *machinedService) Main(ctx context.Context, r runtime.Runtime, logWriter
 	server := factory.NewServer(
 		&v1alpha1server.Server{
 			Controller: s.c,
+			// breaking the import loop cycle between services/ package and v1alpha1_server.go
+			EtcdBootstrapper: BootstrapEtcd,
 		},
 		factory.WithLog("machined ", logWriter),
 


### PR DESCRIPTION
Refactor things to remove the bootstrap sequence, this should help with
the task of sequencer concurrency changes and immediate API feedback.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
