### PR TITLE
fix: wait for network and retry in platform get config funcs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ RUN gofumpt -w ./
 
 FROM go-generate AS gen-proto-go
 WORKDIR /src/
-RUN structprotogen github.com/siderolabs/talos/pkg/machinery/... /api/resource/definitions/
+RUN --mount=type=cache,target=/.cache structprotogen github.com/siderolabs/talos/pkg/machinery/... /api/resource/definitions/
 
 # compile protobuf service definitions
 FROM build AS generate-build

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -169,8 +170,12 @@ func (a *Azure) ParseLoadBalancerIP(lbConfig LoadBalancerMetadata, exIP []netip.
 // Configuration implements the platform.Platform interface.
 func (a *Azure) Configuration(ctx context.Context, r state.State) ([]byte, error) {
 	defer func() {
+		if err := netutils.Wait(ctx, r); err != nil {
+			log.Printf("failed to wait for network, err: %s", err)
+		}
+
 		if err := linuxAgent(ctx); err != nil {
-			log.Printf("failed to update instance status, err: %s", err.Error())
+			log.Printf("failed to update instance status, err: %s", err)
 		}
 	}()
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -26,6 +26,7 @@ import (
 	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -88,6 +89,10 @@ func (p *EquinixMetal) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (p *EquinixMetal) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from: %q", EquinixMetalUserDataEndpoint)
 
 	return download.Download(ctx, EquinixMetalUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -67,6 +68,10 @@ func (e *Exoscale) Name() string {
 
 // Configuration implements the runtime.Platform interface.
 func (e *Exoscale) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from %q", ExoscaleUserDataEndpoint)
 
 	return download.Download(ctx, ExoscaleUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -147,6 +148,10 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 
 // Configuration implements the runtime.Platform interface.
 func (h *Hcloud) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from: %q", HCloudUserDataEndpoint)
 
 	return download.Download(ctx, HCloudUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address/address.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address/address.go
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package utils provides utility functions for the platform package.
-package utils
+// Package address provides utility functions for address parsing.
+package address
 
 import (
 	"fmt"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils/netutils.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils/netutils.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package netutils provides network-related helpers for platform implementation.
+package netutils
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/go-retry/retry"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+// Wait for the network to be ready to interact with platform metadata services.
+func Wait(ctx context.Context, r state.State) error {
+	log.Printf("waiting for network to be ready")
+
+	if err := network.NewReadyCondition(r, network.AddressReady).Wait(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RetryFetch retries fetching from metadata service.
+func RetryFetch(ctx context.Context, f func(ctx context.Context) (string, error)) (string, error) {
+	var (
+		userdata string
+		err      error
+	)
+
+	err = retry.Exponential(
+		constants.ConfigLoadTimeout,
+		retry.WithUnits(time.Second),
+		retry.WithJitter(time.Second),
+		retry.WithErrorLogging(true),
+	).RetryWithContext(
+		ctx, func(ctx context.Context) error {
+			userdata, err = f(ctx)
+
+			return err
+		})
+	if err != nil {
+		return "", err
+	}
+
+	return userdata, err
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -63,6 +64,10 @@ func (m *Metal) Configuration(ctx context.Context, r state.State) ([]byte, error
 	case constants.MetalConfigISOLabel:
 		return readConfigFromISO()
 	default:
+		if err := netutils.Wait(ctx, r); err != nil {
+			return nil, err
+		}
+
 		return download.Download(ctx, *option, download.WithEndpointFunc(getURL))
 	}
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/url_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/url_test.go
@@ -69,6 +69,10 @@ func setup(ctx context.Context, t *testing.T, st state.State, mockUUID, mockSeri
 	linkStatusSpec.TypedSpec().HardwareAddr = nethelpers.HardwareAddr(parsedMockMAC)
 	linkStatusSpec.TypedSpec().LinkState = true
 	assert.NoError(t, createOrUpdate(ctx, st, linkStatusSpec))
+
+	netStatus := network.NewStatus(network.NamespaceName, network.StatusID)
+	netStatus.TypedSpec().AddressReady = true
+	assert.NoError(t, createOrUpdate(ctx, st, netStatus))
 }
 
 func TestPopulateURLParameters(t *testing.T) {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -72,7 +72,7 @@ func (n *Nocloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metada
 
 // Configuration implements the runtime.Platform interface.
 func (n *Nocloud) Configuration(ctx context.Context, r state.State) ([]byte, error) {
-	_, _, machineConfigDl, _, err := n.acquireConfig(ctx) //nolint:dogsled
+	_, _, machineConfigDl, _, err := n.acquireConfig(ctx, r) //nolint:dogsled
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +99,8 @@ func (n *Nocloud) KernelArgs() procfs.Parameters {
 // NetworkConfiguration implements the runtime.Platform interface.
 //
 //nolint:gocyclo
-func (n *Nocloud) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
-	metadataConfigDl, metadataNetworkConfigDl, _, metadata, err := n.acquireConfig(ctx)
+func (n *Nocloud) NetworkConfiguration(ctx context.Context, r state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
+	metadataConfigDl, metadataNetworkConfigDl, _, metadata, err := n.acquireConfig(ctx, r)
 	if stderrors.Is(err, errors.ErrNoConfigSource) {
 		err = nil
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -107,6 +108,10 @@ func (o *Oracle) ParseMetadata(interfaceAddresses []NetworkConfig, metadata *Met
 
 // Configuration implements the platform.Platform interface.
 func (o *Oracle) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from: %q", OracleUserDataEndpoint)
 
 	machineConfigDl, err := download.Download(ctx, OracleUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -162,6 +163,10 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 //
 //nolint:stylecheck
 func (s *Scaleway) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from %q", ScalewayUserDataEndpoint)
 
 	return download.Download(ctx, ScalewayUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -176,6 +177,10 @@ func (u *UpCloud) ParseMetadata(metadata *MetadataConfig) (*runtime.PlatformNetw
 
 // Configuration implements the runtime.Platform interface.
 func (u *UpCloud) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from: %q", UpCloudUserDataEndpoint)
 
 	return download.Download(ctx, UpCloudUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -157,6 +158,10 @@ func (v *Vultr) ParseMetadata(metadata *metadata.MetaData) (*runtime.PlatformNet
 //
 //nolint:stylecheck
 func (v *Vultr) Configuration(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.Wait(ctx, r); err != nil {
+		return nil, err
+	}
+
 	log.Printf("fetching machine config from: %q", VultrUserDataEndpoint)
 
 	return download.Download(ctx, VultrUserDataEndpoint,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -448,7 +448,7 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 		download := func() error {
 			var b []byte
 
-			fetchCtx, ctxCancel := context.WithTimeout(ctx, 70*time.Second)
+			fetchCtx, ctxCancel := context.WithTimeout(ctx, constants.ConfigLoadTimeout)
 			defer ctxCancel()
 
 			b, e := fetchConfig(fetchCtx, r)

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -582,6 +582,9 @@ const (
 	// DefaultDNSDomain is the default DNS domain.
 	DefaultDNSDomain = "cluster.local"
 
+	// ConfigLoadTimeout is the timeout to wait for the config to be loaded from an external source.
+	ConfigLoadTimeout = 3 * time.Minute
+
 	// BootTimeout is the timeout to run all services.
 	BootTimeout = 70 * time.Minute
 


### PR DESCRIPTION
Wait for the network before trying to access the metadata service.

Retry the calls when appropriate (most platforms use `download.Download` function which does proper retries).

Co-authored-by: Noel Georgi <git@frezbo.dev>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
