### PR TITLE
fix: properly populate nodes list in the `get` command insecure mode

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/resources.go
+++ b/cmd/talosctl/pkg/talos/helpers/resources.go
@@ -41,7 +41,7 @@ func ForEachResource(ctx context.Context,
 	nodes := md.Get("nodes")
 
 	if len(nodes) == 0 {
-		return nil
+		nodes = c.GetEndpoints()
 	}
 
 	// fetch the RD from the first node (it doesn't matter which one to use, so we'll use the first one)


### PR DESCRIPTION
It was only populating the endpoints, but the CLI code was changed to
bail out early if no `nodes` set in the gRPC context.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
