### PR TITLE
docs: update to use talosctl install script

### DIFF
--- a/website/content/v1.3/introduction/getting-started.md
+++ b/website/content/v1.3/introduction/getting-started.md
@@ -25,20 +25,8 @@ an easy manner.
 
 Install `talosctl` before continuing:
 
-#### `amd64`
-
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
-chmod +x /usr/local/bin/talosctl
-```
-
-#### `arm64`
-
-For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` architecture.
-
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
-chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ## Acquire the installation image
@@ -120,8 +108,7 @@ For more information about using a shared IP, see the related
 
 ### DNS records
 
-If neither of the other methods work for you, you can use DNS records to
-provide a measure of redundancy.
+You can use DNS records to provide a measure of redundancy.
 In this case, you would add multiple A or AAAA records (one for each control plane node) to a DNS name.
 
 For instance, you could add:
@@ -142,11 +129,11 @@ https://kube.cluster1.mydomain.com:6443
 
 Many administrative tasks are performed by calling the Talos API on Talos Linux control plane nodes.
 
-We recommend accessing the control plane nodes directly from the `talosctl` client, if possible (i.e. set your `endpoints` to the IP addresses of the control plane nodes).
+We recommend directly accessing the control plane nodes from the `talosctl` client, if possible (i.e. set your `endpoints` to the IP addresses of the control plane nodes).
 This requires your control plane nodes to be reachable from the client IP.
 
 If the control plane nodes are not directly reachable from the workstation where you run `talosctl`, then configure a load balancer for TCP port 50000 to be forwarded to the control plane nodes.
-Do not use Talos Linux's built in VIP support for accessing the Talos API, as it will not function in the event of an etcd failure, and you will not be able to access the Talos API to fix things.
+Do not use Talos Linux's built in VIP support for accessing the Talos API, as it will not function in the event of an `etcd` failure, and you will not be able to access the Talos API to fix things.
 
 If you create a load balancer to forward the Talos API calls, make a note of the IP or
 hostname so that you can configure your `talosctl` tool's `endpoints` below.

--- a/website/content/v1.3/introduction/quickstart.md
+++ b/website/content/v1.3/introduction/quickstart.md
@@ -14,20 +14,8 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 Download `talosctl`:
 
-##### `amd64`
-
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
-chmod +x /usr/local/bin/talosctl
-```
-
-##### `arm64`
-
-For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
-
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
-chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 #### `kubectl`
@@ -40,6 +28,12 @@ Now run the following:
 
 ```bash
 talosctl cluster create
+```
+
+You can explore using Talos API commands:
+
+```bash
+talosctl dashboard --nodes 10.5.0.2
 ```
 
 Verify that you can reach Kubernetes:

--- a/website/content/v1.3/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.3/talos-guides/install/local-platforms/qemu.md
@@ -41,19 +41,10 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` and all required binaries via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
+Download `talosctl` via
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ## Install Talos kernel and initramfs

--- a/website/content/v1.3/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.3/talos-guides/install/local-platforms/virtualbox.md
@@ -27,23 +27,14 @@ apt install virtualbox
 ### Install talosctl
 
 You can download `talosctl` via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ### Download ISO Image
 
-In order to install Talos in VirtualBox, you will need the ISO image from the Talos release page.
+Download the ISO image from the Talos release page.
 You can download `talos-amd64.iso` via
 [github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 

--- a/website/content/v1.3/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.3/talos-guides/install/virtualized-platforms/proxmox.md
@@ -23,18 +23,9 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 ### Install talosctl
 
 You can download `talosctl` via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ### Download ISO Image

--- a/website/content/v1.4/introduction/getting-started.md
+++ b/website/content/v1.4/introduction/getting-started.md
@@ -25,20 +25,8 @@ an easy manner.
 
 Install `talosctl` before continuing:
 
-#### `amd64`
-
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
-chmod +x /usr/local/bin/talosctl
-```
-
-#### `arm64`
-
-For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` architecture.
-
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
-chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ## Acquire the installation image
@@ -120,8 +108,7 @@ For more information about using a shared IP, see the related
 
 ### DNS records
 
-If neither of the other methods work for you, you can use DNS records to
-provide a measure of redundancy.
+You can use DNS records to provide a measure of redundancy.
 In this case, you would add multiple A or AAAA records (one for each control plane node) to a DNS name.
 
 For instance, you could add:
@@ -142,11 +129,11 @@ https://kube.cluster1.mydomain.com:6443
 
 Many administrative tasks are performed by calling the Talos API on Talos Linux control plane nodes.
 
-We recommend accessing the control plane nodes directly from the `talosctl` client, if possible (i.e. set your `endpoints` to the IP addresses of the control plane nodes).
+We recommend directly accessing the control plane nodes from the `talosctl` client, if possible (i.e. set your `endpoints` to the IP addresses of the control plane nodes).
 This requires your control plane nodes to be reachable from the client IP.
 
 If the control plane nodes are not directly reachable from the workstation where you run `talosctl`, then configure a load balancer for TCP port 50000 to be forwarded to the control plane nodes.
-Do not use Talos Linux's built in VIP support for accessing the Talos API, as it will not function in the event of an etcd failure, and you will not be able to access the Talos API to fix things.
+Do not use Talos Linux's built in VIP support for accessing the Talos API, as it will not function in the event of an `etcd` failure, and you will not be able to access the Talos API to fix things.
 
 If you create a load balancer to forward the Talos API calls, make a note of the IP or
 hostname so that you can configure your `talosctl` tool's `endpoints` below.

--- a/website/content/v1.4/introduction/quickstart.md
+++ b/website/content/v1.4/introduction/quickstart.md
@@ -14,20 +14,8 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 Download `talosctl`:
 
-##### `amd64`
-
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
-chmod +x /usr/local/bin/talosctl
-```
-
-##### `arm64`
-
-For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
-
-```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
-chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 #### `kubectl`
@@ -40,6 +28,12 @@ Now run the following:
 
 ```bash
 talosctl cluster create
+```
+
+You can explore using Talos API commands:
+
+```bash
+talosctl dashboard --nodes 10.5.0.2
 ```
 
 Verify that you can reach Kubernetes:

--- a/website/content/v1.4/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.4/talos-guides/install/local-platforms/qemu.md
@@ -41,19 +41,10 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` and all required binaries via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
+Download `talosctl` via
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ## Install Talos kernel and initramfs

--- a/website/content/v1.4/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.4/talos-guides/install/local-platforms/virtualbox.md
@@ -27,23 +27,14 @@ apt install virtualbox
 ### Install talosctl
 
 You can download `talosctl` via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ### Download ISO Image
 
-In order to install Talos in VirtualBox, you will need the ISO image from the Talos release page.
+Download the ISO image from the Talos release page.
 You can download `talos-amd64.iso` via
 [github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 

--- a/website/content/v1.4/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.4/talos-guides/install/virtualized-platforms/proxmox.md
@@ -23,18 +23,9 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 ### Install talosctl
 
 You can download `talosctl` via
-[github.com/siderolabs/talos/releases](https://github.com/siderolabs/talos/releases)
 
 ```bash
-curl https://github.com/siderolabs/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
-```
-
-For example version `{{< release >}}` for `linux` platform:
-
-```bash
-curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/talosctl-linux-amd64 -L -o talosctl
-sudo cp talosctl /usr/local/bin
-sudo chmod +x /usr/local/bin/talosctl
+curl -sL https://talos.dev/install | sh
 ```
 
 ### Download ISO Image

--- a/website/static/install
+++ b/website/static/install
@@ -76,15 +76,6 @@ case $OS in
 esac
 OS=$(echo $OS | tr '[:upper:]' '[:lower:]')
 
-
-tmpdir=$(mktemp -d /tmp/talosctl.XXXXXX)
-srcfile="talosctl-${OS}"
-if [ -n "${cli_arch}" ]; then
-  srcfile="${srcfile}-${cli_arch}"
-fi
-
-
-
 dstfile="${INSTALLPATH}/talosctl"
 
 checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
@@ -95,18 +86,21 @@ checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
   exit 1
 }
 
-url="https://github.com/siderolabs/talos/releases/latest/download/${srcfile}"
-
 if [ -e "${dstfile}" ]; then
     echo ""
     echo "talosctl was already downloaded;  🎉"
     echo ""
     echo "To force re-downloading, delete '${dstfile}' then run me again."
-    (
-      rm -rf "${tmpdir}"
-    )
     happyexit
 fi
+
+tmpdir=$(mktemp -d /tmp/talosctl.XXXXXX)
+srcfile="talosctl-${OS}"
+if [ -n "${cli_arch}" ]; then
+  srcfile="${srcfile}-${cli_arch}"
+fi
+
+url="https://github.com/siderolabs/talos/releases/latest/download/${srcfile}"
 
 (
   cd "$tmpdir"
@@ -123,10 +117,23 @@ fi
 )
 
 (
-  mv "${tmpdir}/${srcfile}" "${dstfile}"
-  chmod +x "${dstfile}"
-)
+  super=''
+  if [ ! -w "${INSTALLPATH}" ]; then
+    if $(command -v sudo > /dev/null 2>&1); then
+      super='sudo -E sh -c'
+    elif $(command -v  su > /dev/null 2>&1); then
+      super='su -c'
+    fi
+  fi
 
+  if [ -z "${super}" ]; then
+    mv "${tmpdir}"/"${srcfile}" "${dstfile}"
+    chmod +x "${dstfile}"
+  else
+    ${super} 'mv "'${tmpdir}/${srcfile}'" "'${dstfile}'"'
+    ${super} 'chmod +x "'${dstfile}'"'
+  fi
+)
 
 rm -r "$tmpdir"
 


### PR DESCRIPTION
Signed-off-by: Steve Francis <steve.francis@talos-systems.com>

Replaced multiple curl examples to get the correct talosctl with a curl that executes the install script.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
