### PR TITLE
fix: kubernetes removed resource version check

### DIFF
--- a/pkg/cluster/kubernetes/upgrade_checks_test.go
+++ b/pkg/cluster/kubernetes/upgrade_checks_test.go
@@ -55,7 +55,7 @@ func (suite *UpgradeCheckSuite) TestK8sComponentRemovedItemsNoError() {
 		ToVersion:   "1.25.0",
 	}
 
-	checks, err := kubernetes.NewK8sUpgradeChecks(resourceState, upgradeOptions, []string{"10.5.0.2"})
+	checks, err := kubernetes.NewK8sUpgradeChecks(resourceState, nil, upgradeOptions, []string{"10.5.0.2"})
 	suite.Require().NoError(err)
 
 	checkErrors := checks.Run(ctx)
@@ -159,7 +159,7 @@ func (suite *UpgradeCheckSuite) TestK8sComponentRemovedItemsWithError() {
 		ToVersion:   "1.25.0",
 	}
 
-	checks, err := kubernetes.NewK8sUpgradeChecks(resourceState, upgradeOptions, []string{"10.5.0.2"})
+	checks, err := kubernetes.NewK8sUpgradeChecks(resourceState, nil, upgradeOptions, []string{"10.5.0.2"})
 	suite.Require().NoError(err)
 
 	checkErrors := checks.Run(ctx)


### PR DESCRIPTION
Not all Kubernetes deprecated resources are same - if the old API version is deprecated, but new one is available, API server handles trnasition for us. If some resource is removed completely, we need to check for it. This reduces number of items to check, and simplifies the check.

Move the check under the umbrella of the 'upgrade pre-checks', and make it actually fatal.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
