### PR TITLE
vsphere.sh > vmware.sh

### DIFF
--- a/website/content/v1.0/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.0/talos-guides/install/virtualized-platforms/vmware.md
@@ -23,8 +23,8 @@ Using the VIP chosen in the prereq steps, we will now generate the base configur
 This can be done with the `talosctl gen config ...` command.
 Take note that we will also use a JSON6902 patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
 
-First, download `the cp.patch` to your local machine and edit the VIP to match your chosen IP.
-You can do this by issuing `https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/virtualized-platforms/vmware/cp.patch.yaml`.
+First, download `cp.patch.yaml` to your local machine and edit the VIP to match your chosen IP.
+You can do this by issuing: `curl -fsSLO https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml`.
 It's contents should look like the following:
 
 ```yaml
@@ -101,7 +101,7 @@ This script has default variables for things like Talos version and cluster name
 To create a content library and import the Talos OVA corresponding to the mentioned Talos version, simply issue:
 
 ```bash
-./vsphere.sh upload_ova
+./vmware.sh upload_ova
 ```
 
 #### Create Cluster
@@ -109,7 +109,7 @@ To create a content library and import the Talos OVA corresponding to the mentio
 With the OVA uploaded to the content library, you can create a 5 node (by default) cluster with 3 control plane and 2 worker nodes:
 
 ```bash
-./vsphere.sh create
+./vmware.sh create
 ```
 
 This step will create a VM from the OVA, edit the settings based on the env variables used for VM size/specs, then power on the VMs.

--- a/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
@@ -101,7 +101,7 @@ This script has default variables for things like Talos version and cluster name
 To create a content library and import the Talos OVA corresponding to the mentioned Talos version, simply issue:
 
 ```bash
-./vsphere.sh upload_ova
+./vmware.sh upload_ova
 ```
 
 #### Create Cluster
@@ -109,7 +109,7 @@ To create a content library and import the Talos OVA corresponding to the mentio
 With the OVA uploaded to the content library, you can create a 5 node (by default) cluster with 3 control plane and 2 worker nodes:
 
 ```bash
-./vsphere.sh create
+./vmware.sh create
 ```
 
 This step will create a VM from the OVA, edit the settings based on the env variables used for VM size/specs, then power on the VMs.

--- a/website/content/v1.2/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.2/talos-guides/install/virtualized-platforms/vmware.md
@@ -101,7 +101,7 @@ This script has default variables for things like Talos version and cluster name
 To create a content library and import the Talos OVA corresponding to the mentioned Talos version, simply issue:
 
 ```bash
-./vsphere.sh upload_ova
+./vmware.sh upload_ova
 ```
 
 #### Create Cluster
@@ -109,7 +109,7 @@ To create a content library and import the Talos OVA corresponding to the mentio
 With the OVA uploaded to the content library, you can create a 5 node (by default) cluster with 3 control plane and 2 worker nodes:
 
 ```bash
-./vsphere.sh create
+./vmware.sh create
 ```
 
 This step will create a VM from the OVA, edit the settings based on the env variables used for VM size/specs, then power on the VMs.

--- a/website/content/v1.3/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.3/talos-guides/install/virtualized-platforms/vmware.md
@@ -101,7 +101,7 @@ This script has default variables for things like Talos version and cluster name
 To create a content library and import the Talos OVA corresponding to the mentioned Talos version, simply issue:
 
 ```bash
-./vsphere.sh upload_ova
+./vmware.sh upload_ova
 ```
 
 #### Create Cluster
@@ -109,7 +109,7 @@ To create a content library and import the Talos OVA corresponding to the mentio
 With the OVA uploaded to the content library, you can create a 5 node (by default) cluster with 3 control plane and 2 worker nodes:
 
 ```bash
-./vsphere.sh create
+./vmware.sh create
 ```
 
 This step will create a VM from the OVA, edit the settings based on the env variables used for VM size/specs, then power on the VMs.

--- a/website/content/v1.4/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.4/talos-guides/install/virtualized-platforms/vmware.md
@@ -101,7 +101,7 @@ This script has default variables for things like Talos version and cluster name
 To create a content library and import the Talos OVA corresponding to the mentioned Talos version, simply issue:
 
 ```bash
-./vsphere.sh upload_ova
+./vmware.sh upload_ova
 ```
 
 #### Create Cluster
@@ -109,7 +109,7 @@ To create a content library and import the Talos OVA corresponding to the mentio
 With the OVA uploaded to the content library, you can create a 5 node (by default) cluster with 3 control plane and 2 worker nodes:
 
 ```bash
-./vsphere.sh create
+./vmware.sh create
 ```
 
 This step will create a VM from the OVA, edit the settings based on the env variables used for VM size/specs, then power on the VMs.


### PR DESCRIPTION
# Pull Request

## What? (description)

https://www.talos.dev/v1.3/talos-guides/install/virtualized-platforms/vmware/ mentions 

>Download the vmware.sh script to your local machine. You can do this by issuing curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/v1.3/talos-guides/install/virtualized-platforms/vmware/vmware.sh".

But the command example refers to it as `vsphere.sh`. This changes it to `vmware.sh`

also fixed the upcoming docs for 1.4. not sure if you have a backport function for historical releases.

Signed-off-by: Rowan Smith <86935689+rowansmithhc@users.noreply.github.com>

## Why? (reasoning)

Correct the docs 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

This was a simple one line change