### PR TITLE
fix: correct link to api access from k8s

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -82,7 +82,7 @@ talosctl inject serviceaccount -f manifests.yaml > manifests-injected.yaml
 kubectl apply -f manifests-injected.yaml
 ```
 
-See [documentation](https://www.talos.dev/v1.2/advanced/configuration/talos-api-access-from-k8s/) for more details.
+See [documentation](https://www.talos.dev/v1.2/advanced/talos-api-access-from-k8s/) for more details.
 """
 
     [notes.seccomp]


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Correct link to the Talos API access from Kubernetes.

## Why? (reasoning)

The previous link went to a non-existent page.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
