### PR TITLE
New sub-command `talosctl config remove` to remove contexts

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/confirm.go
+++ b/cmd/talosctl/pkg/talos/helpers/confirm.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+var okays = []string{"y", "yes"}
+
+// Confirm asks the user to confirm their action. Anything other than
+// `y` and `yes` returns false.
+func Confirm(prompt string) bool {
+	var inp string
+
+	fmt.Printf("%s (y/N): ", prompt)
+	fmt.Scanf("%s", &inp)
+	inp = strings.TrimSpace(inp)
+
+	for _, ok := range okays {
+		if strings.EqualFold(inp, ok) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/website/content/v1.4/reference/cli.md
+++ b/website/content/v1.4/reference/cli.md
@@ -571,6 +571,36 @@ talosctl config node <endpoint>... [flags]
 
 * [talosctl config](#talosctl-config)	 - Manage the client configuration file (talosconfig)
 
+## talosctl config remove
+
+Remove contexts
+
+```
+talosctl config remove <context> [flags]
+```
+
+### Options
+
+```
+      --dry-run     dry run
+  -h, --help        help for remove
+  -y, --noconfirm   do not ask for confirmation
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string       Cluster to connect to if a proxy endpoint is used.
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl config](#talosctl-config)	 - Manage the client configuration file (talosconfig)
+
 ## talosctl config
 
 Manage the client configuration file (talosconfig)
@@ -602,6 +632,7 @@ Manage the client configuration file (talosconfig)
 * [talosctl config merge](#talosctl-config-merge)	 - Merge additional contexts from another client configuration file
 * [talosctl config new](#talosctl-config-new)	 - Generate a new client configuration file
 * [talosctl config node](#talosctl-config-node)	 - Set the node(s) for the current context
+* [talosctl config remove](#talosctl-config-remove)	 - Remove contexts
 
 ## talosctl conformance kubernetes
 


### PR DESCRIPTION
## What? (description)

Adds a new sub-command to `talosctl config`. It takes in the context to be deleted as argument and supports glob matching.

A local flag `--noconfirm|-y` can be passed to bypass the confirmation prompt.

It also supports dry run by passing the `--dry-run` flag similar to `apply-config` and `edit` commands.

Example:

```
$ talosctl config remove 'ctx-*'
Remove context ctx-a(*)? (y/N): n
Remove context ctx-b? (y/N): y
Remove context ctx-c? (y/N): y
```

## Why? (reasoning)

`talosctl` has a command to add contexts (`talosctl config add myctx`) but it was missing one to remove contexts.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

References #3989