### PR TITLE
docs: make 1.2.0 docs default ones

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -108,7 +108,7 @@ version_menu = "Releases"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/v1.1"
+url_latest_version = "/v1.2"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 # github_repo = "https://github.com/googley-example"
@@ -137,11 +137,11 @@ prism_syntax_highlighting = false
 
 [[params.versions]]
 url = "/v1.2/"
-version = "v1.2 (pre-release)"
+version = "v1.2 (latest)"
 
 [[params.versions]]
 url = "/v1.1/"
-version = "v1.1 (latest)"
+version = "v1.1"
 
 [[params.versions]]
 url = "/v1.0/"

--- a/website/content/v1.1/_index.md
+++ b/website/content/v1.1/_index.md
@@ -10,7 +10,6 @@ kubernetesRelease: "1.24.2"
 prevKubernetesRelease: "1.23.5"
 iscsiToolsRelease: "v0.1.1"
 theilaRelease: "v0.2.1"
-menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.2/_index.md
+++ b/website/content/v1.2/_index.md
@@ -4,13 +4,13 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-preRelease: true
-lastRelease: v1.2.0-beta.2
+lastRelease: v1.2.0
 kubernetesRelease: "v1.25.0"
 prevKubernetesRelease: "1.24.3"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.10.0"
 nvidiaDriverRelease: "515.65.01"
+menu: main
 ---
 
 ## Welcome


### PR DESCRIPTION
Update latest release to 1.2.0.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
