### PR TITLE
chore: validate that etcd ca is not empty

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -43,6 +43,8 @@ var (
 
 	// Security.
 
+	// ErrEmptyKeyCert denotes that crypto key/cert combination should not be empty.
+	ErrEmptyKeyCert = errors.New("key/cert combination should not be empty")
 	// ErrInvalidCert denotes that the certificate specified is invalid.
 	ErrInvalidCert = errors.New("certificate is invalid")
 	// ErrInvalidCertType denotes that the certificate type is invalid.
@@ -792,9 +794,13 @@ func (k *KubeletConfig) Validate() ([]string, error) {
 	return nil, result.ErrorOrNil()
 }
 
-// Validate kubelet configuration.
+// Validate etcd configuration.
 func (e *EtcdConfig) Validate() error {
 	var result *multierror.Error
+
+	if e.CA() == nil {
+		result = multierror.Append(result, ErrEmptyKeyCert)
+	}
 
 	if e.EtcdSubnet != "" && len(e.EtcdAdvertisedSubnets) > 0 {
 		result = multierror.Append(result, fmt.Errorf("etcd subnet can't be set when advertised subnets are set"))

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/talos-systems/crypto/x509"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
@@ -961,6 +962,7 @@ func TestValidate(t *testing.T) {
 						},
 					},
 					EtcdConfig: &v1alpha1.EtcdConfig{
+						RootCA: &x509.PEMEncodedCertificateAndKey{},
 						EtcdAdvertisedSubnets: []string{
 							"10.0.0.0/8",
 							"!1.1.1.1/32",
@@ -988,6 +990,7 @@ func TestValidate(t *testing.T) {
 						},
 					},
 					EtcdConfig: &v1alpha1.EtcdConfig{
+						RootCA: &x509.PEMEncodedCertificateAndKey{},
 						EtcdAdvertisedSubnets: []string{
 							"1234:",
 						},


### PR DESCRIPTION
Validate that the etcd CA is not empty in machine configuration.

Signed-off-by: Noel Georgi <git@frezbo.dev>