### PR TITLE
fix: lookup Equinix Metal bond slaves using 'permanent addr' 

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -36,6 +36,7 @@ const externalLink = "external"
 // PlatformConfigController manages updates hostnames and addressstatuses based on platform information.
 type PlatformConfigController struct {
 	V1alpha1Platform v1alpha1runtime.Platform
+	PlatformState    state.State
 	StatePath        string
 }
 
@@ -126,7 +127,7 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 		defer platformWg.Done()
 
 		ctrl.runWithRestarts(platformCtx, logger, func() error {
-			return ctrl.V1alpha1Platform.NetworkConfiguration(platformCtx, platformCh)
+			return ctrl.V1alpha1Platform.NetworkConfiguration(platformCtx, ctrl.PlatformState, platformCh)
 		})
 	}()
 

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -180,6 +180,7 @@ func (suite *PlatformConfigSuite) TestPlatformMockHostnameNoDomain() {
 			&netctrl.PlatformConfigController{
 				V1alpha1Platform: &platformMock{hostname: []byte("talos-e2e-897b4e49-gcp-controlplane-jvcnl")},
 				StatePath:        suite.statePath,
+				PlatformState:    suite.state,
 			},
 		),
 	)
@@ -217,7 +218,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockAddresses() {
 						netip.MustParsePrefix("2001:fd::3/64"),
 					},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -260,7 +262,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockLinks() {
 				V1alpha1Platform: &platformMock{
 					linksUp: []string{"eth0", "eth1"},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -295,7 +298,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockRoutes() {
 				V1alpha1Platform: &platformMock{
 					defaultRoutes: []netip.Addr{netip.MustParseAddr("10.0.0.1")},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -329,7 +333,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockOperators() {
 				V1alpha1Platform: &platformMock{
 					dhcp4Links: []string{"eth1", "eth2"},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -364,7 +369,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockResolvers() {
 				V1alpha1Platform: &platformMock{
 					resolvers: []netip.Addr{netip.MustParseAddr("1.1.1.1")},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -398,7 +404,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockTimeServers() {
 				V1alpha1Platform: &platformMock{
 					timeServers: []string{"pool.ntp.org"},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -435,7 +442,8 @@ func (suite *PlatformConfigSuite) TestPlatformMockExternalIPs() {
 						netip.MustParseAddr("2001:470:6d:30e:96f4:4219:5733:b860"),
 					},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -482,7 +490,8 @@ func (suite *PlatformConfigSuite) TestStoreConfig() {
 						netip.MustParseAddr("2001:470:6d:30e:96f4:4219:5733:b860"),
 					},
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -520,7 +529,8 @@ func (suite *PlatformConfigSuite) TestLoadConfig() {
 				V1alpha1Platform: &platformMock{
 					noData: true,
 				},
-				StatePath: suite.statePath,
+				StatePath:     suite.statePath,
+				PlatformState: suite.state,
 			},
 		),
 	)
@@ -631,6 +641,7 @@ func (mock *platformMock) KernelArgs() procfs.Parameters {
 //nolint:gocyclo
 func (mock *platformMock) NetworkConfiguration(
 	ctx context.Context,
+	st state.State,
 	ch chan<- *v1alpha1runtime.PlatformNetworkConfig,
 ) error {
 	if mock.noData {

--- a/internal/app/machined/pkg/runtime/platform.go
+++ b/internal/app/machined/pkg/runtime/platform.go
@@ -36,7 +36,7 @@ type Platform interface {
 	// Controller will run this in function a separate goroutine, restarting it
 	// on error. Platform is expected to deliver network configuration over the channel,
 	// including updates to the configuration over time.
-	NetworkConfiguration(context.Context, chan<- *PlatformNetworkConfig) error
+	NetworkConfiguration(context.Context, state.State, chan<- *PlatformNetworkConfig) error
 }
 
 // PlatformNetworkConfig describes the network configuration produced by the platform.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -88,7 +88,7 @@ func (a *AWS) KernelArgs() procfs.Parameters {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (a *AWS) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (a *AWS) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	getMetadataKey := func(key string) (string, error) {
 		v, err := a.metadataClient.GetMetadataWithContext(ctx, key)
 		if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -249,7 +249,7 @@ func (a *Azure) configFromCD() ([]byte, error) {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (a *Azure) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (a *Azure) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching network config from %q", AzureInterfacesEndpoint)
 
 	metadataNetworkConfig, err := download.Download(ctx, AzureInterfacesEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -55,7 +55,7 @@ func (c *Container) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (c *Container) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (c *Container) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	networkConfig := &runtime.PlatformNetworkConfig{}
 
 	hostname, err := os.ReadFile("/etc/hostname")

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -60,7 +60,7 @@ func (d *DigitalOcean) KernelArgs() procfs.Parameters {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (d *DigitalOcean) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (d *DigitalOcean) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	host, err := download.Download(ctx, DigitalOceanHostnameEndpoint,
 		download.WithErrorOnNotFound(errors.ErrNoHostname),
 		download.WithErrorOnEmptyResponse(errors.ErrNoHostname))

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -11,11 +11,12 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/netip"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
@@ -114,7 +115,7 @@ func (p *EquinixMetal) KernelArgs() procfs.Parameters {
 // ParseMetadata converts Equinix Metal metadata into Talos network configuration.
 //
 //nolint:gocyclo,cyclop
-func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.PlatformNetworkConfig, error) {
+func (p *EquinixMetal) ParseMetadata(ctx context.Context, equinixMetadata *Metadata, st state.State) (*runtime.PlatformNetworkConfig, error) {
 	networkConfig := &runtime.PlatformNetworkConfig{}
 
 	// 1. Links
@@ -125,7 +126,7 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 	// determine bond name and build list of interfaces enslaved by the bond
 	bondName := ""
 
-	hostInterfaces, err := net.Interfaces()
+	hostInterfaces, err := safe.StateList[*network.LinkStatus](ctx, st, resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "", resource.VersionUndefined))
 	if err != nil {
 		return nil, fmt.Errorf("error listing host interfaces: %w", err)
 	}
@@ -145,15 +146,18 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 
 		found := false
 
-		for _, hostIf := range hostInterfaces {
-			// if the bond configuration has already been applied, bond0 inherits the MAC address of the first slave (e.g. eth0)
-			// we don't want to match on the bond, so we skip it explicitly
-			if hostIf.HardwareAddr.String() == iface.MAC && hostIf.Name != iface.Bond {
+		hostInterfaceIter := safe.IteratorFromList(hostInterfaces)
+
+		for hostInterfaceIter.Next() {
+			// match using permanent MAC address:
+			// - bond interfaces don't have permanent addresses set, so we skip them this way
+			// - if the bond is already configured, regular hardware address is overwritten with bond address
+			if hostInterfaceIter.Value().TypedSpec().PermanentAddr.String() == iface.MAC {
 				found = true
 
 				networkConfig.Links = append(networkConfig.Links,
 					network.LinkSpecSpec{
-						Name: hostIf.Name,
+						Name: hostInterfaceIter.Value().Metadata().ID(),
 						Up:   true,
 						BondSlave: network.BondSlave{
 							MasterName: bondName,
@@ -324,7 +328,7 @@ func (p *EquinixMetal) ParseMetadata(equinixMetadata *Metadata) (*runtime.Platfo
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (p *EquinixMetal) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (p *EquinixMetal) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching equinix network config from: %q", EquinixMetalMetaDataEndpoint)
 
 	metadataConfig, err := download.Download(ctx, EquinixMetalMetaDataEndpoint)
@@ -337,7 +341,7 @@ func (p *EquinixMetal) NetworkConfiguration(ctx context.Context, ch chan<- *runt
 		return err
 	}
 
-	networkConfig, err := p.ParseMetadata(&equinixMetadata)
+	networkConfig, err := p.ParseMetadata(ctx, &equinixMetadata, st)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
@@ -18,7 +18,7 @@ addresses:
       flags: permanent
       layer: platform
 links:
-    - name: eth0
+    - name: eth1
       logical: false
       up: true
       mtu: 0
@@ -26,7 +26,7 @@ links:
       type: netrom
       masterName: bond0
       layer: platform
-    - name: eth1
+    - name: eth2
       logical: false
       up: true
       mtu: 0

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -57,7 +57,7 @@ func (g *GCP) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (g *GCP) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (g *GCP) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	networkConfig := &runtime.PlatformNetworkConfig{}
 
 	hostname, err := metadata.Hostname()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -182,7 +182,7 @@ func (h *Hcloud) KernelArgs() procfs.Parameters {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (h *Hcloud) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (h *Hcloud) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching hcloud network config from: %q", HCloudNetworkEndpoint)
 
 	metadataNetworkConfig, err := download.Download(ctx, HCloudNetworkEndpoint)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -335,6 +335,6 @@ func (m *Metal) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (m *Metal) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (m *Metal) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	return nil
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -88,7 +88,7 @@ func (n *Nocloud) KernelArgs() procfs.Parameters {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (n *Nocloud) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (n *Nocloud) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	metadataConfigDl, metadataNetworkConfigDl, _, hostname, err := n.acquireConfig(ctx)
 	if stderrors.Is(err, errors.ErrNoConfigSource) {
 		err = nil

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -242,7 +242,7 @@ func (o *Openstack) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (o *Openstack) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (o *Openstack) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	metadataConfigDl, metadataNetworkConfigDl, _, err := o.configFromCD()
 	if err != nil {
 		metadataConfigDl, metadataNetworkConfigDl, _, err = o.configFromNetwork(ctx)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
@@ -116,7 +116,7 @@ func (o *Oracle) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (o *Oracle) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (o *Oracle) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching network config from %q", OracleNetworkEndpoint)
 
 	metadataNetworkConfig, err := download.Download(ctx, OracleNetworkEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -167,7 +167,7 @@ func (s *Scaleway) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (s *Scaleway) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (s *Scaleway) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching scaleway instance config from: %q", ScalewayMetadataEndpoint)
 
 	metadataDl, err := download.Download(ctx, ScalewayMetadataEndpoint)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -214,7 +214,7 @@ func (u *UpCloud) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (u *UpCloud) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (u *UpCloud) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching UpCloud instance config from: %q ", UpCloudMetadataEndpoint)
 
 	metaConfigDl, err := download.Download(ctx, UpCloudMetadataEndpoint)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -200,6 +200,6 @@ func (v *VMware) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (v *VMware) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (v *VMware) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	return nil
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -40,6 +40,6 @@ func (v *VMware) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (v *VMware) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (v *VMware) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	return nil
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
@@ -141,7 +141,7 @@ func (v *Vultr) KernelArgs() procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (v *Vultr) NetworkConfiguration(ctx context.Context, ch chan<- *runtime.PlatformNetworkConfig) error {
+func (v *Vultr) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	log.Printf("fetching Vultr instance config from: %q ", VultrMetadataEndpoint)
 
 	metaConfigDl, err := download.Download(ctx, VultrMetadataEndpoint)

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -192,6 +192,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		},
 		&network.PlatformConfigController{
 			V1alpha1Platform: ctrl.v1alpha1Runtime.State().Platform(),
+			PlatformState:    ctrl.v1alpha1Runtime.State().V1Alpha2().Resources(),
 		},
 		&network.ResolverConfigController{
 			Cmdline: procfs.ProcCmdline(),


### PR DESCRIPTION
See https://github.com/siderolabs/talos/pull/6333

Using permanent address fixes issues with mis-matching the links after
they got bonded.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>