### PR TITLE
fix: kubeconfig permission

### DIFF
--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -119,7 +119,7 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				return extractAndMerge(data, localPath)
 			}
 
-			return os.WriteFile(localPath, data, 0o640)
+			return os.WriteFile(localPath, data, 0o600)
 		})
 	},
 }


### PR DESCRIPTION
Set kubeconfig permission to `-rw-------`

To avoid the message 
```sh
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: kubeconfig
```

Default permission of user kube-config (~/.kube/config) is the same 0600

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
