### PR TITLE
fix: ignore many more filesystems in IMA

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -342,6 +342,20 @@ var rules = []string{
 	"dont_measure fsmagic=0xde5e81e4", // EFIVARFS_MAGIC
 	"dont_measure fsmagic=0x58465342", // XFS_MAGIC
 	"dont_measure fsmagic=0x794c7630", // OVERLAYFS_SUPER_MAGIC
+	"dont_measure fsmagic=0x9123683e", // BTRFS_SUPER_MAGIC
+	"dont_measure fsmagic=0x72b6",     // JFFS2_SUPER_MAGIC
+	"dont_measure fsmagic=0x4d44",     // MSDOS_SUPER_MAGIC
+	"dont_measure fsmagic=0x2011bab0", // EXFAT_SUPER_MAGIC
+	"dont_measure fsmagic=0x6969",     // NFS_SUPER_MAGIC
+	"dont_measure fsmagic=0x5346544e", // NTFS_SB_MAGIC
+	"dont_measure fsmagic=0x9660",     // ISOFS_SUPER_MAGIC
+	"dont_measure fsmagic=0x15013346", // UDF_SUPER_MAGIC
+	"dont_measure fsmagic=0x52654973", // REISERFS_SUPER_MAGIC
+	"dont_measure fsmagic=0x137d",     // EXT_SUPER_MAGIC
+	"dont_measure fsmagic=0xef51",     // EXT2_OLD_SUPER_MAGIC
+	"dont_measure fsmagic=0xef53",     // EXT2_SUPER_MAGIC / EXT3_SUPER_MAGIC / EXT4_SUPER_MAGIC
+	"dont_measure fsmagic=0x00c36400", // CEPH_SUPER_MAGIC
+	"dont_measure fsmagic=0x65735543", // FUSE_CTL_SUPER_MAGIC
 	"measure func=MMAP_CHECK mask=MAY_EXEC",
 	"measure func=BPRM_CHECK mask=MAY_EXEC",
 	"measure func=FILE_CHECK mask=^MAY_READ euid=0",


### PR DESCRIPTION
Fixes #6553

Talos itself defaults to XFS, so IMA measurements weren't done for Talos own filesystems. But many other solutions create by default ext4 filesystems, or it might be something mounted by other means.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
