### PR TITLE
fix: retry Conflict errors when upgrading k8s manifests

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -518,7 +518,7 @@ func syncManifests(ctx context.Context, objects []*unstructured.Unstructured, cl
 
 		err = retry.Constant(3*time.Minute, retry.WithUnits(10*time.Second), retry.WithErrorLogging(true)).RetryWithContext(ctx, func(ctx context.Context) error {
 			resp, diff, skipped, err = updateManifest(ctx, mapper, k8sClient, obj, options.DryRun)
-			if kubernetes.IsRetryableError(err) {
+			if kubernetes.IsRetryableError(err) || apierrors.IsConflict(err) {
 				return retry.ExpectedError(err)
 			}
 


### PR DESCRIPTION
Fixes #5985

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
