### PR TITLE
fix: redact service account key in config in RedactSecrets method

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -103,6 +103,8 @@ func (c *Config) Bytes() ([]byte, error) {
 }
 
 // RedactSecrets implements the config.Provider interface.
+//
+//nolint:gocyclo
 func (c *Config) RedactSecrets(replacement string) config.Provider {
 	if c == nil {
 		return nil
@@ -134,6 +136,10 @@ func (c *Config) RedactSecrets(replacement string) config.Provider {
 		clone.ClusterConfig.BootstrapToken = redactStr(clone.ClusterConfig.BootstrapToken)
 		clone.ClusterConfig.ClusterAESCBCEncryptionSecret = redactStr(clone.ClusterConfig.ClusterAESCBCEncryptionSecret)
 		clone.ClusterConfig.ClusterSecretboxEncryptionSecret = redactStr(clone.ClusterConfig.ClusterSecretboxEncryptionSecret)
+
+		if clone.ClusterConfig.ClusterServiceAccount != nil {
+			clone.ClusterConfig.ClusterServiceAccount.Key = redactBytes(clone.ClusterConfig.ClusterServiceAccount.Key)
+		}
 
 		if clone.ClusterConfig.ClusterCA != nil {
 			clone.ClusterConfig.ClusterCA.Key = redactBytes(clone.ClusterConfig.ClusterCA.Key)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_redact_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_redact_test.go
@@ -34,6 +34,7 @@ func TestRedactSecrets(t *testing.T) {
 	require.NotEmpty(t, config.ClusterConfig.ClusterSecretboxEncryptionSecret)
 	require.NotEmpty(t, config.ClusterConfig.ClusterCA.Key)
 	require.NotEmpty(t, config.ClusterConfig.EtcdConfig.RootCA.Key)
+	require.NotEmpty(t, config.ClusterConfig.ClusterServiceAccount.Key)
 
 	replacement := "**.***"
 
@@ -55,4 +56,5 @@ func TestRedactSecrets(t *testing.T) {
 	require.Equal(t, replacement, redacted.Cluster().SecretboxEncryptionSecret())
 	require.Equal(t, replacement, string(redacted.Cluster().CA().Key))
 	require.Equal(t, replacement, string(redacted.Cluster().Etcd().CA().Key))
+	require.Equal(t, replacement, string(redacted.Cluster().ServiceAccount().Key))
 }


### PR DESCRIPTION
Include the previously missing service account key field in the redaction.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
