### PR TITLE
fix: properly cleanup legacy static pod manifests directory

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -211,6 +211,9 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 		"overlay",
 		MountOverlayFilesystems,
 	).Append(
+		"legacyCleanup",
+		CleanupLegacyStaticPodFiles,
+	).Append(
 		"udevSetup",
 		WriteUdevRules,
 	).AppendWhen(


### PR DESCRIPTION
When upgrading from older version of Talos using static pod manifests directory to new version providing static pods via internal web server, we need to make sure that legacy static pods are cleaned up, otherwise kubelet receives "two" versions of the static pods which makes it fail to run them.

The previous cleanup location wasn't working properly, as `/etc/kubernetes/manifests` exists in the rootfs (and it's empty), while actual contents are in `/var`, and they appear only when respective overlay mount is done.

The controller tried to clean up on start, saw nothing (looking into rootfs), then started doing other functions. The result was that when overlay was mounted, static pods were still there, while the controller will do next attempt only when it fails, and it fails next time when kubelet is already running, and when it already picked up those stale definitions.

Fix all of that by moving cleanup into sequencer after overlayfs mount.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
