### PR TITLE
docs: specify that only XFS partitions are detected

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -727,7 +727,7 @@ type MachineConfig struct {
 	//   description: |
 	//     Used to partition, format and mount additional disks.
 	//     Since the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.
-	//     Note that the partitioning and formating is done only once, if and only if no existing partitions are found.
+	//     Note that the partitioning and formatting is done only once, if and only if no existing XFS partitions are found.
 	//     If `size:` is omitted, the partition is sized to occupy the full disk.
 	//   examples:
 	//     - name: MachineDisks list example.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -207,7 +207,7 @@ func init() {
 	MachineConfigDoc.Fields[8].Name = "disks"
 	MachineConfigDoc.Fields[8].Type = "[]MachineDisk"
 	MachineConfigDoc.Fields[8].Note = "Note: `size` is in units of bytes.\n"
-	MachineConfigDoc.Fields[8].Description = "Used to partition, format and mount additional disks.\nSince the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.\nNote that the partitioning and formating is done only once, if and only if no existing partitions are found.\nIf `size:` is omitted, the partition is sized to occupy the full disk."
+	MachineConfigDoc.Fields[8].Description = "Used to partition, format and mount additional disks.\nSince the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.\nNote that the partitioning and formatting is done only once, if and only if no existing XFS partitions are found.\nIf `size:` is omitted, the partition is sized to occupy the full disk."
 	MachineConfigDoc.Fields[8].Comments[encoder.LineComment] = "Used to partition, format and mount additional disks."
 
 	MachineConfigDoc.Fields[8].AddExample("MachineDisks list example.", machineDisksExample)

--- a/website/content/v1.3/reference/configuration.md
+++ b/website/content/v1.3/reference/configuration.md
@@ -244,7 +244,7 @@ network:
     # kubespan:
     #     enabled: true # Enable the KubeSpan feature.
 {{< /highlight >}}</details> | |
-|`disks` |[]<a href="#machinedisk">MachineDisk</a> |<details><summary>Used to partition, format and mount additional disks.</summary>Since the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.<br />Note that the partitioning and formating is done only once, if and only if no existing partitions are found.<br />If `size:` is omitted, the partition is sized to occupy the full disk.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`disks` |[]<a href="#machinedisk">MachineDisk</a> |<details><summary>Used to partition, format and mount additional disks.</summary>Since the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.<br />Note that the partitioning and formatting is done only once, if and only if no existing XFS partitions are found.<br />If `size:` is omitted, the partition is sized to occupy the full disk.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 disks:
     - device: /dev/sdb # The name of the disk to use.
       # A list of partitions to create on the disk.


### PR DESCRIPTION
# Pull Request

## What? (description)
Update the docs to specify that only XFS partitions are detected when added in a `MachineDisk`. It is possible that other partition types are accepted, but it appears that ext4 is not.

I also fixed a minor typo in the same sentence.

## Why? (reasoning)
#6483 

This should be documented or fixed. I've taken the easier route and changed the documentation, but feel free to close this if you'd rather handle it another way.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

 <!-- -->

- Conformance complained about number of commits and not recognising my signature.
- `make fmt` changed a lot of unrelated files (removing newlines at the end of files) so I ignored those.
- Unit tests don't like my set up, but given it's only documentation and the rest passed, hopefully this is ok.