### PR TITLE
feat: use wrapper for starting processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -468,6 +468,8 @@ COPY --from=machined-build-amd64 /machined /rootfs/sbin/init
 # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
 RUN ln /rootfs/sbin/init /rootfs/sbin/poweroff
 RUN chmod +x /rootfs/sbin/poweroff
+RUN ln /rootfs/sbin/init /rootfs/sbin/wrapperd
+RUN chmod +x /rootfs/sbin/wrapperd
 # NB: We run the cleanup step before creating extra directories, files, and
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
@@ -515,6 +517,8 @@ COPY --from=machined-build-arm64 /machined /rootfs/sbin/init
 # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
 RUN ln /rootfs/sbin/init /rootfs/sbin/poweroff
 RUN chmod +x /rootfs/sbin/poweroff
+RUN ln /rootfs/sbin/init /rootfs/sbin/wrapperd
+RUN chmod +x /rootfs/sbin/wrapperd
 # NB: We run the cleanup step before creating extra directories, files, and
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/maintenance"
 	"github.com/siderolabs/talos/internal/app/poweroff"
 	"github.com/siderolabs/talos/internal/app/trustd"
+	"github.com/siderolabs/talos/internal/app/wrapperd"
 	"github.com/siderolabs/talos/internal/pkg/mount"
 	"github.com/siderolabs/talos/pkg/httpdefaults"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -306,6 +307,10 @@ func main() {
 	// Azure uses the hv_utils kernel module to shutdown the node in hyper-v by calling perform_shutdown which will call orderly_poweroff which will call /sbin/poweroff.
 	case "/sbin/poweroff":
 		poweroff.Main()
+
+		return
+	case "/sbin/wrapperd":
+		wrapperd.Main()
 
 		return
 	default:

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -63,6 +63,8 @@ type Options struct {
 	CgroupPath string
 	// OverrideSeccompProfile default Linux seccomp profile.
 	OverrideSeccompProfile func(*specs.LinuxSeccomp)
+	// DroppedCapabilities is the list of capabilities to drop.
+	DroppedCapabilities []string
 }
 
 // Option is the functional option func.
@@ -162,5 +164,12 @@ func WithCgroupPath(path string) Option {
 func WithCustomSeccompProfile(override func(*specs.LinuxSeccomp)) Option {
 	return func(args *Options) {
 		args.OverrideSeccompProfile = override
+	}
+}
+
+// WithBoundedCapabilities sets the list of capabilities to drop.
+func WithBoundedCapabilities(caps []string) Option {
+	return func(args *Options) {
+		args.DroppedCapabilities = caps
 	}
 }

--- a/internal/app/wrapperd/main.go
+++ b/internal/app/wrapperd/main.go
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package wrapperd provides a wrapper for running services.
+package wrapperd
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/containerd/cgroups"
+	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/containerd/sys"
+	"github.com/siderolabs/gen/slices"
+	"golang.org/x/sys/unix"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+var (
+	name        string
+	droppedCaps string
+	cgroupPath  string
+	oomScore    int
+)
+
+// Main is the entrypoint into /sbin/wrapperd.
+// nolint: gocyclo
+func Main() {
+	flag.StringVar(&name, "name", "", "process name")
+	flag.StringVar(&droppedCaps, "dropped-caps", "", "comma-separated list of capabilities to drop")
+	flag.StringVar(&cgroupPath, "cgroup-path", "", "cgroup path to use")
+	flag.IntVar(&oomScore, "oom-score", 0, "oom score to set")
+	flag.Parse()
+
+	currentPid := os.Getpid()
+
+	if oomScore != 0 {
+		if err := sys.AdjustOOMScore(currentPid, oomScore); err != nil {
+			log.Fatalf("Failed to change OOMScoreAdj of process %s to %d", name, oomScore)
+		}
+	}
+
+	// load the cgroup and put the process into the cgroup
+	if cgroupPath != "" {
+		if cgroups.Mode() == cgroups.Unified {
+			cgv2, err := cgroupsv2.LoadManager(constants.CgroupMountPath, cgroupPath)
+			if err != nil {
+				log.Fatalf("failed to load cgroup %s: %v", cgroupPath, err)
+			}
+
+			if err := cgv2.AddProc(uint64(currentPid)); err != nil {
+				log.Fatalf("Failed to move process %s to cgroup: %v", name, err)
+			}
+		} else {
+			cgv1, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgroupPath))
+			if err != nil {
+				log.Fatalf("failed to load cgroup %s: %v", cgroupPath, err)
+			}
+
+			if err := cgv1.Add(cgroups.Process{
+				Pid: currentPid,
+			}); err != nil {
+				log.Fatalf("Failed to move process %s to cgroup: %v", name, err)
+			}
+		}
+	}
+
+	if droppedCaps != "" {
+		caps := strings.Split(droppedCaps, ",")
+		dropCaps := slices.Map(caps, func(c string) cap.Value {
+			capability, err := cap.FromName(c)
+			if err != nil {
+				log.Fatalf("failed to parse capability: %v", err)
+			}
+
+			return capability
+		})
+
+		// drop capabilities
+		iab := cap.IABGetProc()
+		if err := iab.SetVector(cap.Bound, true, dropCaps...); err != nil {
+			log.Fatalf("failed to set capabilities: %v", err)
+		}
+
+		if err := iab.SetProc(); err != nil {
+			log.Fatalf("failed to apply capabilities: %v", err)
+		}
+	}
+
+	if err := unix.Exec(flag.Args()[0], flag.Args()[0:], os.Environ()); err != nil {
+		log.Fatalf("failed to exec: %v", err)
+	}
+}


### PR DESCRIPTION
Use a wrapper for starting processes which can setup proper cgroups, OOMscore, and also drop capabilities for the process, then it calls `execve`.

The containerd tests is also fixed to support cgroups when running tests in buildkit. It used to pass previosuly as we did not error if cgroup setup failed.

Signed-off-by: Noel Georgi <git@frezbo.dev>