### PR TITLE
feat: start machined earlier & in maintenance mode

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -1134,8 +1134,13 @@ func (s *Server) Version(ctx context.Context, in *emptypb.Empty) (reply *machine
 		}
 	}
 
-	features := &machine.FeaturesInfo{
-		Rbac: s.Controller.Runtime().Config().Machine().Features().RBACEnabled(),
+	var features *machine.FeaturesInfo
+
+	config := s.Controller.Runtime().Config()
+	if config != nil {
+		features = &machine.FeaturesInfo{
+			Rbac: config.Machine().Features().RBACEnabled(),
+		}
 	}
 
 	return &machine.VersionResponse{

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -232,6 +232,11 @@ func run() error {
 	// Inject controller into maintenance service.
 	maintenance.InjectController(c)
 
+	// Load machined service.
+	system.Services(c.Runtime()).Load(
+		&services.Machined{Controller: c},
+	)
+
 	initializeCanceled := false
 
 	// Initialize the machine.
@@ -252,7 +257,6 @@ func run() error {
 
 		// Start the machine API.
 		system.Services(c.Runtime()).LoadAndStart(
-			&services.Machined{Controller: c},
 			&services.APID{},
 		)
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -77,6 +77,9 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			CreateSystemCgroups,
 			CreateOSReleaseFile,
 		).Append(
+			"machined",
+			StartMachined,
+		).Append(
 			"config",
 			LoadConfig,
 		)
@@ -100,8 +103,9 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			CreateSystemCgroups,
 			CreateOSReleaseFile,
 		).Append(
-			"udevd",
+			"earlyServices",
 			StartUdevd,
+			StartMachined,
 		).AppendWithDeferredCheck(
 			func() bool {
 				return r.State().Machine().Installed()

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	stdlibruntime "runtime"
 	"sync"
 
@@ -89,14 +88,7 @@ func (r *goroutineRunner) wrappedMain() (err error) {
 	//nolint:errcheck
 	defer w.Close()
 
-	var writer io.Writer
-	if r.runtime.Config().Debug() {
-		writer = io.MultiWriter(w, os.Stdout)
-	} else {
-		writer = w
-	}
-
-	err = r.main(r.ctx, r.runtime, writer)
+	err = r.main(r.ctx, r.runtime, w)
 	if err == context.Canceled {
 		// clear error if service was aborted
 		err = nil

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -63,7 +63,7 @@ func trustdMain() error {
 
 	go runDebugServer(ctx)
 
-	startup.LimitMaxProcs(constants.ApidMaxProcs)
+	startup.LimitMaxProcs(constants.TrustdMaxProcs)
 
 	var err error
 


### PR DESCRIPTION
Load & start machined earlier and in initialize sequence, so that it is possible to use its API over its unix socket in maintenance mode.

Additionally, do not return features from Version API  if a config is not yet available.

Related to siderolabs/talos#4791.
