### PR TITLE
fix: enable stable hostnames for worker configs as well

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/worker.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/worker.go
@@ -61,6 +61,10 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		machine.MachineFeatures.RBAC = pointer.To(true)
 	}
 
+	if in.VersionContract.StableHostnameEnabled() {
+		machine.MachineFeatures.StableHostname = pointer.To(true)
+	}
+
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
 	if err != nil {
 		return config, err


### PR DESCRIPTION
This fixes a small bug with stable hostnames when they were only enabled
for control plane nodes.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
