### PR TITLE
fix: properly handle `configContext` being `nil` in Talos client

### DIFF
--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -136,7 +136,9 @@ func (c *Client) GetClusterName() string {
 			return ""
 		}
 
-		return c.options.configContext.Cluster
+		if c.options.configContext != nil {
+			return c.options.configContext.Cluster
+		}
 	}
 
 	return ""


### PR DESCRIPTION
Client crashes if you try using it in the unixSocket mode.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>