### PR TITLE
fix: default dns domain to 'cluster.local' in local case

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
@@ -236,7 +236,7 @@ func (suite *KubeletConfigSuite) TestReconcileDefaults() {
 
 				suite.Assert().Equal("kubelet", spec.Image)
 				suite.Assert().Equal([]string{"10.96.0.10"}, spec.ClusterDNS)
-				suite.Assert().Equal("", spec.ClusterDomain)
+				suite.Assert().Equal(constants.DefaultDNSDomain, spec.ClusterDomain)
 				suite.Assert().Empty(spec.ExtraArgs)
 				suite.Assert().Empty(spec.ExtraMounts)
 				suite.Assert().False(spec.CloudProviderExternal)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -237,7 +237,7 @@ func (c *ClusterConfig) ServiceCIDRs() []string {
 
 // DNSDomain implements the config.ClusterNetwork interface.
 func (c *ClusterConfig) DNSDomain() string {
-	if c.ClusterNetwork == nil {
+	if c.ClusterNetwork == nil || c.ClusterNetwork.DNSDomain == "" {
 		return constants.DefaultDNSDomain
 	}
 


### PR DESCRIPTION
One case was missing: when network section is present, but value is omitted.

Fixes #6825

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
