### PR TITLE
feat: add ISO wipe GRUB boot option

### DIFF
--- a/cmd/installer/cmd/grub.iso.cfg
+++ b/cmd/installer/cmd/grub.iso.cfg
@@ -12,3 +12,10 @@ menuentry "Talos ISO" {
 	linux /boot/vmlinuz {{ .Cmdline }}
 	initrd /boot/initramfs.xz
 }
+
+menuentry "Reset Talos installation" {
+	set gfxmode=auto
+	set gfxpayload=text
+	linux /boot/vmlinuz {{ .Cmdline }} talos.experimental.wipe=system
+	initrd /boot/initramfs.xz
+}


### PR DESCRIPTION
This simply uses existing `talos.experimental.wipe` kernel flag to wipe the currently installed Talos.

This allows to use Talos ISO to reset the system disk and revert back to maintenance mode.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
