### PR TITLE
feat: cloud-init configuration improvements on the OpenStack platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
@@ -45,10 +45,14 @@ const (
 // NetworkConfig holds NetworkData config.
 type NetworkConfig struct {
 	Links []struct {
-		ID   string `json:"id,omitempty"`
-		Type string `json:"type"`
-		Mac  string `json:"ethernet_mac_address,omitempty"`
-		MTU  int    `json:"mtu,omitempty"`
+		ID             string   `json:"id,omitempty"`
+		Type           string   `json:"type"`
+		Mac            string   `json:"ethernet_mac_address,omitempty"`
+		MTU            int      `json:"mtu,omitempty"`
+		BondMode       string   `json:"bond_mode,omitempty"`
+		BondLinks      []string `json:"bond_links,omitempty"`
+		BondMIIMon     uint32   `json:"bond_miimon,string,omitempty"`
+		BondHashPolicy string   `json:"bond_xmit_hash_policy,omitempty"`
 	} `json:"links"`
 	Networks []struct {
 		ID      string `json:"id,omitempty"`

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
@@ -5,16 +5,22 @@
 package openstack_test
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"net/netip"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
 
 //go:embed testdata/metadata.json
@@ -37,7 +43,33 @@ func TestParseMetadata(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal(rawNetwork, &n))
 
-	networkConfig, err := o.ParseMetadata(&n, []netip.Addr{netip.MustParseAddr("1.2.3.4")}, &metadata)
+	ctx := context.Background()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+	eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x30}
+	require.NoError(t, st.Create(ctx, eth0))
+
+	eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
+	eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x31}
+	require.NoError(t, st.Create(ctx, eth1))
+
+	eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
+	eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x33}
+	require.NoError(t, st.Create(ctx, eth2))
+
+	// Bond slaves
+
+	eth3 := network.NewLinkStatus(network.NamespaceName, "eth3")
+	eth3.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf8}
+	require.NoError(t, st.Create(ctx, eth3))
+
+	eth4 := network.NewLinkStatus(network.NamespaceName, "eth4")
+	eth4.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf7}
+	require.NoError(t, st.Create(ctx, eth4))
+
+	networkConfig, err := o.ParseMetadata(ctx, &n, []netip.Addr{netip.MustParseAddr("1.2.3.4")}, &metadata, st)
 	require.NoError(t, err)
 
 	marshaled, err := yaml.Marshal(networkConfig)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -23,7 +23,37 @@ addresses:
       scope: global
       flags: permanent
       layer: platform
+    - address: 94.156.45.48/24
+      linkName: bond0
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
 links:
+    - name: bond0
+      logical: true
+      up: true
+      mtu: 1500
+      kind: bond
+      type: ether
+      bondMaster:
+        mode: 802.3ad
+        xmitHashPolicy: layer2+3
+        lacpRate: fast
+        arpValidate: none
+        arpAllTargets: any
+        primaryReselect: always
+        failOverMac: 0
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+        resendIgmp: 1
+        lpInterval: 1
+        packetsPerSlave: 1
+        numPeerNotif: 1
+        tlbLogicalLb: 1
+        adActorSysPrio: 65535
+      layer: platform
     - name: eth0
       logical: false
       up: true
@@ -44,6 +74,23 @@ links:
       mtu: 0
       kind: ""
       type: netrom
+      layer: platform
+    - name: eth3
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond0
+      layer: platform
+    - name: eth4
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond0
+      slaveIndex: 1
       layer: platform
 routes:
     - family: inet6
@@ -99,6 +146,18 @@ routes:
       src: ""
       gateway: fd00::1
       outLinkName: eth1
+      table: main
+      priority: 1024
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 94.156.45.1
+      outLinkName: bond0
       table: main
       priority: 1024
       scope: global

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
@@ -19,6 +19,30 @@
             "id": "aae16046-6c74-4f33-acf2-a16e9ab093ed",
             "type": "vif",
             "vif_id": "c816df7e-7bcc-45ca-9eb2-3d3d3dca063a"
+        },
+        {
+            "id": "tap7819ff08-20",
+            "vif_id": "7819ff08-204b-4193-8c4d-1fff242932e5",
+            "type": "bond",
+            "mtu": 1500,
+            "ethernet_mac_address": "4c:d9:8f:b3:34:f7",
+            "bond_mode": "802.3ad",
+            "bond_links": [
+                "411f3980-d8f9-4bf0-a09a-9c01c81e1022",
+                "83f59825-bf2d-4ea7-98be-edc772fe82de"
+            ],
+            "bond_miimon": "100",
+            "bond_xmit_hash_policy": "layer2+3"
+        },
+        {
+            "id": "411f3980-d8f9-4bf0-a09a-9c01c81e1022",
+            "type": "phy",
+            "ethernet_mac_address": "4c:d9:8f:b3:34:f8"
+        },
+        {
+            "id": "83f59825-bf2d-4ea7-98be-edc772fe82de",
+            "type": "phy",
+            "ethernet_mac_address": "4c:d9:8f:b3:34:f7"
         }
     ],
     "networks": [
@@ -89,6 +113,31 @@
             "ip_address": "fd60:172:16:84:f816:3eff:fe73:5901",
             "netmask": "ffff:ffff:ffff:ffff::",
             "routes": []
+        },
+        {
+            "id": "network0",
+            "type": "ipv4",
+            "link": "tap7819ff08-20",
+            "ip_address": "94.156.45.48",
+            "netmask": "255.255.255.0",
+            "routes": [
+                {
+                    "network": "0.0.0.0",
+                    "netmask": "0.0.0.0",
+                    "gateway": "94.156.45.1"
+                }
+            ],
+            "network_id": "dc4b2e65-869b-46b1-b53b-538774dbdc16",
+            "services": [
+                {
+                    "type": "dns",
+                    "address": "8.8.8.8"
+                },
+                {
+                    "type": "dns",
+                    "address": "8.8.4.4"
+                }
+            ]
         }
     ],
     "services": [


### PR DESCRIPTION
# Pull Request
## What? (description)

- [x] Added support for bonding
- [x] Added interface selection by MAC address
- [x] Fixed bug where network configuration from config-drive was not being applied due to errors when discovering `hostname` and `extIPs` from OpenStack API.

## Acceptance
- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)