### PR TITLE
feat: use rel=canonical in the head of docs pages

### DIFF
--- a/website/themes/docsy/layouts/partials/head.html
+++ b/website/themes/docsy/layouts/partials/head.html
@@ -11,6 +11,8 @@
 {{ else -}}
 <meta name="robots" content="noindex, nofollow">
 {{ end -}}
+{{ $latest_doc := partial "doc_latest_version.html" . -}}
+<link rel="canonical" href="{{ $latest_doc | safeURL }}" />
 
 {{ partialCached "favicons.html" . }}
 <title>


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Adds `<link rel="canonical">` tags to page headers

## Why? (reasoning)
Google is indexing and preferring old versions of the docs. Specifying a canonical target will hint to Google that newer versions of the page are preferable to surface to searchers.

In SEO terms, this is preferable to setting `noindex` on pages -- old pages will still be indexed and appear in search results (e.g. for queries like `inurl:talos.dev/v1.0`, but ranking signals for old docs pages will be "forwarded to" the new ones when new versions get published, and Google should generally surface the most recent docs when people perform generic searches (e.g. `talos linux iscsi`)

It is peaceful to include a self-referencing rel=canonical tag.

If this is not behavior you want, feel free to reject/close the PR with no explanation :) 

(It seemed unfortunate to edit a file inside of what appears to be a vendor directory, but the docsy docs themselves suggest that this is kosher -- at least for hooks -- and it seemed the cleanest way to do it)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
