### PR TITLE
fix: dbus shutdown when it's not initialized

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_dbus.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_dbus.go
@@ -75,6 +75,10 @@ func (dbus *DBusState) Stop() error {
 
 // WaitShutdown signals the shutdown over the D-Bus and waits for the inhibit lock to be released.
 func (dbus *DBusState) WaitShutdown(ctx context.Context) error {
+	if dbus.logindMock == nil {
+		return nil
+	}
+
 	if err := dbus.logindMock.EmitShutdown(); err != nil {
 		return err
 	}


### PR DESCRIPTION
If dbus is not started and a shutdown was called talos panics, fix by checking if the mock is nil.

Signed-off-by: Noel Georgi <git@frezbo.dev>