### PR TITLE
feat: add timeout to cli action tracking, track by default & refactor

### DIFF
--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -16,9 +16,8 @@ import (
 )
 
 var shutdownCmdFlags struct {
+	trackableActionCmdFlags
 	force bool
-	wait  bool
-	debug bool
 }
 
 // shutdownCmd represents the shutdown command.
@@ -52,7 +51,13 @@ var shutdownCmd = &cobra.Command{
 
 		cmd.SilenceErrors = true
 
-		return action.NewTracker(&GlobalArgs, action.StopAllServicesEventFn, shutdownGetActorID, nil, shutdownCmdFlags.debug).Run()
+		return action.NewTracker(
+			&GlobalArgs,
+			action.StopAllServicesEventFn,
+			shutdownGetActorID,
+			action.WithDebug(shutdownCmdFlags.debug),
+			action.WithTimeout(shutdownCmdFlags.timeout),
+		).Run()
 	},
 }
 
@@ -71,7 +76,6 @@ func shutdownGetActorID(ctx context.Context, c *client.Client) (string, error) {
 
 func init() {
 	shutdownCmd.Flags().BoolVar(&shutdownCmdFlags.force, "force", false, "if true, force a node to shutdown without a cordon/drain")
-	shutdownCmd.Flags().BoolVar(&shutdownCmdFlags.wait, "wait", false, "wait for the operation to complete, tracking its progress. always set to true when --debug is set")
-	shutdownCmd.Flags().BoolVar(&shutdownCmdFlags.debug, "debug", false, "debug operation from kernel logs. --no-wait is set to false when this flag is set")
+	shutdownCmdFlags.addTrackActionFlags(shutdownCmd)
 	addCommand(shutdownCmd)
 }

--- a/cmd/talosctl/cmd/talos/track.go
+++ b/cmd/talosctl/cmd/talos/track.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type trackableActionCmdFlags struct {
+	wait    bool
+	debug   bool
+	timeout time.Duration
+}
+
+func (f *trackableActionCmdFlags) addTrackActionFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.wait, "wait", true, "wait for the operation to complete, tracking its progress. always set to true when --debug is set")
+	cmd.Flags().BoolVar(&f.debug, "debug", false, "debug operation from kernel logs. --no-wait is set to false when this flag is set")
+	cmd.Flags().DurationVar(&f.timeout, "timeout", 30*time.Minute, "time to wait for the operation is complete if --debug or --wait is set")
+}

--- a/hack/structprotogen/main.go
+++ b/hack/structprotogen/main.go
@@ -13,12 +13,11 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
-
 	"github.com/siderolabs/structprotogen/ast"
 	"github.com/siderolabs/structprotogen/loader"
 	"github.com/siderolabs/structprotogen/proto"
 	"github.com/siderolabs/structprotogen/types"
+	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands.

--- a/hack/structprotogen/proto/proto.go
+++ b/hack/structprotogen/proto/proto.go
@@ -12,10 +12,9 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/typ.v4/slices"
-
 	"github.com/siderolabs/structprotogen/sliceutil"
 	"github.com/siderolabs/structprotogen/types"
+	"gopkg.in/typ.v4/slices"
 )
 
 // Pkg represents a protobuf package.

--- a/hack/structprotogen/types/types.go
+++ b/hack/structprotogen/types/types.go
@@ -12,11 +12,10 @@ import (
 	"path"
 	"strings"
 
-	"golang.org/x/tools/go/packages"
-	"gopkg.in/typ.v4/slices"
-
 	"github.com/siderolabs/structprotogen/ast"
 	"github.com/siderolabs/structprotogen/sliceutil"
+	"golang.org/x/tools/go/packages"
+	"gopkg.in/typ.v4/slices"
 )
 
 // PkgDecl is a struct which contains package path and tagged struct declarations.

--- a/website/content/v1.3/reference/cli.md
+++ b/website/content/v1.3/reference/cli.md
@@ -1901,10 +1901,11 @@ talosctl reboot [flags]
 ### Options
 
 ```
-      --debug         debug operation from kernel logs. --no-wait is set to false when this flag is set
-  -h, --help          help for reboot
-  -m, --mode string   select the reboot mode: "default", "powercycle" (skips kexec) (default "default")
-      --wait          wait for the operation to complete, tracking its progress. always set to true when --debug is set
+      --debug              debug operation from kernel logs. --no-wait is set to false when this flag is set
+  -h, --help               help for reboot
+  -m, --mode string        select the reboot mode: "default", "powercycle" (skips kexec) (default "default")
+      --timeout duration   time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
+      --wait               wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
 
 ### Options inherited from parent commands
@@ -1937,7 +1938,8 @@ talosctl reset [flags]
   -h, --help                            help for reset
       --reboot                          if true, reboot the node after resetting instead of shutting down
       --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact
-      --wait                            wait for the operation to complete, tracking its progress. always set to true when --debug is set
+      --timeout duration                time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
+      --wait                            wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
 
 ### Options inherited from parent commands
@@ -2056,10 +2058,11 @@ talosctl shutdown [flags]
 ### Options
 
 ```
-      --debug   debug operation from kernel logs. --no-wait is set to false when this flag is set
-      --force   if true, force a node to shutdown without a cordon/drain
-  -h, --help    help for shutdown
-      --wait    wait for the operation to complete, tracking its progress. always set to true when --debug is set
+      --debug              debug operation from kernel logs. --no-wait is set to false when this flag is set
+      --force              if true, force a node to shutdown without a cordon/drain
+  -h, --help               help for shutdown
+      --timeout duration   time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
+      --wait               wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
 
 ### Options inherited from parent commands
@@ -2198,14 +2201,15 @@ talosctl upgrade [flags]
 ### Options
 
 ```
-      --debug          debug operation from kernel logs. --no-wait is set to false when this flag is set
-  -f, --force          force the upgrade (skip checks on etcd health and members, might lead to data loss)
-  -h, --help           help for upgrade
-  -i, --image string   the container image to use for performing the install
-      --insecure       upgrade using the insecure (encrypted with no auth) maintenance service
-  -p, --preserve       preserve data
-  -s, --stage          stage the upgrade to perform it after a reboot
-      --wait           wait for the operation to complete, tracking its progress. always set to true when --debug is set
+      --debug              debug operation from kernel logs. --no-wait is set to false when this flag is set
+  -f, --force              force the upgrade (skip checks on etcd health and members, might lead to data loss)
+  -h, --help               help for upgrade
+  -i, --image string       the container image to use for performing the install
+      --insecure           upgrade using the insecure (encrypted with no auth) maintenance service
+  -p, --preserve           preserve data
+  -s, --stage              stage the upgrade to perform it after a reboot
+      --timeout duration   time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
+      --wait               wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Add a timeout of 15 minutes to the trackable CLI actions reboot, reset, shutdown and upgrade and refactor the action tracking.
Make waiting for these operations the default behavior (set `--wait` to `true` by default).

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>