### PR TITLE
fix: skip bond itself when matching interface (Equinix Metal)

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -145,7 +145,9 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 		found := false
 
 		for _, hostIf := range hostInterfaces {
-			if hostIf.HardwareAddr.String() == iface.MAC {
+			// if the bond configuration has already been applied, bond0 inherits the MAC address of the first slave (e.g. eth0)
+			// we don't want to match on the bond, so we skip it explicitly
+			if hostIf.HardwareAddr.String() == iface.MAC && hostIf.Name != iface.Bond {
 				found = true
 
 				networkConfig.Links = append(networkConfig.Links,


### PR DESCRIPTION
This fixes a problem when platform network configuration might have
already been applied from the cached on disk representation, and in that
base e.g. `bond0` MAC is same as `eth0`, so Talos might mistakenly pick
up `bond0` as a slave to itself instead of `eth0`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
