### PR TITLE
chore: remove old build tags syntax

### DIFF
--- a/cmd/talosctl/cmd/mgmt/qemu_launch_linux.go
+++ b/cmd/talosctl/cmd/mgmt/qemu_launch_linux.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build linux
-// +build linux
 
 package mgmt
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build amd64
-// +build amd64
 
 package vmware
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build !amd64
-// +build !amd64
 
 package vmware
 

--- a/internal/integration/api/api.go
+++ b/internal/integration/api/api.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package api provides API integration tests for Talos
 package api

--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/discovery.go
+++ b/internal/integration/api/discovery.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/diskusage.go
+++ b/internal/integration/api/diskusage.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/etcd-recover.go
+++ b/internal/integration/api/etcd-recover.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/generate-config.go
+++ b/internal/integration/api/generate-config.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/machine-status.go
+++ b/internal/integration/api/machine-status.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/resources.go
+++ b/internal/integration/api/resources.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/serviceaccount.go
+++ b/internal/integration/api/serviceaccount.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/update-endpoint.go
+++ b/internal/integration/api/update-endpoint.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/update-hostname.go
+++ b/internal/integration/api/update-hostname.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/api/version.go
+++ b/internal/integration/api/version.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package api
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_api
-// +build integration_api
 
 package base
 

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package base provides shared definition of base suites for tests
 package base

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package base
 

--- a/internal/integration/base/cluster.go
+++ b/internal/integration/base/cluster.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 package base
 

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_k8s
-// +build integration_k8s
 
 package base
 

--- a/internal/integration/base/discovery_nok8s.go
+++ b/internal/integration/base/discovery_nok8s.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration && !integration_k8s
-// +build integration,!integration_k8s
 
 package base
 

--- a/internal/integration/base/errors.go
+++ b/internal/integration/base/errors.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 package base
 

--- a/internal/integration/base/flags.go
+++ b/internal/integration/base/flags.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 package base
 

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_k8s
-// +build integration_k8s
 
 package base
 

--- a/internal/integration/base/run.go
+++ b/internal/integration/base/run.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package base
 

--- a/internal/integration/cli/apply-config.go
+++ b/internal/integration/cli/apply-config.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/cli.go
+++ b/internal/integration/cli/cli.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package cli provides CLI (talosctl) integration tests for Talos
 package cli

--- a/internal/integration/cli/completion.go
+++ b/internal/integration/cli/completion.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/disk.go
+++ b/internal/integration/cli/disk.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/dmesg.go
+++ b/internal/integration/cli/dmesg.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/etcd.go
+++ b/internal/integration/cli/etcd.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/images.go
+++ b/internal/integration/cli/images.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/inject.go
+++ b/internal/integration/cli/inject.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/memory.go
+++ b/internal/integration/cli/memory.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/mounts.go
+++ b/internal/integration/cli/mounts.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/patch.go
+++ b/internal/integration/cli/patch.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/pcap.go
+++ b/internal/integration/cli/pcap.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/processes.go
+++ b/internal/integration/cli/processes.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/read.go
+++ b/internal/integration/cli/read.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/services.go
+++ b/internal/integration/cli/services.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/support.go
+++ b/internal/integration/cli/support.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/time.go
+++ b/internal/integration/cli/time.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_cli
-// +build integration_cli
 
 package cli
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package integration_test contains core runners for integration tests
 package integration_test

--- a/internal/integration/k8s/k8s.go
+++ b/internal/integration/k8s/k8s.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package k8s provides Kubernetes integration tests for Talos
 package k8s

--- a/internal/integration/k8s/version.go
+++ b/internal/integration/k8s/version.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_k8s
-// +build integration_k8s
 
 package k8s
 

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package provision provides integration tests which rely on provisioning cluster per test.
 package provision

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration_provision
-// +build integration_provision
 
 package provision
 

--- a/internal/integration/version_test.go
+++ b/internal/integration/version_test.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build integration
-// +build integration
 
 // Package integration_test contains core runners for integration tests
 package integration_test

--- a/pkg/machinery/client/insecure_credentials.go
+++ b/pkg/machinery/client/insecure_credentials.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build sidero.debug
-// +build sidero.debug
 
 package client
 

--- a/pkg/machinery/client/secure_credentials.go
+++ b/pkg/machinery/client/secure_credentials.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build !sidero.debug
-// +build !sidero.debug
 
 package client
 

--- a/pkg/machinery/config/configloader/configloader_fuzz_test.go
+++ b/pkg/machinery/config/configloader/configloader_fuzz_test.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build go1.18
-// +build go1.18
 
 package configloader_test
 

--- a/pkg/provision/providers/qemu_linux.go
+++ b/pkg/provision/providers/qemu_linux.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build linux
-// +build linux
 
 package providers
 

--- a/pkg/provision/providers/qemu_other.go
+++ b/pkg/provision/providers/qemu_other.go
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //go:build !linux
-// +build !linux
 
 package providers
 


### PR DESCRIPTION
This commit removes lines contains old build tag syntax.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>