### PR TITLE
fix: parse and apply DHCP settings properly from cmdline

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_config_test.go
@@ -131,7 +131,7 @@ func (suite *AddressConfigSuite) TestCmdline() {
 	suite.Require().NoError(
 		suite.runtime.RegisterController(
 			&netctrl.AddressConfigController{
-				Cmdline: procfs.NewCmdline("ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1:::::"),
+				Cmdline: procfs.NewCmdline("ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1::::: ip=eth3:dhcp ip=10.3.5.7::10.3.5.1:255.255.255.0::eth4"),
 			},
 		),
 	)
@@ -144,8 +144,14 @@ func (suite *AddressConfigSuite) TestCmdline() {
 				return suite.assertAddresses(
 					[]string{
 						"cmdline/eth1/172.20.0.2/24",
+						"cmdline/eth4/10.3.5.7/24",
 					}, func(r *network.AddressSpec) error {
-						suite.Assert().Equal("eth1", r.TypedSpec().LinkName)
+						switch r.Metadata().ID() {
+						case "cmdline/eth1/172.20.0.2/24":
+							suite.Assert().Equal("eth1", r.TypedSpec().LinkName)
+						case "cmdline/eth4/10.3.5.7/24":
+							suite.Assert().Equal("eth4", r.TypedSpec().LinkName)
+						}
 
 						return nil
 					},

--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -177,7 +177,7 @@ func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 	suite.Require().NoError(
 		suite.runtime.RegisterController(
 			&netctrl.OperatorConfigController{
-				Cmdline: procfs.NewCmdline("ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1:::::"),
+				Cmdline: procfs.NewCmdline("ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1::::: ip=eth3:dhcp"),
 			},
 		),
 	)
@@ -199,6 +199,7 @@ func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 					[]string{
 						"default/dhcp4/eth0",
 						"default/dhcp4/eth2",
+						"cmdline/dhcp4/eth3",
 					}, func(r *network.OperatorSpec) error {
 						suite.Assert().Equal(network.OperatorDHCP4, r.TypedSpec().Operator)
 						suite.Assert().True(r.TypedSpec().RequireUp)
@@ -209,6 +210,8 @@ func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 							suite.Assert().Equal("eth0", r.TypedSpec().LinkName)
 						case "default/dhcp4/eth2":
 							suite.Assert().Equal("eth2", r.TypedSpec().LinkName)
+						case "cmdline/dhcp4/eth3":
+							suite.Assert().Equal("eth3", r.TypedSpec().LinkName)
 						}
 
 						return nil

--- a/website/content/v1.3/reference/kernel.md
+++ b/website/content/v1.3/reference/kernel.md
@@ -26,7 +26,7 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 
 #### `ip`
 
-Initial configuration of the interface, routes, DNS, NTP servers.
+Initial configuration of the interface, routes, DNS, NTP servers (multiple `ip=` kernel parameters are accepted).
 
 Full documentation is available in the [Linux kernel docs](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt).
 
@@ -35,11 +35,14 @@ Full documentation is available in the [Linux kernel docs](https://www.kernel.or
 Talos will use the configuration supplied via the kernel parameter as the initial network configuration.
 This parameter is useful in the environments where DHCP doesn't provide IP addresses or when default DNS and NTP servers should be overridden
 before loading machine configuration.
-Partial configuration can be applied as well, e.g. `ip=<:::::::<dns0-ip>:<dns1-ip>:<ntp0-ip>` sets only the DNS and NTP servers.
+Partial configuration can be applied as well, e.g. `ip=:::::::<dns0-ip>:<dns1-ip>:<ntp0-ip>` sets only the DNS and NTP servers.
 
 IPv6 addresses can be specified by enclosing them in the square brackets, e.g. `ip=[2001:db8::a]:[2001:db8::b]:[fe80::1]::controlplane1:eth1::[2001:4860:4860::6464]:[2001:4860:4860::64]:[2001:4860:4806::]`.
 
 `<device>` can be traditional interface naming scheme `eth0, eth1` or `enx<MAC>`, example: `enx78e7d1ea46da`
+
+DCHP can be enabled by setting `<autoconf>` to `dhcp`, example: `ip=:::::eth0.3:dhcp`.
+Alternative syntax is `ip=eth0.3:dhcp`.
 
 #### `bond`
 


### PR DESCRIPTION
This allows multiple `ip=` parameters, and fixes setting DHCP for any link on the cmdline.

Fixes #6475

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
