### PR TITLE
fix: generate correct Flannel config for IPv6-only clusters

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -292,6 +292,28 @@ func (suite *ManifestSuite) TestReconcileIPv6() {
 
 	v, _, _ = unstructured.NestedString(service.Object, "spec", "ipFamilyPolicy") //nolint:errcheck
 	suite.Assert().Equal("SingleStack", v)
+
+	r, err = suite.state.Get(
+		suite.ctx,
+		resource.NewMetadata(
+			k8s.ControlPlaneNamespaceName,
+			k8s.ManifestType,
+			"05-flannel",
+			resource.VersionUndefined,
+		),
+	)
+	suite.Require().NoError(err)
+
+	manifest = r.(*k8s.Manifest) //nolint:errcheck,forcetypeassert
+	suite.Assert().Len(k8sadapter.Manifest(manifest).Objects(), 5)
+
+	configmap := k8sadapter.Manifest(manifest).Objects()[3]
+	suite.Assert().Equal("ConfigMap", configmap.GetKind())
+
+	v, _, _ = unstructured.NestedString(configmap.Object, "data", "net-conf.json") //nolint:errcheck
+	suite.Assert().Contains(v, `"EnableIPv4": false`)
+	suite.Assert().Contains(v, `"EnableIPv6": true`)
+	suite.Assert().Contains(v, fmt.Sprintf(`"IPv6Network": "%s"`, constants.DefaultIPv6PodNet))
 }
 
 func (suite *ManifestSuite) TestReconcileDisablePSP() {

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -503,7 +503,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "flannel",
@@ -522,13 +522,18 @@ data:
     }
   net-conf.json: |
     {
+      {{- $hasIPv4 := false }}
       {{- range $cidr := .PodCIDRs }}
         {{- if contains $cidr "." }}
+        {{- $hasIPv4 = true }}
       "Network": "{{ $cidr }}",
         {{- else }}
-      "IPv6Network" : "{{ $cidr }}",
-      "EnableIPv6" : true,
+      "IPv6Network": "{{ $cidr }}",
+      "EnableIPv6": true,
         {{- end }}
+      {{- end }}
+      {{- if not $hasIPv4 }}
+      "EnableIPv4": false,
       {{- end }}
       "Backend": {
         "Type": "vxlan",


### PR DESCRIPTION
See https://github.com/flannel-io/flannel/blob/master/Documentation/configuration.md#ipv6-only

Fixes #6427

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
