### PR TITLE
fix: drone config for renovate PR's

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -691,13 +691,13 @@ local notify_steps = [notify];
 local notify_trigger = {
   trigger: {
     status: ['success', 'failure'],
-  },
-  branch: {
+    branch: {
       exclude: [
         'renovate/*',
         'dependabot/*',
       ],
     }
+  }
 };
 
 local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, release_pipeline] + integration_pipelines + e2e_pipelines + conformance_pipelines, false, true) + notify_trigger;


### PR DESCRIPTION
Fix drone config to exclude renovate pushes.

Signed-off-by: Noel Georgi <git@frezbo.dev>