### PR TITLE
fix: allow empty dnsDomain in machine config

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -317,7 +317,7 @@ func (c *ClusterConfig) Validate() error {
 		result = multierror.Append(result, fmt.Errorf("invalid controlplane endpoint: %w", err))
 	}
 
-	if c.ClusterNetwork != nil && !isValidDNSName(c.ClusterNetwork.DNSDomain) {
+	if c.ClusterNetwork != nil && c.ClusterNetwork.DNSDomain != "" && !isValidDNSName(c.ClusterNetwork.DNSDomain) {
 		result = multierror.Append(result, fmt.Errorf("%q is not a valid DNS name", c.ClusterNetwork.DNSDomain))
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -325,6 +325,23 @@ func TestValidate(t *testing.T) {
 			expectedError: "2 errors occurred:\n\t* inline manifest name can't be empty\n\t* inline manifest name \"foo\" is duplicate\n\n",
 		},
 		{
+			name: "DNSDomainEmpty",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{},
+				},
+			},
+		},
+		{
 			name: "DeviceCIDRInvalid",
 			config: &v1alpha1.Config{
 				ConfigVersion: "v1alpha1",


### PR DESCRIPTION
This field has a default value, but validation was prohibiting empty value.

Fixes #6619

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
