### PR TITLE
fix: don't wait for the hostname in maintenance mode

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -397,6 +397,14 @@ local integration_kubespan = Step("e2e-kubespan", target="e2e-qemu", privileged=
         "IMAGE_REGISTRY": local_registry,
         "WITH_CONFIG_PATCH": '[{"op": "replace", "path": "/cluster/discovery/registries/kubernetes/disabled", "value": false}]', # use Kubernetes discovery backend
 });
+local integration_default_hostname = Step("e2e-default-hostname", target="e2e-qemu", privileged=true, depends_on=[integration_kubespan], environment={
+        # regression test: make sure Talos works in maintenance mode when no hostname is set
+        "SHORT_INTEGRATION_TEST": "yes",
+        "IMAGE_REGISTRY": local_registry,
+        "VIA_MAINTENANCE_MODE": "true",
+        "DISABLE_DHCP_HOSTNAME": "true",
+});
+
 local integration_qemu_encrypted_vip = Step("e2e-encrypted-vip", target="e2e-qemu", privileged=true, depends_on=[load_artifacts], environment={
         "WITH_DISK_ENCRYPTION": "true",
         "WITH_VIRTUAL_IP": "true",
@@ -452,7 +460,7 @@ local integration_pipelines = [
   Pipeline('integration-provision-1', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_1]) + integration_trigger(['integration-provision', 'integration-provision-1']),
   Pipeline('integration-provision-2', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_2]) + integration_trigger(['integration-provision', 'integration-provision-2']),
   Pipeline('integration-misc', default_pipeline_steps + [integration_extensions
-, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan]) + integration_trigger(['integration-misc']),
+, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan, integration_default_hostname]) + integration_trigger(['integration-misc']),
   Pipeline('integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip]) + integration_trigger(['integration-qemu-encrypted-vip']),
   Pipeline('integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race]) + integration_trigger(['integration-qemu-race']),
   Pipeline('integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi]) + integration_trigger(['integration-qemu-csi']),
@@ -464,7 +472,7 @@ local integration_pipelines = [
   Pipeline('cron-integration-provision-1', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_1], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-provision-2', default_pipeline_steps + [integration_provision_tests_prepare, integration_provision_tests_track_2], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-misc', default_pipeline_steps + [integration_extensions
-, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
+, integration_cilium, integration_bios, integration_disk_image, integration_control_plane_port, integration_no_cluster_discovery, integration_kubespan, integration_default_hostname], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race], [default_cron_pipeline]) + cron_trigger(['nightly']),
   Pipeline('cron-integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi], [default_cron_pipeline]) + cron_trigger(['nightly']),

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -63,6 +63,23 @@ case "${WITH_CONTROL_PLANE_PORT:-false}" in
     ;;
 esac
 
+case "${VIA_MAINTENANCE_MODE:-false}" in
+  false)
+    ;;
+  *)
+    # apply config via maintenance mode
+    QEMU_FLAGS="${QEMU_FLAGS} --skip-injecting-config --with-apply-config"
+    ;;
+esac
+
+case "${DISABLE_DHCP_HOSTNAME:-false}" in
+  false)
+    ;;
+  *)
+    QEMU_FLAGS="${QEMU_FLAGS} --disable-dhcp-hostname"
+    ;;
+esac
+
 case "${USE_DISK_IMAGE:-false}" in
   false)
     DISK_IMAGE_FLAG=

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -27,7 +27,7 @@ import (
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
 )
 
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRequest, nodeReq provision.NodeRequest, opts *provision.Options) (provision.NodeInfo, error) {
 	arch := Arch(opts.TargetArch)
 	pidPath := state.GetRelativePath(fmt.Sprintf("%s.pid", nodeReq.Name))
@@ -131,13 +131,16 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		CNI:               clusterReq.Network.CNI,
 		CIDRs:             clusterReq.Network.CIDRs,
 		IPs:               nodeReq.IPs,
-		Hostname:          nodeReq.Name,
 		GatewayAddrs:      clusterReq.Network.GatewayAddrs,
 		MTU:               clusterReq.Network.MTU,
 		Nameservers:       clusterReq.Network.Nameservers,
 		TFTPServer:        nodeReq.TFTPServer,
 		IPXEBootFileName:  nodeReq.IPXEBootFilename,
 		APIPort:           apiPort,
+	}
+
+	if !clusterReq.Network.DHCPSkipHostname {
+		launchConfig.Hostname = nodeReq.Name
 	}
 
 	if !nodeReq.PXEBooted {

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -57,6 +57,9 @@ type NetworkRequest struct {
 	// CNI-specific parameters.
 	CNI CNIConfig
 
+	// DHCP options
+	DHCPSkipHostname bool
+
 	// Docker-specific parameters.
 	DockerDisableIPv6 bool
 }

--- a/website/content/v1.2/reference/cli.md
+++ b/website/content/v1.2/reference/cli.md
@@ -108,6 +108,7 @@ talosctl cluster create [flags]
       --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
       --crashdump                                print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                    install custom CNI from the URL (Talos cluster)
+      --disable-dhcp-hostname                    skip announcing hostname via DHCP (QEMU only)
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
       --disk-image-path string                   disk image to use
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")


### PR DESCRIPTION
Fixes #6119

With new stable default hostname feature, any default hostname is
disabled until the machine config is available.

Talos enters maintenance mode when the default config source is empty,
so it doesn't have any machine config available at the moment
maintenance service is started.

Hostname might be set via different sources, e.g. kernel args or via
DHCP before the machine config is available, but if all these sources
are not available, hostname won't be set at all.

This stops waiting for the hostname, and skips setting any DNS names in
the maintenance mode certificate SANs if the hostname is not available.

Also adds a regression test via new `--disable-dhcp-hostname` flag to
`talosctl cluster create`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
