### PR TITLE
feat: cmdline integer netmask

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -174,14 +174,20 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 						return settings, fmt.Errorf("cmdline gateway parse failure: %s", err)
 					}
 				case 3:
-					var netmask netip.Addr
+					var (
+						netmask netip.Addr
+						ones    int
+					)
 
-					netmask, err = netip.ParseAddr(fields[3])
+					ones, err = strconv.Atoi(fields[3])
 					if err != nil {
-						return settings, fmt.Errorf("cmdline netmask parse failure: %s", err)
-					}
+						netmask, err = netip.ParseAddr(fields[3])
+						if err != nil {
+							return settings, fmt.Errorf("cmdline netmask parse failure: %s", err)
+						}
 
-					ones, _ := net.IPMask(netmask.AsSlice()).Size()
+						ones, _ = net.IPMask(netmask.AsSlice()).Size()
+					}
 
 					linkConfig.Address = netip.PrefixFrom(linkConfig.Address.Addr(), ones)
 				case 4:

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -188,6 +188,52 @@ func (suite *CmdlineSuite) TestParse() {
 			},
 		},
 		{
+			name:    "ipv6-mask",
+			cmdline: "ip=[2a03:1:2::12]::[2a03:1:2::11]:[ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff8]:master:eth0:off:[2001:4860:4860::8888]:[2606:4700::1111]:[2606:4700:f1::1]",
+			expectedSettings: network.CmdlineNetworking{
+				LinkConfigs: []network.CmdlineLinkConfig{
+					{
+						Address:  netip.MustParsePrefix("2a03:1:2::12/125"),
+						Gateway:  netip.MustParseAddr("2a03:1:2::11"),
+						LinkName: "eth0",
+					},
+				},
+				Hostname:     "master",
+				DNSAddresses: []netip.Addr{netip.MustParseAddr("2001:4860:4860::8888"), netip.MustParseAddr("2606:4700::1111")},
+				NTPAddresses: []netip.Addr{netip.MustParseAddr("2606:4700:f1::1")},
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth0",
+						Up:          true,
+						ConfigLayer: netconfig.ConfigCmdline,
+					},
+				},
+			},
+		},
+		{
+			name:    "ipv6-mask-number",
+			cmdline: "ip=[2a03:1:2::12]::[2a03:1:2::11]:125:master:eth0:off:[2001:4860:4860::8888]:[2606:4700::1111]:[2606:4700:f1::1]",
+			expectedSettings: network.CmdlineNetworking{
+				LinkConfigs: []network.CmdlineLinkConfig{
+					{
+						Address:  netip.MustParsePrefix("2a03:1:2::12/125"),
+						Gateway:  netip.MustParseAddr("2a03:1:2::11"),
+						LinkName: "eth0",
+					},
+				},
+				Hostname:     "master",
+				DNSAddresses: []netip.Addr{netip.MustParseAddr("2001:4860:4860::8888"), netip.MustParseAddr("2606:4700::1111")},
+				NTPAddresses: []netip.Addr{netip.MustParseAddr("2606:4700:f1::1")},
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth0",
+						Up:          true,
+						ConfigLayer: netconfig.ConfigCmdline,
+					},
+				},
+			},
+		},
+		{
 			name:    "unparseable IP",
 			cmdline: "ip=xyz:",
 

--- a/website/content/v1.4/reference/kernel.md
+++ b/website/content/v1.4/reference/kernel.md
@@ -38,6 +38,8 @@ Partial configuration can be applied as well, e.g. `ip=:::::::<dns0-ip>:<dns1-ip
 
 IPv6 addresses can be specified by enclosing them in the square brackets, e.g. `ip=[2001:db8::a]:[2001:db8::b]:[fe80::1]::controlplane1:eth1::[2001:4860:4860::6464]:[2001:4860:4860::64]:[2001:4860:4806::]`.
 
+`<netmask>` can use either an IP address notation (IPv4: `255.255.255.0`, IPv6: `[ffff:ffff:ffff:ffff::0]`), or simply a number of one bits in the netmask (`24`).
+
 `<device>` can be traditional interface naming scheme `eth0, eth1` or `enx<MAC>`, example: `enx78e7d1ea46da`
 
 DCHP can be enabled by setting `<autoconf>` to `dhcp`, example: `ip=:::::eth0.3:dhcp`.


### PR DESCRIPTION
Can set netmask as number.

close #6861 

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
