### PR TITLE
test: fix cli reboot test

### DIFF
--- a/internal/integration/cli/reboot.go
+++ b/internal/integration/cli/reboot.go
@@ -43,14 +43,18 @@ func (suite *RebootSuite) TestReboot() {
 	)
 
 	suite.RunCLI([]string{"reboot", "-n", nodes, "--debug"}, base.StdoutMatchFunc(func(stdout string) error {
+		if strings.Contains(stdout, "method is not supported") {
+			suite.T().Skip("reboot is not supported")
+		}
+
 		var err error
 
 		for _, node := range []string{controlPlaneNode, workerNode} {
-			if !strings.Contains(stdout, fmt.Sprintf("%v: Events check condition met", node)) {
+			if !strings.Contains(stdout, fmt.Sprintf("%v: events check condition met", node)) {
 				err = multierror.Append(err, fmt.Errorf("events check condition not met on %v", node))
 			}
 
-			if !strings.Contains(stdout, fmt.Sprintf("%v: Post check passed", node)) {
+			if !strings.Contains(stdout, fmt.Sprintf("%v: post check passed", node)) {
 				err = multierror.Append(err, fmt.Errorf("post check not passed on %v", node))
 			}
 		}


### PR DESCRIPTION
Fix the assertions on the reboot cli test to correctly assert the event messages in lowercase.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
