### PR TITLE
feat: add stdout and single config type support to talosctl gen config

### DIFF
--- a/website/content/v1.3/reference/cli.md
+++ b/website/content/v1.3/reference/cli.md
@@ -1136,7 +1136,8 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --install-disk string                      the disk to install to (default "/dev/sda")
       --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")
       --kubernetes-version string                desired kubernetes version to run (default "1.26.0-rc.1")
-  -o, --output-dir string                        destination to output generated files
+  -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
+  -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
   -p, --persist                                  the desired persist value for configs (default true)
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
       --talos-version string                     the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)


### PR DESCRIPTION
Add support to specify the types of outputs to be generated by talosctl gen config.

Add support for writing a single type of output to stdout instead of a file.

Related to siderolabs/talos#6562.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
