### PR TITLE
fix: flip the client-server version check

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -66,8 +66,8 @@ func ClientVersionCheck(ctx context.Context, c *client.Client) error {
 			return fmt.Errorf("%s: error parsing server version: %w", node, err)
 		}
 
-		if serverVersion.Compare(clientVersion) > 0 {
-			warnings = append(warnings, fmt.Sprintf("%s: server version %s is newer than client version %s", node, serverVersion, clientVersion))
+		if serverVersion.Compare(clientVersion) < 0 {
+			warnings = append(warnings, fmt.Sprintf("%s: server version %s is older than client version %s", node, serverVersion, clientVersion))
 		}
 	}
 


### PR DESCRIPTION
It should have been the opposite: it's a problem if the server version
is _older_ than the client verion.

E.g. using talosctl 1.2.0 against Talos 1.1.2 is a problem, not vice
versa.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
