### PR TITLE
feat: support dhcp options for vlan

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -305,6 +305,12 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 								{
 									VlanID: 26,
 								},
+								{
+									VlanID: 27,
+									VlanDHCPOptions: &v1alpha1.DHCPOptions{
+										DHCPRouteMetric: 256,
+									},
+								},
 							},
 						},
 						{
@@ -348,6 +354,12 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 						case "configuration/dhcp4/eth4.25":
 							suite.Assert().Equal("eth4.25", r.TypedSpec().LinkName)
 							suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+						case "configuration/dhcp4/eth4.26":
+							suite.Assert().Equal("eth4.26", r.TypedSpec().LinkName)
+							suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+						case "configuration/dhcp4/eth4.27":
+							suite.Assert().Equal("eth4.27", r.TypedSpec().LinkName)
+							suite.Assert().EqualValues(256, r.TypedSpec().DHCP4.RouteMetric)
 						}
 
 						return nil

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -268,6 +268,7 @@ type Vlan interface {
 	ID() uint16
 	MTU() uint32
 	VIPConfig() VIPConfig
+	DHCPOptions() DHCPOptions
 }
 
 // Route represents a network route.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -977,6 +977,18 @@ func (v *Vlan) DHCP() bool {
 	return pointer.SafeDeref(v.VlanDHCP)
 }
 
+// DHCPOptions implements the MachineNetwork interface.
+func (v *Vlan) DHCPOptions() config.DHCPOptions {
+	// Default route metric on systemd is 1024. This sets the same.
+	if v.VlanDHCPOptions == nil {
+		return &DHCPOptions{
+			DHCPRouteMetric: uint32(0),
+		}
+	}
+
+	return v.VlanDHCPOptions
+}
+
 // ID implements the MachineNetwork interface.
 func (v *Vlan) ID() uint16 {
 	return v.VlanID

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2250,6 +2250,10 @@ type Vlan struct {
 	VlanMTU uint32 `yaml:"mtu,omitempty"`
 	//   description: The VLAN's virtual IP address configuration.
 	VlanVIP *DeviceVIPConfig `yaml:"vip,omitempty"`
+	//   description: |
+	//     DHCP specific options.
+	//     `dhcp` *must* be set to true for these to take effect.
+	VlanDHCPOptions *DHCPOptions `yaml:"dhcpOptions,omitempty"`
 }
 
 // Route represents a network route.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1740,6 +1740,10 @@ func init() {
 			TypeName:  "Device",
 			FieldName: "dhcpOptions",
 		},
+		{
+			TypeName:  "Vlan",
+			FieldName: "dhcpOptions",
+		},
 	}
 	DHCPOptionsDoc.Fields = make([]encoder.Doc, 4)
 	DHCPOptionsDoc.Fields[0].Name = "routeMetric"
@@ -2089,7 +2093,7 @@ func init() {
 			FieldName: "vlans",
 		},
 	}
-	VlanDoc.Fields = make([]encoder.Doc, 7)
+	VlanDoc.Fields = make([]encoder.Doc, 8)
 	VlanDoc.Fields[0].Name = "addresses"
 	VlanDoc.Fields[0].Type = "[]string"
 	VlanDoc.Fields[0].Note = ""
@@ -2120,6 +2124,11 @@ func init() {
 	VlanDoc.Fields[6].Note = ""
 	VlanDoc.Fields[6].Description = "The VLAN's virtual IP address configuration."
 	VlanDoc.Fields[6].Comments[encoder.LineComment] = "The VLAN's virtual IP address configuration."
+	VlanDoc.Fields[7].Name = "dhcpOptions"
+	VlanDoc.Fields[7].Type = "DHCPOptions"
+	VlanDoc.Fields[7].Note = ""
+	VlanDoc.Fields[7].Description = "DHCP specific options.\n`dhcp` *must* be set to true for these to take effect."
+	VlanDoc.Fields[7].Comments[encoder.LineComment] = "DHCP specific options."
 
 	RouteDoc.Type = "Route"
 	RouteDoc.Comments[encoder.LineComment] = "Route represents a network route."

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -2084,6 +2084,11 @@ func (in *Vlan) DeepCopyInto(out *Vlan) {
 		*out = new(DeviceVIPConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.VlanDHCPOptions != nil {
+		in, out := &in.VlanDHCPOptions, &out.VlanDHCPOptions
+		*out = new(DHCPOptions)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/website/content/v1.2/reference/configuration.md
+++ b/website/content/v1.2/reference/configuration.md
@@ -2087,6 +2087,7 @@ DHCPOptions contains options for configuring the DHCP settings for a given inter
 Appears in:
 
 - <code><a href="#device">Device</a>.dhcpOptions</code>
+- <code><a href="#vlan">Vlan</a>.dhcpOptions</code>
 
 
 
@@ -2342,6 +2343,7 @@ Appears in:
 |`vlanId` |uint16 |The VLAN's ID.  | |
 |`mtu` |uint32 |The VLAN's MTU.  | |
 |`vip` |<a href="#devicevipconfig">DeviceVIPConfig</a> |The VLAN's virtual IP address configuration.  | |
+|`dhcpOptions` |<a href="#dhcpoptions">DHCPOptions</a> |<details><summary>DHCP specific options.</summary>`dhcp` *must* be set to true for these to take effect.</details>  | |
 
 
 


### PR DESCRIPTION
Add `DHCPOptions` for VLAN device.

Fixes: #6011

Signed-off-by: Noel Georgi <git@frezbo.dev>