### PR TITLE
fix: clean up `cancelCtxMu` leftovers in PriorityLock

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_priority_lock.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_priority_lock.go
@@ -31,7 +31,6 @@ type PriorityLock[T Priority[T]] struct {
 	takeoverCh chan struct{}
 
 	mu              sync.Mutex
-	cancelCtxMu     sync.Mutex
 	runningPriority T
 	cancelCtx       context.CancelFunc
 }
@@ -63,9 +62,6 @@ func (lock *PriorityLock[T]) setRunningPriority(seq T, cancelCtx context.CancelF
 	if seq == zeroSeq && lock.cancelCtx != nil {
 		lock.cancelCtx()
 	}
-
-	lock.cancelCtxMu.Lock()
-	defer lock.cancelCtxMu.Unlock()
 
 	lock.runningPriority, lock.cancelCtx = seq, cancelCtx
 }


### PR DESCRIPTION
Removed it from one place but forgot to clean up the other usages.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>