### PR TITLE
fix: check if processes is nil to avoid panic

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard/components/tables.go
+++ b/cmd/talosctl/cmd/talos/dashboard/components/tables.go
@@ -70,6 +70,12 @@ func (widget *ProcessTable) Update(node string, data *data.Data) {
 			totalWeightedCPU = 1
 		}
 
+		// All downstream logic relies on nodeData.Processes to be not nil
+		// Putting a check here to reduce cyclomatic complexity
+		if nodeData.Processes == nil {
+			return
+		}
+
 		if nodeData.ProcsDiff != nil {
 			sort.Slice(nodeData.Processes.Processes, func(i, j int) bool {
 				proc1 := nodeData.Processes.Processes[i]

--- a/cmd/talosctl/cmd/talos/dashboard/components/tables_test.go
+++ b/cmd/talosctl/cmd/talos/dashboard/components/tables_test.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components_test
+
+import (
+	"testing"
+
+	"github.com/talos-systems/talos/cmd/talosctl/cmd/talos/dashboard/components"
+	"github.com/talos-systems/talos/cmd/talosctl/cmd/talos/dashboard/data"
+	"github.com/talos-systems/talos/pkg/machinery/api/machine"
+)
+
+func TestUpdate(t *testing.T) {
+	testProcessTable := components.NewProcessTable()
+
+	testData := &data.Data{
+		Nodes: map[string]*data.Node{
+			"node1": {
+				Processes: &machine.Process{
+					Processes: []*machine.ProcessInfo{},
+				},
+				ProcsDiff: map[int32]*machine.ProcessInfo{
+					1: {},
+				},
+				Series: map[string][]float64{},
+			},
+			"node2": {
+				ProcsDiff: map[int32]*machine.ProcessInfo{
+					1: {},
+				},
+			},
+		},
+	}
+	testProcessTable.Update("node1", testData)
+	// Node2 does not have processes, without the check it panics
+	testProcessTable.Update("node2", testData)
+}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

# Pull Request

## What? (description)
Check if `nodeData.Processes` is nil before trying to access `nodeData.Processes.Processes`

## Why? (reasoning)

This can lead to panic.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
 did not work locally, not sure why (not an issue with my branch, saw the same issue with master branch: `ERROR: failed to solve: granting entitlement security.insecure is not allowed by build daemon configuration`)

> See `make help` for a description of the available targets.

Fixes #5873 

