### PR TITLE
feat: hcloud location properties

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -136,6 +136,8 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 	networkConfig.Metadata = &runtimeres.PlatformMetadataSpec{
 		Platform:   h.Name(),
 		Hostname:   metadata.Hostname,
+		Region:     metadata.Region,
+		Zone:       metadata.AvailabilityZone,
 		InstanceID: metadata.InstanceID,
 		ProviderID: fmt.Sprintf("hcloud://%s", metadata.InstanceID),
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud_test.go
@@ -25,9 +25,11 @@ func TestParseMetadata(t *testing.T) {
 	h := &hcloud.Hcloud{}
 
 	metadata := &hcloud.MetadataConfig{
-		Hostname:   "talos.fqdn",
-		PublicIPv4: "1.2.3.4",
-		InstanceID: "0",
+		Hostname:         "talos.fqdn",
+		PublicIPv4:       "1.2.3.4",
+		InstanceID:       "0",
+		Region:           "hel1",
+		AvailabilityZone: "hel1-dc2",
 	}
 
 	var m hcloud.NetworkConfig

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/testdata/expected.yaml
@@ -44,5 +44,7 @@ externalIPs:
 metadata:
     platform: hcloud
     hostname: talos.fqdn
+    region: hel1
+    zone: hel1-dc2
     instanceId: "0"
     providerId: hcloud://0


### PR DESCRIPTION
HCloud starts share the region/availability-zone values.

https://github.com/hetznercloud/csi-driver/pull/293#issuecomment-1320045174

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
