### PR TITLE
feat: publish discovered public IP as one of the KubeSpan endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10
 	github.com/siderolabs/crypto v0.4.0
 	github.com/siderolabs/discovery-api v0.1.1
-	github.com/siderolabs/discovery-client v0.1.2
+	github.com/siderolabs/discovery-client v0.1.3
 	github.com/siderolabs/gen v0.4.0
 	github.com/siderolabs/go-blockdevice v0.4.1
 	github.com/siderolabs/go-circular v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1016,8 +1016,8 @@ github.com/siderolabs/crypto v0.4.0 h1:o1KIR1KyevUcY9nbJlSyQAj7+p+rveGGF8LjAAFMt
 github.com/siderolabs/crypto v0.4.0/go.mod h1:itZpBsJ9i0aH8jiHAuSlKCal7hni7X1aDYo6vGVl5LY=
 github.com/siderolabs/discovery-api v0.1.1 h1:DI+CjD/Nl0nIk8qkaNKz1sEquWTEKHKH4+ERsv+yBWg=
 github.com/siderolabs/discovery-api v0.1.1/go.mod h1:JnJg4h1HbAhOazQl0lYHEjrg63rg/cf9r2te6/DqUxo=
-github.com/siderolabs/discovery-client v0.1.2 h1:QsNwt/boSPM+f8Ww+GlAMv2+9o5KPhLdPUfjvVuNIm8=
-github.com/siderolabs/discovery-client v0.1.2/go.mod h1:4ahEk2dMPKAGCLK5sRUxHfVryROxflwDPL+2c5MrLMI=
+github.com/siderolabs/discovery-client v0.1.3 h1:DsiH2aiObxHGJISLXxih4q+NmSixUzxRegNjLlRC8s4=
+github.com/siderolabs/discovery-client v0.1.3/go.mod h1:4ahEk2dMPKAGCLK5sRUxHfVryROxflwDPL+2c5MrLMI=
 github.com/siderolabs/gen v0.4.0 h1:t+f2TimPoAGBNeXW3qLQBlbDC5GnFik+E/4PWL/uf9c=
 github.com/siderolabs/gen v0.4.0/go.mod h1:vzcXVRNpo9j2tyQJU+9ZQ1J6yoebX9KL1TkHt18HNqw=
 github.com/siderolabs/go-api-signature v0.2.2 h1:C5tUzuFsJYidpYyVfJGYpgQwETglA8B62ET4obkLDGE=

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,13 +24,6 @@ function release-notes {
   echo -e '\n## Images\n\n```' >> ${1}
   ${ARTIFACTS}/talosctl-linux-amd64 images >> ${1}
   echo -e '```\n' >> ${1}
-
-  size=$(stat -c%s "${1}")
-
-  if (( size > 50000 )); then
-    echo "Release notes size exceeds GitHub limit of 50000 bytes"
-    exit 1
-  fi
 }
 
 function cherry-pick {


### PR DESCRIPTION
This resolves a case when a node is behind NAT, but KubeSpan port is forwarded back to the node. Discovery Service returns public IP of the client as it sees from the incoming request. That address is now published to the KubeSpan endpoints.

Fixes #6508

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
