### PR TITLE
fix: add `--force` flag to `talosctl gen config`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -70,6 +70,7 @@ var genConfigCmdFlags struct {
 	withDocs                bool
 	withClusterDiscovery    bool
 	withKubeSpan            bool
+	force                   bool
 	withSecrets             string
 }
 
@@ -325,6 +326,12 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 		return err
 	}
 
+	if !genConfigCmdFlags.force {
+		if _, err := os.Stat(destination); err == nil {
+			return fmt.Errorf("%s already exists, use --force to overwrite", destination)
+		}
+	}
+
 	parentDir := filepath.Dir(destination)
 
 	// Create dir path, ignoring "already exists" messages
@@ -431,6 +438,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withDocs, "with-docs", "", true, "renders all machine configs adding the documentation for each field")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withClusterDiscovery, "with-cluster-discovery", "", true, "enable cluster discovery feature")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withKubeSpan, "with-kubespan", "", false, "enable KubeSpan feature")
+	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.force, "force", "", false, "\"gen\" will overwrite existing files")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.withSecrets, "with-secrets", "", "use a secrets file generated using 'gen secrets'")
 
 	genConfigCmd.Flags().StringSliceVarP(&genConfigCmdFlags.outputTypes, "output-types", "t", allOutputTypes, fmt.Sprintf("types of outputs to be generated. valid types are: %q", allOutputTypes))

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -186,7 +186,7 @@ func (suite *GenSuite) testGenConfigPatch(patch []byte) {
 		tt := tt
 
 		suite.Run(tt.flag, func() {
-			suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--" + tt.flag, string(patch)},
+			suite.RunCLI([]string{"gen", "config", "--force", "foo", "https://192.168.0.1:6443", "--" + tt.flag, string(patch)},
 				base.StdoutEmpty(),
 				base.StderrNotEmpty(),
 				base.StderrShouldMatch(regexp.MustCompile("generating PKI and tokens")))

--- a/website/content/v1.4/reference/cli.md
+++ b/website/content/v1.4/reference/cli.md
@@ -1313,6 +1313,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
+      --force                                    "gen" will overwrite existing files
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
       --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")


### PR DESCRIPTION
Only overwrite existing files if explicitly demanded.

Closes #6847
