### PR TITLE
fix: disable kexec on upgrades from pre-BTF kernel

### DIFF
--- a/cmd/installer/pkg/install/errata.go
+++ b/cmd/installer/pkg/install/errata.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install
+
+import (
+	"log"
+	"os"
+
+	pkgkernel "github.com/siderolabs/talos/pkg/kernel"
+	"github.com/siderolabs/talos/pkg/machinery/kernel"
+)
+
+// errataBTF handles the case when kexec from pre-BTF kernel to BTF enabled kernel always fails.
+//
+// This applies to upgrades of Talos < 1.3.0 to Talos >= 1.3.0.
+func errataBTF() {
+	_, err := os.Stat("/sys/kernel/btf/vmlinux")
+	if err == nil {
+		// BTF is enabled, nothing to do
+		return
+	}
+
+	log.Printf("disabling kexec due to upgrade to the BTF enabled kernel")
+
+	if err = pkgkernel.WriteParam(&kernel.Param{
+		Key:   "proc.sys.kernel.kexec_load_disabled",
+		Value: "1",
+	}); err != nil {
+		log.Printf("failed to disable kexec: %s", err)
+	}
+}

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -179,6 +179,8 @@ func (i *Installer) probeBootPartition() error {
 //
 //nolint:gocyclo,cyclop
 func (i *Installer) Install(seq runtime.Sequence) (err error) {
+	errataBTF()
+
 	if err = i.installExtensions(); err != nil {
 		return err
 	}

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -398,10 +398,6 @@ func (suite *UpgradeSuite) setupCluster() {
 		)
 	}
 
-	genOptions = append(genOptions, generate.WithSysctls(map[string]string{
-		"kernel.kexec_load_disabled": "1",
-	}))
-
 	versionContract, err := config.ParseContractFromVersion(suite.spec.SourceVersion)
 	suite.Require().NoError(err)
 


### PR DESCRIPTION
Enabling BTF in the kernel brakes kexec from pre-BTF kernel (e.g. when upgrading from 1.2.x to 1.3.x).

As there's no way to detect Talos version in the installer at the moment, use another way to detect whether BTF is enabled in the Talos version which is running right now.

Fixes #6443

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
