### PR TITLE
feat: support patching the machine config in the `apply-config` cmd

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -257,6 +257,12 @@ cluster:
 ```
 """
 
+    [notes.apply-config]
+        title = "Apply Config Patches"
+        description="""\
+`talosctl apply-config` now supports patching the machine config file in memory before submitting it to the node.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/cli/apply-config.go
+++ b/internal/integration/cli/apply-config.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_cli
+// +build integration_cli
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+)
+
+// ApplyConfigSuite verifies dmesg command.
+type ApplyConfigSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *ApplyConfigSuite) SuiteName() string {
+	return "cli.ApplyConfigSuite"
+}
+
+// TestApplyWithPatch verifies that .
+func (suite *ApplyConfigSuite) TestApplyWithPatch() {
+	patch := `---
+cluster:
+  apiServer:
+    extraArgs:
+      logging-format: text`
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+
+	patchPath := filepath.Join(suite.T().TempDir(), "patch.yaml")
+
+	suite.Require().NoError(os.WriteFile(patchPath, []byte(patch), 0o777))
+
+	data, _ := suite.RunCLI([]string{"read", "--nodes", node, "/system/state/config.yaml"})
+
+	configPath := filepath.Join(suite.T().TempDir(), "config.yaml")
+
+	suite.Require().NoError(os.WriteFile(configPath, []byte(data), 0o777))
+
+	suite.RunCLI([]string{"apply-config", "--nodes", node, "--config-patch", fmt.Sprintf("@%s", patchPath), "-f", configPath})
+}
+
+func init() {
+	allSuites = append(allSuites, new(ApplyConfigSuite))
+}

--- a/website/content/v1.2/reference/cli.md
+++ b/website/content/v1.2/reference/cli.md
@@ -17,6 +17,7 @@ talosctl apply-config [flags]
 
 ```
       --cert-fingerprint strings                                 list of server certificate fingeprints to accept (defaults to no check)
+  -p, --config-patch strings                                     the list of config patches to apply to the local config file before sending it to the node
       --dry-run                                                  check how the config change will be applied in dry-run mode
   -f, --file string                                              the filename of the updated configuration
   -h, --help                                                     help for apply-config


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/talos/issues/6045

`talosctl apply-config` now supports `--config-patch` flag that takes
machine config patches as the input.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
