### PR TITLE
fix: skip protobuf full unmarshaling for some talosctl commands

### DIFF
--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -123,9 +123,20 @@ func getResources(args []string) func(ctx context.Context, c *client.Client) err
 				watchCh := make(chan state.Event)
 
 				if resourceID == "" {
-					err = c.COSI.WatchKind(nodeCtx, resource.NewMetadata(getCmdFlags.namespace, resourceType, "", resource.VersionUndefined), watchCh, state.WithBootstrapContents(true))
+					err = c.COSI.WatchKind(
+						nodeCtx,
+						resource.NewMetadata(getCmdFlags.namespace, resourceType, "", resource.VersionUndefined),
+						watchCh,
+						state.WithBootstrapContents(true),
+						state.WithWatchKindUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+					)
 				} else {
-					err = c.COSI.Watch(nodeCtx, resource.NewMetadata(getCmdFlags.namespace, resourceType, resourceID, resource.VersionUndefined), watchCh)
+					err = c.COSI.Watch(
+						nodeCtx,
+						resource.NewMetadata(getCmdFlags.namespace, resourceType, resourceID, resource.VersionUndefined),
+						watchCh,
+						state.WithWatchUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+					)
 				}
 
 				if err != nil {

--- a/cmd/talosctl/pkg/talos/helpers/resources.go
+++ b/cmd/talosctl/pkg/talos/helpers/resources.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/state"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -68,13 +69,21 @@ func ForEachResource(ctx context.Context,
 		}
 
 		if resourceID != "" {
-			r, callErr := c.COSI.Get(nodeCtx, resource.NewMetadata(namespace, rd.TypedSpec().Type, resourceID, resource.VersionUndefined))
+			r, callErr := c.COSI.Get(
+				nodeCtx,
+				resource.NewMetadata(namespace, rd.TypedSpec().Type, resourceID, resource.VersionUndefined),
+				state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
 
 			if err = callback(ctx, node, r, callErr); err != nil {
 				return err
 			}
 		} else {
-			items, callErr := c.COSI.List(nodeCtx, resource.NewMetadata(namespace, resourceType, "", resource.VersionUndefined))
+			items, callErr := c.COSI.List(
+				nodeCtx,
+				resource.NewMetadata(namespace, resourceType, "", resource.VersionUndefined),
+				state.WithListUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
 			if callErr != nil {
 				if err = callback(ctx, node, nil, callErr); err != nil {
 					return err

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/containernetworking/plugins v1.1.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/cosi-project/runtime v0.2.0-alpha.1
+	github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosi-project/runtime v0.2.0-alpha.1 h1:W3od7HqWNxcGb7dpKJ9WxpUJgq0tQt2TkcvY6a47tVU=
-github.com/cosi-project/runtime v0.2.0-alpha.1/go.mod h1:6f8SkQWSjKUL+MXTZz19lI65E92dbzccW8UrTM0A9Oc=
+github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548 h1:/CMoJlmVdr1XrAoo4cQDPF4rwB2Ap1WCa/BlFfkqOW0=
+github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548/go.mod h1:u60xdQ7/f8WkO0qsDwPRJuy+0edCDYvwh2xYUvDO+no=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -8,7 +8,7 @@ replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20220527175918-f17b
 
 require (
 	github.com/containerd/go-cni v1.1.7
-	github.com/cosi-project/runtime v0.2.0-alpha.1
+	github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -9,8 +9,8 @@ github.com/containerd/go-cni v1.1.7 h1:1yKpVCQAXI21BJIy8q7Nyk4CWpIgUno6ib7JIDca7
 github.com/containerd/go-cni v1.1.7/go.mod h1:Ve4Q0RB2Bw78D90OL0YVyDjqdTL7FKh9W+UPbhWiZXA=
 github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
-github.com/cosi-project/runtime v0.2.0-alpha.1 h1:W3od7HqWNxcGb7dpKJ9WxpUJgq0tQt2TkcvY6a47tVU=
-github.com/cosi-project/runtime v0.2.0-alpha.1/go.mod h1:6f8SkQWSjKUL+MXTZz19lI65E92dbzccW8UrTM0A9Oc=
+github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548 h1:/CMoJlmVdr1XrAoo4cQDPF4rwB2Ap1WCa/BlFfkqOW0=
+github.com/cosi-project/runtime v0.2.0-alpha.1.0.20221009084302-e8a8fdcc7548/go.mod h1:u60xdQ7/f8WkO0qsDwPRJuy+0edCDYvwh2xYUvDO+no=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
The following commands:

* `talosctl get`
* `talosctl edit mc`, `talosctl patch mc`

Now these commands don't fully unmarshal resources from protobuf representation, but rather use YAML representation.

This allows `talosctl` version to be out of sync with Talos version.

Still other commands do full unmarshaling (e.g. `talosctl upgrade-k8s`), so `talosctl` should match Talos to avoid issues.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
