### PR TITLE
fix: oralce cloud zone

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/metadata.go
@@ -21,6 +21,9 @@ const (
 	OracleUserDataEndpoint = "http://169.254.169.254/opc/v2/instance/metadata/user_data"
 	// OracleNetworkEndpoint is the local network metadata endpoint inside of Oracle Cloud.
 	OracleNetworkEndpoint = "http://169.254.169.254/opc/v2/vnics/"
+
+	oracleResolverServer = "169.254.169.254"
+	oracleTimeServer     = "169.254.169.254"
 )
 
 // MetadataConfig represents a metadata Oracle instance.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/expected.yaml
@@ -5,8 +5,14 @@ hostnames:
     - hostname: talos
       domainname: ""
       layer: platform
-resolvers: []
-timeServers: []
+resolvers:
+    - dnsServers:
+        - 169.254.169.254
+      layer: platform
+timeServers:
+    - timeServers:
+        - 169.254.169.254
+      layer: platform
 operators:
     - operator: dhcp6
       linkName: eth0
@@ -19,7 +25,7 @@ metadata:
     platform: oracle
     hostname: talos
     region: phx
-    zone: emir
+    zone: PHX-AD-1
     instanceType: VM.Standard.E3.Flex
     instanceId: ocid1.instance.oc1.phx.exampleuniqueID
     providerId: oci://ocid1.instance.oc1.phx.exampleuniqueID


### PR DESCRIPTION
Zone definition misspell.
Native services use uppercase zone.

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
