### PR TITLE
fix: use different username for Talos Kubernetes API access

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -343,3 +343,7 @@ func (adapter *generateAdminAdapter) CertLifetime() time.Duration {
 	// this certificate is not delivered to the user, it's used only internally by control plane components
 	return KubernetesCertificateValidityDuration
 }
+
+func (adapter *generateAdminAdapter) CommonName() string {
+	return constants.KubernetesTalosAdminCertCommonName
+}

--- a/pkg/kubeconfig/generate.go
+++ b/pkg/kubeconfig/generate.go
@@ -58,7 +58,7 @@ func GenerateAdmin(config GenerateAdminInput, out io.Writer) error {
 			CA:                  config.CA(),
 			CertificateLifetime: config.AdminKubeconfig().CertLifetime(),
 
-			CommonName:   constants.KubernetesAdminCertCommonName,
+			CommonName:   config.AdminKubeconfig().CommonName(),
 			Organization: constants.KubernetesAdminCertOrganization,
 
 			Endpoint:    config.Endpoint().String(),

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -491,6 +491,7 @@ type ExternalCloudProvider interface {
 
 // AdminKubeconfig defines settings for admin kubeconfig.
 type AdminKubeconfig interface {
+	CommonName() string
 	CertLifetime() time.Duration
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1153,6 +1153,11 @@ func (a *AdminKubeconfigConfig) CertLifetime() time.Duration {
 	return a.AdminKubeconfigCertLifetime
 }
 
+// CommonName implements the config.Provider interface.
+func (a *AdminKubeconfigConfig) CommonName() string {
+	return constants.KubernetesAdminCertCommonName
+}
+
 // Endpoints implements the config.Provider interface.
 func (r *RegistryMirrorConfig) Endpoints() []string {
 	return r.MirrorEndpoints

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -202,6 +202,9 @@ const (
 	// KubernetesAdminCertCommonName defines CN property of Kubernetes admin certificate.
 	KubernetesAdminCertCommonName = "admin"
 
+	// KubernetesTalosAdminCertCommonName defines CN property of Kubernetes admin certificate used by Talos itself.
+	KubernetesTalosAdminCertCommonName = "talos:admin"
+
 	// KubernetesAdminCertOrganization defines Organization values of Kubernetes admin certificate.
 	KubernetesAdminCertOrganization = "system:masters"
 


### PR DESCRIPTION
Fixes #6156

Now access from Talos itself goes with `talos:admin` username in the Kubernetes API server audit log, while access with admin kubeconfig goes with `admin` username as before.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
