### PR TITLE
fix: recursive seccomp mounts

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -103,7 +103,7 @@ machine:
 
 This profile data can be either configured as a YAML definition or as a JSON string.
 
-The profiles are created on the host under `/var/lib/seccomp/profiles` and bind mounted at `/var/lib/kubelet/seccomp/profiles` so Kubelet can use it.
+The profiles are created on the host under `/var/lib/kubelet/seccomp/profiles`.
 
 See [documentation](https://www.talos.dev/v1.2/kubernetes-guides/configuration/seccomp-profiles/) for more details.
 """

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -124,7 +124,6 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: "/var/lib/kubelet", Source: "/var/lib/kubelet", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/var/log/containers", Source: "/var/log/containers", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/var/log/pods", Source: "/var/log/pods", Options: []string{"rbind", "rshared", "rw"}},
-		{Type: "bind", Destination: constants.KubeletSeccompProfilesDirectory, Source: constants.SeccompProfilesDirectory, Options: []string{"bind", "ro"}},
 	}
 
 	// Add extra mounts.

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -277,11 +277,8 @@ const (
 	// Should be less than KubeletShutdownGracePeriod.
 	KubeletShutdownGracePeriodCriticalPods = 10 * time.Second
 
-	// SeccompProfilesDirectory is the path to the directory where user provided seccomp profiles are stored.
-	SeccompProfilesDirectory = "/var/lib/seccomp/profiles"
-
-	// KubeletSeccompProfilesDirectory is the path to the directory where user provided seccomp profiles are mounted inside Kubelet.
-	KubeletSeccompProfilesDirectory = "/var/lib/kubelet/seccomp/profiles"
+	// SeccompProfilesDirectory is the path to the directory where user provided seccomp profiles are mounted inside Kubelet.
+	SeccompProfilesDirectory = "/var/lib/kubelet/seccomp/profiles"
 
 	// DefaultKubernetesVersion is the default target version of the control plane.
 	DefaultKubernetesVersion = "1.25.0-beta.0"

--- a/website/content/v1.2/kubernetes-guides/configuration/seccomp-profiles.md
+++ b/website/content/v1.2/kubernetes-guides/configuration/seccomp-profiles.md
@@ -30,8 +30,7 @@ Apply the machine config to all the nodes using talosctl:
 talosctl -e <endpoint ip/hostname> -n <node ip/hostname> patch mc -p @patch.yaml
 ```
 
-This would create a seccomp profile name `audit.json` on the node at `/var/lib/seccomp/profiles`.
-Talos automatically bind mounts `/var/lib/seccomp/profiles` into `/var/lib/kubelet/seccomp/profiles` so it can be used by the Kubelet.
+This would create a seccomp profile name `audit.json` on the node at `/var/lib/kubelet/seccomp/profiles`.
 
 The profiles can be used by Kubernetes pods by specfying the pod `securityContext` as below:
 
@@ -62,7 +61,7 @@ NODE       NAMESPACE   TYPE             ID           VERSION
 The content of the seccomp profile can be viewed by running the below command:
 
 ```bash
-talosctl -e <endpoint ip/hostname> -n <node ip/hostname> read /var/lib/seccomp/profiles/audit.json
+talosctl -e <endpoint ip/hostname> -n <node ip/hostname> read /var/lib/kubelet/seccomp/profiles/audit.json
 ```
 
 An output similar to below can be observed:


### PR DESCRIPTION
Since `/var/lib/kubelet` was mounted with `rbind` and `rshared`, the
seccomp profile mount from the host at `/var/lib/seccomp/profiles` when
mounted at `/var/lib/kubelet/seccomp/profiles` would create a mount back
to the host creating an extra mount everytime kubelet starts/restarts.

Fix the issue by using the same path for the seccomp profiles on both
host and kubelet.

Signed-off-by: Noel Georgi <git@frezbo.dev>