### PR TITLE
feat: add talosctl machineconfig patch command

### DIFF
--- a/cmd/talosctl/cmd/mgmt/machineconfig/gen.go
+++ b/cmd/talosctl/cmd/mgmt/machineconfig/gen.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package machineconfig
+
+import "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/gen"
+
+func init() {
+	// alias for `talosctl gen config`
+	Cmd.AddCommand(gen.NewConfigCmd("gen"))
+}

--- a/cmd/talosctl/cmd/mgmt/machineconfig/machineconfig.go
+++ b/cmd/talosctl/cmd/mgmt/machineconfig/machineconfig.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package machineconfig
+
+import "github.com/spf13/cobra"
+
+// Cmd represents the `machineconfig` command.
+var Cmd = &cobra.Command{
+	Use:     "machineconfig",
+	Short:   "Machine config related commands",
+	Aliases: []string{"mc"},
+}

--- a/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
+++ b/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package machineconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+)
+
+var patchCmdFlags struct {
+	patches []string
+	output  string
+}
+
+// patchCmd represents the `machineconfig patch` command.
+var patchCmd = &cobra.Command{
+	Use:   "patch <machineconfig-file>",
+	Short: "Patch a machine config",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+
+		patches, err := configpatcher.LoadPatches(patchCmdFlags.patches)
+		if err != nil {
+			return err
+		}
+
+		patched, err := configpatcher.Apply(configpatcher.WithBytes(data), patches)
+		if err != nil {
+			return err
+		}
+
+		patchedData, err := patched.Bytes()
+		if err != nil {
+			return err
+		}
+
+		if patchCmdFlags.output == "" { // write to stdout
+			fmt.Printf("%s\n", patchedData)
+
+			return nil
+		}
+
+		// write to file
+
+		parentDir := filepath.Dir(patchCmdFlags.output)
+
+		// Create dir path, ignoring "already exists" messages
+		if err := os.MkdirAll(parentDir, os.ModePerm); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create output dir: %w", err)
+		}
+
+		return os.WriteFile(patchCmdFlags.output, patchedData, 0o644)
+	},
+}
+
+func init() {
+	// use StringArrayVarP instead of StringSliceVarP to prevent cobra from splitting the patch string on commas
+	patchCmd.Flags().StringArrayVarP(&patchCmdFlags.patches, "patch", "p", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file")
+	patchCmd.Flags().StringVarP(&patchCmdFlags.output, "output", "o", "", "output destination. if not specified, output will be printed to stdout")
+
+	Cmd.AddCommand(patchCmd)
+}

--- a/cmd/talosctl/cmd/mgmt/root.go
+++ b/cmd/talosctl/cmd/mgmt/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/debug"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/gen"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/inject"
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/machineconfig"
 )
 
 // Commands is a list of commands published by the package.
@@ -30,4 +31,5 @@ func init() {
 	addCommand(gen.Cmd)
 	addCommand(debug.Cmd)
 	addCommand(inject.Cmd)
+	addCommand(machineconfig.Cmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.6
 	go.etcd.io/etcd/etcdutl/v3 v3.5.6
 	go.uber.org/atomic v1.10.0
+	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.23.0
 	go4.org/netipx v0.0.0-20220925034521-797b0c90d8ab
 	golang.org/x/net v0.2.0
@@ -276,7 +277,6 @@ require (
 	go.opentelemetry.io/otel v1.10.0 // indirect
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.1.0 // indirect

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -245,6 +245,26 @@ See [Kubernetes documentation](https://kubernetes.io/blog/2022/11/28/registry-k8
 If using registry mirrors, or in air-gapped installations you may need to update your configuration.
 """
 
+    [notes.talosctl_machineconfig_patch]
+        title = "talosctl machineconfig patch"
+        description = """\
+A new subcommand, `machineconfig patch` is added to `talosctl` to allow patching of machine configuration.
+
+It accepts a machineconfig file and a list of patches as input and outputs the patched machine configuration.
+
+Patches can be sourced from the command line or from a file. Output can be written to a file or to stdout.
+
+Example:
+
+```bash
+talosctl machineconfig patch controlplane.yaml \
+  --patch '[{"op":"replace","path":"/cluster/clusterName","value":"patch1"}]' \
+  --patch @/path/to/patch2.json
+```
+
+Additionally, `talosctl machineconfig gen` subcommand is introduced as an alias to `talosctl gen config`.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -21,7 +21,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1/generate"
 )
 
-// GenSuite verifies dmesg command.
+// GenSuite verifies gen command.
 type GenSuite struct {
 	base.CLISuite
 

--- a/internal/integration/cli/machineconfig.go
+++ b/internal/integration/cli/machineconfig.go
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/multierr"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+)
+
+// MachineConfigSuite verifies machineconfig command.
+type MachineConfigSuite struct {
+	base.CLISuite
+
+	savedCwd string
+}
+
+// SuiteName ...
+func (suite *MachineConfigSuite) SuiteName() string {
+	return "cli.MachineConfigSuite"
+}
+
+// SetupTest ...
+func (suite *MachineConfigSuite) SetupTest() {
+	var err error
+	suite.savedCwd, err = os.Getwd()
+	suite.Require().NoError(err)
+}
+
+// TearDownTest ...
+func (suite *MachineConfigSuite) TearDownTest() {
+	if suite.savedCwd != "" {
+		suite.Require().NoError(os.Chdir(suite.savedCwd))
+	}
+}
+
+// TestGen tests the gen subcommand.
+// Identical to GenSuite.TestGenConfigToStdoutControlPlane
+// The remaining functionality is checked for `talosctl gen config` in GenSuite.
+func (suite *MachineConfigSuite) TestGen() {
+	suite.RunCLI([]string{
+		"gen", "config",
+		"foo", "https://192.168.0.1:6443",
+		"--output-types", "controlplane",
+		"--output", "-",
+	}, base.StdoutMatchFunc(func(output string) error {
+		expected := "type: controlplane"
+		if !strings.Contains(output, expected) {
+			return fmt.Errorf("stdout does not contain %q: %q", expected, output)
+		}
+
+		return nil
+	}))
+}
+
+// TestPatchPrintStdout tests the patch subcommand with output set to stdout
+// with multiple patches from the command line and from file.
+func (suite *MachineConfigSuite) TestPatchPrintStdout() {
+	patch1, err := json.Marshal([]map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/cluster/clusterName",
+			"value": "replaced",
+		},
+	})
+	suite.Require().NoError(err)
+
+	patch2, err := json.Marshal([]map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/cluster/controlPlane/endpoint",
+			"value": "replaced",
+		},
+	})
+	suite.Require().NoError(err)
+
+	patch2Path := filepath.Join(suite.T().TempDir(), "patch2.json")
+
+	err = os.WriteFile(patch2Path, patch2, 0o644)
+	suite.Require().NoError(err)
+
+	mc := filepath.Join(suite.T().TempDir(), "input.yaml")
+
+	suite.RunCLI([]string{
+		"gen", "config",
+		"foo", "https://192.168.0.1:6443",
+		"--output-types", "controlplane",
+		"--output", mc,
+	})
+
+	suite.RunCLI([]string{
+		"machineconfig", "patch", mc, "--patch", string(patch1), "-p", "@" + patch2Path,
+	}, base.StdoutMatchFunc(func(output string) error {
+		var matchErr error
+
+		if !strings.Contains(output, "clusterName: replaced") {
+			matchErr = multierr.Append(matchErr, fmt.Errorf("clusterName not replaced"))
+		}
+
+		if !strings.Contains(output, "endpoint: replaced") {
+			matchErr = multierr.Append(matchErr, fmt.Errorf("endpoint not replaced"))
+		}
+
+		return matchErr
+	}))
+}
+
+// TestPatchWriteToFile tests the patch subcommand with output set to a file.
+func (suite *MachineConfigSuite) TestPatchWriteToFile() {
+	patch1, err := json.Marshal([]map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/cluster/clusterName",
+			"value": "replaced",
+		},
+	})
+	suite.Require().NoError(err)
+
+	mc := filepath.Join(suite.T().TempDir(), "input2.yaml")
+
+	suite.RunCLI([]string{
+		"gen", "config",
+		"foo", "https://192.168.0.1:6443",
+		"--output-types", "controlplane",
+		"--output", mc,
+	})
+
+	outputFile := filepath.Join(suite.T().TempDir(), "inner", "output.yaml")
+
+	suite.RunCLI([]string{
+		"machineconfig", "patch", mc, "--patch", string(patch1), "--output", outputFile,
+	}, base.StdoutEmpty())
+
+	outputBytes, err := os.ReadFile(outputFile)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Contains(string(outputBytes), "clusterName: replaced")
+}
+
+func init() {
+	allSuites = append(allSuites, new(MachineConfigSuite))
+}

--- a/website/content/v1.3/reference/cli.md
+++ b/website/content/v1.3/reference/cli.md
@@ -1681,6 +1681,97 @@ talosctl logs <service name> [flags]
 
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 
+## talosctl machineconfig gen
+
+Generates a set of configuration files for Talos cluster
+
+### Synopsis
+
+The cluster endpoint is the URL for the Kubernetes API. If you decide to use
+a control plane node, common in a single node control plane setup, use port 6443 as
+this is the port that the API server binds to on every control plane node. For an HA
+setup, usually involving a load balancer, use the IP and port of the load balancer.
+
+```
+talosctl machineconfig gen <cluster name> <cluster endpoint> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for gen
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string       Cluster to connect to if a proxy endpoint is used.
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl machineconfig](#talosctl-machineconfig)	 - Machine config related commands
+
+## talosctl machineconfig patch
+
+Patch a machine config
+
+```
+talosctl machineconfig patch <machineconfig-file> [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for patch
+  -o, --output string       output destination. if not specified, output will be printed to stdout
+  -p, --patch stringArray   patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string       Cluster to connect to if a proxy endpoint is used.
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl machineconfig](#talosctl-machineconfig)	 - Machine config related commands
+
+## talosctl machineconfig
+
+Machine config related commands
+
+### Options
+
+```
+  -h, --help   help for machineconfig
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string       Cluster to connect to if a proxy endpoint is used.
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
+* [talosctl machineconfig gen](#talosctl-machineconfig-gen)	 - Generates a set of configuration files for Talos cluster
+* [talosctl machineconfig patch](#talosctl-machineconfig-patch)	 - Patch a machine config
+
 ## talosctl memory
 
 Show memory usage
@@ -2399,6 +2490,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl kubeconfig](#talosctl-kubeconfig)	 - Download the admin kubeconfig from the node
 * [talosctl list](#talosctl-list)	 - Retrieve a directory listing
 * [talosctl logs](#talosctl-logs)	 - Retrieve logs for a service
+* [talosctl machineconfig](#talosctl-machineconfig)	 - Machine config related commands
 * [talosctl memory](#talosctl-memory)	 - Show memory usage
 * [talosctl mounts](#talosctl-mounts)	 - List mounts
 * [talosctl patch](#talosctl-patch)	 - Update field(s) of a resource using a JSON patch.


### PR DESCRIPTION
Add talosctl machineconfig patch command which accepts a machine config as input and a list of patches, applying the patches and writing the result to a file or to stdout.

Link `talosctl machineconfig gen` to `talosctl gen config`, so they work the same way.

Closes siderolabs/talos#6562.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
