### PR TITLE
fix: introduce 'routed' NodeAddresses and use them in kubelet

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/nodeip_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_test.go
@@ -66,8 +66,6 @@ func (suite *NodeIPSuite) startRuntime() {
 }
 
 func (suite *NodeIPSuite) TestReconcileIPv4() {
-	suite.T().Skip("skipping as the code relies on net.IPAddrs")
-
 	cfg := k8s.NewNodeIPConfig(k8s.NamespaceName, k8s.KubeletID)
 
 	cfg.TypedSpec().ValidSubnets = []string{"10.0.0.0/24", "::/0"}
@@ -77,13 +75,12 @@ func (suite *NodeIPSuite) TestReconcileIPv4() {
 
 	addresses := network.NewNodeAddress(
 		network.NamespaceName,
-		network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s),
+		network.FilteredNodeAddressID(network.NodeAddressRoutedID, k8s.NodeAddressFilterNoK8s),
 	)
 
 	addresses.TypedSpec().Addresses = []netaddr.IPPrefix{
 		netaddr.MustParseIPPrefix("10.0.0.2/32"), // excluded explicitly
 		netaddr.MustParseIPPrefix("10.0.0.5/24"),
-		netaddr.MustParseIPPrefix("fdae:41e4:649b:9303::1/64"), // SideroLink IP
 	}
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, addresses))
@@ -114,8 +111,6 @@ func (suite *NodeIPSuite) TestReconcileIPv4() {
 }
 
 func (suite *NodeIPSuite) TestReconcileDefaultSubnets() {
-	suite.T().Skip("skipping as the code relies on net.IPAddrs")
-
 	cfg := k8s.NewNodeIPConfig(k8s.NamespaceName, k8s.KubeletID)
 
 	cfg.TypedSpec().ValidSubnets = []string{"0.0.0.0/0", "::/0"}
@@ -124,7 +119,7 @@ func (suite *NodeIPSuite) TestReconcileDefaultSubnets() {
 
 	addresses := network.NewNodeAddress(
 		network.NamespaceName,
-		network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s),
+		network.FilteredNodeAddressID(network.NodeAddressRoutedID, k8s.NodeAddressFilterNoK8s),
 	)
 
 	addresses.TypedSpec().Addresses = []netaddr.IPPrefix{

--- a/pkg/machinery/nethelpers/std_netaddr.go
+++ b/pkg/machinery/nethelpers/std_netaddr.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nethelpers
+
+import (
+	"net"
+
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/generic/slices"
+)
+
+// MapStdToNetAddr converts a slice of net.IP to a slice of netaddr.Addr.
+func MapStdToNetAddr(in []net.IP) []netaddr.IP {
+	return slices.Map(in, func(std net.IP) netaddr.IP {
+		addr, _ := netaddr.FromStdIP(std)
+
+		return addr.Unmap()
+	})
+}
+
+// MapNetAddrToStd converts a slice of netaddr.Addr to a slice of net.IP.
+func MapNetAddrToStd(in []netaddr.IP) []net.IP {
+	return slices.Map(in, func(addr netaddr.IP) net.IP {
+		return addr.Unmap().IPAddr().IP
+	})
+}

--- a/pkg/machinery/resources/network/node_address.go
+++ b/pkg/machinery/resources/network/node_address.go
@@ -37,6 +37,12 @@ const (
 	//
 	// If some address is no longer present, it will be still kept in the accumulative list.
 	NodeAddressAccumulativeID = "accumulative"
+	// Routed current node addresses (as seen at the moment).
+	//
+	// This is current addresses minus 'external' IPs, and SideroLink IPs.
+	//
+	// This list is used to pick advertised/listen addresses for different services.
+	NodeAddressRoutedID = "routed"
 )
 
 // NodeAddressSpec describes a set of node addresses.

--- a/pkg/machinery/resources/network/ula.go
+++ b/pkg/machinery/resources/network/ula.go
@@ -69,6 +69,11 @@ func IsStdULA(ip net.IP, purpose ULAPurpose) bool {
 	return IsULA(addr, purpose)
 }
 
+// NotSideroLinkIP is a shorthand for !IsULA(ip, ULASideroLink).
+func NotSideroLinkIP(ip netaddr.IP) bool {
+	return !IsULA(ip, ULASideroLink)
+}
+
 // NotSideroLinkStdIP is a shorthand for !IsStdULA(ip, ULASideroLink).
 func NotSideroLinkStdIP(ip net.IP) bool {
 	return !IsStdULA(ip, ULASideroLink)


### PR DESCRIPTION
Same change will be done for the etcd in a separate PR.

The idea is to introduce a subset of `current` addresses: `routed`
addresses don't include external IPs (like AWS), as they are not on the
node, and excludes SideroLink IPs (as these are not routeable).

Reimplement `kubelet` nodeIP selection based on the new resources
removing the reliance on `net.IPAddrs`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
