### PR TITLE
fix: set etcd options consistently

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -484,6 +484,7 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime, spec 
 		"peer-key-file":                      constants.EtcdPeerKey,
 		"peer-trusted-ca-file":               constants.EtcdCACert,
 		"experimental-initial-corrupt-check": "true",
+		"experimental-watch-progress-notify-interval": "5s",
 	}
 
 	extraArgs := argsbuilder.Args(r.Config().Cluster().Etcd().ExtraArgs())


### PR DESCRIPTION
This fixes an issue introduced in #5879: options should be set same way for both `init` and `controlplane` cases.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
