### PR TITLE
fix: always abort the maintenance service

### DIFF
--- a/internal/app/maintenance/main.go
+++ b/internal/app/maintenance/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/netip"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -144,7 +145,10 @@ func Run(ctx context.Context, logger *log.Logger, r runtime.Runtime) ([]byte, er
 
 	select {
 	case cfg := <-cfgCh:
-		server.GracefulStop()
+		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer shutdownCancel()
+
+		factory.ServerGracefulStop(server, shutdownCtx)
 
 		return cfg, err
 	case <-ctx.Done():


### PR DESCRIPTION
I hit this bug when one the API calls got hanging, and submitting the
machine config with `apply-config` never takes the node out of
maintenance mode, as `.GracefulStop()` may hang forever waiting for all
the calls to finish.

This way we always abort at some timeout and stop the server forcefully.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
