### PR TITLE
Minor doc update: bond devices are comma separated

### DIFF
--- a/website/content/v1.0/reference/kernel.md
+++ b/website/content/v1.0/reference/kernel.md
@@ -59,8 +59,8 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
   * `bond=bond0:`
   * `bond=bond0::`
   * `bond=bond0:::`
-  * `bond=bond0:eth0:eth1`
-  * `bond=bond0:eth0:eth1:balance-rr`
+  * `bond=bond0:eth0,eth1`
+  * `bond=bond0:eth0,eth1:balance-rr`
 
   An example of a bond configuration with all options specified:
 

--- a/website/content/v1.1/reference/kernel.md
+++ b/website/content/v1.1/reference/kernel.md
@@ -59,8 +59,8 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
   * `bond=bond0:`
   * `bond=bond0::`
   * `bond=bond0:::`
-  * `bond=bond0:eth0:eth1`
-  * `bond=bond0:eth0:eth1:balance-rr`
+  * `bond=bond0:eth0,eth1`
+  * `bond=bond0:eth0,eth1:balance-rr`
 
   An example of a bond configuration with all options specified:
 

--- a/website/content/v1.2/reference/kernel.md
+++ b/website/content/v1.2/reference/kernel.md
@@ -59,8 +59,8 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
   * `bond=bond0:`
   * `bond=bond0::`
   * `bond=bond0:::`
-  * `bond=bond0:eth0:eth1`
-  * `bond=bond0:eth0:eth1:balance-rr`
+  * `bond=bond0:eth0,eth1`
+  * `bond=bond0:eth0,eth1:balance-rr`
 
   An example of a bond configuration with all options specified:
 


### PR DESCRIPTION
Minor doc update. Doc specifies colon separated eth devices for bond devices. Dracut specifies comma.

>        bond=<bondname>[:<bondslaves>:[:<options>[:<mtu>]]]
>            Setup bonding device <bondname> on top of <bondslaves>.
>            <bondslaves> is a comma-separated list of physical (ethernet)
>            interfaces. <options> is a comma-separated list on bonding
>            options (modinfo bonding for details) in format compatible
>            with initscripts. If <options> includes multi-valued
>            arp_ip_target option, then its values should be separated by
>            semicolon. if the mtu is specified, it will be set on the
>            bond master. Bond without parameters assumes
>            bond=bond0:eth0,eth1:mode=balance-rr

Tested OK.
