### PR TITLE
chore: bump kernel + ice drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -555,6 +555,9 @@ COPY --from=init-build-arm64 /init .
 # copying over firmware binary blobs to initramfs
 COPY --from=pkg-linux-firmware /lib/firmware/rtl_nic ./lib/firmware/rtl_nic
 COPY --from=pkg-linux-firmware /lib/firmware/nvidia/tegra210 ./lib/firmware/nvidia/tegra210
+# the intel ice pkg file from linux-firmware has the version appended to it, but kernel only looks up ice.pkg
+# ref: https://github.com/torvalds/linux/blob/v5.15/Documentation/networking/device_drivers/ethernet/intel/ice.rst#dynamic-device-personalization
+COPY --from=pkg-linux-firmware /lib/firmware/intel/ice/ddp/ice-*.pkg ./lib/firmware/intel/ice/ddp/ice.pkg
 RUN find . -print0 \
     | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
 RUN set -o pipefail \
@@ -571,6 +574,9 @@ COPY --from=init-build-amd64 /init .
 # copying over firmware binary blobs to initramfs
 COPY --from=pkg-linux-firmware /lib/firmware/bnx2 ./lib/firmware/bnx2
 COPY --from=pkg-linux-firmware /lib/firmware/bnx2x ./lib/firmware/bnx2x
+# the intel ice pkg file from linux-firmware has the version appended to it, but kernel only looks up ice.pkg
+# ref: https://github.com/torvalds/linux/blob/v5.15/Documentation/networking/device_drivers/ethernet/intel/ice.rst#dynamic-device-personalization
+COPY --from=pkg-linux-firmware /lib/firmware/intel/ice/ddp/ice-*.pkg ./lib/firmware/intel/ice/ddp/ice.pkg
 RUN find . -print0 \
     | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
 RUN set -o pipefail \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.3.0-alpha.0-14-g5df6589
-PKGS ?= v1.3.0-alpha.0-19-g32aea3f
+PKGS ?= v1.3.0-alpha.0-22-ged269ca
 EXTRAS ?= v1.2.0
 GO_VERSION ?= 1.19
 GOIMPORTS_VERSION ?= v0.1.11

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -45,7 +45,7 @@ Talos now supports the Nano Pi R4S SBC.
 * Flannel: v0.19.2
 * CoreDNS: v1.10.0
 * etcd: v3.5.5
-* Linux: 5.15.68
+* Linux: 5.15.69
 """
 
     [notes.etcd]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.68-talos"
+	DefaultKernelVersion = "5.15.69-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.3.0-alpha.0-19-g32aea3f
+v1.3.0-alpha.0-22-ged269ca


### PR DESCRIPTION
Bump kernel to [5.15.69](https://github.com/siderolabs/pkgs/pull/592) Add Intel ice drivers

Signed-off-by: Noel Georgi <git@frezbo.dev>