### PR TITLE
feat: set stable default hostname based on machine-id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20220504074936-1ca156eafb9f
 	github.com/jsimonetti/rtnetlink v1.2.0
 	github.com/jxskiss/base62 v1.1.0
+	github.com/martinlindhe/base36 v1.1.1
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875
 	github.com/mdlayher/ethtool v0.0.0-20220213132912-856bd6cb8a38

--- a/go.sum
+++ b/go.sum
@@ -793,6 +793,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/martinlindhe/base36 v1.1.1 h1:1F1MZ5MGghBXDZ2KJ3QfxmiydlWOGB8HCEtkap5NkVg=
+github.com/martinlindhe/base36 v1.1.1/go.mod h1:vMS8PaZ5e/jV9LwFKlm0YLnXl/hpOihiBxKkIoc3g08=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -106,6 +106,15 @@ Talos now supports capturing packets on a network interface with `talosctl pcap`
   talosctl pcap --interface eth0
 """
 
+    [notes.stable-hostname]
+        title = "Stable Default Hostname"
+        description="""\
+Talos now generates the default hostname (when there is no explicitly specified hostname) for the nodes based on the
+node id (e.g. `talos-2gd-76y`) instead of using the DHCP assigned IP address (e.g. `talos-172-20-0-2`).
+
+This ensures that the node hostname is not changed when DHCP assigns a new IP to a node.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion1_2     = &VersionContract{1, 2}
 	TalosVersion1_1     = &VersionContract{1, 1}
 	TalosVersion1_0     = &VersionContract{1, 0}
 	TalosVersion0_14    = &VersionContract{0, 14}
@@ -108,4 +109,9 @@ func (contract *VersionContract) PodSecurityPolicyEnabled() bool {
 // PodSecurityAdmissionEnabled returns true if pod security admission should be enabled by default.
 func (contract *VersionContract) PodSecurityAdmissionEnabled() bool {
 	return contract.Greater(TalosVersion1_0)
+}
+
+// StableHostnameEnabled returns true if stable hostname generation should be enabled by default.
+func (contract *VersionContract) StableHostnameEnabled() bool {
+	return contract.Greater(TalosVersion1_1)
 }

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -56,6 +56,22 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.ClusterDiscoveryEnabled())
 	assert.False(t, contract.PodSecurityPolicyEnabled())
 	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.True(t, contract.StableHostnameEnabled())
+}
+
+func TestContract1_2(t *testing.T) {
+	contract := config.TalosVersion1_2
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.False(t, contract.PodSecurityPolicyEnabled())
+	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.True(t, contract.StableHostnameEnabled())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -70,6 +86,7 @@ func TestContract1_1(t *testing.T) {
 	assert.True(t, contract.ClusterDiscoveryEnabled())
 	assert.False(t, contract.PodSecurityPolicyEnabled())
 	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -84,6 +101,7 @@ func TestContract1_0(t *testing.T) {
 	assert.True(t, contract.ClusterDiscoveryEnabled())
 	assert.False(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_14(t *testing.T) {
@@ -98,6 +116,7 @@ func TestContract0_14(t *testing.T) {
 	assert.True(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_13(t *testing.T) {
@@ -112,6 +131,7 @@ func TestContract0_13(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_12(t *testing.T) {
@@ -126,6 +146,7 @@ func TestContract0_12(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_11(t *testing.T) {
@@ -140,6 +161,7 @@ func TestContract0_11(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_10(t *testing.T) {
@@ -154,6 +176,7 @@ func TestContract0_10(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_9(t *testing.T) {
@@ -168,6 +191,7 @@ func TestContract0_9(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }
 
 func TestContract0_8(t *testing.T) {
@@ -182,4 +206,5 @@ func TestContract0_8(t *testing.T) {
 	assert.False(t, contract.ClusterDiscoveryEnabled())
 	assert.True(t, contract.PodSecurityPolicyEnabled())
 	assert.False(t, contract.PodSecurityAdmissionEnabled())
+	assert.False(t, contract.StableHostnameEnabled())
 }

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -514,6 +514,7 @@ type SystemDiskEncryption interface {
 // Features describe individual Talos features that can be switched on or off.
 type Features interface {
 	RBACEnabled() bool
+	StableHostnameEnabled() bool
 }
 
 // VolumeMount describes extra volume mount for the static pods.

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -60,6 +60,10 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		machine.MachineFeatures.RBAC = pointer.To(true)
 	}
 
+	if in.VersionContract.StableHostnameEnabled() {
+		machine.MachineFeatures.StableHostname = pointer.To(true)
+	}
+
 	certSANs := in.GetAPIServerSANs()
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_features.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_features.go
@@ -4,6 +4,8 @@
 
 package v1alpha1
 
+import "github.com/siderolabs/go-pointer"
+
 // RBACEnabled implements config.Features interface.
 func (f *FeaturesConfig) RBACEnabled() bool {
 	if f.RBAC == nil {
@@ -11,4 +13,9 @@ func (f *FeaturesConfig) RBACEnabled() bool {
 	}
 
 	return *f.RBAC
+}
+
+// StableHostnameEnabled implements config.Features interface.
+func (f *FeaturesConfig) StableHostnameEnabled() bool {
+	return pointer.SafeDeref(f.StableHostname)
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2279,6 +2279,9 @@ type FeaturesConfig struct {
 	//   description: |
 	//     Enable role-based access control (RBAC).
 	RBAC *bool `yaml:"rbac,omitempty"`
+	//   description: |
+	//     Enable stable default hostname.
+	StableHostname *bool `yaml:"stableHostname,omitempty"`
 }
 
 // VolumeMountConfig struct describes extra volume mount for the static pods.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -2250,12 +2250,17 @@ func init() {
 			FieldName: "features",
 		},
 	}
-	FeaturesConfigDoc.Fields = make([]encoder.Doc, 1)
+	FeaturesConfigDoc.Fields = make([]encoder.Doc, 2)
 	FeaturesConfigDoc.Fields[0].Name = "rbac"
 	FeaturesConfigDoc.Fields[0].Type = "bool"
 	FeaturesConfigDoc.Fields[0].Note = ""
 	FeaturesConfigDoc.Fields[0].Description = "Enable role-based access control (RBAC)."
 	FeaturesConfigDoc.Fields[0].Comments[encoder.LineComment] = "Enable role-based access control (RBAC)."
+	FeaturesConfigDoc.Fields[1].Name = "stableHostname"
+	FeaturesConfigDoc.Fields[1].Type = "bool"
+	FeaturesConfigDoc.Fields[1].Note = ""
+	FeaturesConfigDoc.Fields[1].Description = "Enable stable default hostname."
+	FeaturesConfigDoc.Fields[1].Comments[encoder.LineComment] = "Enable stable default hostname."
 
 	VolumeMountConfigDoc.Type = "VolumeMountConfig"
 	VolumeMountConfigDoc.Comments[encoder.LineComment] = "VolumeMountConfig struct describes extra volume mount for the static pods."

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -922,6 +922,11 @@ func (in *FeaturesConfig) DeepCopyInto(out *FeaturesConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.StableHostname != nil {
+		in, out := &in.StableHostname, &out.StableHostname
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/website/content/v1.2/reference/configuration.md
+++ b/website/content/v1.2/reference/configuration.md
@@ -2529,6 +2529,7 @@ rbac: true # Enable role-based access control (RBAC).
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`rbac` |bool |Enable role-based access control (RBAC).  | |
+|`stableHostname` |bool |Enable stable default hostname.  | |
 
 
 


### PR DESCRIPTION
Use machine-id as the source for the default hostname (e.g. `talos-2gd-76y`) instead of DHCP-assigned IP (e.g. `talos-172-20-0-2`). This way, DHCP IP changes won't impact the hostname. Defaults to true for Talos version >=1.2.

Closes siderolabs/talos#5896.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
