### PR TITLE
fix: list COSI APIs for the apid authenticator

### DIFF
--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -75,6 +75,12 @@ var rules = map[string]role.Set{
 	"/resource.ResourceService/Get":   role.MakeSet(role.Admin, role.Reader),
 	"/resource.ResourceService/List":  role.MakeSet(role.Admin, role.Reader),
 	"/resource.ResourceService/Watch": role.MakeSet(role.Admin, role.Reader),
+	"/cosi.resource.State/Create":     role.MakeSet(role.Admin),
+	"/cosi.resource.State/Destroy":    role.MakeSet(role.Admin),
+	"/cosi.resource.State/Get":        role.MakeSet(role.Admin, role.Reader),
+	"/cosi.resource.State/List":       role.MakeSet(role.Admin, role.Reader),
+	"/cosi.resource.State/Update":     role.MakeSet(role.Admin),
+	"/cosi.resource.State/Watch":      role.MakeSet(role.Admin, role.Reader),
 
 	"/storage.StorageService/Disks": role.MakeSet(role.Admin, role.Reader),
 

--- a/internal/app/machined/pkg/system/services/machined_test.go
+++ b/internal/app/machined/pkg/system/services/machined_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	cosi "github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -24,6 +25,7 @@ func collectMethods(t *testing.T) map[string]struct{} {
 	methods := make(map[string]struct{})
 
 	for _, service := range []grpc.ServiceDesc{
+		cosi.State_ServiceDesc,
 		cluster.ClusterService_ServiceDesc,
 		inspect.InspectService_ServiceDesc,
 		machine.MachineService_ServiceDesc,

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -127,7 +127,7 @@ func (suite *TalosconfigSuite) TestNew() {
 			adminOpts: []base.RunOption{base.StdoutShouldMatch(regexp.MustCompile(`MachineConfig`))},
 			readerOpts: []base.RunOption{
 				base.ShouldFail(),
-				base.StdoutEmpty(),
+				base.StdoutShouldMatch(regexp.MustCompile(`\QNODE   NAMESPACE   TYPE   ID   VERSION`)),
 				base.StderrShouldMatch(regexp.MustCompile(`\Qrpc error: code = PermissionDenied desc = not authorized`)),
 			},
 		},
@@ -136,7 +136,7 @@ func (suite *TalosconfigSuite) TestNew() {
 			adminOpts: []base.RunOption{base.StdoutShouldMatch(regexp.MustCompile(`OSRootSecret`))},
 			readerOpts: []base.RunOption{
 				base.ShouldFail(),
-				base.StdoutEmpty(),
+				base.StdoutShouldMatch(regexp.MustCompile(`\QNODE   NAMESPACE   TYPE   ID   VERSION`)),
 				base.StderrShouldMatch(regexp.MustCompile(`\Qrpc error: code = PermissionDenied desc = not authorized`)),
 			},
 		},


### PR DESCRIPTION
As APIs were not listed explicitly, access with `os:reader` was denied by default, while it should have been checked down in the access filter.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
