### PR TITLE
fix: make `talosctl` command return nonzero error codes if it had errors

### DIFF
--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -69,12 +69,16 @@ var logsCmd = &cobra.Command{
 
 			respCh, errCh := newLineSlicer(stream)
 
+			var gotErrors bool
+
 			for data := range respCh {
 				if data.Metadata != nil && data.Metadata.Error != "" {
 					_, err = fmt.Fprintf(os.Stderr, "ERROR: %s\n", data.Metadata.Error)
 					if err != nil {
 						return err
 					}
+
+					gotErrors = true
 
 					continue
 				}
@@ -92,6 +96,10 @@ var logsCmd = &cobra.Command{
 
 			if err = <-errCh; err != nil {
 				return fmt.Errorf("error getting logs: %v", err)
+			}
+
+			if gotErrors {
+				os.Exit(1)
 			}
 
 			return nil

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
+	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/talos-systems/talos/pkg/cli"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -42,10 +43,16 @@ var memoryCmd = &cobra.Command{
 			}
 
 			if verbose {
-				return verboseRender(&remotePeer, resp)
+				verboseRender(&remotePeer, resp)
+			} else {
+				err = briefRender(&remotePeer, resp)
+
+				if err != nil {
+					return err
+				}
 			}
 
-			return briefRender(&remotePeer, resp)
+			return helpers.CheckErrors(resp.Messages...)
 		})
 	},
 }
@@ -79,7 +86,7 @@ func briefRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) error {
 	return w.Flush()
 }
 
-func verboseRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) error {
+func verboseRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) {
 	defaultNode := client.AddrFromPeer(remotePeer)
 
 	// Dump as /proc/meminfo
@@ -140,8 +147,6 @@ func verboseRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) error
 		fmt.Printf("%s: %d %s\n", "DirectMap2M", msg.Meminfo.Directmap2M, "kB")
 		fmt.Printf("%s: %d %s\n", "DirectMap1G", msg.Meminfo.Directmap1G, "kB")
 	}
-
-	return nil
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -89,7 +89,7 @@ var supportCmd = &cobra.Command{
 			return nil
 		})
 
-		err = collectData(archive, progress)
+		collectErr := collectData(archive, progress)
 
 		close(progress)
 
@@ -97,15 +97,23 @@ var supportCmd = &cobra.Command{
 			return e
 		}
 
-		if err != nil {
-			if err = printErrors(err); err != nil {
+		if collectErr != nil {
+			if err = printErrors(collectErr); err != nil {
 				return err
 			}
 		}
 
 		fmt.Printf("Support bundle is written to %s\n", supportCmdFlags.output)
 
-		return archive.Archive.Close()
+		if err = archive.Archive.Close(); err != nil {
+			return err
+		}
+
+		if collectErr != nil {
+			os.Exit(1)
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/metadata"
+
+	"github.com/talos-systems/talos/pkg/machinery/api/common"
 )
 
 // FailIfMultiNodes checks if ctx contains multi-node request metadata.
@@ -23,4 +25,18 @@ func FailIfMultiNodes(ctx context.Context, command string) error {
 	}
 
 	return fmt.Errorf("command %q is not supported with multiple nodes", command)
+}
+
+// CheckErrors goes through the returned message list and checks if any messages have errors set.
+func CheckErrors[T interface{ GetMetadata() *common.Metadata }](messages ...T) error {
+	var err error
+
+	for _, msg := range messages {
+		md := msg.GetMetadata()
+		if md.Error != "" {
+			err = AppendErrors(err, fmt.Errorf(md.Error))
+		}
+	}
+
+	return err
 }

--- a/cmd/talosctl/pkg/talos/helpers/error.go
+++ b/cmd/talosctl/pkg/talos/helpers/error.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/gertd/go-pluralize"
+	"github.com/hashicorp/go-multierror"
+)
+
+// AppendErrors adds errors to the multierr wrapper.
+func AppendErrors(err error, errs ...error) error {
+	res := multierror.Append(err, errs...)
+
+	res.ErrorFormat = func(errs []error) string {
+		lines := []string{}
+
+		for _, err := range errs {
+			lines = append(lines, fmt.Sprintf(" %s", err.Error()))
+		}
+
+		count := pluralize.NewClient().Pluralize("error", len(lines), true)
+
+		return color.RedString(fmt.Sprintf("%s occurred:\n%s", count, strings.Join(lines, "\n")))
+	}
+
+	return res
+}

--- a/cmd/talosctl/pkg/talos/helpers/stream.go
+++ b/cmd/talosctl/pkg/talos/helpers/stream.go
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	"github.com/talos-systems/talos/pkg/machinery/api/common"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/proto"
+)
+
+// Stream implements the contract for the grpc stream of a specific type.
+type Stream[T proto.Message] interface {
+	Recv() (T, error)
+	grpc.ClientStream
+}
+
+// Message defines the contract for the grpc message.
+type Message interface {
+	GetMetadata() *common.Metadata
+	proto.Message
+}
+
+// ReadGRPCStream consumes all messages from the gRPC stream, handles errors, calls the passed handler for each message.
+func ReadGRPCStream[S Stream[T], T Message](stream S, handler func(T, string, bool) error) error {
+	var streamErrs error
+
+	defaultNode := client.RemotePeer(stream.Context())
+
+	multipleNodes := false
+
+	for {
+		info, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF || client.StatusCode(err) == codes.Canceled {
+				return streamErrs
+			}
+
+			return fmt.Errorf("error streaming results: %s", err)
+		}
+
+		node := defaultNode
+
+		if info.GetMetadata() != nil {
+			if info.GetMetadata().Hostname != "" {
+				multipleNodes = true
+				node = info.GetMetadata().Hostname
+			}
+
+			if info.GetMetadata().Error != "" {
+				streamErrs = AppendErrors(streamErrs, fmt.Errorf(info.GetMetadata().Error))
+
+				continue
+			}
+		}
+
+		if err = handler(info, node, multipleNodes); err != nil {
+			var errNonFatal *ErrNonFatalError
+			if errors.As(err, &errNonFatal) {
+				streamErrs = AppendErrors(streamErrs, err)
+
+				continue
+			}
+
+			return err
+		}
+	}
+}
+
+// ErrNonFatalError represents the error that can be returned from the handler in the gRPC stream reader
+// which doesn't mean that we should stop iterating over the messages in the stream, but log this error
+// and continue the process.
+type ErrNonFatalError struct {
+	err error
+}
+
+// Error implements error interface.
+func (e *ErrNonFatalError) Error() string {
+	return e.err.Error()
+}
+
+// NonFatalError wraps another error into a ErrNonFatal.
+func NonFatalError(err error) error {
+	return &ErrNonFatalError{
+		err: err,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/gdamore/tcell/v2 v2.5.2
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/golang/mock v1.6.0
@@ -168,7 +169,6 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
-	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -120,6 +120,7 @@ func (suite *TalosconfigSuite) TestNew() {
 			readerOpts: []base.RunOption{
 				base.StdoutEmpty(),
 				base.StderrShouldMatch(regexp.MustCompile(`\Qrpc error: code = PermissionDenied desc = not authorized`)),
+				base.ShouldFail(),
 			},
 		},
 		{
@@ -142,7 +143,7 @@ func (suite *TalosconfigSuite) TestNew() {
 			args:      []string{"kubeconfig", "--force", tempDir},
 			adminOpts: []base.RunOption{base.StdoutEmpty()},
 			readerOpts: []base.RunOption{
-				base.ShouldFail(), // why this one fails, but not others?
+				base.ShouldFail(),
 				base.StdoutEmpty(),
 				base.StderrShouldMatch(regexp.MustCompile(`\Qrpc error: code = PermissionDenied desc = not authorized`)),
 			},

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -133,8 +133,10 @@ func (suite *DiskUsageSuite) TestError() {
 		"usage", "--nodes",
 		suite.RandomDiscoveredNodeInternalIP(), "/no/such/folder/here/just/for/sure",
 	},
+		base.ShouldFail(),
 		base.StderrNotEmpty(),
-		base.StdoutEmpty())
+		base.StdoutEmpty(),
+	)
 }
 
 func init() {

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -56,6 +56,7 @@ func (suite *LogsSuite) TestServiceNotFound() {
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`ERROR:.+ log "servicenotfound" was not registered`)),
+		base.ShouldFail(),
 	)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/talos/issues/6016

Multinode requests were printing out the errors for each node to stderr,
but they didn't set the global error.

Refactor the code a bit to use a single function for handling that logic
to avoid rewriting it in many other places.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>