### PR TITLE
fix: kubespan mss clamping

### DIFF
--- a/internal/app/machined/pkg/controllers/kubespan/manager.go
+++ b/internal/app/machined/pkg/controllers/kubespan/manager.go
@@ -230,11 +230,11 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 			}
 		}
 
+		cfgSpec := cfg.(*kubespan.Config).TypedSpec()
+
 		if nfTablesMgr == nil {
 			nfTablesMgr = ctrl.NfTablesManagerFactory(constants.KubeSpanDefaultFirewallMark, constants.KubeSpanDefaultForceFirewallMark, constants.KubeSpanDefaultFirewallMask)
 		}
-
-		cfgSpec := cfg.(*kubespan.Config).TypedSpec()
 
 		localIdentity, err := r.Get(ctx, resource.NewMetadata(kubespan.NamespaceName, kubespan.IdentityType, kubespan.LocalIdentity, resource.VersionUndefined))
 		if err != nil {
@@ -416,9 +416,6 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 		}
 
 		mtu := cfgSpec.MTU
-		if mtu == 0 {
-			mtu = constants.KubeSpanLinkMTU
-		}
 
 		for _, spec := range []network.RouteSpecSpec{
 			{
@@ -499,7 +496,7 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 			return fmt.Errorf("error modifying link spec: %w", err)
 		}
 
-		if err = nfTablesMgr.Update(allowedIPsSet); err != nil {
+		if err = nfTablesMgr.Update(allowedIPsSet, mtu); err != nil {
 			return fmt.Errorf("failed updating nftables: %w", err)
 		}
 

--- a/internal/app/machined/pkg/controllers/kubespan/manager_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/manager_test.go
@@ -92,7 +92,7 @@ type mockNftablesManager struct {
 	ipSet *netipx.IPSet
 }
 
-func (mock *mockNftablesManager) Update(ipSet *netipx.IPSet) error {
+func (mock *mockNftablesManager) Update(ipSet *netipx.IPSet, mtu uint32) error {
 	mock.mu.Lock()
 	defer mock.mu.Unlock()
 

--- a/internal/app/machined/pkg/controllers/kubespan/nftables_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/nftables_test.go
@@ -17,7 +17,11 @@ import (
 
 func TestNfTables(t *testing.T) {
 	// use a different mark to avoid conflicts with running kubespan
-	mgr := kubespan.NewNfTablesManager(constants.KubeSpanDefaultFirewallMark+10, constants.KubeSpanDefaultForceFirewallMark<<1, constants.KubeSpanDefaultFirewallMask<<1)
+	mgr := kubespan.NewNfTablesManager(
+		constants.KubeSpanDefaultFirewallMark<<1,
+		constants.KubeSpanDefaultForceFirewallMark<<1,
+		constants.KubeSpanDefaultFirewallMask<<1,
+	)
 
 	// cleanup should be fine if nothing is installed
 	assert.NoError(t, mgr.Cleanup())
@@ -32,14 +36,14 @@ func TestNfTables(t *testing.T) {
 	ipSet, err := builder.IPSet()
 	require.NoError(t, err)
 
-	assert.NoError(t, mgr.Update(ipSet))
+	assert.NoError(t, mgr.Update(ipSet, constants.KubeSpanLinkMTU))
 
 	builder.AddPrefix(netip.MustParsePrefix("10.0.0.0/8"))
 
 	ipSet, err = builder.IPSet()
 	require.NoError(t, err)
 
-	assert.NoError(t, mgr.Update(ipSet))
+	assert.NoError(t, mgr.Update(ipSet, constants.KubeSpanLinkMTU))
 
 	assert.NoError(t, mgr.Cleanup())
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1081,7 +1081,12 @@ func (k *NetworkKubeSpan) AdvertiseKubernetesNetworks() bool {
 
 // MTU implements the KubeSpan interface.
 func (k *NetworkKubeSpan) MTU() uint32 {
-	return pointer.SafeDeref(k.KubeSpanMTU)
+	mtu := pointer.SafeDeref(k.KubeSpanMTU)
+	if mtu == 0 {
+		mtu = constants.KubeSpanLinkMTU
+	}
+
+	return mtu
 }
 
 // Filters implements the KubeSpan interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -188,6 +188,12 @@ func (c *Config) Validate(mode config.RuntimeMode, options ...config.ValidationO
 			warnings = append(warnings, warn...)
 			result = multierror.Append(result, err)
 		}
+
+		if c.Machine().Network().KubeSpan().Enabled() {
+			if c.Machine().Network().KubeSpan().MTU() < constants.KubeSpanLinkMinimumMTU {
+				result = multierror.Append(result, fmt.Errorf("kubespan link MTU must be at least %d", constants.KubeSpanLinkMinimumMTU))
+			}
+		}
 	}
 
 	if c.MachineConfig.MachineDisks != nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -1339,6 +1339,34 @@ func TestValidate(t *testing.T) {
 			},
 			expectedError: "2 errors occurred:\n\t* KubeSpan endpoint filer is not valid: \"10\"\n\t* KubeSpan endpoint filer is not valid: \"123::/456\"\n\n",
 		},
+		{
+			name: "KubeSpanSmallMTU",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "worker",
+					MachineNetwork: &v1alpha1.NetworkConfig{
+						NetworkKubeSpan: &v1alpha1.NetworkKubeSpan{
+							KubeSpanEnabled: pointer.To(true),
+							KubeSpanMTU:     pointer.To(uint32(576)),
+						},
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ClusterID:     "test",
+					ClusterSecret: "test",
+					ClusterDiscoveryConfig: &v1alpha1.ClusterDiscoveryConfig{
+						DiscoveryEnabled: pointer.To(true),
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* kubespan link MTU must be at least 1280\n\n",
+		},
 	} {
 		test := test
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -686,8 +686,14 @@ const (
 	// KubeSpanLinkName is the link name for the KubeSpan Wireguard interface.
 	KubeSpanLinkName = "kubespan"
 
-	// KubeSpanLinkMTU is the default link mtu size for the KubeSpan Wireguard interface.
+	// KubeSpanLinkMTU is the default link MTU size for the KubeSpan Wireguard interface.
 	KubeSpanLinkMTU = 1420
+
+	// KubeSpanLinkMinimumMTU is the minimum link MTU size for the KubeSpan Wireguard interface.
+	//
+	// This is the minimum MTU size for the Wireguard interface with IPv6 enabled.
+	// See: https://lore.kernel.org/wireguard/20190321033638.1ff82682@natsu/t/
+	KubeSpanLinkMinimumMTU = 1280
 
 	// UdevRulesPath rules file path.
 	UdevRulesPath = "/usr/etc/udev/rules.d/99-talos.rules"


### PR DESCRIPTION
Second step to solve the wireguard mtu issue.

The standard ICMP-method to discover optimal MTU size is not working with wireguard. All icmp packages cannot reach the sender because the OS cannot understand who it was. As a result we have an ICMP black hole.

We can switch on the net.ipv4.tcp_mtu_probing but it will affect all containers. I do not think this is a good idea. We will decrease the MSS of tcp packages which go through the tunnel.


```shell
# nft -n -a list table inet talos_kubespan
...
	chain kubespan_outgoing { # handle 2
		type route hook output priority 0; policy accept;
		meta mark & 0x00000060 == 0x00000020 accept # handle 15
		oifname "lo" accept # handle 16
		ip daddr @kubespan_targets_ipv4 tcp flags & (0x2 | 0x4) == 0x2 tcp option maxseg size > 1260 tcp option maxseg size set 1260 # handle 19
		ip daddr @kubespan_targets_ipv4 meta mark set meta mark & 0xffffffdf | 0x00000040 accept # handle 20
		ip6 daddr @kubespan_targets_ipv6 tcp flags & (0x2 | 0x4) == 0x2 tcp option maxseg size > 1240 tcp option maxseg size set 1240 # handle 21
		ip6 daddr @kubespan_targets_ipv6 meta mark set meta mark & 0xffffffdf | 0x00000040 accept # handle 22
	}
```
Reference:
* https://blog.cloudflare.com/path-mtu-discovery-in-practice/
* https://www.ietf.org/rfc/rfc4821.txt

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
