### PR TITLE
fix: folder permissions of overlay mounted folders

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -463,7 +463,7 @@ func readonlyOverlay(p *Point) error {
 
 func ensureDirectory(target string) (err error) {
 	if _, err := os.Stat(target); os.IsNotExist(err) {
-		if err = os.MkdirAll(target, os.ModeDir); err != nil {
+		if err = os.MkdirAll(target, 0o755); err != nil {
 			return fmt.Errorf("error creating mount point directory %s: %w", target, err)
 		}
 	}


### PR DESCRIPTION
Set the correct permissions for the overlay mounted folders. This issue
was identified from #5948

Signed-off-by: Noel Georgi <git@frezbo.dev>