### PR TITLE
chore: fix typo in `powercycle`

### DIFF
--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -46,6 +46,6 @@ var rebootCmd = &cobra.Command{
 }
 
 func init() {
-	rebootCmd.Flags().StringVarP(&rebootCmdFlags.mode, "mode", "m", "default", "select the reboot mode: \"default\", \"powercyle\" (skips kexec)")
+	rebootCmd.Flags().StringVarP(&rebootCmdFlags.mode, "mode", "m", "default", "select the reboot mode: \"default\", \"powercycle\" (skips kexec)")
 	addCommand(rebootCmd)
 }

--- a/website/content/v1.1/reference/cli.md
+++ b/website/content/v1.1/reference/cli.md
@@ -1686,7 +1686,7 @@ talosctl reboot [flags]
 
 ```
   -h, --help          help for reboot
-  -m, --mode string   select the reboot mode: "default", "powercyle" (skips kexec) (default "default")
+  -m, --mode string   select the reboot mode: "default", "powercycle" (skips kexec) (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -2171,4 +2171,3 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl usage](#talosctl-usage)	 - Retrieve a disk usage
 * [talosctl validate](#talosctl-validate)	 - Validate config
 * [talosctl version](#talosctl-version)	 - Prints the version
-

--- a/website/content/v1.2/reference/cli.md
+++ b/website/content/v1.2/reference/cli.md
@@ -1780,7 +1780,7 @@ talosctl reboot [flags]
 
 ```
   -h, --help          help for reboot
-  -m, --mode string   select the reboot mode: "default", "powercyle" (skips kexec) (default "default")
+  -m, --mode string   select the reboot mode: "default", "powercycle" (skips kexec) (default "default")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fix typo in `powercycle`

Signed-off-by: Noel Georgi <git@frezbo.dev>