### PR TITLE
fix: properly read kexec disabled sysctl

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -294,7 +294,7 @@ func SetRLimit(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFun
 // DropCapabilities drops some capabilities so that they can't be restored by child processes.
 func DropCapabilities(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		prop, err := krnl.ReadParam(&kernel.Param{Key: "kernel.kexec_load_disabled"})
+		prop, err := krnl.ReadParam(&kernel.Param{Key: "proc.sys.kernel.kexec_load_disabled"})
 		if v := strings.TrimSpace(string(prop)); err == nil && v != "0" {
 			logger.Printf("kernel.kexec_load_disabled is %v, skipping dropping capabilities", v)
 


### PR DESCRIPTION
Fixes #6046

Fix by @bzub

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
