### PR TITLE
fix: remove data race in pcap capture

### DIFF
--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -101,6 +101,10 @@ e.g. by excluding packets with the port 50000.
 			go func() {
 				defer wg.Done()
 				for err := range errCh {
+					if client.StatusCode(err) == codes.DeadlineExceeded {
+						continue
+					}
+
 					fmt.Fprintln(os.Stderr, err.Error())
 				}
 			}()

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -2120,6 +2120,7 @@ func (s *Server) PacketCapture(in *machine.PacketCaptureRequest, srv machine.Mac
 
 	go func() {
 		defer pw.Close() //nolint:errcheck
+		defer handle.Close()
 
 		pcapw := pcapgo.NewWriterNanos(pw)
 
@@ -2141,7 +2142,6 @@ func (s *Server) PacketCapture(in *machine.PacketCaptureRequest, srv machine.Mac
 		}
 	}()
 
-	defer handle.Close()
 	defer pr.Close() //nolint:errcheck
 
 	ctx, cancel := context.WithCancel(srv.Context())


### PR DESCRIPTION
Capture handle should be closed in the same goroutine with packet
reading.

Fix a spurious error which might appear in `talosctl pcap`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
