### PR TITLE
docs: update docs for upcoming 1.2.0 release

### DIFF
--- a/website/content/v1.1/introduction/support-matrix.md
+++ b/website/content/v1.1/introduction/support-matrix.md
@@ -20,7 +20,7 @@ description: "Table of supported Talos Linux versions and respective platforms."
 | **Cluster API**                                                                                                |                                    |                                    |
 | [CAPI Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)            | >= 0.5.4                           | >= 0.5.3                           |
 | [CAPI Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)    | >= 0.4.6                           | >= 0.4.5                           |
-| [Sidero](https://www.sidero.dev/)                                                                              | >= 0.5.1                           | >= 0.5.0                           |
+| [Sidero](https://www.sidero.dev/)                                                                              | >= 0.5.4                           | >= 0.5.0                           |
 | **UI**                                                                                                         |                                    |                                    |
 | [Theila](https://github.com/siderolabs/theila)                                                                 | ✓                                  | ✓                                  |
 

--- a/website/content/v1.2/_index.md
+++ b/website/content/v1.2/_index.md
@@ -5,7 +5,7 @@ linkTitle: "Documentation"
 cascade:
   type: docs
 preRelease: true
-lastRelease: v1.2.0-beta.1
+lastRelease: v1.2.0-beta.2
 kubernetesRelease: "v1.25.0"
 prevKubernetesRelease: "1.24.3"
 theilaRelease: "v0.2.1"

--- a/website/content/v1.2/advanced/developing-talos.md
+++ b/website/content/v1.2/advanced/developing-talos.md
@@ -72,7 +72,7 @@ sudo --preserve-env=HOME _out/talosctl-linux-amd64 cluster create \
     --registry-mirror ghcr.io=http://172.20.0.1:5004 \
     --registry-mirror 127.0.0.1:5005=http://172.20.0.1:5005 \
     --install-image=127.0.0.1:5005/siderolabs/installer:<RECORDED HASH from the build step> \
-    --masters 3 \
+    --controlplanes 3 \
     --workers 2 \
     --with-bootloader=false
 ```
@@ -81,7 +81,7 @@ sudo --preserve-env=HOME _out/talosctl-linux-amd64 cluster create \
 - custom `--cidr` to make QEMU cluster use different network than default Docker setup (optional)
 - `--registry-mirror` uses the caching proxies set up above to speed up boot time a lot, last one adds your local registry (installer image was pushed to it)
 - `--install-image` is the image you built with `make installer` above
-- `--masters` & `--workers` configure cluster size, choose to match your resources; 3 masters give you HA control plane; 1 master is enough, never do 2 masters
+- `--controlplanes` & `--workers` configure cluster size, choose to match your resources; 3 controlplanes give you HA control plane; 1 controlplane is enough, never do 2 controlplanes
 - `--with-bootloader=false` disables boot from disk (Talos will always boot from `_out/vmlinuz-amd64` and `_out/initramfs-amd64.xz`).
   This speeds up development cycle a lot - no need to rebuild installer and perform install, rebooting is enough to get new code.
 

--- a/website/content/v1.2/advanced/static-pods.md
+++ b/website/content/v1.2/advanced/static-pods.md
@@ -41,7 +41,7 @@ Kubelet mirrors pod definition to the API server state, so static pods can be in
 ```bash
 $ kubectl get pods
 NAME                           READY   STATUS    RESTARTS   AGE
-nginx-talos-default-master-2   1/1     Running   0          17s
+nginx-talos-default-controlplane-2   1/1     Running   0          17s
 ```
 
 If the API server is not available, status of the static pod can also be inspected with `talosctl containers --kubernetes`:
@@ -49,15 +49,15 @@ If the API server is not available, status of the static pod can also be inspect
 ```bash
 $ talosctl containers --kubernetes
 NODE         NAMESPACE   ID                                                                                      IMAGE                                                         PID    STATUS
-172.20.0.3   k8s.io      default/nginx-talos-default-master-2                                                    k8s.gcr.io/pause:3.6                                          4886   SANDBOX_READY
-172.20.0.3   k8s.io      └─ default/nginx-talos-default-master-2:nginx                                           docker.io/library/nginx:latest
+172.20.0.3   k8s.io      default/nginx-talos-default-controlplane-2                                                    k8s.gcr.io/pause:3.6                                          4886   SANDBOX_READY
+172.20.0.3   k8s.io      └─ default/nginx-talos-default-controlplane-2:nginx                                           docker.io/library/nginx:latest
 ...
 ```
 
 Logs of static pods can be retrieved with `talosctl logs --kubernetes`:
 
 ```bash
-$ talosctl logs --kubernetes default/nginx-talos-default-master-2:nginx
+$ talosctl logs --kubernetes default/nginx-talos-default-controlplane-2:nginx
 172.20.0.3: 2022-02-10T15:26:01.289208227Z stderr F 2022/02/10 15:26:01 [notice] 1#1: using the "epoll" event method
 172.20.0.3: 2022-02-10T15:26:01.2892466Z stderr F 2022/02/10 15:26:01 [notice] 1#1: nginx/1.21.6
 172.20.0.3: 2022-02-10T15:26:01.28925723Z stderr F 2022/02/10 15:26:01 [notice] 1#1: built by gcc 10.2.1 20210110 (Debian 10.2.1-6)
@@ -93,8 +93,8 @@ On control plane nodes status of the running static pods is available in the `St
 ```bash
 $ talosctl get staticpodstatus
 NODE         NAMESPACE   TYPE              ID                                                           VERSION   READY
-172.20.0.3   k8s         StaticPodStatus   default/nginx-talos-default-master-2                         2         True
-172.20.0.3   k8s         StaticPodStatus   kube-system/kube-apiserver-talos-default-master-2            2         True
-172.20.0.3   k8s         StaticPodStatus   kube-system/kube-controller-manager-talos-default-master-2   3         True
-172.20.0.3   k8s         StaticPodStatus   kube-system/kube-scheduler-talos-default-master-2            3         True
+172.20.0.3   k8s         StaticPodStatus   default/nginx-talos-default-controlplane-2                         2         True
+172.20.0.3   k8s         StaticPodStatus   kube-system/kube-apiserver-talos-default-controlplane-2            2         True
+172.20.0.3   k8s         StaticPodStatus   kube-system/kube-controller-manager-talos-default-controlplane-2   3         True
+172.20.0.3   k8s         StaticPodStatus   kube-system/kube-scheduler-talos-default-controlplane-2            3         True
 ```

--- a/website/content/v1.2/advanced/troubleshooting-control-plane.md
+++ b/website/content/v1.2/advanced/troubleshooting-control-plane.md
@@ -201,7 +201,7 @@ This is expected during initial cluster bootstrap and sometimes after a reboot:
 
 ```bash
 [   70.093289] [talos] task labelNodeAsControlPlane (1/1): starting
-[   80.094038] [talos] retrying error: an error on the server ("") has prevented the request from succeeding (get nodes talos-default-master-1)
+[   80.094038] [talos] retrying error: an error on the server ("") has prevented the request from succeeding (get nodes talos-default-controlplane-1)
 ```
 
 Initially `kube-apiserver` component is not running yet, and it takes some time before it becomes fully up
@@ -215,16 +215,16 @@ In any case, the status of the control plane components on each control plane no
 
 ```bash
 $ talosctl -n <IP> containers --kubernetes
-NODE         NAMESPACE   ID                                                                                      IMAGE                                        PID    STATUS
-172.20.0.2   k8s.io      kube-system/kube-apiserver-talos-default-master-1                                       k8s.gcr.io/pause:3.2                         2539   SANDBOX_READY
-172.20.0.2   k8s.io      └─ kube-system/kube-apiserver-talos-default-master-1:kube-apiserver                     k8s.gcr.io/kube-apiserver:v{{< k8s_release >}}            2572   CONTAINER_RUNNING
+NODE         NAMESPACE   ID                                                                                            IMAGE                                              PID    STATUS
+172.20.0.2   k8s.io      kube-system/kube-apiserver-talos-default-controlplane-1                                       k8s.gcr.io/pause:3.2                               2539   SANDBOX_READY
+172.20.0.2   k8s.io      └─ kube-system/kube-apiserver-talos-default-controlplane-1:kube-apiserver                     k8s.gcr.io/kube-apiserver:v{{< k8s_release >}}     2572   CONTAINER_RUNNING
 ```
 
 If `kube-apiserver` shows as `CONTAINER_EXITED`, it might have exited due to configuration error.
 Logs can be checked with `taloctl logs --kubernetes` (or with `-k` as a shorthand):
 
 ```bash
-$ talosctl -n <IP> logs -k kube-system/kube-apiserver-talos-default-master-1:kube-apiserver
+$ talosctl -n <IP> logs -k kube-system/kube-apiserver-talos-default-controlplane-1:kube-apiserver
 172.20.0.2: 2021-03-05T20:46:13.133902064Z stderr F 2021/03/05 20:46:13 Running command:
 172.20.0.2: 2021-03-05T20:46:13.133933824Z stderr F Command env: (log-file=, also-stdout=false, redirect-stderr=true)
 172.20.0.2: 2021-03-05T20:46:13.133938524Z stderr F Run from directory:
@@ -232,7 +232,7 @@ $ talosctl -n <IP> logs -k kube-system/kube-apiserver-talos-default-master-1:kub
 ...
 ```
 
-### Talos prints error `nodes "talos-default-master-1" not found`
+### Talos prints error `nodes "talos-default-controlplane-1" not found`
 
 This error means that `kube-apiserver` is up and the control plane endpoint is healthy, but the `kubelet` hasn't received
 its client certificate yet, and it wasn't able to register itself to Kubernetes.
@@ -304,10 +304,10 @@ If the control plane endpoint is up, the status of the pods can be ascertained w
 
 ```bash
 $ kubectl get pods -n kube-system -l k8s-app=kube-controller-manager
-NAME                                             READY   STATUS    RESTARTS   AGE
-kube-controller-manager-talos-default-master-1   1/1     Running   0          28m
-kube-controller-manager-talos-default-master-2   1/1     Running   0          28m
-kube-controller-manager-talos-default-master-3   1/1     Running   0          28m
+NAME                                                   READY   STATUS    RESTARTS   AGE
+kube-controller-manager-talos-default-controlplane-1   1/1     Running   0          28m
+kube-controller-manager-talos-default-controlplane-2   1/1     Running   0          28m
+kube-controller-manager-talos-default-controlplane-3   1/1     Running   0          28m
 ```
 
 If the control plane endpoint is not yet up, the container status of the control plane components can be queried with
@@ -315,12 +315,12 @@ If the control plane endpoint is not yet up, the container status of the control
 
 ```bash
 $ talosctl -n <IP> c -k
-NODE         NAMESPACE   ID                                                                                      IMAGE                                        PID    STATUS
+NODE         NAMESPACE   ID                                                                                            IMAGE                                        PID    STATUS
 ...
-172.20.0.2   k8s.io      kube-system/kube-controller-manager-talos-default-master-1                              k8s.gcr.io/pause:3.2                         2547   SANDBOX_READY
-172.20.0.2   k8s.io      └─ kube-system/kube-controller-manager-talos-default-master-1:kube-controller-manager   k8s.gcr.io/kube-controller-manager:v{{< k8s_release >}}   2580   CONTAINER_RUNNING
-172.20.0.2   k8s.io      kube-system/kube-scheduler-talos-default-master-1                                       k8s.gcr.io/pause:3.2                         2638   SANDBOX_READY
-172.20.0.2   k8s.io      └─ kube-system/kube-scheduler-talos-default-master-1:kube-scheduler                     k8s.gcr.io/kube-scheduler:v{{< k8s_release >}}            2670   CONTAINER_RUNNING
+172.20.0.2   k8s.io      kube-system/kube-controller-manager-talos-default-controlplane-1                              k8s.gcr.io/pause:3.2                         2547   SANDBOX_READY
+172.20.0.2   k8s.io      └─ kube-system/kube-controller-manager-talos-default-controlplane-1:kube-controller-manager   k8s.gcr.io/kube-controller-manager:v{{< k8s_release >}}   2580   CONTAINER_RUNNING
+172.20.0.2   k8s.io      kube-system/kube-scheduler-talos-default-controlplane-1                                       k8s.gcr.io/pause:3.2                         2638   SANDBOX_READY
+172.20.0.2   k8s.io      └─ kube-system/kube-scheduler-talos-default-controlplane-1:kube-scheduler                     k8s.gcr.io/kube-scheduler:v{{< k8s_release >}}            2670   CONTAINER_RUNNING
 ...
 ```
 
@@ -329,7 +329,7 @@ Otherwise the process might crashing.
 The logs can be checked with `talosctl logs --kubernetes <containerID>`:
 
 ```bash
-$ talosctl -n <IP> logs -k kube-system/kube-controller-manager-talos-default-master-1:kube-controller-manager
+$ talosctl -n <IP> logs -k kube-system/kube-controller-manager-talos-default-controlplane-1:kube-controller-manager
 172.20.0.3: 2021-03-09T13:59:34.291667526Z stderr F 2021/03/09 13:59:34 Running command:
 172.20.0.3: 2021-03-09T13:59:34.291702262Z stderr F Command env: (log-file=, also-stdout=false, redirect-stderr=true)
 172.20.0.3: 2021-03-09T13:59:34.291707121Z stderr F Run from directory:
@@ -416,10 +416,10 @@ The status of the static pods can queried with `talosctl get staticpodstatus`:
 
 ```bash
 $ talosctl -n <IP> get staticpodstatus
-NODE         NAMESPACE      TYPE              ID                                                           VERSION   READY
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-apiserver-talos-default-master-1            1         True
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-controller-manager-talos-default-master-1   1         True
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-scheduler-talos-default-master-1            1         True
+NODE         NAMESPACE      TYPE              ID                                                                 VERSION   READY
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-apiserver-talos-default-controlplane-1            1         True
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-controller-manager-talos-default-controlplane-1   1         True
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-scheduler-talos-default-controlplane-1            1         True
 ```
 
 The most important status field is `READY`, which is the last column printed.

--- a/website/content/v1.2/introduction/quickstart.md
+++ b/website/content/v1.2/introduction/quickstart.md
@@ -47,7 +47,7 @@ Verify that you can reach Kubernetes:
 ```bash
 $ kubectl get nodes -o wide
 NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
-talos-default-master-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
+talos-default-controlplane-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 talos-default-worker-1   Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 ```
 

--- a/website/content/v1.2/introduction/support-matrix.md
+++ b/website/content/v1.2/introduction/support-matrix.md
@@ -18,9 +18,9 @@ description: "Table of supported Talos Linux versions and respective platforms."
 | - SBCs                                                                                                         | Banana Pi M64, Jetson Nano, Libre Computer Board ALL-H3-CC, Pine64, Pine64 Rock64, Radxa ROCK Pi 4c, Raspberry Pi 4B | Banana Pi M64, Jetson Nano, Libre Computer Board ALL-H3-CC, Pine64, Pine64 Rock64, Radxa ROCK Pi 4c, Raspberry Pi 4B |
 | - local                                                                                                        | Docker, QEMU                       | Docker, QEMU                       |
 | **Cluster API**                                                                                                |                                    |                                    |
-| [CAPI Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)            | >= 0.5.4                           | >= 0.5.3                           |
-| [CAPI Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)    | >= 0.4.6                           | >= 0.4.6                           |
-| [Sidero](https://www.sidero.dev/)                                                                              | >= 0.5.1                           | >= 0.5.1                           |
+| [CAPI Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)            | >= 0.5.5                           | >= 0.5.3                           |
+| [CAPI Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)    | >= 0.4.8                           | >= 0.4.6                           |
+| [Sidero](https://www.sidero.dev/)                                                                              | >= 0.5.5                           | >= 0.5.4                           |
 | **UI**                                                                                                         |                                    |                                    |
 | [Theila](https://github.com/siderolabs/theila)                                                                 | ✓                                  | ✓                                  |
 

--- a/website/content/v1.2/introduction/what-is-new.md
+++ b/website/content/v1.2/introduction/what-is-new.md
@@ -4,4 +4,298 @@ weight: 50
 description: "List of new and shiny features in Talos Linux."
 ---
 
-TBD
+See also [upgrade notes]({{< relref "../talos-guides/upgrading-talos/">}}) for important changes.
+
+## Component Updates
+
+* Linux: 5.15.64
+* Flannel 0.19.1
+* containerd 1.6.8
+* runc: v1.1.4
+* Kubernetes: v1.25.0
+
+Talos is built with Go 1.19.
+
+## Kubernetes
+
+### Control Plane Labels and Taints
+
+Talos now defaults to `node-role.kubernetes.io/control-plane` label/taint.
+
+On upgrades Talos now removes the `node-role.kubernetes.io/master` label/taint on control-plane nodes and replaces it with the `node-role.kubernetes.io/control-plane` label/taint.
+Workloads that tolerate the old taints or have node selectors with the old labels will need to be updated.
+
+> Previously Talos labeled control plane nodes with both `control-plane` and `master` labels and tainted the node with `master` taint.
+
+### Scheduling on Control Plane Nodes
+
+Machine configuration `.cluster.allowSchedulingOnMasters` is deprecated and replaced by `.cluster.allowSchedulingOnControlPlanes`.
+The `.cluster.allowSchedulingOnMasters` will be removed in a future release of Talos.
+If both `.cluster.allowSchedulingOnMasters` and `.cluster.allowSchedulingOnControlPlanes` are set to `true`, the `.cluster.allowSchedulingOnControlPlanes` will be used.
+
+### Control Plane Components
+
+Talos now run all Kubernetes Control Plane Components with the CRI default Seccomp Profile and other recommendations as described in
+[KEP-2568](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane).
+
+### `k8s.gcr.io` Registry
+
+Talos now defaults to adding a registry mirror configuration in the machine configuration for `k8s.gcr.io` pointing to both `registry.k8s.io` and `k8s.gcr.io` unless overridden.
+
+This is in line with the Kubernetes 1.25 release having the new `registry.k8s.io` registry endpoint.
+
+This is only enabled by default on newly generated configurations and not on upgrades.
+This can be enabled with a machine configuration as follows:
+
+```yaml
+machine:
+  registries:
+    mirrors:
+      k8s.gcr.io:
+        endpoints:
+          - https://registry.k8s.io
+          - https://k8s.gcr.io
+```
+
+### `seccomp` Profiles
+
+Talos now supports creating custom seccomp profiles on the host machine which in turn can be used by Kubernetes workloads.
+It can be configured in the machine config as below:
+
+```yaml
+machine:
+  seccompProfiles:
+    - name: audit.json
+      value:
+        defaultAction: SCMP_ACT_LOG
+    - name: deny.json
+      value: {"defaultAction":"SCMP_ACT_LOG"}
+```
+
+This profile data can be either configured as a YAML definition or as a JSON string.
+
+The profiles are created on the host under `/var/lib/kubelet/seccomp/profiles`.
+
+### Default `seccomp` Profile
+
+Talos now runs Kubelet with the CRI default Seccomp Profile enabled.
+This can be disabled by setting `.machine.kubelet.defaultRuntimeSeccompProfileEnabled` to `false`.
+
+This feature is not enabled automatically on upgrades, so upgrading to Talos v1.2 needs this to be explicitly enabled.
+
+See [documentation]({{< relref "../kubernetes-guides/configuration/seccomp-profiles/" >}}) for more details.
+
+## Machine Configuration
+
+### Strategic Merge Patching
+
+In addition to JSON (RFC6902) patches Talos now supports [strategic merge patching]({{< relref "../talos-guides/configuration/patching/">}}).
+
+For example, machine hostname can be set with the following patch:
+
+```yaml
+machine:
+  network:
+    hostname: worker1
+```
+
+Patch format is detected automatically.
+
+### `talosctl apply-config`
+
+`talosctl apply-config` now supports patching the machine config file in memory before submitting it to the node.
+
+## Networking
+
+### Bridge Support
+
+Talos now supports configuration of Linux bridge interfaces:
+
+```yaml
+machine:
+  network:
+    interfaces:
+      - interface: br0
+        bridge:
+          stp:
+            enabled: true
+          interfaces:
+            - eth0
+            - eth1
+```
+
+See [configuration reference]({{< relref "../reference/configuration/#bridge" >}}) for more details.
+
+### VLANs
+
+Talos now supports dracut-style `vlan` kernel argument to allow
+installing Talos Linux in networks where ports are not tagged
+with a default VLAN:
+
+```text
+vlan=eth1.5:eth1 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1.5:::::
+```
+
+[Machine configuration]({{<relref "../reference/configuration#vlan" >}}) now supports specifying DHCP options for VLANs.
+
+### Stable Default Hostname
+
+Talos now generates the default hostname (when there is no explicitly specified hostname) for the nodes based on the
+node id (e.g. `talos-2gd-76y`) instead of using the DHCP assigned IP address (e.g. `talos-172-20-0-2`).
+
+This ensures that the node hostname is not changed when DHCP assigns a new IP to a node.
+
+> Note: the stable hostname generation algorithm changed between v1.2.0-beta.0 and v1.2.0-beta.1, please take care when upgrading
+> from versions >= 1.2.0-alpha.1 to versions >= 1.2.0-beta.1 when using stable default hostname feature.
+
+### Packet Capture
+
+Talos now supports capturing packets on a network interface with `talosctl pcap` command:
+
+```shell
+talosctl pcap --interface eth0
+```
+
+## Cluster Discovery and KubeSpan
+
+### KubeSpan Kubernetes Network Advertisement
+
+KubeSpan no longer by default advertises Kubernetes pod networks of the node over KubeSpan.
+This means that CNI should handle encapsulation of pod-to-pod traffic into the node-to-node tunnel,
+and node-to-node traffic will be handled by KubeSpan.
+This provides better compatibility with popular CNIs like Calico and Cilium.
+
+Old behavior can be restored by setting `.machine.kubespan.advertiseKubernetesNetworks = true` in the machine config.
+
+### Kubernetes Discovery Backend
+
+Kubernetes cluster discovery backend is now disabled by default for new clusters.
+This backend doesn't provide any benefits over the Discovery Service based backend, while it
+causes issues for KubeSpan enabled clusters when control plane endpoint is KubeSpan-routed.
+
+For air-gapped installations when the Discovery Service is not enabled, Kubernetes Discovery Backend can be enabled by applying
+the following machine configuration patch:
+
+```yaml
+cluster:
+  discovery:
+    registries:
+      kubernetes:
+        disabled: false
+```
+
+## `etcd`
+
+### Advertised and Listen Subnets
+
+Machine configuration setting `cluster.etcd.subnet` is deprecated, but still supported.
+
+Two new configuration settings are introduced to control precisely which subnet is used for etcd peer communication:
+
+```yaml
+cluster:
+  etcd:
+    advertisedSubnets:
+       - 10.0.0.0/24
+    listenSubnets:
+       - 10.0.0.0/24
+       - 192.168.0.0/24
+```
+
+The `advertisedSubnets` setting is used to control which subnet is used for etcd peer communication, it will be advertised
+by each peer for other peers to connect to.
+If `advertiseSubnets` is set, `listenSubnets` defaults to the same value, so that
+`etcd` only listens on the same subnet as it advertises.
+Additional subnets can be configured in `listenSubnets` if needed.
+
+Default behavior hasn't changed - if the `advertisedSubnets` is not set, Talos picks up the first available network address as
+an advertised address and `etcd` is configured to listen on all interfaces.
+
+> Note: most of the `etcd` configuration changes are accepted on the fly, but they are fully applied only after a reboot.
+
+## CLI
+
+### Tracking Progress of API Calls
+
+`talosctl` subcommands `shutdown`, `reboot`, `reset` and `upgrade` now have a new flag `--wait` to
+wait until the operation is completed, displaying information on the current status of each node.
+
+A new `--debug` flag is added to these commands to get the kernel logs output from these nodes if the operation fails.
+
+![track-cli-action-progress](/images/track-reboot.gif)
+
+## Integrations
+
+### Talos API access from Kubernetes
+
+Talos now supports access to its API from within Kubernetes.
+
+It can be configured in the machine config as below:
+
+```yaml
+machine:
+  features:
+    kubernetesTalosAPIAccess:
+      enabled: true
+      allowedRoles:
+        - os:reader
+      allowedKubernetesNamespaces:
+        - kube-system
+```
+
+This feature introduces a new custom resource definition, `serviceaccounts.talos.dev`.
+Creating custom resources of this type will provide credentials to access Talos API from within Kubernetes.
+
+The new CLI subcommand `talosctl inject serviceaccount` can be used to configure Kubernetes manifests with Talos service accounts as below:
+
+```shell
+talosctl inject serviceaccount -f manifests.yaml > manifests-injected.yaml
+kubectl apply -f manifests-injected.yaml
+```
+
+See [documentation]({{< relref "../advanced/talos-api-access-from-k8s/" >}}) for more details.
+
+## Migration
+
+### Migrating from `kubeadm`
+
+`talosctl gen` command supports generating a secrets bundle from a Kubernetes PKI directory (e.g. `/etc/kubernetes/pki`).
+
+This secrets bundle can then be used to generate a machine config.
+
+This facilitates [migrating clusters]({{< relref "../advanced/migrating-from-kubeadm" >}}) (e.g. created using `kubeadm`) to Talos.
+
+```shell
+talosctl gen secrets --kubernetes-bootstrap-token znzio1.1ifu15frz7jd59pv --from-kubernetes-pki /etc/kubernetes/pki
+talosctl gen config --with-secrets secrets.yaml my-cluster https://172.20.0.1:6443
+```
+
+## Platform Updates
+
+### Metal
+
+The kernel parameter `talos.config` can now substitute system information into placeholders inside its URL query values.
+
+This example shows all supported variables:
+
+```text
+http://example.com/metadata?h=${hostname}&m=${mac}&s=${serial}&u=${uuid}
+```
+
+## Extensions
+
+### NVIDIA GPU support promoted to beta
+
+NVIDIA GPU support on Talos has been promoted to beta and SideroLabs now publishes the NVIDIA Open GPU Kernel Modules as a system extension making it easier to run GPU workloads on Talos.
+Refer to enabling NVIDIA GPU support docs here:
+
+* [OSS Drivers]({{<relref "../talos-guides/configuration/nvidia-gpu/">}})
+* [Proprietary Drivers]({{<relref "../talos-guides/configuration/nvidia-gpu-proprietary/">}})
+* [Fabric Manager]({{<relref "../talos-guides/configuration/nvidia-fabricmanager/">}})
+
+## Deprecations
+
+`--masters` flag on `talosctl cluster create` is deprecated.
+Use `--controlplanes` instead.
+
+Machine configuration `.cluster.allowSchedulingOnMasters` is deprecated and replaced by `.cluster.allowSchedulingOnControlPlanes`.

--- a/website/content/v1.2/kubernetes-guides/configuration/cluster-endpoint.md
+++ b/website/content/v1.2/kubernetes-guides/configuration/cluster-endpoint.md
@@ -9,7 +9,7 @@ In this section, we will step through the configuration of a Talos based Kuberne
 There are three major components we will configure:
 
 - `apid` and `talosctl`
-- the master nodes
+- the controlplane nodes
 - the worker nodes
 
 Talos enforces a high level of security by using mutual TLS for authentication and authorization.

--- a/website/content/v1.2/kubernetes-guides/configuration/discovery.md
+++ b/website/content/v1.2/kubernetes-guides/configuration/discovery.md
@@ -74,12 +74,12 @@ An affiliate is a proposed member attributed to the fact that the node has the s
 
 ```sh
 $ talosctl get affiliates
-ID                                             VERSION   HOSTNAME                 MACHINE TYPE   ADDRESSES
-2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF    2         talos-default-master-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
-6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA   2         talos-default-worker-1   worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
-NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB   2         talos-default-worker-2   worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
-Utoh3O0ZneV0kT2IUBrh7TgdouRcUW2yzaaMl4VXnCd    4         talos-default-master-1   controlplane   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
-b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C   2         talos-default-master-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
+ID                                             VERSION   HOSTNAME                       MACHINE TYPE   ADDRESSES
+2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF    2         talos-default-controlplane-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
+6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA   2         talos-default-worker-1         worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
+NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB   2         talos-default-worker-2         worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
+Utoh3O0ZneV0kT2IUBrh7TgdouRcUW2yzaaMl4VXnCd    4         talos-default-controlplane-1   controlplane   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
+b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C   2         talos-default-controlplane-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
 ```
 
 One of the `Affiliates` with the `ID` matching node identity is populated from the node data, other `Affiliates` are pulled from the registries.
@@ -89,15 +89,15 @@ Details about data coming from each registry can be queried from the `cluster-ra
 
 ```sh
 $ talosctl get affiliates --namespace=cluster-raw
-ID                                                     VERSION   HOSTNAME                 MACHINE TYPE   ADDRESSES
-k8s/2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF        3         talos-default-master-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
-k8s/6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA       2         talos-default-worker-1   worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
-k8s/NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB       2         talos-default-worker-2   worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
-k8s/b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C       3         talos-default-master-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
-service/2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF    23        talos-default-master-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
-service/6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA   26        talos-default-worker-1   worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
-service/NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB   20        talos-default-worker-2   worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
-service/b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C   14        talos-default-master-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
+ID                                                     VERSION   HOSTNAME                       MACHINE TYPE   ADDRESSES
+k8s/2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF        3         talos-default-controlplane-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
+k8s/6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA       2         talos-default-worker-1         worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
+k8s/NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB       2         talos-default-worker-2         worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
+k8s/b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C       3         talos-default-controlplane-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
+service/2VfX3nu67ZtZPl57IdJrU87BMjVWkSBJiL9ulP9TCnF    23        talos-default-controlplane-2   controlplane   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
+service/6EVq8RHIne03LeZiJ60WsJcoQOtttw1ejvTS6SOBzhUA   26        talos-default-worker-1         worker         ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
+service/NVtfu1bT1QjhNq5xJFUZl8f8I8LOCnnpGrZfPpdN9WlB   20        talos-default-worker-2         worker         ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
+service/b3DebkPaCRLTLLWaeRF1ejGaR0lK3m79jRJcPn0mfA6C   14        talos-default-controlplane-3   controlplane   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
 ```
 
 Each `Affiliate` ID is prefixed with `k8s/` for data coming from the Kubernetes registry and with `service/` for data coming from the discovery service.
@@ -109,10 +109,10 @@ The members of the cluster can be obtained with:
 
 ```sh
 $ talosctl get members
-ID                       VERSION   HOSTNAME                 MACHINE TYPE   OS                ADDRESSES
-talos-default-master-1   2         talos-default-master-1   controlplane   Talos ({{< release >}})   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
-talos-default-master-2   1         talos-default-master-2   controlplane   Talos ({{< release >}})   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
-talos-default-master-3   1         talos-default-master-3   controlplane   Talos ({{< release >}})   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
-talos-default-worker-1   1         talos-default-worker-1   worker         Talos ({{< release >}})   ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
-talos-default-worker-2   1         talos-default-worker-2   worker         Talos ({{< release >}})   ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
+ID                             VERSION   HOSTNAME                       MACHINE TYPE   OS                ADDRESSES
+talos-default-controlplane-1   2         talos-default-controlplane-1   controlplane   Talos ({{< release >}})   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
+talos-default-controlplane-2   1         talos-default-controlplane-2   controlplane   Talos ({{< release >}})   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
+talos-default-controlplane-3   1         talos-default-controlplane-3   controlplane   Talos ({{< release >}})   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
+talos-default-worker-1         1         talos-default-worker-1         worker         Talos ({{< release >}})   ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
+talos-default-worker-2         1         talos-default-worker-2         worker         Talos ({{< release >}})   ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
 ```

--- a/website/content/v1.2/kubernetes-guides/network/kubespan.md
+++ b/website/content/v1.2/kubernetes-guides/network/kubespan.md
@@ -136,11 +136,11 @@ A node's WireGuard peers can be obtained with:
 
 ```sh
 $ talosctl get kubespanpeerspecs
-ID                                             VERSION   LABEL                    ENDPOINTS
-06D9QQOydzKrOL7oeLiqHy9OWE8KtmJzZII2A5/FLFI=   2         talos-default-master-2   ["172.20.0.3:51820"]
-THtfKtfNnzJs1nMQKs5IXqK0DFXmM//0WMY+NnaZrhU=   2         talos-default-master-3   ["172.20.0.4:51820"]
-nVHu7l13uZyk0AaI1WuzL2/48iG8af4WRv+LWmAax1M=   2         talos-default-worker-2   ["172.20.0.6:51820"]
-zXP0QeqRo+CBgDH1uOBiQ8tA+AKEQP9hWkqmkE/oDlc=   2         talos-default-worker-1   ["172.20.0.5:51820"]
+ID                                             VERSION   LABEL                          ENDPOINTS
+06D9QQOydzKrOL7oeLiqHy9OWE8KtmJzZII2A5/FLFI=   2         talos-default-controlplane-2   ["172.20.0.3:51820"]
+THtfKtfNnzJs1nMQKs5IXqK0DFXmM//0WMY+NnaZrhU=   2         talos-default-controlplane-3   ["172.20.0.4:51820"]
+nVHu7l13uZyk0AaI1WuzL2/48iG8af4WRv+LWmAax1M=   2         talos-default-worker-2         ["172.20.0.6:51820"]
+zXP0QeqRo+CBgDH1uOBiQ8tA+AKEQP9hWkqmkE/oDlc=   2         talos-default-worker-1         ["172.20.0.5:51820"]
 ```
 
 The peer ID is the Wireguard public key.
@@ -152,11 +152,11 @@ The status of a node's WireGuard peers can be obtained with:
 
 ```sh
 $ talosctl get kubespanpeerstatuses
-ID                                             VERSION   LABEL                    ENDPOINT           STATE   RX         TX
-06D9QQOydzKrOL7oeLiqHy9OWE8KtmJzZII2A5/FLFI=   63        talos-default-master-2   172.20.0.3:51820   up      15043220   17869488
-THtfKtfNnzJs1nMQKs5IXqK0DFXmM//0WMY+NnaZrhU=   62        talos-default-master-3   172.20.0.4:51820   up      14573208   18157680
-nVHu7l13uZyk0AaI1WuzL2/48iG8af4WRv+LWmAax1M=   60        talos-default-worker-2   172.20.0.6:51820   up      130072     46888
-zXP0QeqRo+CBgDH1uOBiQ8tA+AKEQP9hWkqmkE/oDlc=   60        talos-default-worker-1   172.20.0.5:51820   up      130044     46556
+ID                                             VERSION   LABEL                          ENDPOINT           STATE   RX         TX
+06D9QQOydzKrOL7oeLiqHy9OWE8KtmJzZII2A5/FLFI=   63        talos-default-controlplane-2   172.20.0.3:51820   up      15043220   17869488
+THtfKtfNnzJs1nMQKs5IXqK0DFXmM//0WMY+NnaZrhU=   62        talos-default-controlplane-3   172.20.0.4:51820   up      14573208   18157680
+nVHu7l13uZyk0AaI1WuzL2/48iG8af4WRv+LWmAax1M=   60        talos-default-worker-2         172.20.0.6:51820   up      130072     46888
+zXP0QeqRo+CBgDH1uOBiQ8tA+AKEQP9hWkqmkE/oDlc=   60        talos-default-worker-1         172.20.0.5:51820   up      130044     46556
 ```
 
 KubeSpan peer status includes following information:

--- a/website/content/v1.2/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.2/kubernetes-guides/upgrading-kubernetes.md
@@ -22,14 +22,14 @@ Upgrading Kubernetes is non-disruptive to the cluster workloads.
 
 To trigger a Kubernetes upgrade, issue a command specifiying the version of Kubernetes to ugprade to, such as:
 
-`talosctl --nodes <master node> upgrade-k8s --to {{< k8s_release >}}`
+`talosctl --nodes <controlplane node> upgrade-k8s --to {{< k8s_release >}}`
 
 Note that the `--nodes` parameter specifies the control plane node to send the API call to, but all members of the cluster will be upgraded.
 
 To check what will be upgraded you can run `talosctl upgrade-k8s` with the `--dry-run` flag:
 
 ```bash
-$ talosctl --nodes <master node> upgrade-k8s --to {{< k8s_release >}} --dry-run
+$ talosctl --nodes <controlplane node> upgrade-k8s --to {{< k8s_release >}} --dry-run
 WARNING: found resources which are going to be deprecated/migrated in the version {{< k8s_release >}}
 RESOURCE                                                               COUNT
 validatingwebhookconfigurations.v1beta1.admissionregistration.k8s.io   4
@@ -39,7 +39,7 @@ apiservices.v1beta1.apiregistration.k8s.io                             54
 leases.v1beta1.coordination.k8s.io                                     4
 automatically detected the lowest Kubernetes version {{< k8s_prev_release >}}
 checking for resource APIs to be deprecated in version {{< k8s_release >}}
-discovered master nodes ["172.20.0.2" "172.20.0.3" "172.20.0.4"]
+discovered controlplane nodes ["172.20.0.2" "172.20.0.3" "172.20.0.4"]
 discovered worker nodes ["172.20.0.5" "172.20.0.6"]
 updating "kube-apiserver" to version "{{< k8s_release >}}"
  > "172.20.0.2": starting update
@@ -70,10 +70,10 @@ updating manifests
 To upgrade Kubernetes from v{{< k8s_prev_release >}} to v{{< k8s_release >}} run:
 
 ```bash
-$ talosctl --nodes <master node> upgrade-k8s --to {{< k8s_release >}}
+$ talosctl --nodes <controlplane node> upgrade-k8s --to {{< k8s_release >}}
 automatically detected the lowest Kubernetes version {{< k8s_prev_release >}}
 checking for resource APIs to be deprecated in version {{< k8s_release >}}
-discovered master nodes ["172.20.0.2" "172.20.0.3" "172.20.0.4"]
+discovered controlplane nodes ["172.20.0.2" "172.20.0.3" "172.20.0.4"]
 discovered worker nodes ["172.20.0.5" "172.20.0.6"]
 updating "kube-apiserver" to version "{{< k8s_release >}}"
  > "172.20.0.2": starting update
@@ -112,7 +112,7 @@ In order to edit the control plane, you need a working `kubectl` config.
 If you don't already have one, you can get one by running:
 
 ```bash
-talosctl --nodes <master node> kubeconfig
+talosctl --nodes <controlplane node> kubeconfig
 ```
 
 ### API Server
@@ -152,19 +152,19 @@ spec:
 ```
 
 In this example, the new version is `5`.
-Wait for the new pod definition to propagate to the API server state (replace `talos-default-master-1` with the node name):
+Wait for the new pod definition to propagate to the API server state (replace `talos-default-controlplane-1` with the node name):
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-apiserver --field-selector spec.nodeName=talos-default-master-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
+$ kubectl get pod -n kube-system -l k8s-app=kube-apiserver --field-selector spec.nodeName=talos-default-controlplane-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
 5
 ```
 
 Check that the pod is running:
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-apiserver --field-selector spec.nodeName=talos-default-master-1
+$ kubectl get pod -n kube-system -l k8s-app=kube-apiserver --field-selector spec.nodeName=talos-default-controlplane-1
 NAME                                    READY   STATUS    RESTARTS   AGE
-kube-apiserver-talos-default-master-1   1/1     Running   0          16m
+kube-apiserver-talos-default-controlplane-1   1/1     Running   0          16m
 ```
 
 Repeat this process for every control plane node, verifying that state got propagated successfully between each node update.
@@ -201,19 +201,19 @@ spec:
 ```
 
 In this example, new version is `3`.
-Wait for the new pod definition to propagate to the API server state (replace `talos-default-master-1` with the node name):
+Wait for the new pod definition to propagate to the API server state (replace `talos-default-controlplane-1` with the node name):
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-controller-manager --field-selector spec.nodeName=talos-default-master-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
+$ kubectl get pod -n kube-system -l k8s-app=kube-controller-manager --field-selector spec.nodeName=talos-default-controlplane-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
 3
 ```
 
 Check that the pod is running:
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-controller-manager --field-selector spec.nodeName=talos-default-master-1
+$ kubectl get pod -n kube-system -l k8s-app=kube-controller-manager --field-selector spec.nodeName=talos-default-controlplane-1
 NAME                                             READY   STATUS    RESTARTS   AGE
-kube-controller-manager-talos-default-master-1   1/1     Running   0          35m
+kube-controller-manager-talos-default-controlplane-1   1/1     Running   0          35m
 ```
 
 Repeat this process for every control plane node, verifying that state propagated successfully between each node update.
@@ -247,19 +247,19 @@ spec:
 ```
 
 In this example, new version is `3`.
-Wait for the new pod definition to propagate to the API server state (replace `talos-default-master-1` with the node name):
+Wait for the new pod definition to propagate to the API server state (replace `talos-default-controlplane-1` with the node name):
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-scheduler --field-selector spec.nodeName=talos-default-master-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
+$ kubectl get pod -n kube-system -l k8s-app=kube-scheduler --field-selector spec.nodeName=talos-default-controlplane-1 -o jsonpath='{.items[0].metadata.annotations.talos\.dev/config\-version}'
 3
 ```
 
 Check that the pod is running:
 
 ```bash
-$ kubectl get pod -n kube-system -l k8s-app=kube-scheduler --field-selector spec.nodeName=talos-default-master-1
+$ kubectl get pod -n kube-system -l k8s-app=kube-scheduler --field-selector spec.nodeName=talos-default-controlplane-1
 NAME                                    READY   STATUS    RESTARTS   AGE
-kube-scheduler-talos-default-master-1   1/1     Running   0          39m
+kube-scheduler-talos-default-controlplane-1   1/1     Running   0          39m
 ```
 
 Repeat this process for every control plane node, verifying that state got propagated successfully between each node update.
@@ -314,7 +314,7 @@ kubectl edit daemonsets -n kube-system kube-proxy
 Bootstrap manifests can be retrieved in a format which works for `kubectl` with the following command:
 
 ```bash
-talosctl -n <master IP> get manifests -o yaml | yq eval-all '.spec | .[] | splitDoc' - > manifests.yaml
+talosctl -n <controlplane IP> get manifests -o yaml | yq eval-all '.spec | .[] | splitDoc' - > manifests.yaml
 ```
 
 Diff the manifests with the cluster:
@@ -343,7 +343,7 @@ patched mc at the node 172.20.0.2
 Once `kubelet` restarts with the new configuration, confirm upgrade with `kubectl get nodes <name>`:
 
 ```bash
-$ kubectl get nodes talos-default-master-1
-NAME                     STATUS   ROLES                  AGE    VERSION
-talos-default-master-1   Ready    control-plane,master   123m   v{{< k8s_release >}}
+$ kubectl get nodes talos-default-controlplane-1
+NAME                           STATUS   ROLES                  AGE    VERSION
+talos-default-controlplane-1   Ready    control-plane          123m   v{{< k8s_release >}}
 ```

--- a/website/content/v1.2/learn-more/controllers-resources.md
+++ b/website/content/v1.2/learn-more/controllers-resources.md
@@ -171,9 +171,9 @@ Getting control plane static pod statuses:
 ```bash
 $ talosctl get staticpodstatus
 NODE         NAMESPACE      TYPE              ID                                                           VERSION   READY
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-apiserver-talos-default-master-1            3         True
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-controller-manager-talos-default-master-1   3         True
-172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-scheduler-talos-default-master-1            4         True
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-apiserver-talos-default-controlplane-1            3         True
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-controller-manager-talos-default-controlplane-1   3         True
+172.20.0.2   controlplane   StaticPodStatus   kube-system/kube-scheduler-talos-default-controlplane-1            4         True
 ```
 
 Getting static pod definition for `kube-apiserver`:

--- a/website/content/v1.2/learn-more/networking-resources.md
+++ b/website/content/v1.2/learn-more/networking-resources.md
@@ -202,19 +202,19 @@ metadata:
     finalizers:
         - network.HostnameSpecController
 spec:
-    hostname: talos-default-master-1
+    hostname: talos-default-controlplane-1
     domainname: ""
     layer: operator
 ```
 
-We can see that the final configuration for the hostname is `talos-default-master-1`.
+We can see that the final configuration for the hostname is `talos-default-controlplane-1`.
 And this is the hostname that was actually applied.
 This can be verified by querying a `HostnameStatus` resource:
 
 ```sh
 $ talosctl get hostnamestatus
 NODE         NAMESPACE   TYPE             ID         VERSION   HOSTNAME                 DOMAINNAME
-172.20.0.2   network     HostnameStatus   hostname   1         talos-default-master-1
+172.20.0.2   network     HostnameStatus   hostname   1         talos-default-controlplane-1
 ```
 
 Initial configuration for the hostname in the `network-config` namespace is:
@@ -247,7 +247,7 @@ metadata:
     created: 2021-06-29T20:23:18Z
     updated: 2021-06-29T20:23:18Z
 spec:
-    hostname: talos-default-master-1
+    hostname: talos-default-controlplane-1
     domainname: ""
     layer: operator
 ```
@@ -255,7 +255,7 @@ spec:
 We can see that there are two specs for the hostname:
 
 * one from the `default` configuration layer which defines the hostname as `talos-172-20-0-2` (default driven by the default node address);
-* another one from the layer `operator` that defines the hostname as `talos-default-master-1` (DHCP).
+* another one from the layer `operator` that defines the hostname as `talos-default-controlplane-1` (DHCP).
 
 Talos merges these two specs into a final `HostnameSpec` based on the configuration layer and merge rules.
 Here is the order of precedence from low to high:
@@ -266,7 +266,7 @@ Here is the order of precedence from low to high:
 * `operator` (various dynamic configuration options: DHCP, Virtual IP, etc);
 * `configuration` (derived from the machine configuration).
 
-So in our example the `operator` layer `HostnameSpec` overrides the `default` layer producing the final hostname `talos-default-master-1`.
+So in our example the `operator` layer `HostnameSpec` overrides the `default` layer producing the final hostname `talos-default-controlplane-1`.
 
 The merge process applies to all six core networking specs.
 For each spec, the `layer` controls the merge behavior

--- a/website/content/v1.2/reference/kernel.md
+++ b/website/content/v1.2/reference/kernel.md
@@ -12,170 +12,173 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 
 **Required** parameters:
 
-- `talos.config`: the HTTP(S) URL at which the machine configuration data can be found
-- `talos.platform`: can be one of `aws`, `azure`, `container`, `digitalocean`, `gcp`, `metal`, `equinixMetal`, or `vmware`
-- `init_on_alloc=1`: required by KSPP
-- `slab_nomerge`: required by KSPP
-- `pti=on`: required by KSPP
+* `talos.config`: the HTTP(S) URL at which the machine configuration data can be found
+* `talos.platform`: can be one of `aws`, `azure`, `container`, `digitalocean`, `gcp`, `metal`, `equinixMetal`, or `vmware`
+* `init_on_alloc=1`: required by KSPP
+* `slab_nomerge`: required by KSPP
+* `pti=on`: required by KSPP
 
 **Recommended** parameters:
 
- - `init_on_free=1`: advised by KSPP if minimizing stale data lifetime is
+* `init_on_free=1`: advised by KSPP if minimizing stale data lifetime is
      important
 
 ### Available Talos-specific parameters
 
 #### `ip`
 
-  Initial configuration of the interface, routes, DNS, NTP servers.
+Initial configuration of the interface, routes, DNS, NTP servers.
 
-  Full documentation is available in the [Linux kernel docs](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt).
+Full documentation is available in the [Linux kernel docs](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt).
 
-  `ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>`
+`ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>`
 
-  Talos will use the configuration supplied via the kernel parameter as the initial network configuration.
-  This parameter is useful in the environments where DHCP doesn't provide IP addresses or when default DNS and NTP servers should be overridden
-  before loading machine configuration.
-  Partial configuration can be applied as well, e.g. `ip=<:::::::<dns0-ip>:<dns1-ip>:<ntp0-ip>` sets only the DNS and NTP servers.
+Talos will use the configuration supplied via the kernel parameter as the initial network configuration.
+This parameter is useful in the environments where DHCP doesn't provide IP addresses or when default DNS and NTP servers should be overridden
+before loading machine configuration.
+Partial configuration can be applied as well, e.g. `ip=<:::::::<dns0-ip>:<dns1-ip>:<ntp0-ip>` sets only the DNS and NTP servers.
 
-  IPv6 addresses can be specified by enclosing them in the square brackets, e.g. `ip=[2001:db8::a]:[2001:db8::b]:[fe80::1]::master1:eth1::[2001:4860:4860::6464]:[2001:4860:4860::64]:[2001:4860:4806::]`.
+IPv6 addresses can be specified by enclosing them in the square brackets, e.g. `ip=[2001:db8::a]:[2001:db8::b]:[fe80::1]::controlplane1:eth1::[2001:4860:4860::6464]:[2001:4860:4860::64]:[2001:4860:4806::]`.
 
 #### `bond`
 
-  Bond interface configuration.
+Bond interface configuration.
 
-  Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
+Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
 
-  `bond=<bondname>:<bondslaves>:<options>:<mtu>`
+`bond=<bondname>:<bondslaves>:<options>:<mtu>`
 
-  Talos will use the `bond=` kernel parameter if supplied to set the initial bond configuration.
-  This parameter is useful in environments where the switch ports are suspended if the machine doesn't setup a LACP bond.
+Talos will use the `bond=` kernel parameter if supplied to set the initial bond configuration.
+This parameter is useful in environments where the switch ports are suspended if the machine doesn't setup a LACP bond.
 
-  If only the bond name is supplied, the bond will be created with `eth0` and `eth1` as slaves and bond mode set as `balance-rr`
+If only the bond name is supplied, the bond will be created with `eth0` and `eth1` as slaves and bond mode set as `balance-rr`
 
-  All these below configurations are equivalent:
+All these below configurations are equivalent:
 
-  * `bond=bond0`
-  * `bond=bond0:`
-  * `bond=bond0::`
-  * `bond=bond0:::`
-  * `bond=bond0:eth0,eth1`
-  * `bond=bond0:eth0,eth1:balance-rr`
+* `bond=bond0`
+* `bond=bond0:`
+* `bond=bond0::`
+* `bond=bond0:::`
+* `bond=bond0:eth0,eth1`
+* `bond=bond0:eth0,eth1:balance-rr`
 
-  An example of a bond configuration with all options specified:
+An example of a bond configuration with all options specified:
 
-  `bond=bond1:eth3,eth4:mode=802.3ad,xmit_hash_policy=layer2+3:1450`
+`bond=bond1:eth3,eth4:mode=802.3ad,xmit_hash_policy=layer2+3:1450`
 
-  This will create a bond interface named `bond1` with `eth3` and `eth4` as slaves and set the bond mode to `802.3ad`, the transmit hash policy to `layer2+3` and bond interface MTU to 1450.
+This will create a bond interface named `bond1` with `eth3` and `eth4` as slaves and set the bond mode to `802.3ad`, the transmit hash policy to `layer2+3` and bond interface MTU to 1450.
 
 #### `vlan`
 
-  The interface vlan configuration.
+The interface vlan configuration.
 
-  Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
+Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
 
-  Talos will use the `vlan=` kernel parameter if supplied to set the initial vlan configuration.
-  This parameter is useful in environments where the switch ports are VLAN tagged with no native VLAN.
+Talos will use the `vlan=` kernel parameter if supplied to set the initial vlan configuration.
+This parameter is useful in environments where the switch ports are VLAN tagged with no native VLAN.
 
-  Only one vlan can be configured at this stage.
+Only one vlan can be configured at this stage.
 
-  An example of a vlan configuration including static ip configuration:
+An example of a vlan configuration including static ip configuration:
 
-  `vlan=eth0.100:eth0 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth0.100:::::`
+`vlan=eth0.100:eth0 ip=172.20.0.2::172.20.0.1:255.255.255.0::eth0.100:::::`
 
-  This will create a vlan interface named `eth0.100` with `eth0` as the underlying interface and set the vlan id to 100 with static IP 172.20.0.2/24 and 172.20.0.1 as default gateway.
+This will create a vlan interface named `eth0.100` with `eth0` as the underlying interface and set the vlan id to 100 with static IP 172.20.0.2/24 and 172.20.0.1 as default gateway.
 
 #### `panic`
 
-  The amount of time to wait after a panic before a reboot is issued.
+The amount of time to wait after a panic before a reboot is issued.
 
-  Talos will always reboot if it encounters an unrecoverable error.
-  However, when collecting debug information, it may reboot too quickly for
-  humans to read the logs.
-  This option allows the user to delay the reboot to give time to collect debug
-  information from the console screen.
+Talos will always reboot if it encounters an unrecoverable error.
+However, when collecting debug information, it may reboot too quickly for
+humans to read the logs.
+This option allows the user to delay the reboot to give time to collect debug
+information from the console screen.
 
-  A value of `0` disables automatic rebooting entirely.
+A value of `0` disables automatic rebooting entirely.
 
 #### `talos.config`
 
-  The URL at which the machine configuration data may be found.
-  
-  This parameter supports variable substitution inside URL query values for the following case-insensitive placeholders:
-  
-  * `${uuid}` the SMBIOS UUID
-  * `${serial}` the SMBIOS Serial Number
-  * `${mac}` the MAC address of the first network interface attaining link state `up`
-  * `${hostname}` the hostname of the machine
-  
-  The following example
+The URL at which the machine configuration data may be found.
 
-  `http://example.com/metadata?h=${hostname}&m=${mac}&s=${serial}&u=${uuid}`
-  
-  may translate to
-  
-  `http://example.com/metadata?h=myTestHostname&m=52%3A2f%3Afd%3Adf%3Afc%3Ac0&s=0OCZJ19N65&u=40dcbd19-3b10-444e-bfff-aaee44a51fda`
-  
-  For backwards compatibility we insert the system UUID into the query parameter `uuid` if its value is empty. As in
+This parameter supports variable substitution inside URL query values for the following case-insensitive placeholders:
 
-  `http://example.com/metadata?uuid=` => `http://example.com/metadata?uuid=40dcbd19-3b10-444e-bfff-aaee44a51fda`
+* `${uuid}` the SMBIOS UUID
+* `${serial}` the SMBIOS Serial Number
+* `${mac}` the MAC address of the first network interface attaining link state `up`
+* `${hostname}` the hostname of the machine
+
+The following example
+
+`http://example.com/metadata?h=${hostname}&m=${mac}&s=${serial}&u=${uuid}`
+
+may translate to
+
+`http://example.com/metadata?h=myTestHostname&m=52%3A2f%3Afd%3Adf%3Afc%3Ac0&s=0OCZJ19N65&u=40dcbd19-3b10-444e-bfff-aaee44a51fda`
+
+For backwards compatibility we insert the system UUID into the query parameter `uuid` if its value is empty. As in
+`http://example.com/metadata?uuid=` => `http://example.com/metadata?uuid=40dcbd19-3b10-444e-bfff-aaee44a51fda`
 
 #### `talos.platform`
 
-  The platform name on which Talos will run.
+The platform name on which Talos will run.
 
-  Valid options are:
-    - `aws`
-    - `azure`
-    - `container`
-    - `digitalocean`
-    - `gcp`
-    - `metal`
-    - `equinixMetal`
-    - `vmware`
+Valid options are:
+
+* `aws`
+* `azure`
+* `container`
+* `digitalocean`
+* `gcp`
+* `metal`
+* `equinixMetal`
+* `vmware`
 
 #### `talos.board`
 
-  The board name, if Talos is being used on an ARM64 SBC.
+The board name, if Talos is being used on an ARM64 SBC.
 
-  Supported boards are:
-    - `bananapi_m64`: Banana Pi M64
-    - `libretech_all_h3_cc_h5`: Libre Computer ALL-H3-CC
-    - `rock64`: Pine64 Rock64
-    - `rpi_4`: Raspberry Pi 4, Model B
+Supported boards are:
+
+* `bananapi_m64`: Banana Pi M64
+* `libretech_all_h3_cc_h5`: Libre Computer ALL-H3-CC
+* `rock64`: Pine64 Rock64
+* `rpi_4`: Raspberry Pi 4, Model B
 
 #### `talos.hostname`
 
-  The hostname to be used.
-  The hostname is generally specified in the machine config.
-  However, in some cases, the DHCP server needs to know the hostname
-  before the machine configuration has been acquired.
+The hostname to be used.
+The hostname is generally specified in the machine config.
+However, in some cases, the DHCP server needs to know the hostname
+before the machine configuration has been acquired.
 
-  Unless specifically required, the machine configuration should be used
-  instead.
+Unless specifically required, the machine configuration should be used
+instead.
 
 #### `talos.shutdown`
 
-  The type of shutdown to use when Talos is told to shutdown.
+The type of shutdown to use when Talos is told to shutdown.
 
-  Valid options are:
-    - `halt`
-    - `poweroff`
+Valid options are:
+
+* `halt`
+* `poweroff`
 
 #### `talos.network.interface.ignore`
 
-  A network interface which should be ignored and not configured by Talos.
+A network interface which should be ignored and not configured by Talos.
 
-  Before a configuration is applied (early on each boot), Talos attempts to
-  configure each network interface by DHCP.
-  If there are many network interfaces on the machine which have link but no
-  DHCP server, this can add significant boot delays.
+Before a configuration is applied (early on each boot), Talos attempts to
+configure each network interface by DHCP.
+If there are many network interfaces on the machine which have link but no
+DHCP server, this can add significant boot delays.
 
-  This option may be specified multiple times for multiple network interfaces.
+This option may be specified multiple times for multiple network interfaces.
 
 #### `talos.experimental.wipe`
 
-  Resets the disk before starting up the system.
+Resets the disk before starting up the system.
 
-  Valid options are:
-    - `system` resets system disk.
+Valid options are:
+
+* `system` resets system disk.

--- a/website/content/v1.2/talos-guides/install/cloud-platforms/nocloud.md
+++ b/website/content/v1.2/talos-guides/install/cloud-platforms/nocloud.md
@@ -1,7 +1,7 @@
 ---
 title: "Nocloud"
 description: "Creating a cluster via the CLI using qemu."
-aliases: 
+aliases:
   - ../../../cloud-platforms/nocloud
 ---
 
@@ -114,14 +114,14 @@ Edit the cloud-init config information in Proxmox as follows, substitute your ow
 and then update ```cicustom``` param at `/etc/pve/qemu-server/$ID.conf`.
 
 ```config
-cicustom: user=local:snippets/master-1.yml
+cicustom: user=local:snippets/controlplane-1.yml
 ipconfig0: ip=192.168.1.10/24,gw=192.168.10.254
 nameserver: 1.1.1.1
 searchdomain: local
 ```
 
-> Note: `snippets/master-1.yml` is Talos machine config.
-It is usually located at `/var/lib/vz/snippets/master-1.yml`.
+> Note: `snippets/controlplane-1.yml` is Talos machine config.
+It is usually located at `/var/lib/vz/snippets/controlplane-1.yml`.
 This file must be placed to this path manually, as Proxmox does not support snippet uploading via API/GUI.
 
 Click on `Regenerate Image` button after the above changes are made.

--- a/website/content/v1.2/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.2/talos-guides/install/local-platforms/qemu.md
@@ -118,11 +118,11 @@ NETWORK MTU       1500
 
 NODES:
 
-NAME                     TYPE           IP         CPU    RAM      DISK
-talos-default-master-1   Init           10.5.0.2   1.00   1.6 GB   4.3 GB
-talos-default-master-2   ControlPlane   10.5.0.3   1.00   1.6 GB   4.3 GB
-talos-default-master-3   ControlPlane   10.5.0.4   1.00   1.6 GB   4.3 GB
-talos-default-worker-1   Worker         10.5.0.5   1.00   1.6 GB   4.3 GB
+NAME                           TYPE           IP         CPU    RAM      DISK
+talos-default-controlplane-1   ControlPlane   10.5.0.2   1.00   1.6 GB   4.3 GB
+talos-default-controlplane-2   ControlPlane   10.5.0.3   1.00   1.6 GB   4.3 GB
+talos-default-controlplane-3   ControlPlane   10.5.0.4   1.00   1.6 GB   4.3 GB
+talos-default-worker-1         Worker         10.5.0.5   1.00   1.6 GB   4.3 GB
 ```
 
 ## Cleaning Up

--- a/website/content/v1.2/talos-guides/upgrading-talos.md
+++ b/website/content/v1.2/talos-guides/upgrading-talos.md
@@ -25,6 +25,20 @@ This means an upgrade of the Talos Linux OS will not apply an upgrade of the Kub
 Kubernetes upgrades should be managed separately per [upgrading kubernetes]({{< relref "../kubernetes-guides/upgrading-kubernetes" >}}).
 Each release of Talos Linux includes the latest stable Kubernetes version by default.
 
+## Before Upgrade to {{% release %}}
+
+### PodSecurityPolicy removal
+
+`PodSecurityPolicy` is removed in Kubernetes 1.25, so make sure that it is disabled on Talos side before trying to use Kubernetes 1.25:
+
+```yaml
+cluster:
+  apiServer:
+    disablePodSecurityPolicy: true
+```
+
+This setting defaulted to `true` since Talos v1.0.0 release.
+
 ## Video Walkthrough
 
 To see a live demo of an upgrade of Talos Linux, see the video below:
@@ -56,11 +70,11 @@ However, if you are running a single-node control-plane, you will want to make s
 Rarely, a upgrade command will fail to run due to a process holding a file open on disk, or you may wish to set a node to upgrade, but delay the actual reboot as long as possible.
 In these cases, you can use the `--stage` flag.
 This puts the upgrade artifacts on disk, and adds some metadata to a disk partition that gets checked very early in the boot process.
-The node is *not* rebooted by the `upgrade --stage` process.
-However, whenever the system does next reboot, Talos sees that it needs to apply an upgrade, and will do so immediately.
+Finally, the node is rebooted by the `upgrade --stage` process.
+On the reboot, Talos sees that it needs to apply an upgrade, and will do so immediately.
 Because this occurs in a just rebooted system, there will be no conflict with any files being held open.
 After the upgrade is applied, the node will reboot again, in order to boot into the new version.
-Note that because Talos Linux now reboots via the kexec syscall, the extra reboot adds very little time.
+Note that because Talos Linux now reboots via the `kexec` syscall, the extra reboot adds very little time.
 
 <!--
 ## Talos Controller Manager
@@ -81,7 +95,16 @@ future.
 
 ## Machine Configuration Changes
 
-TBD
+* [`.machine.features.stableHostname`]({{<relref "../reference/configuration#featuresconfig" >}}) allows to generate a default hostname based on machine IDs
+* [`.machine.features.kubernetesTalosAPIAccess`]({{<relref "../reference/configuration#featuresconfig" >}}) configures [Talos API access from Kubernetes]({{<relref "../advanced/talos-api-access-from-k8s">}}) feature
+* [`.machine.kubelet.defaultRuntimeSeccompProfileEnabled`]({{<relref "../reference/configuration#kubeletconfig" >}}) enables seccomp profile by default for Kubernetes workloads
+* [`.machine.kubelet.skipNodeRegistration`]({{<relref "../reference/configuration#kubeletconfig" >}}) allows to skip Kubernetes node registration (node only runs static pods)
+* [`.machine.network.interfaces`]({{<relref "../reference/configuration#device" >}}) supports bridge interfaces
+* [`.machine.network.interfaces.*.vlan`]({{<relref "../reference/configuration#vlan" >}}) supports DHCP settings for VLANs
+* [`.machine.network.kubespan.advertiseKubernetesNetworks`]({{<relref "../reference/configuration#networkkubespan" >}}) controls whether KubeSpan advertises Kubernetes pod networks or just host networks (defaults to false in 1.2.0)
+* [`.machine.seccompProfiles`]({{<relref "../reference/configuration#machineseccompprofile" >}}) configures additional seccomp profiles
+* `.cluster.allowSchedulingOnMasters` renamed to `.cluster.allowSchedulingOnControlPlanes`, old setting is still supported
+* [`.cluster.etcd`]({{<relref "../reference/configuration#etcdconfig" >}}) now has more options to configure etcd advertised and listen subnets, old settings are still supported
 
 ## Upgrade Sequence
 


### PR DESCRIPTION
Update what's new, upgrading docs.

Fix up instances of `master` leftover in the docs.

Fix the formatting of kernel params reference.

Fixes #6150

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
