### PR TITLE
feat: add event actor id to client api and events cmd

### DIFF
--- a/pkg/machinery/client/events.go
+++ b/pkg/machinery/client/events.go
@@ -47,6 +47,13 @@ func WithTailDuration(dur time.Duration) EventsOptionFunc {
 	}
 }
 
+// WithActorID sets up Watcher to return events with the specified actor ID.
+func WithActorID(actorID string) EventsOptionFunc {
+	return func(opts *machineapi.EventsRequest) {
+		opts.WithActorId = actorID
+	}
+}
+
 // Events implements the proto.OSClient interface.
 func (c *Client) Events(ctx context.Context, opts ...EventsOptionFunc) (stream machineapi.MachineService_EventsClient, err error) {
 	var req machineapi.EventsRequest
@@ -63,6 +70,7 @@ type Event struct {
 	Node    string
 	TypeURL string
 	ID      string
+	ActorID string
 	Payload proto.Message
 }
 
@@ -252,6 +260,7 @@ func UnmarshalEvent(event *machineapi.Event) (*Event, error) {
 		TypeURL: typeURL,
 		ID:      event.Id,
 		Payload: msg,
+		ActorID: event.ActorId,
 	}
 
 	if event.Metadata != nil {

--- a/website/content/v1.2/reference/cli.md
+++ b/website/content/v1.2/reference/cli.md
@@ -1024,6 +1024,7 @@ talosctl events [flags]
 ### Options
 
 ```
+      --actor-id string     filter events by the specified actor ID (default is no filter)
       --duration duration   show events for the past duration interval (one second resolution, default is to show no history)
   -h, --help                help for events
       --since string        show events after the specified event ID (default is to show no history)


### PR DESCRIPTION
Add the missing actor id on the event and a way to filter by it to the events cli command.

Related to siderolabs/talos#5499.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
