### PR TITLE
fix: lowercase nodename

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/nodename.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodename.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -93,9 +94,9 @@ func (ctrl *NodenameController) Run(ctx context.Context, r controller.Runtime, l
 				nodename := r.(*k8s.Nodename) //nolint:errcheck,forcetypeassert
 
 				if cfgProvider.Machine().Kubelet().RegisterWithFQDN() {
-					nodename.TypedSpec().Nodename = hostnameStatus.FQDN()
+					nodename.TypedSpec().Nodename = strings.ToLower(hostnameStatus.FQDN())
 				} else {
-					nodename.TypedSpec().Nodename = hostnameStatus.Hostname
+					nodename.TypedSpec().Nodename = strings.ToLower(hostnameStatus.Hostname)
 				}
 
 				nodename.TypedSpec().HostnameVersion = hostnameResource.Metadata().Version().String()

--- a/internal/app/machined/pkg/controllers/k8s/nodename_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodename_test.go
@@ -118,7 +118,7 @@ func (suite *NodenameSuite) TestDefault() {
 	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
 
 	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
-	hostnameStatus.TypedSpec().Hostname = "foo"
+	hostnameStatus.TypedSpec().Hostname = "Foo"
 	hostnameStatus.TypedSpec().Domainname = "bar.ltd"
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))


### PR DESCRIPTION
Kubernetes always lowercases whatever nodename is given to the kubelet, so we should do the same, otherwise Talos looks for a `Node` with uppercase letter which is never going to be registered.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
