### PR TITLE
fix: ignore k8s additional addresses if nil

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -225,7 +225,7 @@ func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runt
 						spec.KubeSpan.Address = kubespanIdentity.(*kubespan.Identity).TypedSpec().Address.Addr()
 						spec.KubeSpan.PublicKey = kubespanIdentity.(*kubespan.Identity).TypedSpec().PublicKey
 
-						if kubespanConfig.TypedSpec().AdvertiseKubernetesNetworks {
+						if kubespanConfig.TypedSpec().AdvertiseKubernetesNetworks && ksAdditionalAddresses != nil {
 							spec.KubeSpan.AdditionalAddresses = append([]netip.Prefix(nil), ksAdditionalAddresses.(*network.NodeAddress).TypedSpec().Addresses...)
 						} else {
 							spec.KubeSpan.AdditionalAddresses = nil


### PR DESCRIPTION
This fixes a potential panic which I found in the unit-tests logs.

The error 'not found' is ignored, so need an addiitonal check.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
