### PR TITLE
feat: follow KEP-2568 non-root enhancements

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -423,12 +423,26 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 								v1.ResourceMemory: apiresource.MustParse("512Mi"),
 							},
 						},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.To(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{"ALL"},
+								// kube-apiserver binary has cap_net_bind_service=+ep set.
+								// It does not matter if ports < 1024 are configured, the setcap flag causes a capability dependency.
+								// https://github.com/kubernetes/kubernetes/blob/5b92e46b2238b4d84358451013e634361084ff7d/build/server-image/kube-apiserver/Dockerfile#L26
+								Add: []v1.Capability{"NET_BIND_SERVICE"},
+							},
+							SeccompProfile: &v1.SeccompProfile{
+								Type: v1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					},
 				},
 				HostNetwork: true,
 				SecurityContext: &v1.PodSecurityContext{
 					RunAsNonRoot: pointer.To(true),
-					RunAsUser:    pointer.To[int64](constants.KubernetesRunUser),
+					RunAsUser:    pointer.To[int64](constants.KubernetesAPIServerRunUser),
+					RunAsGroup:   pointer.To[int64](constants.KubernetesAPIServerRunGroup),
 				},
 				Volumes: append([]v1.Volume{
 					{
@@ -568,12 +582,22 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 								v1.ResourceMemory: apiresource.MustParse("256Mi"),
 							},
 						},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.To(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{"ALL"},
+							},
+							SeccompProfile: &v1.SeccompProfile{
+								Type: v1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					},
 				},
 				HostNetwork: true,
 				SecurityContext: &v1.PodSecurityContext{
 					RunAsNonRoot: pointer.To(true),
-					RunAsUser:    pointer.To[int64](constants.KubernetesRunUser),
+					RunAsUser:    pointer.To[int64](constants.KubernetesControllerManagerRunUser),
+					RunAsGroup:   pointer.To[int64](constants.KubernetesControllerManagerRunGroup),
 				},
 				Volumes: append([]v1.Volume{
 					{
@@ -678,12 +702,22 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 								v1.ResourceMemory: apiresource.MustParse("64Mi"),
 							},
 						},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.To(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{"ALL"},
+							},
+							SeccompProfile: &v1.SeccompProfile{
+								Type: v1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					},
 				},
 				HostNetwork: true,
 				SecurityContext: &v1.PodSecurityContext{
 					RunAsNonRoot: pointer.To(true),
-					RunAsUser:    pointer.To[int64](constants.KubernetesRunUser),
+					RunAsUser:    pointer.To[int64](constants.KubernetesSchedulerRunUser),
+					RunAsGroup:   pointer.To[int64](constants.KubernetesSchedulerRunGroup),
 				},
 				Volumes: append([]v1.Volume{
 					{

--- a/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
@@ -93,11 +93,15 @@ func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r control
 		for _, pod := range []struct {
 			name      string
 			directory string
+			uid       int
+			gid       int
 			configs   []configFile
 		}{
 			{
 				name:      "kube-apiserver",
 				directory: constants.KubernetesAPIServerConfigDir,
+				uid:       constants.KubernetesAPIServerRunUser,
+				gid:       constants.KubernetesAPIServerRunGroup,
 				configs: []configFile{
 					{
 						filename: "admission-control-config.yaml",
@@ -128,7 +132,7 @@ func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r control
 					return fmt.Errorf("error writing configuration %q for %q: %w", configFile.filename, pod.name, err)
 				}
 
-				if err = os.Chown(filepath.Join(pod.directory, configFile.filename), constants.KubernetesRunUser, -1); err != nil {
+				if err = os.Chown(filepath.Join(pod.directory, configFile.filename), pod.uid, pod.gid); err != nil {
 					return fmt.Errorf("error chowning %q for %q: %w", configFile.filename, pod.name, err)
 				}
 			}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -856,7 +856,7 @@ func SetupVarDirectory(seq runtime.Sequence, data interface{}) (runtime.TaskExec
 				return err
 			}
 
-			if err = os.Chown(p, constants.KubernetesRunUser, -1); err != nil {
+			if err = os.Chown(p, constants.KubernetesAPIServerRunUser, constants.KubernetesAPIServerRunGroup); err != nil {
 				return fmt.Errorf("failed to chown %s: %w", p, err)
 			}
 		}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -232,8 +232,23 @@ const (
 	// KubernetesSchedulerSecretsDir defines ephemeral directory with kube-scheduler secrets.
 	KubernetesSchedulerSecretsDir = KubebernetesStaticSecretsDir + "/" + "kube-scheduler"
 
-	// KubernetesRunUser defines UID to run control plane components.
-	KubernetesRunUser = 65534
+	// KubernetesAPIServerRunUser defines UID to the API Server.
+	KubernetesAPIServerRunUser = 65534
+
+	// KubernetesAPIServerRunGroup defines GID to run the API Server.
+	KubernetesAPIServerRunGroup = 65534
+
+	// KubernetesControllerManagerRunUser defines UID to the Controller Manager.
+	KubernetesControllerManagerRunUser = 65535
+
+	// KubernetesControllerManagerRunGroup defines GID to run the Controller Manager.
+	KubernetesControllerManagerRunGroup = 65535
+
+	// KubernetesSchedulerRunUser defines UID to the Scheduler.
+	KubernetesSchedulerRunUser = 65536
+
+	// KubernetesSchedulerRunGroup defines GID to run the Scheduler.
+	KubernetesSchedulerRunGroup = 65536
 
 	// KubeletBootstrapKubeconfig is the path to the kubeconfig required to
 	// bootstrap the kubelet.


### PR DESCRIPTION
# Pull Request
~~WIP: works for new clusters, haven't tested upgrades (likely this breaks because of existing file permissions...?)~~
EDIT: tested and it just works, even with --preserve files are recreated with correct permission

~~Question: Should I include the seccomp yaml for the control-plane?~~

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Follow KEP-2568 (https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane). Seperation UIDs, Adding GIDs, allowPriviledgeEscalation: false,drop unneeded capabilities and add seccomp CP manifest changes.

~~Seccomp is excluded as i think it has a dependency on https://github.com/siderolabs/talos/issues/5293 ? Also I have no idea how to test that.~~

## Why? (reasoning)
Mainly better compatibility (this KEP is scheduled to be implented for kubeadm 1.25) + security:
* `allowPrivilegeEscalation: false`: adds [no_new_privs](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) flag on the container process
* `Capabilities: { Drop: [ "ALL" ] }`: Capabilities are a more fine-grained permissions model, and all capabilities should be dropped from a pod, with only those required added back. (NET_BIND_SERVICE is needed for kube-apiserver as it has setcap flags)
*  `RunAsUser` & `RunAsGroup`: Assigning an unique ID helps with limiting the file exposure of secrets
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`) (GPG identity fails)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
