### PR TITLE
fix: omit zero MTU in the machine config

### DIFF
--- a/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
@@ -9,7 +9,6 @@ machine:
             - interface: eth0
               addresses:
                 - 10.1.2.3/24
-              mtu: 0
               dhcp: false
               vip:
                 ip: 10.3.5.6

--- a/pkg/machinery/config/types/v1alpha1/testdata/strategic/001/expected.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/strategic/001/expected.yaml
@@ -15,7 +15,6 @@ machine:
             - interface: eth0
               addresses:
                 - 10.3.5.7/24
-              mtu: 0
               dhcp: false
     install:
         disk: /dev/sda

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2163,7 +2163,7 @@ type Device struct {
 	//   description: |
 	//     The interface's MTU.
 	//     If used in combination with DHCP, this will override any MTU settings returned from DHCP server.
-	DeviceMTU int `yaml:"mtu"`
+	DeviceMTU int `yaml:"mtu,omitempty"`
 	//   description: |
 	//     Indicates if DHCP should be used to configure the interface.
 	//     The following DHCP options are supported:


### PR DESCRIPTION
Fixes #6747

The setting `mtu: 0` always meant "don't touch MTU", but the presence of such line is very confusing.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
