### PR TITLE
feat: read talosconfig from secrets directory

### DIFF
--- a/pkg/machinery/client/config/path.go
+++ b/pkg/machinery/client/config/path.go
@@ -27,6 +27,17 @@ func GetDefaultPath() (string, error) {
 		return path, nil
 	}
 
+	talosSAPath := filepath.Join(constants.ServiceAccountMountPath, constants.ServiceAccountTalosconfigFilename)
+
+	_, err := os.Stat(talosSAPath)
+	if err != nil && !os.IsNotExist(err) && !os.IsPermission(err) {
+		return "", err
+	}
+
+	if err == nil {
+		return talosSAPath, nil
+	}
+
 	talosDir, err := GetTalosDirectory()
 	if err != nil {
 		return "", err

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -704,6 +704,12 @@ const (
 
 	// KubernetesTalosProvider is the name of the Talos provider as a Kubernetes label.
 	KubernetesTalosProvider = "talos.dev"
+
+	// ServiceAccountTalosconfigFilename is the file name of Talosconfig when it is injected into a pod.
+	ServiceAccountTalosconfigFilename = "config"
+
+	// ServiceAccountMountPath is the path of the directory in which the Talos service account secrets are mounted.
+	ServiceAccountMountPath = "/var/run/secrets/talos.dev/"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Similar to the way kubectl reads kubeconfig, we attempt to load talosconfig file from multiple locations. If the file exists under `/var/run/secrets/talos.dev/config`, we load with higher priority before falling back to `~/.talos/config`. This will allow talosctl to be able to access Talos API from inside a pod when talosconfig is mounted into `/var/run/secrets/talos.dev/config`, similar to the way Kubernetes service account tokens work.

Part of siderolabs/talos#5980.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
