### PR TITLE
docs: mark Talos 1.3 docs as default

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -108,7 +108,7 @@ version_menu = "Releases"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/v1.2"
+url_latest_version = "/v1.3"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 # github_repo = "https://github.com/googley-example"
@@ -141,11 +141,11 @@ version = "v1.4 (pre-release)"
 
 [[params.versions]]
 url = "/v1.3/"
-version = "v1.3 (pre-release)"
+version = "v1.3 (latest)"
 
 [[params.versions]]
 url = "/v1.2/"
-version = "v1.2 (latest)"
+version = "v1.2"
 
 [[params.versions]]
 url = "/v1.1/"

--- a/website/content/v1.2/_index.md
+++ b/website/content/v1.2/_index.md
@@ -11,7 +11,6 @@ theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.10.0"
 nvidiaDriverRelease: "515.65.01"
 iscsiToolsRelease: "v0.1.1"
-menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.3/_index.md
+++ b/website/content/v1.3/_index.md
@@ -4,14 +4,14 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.3.0-beta.2
+lastRelease: v1.3.0
 kubernetesRelease: "1.26.0"
 prevKubernetesRelease: "1.25.3"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.10.0"
 nvidiaDriverRelease: "515.65.01"
 iscsiToolsRelease: "v0.1.1"
-preRelease: true
+menu: main
 ---
 
 ## Welcome


### PR DESCRIPTION
Just in time for Talos 1.3.0.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
