### PR TITLE
docs: update docs for pod security

### DIFF
--- a/website/content/v1.2/learn-more/knowledge-base.md
+++ b/website/content/v1.2/learn-more/knowledge-base.md
@@ -84,3 +84,15 @@ machine:
 ```
 
 > Note: Talos needs to be upgraded for the `extraKernelArgs` to take effect.
+
+## Disable `admissionControl` on control plane nodes
+
+Talos Linux enables admission control in the API Server by default.
+
+Although it is not recommended from a security point of view, admission control can be removed by patching your control plane machine configuration:
+
+```bash
+talosctl gen config \
+    my-cluster https://mycluster.local:6443 \
+    --config-patch-control-plane '[{"op": "remove", "path": "/cluster/apiServer/admissionControl"}]'
+```

--- a/website/content/v1.3/learn-more/knowledge-base.md
+++ b/website/content/v1.3/learn-more/knowledge-base.md
@@ -84,3 +84,15 @@ machine:
 ```
 
 > Note: Talos needs to be upgraded for the `extraKernelArgs` to take effect.
+
+## Disable `admissionControl` on control plane nodes
+
+Talos Linux enables admission control in the API Server by default.
+
+Although it is not recommended from a security point of view, admission control can be removed by patching your control plane machine configuration:
+
+```bash
+talosctl gen config \
+    my-cluster https://mycluster.local:6443 \
+    --config-patch-control-plane '[{"op": "remove", "path": "/cluster/apiServer/admissionControl"}]'
+```


### PR DESCRIPTION
add new section to see how to disable admission control in control plane

Signed-off-by: Pau Campana <pau.campanya.soler@gmail.com>

# Pull Request

Add a section for how admission control can be disabled in the control plane

## Why? (reasoning)

It is not clear how it could be disabled.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
