### PR TITLE
feat: add install script to improve talosctl installation 

### DIFF
--- a/website/static/install
+++ b/website/static/install
@@ -1,0 +1,135 @@
+#!/usr/bin/env sh
+
+set -eu
+
+INSTALLPATH=${INSTALLPATH:-/usr/local/bin}
+
+happyexit() {
+  echo "Installed version:"
+  echo "$(talosctl version 2>/dev/null )"
+  echo ""
+  echo "Now run:"
+  echo ""
+  echo "  talosctl cluster create                  # install a local test cluster"
+  echo "  talosctl dashboard                       # If you have created a cluster, launch the dashboard"
+  echo ""
+  echo "Looking for more? Visit https://talos.dev/latest"
+  echo ""
+  exit 0
+}
+
+validate_checksum() {
+  filename=$1
+  url="https://github.com/siderolabs/talos/releases/latest/download/sha256sum.txt"
+  SHA=$(curl --proto '=https' --tlsv1.2 -sSfL "${url}" | grep "${filename}" | awk '{print $1 }')
+  echo ""
+  echo "Validating checksum..."
+
+  case $checksumbin in
+    *openssl)
+      checksum=$($checksumbin dgst -sha256 "${filename}" | sed -e 's/^.* //')
+      ;;
+    *shasum)
+      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/ .*$//')
+      ;;
+  esac
+
+  if [ "$checksum" != "$SHA" ]; then
+    echo "Checksum validation failed." >&2
+    return 1
+  fi
+  echo "Checksum valid."
+  return 0
+}
+
+OS=$(uname -s)
+arch=$(uname -m)
+cli_arch=""
+case $OS in
+  CYGWIN* | MINGW64*)
+    OS=windows-amd64.exe
+    ;;
+  Darwin | Linux | FreeBSD)
+    case $arch in
+      x86_64)
+        cli_arch=amd64
+        ;;
+      armv8*)
+        cli_arch=arm64
+        ;;
+      aarch64*)
+        cli_arch=arm64
+        ;;
+      amd64|arm64)
+        cli_arch=$arch
+        ;;
+      *)
+        echo "There is no talosctl $OS support for $arch. Please open an issue with your platform details."
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "There is no talosctl support for $OS/$arch. Please open an issue with your platform details."
+    exit 1
+    ;;
+esac
+OS=$(echo $OS | tr '[:upper:]' '[:lower:]')
+
+
+tmpdir=$(mktemp -d /tmp/talosctl.XXXXXX)
+srcfile="talosctl-${OS}"
+if [ -n "${cli_arch}" ]; then
+  srcfile="${srcfile}-${cli_arch}"
+fi
+
+
+
+dstfile="${INSTALLPATH}/talosctl"
+
+checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
+  echo "Failed to find checksum binary. Please install openssl or shasum."
+  echo ""
+  echo "You can also elect to just download/install https://github.com/siderolabs/talos/releases/latest/download/${srcfile}"
+  echo "into ${dstfile}"
+  exit 1
+}
+
+url="https://github.com/siderolabs/talos/releases/latest/download/${srcfile}"
+
+if [ -e "${dstfile}" ]; then
+    echo ""
+    echo "talosctl was already downloaded;  🎉"
+    echo ""
+    echo "To force re-downloading, delete '${dstfile}' then run me again."
+    (
+      rm -rf "${tmpdir}"
+    )
+    happyexit
+fi
+
+(
+  cd "$tmpdir"
+
+  echo "Downloading ${srcfile}..."
+  curl --proto '=https' --tlsv1.2 -fLO "${url}"
+  echo "Download complete!"
+
+  if ! validate_checksum "${srcfile}"; then
+    exit 1
+  fi
+  echo ""
+  exit
+)
+
+(
+  mv "${tmpdir}/${srcfile}" "${dstfile}"
+  chmod +x "${dstfile}"
+)
+
+
+rm -r "$tmpdir"
+
+echo "talosctl was successfully installed 🎉"
+echo ""
+happyexit


### PR DESCRIPTION


This install script detects the platform and architecture, and downloads the correct talosctl, and checks the gpg checksums. It also installs and chmods the binary.

Signed-off-by: Steve Francis <steve.francis@talos-systems.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
