### PR TITLE
fix: Disable Wireless Lan using dtoverlay

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
@@ -15,3 +15,5 @@ arm_boost=1
 enable_uart=1
 # Disable Bluetooth.
 dtoverlay=disable-bt
+# Disable Wireless Lan.
+dtoverlay=disable-wifi

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic/config.txt
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic/config.txt
@@ -15,3 +15,5 @@ arm_boost=1
 enable_uart=1
 # Disable Bluetooth.
 dtoverlay=disable-bt
+# Disable Wireless Lan.
+dtoverlay=disable-wifi


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Possible save power consumption on the raspberry by disabling WLAN using dtoverlay.

It could save 45 mA according to https://forums.raspberrypi.com/viewtopic.php?t=257144#p1568474

Or nothing and only held it in reset according to: https://forums.raspberrypi.com/viewtopic.php?t=343854#p2060246

## Why? (reasoning)
We should build a greener future and power is not cheap anymore.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
