### PR TITLE
fix: don't advertise Kubernetes pod networks over KubeSpan by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -154,6 +154,17 @@ node id (e.g. `talos-2gd-76y`) instead of using the DHCP assigned IP address (e.
 This ensures that the node hostname is not changed when DHCP assigns a new IP to a node.
 """
 
+    [notes.kubespan-kubernetes-nets]
+        title = "KubeSpan Kubernetes Network Advertisement"
+        description="""\
+KubeSpan no longer by default advertises Kubernetes pod networks of the node over KubeSpan.
+This means that CNI should handle encapsulation of pod-to-pod traffic into the node-to-node tunnel,
+and node-to-node traffic will be handled by KubeSpan.
+This provides better compatibility with popular CNIs like Calico and Cilium.
+
+Old behavior can be restored by setting `.machine.kubespan.advertiseKubernetesNetworks = true` in the machine config.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/kubespan/config.go
+++ b/internal/app/machined/pkg/controllers/kubespan/config.go
@@ -74,6 +74,7 @@ func (ctrl *ConfigController) Run(ctx context.Context, r controller.Runtime, log
 					res.(*kubespan.Config).TypedSpec().ClusterID = c.Cluster().ID()
 					res.(*kubespan.Config).TypedSpec().SharedSecret = c.Cluster().Secret()
 					res.(*kubespan.Config).TypedSpec().ForceRouting = c.Machine().Network().KubeSpan().ForceRouting()
+					res.(*kubespan.Config).TypedSpec().AdvertiseKubernetesNetworks = c.Machine().Network().KubeSpan().AdvertiseKubernetesNetworks()
 
 					return nil
 				}); err != nil {

--- a/internal/app/machined/pkg/controllers/kubespan/config_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/config_test.go
@@ -56,6 +56,7 @@ func (suite *ConfigSuite) TestReconcileConfig() {
 				suite.Assert().Equal("8XuV9TZHW08DOk3bVxQjH9ih_TBKjnh-j44tsCLSBzo=", spec.ClusterID)
 				suite.Assert().Equal("I+1In7fLnpcRIjUmEoeugZnSyFoTF6MztLxICL5Yu0s=", spec.SharedSecret)
 				suite.Assert().True(spec.ForceRouting)
+				suite.Assert().False(spec.AdvertiseKubernetesNetworks)
 
 				return nil
 			},

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -282,6 +282,7 @@ type Route interface {
 type KubeSpan interface {
 	Enabled() bool
 	ForceRouting() bool
+	AdvertiseKubernetesNetworks() bool
 }
 
 // NetworkDeviceSelector defines the set of fields that can be used to pick network a device.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -987,6 +987,11 @@ func (k *NetworkKubeSpan) ForceRouting() bool {
 	return !pointer.SafeDeref(k.KubeSpanAllowDownPeerBypass)
 }
 
+// AdvertiseKubernetesNetworks implements KubeSpan interface.
+func (k *NetworkKubeSpan) AdvertiseKubernetesNetworks() bool {
+	return pointer.SafeDeref(k.KubeSpanAdvertiseKubernetesNetworks)
+}
+
 // Disabled implements the config.Provider interface.
 func (t *TimeConfig) Disabled() bool {
 	return pointer.SafeDeref(t.TimeDisabled)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2403,6 +2403,14 @@ type NetworkKubeSpan struct {
 	//   Cluster discovery should be enabled with .cluster.discovery.enabled for KubeSpan to be enabled.
 	KubeSpanEnabled *bool `yaml:"enabled,omitempty"`
 	// description: |
+	//   Control whether Kubernetes pod CIDRs are announced over KubeSpan from the node.
+	//   If disabled, CNI handles encapsulating pod-to-pod traffic into some node-to-node tunnel,
+	//   and KubeSpan handles the node-to-node traffic.
+	//   If enabled, KubeSpan will take over pod-to-pod traffic and send it over KubeSpan directly.
+	//   When enabled, KubeSpan should have a way to detect complete pod CIDRs of the node which
+	//   is not always the case with CNIs not relying on Kubernetes for IPAM.
+	KubeSpanAdvertiseKubernetesNetworks *bool `yaml:"advertiseKubernetesNetworks,omitempty"`
+	// description: |
 	//   Skip sending traffic via KubeSpan if the peer connection state is not up.
 	//   This provides configurable choice between connectivity and security: either traffic is always
 	//   forced to go via KubeSpan (even if Wireguard peer connection is not up), or traffic can go directly

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -2410,17 +2410,22 @@ func init() {
 			FieldName: "kubespan",
 		},
 	}
-	NetworkKubeSpanDoc.Fields = make([]encoder.Doc, 2)
+	NetworkKubeSpanDoc.Fields = make([]encoder.Doc, 3)
 	NetworkKubeSpanDoc.Fields[0].Name = "enabled"
 	NetworkKubeSpanDoc.Fields[0].Type = "bool"
 	NetworkKubeSpanDoc.Fields[0].Note = ""
 	NetworkKubeSpanDoc.Fields[0].Description = "Enable the KubeSpan feature.\nCluster discovery should be enabled with .cluster.discovery.enabled for KubeSpan to be enabled."
 	NetworkKubeSpanDoc.Fields[0].Comments[encoder.LineComment] = "Enable the KubeSpan feature."
-	NetworkKubeSpanDoc.Fields[1].Name = "allowDownPeerBypass"
+	NetworkKubeSpanDoc.Fields[1].Name = "advertiseKubernetesNetworks"
 	NetworkKubeSpanDoc.Fields[1].Type = "bool"
 	NetworkKubeSpanDoc.Fields[1].Note = ""
-	NetworkKubeSpanDoc.Fields[1].Description = "Skip sending traffic via KubeSpan if the peer connection state is not up.\nThis provides configurable choice between connectivity and security: either traffic is always\nforced to go via KubeSpan (even if Wireguard peer connection is not up), or traffic can go directly\nto the peer if Wireguard connection can't be established."
-	NetworkKubeSpanDoc.Fields[1].Comments[encoder.LineComment] = "Skip sending traffic via KubeSpan if the peer connection state is not up."
+	NetworkKubeSpanDoc.Fields[1].Description = "Control whether Kubernetes pod CIDRs are announced over KubeSpan from the node.\nIf disabled, CNI handles encapsulating pod-to-pod traffic into some node-to-node tunnel,\nand KubeSpan handles the node-to-node traffic.\nIf enabled, KubeSpan will take over pod-to-pod traffic and send it over KubeSpan directly.\nWhen enabled, KubeSpan should have a way to detect complete pod CIDRs of the node which\nis not always the case with CNIs not relying on Kubernetes for IPAM."
+	NetworkKubeSpanDoc.Fields[1].Comments[encoder.LineComment] = "Control whether Kubernetes pod CIDRs are announced over KubeSpan from the node."
+	NetworkKubeSpanDoc.Fields[2].Name = "allowDownPeerBypass"
+	NetworkKubeSpanDoc.Fields[2].Type = "bool"
+	NetworkKubeSpanDoc.Fields[2].Note = ""
+	NetworkKubeSpanDoc.Fields[2].Description = "Skip sending traffic via KubeSpan if the peer connection state is not up.\nThis provides configurable choice between connectivity and security: either traffic is always\nforced to go via KubeSpan (even if Wireguard peer connection is not up), or traffic can go directly\nto the peer if Wireguard connection can't be established."
+	NetworkKubeSpanDoc.Fields[2].Comments[encoder.LineComment] = "Skip sending traffic via KubeSpan if the peer connection state is not up."
 
 	NetworkDeviceSelectorDoc.Type = "NetworkDeviceSelector"
 	NetworkDeviceSelectorDoc.Comments[encoder.LineComment] = "NetworkDeviceSelector struct describes network device selector."

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -1618,6 +1618,11 @@ func (in *NetworkKubeSpan) DeepCopyInto(out *NetworkKubeSpan) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.KubeSpanAdvertiseKubernetesNetworks != nil {
+		in, out := &in.KubeSpanAdvertiseKubernetesNetworks, &out.KubeSpanAdvertiseKubernetesNetworks
+		*out = new(bool)
+		**out = **in
+	}
 	if in.KubeSpanAllowDownPeerBypass != nil {
 		in, out := &in.KubeSpanAllowDownPeerBypass, &out.KubeSpanAllowDownPeerBypass
 		*out = new(bool)

--- a/pkg/machinery/resources/kubespan/config.go
+++ b/pkg/machinery/resources/kubespan/config.go
@@ -33,6 +33,8 @@ type ConfigSpec struct {
 	SharedSecret string `yaml:"sharedSecret" protobuf:"3"`
 	// Force routing via KubeSpan even if the peer connection is not up.
 	ForceRouting bool `yaml:"forceRouting" protobuf:"4"`
+	// Advertise Kubernetes pod networks or skip it completely.
+	AdvertiseKubernetesNetworks bool `yaml:"advertiseKubernetesNetworks" protobuf:"5"`
 }
 
 // NewConfig initializes a Config resource.

--- a/website/content/v1.2/learn-more/kubespan.md
+++ b/website/content/v1.2/learn-more/kubespan.md
@@ -33,9 +33,8 @@ See [discovery service]({{< relref "discovery" >}}) to learn more about the exte
 
 The Kubernetes-based system utilises annotations on Kubernetes Nodes which describe each node's public key and local addresses.
 
-On top of this, we also route Pod subnets.
+On top of this, we also optionally route Pod subnets.
 This is often (maybe even usually) taken care of by the CNI, but there are many situations where the CNI fails to be able to do this itself, across networks.
-So we also scrape the Kubernetes Node resource to discover its `podCIDRs`.
 
 ## NAT, Multiple Routes, Multiple IPs
 

--- a/website/content/v1.2/reference/configuration.md
+++ b/website/content/v1.2/reference/configuration.md
@@ -2689,6 +2689,7 @@ enabled: true # Enable the KubeSpan feature.
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`enabled` |bool |<details><summary>Enable the KubeSpan feature.</summary>Cluster discovery should be enabled with .cluster.discovery.enabled for KubeSpan to be enabled.</details>  | |
+|`advertiseKubernetesNetworks` |bool |<details><summary>Control whether Kubernetes pod CIDRs are announced over KubeSpan from the node.</summary>If disabled, CNI handles encapsulating pod-to-pod traffic into some node-to-node tunnel,<br />and KubeSpan handles the node-to-node traffic.<br />If enabled, KubeSpan will take over pod-to-pod traffic and send it over KubeSpan directly.<br />When enabled, KubeSpan should have a way to detect complete pod CIDRs of the node which<br />is not always the case with CNIs not relying on Kubernetes for IPAM.</details>  | |
 |`allowDownPeerBypass` |bool |<details><summary>Skip sending traffic via KubeSpan if the peer connection state is not up.</summary>This provides configurable choice between connectivity and security: either traffic is always<br />forced to go via KubeSpan (even if Wireguard peer connection is not up), or traffic can go directly<br />to the peer if Wireguard connection can't be established.</details>  | |
 
 


### PR DESCRIPTION
This is incompatible with Calico and Cilium in default configuration, as
it's not easy to figure out exact PodCIDRs of the node.

We change the default but provide the option to revert the old behavior.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
