### PR TITLE
fix: stable default hostname bias

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -78,6 +78,9 @@ Talos now generates the default hostname (when there is no explicitly specified 
 node id (e.g. `talos-2gd-76y`) instead of using the DHCP assigned IP address (e.g. `talos-172-20-0-2`).
 
 This ensures that the node hostname is not changed when DHCP assigns a new IP to a node.
+
+Please note: the stable hostname generation algorithm changed between v1.2.0-beta.0 and v1.2.0-beta.1, please take care when upgrading
+from versions >= 1.2.0-alpha.1 to versions >= 1.2.0-beta.1 when using stable default hostname feature.
 """
 
     [notes.kubespan-kubernetes-nets]

--- a/internal/app/machined/pkg/controllers/network/hostname_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config.go
@@ -200,14 +200,10 @@ func (ctrl *HostnameConfigController) apply(ctx context.Context, r controller.Ru
 }
 
 func (ctrl *HostnameConfigController) getStableDefault(nodeID string) *network.HostnameSpecSpec {
-	h := sha256.New()
-	h.Write([]byte(nodeID))
+	hashBytes := sha256.Sum256([]byte(nodeID))
+	b36 := strings.ToLower(base36.EncodeBytes(hashBytes[:8]))
 
-	hashBytes := h.Sum(nil)
-
-	b36 := strings.ToLower(base36.EncodeBytes(hashBytes))
-
-	hostname := fmt.Sprintf("talos-%s-%s", b36[0:3], b36[3:6])
+	hostname := fmt.Sprintf("talos-%s-%s", b36[1:4], b36[4:7])
 
 	return &network.HostnameSpecSpec{
 		Hostname:    hostname,

--- a/internal/app/machined/pkg/controllers/network/hostname_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config_test.go
@@ -206,7 +206,7 @@ func (suite *HostnameConfigSuite) TestDefaultStableHostname() {
 					[]string{
 						"default/hostname",
 					}, func(r *network.HostnameSpec) error {
-						suite.Assert().Equal("talos-2gd-76y", r.TypedSpec().Hostname)
+						suite.Assert().Equal("talos-hwz-sw5", r.TypedSpec().Hostname)
 
 						return nil
 					},


### PR DESCRIPTION
When converting to base36 a 256-bit number there's a bias in the
first character of the base36 encoding, as 256-bit number never fits
perfectly base 36 number.

To give an example, when converting 4-digit binary number to decimal,
the first digit of the decimal number will be [0..3], while the
second digit won't be biased:

```
0000 -> 00
0001 -> 01
...
0111 -> 15
1000 -> 16
...
1111 -> 31
```

Same issue happens when going from e.g. base16 to base36.

Stable hostnames were biased towards having a digit as the first
character.

The fix is to skip the first character of the base36 representation, and
also we don't need to convert all 256 bits to base36, if we use only 6
characters, we can save some CPU resources by taking only 8 bytes
instead of full 32 bytes.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
