### PR TITLE
fix: correctly quote and unquote strings in GRUB config

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
@@ -28,7 +28,7 @@ terminal_output console
 menuentry "{{ $entry.Name }}" {
   set gfxmode=auto
   set gfxpayload=text
-  linux {{ $entry.Linux }} {{ $entry.Cmdline }}
+  linux {{ $entry.Linux }} {{ quote $entry.Cmdline }}
   initrd {{ $entry.Initrd }}
 }
 {{ end -}}
@@ -59,7 +59,9 @@ func (c *Config) Encode(wr io.Writer) error {
 		return err
 	}
 
-	t := template.Must(template.New("grub").Parse(confTemplate))
+	t := template.Must(template.New("grub").Funcs(template.FuncMap{
+		"quote": quote,
+	}).Parse(confTemplate))
 
 	return t.Execute(wr, c)
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/export_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/export_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package grub
+
+// Quote exported for testing.
+func Quote(s string) string {
+	return quote(s)
+}
+
+// Unquote exported for testing.
+func Unquote(s string) string {
+	return unquote(s)
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub_test.go
@@ -52,6 +52,22 @@ func TestDecode(t *testing.T) {
 	assert.True(t, strings.HasPrefix(b.Initrd, "/B/"))
 }
 
+func TestEncodeDecode(t *testing.T) {
+	config := grub.NewConfig("talos.platform=metal talos.config=https://my-metadata.server/talos/config?hostname=${hostname}&mac=${mac}")
+	require.NoError(t, config.Put(grub.BootB, "talos.platform=metal talos.config=https://my-metadata.server/talos/config?uuid=${uuid}"))
+
+	var b bytes.Buffer
+
+	require.NoError(t, config.Encode(&b))
+
+	t.Logf("config encoded to:\n%s", b.String())
+
+	config2, err := grub.Decode(b.Bytes())
+	require.NoError(t, err)
+
+	assert.Equal(t, config, config2)
+}
+
 func TestParseBootLabel(t *testing.T) {
 	label, err := grub.ParseBootLabel("A - v1")
 	assert.NoError(t, err)

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package grub
+
+import (
+	"strings"
+)
+
+// quote according to (incomplete) GRUB quoting rules.
+//
+// See https://www.gnu.org/software/grub/manual/grub/html_node/Shell_002dlike-scripting.html
+func quote(s string) string {
+	for _, c := range `\{}$|;<>"` {
+		s = strings.ReplaceAll(s, string(c), `\`+string(c))
+	}
+
+	return s
+}
+
+// unquote according to (incomplete) GRUB quoting rules.
+func unquote(s string) string {
+	for _, c := range `{}$|;<>\"` {
+		s = strings.ReplaceAll(s, `\`+string(c), string(c))
+	}
+
+	return s
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package grub_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
+)
+
+//nolint:dupl
+func TestQuote(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no special characters",
+			input:    "foo",
+			expected: "foo",
+		},
+		{
+			name:     "backslash",
+			input:    `foo\`,
+			expected: `foo\\`,
+		},
+		{
+			name:     "escaped backslash",
+			input:    `foo\$`,
+			expected: `foo\\\$`,
+		},
+	} {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := grub.Quote(test.input)
+
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+//nolint:dupl
+func TestUnquote(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no special characters",
+			input:    "foo",
+			expected: "foo",
+		},
+		{
+			name:     "backslash",
+			input:    `foo\\`,
+			expected: `foo\`,
+		},
+		{
+			name:     "escaped backslash",
+			input:    `foo\\\$`,
+			expected: `foo\$`,
+		},
+	} {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := grub.Unquote(test.input)
+
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One of the fields in the GRUB config - boot arguments - contains user-controlled input. Talos supports variable expansion in `talos.config` parameter, and uses `${var}` syntax.

In GRUB config, `}` is a special character, and introduction of `}` breaks config parsing both for GRUB and Talos.

Correctly escape and unescape special characters.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
