### PR TITLE
fix: implement upgrade version checks for Talos 1.4

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
 )
 
 // KubernetesVersion embeds Kubernetes version.
@@ -35,18 +36,24 @@ func (v *KubernetesVersion) String() string {
 
 // SupportedWith checks if the Kubernetes version is supported with specified version of Talos.
 func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
+	var minK8sVersion, maxK8sVersion *version.Version
+
 	switch target.majorMinor {
 	case talos13.MajorMinor: // upgrades to 1.3.x
-		if v.version.Core().LessThan(talos13.MinimumKubernetesVersion) {
-			return fmt.Errorf("version of Kubernetes %s is too old to be used with Talos %s", v.version.String(), target.version.String())
-		}
-
-		if v.version.Core().GreaterThanOrEqual(talos13.MaximumKubernetesVersion) {
-			return fmt.Errorf("version of Kubernetes %s is too new to be used with Talos %s", v.version.String(), target.version.String())
-		}
-
-		return nil
+		minK8sVersion, maxK8sVersion = talos13.MinimumKubernetesVersion, talos13.MaximumKubernetesVersion
+	case talos14.MajorMinor: // upgrades to 1.4.x
+		minK8sVersion, maxK8sVersion = talos14.MinimumKubernetesVersion, talos14.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}
+
+	if v.version.Core().LessThan(minK8sVersion) {
+		return fmt.Errorf("version of Kubernetes %s is too old to be used with Talos %s", v.version.String(), target.version.String())
+	}
+
+	if v.version.Core().GreaterThanOrEqual(maxK8sVersion) {
+		return fmt.Errorf("version of Kubernetes %s is too new to be used with Talos %s", v.version.String(), target.version.String())
+	}
+
+	return nil
 }

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -67,12 +67,41 @@ func TestKubernetesCompatibility13(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility14(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.24.1",
+			target:            "1.4.0",
+		},
+		{
+			kubernetesVersion: "1.25.3",
+			target:            "1.4.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.26.0-rc.0",
+			target:            "1.4.7",
+		},
+		{
+			kubernetesVersion: "1.27.0-alpha.0",
+			target:            "1.4.0",
+			expectedError:     "version of Kubernetes 1.27.0-alpha.0 is too new to be used with Talos 1.4.0",
+		},
+		{
+			kubernetesVersion: "1.23.4",
+			target:            "1.4.0",
+			expectedError:     "version of Kubernetes 1.23.4 is too old to be used with Talos 1.4.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.4.0-alpha.0",
-			expectedError:     "compatibility with version 1.4.0-alpha.0 is not supported",
+			target:            "1.5.0-alpha.0",
+			expectedError:     "compatibility with version 1.5.0-alpha.0 is not supported",
 		},
 		{
 			kubernetesVersion: "1.25.0",

--- a/pkg/machinery/compatibility/talos14/talos14.go
+++ b/pkg/machinery/compatibility/talos14/talos14.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos14 provides compatibility constants for Talos 1.4
+package talos14
+
+import "github.com/hashicorp/go-version"
+
+// MajorMinor is the major.minor version of Talos 1.4.
+var MajorMinor = [2]int{1, 4}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.4.
+var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.4.
+var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.6.0"))
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.4.
+var DeniedHostUpgradeVersions = []*version.Version{}
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.4.
+var MinimumKubernetesVersion = version.Must(version.NewVersion("1.24.0"))
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.4.
+var MaximumKubernetesVersion = version.Must(version.NewVersion("1.26.99"))

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -81,12 +81,58 @@ func TestTalosUpgradeCompatibility13(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility14(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.3.0",
+			target: "1.4.0",
+		},
+		{
+			host:   "1.0.0-alpha.0",
+			target: "1.4.0",
+		},
+		{
+			host:   "1.2.0-alpha.0",
+			target: "1.4.0-alpha.0",
+		},
+		{
+			host:   "1.4.0",
+			target: "1.4.1",
+		},
+		{
+			host:   "1.4.0-beta.0",
+			target: "1.4.0",
+		},
+		{
+			host:   "1.5.5",
+			target: "1.4.3",
+		},
+		{
+			host:          "0.14.3",
+			target:        "1.4.0",
+			expectedError: `host version 0.14.3 is too old to upgrade to Talos 1.4.0`,
+		},
+		{
+			host:          "1.6.0-alpha.0",
+			target:        "1.4.0",
+			expectedError: `host version 1.6.0-alpha.0 is too new to downgrade to Talos 1.4.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.4.0-alpha.0",
-			expectedError: `upgrades to version 1.4.0-alpha.0 are not supported`,
+			target:        "1.5.0-alpha.0",
+			expectedError: `upgrades to version 1.5.0-alpha.0 are not supported`,
+		},
+		{
+			host:          "1.4.0",
+			target:        "1.6.0-alpha.0",
+			expectedError: `upgrades to version 1.6.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)


### PR DESCRIPTION
I missed that before cutting 1.4.0-alpha.0 release, which means unfortunately that Talos 1.4.0-alpha.0 can't upgrade Talos 1.4.0-alpha.0.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
