### PR TITLE
fix: handle grub config being empty in the `Revert` function

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/meta.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/meta.go
@@ -117,6 +117,10 @@ func (m *Meta) Revert() (err error) {
 		return err
 	}
 
+	if conf == nil {
+		return nil
+	}
+
 	bootEntry, err := grub.ParseBootLabel(label)
 	if err != nil {
 		return err


### PR DESCRIPTION
Looks like it returns nil if it doesn't exist and the code doesn't
handle it properly.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>