### PR TITLE
fix: return proper error if download attempts time out

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -103,13 +103,12 @@ func Download(ctx context.Context, endpoint string, opts ...Option) (b []byte, e
 
 	dlOpts.Endpoint = endpoint
 
-	err = retry.Exponential(180*time.Second, retry.WithUnits(time.Second), retry.WithJitter(time.Second), retry.WithErrorLogging(true)).Retry(func() error {
-		select {
-		case <-ctx.Done():
-			return context.Canceled
-		default:
-		}
-
+	err = retry.Exponential(
+		180*time.Second,
+		retry.WithUnits(time.Second),
+		retry.WithJitter(time.Second),
+		retry.WithErrorLogging(true),
+	).RetryWithContext(ctx, func(ctx context.Context) error {
 		dlOpts = downloadDefaults()
 
 		dlOpts.Endpoint = endpoint


### PR DESCRIPTION
Fixes #6795

This fixes a problem with Talos being stuck if the download attempts time out - the returned context.Canceled error was triggering a different flow which treats sequence take over as a special case, while there is no other sequence to run.

Correct error should be timeout.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
