### PR TITLE
feat: use 'localhost' endpoint for controlplane nodes

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/node_labels_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_labels_apply.go
@@ -113,18 +113,7 @@ func (ctrl *NodeLabelsApplyController) getK8sClient(ctx context.Context, r contr
 	}
 
 	if machineType.MachineType().IsControlPlane() {
-		k8sRoot, err := safe.ReaderGet[*secrets.KubernetesRoot](ctx, r, resource.NewMetadata(secrets.NamespaceName, secrets.KubernetesRootType, secrets.KubernetesRootID, resource.VersionUndefined))
-		if err != nil {
-			if state.IsNotFoundError(err) {
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
-		}
-
-		k8sRootSpec := k8sRoot.TypedSpec()
-
-		return kubernetes.NewTemporaryClientFromPKI(k8sRootSpec.CA, k8sRootSpec.Endpoint)
+		return kubernetes.NewTemporaryClientControlPlane(ctx, r)
 	}
 
 	logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))


### PR DESCRIPTION
This switches the last usage of Kubernetes controlplane endpoint to use `localhost` (itself) for controlplane nodes.

Worker nodes still use cluster-wide controlplane endpoint.

This allows controlplane nodes to boot fully even if the controlplane endpoint (e.g. loadbalancer) doesn't function.

The process of joining etcd still requires either a discovery service or a proper functioning controlplane endpoint.

With this fix, Talos controlplane nodes can boot successfully without a loadbalancer being up, while worker nodes obviously won't join.

This improves Talos behaviour in single-node clusters when controlplane endpoint is not available, the node will still boot just fine and function properly.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
