### PR TITLE
test: fix log streaming for conformance tests

### DIFF
--- a/pkg/cluster/sonobuoy/sonobuoy.go
+++ b/pkg/cluster/sonobuoy/sonobuoy.go
@@ -137,6 +137,9 @@ func Run(ctx context.Context, cluster cluster.K8sProvider, options *Options) err
 		return fmt.Errorf("error getting kubernetes config: %w", err)
 	}
 
+	// reset timeout to prevent log streaming from timing out
+	cfg.Timeout = 0
+
 	skc, err := sonodynamic.NewAPIHelperFromRESTConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("couldn't get sonobuoy api helper: %w", err)


### PR DESCRIPTION
Global timeout in kubeconfig was causing log streaming to abort.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
