### PR TITLE
fix: correctly render hosts.toml with multiple endpoints

### DIFF
--- a/internal/pkg/containers/cri/containerd/hosts_test.go
+++ b/internal/pkg/containers/cri/containerd/hosts_test.go
@@ -59,7 +59,7 @@ func TestGenerateHosts(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("\n[host]\n\n  [host.\"https://registry-1.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n\n[host]\n\n  [host.\"https://registry-2.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n    skip_verify = true\n"), //nolint:lll
+						Contents: []byte("\n[host]\n\n  [host.\"https://registry-1.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n\n  [host.\"https://registry-2.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n    skip_verify = true\n"), //nolint:lll
 					},
 				},
 			},
@@ -127,7 +127,7 @@ func TestGenerateHosts(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("\n[host]\n\n  [host.\"https://registry-1.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n\n[host]\n\n  [host.\"https://registry-2.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n"), //nolint:lll
+						Contents: []byte("\n[host]\n\n  [host.\"https://registry-1.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n\n  [host.\"https://registry-2.docker.io\"]\n    capabilities = [\"pull\", \"resolve\"]\n"), //nolint:lll
 					},
 				},
 			},


### PR DESCRIPTION
We should preserve the order of keys in generated `hosts.toml`, but
go-toml library has no real way to do that on marshaling, so fix the
previous workaround, as it was generating invalid TOML.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
