### PR TITLE
fix: introduce 'overridePath' setting and fix Talos resolver

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -265,6 +265,36 @@ talosctl machineconfig patch controlplane.yaml \
 Additionally, `talosctl machineconfig gen` subcommand is introduced as an alias to `talosctl gen config`.
 """
 
+    [notes.registry-mirrors]
+        title = "Registry Mirrors"
+        description = """\
+Talos had an inconsistency in the way registry mirror endpoints are handled when compared with `containerd` implementation:
+
+```yaml
+machine:
+    registries:
+        mirrors:
+            docker.io:
+                endpoints:
+                    - "https://mirror-registry/v2/mirror.docker.io"
+```
+
+Talos would use endpoint `https://mirror-registry/v2/mirror.docker.io`, while `containerd` would use `https://mirror-registry/v2/mirror.docker.io/v2`.
+This inconsistency is now fixed, and Talos uses same endpoint as `containerd`.
+
+New `overridePath` configuration is introduced to skip appending `/v2` both on Talos and containerd side:
+
+```yaml
+machine:
+    registries:
+        mirrors:
+            docker.io:
+                endpoints:
+                    - "https://mirror-registry/v2/mirror.docker.io"
+                overridePath: true
+```
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -351,6 +351,7 @@ type Registries interface {
 // RegistryMirrorConfig represents mirror configuration for a registry.
 type RegistryMirrorConfig interface {
 	Endpoints() []string
+	OverridePath() bool
 }
 
 // RegistryConfig specifies auth & TLS config per registry.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1197,6 +1197,11 @@ func (r *RegistryMirrorConfig) Endpoints() []string {
 	return r.MirrorEndpoints
 }
 
+// OverridePath implements the Registries interface.
+func (r *RegistryMirrorConfig) OverridePath() bool {
+	return pointer.SafeDeref(r.MirrorOverridePath)
+}
+
 // Content implements the config.Provider interface.
 func (f *MachineFile) Content() string {
 	return f.FileContent

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2348,6 +2348,11 @@ type RegistryMirrorConfig struct {
 	//     Endpoint configures HTTP/HTTPS access mode, host name,
 	//     port and path (if path is not set, it defaults to `/v2`).
 	MirrorEndpoints []string `yaml:"endpoints"`
+	//   description: |
+	//     Use the exact path specified for the endpoint (don't append /v2/).
+	//     This setting is often required for setting up multiple mirrors
+	//     on a single instance of a registry.
+	MirrorOverridePath *bool `yaml:"overridePath,omitempty"`
 }
 
 // RegistryConfig specifies auth & TLS config per registry.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -2219,12 +2219,17 @@ func init() {
 			FieldName: "mirrors",
 		},
 	}
-	RegistryMirrorConfigDoc.Fields = make([]encoder.Doc, 1)
+	RegistryMirrorConfigDoc.Fields = make([]encoder.Doc, 2)
 	RegistryMirrorConfigDoc.Fields[0].Name = "endpoints"
 	RegistryMirrorConfigDoc.Fields[0].Type = "[]string"
 	RegistryMirrorConfigDoc.Fields[0].Note = ""
 	RegistryMirrorConfigDoc.Fields[0].Description = "List of endpoints (URLs) for registry mirrors to use.\nEndpoint configures HTTP/HTTPS access mode, host name,\nport and path (if path is not set, it defaults to `/v2`)."
 	RegistryMirrorConfigDoc.Fields[0].Comments[encoder.LineComment] = "List of endpoints (URLs) for registry mirrors to use."
+	RegistryMirrorConfigDoc.Fields[1].Name = "overridePath"
+	RegistryMirrorConfigDoc.Fields[1].Type = "bool"
+	RegistryMirrorConfigDoc.Fields[1].Note = ""
+	RegistryMirrorConfigDoc.Fields[1].Description = "Use the exact path specified for the endpoint (don't append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry."
+	RegistryMirrorConfigDoc.Fields[1].Comments[encoder.LineComment] = "Use the exact path specified for the endpoint (don't append /v2/)."
 
 	RegistryConfigDoc.Type = "RegistryConfig"
 	RegistryConfigDoc.Comments[encoder.LineComment] = "RegistryConfig specifies auth & TLS config per registry."

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -1876,6 +1876,11 @@ func (in *RegistryMirrorConfig) DeepCopyInto(out *RegistryMirrorConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MirrorOverridePath != nil {
+		in, out := &in.MirrorOverridePath, &out.MirrorOverridePath
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/website/content/v1.3/reference/configuration.md
+++ b/website/content/v1.3/reference/configuration.md
@@ -2429,6 +2429,7 @@ ghcr.io:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`endpoints` |[]string |<details><summary>List of endpoints (URLs) for registry mirrors to use.</summary>Endpoint configures HTTP/HTTPS access mode, host name,<br />port and path (if path is not set, it defaults to `/v2`).</details>  | |
+|`overridePath` |bool |<details><summary>Use the exact path specified for the endpoint (don't append /v2/).</summary>This setting is often required for setting up multiple mirrors<br />on a single instance of a registry.</details>  | |
 
 
 


### PR DESCRIPTION
There was inconsistency in the way `/v2` was appended to registry endpoint path between containerd (CRI) and Talos:

* Talos only appended `/v2` to empty paths
* containerd appended `/v2` if it's not the suffix already

Fix Talos to act same as containerd, and introduce a setting `overridePath` which stops both Talos and `containerd` from appending `/v2` (should be required with e.g. Harbor registry mirror).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
