### PR TITLE
fix: kernel module dependency tree generation

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -444,7 +444,12 @@ func overlay(p *Point) error {
 		}
 	}
 
-	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", p.target, diff, workdir)
+	lowerDir := p.target
+	if p.source != "" {
+		lowerDir = p.source
+	}
+
+	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, diff, workdir)
 	if err := unix.Mount("overlay", p.target, "overlay", 0, opts); err != nil {
 		return fmt.Errorf("error creating overlay mount to %s: %w", p.target, err)
 	}


### PR DESCRIPTION
This fixes the issue when the overlay mount target directory was used as lowerdir for the mount, creating extra folders in the extension.

Fix the issue by adding support for normal overlay mounts to use a source directory when specified.

Also fixes a small issue where messages was logged when error is nil.

Signed-off-by: Noel Georgi <git@frezbo.dev>