### PR TITLE
fix: use passed `--context` in `talosctl config` cmd

### DIFF
--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"


### PR DESCRIPTION
Use context from command line flags. Also some minor fixes.

Closes #6846
