### PR TITLE
fix: shutdown some streaming API calls when machined API is shutting down

### DIFF
--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -105,6 +105,8 @@ func (s *machinedService) Main(ctx context.Context, r runtime.Runtime, logWriter
 			Controller: s.c,
 			// breaking the import loop cycle between services/ package and v1alpha1_server.go
 			EtcdBootstrapper: BootstrapEtcd,
+
+			ShutdownCtx: ctx,
 		},
 		factory.WithLog("machined ", logWriter),
 


### PR DESCRIPTION
This provides a "quick" shutdown when the API server is going down.

This solves to have a "clean" shutdown of the `talosctl events` stream
when the server is rebooting.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
