### PR TITLE
feat: implement pre-flight checks in the installer

### DIFF
--- a/cmd/installer/pkg/install/preflight.go
+++ b/cmd/installer/pkg/install/preflight.go
@@ -1,0 +1,270 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+	"github.com/siderolabs/talos/pkg/machinery/role"
+	"github.com/siderolabs/talos/pkg/version"
+)
+
+// PreflightChecks runs the preflight checks.
+type PreflightChecks struct {
+	disabled bool
+	client   *client.Client
+
+	installerTalosVersion *compatibility.TalosVersion
+	hostTalosVersion      *compatibility.TalosVersion
+}
+
+// NewPreflightChecks initializes and returns the install PreflightChecks.
+func NewPreflightChecks(ctx context.Context) (*PreflightChecks, error) {
+	if _, err := os.Stat(constants.MachineSocketPath); err != nil {
+		log.Printf("pre-flight checks disabled, as host Talos version is too old")
+
+		return &PreflightChecks{disabled: true}, nil //nolint:nilerr
+	}
+
+	c, err := client.New(ctx,
+		client.WithUnixSocket(constants.MachineSocketPath),
+		client.WithGRPCDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to the machine service: %w", err)
+	}
+
+	return &PreflightChecks{
+		client: c,
+	}, nil
+}
+
+// Close closes the client.
+func (checks *PreflightChecks) Close() error {
+	if checks.disabled {
+		return nil
+	}
+
+	return checks.client.Close()
+}
+
+// Run the checks, return the error if the check fails.
+func (checks *PreflightChecks) Run(ctx context.Context) error {
+	if checks.disabled {
+		return nil
+	}
+
+	log.Printf("running pre-flight checks")
+
+	// inject "fake" authorization
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(constants.APIAuthzRoleMetadataKey, string(role.Admin)))
+
+	for _, check := range []func(context.Context) error{
+		checks.talosVersion,
+		checks.kubernetesVersion,
+	} {
+		if err := check(ctx); err != nil {
+			return fmt.Errorf("pre-flight checks failed: %w", err)
+		}
+	}
+
+	log.Printf("all pre-flight checks successful")
+
+	return nil
+}
+
+func (checks *PreflightChecks) talosVersion(ctx context.Context) error {
+	resp, err := checks.client.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting Talos version: %w", err)
+	}
+
+	hostVersion := unpack(resp.Messages)
+
+	log.Printf("host Talos version: %s", hostVersion.Version.Tag)
+
+	checks.hostTalosVersion, err = compatibility.ParseTalosVersion(hostVersion.Version)
+	if err != nil {
+		return fmt.Errorf("error parsing host Talos version: %w", err)
+	}
+
+	checks.installerTalosVersion, err = compatibility.ParseTalosVersion(version.NewVersion())
+	if err != nil {
+		return fmt.Errorf("error parsing installer Talos version: %w", err)
+	}
+
+	return checks.hostTalosVersion.UpgradeableFrom(checks.installerTalosVersion)
+}
+
+type k8sVersions struct {
+	kubelet           *compatibility.KubernetesVersion
+	apiServer         *compatibility.KubernetesVersion
+	scheduler         *compatibility.KubernetesVersion
+	controllerManager *compatibility.KubernetesVersion
+}
+
+//nolint:gocyclo
+func (versions *k8sVersions) gatherVersions(ctx context.Context, client *client.Client) error {
+	kubeletSpec, err := safe.StateGet[*k8s.KubeletSpec](ctx, client.COSI, k8s.NewKubeletSpec(k8s.NamespaceName, k8s.KubeletID).Metadata())
+	if err != nil && !state.IsNotFoundError(err) {
+		return fmt.Errorf("error getting kubelet spec: %w", err)
+	}
+
+	if kubeletSpec != nil {
+		versions.kubelet, err = kubernetesVersionFromImageRef(kubeletSpec.TypedSpec().Image)
+		if err != nil {
+			return fmt.Errorf("error parsing kubelet version: %w", err)
+		}
+	}
+
+	apiServerSpec, err := safe.StateGet[*k8s.APIServerConfig](ctx, client.COSI, k8s.NewAPIServerConfig().Metadata())
+	if err != nil && !state.IsNotFoundError(err) {
+		return fmt.Errorf("error getting API server spec: %w", err)
+	}
+
+	if apiServerSpec != nil {
+		versions.apiServer, err = kubernetesVersionFromImageRef(apiServerSpec.TypedSpec().Image)
+		if err != nil {
+			return fmt.Errorf("error parsing API server version: %w", err)
+		}
+	}
+
+	schedulerSpec, err := safe.StateGet[*k8s.SchedulerConfig](ctx, client.COSI, k8s.NewSchedulerConfig().Metadata())
+	if err != nil && !state.IsNotFoundError(err) {
+		return fmt.Errorf("error getting scheduler spec: %w", err)
+	}
+
+	if schedulerSpec != nil {
+		versions.scheduler, err = kubernetesVersionFromImageRef(schedulerSpec.TypedSpec().Image)
+		if err != nil {
+			return fmt.Errorf("error parsing scheduler version: %w", err)
+		}
+	}
+
+	controllerManagerSpec, err := safe.StateGet[*k8s.ControllerManagerConfig](ctx, client.COSI, k8s.NewControllerManagerConfig().Metadata())
+	if err != nil && !state.IsNotFoundError(err) {
+		return fmt.Errorf("error getting controller manager spec: %w", err)
+	}
+
+	if controllerManagerSpec != nil {
+		versions.controllerManager, err = kubernetesVersionFromImageRef(controllerManagerSpec.TypedSpec().Image)
+		if err != nil {
+			return fmt.Errorf("error parsing controller manager version: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (versions *k8sVersions) checkCompatibility(target *compatibility.TalosVersion) error {
+	for _, component := range []struct {
+		name    string
+		version *compatibility.KubernetesVersion
+	}{
+		{
+			name:    "kubelet",
+			version: versions.kubelet,
+		},
+		{
+			name:    "kube-apiserver",
+			version: versions.apiServer,
+		},
+		{
+			name:    "kube-scheduler",
+			version: versions.scheduler,
+		},
+		{
+			name:    "kube-controller-manager",
+			version: versions.controllerManager,
+		},
+	} {
+		if component.version == nil {
+			continue
+		}
+
+		if err := component.version.SupportedWith(target); err != nil {
+			return fmt.Errorf("component %s version issue: %w", component.name, err)
+		}
+	}
+
+	return nil
+}
+
+func (versions *k8sVersions) String() string {
+	var components []string //nolint:prealloc
+
+	for _, component := range []struct {
+		name    string
+		version *compatibility.KubernetesVersion
+	}{
+		{
+			name:    "kubelet",
+			version: versions.kubelet,
+		},
+		{
+			name:    "kube-apiserver",
+			version: versions.apiServer,
+		},
+		{
+			name:    "kube-scheduler",
+			version: versions.scheduler,
+		},
+		{
+			name:    "kube-controller-manager",
+			version: versions.controllerManager,
+		},
+	} {
+		if component.version == nil {
+			continue
+		}
+
+		components = append(components, fmt.Sprintf("%s: %s", component.name, component.version))
+	}
+
+	return strings.Join(components, ", ")
+}
+
+func (checks *PreflightChecks) kubernetesVersion(ctx context.Context) error {
+	var versions k8sVersions
+
+	if err := versions.gatherVersions(ctx, checks.client); err != nil {
+		return err
+	}
+
+	log.Printf("host Kubernetes versions: %s", &versions)
+
+	return versions.checkCompatibility(checks.installerTalosVersion)
+}
+
+func kubernetesVersionFromImageRef(ref string) (*compatibility.KubernetesVersion, error) {
+	idx := strings.LastIndex(ref, ":v")
+	if idx == -1 {
+		return nil, fmt.Errorf("invalid image reference: %q", ref)
+	}
+
+	return compatibility.ParseKubernetesVersion(ref[idx+2:])
+}
+
+func unpack[T any](s []T) T {
+	if len(s) != 1 {
+		panic("unpack: slice length is not 1")
+	}
+
+	return s[0]
+}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -128,6 +128,13 @@ func RunInstallerContainer(disk, platform, ref string, cfg config.Provider, opts
 		{Type: "bind", Destination: constants.SystemExtensionsPath, Source: constants.SystemExtensionsPath, Options: []string{"rbind", "rshared", "ro"}},
 	}
 
+	// mount the machined socket into the container for upgrade pre-checks if the socket exists
+	if _, err = os.Stat(constants.MachineSocketPath); err == nil {
+		mounts = append(mounts,
+			specs.Mount{Type: "bind", Destination: constants.MachineSocketPath, Source: constants.MachineSocketPath, Options: []string{"rbind", "rshared", "ro"}},
+		)
+	}
+
 	// TODO(andrewrynhard): To handle cases when the newer version changes the
 	// platform name, this should be determined in the installer container.
 	config := constants.ConfigNone

--- a/pkg/machinery/compatibility/compatibility.go
+++ b/pkg/machinery/compatibility/compatibility.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package compatibility provides version compatibility checks for Talos.
+package compatibility

--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package compatibility
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
+)
+
+// KubernetesVersion embeds Kubernetes version.
+type KubernetesVersion struct {
+	version version.Version
+}
+
+// ParseKubernetesVersion parses Talos version.
+func ParseKubernetesVersion(v string) (*KubernetesVersion, error) {
+	parsed, err := version.NewVersion(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubernetesVersion{
+		version: *parsed,
+	}, nil
+}
+
+func (v *KubernetesVersion) String() string {
+	return v.version.String()
+}
+
+// SupportedWith checks if the Kubernetes version is supported with specified version of Talos.
+func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
+	switch target.majorMinor {
+	case talos13.MajorMinor: // upgrades to 1.3.x
+		if v.version.Core().LessThan(talos13.MinimumKubernetesVersion) {
+			return fmt.Errorf("version of Kubernetes %s is too old to be used with Talos %s", v.version.String(), target.version.String())
+		}
+
+		if v.version.Core().GreaterThanOrEqual(talos13.MaximumKubernetesVersion) {
+			return fmt.Errorf("version of Kubernetes %s is too new to be used with Talos %s", v.version.String(), target.version.String())
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("compatibility with version %s is not supported", target.String())
+	}
+}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package compatibility_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility"
+)
+
+type kubernetesVersionTest struct {
+	kubernetesVersion string
+	target            string
+	expectedError     string
+}
+
+func runKubernetesVersionTest(t *testing.T, tt kubernetesVersionTest) {
+	t.Run(tt.kubernetesVersion+" -> "+tt.target, func(t *testing.T) {
+		k8sVersion, err := compatibility.ParseKubernetesVersion(tt.kubernetesVersion)
+		require.NoError(t, err)
+
+		target, err := compatibility.ParseTalosVersion(&machine.VersionInfo{
+			Tag: tt.target,
+		})
+		require.NoError(t, err)
+
+		err = k8sVersion.SupportedWith(target)
+		if tt.expectedError != "" {
+			require.EqualError(t, err, tt.expectedError)
+		} else {
+			require.NoError(t, err)
+		}
+	})
+}
+
+func TestKubernetesCompatibility13(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.24.1",
+			target:            "1.3.0",
+		},
+		{
+			kubernetesVersion: "1.25.3",
+			target:            "1.3.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.26.0-rc.0",
+			target:            "1.3.7",
+		},
+		{
+			kubernetesVersion: "1.27.0-alpha.0",
+			target:            "1.3.0",
+			expectedError:     "version of Kubernetes 1.27.0-alpha.0 is too new to be used with Talos 1.3.0",
+		},
+		{
+			kubernetesVersion: "1.23.4",
+			target:            "1.3.0",
+			expectedError:     "version of Kubernetes 1.23.4 is too old to be used with Talos 1.3.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
+func TestKubernetesCompatibilityUnsupported(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.25.0",
+			target:            "1.4.0-alpha.0",
+			expectedError:     "compatibility with version 1.4.0-alpha.0 is not supported",
+		},
+		{
+			kubernetesVersion: "1.25.0",
+			target:            "1.2.0",
+			expectedError:     "compatibility with version 1.2.0 is not supported",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}

--- a/pkg/machinery/compatibility/talos13/talos13.go
+++ b/pkg/machinery/compatibility/talos13/talos13.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos13 provides compatibility constants for Talos 1.3.
+package talos13
+
+import "github.com/hashicorp/go-version"
+
+// MajorMinor is the major.minor version of Talos 1.3.
+var MajorMinor = [2]int{1, 3}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.3.
+var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.3.
+var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.5.0"))
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.3.
+var DeniedHostUpgradeVersions = []*version.Version{}
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.3.
+var MinimumKubernetesVersion = version.Must(version.NewVersion("1.24.0"))
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.3.
+var MaximumKubernetesVersion = version.Must(version.NewVersion("1.26.99"))

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package compatibility
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
+)
+
+// TalosVersion embeds Talos version.
+type TalosVersion struct {
+	version    version.Version
+	majorMinor [2]int
+}
+
+// ParseTalosVersion parses Talos version.
+func ParseTalosVersion(v *machine.VersionInfo) (*TalosVersion, error) {
+	parsed, err := version.NewVersion(v.Tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TalosVersion{
+		version:    *parsed,
+		majorMinor: [2]int{parsed.Segments()[0], parsed.Segments()[1]},
+	}, nil
+}
+
+func (v *TalosVersion) String() string {
+	return v.version.String()
+}
+
+// UpgradeableFrom checks if the current version of Talos can be used as an upgrade for the given host version.
+func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
+	switch v.majorMinor {
+	case talos13.MajorMinor: // upgrades to 1.3.x
+		if host.version.Core().LessThan(talos13.MinimumHostUpgradeVersion) {
+			return fmt.Errorf("host version %s is too old to upgrade to Talos %s", host.version.String(), v.version.String())
+		}
+
+		if host.version.Core().GreaterThanOrEqual(talos13.MaximumHostDowngradeVersion) {
+			return fmt.Errorf("host version %s is too new to downgrade to Talos %s", host.version.String(), v.version.String())
+		}
+
+		for _, blacklisted := range talos13.DeniedHostUpgradeVersions {
+			if host.version.Equal(blacklisted) {
+				return fmt.Errorf("host version %s is blacklisted for upgrade to Talos %s", host.version.String(), v.version.String())
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
+	}
+}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package compatibility_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility"
+)
+
+type talosVersionTest struct {
+	host          string
+	target        string
+	expectedError string
+}
+
+func runTalosVersionTest(t *testing.T, tt talosVersionTest) {
+	t.Run(tt.host+" -> "+tt.target, func(t *testing.T) {
+		host, err := compatibility.ParseTalosVersion(&machine.VersionInfo{
+			Tag: tt.host,
+		})
+		require.NoError(t, err)
+
+		target, err := compatibility.ParseTalosVersion(&machine.VersionInfo{
+			Tag: tt.target,
+		})
+		require.NoError(t, err)
+
+		err = target.UpgradeableFrom(host)
+		if tt.expectedError != "" {
+			require.EqualError(t, err, tt.expectedError)
+		} else {
+			require.NoError(t, err)
+		}
+	})
+}
+
+func TestTalosUpgradeCompatibility13(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.2.0",
+			target: "1.3.0",
+		},
+		{
+			host:   "1.0.0-alpha.0",
+			target: "1.3.0",
+		},
+		{
+			host:   "1.2.0-alpha.0",
+			target: "1.3.0-alpha.0",
+		},
+		{
+			host:   "1.3.0",
+			target: "1.3.1",
+		},
+		{
+			host:   "1.3.0-beta.0",
+			target: "1.3.0",
+		},
+		{
+			host:   "1.4.5",
+			target: "1.3.3",
+		},
+		{
+			host:          "0.14.3",
+			target:        "1.3.0",
+			expectedError: `host version 0.14.3 is too old to upgrade to Talos 1.3.0`,
+		},
+		{
+			host:          "1.5.0-alpha.0",
+			target:        "1.3.0",
+			expectedError: `host version 1.5.0-alpha.0 is too new to downgrade to Talos 1.3.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
+func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:          "1.3.0",
+			target:        "1.4.0-alpha.0",
+			expectedError: `upgrades to version 1.4.0-alpha.0 are not supported`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-version v1.6.0
 	github.com/jsimonetti/rtnetlink v1.2.3
 	github.com/mdlayher/ethtool v0.0.0-20220830195143-0e16326d06d1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -67,6 +67,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=


### PR DESCRIPTION
Host Talos mounts machined socket for API access into the installer contianer (for upgrades).

Installer runs any check it might need to verify compatibility.

At the moment following checks are implemented:

* Talos version (whether upgrade from version X to Y is supported)
* Kubernetes version (whether Kubernetes version X is supported with Talos Y).

Fixes #6149

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
