### PR TITLE
fix: quote the ampersand character in GRUB config

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote.go
@@ -12,7 +12,7 @@ import (
 //
 // See https://www.gnu.org/software/grub/manual/grub/html_node/Shell_002dlike-scripting.html
 func quote(s string) string {
-	for _, c := range `\{}$|;<>"` {
+	for _, c := range `\{}&$|;<>"` {
 		s = strings.ReplaceAll(s, string(c), `\`+string(c))
 	}
 
@@ -21,7 +21,7 @@ func quote(s string) string {
 
 // unquote according to (incomplete) GRUB quoting rules.
 func unquote(s string) string {
-	for _, c := range `{}$|;<>\"` {
+	for _, c := range `{}&$|;<>\"` {
 		s = strings.ReplaceAll(s, `\`+string(c), string(c))
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/quote_test.go
@@ -39,6 +39,11 @@ func TestQuote(t *testing.T) {
 			input:    `foo\$`,
 			expected: `foo\\\$`,
 		},
+		{
+			name:     "url",
+			input:    "http://my-host/config.yaml?uuid=${uuid}&serial=${serial}&mac=${mac}&hostname=${hostname}",
+			expected: "http://my-host/config.yaml?uuid=\\$\\{uuid\\}\\&serial=\\$\\{serial\\}\\&mac=\\$\\{mac\\}\\&hostname=\\$\\{hostname\\}",
+		},
 	} {
 		test := test
 
@@ -82,6 +87,11 @@ func TestUnquote(t *testing.T) {
 			name:     "escaped backslash",
 			input:    `foo\\\$`,
 			expected: `foo\$`,
+		},
+		{
+			name:     "url",
+			input:    "http://my-host/config.yaml?uuid=\\$\\{uuid\\}\\&serial=\\$\\{serial\\}\\&mac=\\$\\{mac\\}\\&hostname=\\$\\{hostname\\}",
+			expected: "http://my-host/config.yaml?uuid=${uuid}&serial=${serial}&mac=${mac}&hostname=${hostname}",
 		},
 	} {
 		test := test


### PR DESCRIPTION
Not sure how I missed it in the first PR, but that's the only character which was not quoted properly.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
