### PR TITLE
chore: support glibc apps extension spec

### DIFF
--- a/pkg/machinery/extensions/extensions.go
+++ b/pkg/machinery/extensions/extensions.go
@@ -9,6 +9,7 @@ package extensions
 var AllowedPaths = []string{
 	"/etc/cri/conf.d",
 	"/lib/firmware",
+	"/lib64/ld-linux-x86-64.so.2",
 	"/usr/etc/udev/rules.d",
 	"/usr/local",
 }


### PR DESCRIPTION
Update extension spec to support glibc standard path.

Ref: https://github.com/siderolabs/extensions/pull/49

Signed-off-by: Noel Georgi <git@frezbo.dev>