### PR TITLE
docs: update last release for Talos 1.2.x

### DIFF
--- a/website/content/v1.2/_index.md
+++ b/website/content/v1.2/_index.md
@@ -4,8 +4,8 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.2.7
-kubernetesRelease: "1.25.4"
+lastRelease: v1.2.8
+kubernetesRelease: "1.25.5"
 prevKubernetesRelease: "1.24.3"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.10.0"

--- a/website/content/v1.2/introduction/support-matrix.md
+++ b/website/content/v1.2/introduction/support-matrix.md
@@ -7,7 +7,7 @@ description: "Table of supported Talos Linux versions and respective platforms."
 | Talos Version                                                                                                  | 1.2                                | 1.1                                |
 |----------------------------------------------------------------------------------------------------------------|------------------------------------|------------------------------------|
 | Release Date                                                                                                   | 2022-09-01                         | 2022-06-22 (1.1.0)                 |
-| End of Community Support                                                                                       | 1.3.0 release (2022-12-01, TBD)    | 1.2.0 release (2022-09-01)         |
+| End of Community Support                                                                                       | 1.3.0 release (2022-12-15)         | 1.2.0 release (2022-09-01)         |
 | Enterprise Support                                                                                             | [offered by Sidero Labs Inc.](https://www.siderolabs.com/support/) | [offered by Sidero Labs Inc.](https://www.siderolabs.com/support/) |
 | Kubernetes                                                                                                     | 1.25, 1.24, 1.23                   | 1.24, 1.23, 1.22                   |
 | Architecture                                                                                                   | amd64, arm64                       | amd64, arm64                       |

--- a/website/content/v1.3/_index.md
+++ b/website/content/v1.3/_index.md
@@ -6,7 +6,7 @@ cascade:
   type: docs
 lastRelease: v1.3.0
 kubernetesRelease: "1.26.0"
-prevKubernetesRelease: "1.25.3"
+prevKubernetesRelease: "1.25.5"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.11.0"
 nvidiaDriverRelease: "515.65.01"


### PR DESCRIPTION
Update support matrix, as Talos 1.3.0 got released.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
