### PR TITLE
chore: make organization selection an interface

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -349,3 +349,7 @@ func (adapter *generateAdminAdapter) CertLifetime() time.Duration {
 func (adapter *generateAdminAdapter) CommonName() string {
 	return constants.KubernetesTalosAdminCertCommonName
 }
+
+func (adapter *generateAdminAdapter) CertOrganization() string {
+	return constants.KubernetesAdminCertOrganization
+}

--- a/pkg/kubeconfig/generate.go
+++ b/pkg/kubeconfig/generate.go
@@ -16,7 +16,6 @@ import (
 	"github.com/siderolabs/crypto/x509"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 const kubeConfigTemplate = `apiVersion: v1
@@ -59,7 +58,7 @@ func GenerateAdmin(config GenerateAdminInput, out io.Writer) error {
 			CertificateLifetime: config.AdminKubeconfig().CertLifetime(),
 
 			CommonName:   config.AdminKubeconfig().CommonName(),
-			Organization: constants.KubernetesAdminCertOrganization,
+			Organization: config.AdminKubeconfig().CertOrganization(),
 
 			Endpoint:    config.Endpoint().String(),
 			Username:    "admin",

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -521,6 +521,7 @@ type ExternalCloudProvider interface {
 // AdminKubeconfig defines settings for admin kubeconfig.
 type AdminKubeconfig interface {
 	CommonName() string
+	CertOrganization() string
 	CertLifetime() time.Duration
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1247,6 +1247,11 @@ func (a *AdminKubeconfigConfig) CommonName() string {
 	return constants.KubernetesAdminCertCommonName
 }
 
+// CertOrganization implements the config.Provider interface.
+func (a *AdminKubeconfigConfig) CertOrganization() string {
+	return constants.KubernetesAdminCertOrganization
+}
+
 // Endpoints implements the config.Provider interface.
 func (r *RegistryMirrorConfig) Endpoints() []string {
 	return r.MirrorEndpoints


### PR DESCRIPTION
Making organization a interface for preparing to avoid giving system:masters access to the talosctl kubeconfig generated certificate.

Before making selecting organization a machine config option this change simplfies the patch needed to remove the system:masters organization from "human" admin user

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>