### PR TITLE
fix: filter up duplicate IPs out of NodeAddresses

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -193,7 +193,6 @@ func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runt
 					spec.OperatingSystem = fmt.Sprintf("%s (%s)", version.Name, version.Tag)
 
 					nodeIPs := addresses.(*network.NodeAddress).TypedSpec().IPs()
-
 					spec.Addresses = make([]netip.Addr, 0, len(nodeIPs))
 
 					for _, ip := range nodeIPs {

--- a/pkg/machinery/resources/network/node_address.go
+++ b/pkg/machinery/resources/network/node_address.go
@@ -80,7 +80,23 @@ func (NodeAddressRD) ResourceDefinition(resource.Metadata, NodeAddressSpec) meta
 
 // IPs returns IP without prefix.
 func (spec *NodeAddressSpec) IPs() []netip.Addr {
-	return slices.Map(spec.Addresses, netip.Prefix.Addr)
+	// make sure addresses are unique, as different prefixes can have the same IP
+	// at the same we want to preserve order
+	ips := slices.Map(spec.Addresses, netip.Prefix.Addr)
+
+	result := make([]netip.Addr, 0, len(ips))
+
+	for _, ip := range ips {
+		if slices.Contains(result, func(addr netip.Addr) bool {
+			return addr == ip
+		}) {
+			continue
+		}
+
+		result = append(result, ip)
+	}
+
+	return result
 }
 
 // FilteredNodeAddressID returns resource ID for node addresses with filter applied.


### PR DESCRIPTION
Node can have two IPv6 of the same addresses:
* IPv6/64
* IPv6/128

In this case, the node will advertise two of the same IP:PORT endpoints. Which adds more time to create/recover a p2p (kubespan) connection.

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
