### PR TITLE
docs: fix auditpolicy example typo

### DIFF
--- a/website/content/v1.3/introduction/what-is-new.md
+++ b/website/content/v1.3/introduction/what-is-new.md
@@ -26,7 +26,7 @@ Talos now supports setting custom audit policy for `kube-apiserver` in the machi
 ```yaml
 cluster:
   apiServer:
-    auditPolicy: |
+    auditPolicy:
       apiVersion: audit.k8s.io/v1
       kind: Policy
       rules:


### PR DESCRIPTION
Fixes a simple typo in the Whats New auditPolicy example.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>