### PR TITLE
fix: correctly expand parameters in the URL

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -51,7 +51,7 @@ func (m *Metal) Configuration(ctx context.Context, r state.State) ([]byte, error
 	getURL := func() string {
 		downloadEndpoint, err := PopulateURLParameters(ctx, *option, r)
 		if err != nil {
-			log.Fatalf("failed to populate talos.config fetch URL: %q ; %s", *option, err.Error())
+			log.Printf("failed to populate talos.config fetch URL: %q ; %s", *option, err.Error())
 		}
 
 		log.Printf("fetching machine config from: %q", downloadEndpoint)


### PR DESCRIPTION
This fixes multiple issues:

* `log.Fatalf` in the machined code leads to kernel panic
* return URL if some expansion fails
* correctly handle destroyed event (wait for the next one)

Fixes #6807

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
