### PR TITLE
fix: docker talosctl cluster create provisioner

### DIFF
--- a/pkg/provision/providers/docker/reflect.go
+++ b/pkg/provision/providers/docker/reflect.go
@@ -71,7 +71,12 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory s
 		var ips []netip.Addr
 
 		if network, ok := node.NetworkSettings.Networks[res.clusterInfo.Network.Name]; ok {
-			addr, err := netip.ParseAddr(network.IPAddress)
+			ip := network.IPAddress
+			if ip == "" && network.IPAMConfig != nil {
+				ip = network.IPAMConfig.IPv4Address
+			}
+
+			addr, err := netip.ParseAddr(ip)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Recent Docker versions seem to have changed the API in the way container IP addresses are reported.

Also fix running Talos 1.3 image under talosctl 1.4.
