### PR TITLE
chore: mark machine configuration validation failure as InvalidArgument

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -181,7 +181,7 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 
 	cfgProvider, err := s.Controller.Runtime().LoadAndValidateConfig(in.GetData())
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	//nolint:exhaustive


### PR DESCRIPTION
This makes it easier to distinguish between retriable and fatal failures.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
