### PR TITLE
fix: mark DigitalOcean anchor IP as scope link

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -182,7 +182,7 @@ func (d *DigitalOcean) ParseMetadata(metadata *MetadataConfig) (*runtime.Platfor
 					ConfigLayer: network.ConfigPlatform,
 					LinkName:    "eth0",
 					Address:     ifAddr,
-					Scope:       nethelpers.ScopeGlobal,
+					Scope:       nethelpers.ScopeLink,
 					Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
 					Family:      nethelpers.FamilyInet4,
 				},

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/testdata/expected.yaml
@@ -14,7 +14,7 @@ addresses:
     - address: 10.18.0.5/16
       linkName: eth0
       family: inet4
-      scope: global
+      scope: link
       flags: permanent
       layer: platform
     - address: 10.133.0.2/16


### PR DESCRIPTION
This excludes it out of the `NodeAddress`.

Needs extra testing to confirm that it actually still works as anchor IP.

Fixes #6760
