### PR TITLE
chore: bump kernel to 5.15.62

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.2.0
-PKGS ?= v1.3.0-alpha.0-2-g2ecd14e
+PKGS ?= v1.3.0-alpha.0-5-ge70e3c1
 EXTRAS ?= v1.2.0
 GO_VERSION ?= 1.19
 GOIMPORTS_VERSION ?= v0.1.11

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -20,6 +20,7 @@ preface = """\
         title = "Component Updates"
         description="""\
 * containerd 1.6.8
+* Linux kernel 5.15.62
 """
 
     [notes.talos-config-kernel-param-variable-substitution]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.60-talos"
+	DefaultKernelVersion = "5.15.62-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.3.0-alpha.0-2-g2ecd14e
+v1.3.0-alpha.0-5-ge70e3c1


### PR DESCRIPTION
Bump kernel to 5.15.62. Ref: https://github.com/siderolabs/pkgs/pull/559

This PR uses pkgs from https://github.com/siderolabs/pkgs/pull/562

Signed-off-by: Noel Georgi <git@frezbo.dev>