### PR TITLE
chore: publish ami's with imds v2 enabled

### DIFF
--- a/hack/cloud-image-uploader/aws.go
+++ b/hack/cloud-image-uploader/aws.go
@@ -291,6 +291,7 @@ func (au *AWSUploader) registerAMIArch(ctx context.Context, region string, svc *
 		EnaSupport:         aws.Bool(true),
 		Description:        aws.String(fmt.Sprintf("Talos AMI %s %s %s", au.Options.Tag, arch, region)),
 		Architecture:       aws.String(awsArchitectures[arch]),
+		ImdsSupport:        aws.String("v2.0"),
 	})
 	if err != nil {
 		return err

--- a/hack/cloud-image-uploader/go.mod
+++ b/hack/cloud-image-uploader/go.mod
@@ -3,7 +3,7 @@ module github.com/talos-systems/cloud-image-uploader
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.44.105
+	github.com/aws/aws-sdk-go v1.44.110
 	github.com/google/uuid v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/talos-systems/go-retry v0.3.1

--- a/hack/cloud-image-uploader/go.sum
+++ b/hack/cloud-image-uploader/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.105 h1:UUwoD1PRKIj3ltrDUYTDQj5fOTK3XsnqolLpRTMmSEM=
-github.com/aws/aws-sdk-go v1.44.105/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.110 h1:unno3l2FYQo6p0wYCp9gUk8YNzhOxqSktM0Y1vukl9k=
+github.com/aws/aws-sdk-go v1.44.110/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Publish AMI's with IMDS v2 enabled.

Ref: https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-machine-images-support-instance-metadata-service-version-2-default/

Signed-off-by: Noel Georgi <git@frezbo.dev>