### PR TITLE
feat: allow modules to be loaded via extension

### DIFF
--- a/pkg/machinery/extensions/extensions.go
+++ b/pkg/machinery/extensions/extensions.go
@@ -9,6 +9,7 @@ package extensions
 var AllowedPaths = []string{
 	"/etc/cri/conf.d",
 	"/lib/firmware",
+	"/lib/modules",
 	"/lib64/ld-linux-x86-64.so.2",
 	"/usr/etc/udev/rules.d",
 	"/usr/local",


### PR DESCRIPTION
Allow modules to be loaded via [extensions](https://github.com/siderolabs/extensions/pull/52).

Signed-off-by: Noel Georgi <git@frezbo.dev>