### PR TITLE
feat: support encryption with secretbox

### DIFF
--- a/api/resource/definitions/secrets/secrets.proto
+++ b/api/resource/definitions/secrets/secrets.proto
@@ -66,6 +66,7 @@ message KubernetesRootSpec {
   string aescbc_encryption_secret = 10;
   string bootstrap_token_id = 11;
   string bootstrap_token_secret = 12;
+  string secretbox_encryption_secret = 13;
 }
 
 // OSRootSpec describes operating system CA.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -111,6 +111,22 @@ machine:
 ```
 """
 
+    [notes.secretbox]
+        title = "Encryption with secretbox"
+        description = """\
+By default new clusters will use secretbox for encryption instead of AESCBC.
+If both are configured secretbox will take precedence.
+Old clusters may keep using AESCBC.
+To enable secretbox you may add an encryption secret at `cluster.secretboxEncryptionSecret`.
+You should keep `aescbcEncryptionSecret` however, even if secretbox is enabled older data will still be encrypted with AESCBC.
+
+How to generate the secret:
+
+```bash
+dd if=/dev/random of=/dev/stdout bs=32 count=1 | base64
+```
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -12,10 +12,18 @@ resources:
 - resources:
   - secrets
   providers:
+  {{if .Root.SecretboxEncryptionSecret}}
+  - secretbox:
+      keys:
+      - name: key2
+        secret: {{ .Root.SecretboxEncryptionSecret }}
+  {{end}}
+  {{if .Root.AESCBCEncryptionSecret}}
   - aescbc:
       keys:
       - name: key1
         secret: {{ .Root.AESCBCEncryptionSecret }}
+  {{end}}
   - identity: {}
 `)
 

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -202,6 +202,7 @@ func (ctrl *RootController) updateK8sSecrets(cfgProvider talosconfig.Provider, k
 	k8sSecrets.ServiceAccount = cfgProvider.Cluster().ServiceAccount()
 
 	k8sSecrets.AESCBCEncryptionSecret = cfgProvider.Cluster().AESCBCEncryptionSecret()
+	k8sSecrets.SecretboxEncryptionSecret = cfgProvider.Cluster().SecretboxEncryptionSecret()
 
 	k8sSecrets.BootstrapTokenID = cfgProvider.Cluster().Token().ID()
 	k8sSecrets.BootstrapTokenSecret = cfgProvider.Cluster().Token().Secret()

--- a/pkg/machinery/api/resource/definitions/secrets/secrets.pb.go
+++ b/pkg/machinery/api/resource/definitions/secrets/secrets.pb.go
@@ -445,18 +445,19 @@ type KubernetesRootSpec struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name                   string                              `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Endpoint               *common.URL                         `protobuf:"bytes,2,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
-	LocalEndpoint          *common.URL                         `protobuf:"bytes,3,opt,name=local_endpoint,json=localEndpoint,proto3" json:"local_endpoint,omitempty"`
-	CertSaNs               []string                            `protobuf:"bytes,4,rep,name=cert_sa_ns,json=certSaNs,proto3" json:"cert_sa_ns,omitempty"`
-	ApiServerIps           [][]byte                            `protobuf:"bytes,5,rep,name=api_server_ips,json=apiServerIps,proto3" json:"api_server_ips,omitempty"`
-	DnsDomain              string                              `protobuf:"bytes,6,opt,name=dns_domain,json=dnsDomain,proto3" json:"dns_domain,omitempty"`
-	Ca                     *common.PEMEncodedCertificateAndKey `protobuf:"bytes,7,opt,name=ca,proto3" json:"ca,omitempty"`
-	ServiceAccount         *common.PEMEncodedKey               `protobuf:"bytes,8,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty"`
-	AggregatorCa           *common.PEMEncodedCertificateAndKey `protobuf:"bytes,9,opt,name=aggregator_ca,json=aggregatorCa,proto3" json:"aggregator_ca,omitempty"`
-	AescbcEncryptionSecret string                              `protobuf:"bytes,10,opt,name=aescbc_encryption_secret,json=aescbcEncryptionSecret,proto3" json:"aescbc_encryption_secret,omitempty"`
-	BootstrapTokenId       string                              `protobuf:"bytes,11,opt,name=bootstrap_token_id,json=bootstrapTokenId,proto3" json:"bootstrap_token_id,omitempty"`
-	BootstrapTokenSecret   string                              `protobuf:"bytes,12,opt,name=bootstrap_token_secret,json=bootstrapTokenSecret,proto3" json:"bootstrap_token_secret,omitempty"`
+	Name                      string                              `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Endpoint                  *common.URL                         `protobuf:"bytes,2,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	LocalEndpoint             *common.URL                         `protobuf:"bytes,3,opt,name=local_endpoint,json=localEndpoint,proto3" json:"local_endpoint,omitempty"`
+	CertSaNs                  []string                            `protobuf:"bytes,4,rep,name=cert_sa_ns,json=certSaNs,proto3" json:"cert_sa_ns,omitempty"`
+	ApiServerIps              [][]byte                            `protobuf:"bytes,5,rep,name=api_server_ips,json=apiServerIps,proto3" json:"api_server_ips,omitempty"`
+	DnsDomain                 string                              `protobuf:"bytes,6,opt,name=dns_domain,json=dnsDomain,proto3" json:"dns_domain,omitempty"`
+	Ca                        *common.PEMEncodedCertificateAndKey `protobuf:"bytes,7,opt,name=ca,proto3" json:"ca,omitempty"`
+	ServiceAccount            *common.PEMEncodedKey               `protobuf:"bytes,8,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty"`
+	AggregatorCa              *common.PEMEncodedCertificateAndKey `protobuf:"bytes,9,opt,name=aggregator_ca,json=aggregatorCa,proto3" json:"aggregator_ca,omitempty"`
+	AescbcEncryptionSecret    string                              `protobuf:"bytes,10,opt,name=aescbc_encryption_secret,json=aescbcEncryptionSecret,proto3" json:"aescbc_encryption_secret,omitempty"`
+	BootstrapTokenId          string                              `protobuf:"bytes,11,opt,name=bootstrap_token_id,json=bootstrapTokenId,proto3" json:"bootstrap_token_id,omitempty"`
+	BootstrapTokenSecret      string                              `protobuf:"bytes,12,opt,name=bootstrap_token_secret,json=bootstrapTokenSecret,proto3" json:"bootstrap_token_secret,omitempty"`
+	SecretboxEncryptionSecret string                              `protobuf:"bytes,13,opt,name=secretbox_encryption_secret,json=secretboxEncryptionSecret,proto3" json:"secretbox_encryption_secret,omitempty"`
 }
 
 func (x *KubernetesRootSpec) Reset() {
@@ -571,6 +572,13 @@ func (x *KubernetesRootSpec) GetBootstrapTokenId() string {
 func (x *KubernetesRootSpec) GetBootstrapTokenSecret() string {
 	if x != nil {
 		return x.BootstrapTokenSecret
+	}
+	return ""
+}
+
+func (x *KubernetesRootSpec) GetSecretboxEncryptionSecret() string {
+	if x != nil {
+		return x.SecretboxEncryptionSecret
 	}
 	return ""
 }
@@ -796,7 +804,7 @@ var file_resource_definitions_secrets_secrets_proto_rawDesc = []byte{
 	0x69, 0x6e, 0x4b, 0x75, 0x62, 0x65, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x29, 0x0a, 0x10,
 	0x61, 0x64, 0x6d, 0x69, 0x6e, 0x5f, 0x6b, 0x75, 0x62, 0x65, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67,
 	0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x4b, 0x75, 0x62,
-	0x65, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x22, 0xc5, 0x04, 0x0a, 0x12, 0x4b, 0x75, 0x62, 0x65,
+	0x65, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x22, 0x85, 0x05, 0x0a, 0x12, 0x4b, 0x75, 0x62, 0x65,
 	0x72, 0x6e, 0x65, 0x74, 0x65, 0x73, 0x52, 0x6f, 0x6f, 0x74, 0x53, 0x70, 0x65, 0x63, 0x12, 0x12,
 	0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61,
 	0x6d, 0x65, 0x12, 0x27, 0x0a, 0x08, 0x65, 0x6e, 0x64, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x18, 0x02,
@@ -832,7 +840,11 @@ var file_resource_definitions_secrets_secrets_proto_rawDesc = []byte{
 	0x61, 0x70, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x49, 0x64, 0x12, 0x34, 0x0a, 0x16, 0x62, 0x6f, 0x6f,
 	0x74, 0x73, 0x74, 0x72, 0x61, 0x70, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x5f, 0x73, 0x65, 0x63,
 	0x72, 0x65, 0x74, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x09, 0x52, 0x14, 0x62, 0x6f, 0x6f, 0x74, 0x73,
-	0x74, 0x72, 0x61, 0x70, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x22,
+	0x74, 0x72, 0x61, 0x70, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x12,
+	0x3e, 0x0a, 0x1b, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x62, 0x6f, 0x78, 0x5f, 0x65, 0x6e, 0x63,
+	0x72, 0x79, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x18, 0x0d,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x19, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x62, 0x6f, 0x78, 0x45,
+	0x6e, 0x63, 0x72, 0x79, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x22,
 	0xb4, 0x01, 0x0a, 0x0a, 0x4f, 0x53, 0x52, 0x6f, 0x6f, 0x74, 0x53, 0x70, 0x65, 0x63, 0x12, 0x33,
 	0x0a, 0x02, 0x63, 0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x63, 0x6f, 0x6d,
 	0x6d, 0x6f, 0x6e, 0x2e, 0x50, 0x45, 0x4d, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x65, 0x64, 0x43, 0x65,

--- a/pkg/machinery/api/resource/definitions/secrets/secrets_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/secrets/secrets_vtproto.pb.go
@@ -618,6 +618,13 @@ func (m *KubernetesRootSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.SecretboxEncryptionSecret) > 0 {
+		i -= len(m.SecretboxEncryptionSecret)
+		copy(dAtA[i:], m.SecretboxEncryptionSecret)
+		i = encodeVarint(dAtA, i, uint64(len(m.SecretboxEncryptionSecret)))
+		i--
+		dAtA[i] = 0x6a
+	}
 	if len(m.BootstrapTokenSecret) > 0 {
 		i -= len(m.BootstrapTokenSecret)
 		copy(dAtA[i:], m.BootstrapTokenSecret)
@@ -1300,6 +1307,10 @@ func (m *KubernetesRootSpec) SizeVT() (n int) {
 		n += 1 + l + sov(uint64(l))
 	}
 	l = len(m.BootstrapTokenSecret)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
+	}
+	l = len(m.SecretboxEncryptionSecret)
 	if l > 0 {
 		n += 1 + l + sov(uint64(l))
 	}
@@ -3039,6 +3050,38 @@ func (m *KubernetesRootSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.BootstrapTokenSecret = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecretboxEncryptionSecret", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SecretboxEncryptionSecret = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -152,3 +152,8 @@ func (contract *VersionContract) APIServerAuditPolicySupported() bool {
 func (contract *VersionContract) KubeletManifestsDirectoryDisabled() bool {
 	return contract.Greater(TalosVersion1_2)
 }
+
+// SecretboxEncryptionSupported returns true if encryption with secretbox is supported.
+func (contract *VersionContract) SecretboxEncryptionSupported() bool {
+	return contract.Greater(TalosVersion1_2)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -64,6 +64,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.True(t, contract.APIServerAuditPolicySupported())
 	assert.True(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.True(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -86,6 +87,7 @@ func TestContract1_3(t *testing.T) {
 	assert.True(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.True(t, contract.APIServerAuditPolicySupported())
 	assert.True(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.True(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -108,6 +110,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -130,6 +133,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -152,6 +156,7 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_14(t *testing.T) {
@@ -174,6 +179,7 @@ func TestContract0_14(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_13(t *testing.T) {
@@ -196,6 +202,7 @@ func TestContract0_13(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_12(t *testing.T) {
@@ -218,6 +225,7 @@ func TestContract0_12(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_11(t *testing.T) {
@@ -240,6 +248,7 @@ func TestContract0_11(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_10(t *testing.T) {
@@ -262,6 +271,7 @@ func TestContract0_10(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_9(t *testing.T) {
@@ -284,6 +294,7 @@ func TestContract0_9(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }
 
 func TestContract0_8(t *testing.T) {
@@ -306,4 +317,5 @@ func TestContract0_8(t *testing.T) {
 	assert.False(t, contract.ApidExtKeyUsageCheckEnabled())
 	assert.False(t, contract.APIServerAuditPolicySupported())
 	assert.False(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.False(t, contract.SecretboxEncryptionSupported())
 }

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -384,6 +384,7 @@ type ClusterConfig interface {
 	AggregatorCA() *x509.PEMEncodedCertificateAndKey
 	ServiceAccount() *x509.PEMEncodedKey
 	AESCBCEncryptionSecret() string
+	SecretboxEncryptionSecret() string
 	Config(machine.Type) (string, error)
 	Etcd() Etcd
 	Network() ClusterNetwork

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -151,13 +151,12 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			ServiceSubnet: in.ServiceNet,
 			CNI:           in.CNIConfig,
 		},
-		ClusterCA:                     in.Certs.K8s,
-		ClusterAggregatorCA:           in.Certs.K8sAggregator,
-		ClusterServiceAccount:         in.Certs.K8sServiceAccount,
-		BootstrapToken:                in.Secrets.BootstrapToken,
-		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
-		ExtraManifests:                []string{},
-		ClusterInlineManifests:        v1alpha1.ClusterInlineManifests{},
+		ClusterCA:              in.Certs.K8s,
+		ClusterAggregatorCA:    in.Certs.K8sAggregator,
+		ClusterServiceAccount:  in.Certs.K8sServiceAccount,
+		BootstrapToken:         in.Secrets.BootstrapToken,
+		ExtraManifests:         []string{},
+		ClusterInlineManifests: v1alpha1.ClusterInlineManifests{},
 	}
 
 	if in.AllowSchedulingOnControlPlanes {
@@ -181,6 +180,12 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 
 	if !in.VersionContract.PodSecurityPolicyEnabled() {
 		cluster.APIServerConfig.DisablePodSecurityPolicyConfig = pointer.To(true)
+	}
+
+	if in.VersionContract.SecretboxEncryptionSupported() {
+		cluster.ClusterSecretboxEncryptionSecret = in.Secrets.SecretboxEncryptionSecret
+	} else {
+		cluster.ClusterAESCBCEncryptionSecret = in.Secrets.AESCBCEncryptionSecret
 	}
 
 	if machine.MachineRegistries.RegistryMirrors == nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -102,6 +102,11 @@ func (c *ClusterConfig) AESCBCEncryptionSecret() string {
 	return c.ClusterAESCBCEncryptionSecret
 }
 
+// SecretboxEncryptionSecret implements the config.ClusterConfig interface.
+func (c *ClusterConfig) SecretboxEncryptionSecret() string {
+	return c.ClusterSecretboxEncryptionSecret
+}
+
 // Config implements the config.ClusterConfig interface.
 func (c *ClusterConfig) Config(t machine.Type) (string, error) {
 	return "", nil

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -882,11 +882,20 @@ type ClusterConfig struct {
 	//       value: '"wlzjyw.bei2zfylhs2by0wd"'
 	BootstrapToken string `yaml:"token,omitempty"`
 	//   description: |
-	//     The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+	//     A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+	//   examples:
+	//     - name: Decryption secret example (do not use in production!).
+	//     Enables encryption with AESCBC.
+	//       value: '"z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM="'
+	ClusterAESCBCEncryptionSecret string `yaml:"aescbcEncryptionSecret,omitempty"`
+	//   description: |
+	//     A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+	//     Enables encryption with secretbox.
+	//     Secretbox has precedence over AESCBC.
 	//   examples:
 	//     - name: Decryption secret example (do not use in production!).
 	//       value: '"z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM="'
-	ClusterAESCBCEncryptionSecret string `yaml:"aescbcEncryptionSecret"`
+	ClusterSecretboxEncryptionSecret string `yaml:"secretboxEncryptionSecret,omitempty"`
 	//   description: |
 	//     The base64 encoded root certificate authority used by Kubernetes.
 	//   examples:

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -348,7 +348,7 @@ func init() {
 			FieldName: "cluster",
 		},
 	}
-	ClusterConfigDoc.Fields = make([]encoder.Doc, 24)
+	ClusterConfigDoc.Fields = make([]encoder.Doc, 25)
 	ClusterConfigDoc.Fields[0].Name = "id"
 	ClusterConfigDoc.Fields[0].Type = "string"
 	ClusterConfigDoc.Fields[0].Note = ""
@@ -388,127 +388,132 @@ func init() {
 	ClusterConfigDoc.Fields[6].Name = "aescbcEncryptionSecret"
 	ClusterConfigDoc.Fields[6].Type = "string"
 	ClusterConfigDoc.Fields[6].Note = ""
-	ClusterConfigDoc.Fields[6].Description = "The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)."
-	ClusterConfigDoc.Fields[6].Comments[encoder.LineComment] = "The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)."
-
-	ClusterConfigDoc.Fields[6].AddExample("Decryption secret example (do not use in production!).", "z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=")
-	ClusterConfigDoc.Fields[7].Name = "ca"
-	ClusterConfigDoc.Fields[7].Type = "PEMEncodedCertificateAndKey"
+	ClusterConfigDoc.Fields[6].Description = "description: |\n    A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).\n  examples:\n    - name: Decryption secret example (do not use in production!).\n    Enables encryption with AESCBC.\n      value: '\"z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=\"'\n"
+	ClusterConfigDoc.Fields[6].Comments[encoder.LineComment] = "description: |"
+	ClusterConfigDoc.Fields[7].Name = "secretboxEncryptionSecret"
+	ClusterConfigDoc.Fields[7].Type = "string"
 	ClusterConfigDoc.Fields[7].Note = ""
-	ClusterConfigDoc.Fields[7].Description = "The base64 encoded root certificate authority used by Kubernetes."
-	ClusterConfigDoc.Fields[7].Comments[encoder.LineComment] = "The base64 encoded root certificate authority used by Kubernetes."
+	ClusterConfigDoc.Fields[7].Description = "A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).\nEnables encryption with secretbox.\nSecretbox has precedence over AESCBC."
+	ClusterConfigDoc.Fields[7].Comments[encoder.LineComment] = "A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)."
 
-	ClusterConfigDoc.Fields[7].AddExample("ClusterCA example.", pemEncodedCertificateExample)
-	ClusterConfigDoc.Fields[8].Name = "aggregatorCA"
+	ClusterConfigDoc.Fields[7].AddExample("Decryption secret example (do not use in production!).", "z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=")
+	ClusterConfigDoc.Fields[8].Name = "ca"
 	ClusterConfigDoc.Fields[8].Type = "PEMEncodedCertificateAndKey"
 	ClusterConfigDoc.Fields[8].Note = ""
-	ClusterConfigDoc.Fields[8].Description = "The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.\n\nThis CA can be self-signed."
-	ClusterConfigDoc.Fields[8].Comments[encoder.LineComment] = "The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation."
+	ClusterConfigDoc.Fields[8].Description = "The base64 encoded root certificate authority used by Kubernetes."
+	ClusterConfigDoc.Fields[8].Comments[encoder.LineComment] = "The base64 encoded root certificate authority used by Kubernetes."
 
-	ClusterConfigDoc.Fields[8].AddExample("AggregatorCA example.", pemEncodedCertificateExample)
-	ClusterConfigDoc.Fields[9].Name = "serviceAccount"
-	ClusterConfigDoc.Fields[9].Type = "PEMEncodedKey"
+	ClusterConfigDoc.Fields[8].AddExample("ClusterCA example.", pemEncodedCertificateExample)
+	ClusterConfigDoc.Fields[9].Name = "aggregatorCA"
+	ClusterConfigDoc.Fields[9].Type = "PEMEncodedCertificateAndKey"
 	ClusterConfigDoc.Fields[9].Note = ""
-	ClusterConfigDoc.Fields[9].Description = "The base64 encoded private key for service account token generation."
-	ClusterConfigDoc.Fields[9].Comments[encoder.LineComment] = "The base64 encoded private key for service account token generation."
+	ClusterConfigDoc.Fields[9].Description = "The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.\n\nThis CA can be self-signed."
+	ClusterConfigDoc.Fields[9].Comments[encoder.LineComment] = "The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation."
 
-	ClusterConfigDoc.Fields[9].AddExample("AggregatorCA example.", pemEncodedKeyExample)
-	ClusterConfigDoc.Fields[10].Name = "apiServer"
-	ClusterConfigDoc.Fields[10].Type = "APIServerConfig"
+	ClusterConfigDoc.Fields[9].AddExample("AggregatorCA example.", pemEncodedCertificateExample)
+	ClusterConfigDoc.Fields[10].Name = "serviceAccount"
+	ClusterConfigDoc.Fields[10].Type = "PEMEncodedKey"
 	ClusterConfigDoc.Fields[10].Note = ""
-	ClusterConfigDoc.Fields[10].Description = "API server specific configuration options."
-	ClusterConfigDoc.Fields[10].Comments[encoder.LineComment] = "API server specific configuration options."
+	ClusterConfigDoc.Fields[10].Description = "The base64 encoded private key for service account token generation."
+	ClusterConfigDoc.Fields[10].Comments[encoder.LineComment] = "The base64 encoded private key for service account token generation."
 
-	ClusterConfigDoc.Fields[10].AddExample("", clusterAPIServerExample)
-	ClusterConfigDoc.Fields[11].Name = "controllerManager"
-	ClusterConfigDoc.Fields[11].Type = "ControllerManagerConfig"
+	ClusterConfigDoc.Fields[10].AddExample("AggregatorCA example.", pemEncodedKeyExample)
+	ClusterConfigDoc.Fields[11].Name = "apiServer"
+	ClusterConfigDoc.Fields[11].Type = "APIServerConfig"
 	ClusterConfigDoc.Fields[11].Note = ""
-	ClusterConfigDoc.Fields[11].Description = "Controller manager server specific configuration options."
-	ClusterConfigDoc.Fields[11].Comments[encoder.LineComment] = "Controller manager server specific configuration options."
+	ClusterConfigDoc.Fields[11].Description = "API server specific configuration options."
+	ClusterConfigDoc.Fields[11].Comments[encoder.LineComment] = "API server specific configuration options."
 
-	ClusterConfigDoc.Fields[11].AddExample("", clusterControllerManagerExample)
-	ClusterConfigDoc.Fields[12].Name = "proxy"
-	ClusterConfigDoc.Fields[12].Type = "ProxyConfig"
+	ClusterConfigDoc.Fields[11].AddExample("", clusterAPIServerExample)
+	ClusterConfigDoc.Fields[12].Name = "controllerManager"
+	ClusterConfigDoc.Fields[12].Type = "ControllerManagerConfig"
 	ClusterConfigDoc.Fields[12].Note = ""
-	ClusterConfigDoc.Fields[12].Description = "Kube-proxy server-specific configuration options"
-	ClusterConfigDoc.Fields[12].Comments[encoder.LineComment] = "Kube-proxy server-specific configuration options"
+	ClusterConfigDoc.Fields[12].Description = "Controller manager server specific configuration options."
+	ClusterConfigDoc.Fields[12].Comments[encoder.LineComment] = "Controller manager server specific configuration options."
 
-	ClusterConfigDoc.Fields[12].AddExample("", clusterProxyExample)
-	ClusterConfigDoc.Fields[13].Name = "scheduler"
-	ClusterConfigDoc.Fields[13].Type = "SchedulerConfig"
+	ClusterConfigDoc.Fields[12].AddExample("", clusterControllerManagerExample)
+	ClusterConfigDoc.Fields[13].Name = "proxy"
+	ClusterConfigDoc.Fields[13].Type = "ProxyConfig"
 	ClusterConfigDoc.Fields[13].Note = ""
-	ClusterConfigDoc.Fields[13].Description = "Scheduler server specific configuration options."
-	ClusterConfigDoc.Fields[13].Comments[encoder.LineComment] = "Scheduler server specific configuration options."
+	ClusterConfigDoc.Fields[13].Description = "Kube-proxy server-specific configuration options"
+	ClusterConfigDoc.Fields[13].Comments[encoder.LineComment] = "Kube-proxy server-specific configuration options"
 
-	ClusterConfigDoc.Fields[13].AddExample("", clusterSchedulerExample)
-	ClusterConfigDoc.Fields[14].Name = "discovery"
-	ClusterConfigDoc.Fields[14].Type = "ClusterDiscoveryConfig"
+	ClusterConfigDoc.Fields[13].AddExample("", clusterProxyExample)
+	ClusterConfigDoc.Fields[14].Name = "scheduler"
+	ClusterConfigDoc.Fields[14].Type = "SchedulerConfig"
 	ClusterConfigDoc.Fields[14].Note = ""
-	ClusterConfigDoc.Fields[14].Description = "Configures cluster member discovery."
-	ClusterConfigDoc.Fields[14].Comments[encoder.LineComment] = "Configures cluster member discovery."
+	ClusterConfigDoc.Fields[14].Description = "Scheduler server specific configuration options."
+	ClusterConfigDoc.Fields[14].Comments[encoder.LineComment] = "Scheduler server specific configuration options."
 
-	ClusterConfigDoc.Fields[14].AddExample("", clusterDiscoveryExample)
-	ClusterConfigDoc.Fields[15].Name = "etcd"
-	ClusterConfigDoc.Fields[15].Type = "EtcdConfig"
+	ClusterConfigDoc.Fields[14].AddExample("", clusterSchedulerExample)
+	ClusterConfigDoc.Fields[15].Name = "discovery"
+	ClusterConfigDoc.Fields[15].Type = "ClusterDiscoveryConfig"
 	ClusterConfigDoc.Fields[15].Note = ""
-	ClusterConfigDoc.Fields[15].Description = "Etcd specific configuration options."
-	ClusterConfigDoc.Fields[15].Comments[encoder.LineComment] = "Etcd specific configuration options."
+	ClusterConfigDoc.Fields[15].Description = "Configures cluster member discovery."
+	ClusterConfigDoc.Fields[15].Comments[encoder.LineComment] = "Configures cluster member discovery."
 
-	ClusterConfigDoc.Fields[15].AddExample("", clusterEtcdExample)
-	ClusterConfigDoc.Fields[16].Name = "coreDNS"
-	ClusterConfigDoc.Fields[16].Type = "CoreDNS"
+	ClusterConfigDoc.Fields[15].AddExample("", clusterDiscoveryExample)
+	ClusterConfigDoc.Fields[16].Name = "etcd"
+	ClusterConfigDoc.Fields[16].Type = "EtcdConfig"
 	ClusterConfigDoc.Fields[16].Note = ""
-	ClusterConfigDoc.Fields[16].Description = "Core DNS specific configuration options."
-	ClusterConfigDoc.Fields[16].Comments[encoder.LineComment] = "Core DNS specific configuration options."
+	ClusterConfigDoc.Fields[16].Description = "Etcd specific configuration options."
+	ClusterConfigDoc.Fields[16].Comments[encoder.LineComment] = "Etcd specific configuration options."
 
-	ClusterConfigDoc.Fields[16].AddExample("", clusterCoreDNSExample)
-	ClusterConfigDoc.Fields[17].Name = "externalCloudProvider"
-	ClusterConfigDoc.Fields[17].Type = "ExternalCloudProviderConfig"
+	ClusterConfigDoc.Fields[16].AddExample("", clusterEtcdExample)
+	ClusterConfigDoc.Fields[17].Name = "coreDNS"
+	ClusterConfigDoc.Fields[17].Type = "CoreDNS"
 	ClusterConfigDoc.Fields[17].Note = ""
-	ClusterConfigDoc.Fields[17].Description = "External cloud provider configuration."
-	ClusterConfigDoc.Fields[17].Comments[encoder.LineComment] = "External cloud provider configuration."
+	ClusterConfigDoc.Fields[17].Description = "Core DNS specific configuration options."
+	ClusterConfigDoc.Fields[17].Comments[encoder.LineComment] = "Core DNS specific configuration options."
 
-	ClusterConfigDoc.Fields[17].AddExample("", clusterExternalCloudProviderConfigExample)
-	ClusterConfigDoc.Fields[18].Name = "extraManifests"
-	ClusterConfigDoc.Fields[18].Type = "[]string"
+	ClusterConfigDoc.Fields[17].AddExample("", clusterCoreDNSExample)
+	ClusterConfigDoc.Fields[18].Name = "externalCloudProvider"
+	ClusterConfigDoc.Fields[18].Type = "ExternalCloudProviderConfig"
 	ClusterConfigDoc.Fields[18].Note = ""
-	ClusterConfigDoc.Fields[18].Description = "A list of urls that point to additional manifests.\nThese will get automatically deployed as part of the bootstrap."
-	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "A list of urls that point to additional manifests."
+	ClusterConfigDoc.Fields[18].Description = "External cloud provider configuration."
+	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "External cloud provider configuration."
 
-	ClusterConfigDoc.Fields[18].AddExample("", []string{
+	ClusterConfigDoc.Fields[18].AddExample("", clusterExternalCloudProviderConfigExample)
+	ClusterConfigDoc.Fields[19].Name = "extraManifests"
+	ClusterConfigDoc.Fields[19].Type = "[]string"
+	ClusterConfigDoc.Fields[19].Note = ""
+	ClusterConfigDoc.Fields[19].Description = "A list of urls that point to additional manifests.\nThese will get automatically deployed as part of the bootstrap."
+	ClusterConfigDoc.Fields[19].Comments[encoder.LineComment] = "A list of urls that point to additional manifests."
+
+	ClusterConfigDoc.Fields[19].AddExample("", []string{
 		"https://www.example.com/manifest1.yaml",
 		"https://www.example.com/manifest2.yaml",
 	})
-	ClusterConfigDoc.Fields[19].Name = "extraManifestHeaders"
-	ClusterConfigDoc.Fields[19].Type = "map[string]string"
-	ClusterConfigDoc.Fields[19].Note = ""
-	ClusterConfigDoc.Fields[19].Description = "A map of key value pairs that will be added while fetching the extraManifests."
-	ClusterConfigDoc.Fields[19].Comments[encoder.LineComment] = "A map of key value pairs that will be added while fetching the extraManifests."
+	ClusterConfigDoc.Fields[20].Name = "extraManifestHeaders"
+	ClusterConfigDoc.Fields[20].Type = "map[string]string"
+	ClusterConfigDoc.Fields[20].Note = ""
+	ClusterConfigDoc.Fields[20].Description = "A map of key value pairs that will be added while fetching the extraManifests."
+	ClusterConfigDoc.Fields[20].Comments[encoder.LineComment] = "A map of key value pairs that will be added while fetching the extraManifests."
 
-	ClusterConfigDoc.Fields[19].AddExample("", map[string]string{
+	ClusterConfigDoc.Fields[20].AddExample("", map[string]string{
 		"Token":       "1234567",
 		"X-ExtraInfo": "info",
 	})
-	ClusterConfigDoc.Fields[20].Name = "inlineManifests"
-	ClusterConfigDoc.Fields[20].Type = "ClusterInlineManifests"
-	ClusterConfigDoc.Fields[20].Note = ""
-	ClusterConfigDoc.Fields[20].Description = "A list of inline Kubernetes manifests.\nThese will get automatically deployed as part of the bootstrap."
-	ClusterConfigDoc.Fields[20].Comments[encoder.LineComment] = "A list of inline Kubernetes manifests."
-
-	ClusterConfigDoc.Fields[20].AddExample("", clusterInlineManifestsExample)
-	ClusterConfigDoc.Fields[21].Name = "adminKubeconfig"
-	ClusterConfigDoc.Fields[21].Type = "AdminKubeconfigConfig"
+	ClusterConfigDoc.Fields[21].Name = "inlineManifests"
+	ClusterConfigDoc.Fields[21].Type = "ClusterInlineManifests"
 	ClusterConfigDoc.Fields[21].Note = ""
-	ClusterConfigDoc.Fields[21].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
-	ClusterConfigDoc.Fields[21].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
+	ClusterConfigDoc.Fields[21].Description = "A list of inline Kubernetes manifests.\nThese will get automatically deployed as part of the bootstrap."
+	ClusterConfigDoc.Fields[21].Comments[encoder.LineComment] = "A list of inline Kubernetes manifests."
 
-	ClusterConfigDoc.Fields[21].AddExample("", clusterAdminKubeconfigExample)
-	ClusterConfigDoc.Fields[23].Name = "allowSchedulingOnControlPlanes"
-	ClusterConfigDoc.Fields[23].Type = "bool"
-	ClusterConfigDoc.Fields[23].Note = ""
-	ClusterConfigDoc.Fields[23].Description = "Allows running workload on control-plane nodes."
-	ClusterConfigDoc.Fields[23].Comments[encoder.LineComment] = "Allows running workload on control-plane nodes."
-	ClusterConfigDoc.Fields[23].Values = []string{
+	ClusterConfigDoc.Fields[21].AddExample("", clusterInlineManifestsExample)
+	ClusterConfigDoc.Fields[22].Name = "adminKubeconfig"
+	ClusterConfigDoc.Fields[22].Type = "AdminKubeconfigConfig"
+	ClusterConfigDoc.Fields[22].Note = ""
+	ClusterConfigDoc.Fields[22].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
+	ClusterConfigDoc.Fields[22].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
+
+	ClusterConfigDoc.Fields[22].AddExample("", clusterAdminKubeconfigExample)
+	ClusterConfigDoc.Fields[24].Name = "allowSchedulingOnControlPlanes"
+	ClusterConfigDoc.Fields[24].Type = "bool"
+	ClusterConfigDoc.Fields[24].Note = ""
+	ClusterConfigDoc.Fields[24].Description = "Allows running workload on control-plane nodes."
+	ClusterConfigDoc.Fields[24].Comments[encoder.LineComment] = "Allows running workload on control-plane nodes."
+	ClusterConfigDoc.Fields[24].Values = []string{
 		"true",
 		"yes",
 		"false",

--- a/pkg/machinery/resources/secrets/kubernetes_root.go
+++ b/pkg/machinery/resources/secrets/kubernetes_root.go
@@ -45,6 +45,8 @@ type KubernetesRootSpec struct {
 
 	BootstrapTokenID     string `yaml:"bootstrapTokenID" protobuf:"11"`
 	BootstrapTokenSecret string `yaml:"bootstrapTokenSecret" protobuf:"12"`
+
+	SecretboxEncryptionSecret string `yaml:"secretboxEncryptionSecret" protobuf:"13"`
 }
 
 // NewKubernetesRoot initializes a KubernetesRoot resource.

--- a/website/content/v1.3/reference/api.md
+++ b/website/content/v1.3/reference/api.md
@@ -3291,6 +3291,7 @@ KubernetesRootSpec describes root Kubernetes secrets.
 | aescbc_encryption_secret | [string](#string) |  |  |
 | bootstrap_token_id | [string](#string) |  |  |
 | bootstrap_token_secret | [string](#string) |  |  |
+| secretbox_encryption_secret | [string](#string) |  |  |
 
 
 

--- a/website/content/v1.3/reference/configuration.md
+++ b/website/content/v1.3/reference/configuration.md
@@ -485,8 +485,9 @@ network:
 |`token` |string |The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) used to join the cluster. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 token: wlzjyw.bei2zfylhs2by0wd
 {{< /highlight >}}</details> | |
-|`aescbcEncryptionSecret` |string |The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/). <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-aescbcEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+|`aescbcEncryptionSecret` |string |<details><summary>description: |</summary>    A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).<br />  examples:<br />    - name: Decryption secret example (do not use in production!).<br />    Enables encryption with AESCBC.<br />      value: '"z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM="'<br /></details>  | |
+|`secretboxEncryptionSecret` |string |<details><summary>A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).</summary>Enables encryption with secretbox.<br />Secretbox has precedence over AESCBC.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+secretboxEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
 {{< /highlight >}}</details> | |
 |`ca` |PEMEncodedCertificateAndKey |The base64 encoded root certificate authority used by Kubernetes. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 ca:


### PR DESCRIPTION
We add support for encryption with secretbox. While AESCBC is still supported secretbox will take precedence if both are configured. Secretbox is not the default encryption for new clusters.

Fixes: #6362

Signed-off-by: Philipp Sauter <philipp.sauter@siderolabs.com>