### PR TITLE
Fix talosctl upgrade force flag parsing

### DIFF
--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -22,11 +22,11 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
-var (
+var kubeconfigFlags struct {
 	force            bool
 	forceContextName string
 	merge            bool
-)
+}
 
 // kubeconfigCmd represents the kubeconfig command.
 var kubeconfigCmd = &cobra.Command{
@@ -48,7 +48,7 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				// no path given, use defaults
 				var err error
 
-				if merge {
+				if kubeconfigFlags.merge {
 					localPath, err = kubeconfig.SinglePath()
 					if err != nil {
 						return err
@@ -81,12 +81,12 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 			}
 
 			_, err = os.Stat(localPath)
-			if err == nil && !(force || merge) {
+			if err == nil && !(kubeconfigFlags.force || kubeconfigFlags.merge) {
 				return fmt.Errorf("kubeconfig file already exists, use --force to overwrite: %q", localPath)
 			} else if err != nil {
 				if os.IsNotExist(err) {
 					// merge doesn't make sense if target path doesn't exist
-					merge = false
+					kubeconfigFlags.merge = false
 				} else {
 					return fmt.Errorf("error checking path %q: %w", localPath, err)
 				}
@@ -115,7 +115,7 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				return err
 			}
 
-			if merge {
+			if kubeconfigFlags.merge {
 				return extractAndMerge(data, localPath)
 			}
 
@@ -139,10 +139,10 @@ func extractAndMerge(data []byte, localPath string) error {
 
 	err = merger.Merge(config, kubeconfig.MergeOptions{
 		ActivateContext:  true,
-		ForceContextName: forceContextName,
+		ForceContextName: kubeconfigFlags.forceContextName,
 		OutputWriter:     os.Stdout,
 		ConflictHandler: func(component kubeconfig.ConfigComponent, name string) (kubeconfig.ConflictDecision, error) {
-			if force {
+			if kubeconfigFlags.force {
 				return kubeconfig.OverwriteDecision, nil
 			}
 
@@ -182,8 +182,8 @@ func askOverwriteOrRename(prompt string) (kubeconfig.ConflictDecision, error) {
 }
 
 func init() {
-	kubeconfigCmd.Flags().BoolVarP(&force, "force", "f", false, "Force overwrite of kubeconfig if already present, force overwrite on kubeconfig merge")
-	kubeconfigCmd.Flags().StringVar(&forceContextName, "force-context-name", "", "Force context name for kubeconfig merge")
-	kubeconfigCmd.Flags().BoolVarP(&merge, "merge", "m", true, "Merge with existing kubeconfig")
+	kubeconfigCmd.Flags().BoolVarP(&kubeconfigFlags.force, "force", "f", false, "Force overwrite of kubeconfig if already present, force overwrite on kubeconfig merge")
+	kubeconfigCmd.Flags().StringVar(&kubeconfigFlags.forceContextName, "force-context-name", "", "Force context name for kubeconfig merge")
+	kubeconfigCmd.Flags().BoolVarP(&kubeconfigFlags.merge, "merge", "m", true, "Merge with existing kubeconfig")
 	addCommand(kubeconfigCmd)
 }

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -82,7 +82,7 @@ func runUpgradeNoWait() error {
 			upgradeCmdFlags.upgradeImage,
 			upgradeCmdFlags.preserve,
 			upgradeCmdFlags.stage,
-			force,
+			upgradeCmdFlags.force,
 			grpc.Peer(&remotePeer),
 		)
 		if err != nil {
@@ -124,7 +124,7 @@ func upgradeGetActorID(ctx context.Context, c *client.Client) (string, error) {
 		upgradeCmdFlags.upgradeImage,
 		upgradeCmdFlags.preserve,
 		upgradeCmdFlags.stage,
-		force,
+		upgradeCmdFlags.force,
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This PR fixes the `talosctl upgrade` command where the `--force` flag is incorrectly parsed and remains always false.

The upgrade force option is not available for users of `talosctl`, although the server implementation supports it.

## Why? (reasoning)

This seems to have been an oversight during some refactoring in the v1.2 release.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
