### PR TITLE
VMware: Use network information from guestinfo.metadata

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -131,6 +131,14 @@ Talos API was extended to support retrieving a list of network connections (sock
 `talosctl netstat` command was added to retrieve the list of network connections.
 """
 
+    [notes.vmware]
+        title = "VMware Platform"
+        description="""\
+Talos now supports loading network configuration on VMWare platform from the `metadata` key.
+See [CAPV IPAM Support](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/proposal/20220929-ipam-support.md) and
+[Talos issue 6708](https://github.com/siderolabs/talos/issues/6708) for details.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
@@ -1,0 +1,268 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package vmware provides the VMware platform implementation.
+package vmware
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/netip"
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+// NetworkConfig maps to VMware GuestInfo metadata.
+// See also definition of GuestInfo in CAPV https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/pkg/util/constants.go
+type NetworkConfig struct {
+	InstanceID    string `yaml:"instance-id"`
+	LocalHostname string `yaml:"local-hostname"`
+	// Talos doesn't block on network, it will reconfigure itself as network information becomes available. WaitOnNetwork is not used.
+	WaitOnNetwork struct {
+		Ipv4 bool `yaml:"ipv4"`
+		Ipv6 bool `yaml:"ipv6"`
+	} `yaml:"wait-on-network,omitempty"`
+	Network struct {
+		Version   int                 `yaml:"version"`
+		Ethernets map[string]Ethernet `yaml:"ethernets"`
+	}
+	Routes []Route `yaml:"routes,omitempty"`
+}
+
+// Ethernet holds network interface info.
+type Ethernet struct {
+	Match struct {
+		Name   string `yaml:"name,omitempty"`
+		HWAddr string `yaml:"macaddress,omitempty"`
+	} `yaml:"match,omitempty"`
+	SetName        string        `yaml:"set-name,omitempty"`
+	Wakeonlan      bool          `yaml:"wakeonlan,omitempty"`
+	DHCPv4         bool          `yaml:"dhcp4,omitempty"`
+	DHCP4Overrides DHCPOverrides `yaml:"dhcp4-overrides,omitempty"`
+	DHCPv6         bool          `yaml:"dhcp6,omitempty"`
+	DHCP6Overrides DHCPOverrides `yaml:"dhcp6-overrides,omitempty"`
+	Address        []string      `yaml:"addresses,omitempty"`
+	Gateway4       string        `yaml:"gateway4,omitempty"`
+	Gateway6       string        `yaml:"gateway6,omitempty"`
+	MTU            int           `yaml:"mtu,omitempty"`
+	NameServers    struct {
+		Search  []string `yaml:"search,omitempty"`
+		Address []string `yaml:"addresses,omitempty"`
+	} `yaml:"nameservers,omitempty"`
+	Routes []Route `yaml:"routes,omitempty"`
+}
+
+// Route configuration. Not used.
+type Route struct {
+	To     string `yaml:"to,omitempty"`
+	Via    string `yaml:"via,omitempty"`
+	Metric string `yaml:"metric,omitempty"`
+}
+
+// DHCPOverrides is partial implemented. Only RouteMetric is use, the other elements are not processed.
+type DHCPOverrides struct {
+	Hostname     string `yaml:"hostname,omitempty"`
+	RouteMetric  uint32 `yaml:"route-metric,omitempty"`
+	SendHostname string `yaml:"send-hostname,omitempty"`
+	UseDNS       string `yaml:"use-dns,omitempty"`
+	UseDomains   string `yaml:"use-domains,omitempty"`
+	UseHostname  string `yaml:"use-hostname,omitempty"`
+	UseMTU       string `yaml:"use-mtu,omitempty"`
+	UseNTP       string `yaml:"use-ntp,omitempty"`
+	UseRoutes    string `yaml:"use-routes,omitempty"`
+}
+
+// ApplyNetworkConfigV2 gets GuestInfo and applies to the Talos runtime platform network configuration.
+//
+//nolint:gocyclo,cyclop
+func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, config *NetworkConfig, networkConfig *runtime.PlatformNetworkConfig) error {
+	var dnsIPs []netip.Addr
+
+	hostInterfaces, err := safe.StateList[*network.LinkStatus](ctx, st, resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "", resource.VersionUndefined))
+	if err != nil {
+		return fmt.Errorf("error listing host interfaces: %w", err)
+	}
+
+	for name, eth := range config.Network.Ethernets {
+		if eth.SetName != "" {
+			name = eth.SetName
+		}
+
+		if !strings.HasPrefix(name, "eth") {
+			continue
+		}
+
+		if eth.Match.HWAddr != "" {
+			var availableMACAddresses []string
+
+			macAddressMatched := false
+			hostInterfaceIter := safe.IteratorFromList(hostInterfaces)
+
+			for hostInterfaceIter.Next() {
+				macAddress := hostInterfaceIter.Value().TypedSpec().PermanentAddr.String()
+				if macAddress == eth.Match.HWAddr {
+					name = hostInterfaceIter.Value().Metadata().ID()
+					macAddressMatched = true
+
+					break
+				} else {
+					availableMACAddresses = append(availableMACAddresses, macAddress)
+				}
+			}
+
+			if !macAddressMatched {
+				log.Printf("vmware: no link with matching MAC address %q (available %v), defaulted to use name %s instead", eth.Match.HWAddr, availableMACAddresses, name)
+			}
+		}
+
+		networkConfig.Links = append(networkConfig.Links, network.LinkSpecSpec{
+			Name:        name,
+			Up:          true,
+			MTU:         uint32(eth.MTU),
+			ConfigLayer: network.ConfigPlatform,
+		})
+
+		if eth.DHCPv4 {
+			routeMetric := uint32(networkctrl.DefaultRouteMetric)
+
+			if eth.DHCP4Overrides.RouteMetric != 0 {
+				routeMetric = eth.DHCP4Overrides.RouteMetric
+			}
+
+			networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
+				Operator:  network.OperatorDHCP4,
+				LinkName:  name,
+				RequireUp: true,
+				DHCP4: network.DHCP4OperatorSpec{
+					RouteMetric: routeMetric,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			})
+		}
+
+		if eth.DHCPv6 {
+			routeMetric := uint32(2 * networkctrl.DefaultRouteMetric)
+
+			if eth.DHCP4Overrides.RouteMetric != 0 {
+				routeMetric = eth.DHCP6Overrides.RouteMetric
+			}
+
+			networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
+				Operator:  network.OperatorDHCP6,
+				LinkName:  name,
+				RequireUp: true,
+				DHCP6: network.DHCP6OperatorSpec{
+					RouteMetric: routeMetric,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			})
+		}
+
+		for _, addr := range eth.Address {
+			ipPrefix, err := netip.ParsePrefix(addr)
+			if err != nil {
+				return err
+			}
+
+			family := nethelpers.FamilyInet4
+
+			if ipPrefix.Addr().Is6() {
+				family = nethelpers.FamilyInet6
+			}
+
+			networkConfig.Addresses = append(networkConfig.Addresses,
+				network.AddressSpecSpec{
+					ConfigLayer: network.ConfigPlatform,
+					LinkName:    name,
+					Address:     ipPrefix,
+					Scope:       nethelpers.ScopeGlobal,
+					Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+					Family:      family,
+				},
+			)
+		}
+
+		if eth.Gateway4 != "" {
+			gw, err := netip.ParseAddr(eth.Gateway4)
+			if err != nil {
+				return err
+			}
+
+			route := network.RouteSpecSpec{
+				ConfigLayer: network.ConfigPlatform,
+				Gateway:     gw,
+				OutLinkName: name,
+				Table:       nethelpers.TableMain,
+				Protocol:    nethelpers.ProtocolStatic,
+				Type:        nethelpers.TypeUnicast,
+				Family:      nethelpers.FamilyInet4,
+				Priority:    networkctrl.DefaultRouteMetric,
+			}
+
+			route.Normalize()
+
+			networkConfig.Routes = append(networkConfig.Routes, route)
+		}
+
+		if eth.Gateway6 != "" {
+			gw, err := netip.ParseAddr(eth.Gateway6)
+			if err != nil {
+				return err
+			}
+
+			route := network.RouteSpecSpec{
+				ConfigLayer: network.ConfigPlatform,
+				Gateway:     gw,
+				OutLinkName: name,
+				Table:       nethelpers.TableMain,
+				Protocol:    nethelpers.ProtocolStatic,
+				Type:        nethelpers.TypeUnicast,
+				Family:      nethelpers.FamilyInet6,
+				Priority:    2 * networkctrl.DefaultRouteMetric,
+			}
+
+			route.Normalize()
+
+			networkConfig.Routes = append(networkConfig.Routes, route)
+		}
+
+		for _, addr := range eth.NameServers.Address {
+			if ip, err := netip.ParseAddr(addr); err == nil {
+				dnsIPs = append(dnsIPs, ip)
+			} else {
+				return err
+			}
+		}
+	}
+
+	if config.LocalHostname != "" {
+		hostnameSpec := network.HostnameSpecSpec{
+			ConfigLayer: network.ConfigPlatform,
+		}
+
+		if err := hostnameSpec.ParseFQDN(config.LocalHostname); err != nil {
+			return err
+		}
+
+		networkConfig.Hostnames = append(networkConfig.Hostnames, hostnameSpec)
+	}
+
+	if len(dnsIPs) > 0 {
+		networkConfig.Resolvers = append(networkConfig.Resolvers, network.ResolverSpecSpec{
+			DNSServers:  dnsIPs,
+			ConfigLayer: network.ConfigPlatform,
+		})
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/expected-match-by-mac.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/expected-match-by-mac.yaml
@@ -1,0 +1,36 @@
+addresses:
+    - address: 192.168.0.230/24
+      linkName: eth2
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+links:
+    - name: eth2
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      layer: platform
+routes:
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 192.168.0.1
+      outLinkName: eth2
+      table: main
+      priority: 1024
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+hostnames:
+    - hostname: vmware-test-controlplane-zhnhr
+      domainname: ""
+      layer: platform
+resolvers: []
+timeServers: []
+operators: []
+externalIPs: []

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/expected-match-by-name.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/expected-match-by-name.yaml
@@ -1,0 +1,36 @@
+addresses:
+    - address: 192.168.0.230/24
+      linkName: eth1
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+links:
+    - name: eth1
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      layer: platform
+routes:
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 192.168.0.1
+      outLinkName: eth1
+      table: main
+      priority: 1024
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+hostnames:
+    - hostname: vmware-test-controlplane-zhnhr
+      domainname: ""
+      layer: platform
+resolvers: []
+timeServers: []
+operators: []
+externalIPs: []

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/metadata-match-by-mac.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/metadata-match-by-mac.yaml
@@ -1,0 +1,16 @@
+instance-id: "1"
+local-hostname: "vmware-test-controlplane-zhnhr"
+wait-on-network:
+  ipv4: false
+  ipv6: false
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+        macaddress: "68:05:ca:b8:f1:f9"
+      set-name: "eth0"
+      wakeonlan: true
+      addresses:
+      - "192.168.0.230/24"
+      gateway4: "192.168.0.1"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/metadata-match-by-name.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/testdata/metadata-match-by-name.yaml
@@ -1,0 +1,16 @@
+instance-id: "1"
+local-hostname: "vmware-test-controlplane-zhnhr"
+wait-on-network:
+  ipv4: false
+  ipv6: false
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+        name: "eth1"
+      set-name: "eth1"
+      wakeonlan: true
+      addresses:
+      - "192.168.0.230/24"
+      gateway4: "192.168.0.1"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_test.go
@@ -4,11 +4,83 @@
 
 package vmware_test
 
-import "testing"
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+//go:embed testdata/metadata-match-by-mac.yaml
+var rawMetadataMatchByMAC []byte
+
+//go:embed testdata/expected-match-by-mac.yaml
+var expectedNetworkConfigMatchByMAC string
+
+//go:embed testdata/metadata-match-by-name.yaml
+var rawMetadataMatchByName []byte
+
+//go:embed testdata/expected-match-by-name.yaml
+var expectedNetworkConfigMatchByName string
+
+func TestApplyNetworkConfigV2a(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		raw      []byte
+		expected string
+	}{
+		{
+			name:     "byMAC",
+			raw:      rawMetadataMatchByMAC,
+			expected: expectedNetworkConfigMatchByMAC,
+		},
+		{
+			name:     "byName",
+			raw:      rawMetadataMatchByName,
+			expected: expectedNetworkConfigMatchByName,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
+			eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf8}
+			require.NoError(t, st.Create(ctx, eth1))
+
+			eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
+			eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf9}
+			require.NoError(t, st.Create(ctx, eth2))
+
+			var metadata vmware.NetworkConfig
+			require.NoError(t, yaml.Unmarshal(tt.raw, &metadata))
+
+			v := &vmware.VMware{}
+			networkConfig := &runtime.PlatformNetworkConfig{}
+
+			err := v.ApplyNetworkConfigV2(ctx, st, &metadata, networkConfig)
+			require.NoError(t, err)
+
+			marshaled, err := yaml.Marshal(networkConfig)
+			require.NoError(t, err)
+
+			fmt.Print(string(marshaled))
+
+			assert.Equal(t, tt.expected, string(marshaled))
+		})
+	}
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -407,6 +407,9 @@ const (
 	// VMwareGuestInfoFallbackKey is the fallback guestinfo key used to provide a config file.
 	VMwareGuestInfoFallbackKey = "userdata"
 
+	// VMwareGuestInfoMetadataKey is the guestinfo key used to provide metadata.
+	VMwareGuestInfoMetadataKey = "metadata"
+
 	// VMwareGuestInfoOvfEnvKey is the guestinfo key used to provide the OVF environment.
 	VMwareGuestInfoOvfEnvKey = "ovfenv"
 


### PR DESCRIPTION
# Pull Request

## What?
This PR is an implementation of #6708  
metadata is loaded from VMware guestinfo and used for configuration of network.

The vmware metadata which is setup by CAPV is defined here:
[VMware metadata](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/pkg/util/constants.go)

The PR implementation is inspired by the [talos nocloud](https://github.com/siderolabs/talos/tree/main/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud) implementation of metadata and mapping to PlatformNetworkConfig.

## Why? (reasoning)
See #6708 

## Tasks
Question for Sidero Talos maintainers:
1) Consider backwards compatibility. Should metadata from guestinfo always be loaded if present?

2) Not all my commits have a message that comforms to the given standard. Can we squash the commits when merging the PR?

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable). -- only added test of unmarshalling yaml from. More test cases could be added.
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
