### PR TITLE
fix: serve static pod files on 127.0.0.1 instead of localhost

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
@@ -136,7 +136,7 @@ func (ctrl *StaticPodServerController) createServer(ctx context.Context, r contr
 		}
 	})
 
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create listener for serving static pod manifests: %w", err)
 	}


### PR DESCRIPTION
Previously we were serving the static pod files on localhost which assumes DNS. We change that to 127.0.0.1.

Signed-off-by: Philipp Sauter <philipp.sauter@siderolabs.com>