### PR TITLE
feat: update COSI to v0.2.0

### DIFF
--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -155,6 +155,20 @@ func getResources(args []string) func(ctx context.Context, c *client.Client) err
 					return nil
 				}
 
+				if nev.ev.Type == state.Errored {
+					return fmt.Errorf("error watching resource: %w", nev.ev.Error)
+				}
+
+				if nev.ev.Type == state.Bootstrapped {
+					// TODO: in Talos 1.4, use Bootstrapped event to determine whether it's time to flush the first line
+					continue
+				}
+
+				if nev.ev.Resource == nil {
+					// new event type without resource, skip it
+					continue
+				}
+
 				if err = out.WriteResource(nev.node, nev.ev.Resource, nev.ev.Type); err != nil {
 					return err
 				}

--- a/cmd/talosctl/cmd/talos/output/table.go
+++ b/cmd/talosctl/cmd/talos/output/table.go
@@ -91,6 +91,8 @@ func (table *Table) WriteResource(node string, r resource.Resource, event state.
 			label = "-"
 		case state.Updated:
 			label = " "
+		case state.Bootstrapped, state.Errored:
+			return nil
 		}
 
 		values = append([]string{label}, values...)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/containernetworking/plugins v1.1.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/cosi-project/runtime v0.2.0-alpha.3
+	github.com/cosi-project/runtime v0.2.0
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -198,7 +198,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.4 // indirect
@@ -279,7 +279,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
+	golang.org/x/oauth2 v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosi-project/runtime v0.2.0-alpha.3 h1:dtVWvyhB79C95rCxe9EPW4zSWpvYLuQlHeDbu7k1uPo=
-github.com/cosi-project/runtime v0.2.0-alpha.3/go.mod h1:hLD9uvqKG0EESZnqVDCpFlKEMjFEAlr2jIfdHG9gDpI=
+github.com/cosi-project/runtime v0.2.0 h1:4jzNWoftvsHCU3pv49mzmALc6iaXfNwMpRD2U9LSfqE=
+github.com/cosi-project/runtime v0.2.0/go.mod h1:6KLUKBiwLpZNOi4opnz96v6HDl8VUGnTiyCFeqSzQJQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
@@ -591,8 +591,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauGGCMg2zAZIiNZ9uIQ=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 h1:fi9bGIUJOGzzrHBbP8NWbTfNC5fKO6X7kFw40TOqGB8=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0/go.mod h1:uY3Aurq+SxwQCpdX91xZ9CgxIMT1EsYtcidljXufYIY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -1360,8 +1360,8 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=
-golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/oauth2 v0.1.0 h1:isLCZuhj4v+tYv7eskaN4v/TM+A1begWWgyVJDdl1+Y=
+golang.org/x/oauth2 v0.1.0/go.mod h1:G9FE4dLTsbXUu90h/Pf85g4w1D+SSAgR+q46nJZ8M4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/app/apid/pkg/director/local_address.go
+++ b/internal/app/apid/pkg/director/local_address.go
@@ -48,8 +48,11 @@ func NewLocalAddressProvider(st state.State) (LocalAddressProvider, error) {
 
 func (p *localAddressProvider) watch(evCh <-chan state.Event) {
 	for ev := range evCh {
-		if ev.Type == state.Destroyed {
-			// shouldn't happen
+		switch ev.Type {
+		case state.Created, state.Updated:
+			// expected
+		case state.Destroyed, state.Bootstrapped, state.Errored:
+			// shouldn't happen, ignore
 			continue
 		}
 

--- a/internal/app/machined/pkg/controllers/network/operator/vip.go
+++ b/internal/app/machined/pkg/controllers/network/operator/vip.go
@@ -290,8 +290,10 @@ campaignLoop:
 			}
 
 			// break the loop if the kubelet lifecycle is entering teardown phase
-			if event.Resource.Metadata().Type() == kubeletLifecycle.Type() && event.Resource.Metadata().ID() == kubeletLifecycle.ID() && event.Resource.Metadata().Phase() == resource.PhaseTearingDown {
-				return nil
+			if event.Resource != nil {
+				if event.Resource.Metadata().Type() == kubeletLifecycle.Type() && event.Resource.Metadata().ID() == kubeletLifecycle.ID() && event.Resource.Metadata().Phase() == resource.PhaseTearingDown {
+					return nil
+				}
 			}
 		}
 	}
@@ -348,8 +350,10 @@ observeLoop:
 			}
 
 			// break the loop if the kubelet lifecycle is entering teardown phase
-			if event.Resource.Metadata().Type() == kubeletLifecycle.Type() && event.Resource.Metadata().ID() == kubeletLifecycle.ID() && event.Resource.Metadata().Phase() == resource.PhaseTearingDown {
-				break observeLoop
+			if event.Resource != nil {
+				if event.Resource.Metadata().Type() == kubeletLifecycle.Type() && event.Resource.Metadata().ID() == kubeletLifecycle.ID() && event.Resource.Metadata().Phase() == resource.PhaseTearingDown {
+					break observeLoop
+				}
 			}
 		}
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -288,7 +288,7 @@ func (ctrl *Controller) watchMachineConfig(ctx context.Context) {
 		var cfg talosconfig.Provider
 		select {
 		case event := <-watchCh:
-			if event.Type == state.Destroyed {
+			if event.Type != state.Created && event.Type != state.Updated {
 				continue
 			}
 

--- a/internal/app/resources/server.go
+++ b/internal/app/resources/server.go
@@ -275,6 +275,10 @@ func (s *Server) Watch(in *resourceapi.WatchRequest, srv resourceapi.ResourceSer
 			resp.EventType = resourceapi.EventType_UPDATED
 		case state.Destroyed:
 			resp.EventType = resourceapi.EventType_DESTROYED
+		case state.Bootstrapped:
+			// ignore
+		case state.Errored:
+			return fmt.Errorf("error watching resource: %w", event.Error)
 		}
 
 		if err = srv.Send(resp); err != nil {

--- a/internal/app/trustd/internal/provider/provider.go
+++ b/internal/app/trustd/internal/provider/provider.go
@@ -25,6 +25,8 @@ type TLSConfig struct {
 }
 
 // NewTLSConfig builds provider from configuration and endpoints.
+//
+//nolint:gocyclo
 func NewTLSConfig(resources state.State) (*TLSConfig, error) {
 	watchCh := make(chan state.Event)
 
@@ -37,8 +39,15 @@ func NewTLSConfig(resources state.State) (*TLSConfig, error) {
 
 	for {
 		event := <-watchCh
-		if event.Type == state.Destroyed {
+
+		switch event.Type {
+		case state.Created, state.Updated:
+			// expected
+		case state.Destroyed, state.Bootstrapped:
+			// ignore, we'll get another event
 			continue
+		case state.Errored:
+			return nil, fmt.Errorf("error watching for trustd certificates: %w", event.Error)
 		}
 
 		trustdCerts := event.Resource.(*secrets.Trustd) //nolint:errcheck,forcetypeassert
@@ -53,8 +62,15 @@ func NewTLSConfig(resources state.State) (*TLSConfig, error) {
 	go func() {
 		for {
 			event := <-watchCh
-			if event.Type == state.Destroyed {
+
+			switch event.Type {
+			case state.Created, state.Updated:
+				// expected
+			case state.Destroyed, state.Bootstrapped:
+				// ignore, we'll get another event
 				continue
+			case state.Errored:
+				log.Printf("error watching for trustd certificates: %s", event.Error)
 			}
 
 			trustdCerts := event.Resource.(*secrets.Trustd) //nolint:errcheck,forcetypeassert

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -8,7 +8,7 @@ replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20220527175918-f17b
 
 require (
 	github.com/containerd/go-cni v1.1.7
-	github.com/cosi-project/runtime v0.2.0-alpha.3
+	github.com/cosi-project/runtime v0.2.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0
@@ -44,7 +44,7 @@ require (
 	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
 	github.com/mdlayher/genetlink v1.2.0 // indirect

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -21,8 +21,8 @@ github.com/containerd/go-cni v1.1.7 h1:1yKpVCQAXI21BJIy8q7Nyk4CWpIgUno6ib7JIDca7
 github.com/containerd/go-cni v1.1.7/go.mod h1:Ve4Q0RB2Bw78D90OL0YVyDjqdTL7FKh9W+UPbhWiZXA=
 github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
-github.com/cosi-project/runtime v0.2.0-alpha.3 h1:dtVWvyhB79C95rCxe9EPW4zSWpvYLuQlHeDbu7k1uPo=
-github.com/cosi-project/runtime v0.2.0-alpha.3/go.mod h1:hLD9uvqKG0EESZnqVDCpFlKEMjFEAlr2jIfdHG9gDpI=
+github.com/cosi-project/runtime v0.2.0 h1:4jzNWoftvsHCU3pv49mzmALc6iaXfNwMpRD2U9LSfqE=
+github.com/cosi-project/runtime v0.2.0/go.mod h1:6KLUKBiwLpZNOi4opnz96v6HDl8VUGnTiyCFeqSzQJQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0 h1:kr3j8iIMR4ywO/O0rvksXaJvauGGCMg2zAZIiNZ9uIQ=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.12.0/go.mod h1:ummNFgdgLhhX7aIiy35vVmQNS0rWXknfPE0qe6fmFXg=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 h1:fi9bGIUJOGzzrHBbP8NWbTfNC5fKO6X7kFw40TOqGB8=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0/go.mod h1:uY3Aurq+SxwQCpdX91xZ9CgxIMT1EsYtcidljXufYIY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
This brings many fixes, including a new Watch with support for Bootstapped and Errored event types.

`talosctl` from before this change is still compatible, as there's gRPC API level backwards compatibility versioning.

New client doesn't yet depend on new event types, so it will work against Talos 1.2.x.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
