### PR TITLE
fix: pass a pointer to specs.Mount into protoenc.Marshal

### DIFF
--- a/pkg/machinery/proto/proto.go
+++ b/pkg/machinery/proto/proto.go
@@ -231,7 +231,9 @@ func registerDefaultTypes() {
 
 	protoenc.RegisterEncoderDecoder(
 		func(v specs.Mount) ([]byte, error) {
-			return protoenc.Marshal(Mount(v))
+			mount := Mount(v)
+
+			return protoenc.Marshal(&mount)
 		},
 		func(slc []byte) (specs.Mount, error) {
 			var result Mount

--- a/pkg/machinery/resources/k8s/k8s_test.go
+++ b/pkg/machinery/resources/k8s/k8s_test.go
@@ -9,11 +9,14 @@ import (
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/runtime/pkg/state/registry"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/talos-systems/talos/pkg/machinery/resources/k8s"
 )
@@ -47,4 +50,40 @@ func TestRegisterResource(t *testing.T) {
 	} {
 		assert.NoError(t, resourceRegistry.Register(ctx, resource))
 	}
+}
+
+func TestKubeletConfig(t *testing.T) {
+	cfg := k8s.NewKubeletConfig(k8s.NamespaceName, k8s.KubeletID)
+	cfg.TypedSpec().Image = "kubelet:v1.0.0"
+	cfg.TypedSpec().ClusterDNS = []string{"10.96.0.10"}
+	cfg.TypedSpec().ClusterDomain = "cluster.local"
+	cfg.TypedSpec().ExtraArgs = map[string]string{"foo": "bar"}
+	cfg.TypedSpec().ExtraMounts = []specs.Mount{
+		{
+			Destination: "/tmp",
+			Source:      "/var",
+			Type:        "tmpfs",
+		},
+	}
+	cfg.TypedSpec().CloudProviderExternal = true
+
+	res, err := protobuf.FromResource(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestKubeletSpec(t *testing.T) {
+	cfg := k8s.NewKubeletSpec(k8s.NamespaceName, k8s.KubeletID)
+	cfg.TypedSpec().Image = "kubelet:v1.0.0"
+	cfg.TypedSpec().ExtraMounts = []specs.Mount{
+		{
+			Destination: "/tmp",
+			Source:      "/var",
+			Type:        "tmpfs",
+		},
+	}
+
+	res, err := protobuf.FromResource(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
 }


### PR DESCRIPTION
Encoder function `protoenc.Marshal` expects a pointer.

Fixes #6233

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>