### PR TITLE
fix: include all node addresses into etcd cert SANs

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/etcd.go
+++ b/internal/app/machined/pkg/controllers/secrets/etcd.go
@@ -61,7 +61,7 @@ func (ctrl *EtcdController) Inputs() []controller.Input {
 		{
 			Namespace: network.NamespaceName,
 			Type:      network.NodeAddressType,
-			ID:        pointer.To(network.FilteredNodeAddressID(network.NodeAddressRoutedID, k8s.NodeAddressFilterNoK8s)),
+			ID:        pointer.To(network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s)),
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -148,7 +148,7 @@ func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logge
 			resource.NewMetadata(
 				network.NamespaceName,
 				network.NodeAddressType,
-				network.FilteredNodeAddressID(network.NodeAddressRoutedID, k8s.NodeAddressFilterNoK8s),
+				network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s),
 				resource.VersionUndefined,
 			),
 		)

--- a/internal/app/machined/pkg/controllers/secrets/etcd_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/etcd_test.go
@@ -65,7 +65,7 @@ func (suite *EtcdSuite) TestReconcile() {
 	hostnameStatus.TypedSpec().Domainname = "domain"
 	suite.Require().NoError(suite.State().Create(suite.Ctx(), hostnameStatus))
 
-	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressRoutedID, k8s.NodeAddressFilterNoK8s))
+	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s))
 	nodeAddresses.TypedSpec().Addresses = []netip.Prefix{
 		netip.MustParsePrefix("10.3.4.5/24"),
 		netip.MustParsePrefix("2001:db8::1eaf/64"),


### PR DESCRIPTION
That was a mistake to use only 'routed' addresses, as they e.g. do not include SideroLink.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
