### PR TITLE
feat: enable etcd consistency hashcheck

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -47,6 +47,15 @@ Talos now supports the Nano Pi R4S SBC.
 * Linux: 5.15.68
 """
 
+    [notes.etcd]
+        title = "etcd Consistency Check"
+        description="""\
+Talos enables [--experimental-compact-hash-check-enabled](https://github.com/etcd-io/etcd/pull/14120) option by default to improve
+etcd store consistency guarantees.
+
+This options is only available with etcd >= v3.5.5, so Talos doesn't support version of etcd before v3.5.5.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -409,6 +409,7 @@ func (e *Etcd) argsForInit(ctx context.Context, r runtime.Runtime, spec *etcdres
 		"peer-trusted-ca-file":               constants.EtcdCACert,
 		"experimental-initial-corrupt-check": "true",
 		"experimental-watch-progress-notify-interval": "5s",
+		"experimental-compact-hash-check-enabled":     "true",
 	}
 
 	extraArgs := argsbuilder.Args(r.Config().Cluster().Etcd().ExtraArgs())
@@ -485,6 +486,7 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime, spec 
 		"peer-trusted-ca-file":               constants.EtcdCACert,
 		"experimental-initial-corrupt-check": "true",
 		"experimental-watch-progress-notify-interval": "5s",
+		"experimental-compact-hash-check-enabled":     "true",
 	}
 
 	extraArgs := argsbuilder.Args(r.Config().Cluster().Etcd().ExtraArgs())


### PR DESCRIPTION
This will be only enabled for Talos v1.3.x.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
