### PR TITLE
feat: add support for proxying one-to-one to `apid`

### DIFF
--- a/internal/app/apid/pkg/backend/apid.go
+++ b/internal/app/apid/pkg/backend/apid.go
@@ -66,6 +66,7 @@ func (a *APID) GetConnection(ctx context.Context) (context.Context, *grpc.Client
 
 	delete(md, ":authority")
 	delete(md, "nodes")
+	delete(md, "node")
 
 	outCtx := metadata.NewOutgoingContext(ctx, md)
 

--- a/pkg/machinery/client/context.go
+++ b/pkg/machinery/client/context.go
@@ -10,13 +10,30 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// WithNodes wraps the context with metadata to send request to set of nodes.
+// WithNodes wraps the context with metadata to send request to a set of nodes.
+//
+// Responses from all nodes are aggregated by the `apid` service and sent back as a single response.
 func WithNodes(ctx context.Context, nodes ...string) context.Context {
 	md, _ := metadata.FromOutgoingContext(ctx)
 
 	// overwrite any previous nodes in the context metadata with new value
 	md = md.Copy()
+	md.Delete("node")
 	md.Set("nodes", nodes...)
+
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// WithNode wraps the context with metadata to send request to a single node.
+//
+// Request will be proxied by the endpoint to the specified node without any further processing.
+func WithNode(ctx context.Context, node string) context.Context {
+	md, _ := metadata.FromOutgoingContext(ctx)
+
+	// overwrite any previous nodes in the context metadata with new value
+	md = md.Copy()
+	md.Delete("nodes")
+	md.Set("node", node)
 
 	return metadata.NewOutgoingContext(ctx, md)
 }


### PR DESCRIPTION
This adds a new metadata field `node` which performs always proxying to
a single node without touching any protobuf structs on the way.

So with `node`, we can call APIs which do not conform to the Talos API
proxying standards, but from the UX point of view things will work same
way, but multiplexing will be handled on the client side.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
