### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/installer/pkg/install/manifest_test.go
+++ b/cmd/installer/pkg/install/manifest_test.go
@@ -153,12 +153,7 @@ func (suite *manifestSuite) verifyBlockdevice(manifest *install.Manifest, curren
 
 	// verify filesystems by mounting and unmounting
 
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer func() {
-		suite.Assert().NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := suite.T().TempDir()
 
 	mountpoints, err = manifest.SystemMountpoints()
 	suite.Require().NoError(err)
@@ -326,11 +321,7 @@ func (suite *manifestSuite) TestExecuteManifestPreserve() {
 
 func (suite *manifestSuite) TestTargetInstall() {
 	// Create Temp dirname for mountpoint
-	dir, err := ioutil.TempDir("", "talostest")
-	suite.Require().NoError(err)
-
-	//nolint:errcheck
-	defer os.RemoveAll(dir)
+	dir := suite.T().TempDir()
 
 	// Create a tempfile for local copy
 	src, err := ioutil.TempFile(dir, "example")

--- a/hack/gotagsrewrite/main_test.go
+++ b/hack/gotagsrewrite/main_test.go
@@ -27,19 +27,14 @@ func TestRun(t *testing.T) {
 		test := test
 
 		t.Run(name, func(t *testing.T) {
-			tempDir, err := os.MkdirTemp("", "go-pkg-*")
-			require.NoError(t, err)
-
-			t.Cleanup(func() {
-				require.NoError(t, os.RemoveAll(tempDir))
-			})
+			tempDir := t.TempDir()
 
 			tmpFile := filepath.Join(tempDir, "my.go")
 			origPath := filepath.Join("testdata", test.original)
 
 			require.NoError(t, CopyFile(origPath, tmpFile))
 
-			err = Run(tempDir)
+			err := Run(tempDir)
 			require.NoError(t, err)
 
 			fileData := string(must(os.ReadFile(tmpFile))(t))

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -65,8 +65,7 @@ type ContainerdSuite struct {
 func (suite *ContainerdSuite) SetupSuite() {
 	var err error
 
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
@@ -146,8 +145,6 @@ func (suite *ContainerdSuite) TearDownSuite() {
 
 	suite.Require().NoError(suite.containerdRunner.Stop())
 	suite.containerdWg.Wait()
-
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *ContainerdSuite) getLogContents(filename string) []byte {

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
@@ -43,8 +43,7 @@ type GoroutineSuite struct {
 func (suite *GoroutineSuite) SetupSuite() {
 	var err error
 
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
@@ -58,10 +57,6 @@ func (suite *GoroutineSuite) SetupSuite() {
 	r := v1alpha1.NewRuntime(cfg, s, e, suite.loggingManager)
 
 	suite.r = r
-}
-
-func (suite *GoroutineSuite) TearDownSuite() {
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *GoroutineSuite) TestRunSuccess() {

--- a/internal/app/machined/pkg/system/runner/process/process_test.go
+++ b/internal/app/machined/pkg/system/runner/process/process_test.go
@@ -39,10 +39,7 @@ type ProcessSuite struct {
 }
 
 func (suite *ProcessSuite) SetupSuite() {
-	var err error
-
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
@@ -55,8 +52,6 @@ func (suite *ProcessSuite) TearDownSuite() {
 	if suite.runReaper {
 		reaper.Shutdown()
 	}
-
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *ProcessSuite) TestRunSuccess() {

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -7,7 +7,6 @@ package containerd_test
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -69,8 +68,7 @@ func (suite *ContainerdSuite) SetupSuite() {
 
 	var err error
 
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
@@ -146,8 +144,6 @@ func (suite *ContainerdSuite) TearDownSuite() {
 
 	suite.Require().NoError(suite.containerdRunner.Stop())
 	suite.containerdWg.Wait()
-
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *ContainerdSuite) SetupTest() {

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -6,7 +6,6 @@ package cri_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -65,8 +64,7 @@ func (suite *CRISuite) SetupSuite() {
 
 	var err error
 
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
 	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
@@ -140,8 +138,6 @@ func (suite *CRISuite) TearDownSuite() {
 
 	suite.Require().NoError(suite.containerdRunner.Stop())
 	suite.containerdWg.Wait()
-
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *CRISuite) SetupTest() {

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -6,7 +6,6 @@ package cri_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -58,8 +57,7 @@ func (suite *CRISuite) SetupSuite() {
 
 	var err error
 
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
 	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
@@ -127,8 +125,6 @@ func (suite *CRISuite) TearDownSuite() {
 
 	suite.Require().NoError(suite.containerdRunner.Stop())
 	suite.containerdWg.Wait()
-
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func (suite *CRISuite) SetupTest() {

--- a/internal/pkg/mount/mount_test.go
+++ b/internal/pkg/mount/mount_test.go
@@ -88,12 +88,7 @@ func (suite *manifestSuite) skipUnderBuildkit() {
 func (suite *manifestSuite) TestCleanCorrupedXFSFileSystem() {
 	suite.skipUnderBuildkit()
 
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer func() {
-		suite.Assert().NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := suite.T().TempDir()
 
 	mountDir := filepath.Join(tempDir, "var")
 

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -6,7 +6,6 @@ package archiver_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -58,10 +57,7 @@ var filesFixture = []struct {
 }
 
 func (suite *CommonSuite) SetupSuite() {
-	var err error
-
-	suite.tmpDir, err = ioutil.TempDir("", "archiver")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
 	for _, file := range filesFixture {
 		suite.Require().NoError(os.MkdirAll(filepath.Join(suite.tmpDir, filepath.Dir(file.Path)), 0o777))
@@ -89,8 +85,4 @@ func (suite *CommonSuite) SetupSuite() {
 
 		suite.Require().NoError(f.Close())
 	}
-}
-
-func (suite *CommonSuite) TearDownSuite() {
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }

--- a/pkg/chunker/file/file_test.go
+++ b/pkg/chunker/file/file_test.go
@@ -7,7 +7,6 @@ package file_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,10 +26,7 @@ type FileChunkerSuite struct {
 }
 
 func (suite *FileChunkerSuite) SetupSuite() {
-	var err error
-
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 }
 
 func (suite *FileChunkerSuite) SetupTest() {
@@ -48,10 +44,6 @@ func (suite *FileChunkerSuite) SetupTest() {
 func (suite *FileChunkerSuite) TearDownTest() {
 	suite.Require().NoError(suite.writer.Close())
 	suite.reader.Close() //nolint:errcheck
-}
-
-func (suite *FileChunkerSuite) TearDownSuite() {
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 func collectChunks(chunksCh <-chan []byte) <-chan []byte {

--- a/pkg/conditions/files_test.go
+++ b/pkg/conditions/files_test.go
@@ -6,7 +6,6 @@ package conditions_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,13 +23,7 @@ type FilesSuite struct {
 }
 
 func (suite *FilesSuite) SetupSuite() {
-	var err error
-	suite.tempDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-}
-
-func (suite *FilesSuite) TearDownSuite() {
-	suite.Require().NoError(os.RemoveAll(suite.tempDir))
+	suite.tempDir = suite.T().TempDir()
 }
 
 func (suite *FilesSuite) createFile(name string) (path string) {

--- a/pkg/follow/follow_test.go
+++ b/pkg/follow/follow_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,10 +30,7 @@ type FollowSuite struct {
 }
 
 func (suite *FollowSuite) SetupSuite() {
-	var err error
-
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 }
 
 func (suite *FollowSuite) SetupTest() {
@@ -53,10 +49,6 @@ func (suite *FollowSuite) TearDownTest() {
 	suite.Require().NoError(suite.writer.Close())
 
 	suite.reader.Close() //nolint:errcheck
-}
-
-func (suite *FollowSuite) TearDownSuite() {
-	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
 //nolint:unparam


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->
## What? (description)

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
// before
func (suite *FooSuite) SetupSuite() {
	var err error

	suite.tmpDir, err = ioutil.TempDir("", "talos")
	suite.Require().NoError(err)
}

func (suite *FooSuite) TeardownSuite() {
	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
}

// after
func (suite *FooSuite) SetupSuite() {
	suite.tmpDir = suite.T().TempDir()
}
```

## Why? (reasoning)

This saves us at least 2 lines (error check, and cleanup) on every instance.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`): Only GPG Identity is failing
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
