### PR TITLE
feat: ipv6 on gcp

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp_test.go
@@ -19,17 +19,24 @@ import (
 //go:embed testdata/metadata.json
 var rawMetadata []byte
 
+//go:embed testdata/interfaces.json
+var rawInterfaces []byte
+
 //go:embed testdata/expected.yaml
 var expectedNetworkConfig string
 
 func TestParseMetadata(t *testing.T) {
 	p := &gcp.GCP{}
 
-	var metadata gcp.MetadataConfig
+	var (
+		metadata   gcp.MetadataConfig
+		interfaces []gcp.NetworkInterfaceConfig
+	)
 
 	require.NoError(t, json.Unmarshal(rawMetadata, &metadata))
+	require.NoError(t, json.Unmarshal(rawInterfaces, &interfaces))
 
-	networkConfig, err := p.ParseMetadata(&metadata)
+	networkConfig, err := p.ParseMetadata(&metadata, interfaces)
 	require.NoError(t, err)
 
 	marshaled, err := yaml.Marshal(networkConfig)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/expected.yaml
@@ -1,6 +1,30 @@
-addresses: []
-links: []
-routes: []
+addresses:
+    - address: fd20:172:1610:7003:0:1::/96
+      linkName: eth0
+      family: inet6
+      scope: global
+      flags: permanent
+      layer: platform
+links:
+    - name: eth0
+      logical: false
+      up: true
+      mtu: 1500
+      kind: ""
+      type: netrom
+      layer: platform
+routes:
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: fe80::4001:acff:fe10:1
+      outLinkName: eth0
+      table: main
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
 hostnames:
     - hostname: talos
       domainname: ""
@@ -13,8 +37,15 @@ timeServers:
     - timeServers:
         - metadata.google.internal
       layer: platform
-operators: []
-externalIPs: []
+operators:
+    - operator: dhcp4
+      linkName: eth0
+      requireUp: true
+      dhcp4:
+        routeMetric: 1024
+      layer: platform
+externalIPs:
+    - 35.1.2.3
 metadata:
     platform: gcp
     hostname: talos

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/interfaces.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/interfaces.json
@@ -1,0 +1,32 @@
+[
+    {
+        "accessConfigs": [
+            {
+                "externalIp": "35.1.2.3",
+                "type": "ONE_TO_ONE_NAT"
+            }
+        ],
+        "dhcpv6Refresh": "2219726792944608985",
+        "dnsServers": [
+            "169.254.169.254"
+        ],
+        "forwardedIps": [
+            "172.16.0.230"
+        ],
+        "gateway": "172.16.0.1",
+        "gatewayIpv6": "fe80::4001:acff:fe10:1",
+        "ip": "172.16.0.4",
+        "ipAliases": [],
+        "ipv6": [
+            "fd20:172:1610:7003:0:1::/96"
+        ],
+        "ipv6s": [
+            "fd20:172:1610:7003:0:1:0:0"
+        ],
+        "mac": "42:01:ac:10:00:04",
+        "mtu": 1500,
+        "network": "projects/123/networks/main",
+        "subnetmask": "255.255.255.0",
+        "targetInstanceIps": []
+    }
+]


### PR DESCRIPTION
Introduce ipv6 to the google cloud.

It also can work with dhcpv6 is on.
But the route receives through RA packages which not working.

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
