### PR TITLE
fix: don't report link name in route statuses

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_status.go
+++ b/internal/app/machined/pkg/controllers/network/route_status.go
@@ -68,18 +68,6 @@ func (ctrl *RouteStatusController) Run(ctx context.Context, r controller.Runtime
 		case <-r.EventCh():
 		}
 
-		// build links lookup table
-		links, err := conn.Link.List()
-		if err != nil {
-			return fmt.Errorf("error listing links: %w", err)
-		}
-
-		linkLookup := make(map[uint32]string, len(links))
-
-		for _, link := range links {
-			linkLookup[link.Index] = link.Attributes.Name
-		}
-
 		// list resources for cleanup
 		list, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.RouteStatusType, "", resource.VersionUndefined))
 		if err != nil {
@@ -113,8 +101,6 @@ func (ctrl *RouteStatusController) Run(ctx context.Context, r controller.Runtime
 				status.Destination = dstPrefix
 				status.Source = srcAddr
 				status.Gateway = gatewayAddr
-				status.OutLinkIndex = route.Attributes.OutIface
-				status.OutLinkName = linkLookup[route.Attributes.OutIface]
 				status.Priority = route.Attributes.Priority
 				status.Table = nethelpers.RoutingTable(route.Table)
 				status.Scope = nethelpers.Scope(route.Scope)

--- a/internal/app/machined/pkg/controllers/network/route_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_status_test.go
@@ -106,7 +106,6 @@ func (suite *RouteStatusSuite) TestRoutes() {
 				return suite.assertRoutes(
 					[]string{"local/inet4//127.0.0.0/8/0"}, func(r *network.RouteStatus) error {
 						suite.Assert().True(r.TypedSpec().Source.IsLoopback())
-						suite.Assert().Equal("lo", r.TypedSpec().OutLinkName)
 						suite.Assert().Equal(nethelpers.TableLocal, r.TypedSpec().Table)
 						suite.Assert().Equal(nethelpers.ScopeHost, r.TypedSpec().Scope)
 						suite.Assert().Equal(nethelpers.TypeLocal, r.TypedSpec().Type)


### PR DESCRIPTION
This is a band-aid specifically for the `release-1.3` branch, there will be a proper fix in the `main` branch developed.

The problem shows up with Calico CNI, as every pod starting/stopping results in multiple updates to link-local resources (for the routes to IPv6 localhost address) which are repeatedly attached to different `caliXXXX` links. The rate of updates is so high that COSI runtime can't correctly keep up with the event stream leading to runtime crash.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
