### PR TITLE
fix: send diagnostic output to stderr consistently

### DIFF
--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -27,7 +27,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -183,7 +183,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) (err error) {
 	workerMemory := int64(workersMemory) * 1024 * 1024
 
 	// Validate CIDR range and allocate IPs
-	fmt.Println("validating CIDR and reserving IPs")
+	fmt.Fprintln(os.Stderr, "validating CIDR and reserving IPs")
 
 	cidr4, err := netip.ParsePrefix(networkCIDR)
 	if err != nil {
@@ -714,7 +714,7 @@ func saveConfig(talosConfigObj *clientconfig.Config) (err error) {
 
 	renames := c.Merge(talosConfigObj)
 	for _, rename := range renames {
-		fmt.Printf("renamed talosconfig context %s\n", rename.String())
+		fmt.Fprintf(os.Stderr, "renamed talosconfig context %s\n", rename.String())
 	}
 
 	return c.Save(talosconfig)
@@ -726,7 +726,7 @@ func mergeKubeconfig(ctx context.Context, clusterAccess *access.Adapter) error {
 		return err
 	}
 
-	fmt.Printf("\nmerging kubeconfig into %q\n", kubeconfigPath)
+	fmt.Fprintf(os.Stderr, "\nmerging kubeconfig into %q\n", kubeconfigPath)
 
 	k8sconfig, err := clusterAccess.Kubeconfig(ctx)
 	if err != nil {

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -334,7 +334,7 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 
 	err := os.WriteFile(destination, data, permissions)
 
-	fmt.Printf("Created %s\n", destination)
+	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
 
 	return err
 }

--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -280,7 +280,7 @@ var configMergeCmd = &cobra.Command{
 
 		renames := c.Merge(secondConfig)
 		for _, rename := range renames {
-			fmt.Printf("renamed talosconfig context %s\n", rename.String())
+			fmt.Fprintf(os.Stderr, "renamed talosconfig context %s\n", rename.String())
 		}
 
 		if err := c.Save(GlobalArgs.Talosconfig); err != nil {

--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -121,13 +121,13 @@ func editFn(c *client.Client) func(context.Context, string, resource.Resource, e
 			}
 
 			if len(bytes.TrimSpace(bytes.TrimSpace(cmdutil.StripComments(edited)))) == 0 {
-				fmt.Println("Apply was skipped: empty file.")
+				fmt.Fprintln(os.Stderr, "Apply was skipped: empty file.")
 
 				break
 			}
 
 			if bytes.Equal(edited, body) {
-				fmt.Println("Apply was skipped: no changes detected.")
+				fmt.Fprintln(os.Stderr, "Apply was skipped: no changes detected.")
 
 				break
 			}

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -71,12 +72,12 @@ func patchFn(c *client.Client, patches []configpatcher.Patch) func(context.Conte
 			bytes.TrimSpace(cmdutil.StripComments(patched)),
 			bytes.TrimSpace(cmdutil.StripComments(body)),
 		) {
-			fmt.Println("Apply was skipped: no changes detected.")
+			fmt.Fprintln(os.Stderr, "Apply was skipped: no changes detected.")
 
 			return nil
 		}
 
-		fmt.Printf("patched %s/%s at the node %s\n",
+		fmt.Fprintf(os.Stderr, "patched %s/%s at the node %s\n",
 			mc.Metadata().Type(),
 			mc.Metadata().ID(),
 			node,

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -104,7 +104,7 @@ var supportCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Printf("Support bundle is written to %s\n", supportCmdFlags.output)
+		fmt.Fprintf(os.Stderr, "Support bundle is written to %s\n", supportCmdFlags.output)
 
 		if err = archive.Archive.Close(); err != nil {
 			return err
@@ -234,7 +234,7 @@ func printErrors(err error) error {
 	var errs *multierror.Error
 
 	if !errors.As(err, &errs) {
-		fmt.Printf("Processed with errors:\n%s\n", color.RedString(err.Error()))
+		fmt.Fprintf(os.Stderr, "Processed with errors:\n%s\n", color.RedString(err.Error()))
 
 		return nil
 	}
@@ -243,7 +243,7 @@ func printErrors(err error) error {
 		if !wroteHeader {
 			wroteHeader = true
 
-			fmt.Println("Processed with errors:")
+			fmt.Fprintln(os.Stderr, "Processed with errors:")
 			fmt.Fprintln(w, "\tSOURCE\tERROR")
 		}
 

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -210,14 +210,14 @@ func (a *Tracker) Run() error {
 	if len(failedNodes) > 0 {
 		sort.Strings(failedNodes)
 
-		fmt.Printf("console logs for nodes %q:\n", failedNodes)
+		fmt.Fprintf(os.Stderr, "console logs for nodes %q:\n", failedNodes)
 
 		for _, node := range failedNodes {
 			dmesgReader, _ := failedNodesToDmesgs.Get(node)
 
-			_, copyErr := io.Copy(os.Stdout, dmesgReader)
+			_, copyErr := io.Copy(os.Stderr, dmesgReader)
 			if copyErr != nil {
-				fmt.Printf("%q: failed to print debug logs: %v\n", node, copyErr)
+				fmt.Fprintf(os.Stderr, "%q: failed to print debug logs: %v\n", node, copyErr)
 			}
 		}
 	}
@@ -251,7 +251,7 @@ func (a *Tracker) runReporter(ctx context.Context) error {
 
 		case update = <-a.reportCh:
 			if !a.isTerminal {
-				fmt.Printf("%q: %v\n", update.node, update.update.Message)
+				fmt.Fprintf(os.Stderr, "%q: %v\n", update.node, update.update.Message)
 
 				continue
 			}

--- a/cmd/talosctl/pkg/talos/helpers/mode.go
+++ b/cmd/talosctl/pkg/talos/helpers/mode.go
@@ -6,6 +6,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -126,7 +127,7 @@ func PrintApplyResults(resp *machine.ApplyConfigurationResponse) {
 		}
 
 		if m.ModeDetails != "" {
-			fmt.Println(m.ModeDetails)
+			fmt.Fprintln(os.Stderr, m.ModeDetails)
 		}
 	}
 }

--- a/internal/integration/cli/apply-config.go
+++ b/internal/integration/cli/apply-config.go
@@ -49,7 +49,11 @@ machine:
 
 	suite.Require().NoError(os.WriteFile(configPath, []byte(data), 0o777))
 
-	suite.RunCLI([]string{"apply-config", "--nodes", node, "--config-patch", fmt.Sprintf("@%s", patchPath), "-f", configPath})
+	suite.RunCLI([]string{"apply-config", "--nodes", node, "--config-patch", fmt.Sprintf("@%s", patchPath), "-f", configPath},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile("Applied configuration without a reboot")),
+	)
 
 	suite.RunCLI([]string{"get", "--nodes", node, "links"},
 		base.StdoutShouldMatch(regexp.MustCompile("dummy-ap-patch")),

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -39,7 +39,10 @@ func (suite *TalosconfigSuite) TestList() {
 func (suite *TalosconfigSuite) TestMerge() {
 	tempDir := suite.T().TempDir()
 
-	suite.RunCLI([]string{"gen", "config", "-o", tempDir, "foo", "https://192.168.0.1:6443"})
+	suite.RunCLI([]string{"gen", "config", "-o", tempDir, "foo", "https://192.168.0.1:6443"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	talosconfigPath := filepath.Join(tempDir, "talosconfig")
 
@@ -58,7 +61,10 @@ func (suite *TalosconfigSuite) TestMerge() {
 	suite.Require().NotNil(c.Contexts["foo"])
 
 	suite.RunCLI([]string{"config", "merge", "--talosconfig", path, talosconfigPath},
-		base.StdoutShouldMatch(regexp.MustCompile(`renamed`)))
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(`renamed`)),
+	)
 
 	c, err = clientconfig.Open(path)
 	suite.Require().NoError(err)

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -186,7 +186,10 @@ func (suite *GenSuite) testGenConfigPatch(patch []byte) {
 		tt := tt
 
 		suite.Run(tt.flag, func() {
-			suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--" + tt.flag, string(patch)})
+			suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--" + tt.flag, string(patch)},
+				base.StdoutEmpty(),
+				base.StderrNotEmpty(),
+				base.StderrShouldMatch(regexp.MustCompile("generating PKI and tokens")))
 
 			for _, configName := range []string{"controlplane.yaml", "worker.yaml"} {
 				cfg, err := configloader.NewFromFile(configName)
@@ -270,7 +273,10 @@ func (suite *GenSuite) TestConfigWithSecrets() {
 	secretsYaml, err := os.ReadFile("secrets.yaml")
 	suite.Assert().NoError(err)
 
-	suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--with-secrets", "secrets.yaml"})
+	suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--with-secrets", "secrets.yaml"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	config, err := configloader.NewFromFile("controlplane.yaml")
 	suite.Assert().NoError(err)
@@ -290,7 +296,10 @@ func (suite *GenSuite) TestGenConfigWithDeprecatedOutputDirFlag() {
 		"gen", "config",
 		"foo", "https://192.168.0.1:6443",
 		"--output-dir", tempDir,
-	})
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	suite.Assert().FileExists(filepath.Join(tempDir, "controlplane.yaml"))
 	suite.Assert().FileExists(filepath.Join(tempDir, "worker.yaml"))
@@ -304,7 +313,7 @@ func (suite *GenSuite) TestGenConfigToStdoutControlPlane() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "controlplane",
 		"--output", "-",
-	}, base.StdoutMatchFunc(func(output string) error {
+	}, base.StderrNotEmpty(), base.StdoutMatchFunc(func(output string) error {
 		expected := "type: controlplane"
 		if !strings.Contains(output, expected) {
 			return fmt.Errorf("stdout does not contain %q: %q", expected, output)
@@ -321,7 +330,7 @@ func (suite *GenSuite) TestGenConfigToStdoutWorker() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "worker",
 		"--output", "-",
-	}, base.StdoutMatchFunc(func(output string) error {
+	}, base.StderrNotEmpty(), base.StdoutMatchFunc(func(output string) error {
 		expected := "type: worker"
 		if !strings.Contains(output, expected) {
 			return fmt.Errorf("stdout does not contain %q: %q", expected, output)
@@ -338,7 +347,7 @@ func (suite *GenSuite) TestGenConfigToStdoutTalosconfig() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "talosconfig",
 		"--output", "-",
-	}, base.StdoutMatchFunc(func(output string) error {
+	}, base.StderrNotEmpty(), base.StdoutMatchFunc(func(output string) error {
 		expected := "context: foo"
 		if !strings.Contains(output, expected) {
 			return fmt.Errorf("stdout does not contain %q: %q", expected, output)
@@ -376,7 +385,10 @@ func (suite *GenSuite) TestGenConfigMultipleTypesToDirectory() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "controlplane,worker",
 		"--output", tempDir,
-	})
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	suite.Assert().FileExists(filepath.Join(tempDir, "controlplane.yaml"))
 	suite.Assert().FileExists(filepath.Join(tempDir, "worker.yaml"))
@@ -393,7 +405,10 @@ func (suite *GenSuite) TestGenConfigSingleTypeToFile() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "worker",
 		"--output", tempFile,
-	})
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	suite.Assert().FileExists(tempFile)
 }
@@ -408,7 +423,10 @@ func (suite *GenSuite) TestGenConfigSingleTypeWithDeprecatedOutputDirFlagToDirec
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "worker",
 		"--output-dir", tempDir,
-	})
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	suite.Assert().FileExists(filepath.Join(tempDir, "worker.yaml"))
 }

--- a/internal/integration/cli/machineconfig.go
+++ b/internal/integration/cli/machineconfig.go
@@ -53,7 +53,7 @@ func (suite *MachineConfigSuite) TestGen() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "controlplane",
 		"--output", "-",
-	}, base.StdoutMatchFunc(func(output string) error {
+	}, base.StderrNotEmpty(), base.StdoutMatchFunc(func(output string) error {
 		expected := "type: controlplane"
 		if !strings.Contains(output, expected) {
 			return fmt.Errorf("stdout does not contain %q: %q", expected, output)
@@ -96,7 +96,10 @@ func (suite *MachineConfigSuite) TestPatchPrintStdout() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "controlplane",
 		"--output", mc,
-	})
+	},
+		base.StderrNotEmpty(),
+		base.StdoutEmpty(),
+	)
 
 	suite.RunCLI([]string{
 		"machineconfig", "patch", mc, "--patch", string(patch1), "-p", "@" + patch2Path,
@@ -133,7 +136,10 @@ func (suite *MachineConfigSuite) TestPatchWriteToFile() {
 		"foo", "https://192.168.0.1:6443",
 		"--output-types", "controlplane",
 		"--output", mc,
-	})
+	},
+		base.StderrNotEmpty(),
+		base.StdoutEmpty(),
+	)
 
 	outputFile := filepath.Join(suite.T().TempDir(), "inner", "output.yaml")
 

--- a/internal/integration/cli/patch.go
+++ b/internal/integration/cli/patch.go
@@ -42,8 +42,14 @@ func (suite *PatchSuite) TestSuccess() {
 	data, err := json.Marshal(patch)
 	suite.Require().NoError(err)
 
-	suite.RunCLI([]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot"})
-	suite.RunCLI([]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot", "--dry-run"})
+	suite.RunCLI([]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
+	suite.RunCLI([]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot", "--dry-run"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 }
 
 // TestError runs comand with error.

--- a/internal/integration/cli/support.go
+++ b/internal/integration/cli/support.go
@@ -34,7 +34,9 @@ func (suite *SupportSuite) TestSupport() {
 
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
-	suite.RunCLI([]string{"support", "--nodes", node, "-w", "5", "-O", output})
+	suite.RunCLI([]string{"support", "--nodes", node, "-w", "5", "-O", output},
+		base.StderrNotEmpty(),
+	)
 
 	archive, err := zip.OpenReader(output)
 	suite.Require().NoError(err)

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -46,7 +46,10 @@ func (suite *ValidateSuite) TearDownTest() {
 
 // TestValidate generates config and validates it for all the modes.
 func (suite *ValidateSuite) TestValidate() {
-	suite.RunCLI([]string{"gen", "config", "foobar", "https://10.0.0.1"})
+	suite.RunCLI([]string{"gen", "config", "foobar", "https://10.0.0.1"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
 
 	for _, configFile := range []string{"controlplane.yaml", "worker.yaml"} {
 		configFile := configFile

--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -459,7 +459,7 @@ func (syncer *Syncer) adjustTime(offset time.Duration, leapSecond ntp.LeapIndica
 	if err != nil {
 		logLevel = zapcore.WarnLevel
 
-		fmt.Println(&buf, ", error was %s", err)
+		fmt.Fprintf(&buf, ", error was %s", err)
 	}
 
 	if syncer.firstSync && logLevel == zapcore.DebugLevel {

--- a/pkg/machinery/client/siderov1.go
+++ b/pkg/machinery/client/siderov1.go
@@ -79,7 +79,7 @@ func (c *authInterceptorConfig) authenticate(ctx context.Context, cc *grpc.Clien
 
 	err = browser.OpenURL(loginURL)
 	if err != nil {
-		fmt.Printf("Please visit this page to authenticate: %s\n", loginURL)
+		fmt.Fprintf(os.Stderr, "Please visit this page to authenticate: %s\n", loginURL)
 	}
 
 	publicKeyID := pgpKey.Key.Fingerprint()
@@ -89,9 +89,9 @@ func (c *authInterceptorConfig) authenticate(ctx context.Context, cc *grpc.Clien
 		return nil, err
 	}
 
-	fmt.Printf("Public key %s is now registered for user %s\n", publicKeyID, c.identity)
+	fmt.Fprintf(os.Stderr, "Public key %s is now registered for user %s\n", publicKeyID, c.identity)
 
-	fmt.Printf("PGP key saved to %s\n", savePath)
+	fmt.Fprintf(os.Stderr, "PGP key saved to %s\n", savePath)
 
 	return pgpKey, nil
 }

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -89,7 +89,7 @@ func NewConfigBundle(opts ...Option) (*ConfigBundle, error) {
 
 	// Handle generating net-new configs
 	if options.Verbose {
-		fmt.Println("generating PKI and tokens")
+		fmt.Fprintln(os.Stderr, "generating PKI and tokens")
 	}
 
 	if options.InputOptions == nil {

--- a/pkg/machinery/config/types/v1alpha1/bundle/v1alpha1_configurator_bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/v1alpha1_configurator_bundle.go
@@ -63,7 +63,7 @@ func (c *ConfigBundle) Write(outputDir string, commentsFlags encoder.CommentsFla
 			return err
 		}
 
-		fmt.Printf("created %s\n", fullFilePath)
+		fmt.Fprintf(os.Stderr, "created %s\n", fullFilePath)
 	}
 
 	return nil

--- a/pkg/provision/providers/docker/destroy.go
+++ b/pkg/provision/providers/docker/destroy.go
@@ -7,6 +7,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/siderolabs/talos/pkg/provision"
 )
@@ -27,7 +28,7 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
-	fmt.Println("destroying network", cluster.Info().Network.Name)
+	fmt.Fprintln(os.Stderr, "destroying network", cluster.Info().Network.Name)
 
 	return p.destroyNetwork(ctx, cluster.Info().Network.Name)
 }

--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -111,7 +111,7 @@ func (check *preflightCheckContext) cniDirectories(ctx context.Context) error {
 				return fmt.Errorf("error checking CNI directory %q: %w", cniDir, err)
 			}
 
-			fmt.Printf("creating %q\n", cniDir)
+			fmt.Fprintf(os.Stderr, "creating %q\n", cniDir)
 
 			err = os.MkdirAll(cniDir, 0o777)
 			if err != nil {
@@ -173,7 +173,7 @@ func (check *preflightCheckContext) cniBundle(ctx context.Context) error {
 		Mode: getter.ClientModeDir,
 	}
 
-	fmt.Printf("downloading CNI bundle from %q to %q\n", client.Src, client.Dst)
+	fmt.Fprintf(os.Stderr, "downloading CNI bundle from %q to %q\n", client.Src, client.Dst)
 
 	return client.Get()
 }


### PR DESCRIPTION
Fixes #6676

There was a mix of stdout/stderr, move more consistently to stderr.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
