### PR TITLE
fix: change the type of returned gRPC connection object from the client

### DIFF
--- a/pkg/machinery/client/connection.go
+++ b/pkg/machinery/client/connection.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Conn returns underlying client connection.
-func (c *Client) Conn() grpc.ClientConnInterface {
-	return c.conn
+func (c *Client) Conn() *grpc.ClientConn {
+	return c.conn.ClientConn
 }
 
 // getConn creates new gRPC connection.


### PR DESCRIPTION
`client.Conn()` now returns `*grpc.ClientConn` instead of
`gprc.ClientConnInterface`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>