### PR TITLE
chore: provide version compatibility data for Talos 1.2.x

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
 )
@@ -39,6 +40,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 	var minK8sVersion, maxK8sVersion *version.Version
 
 	switch target.majorMinor {
+	case talos12.MajorMinor: // upgrades to 1.2.x
+		minK8sVersion, maxK8sVersion = talos12.MinimumKubernetesVersion, talos12.MaximumKubernetesVersion
 	case talos13.MajorMinor: // upgrades to 1.3.x
 		minK8sVersion, maxK8sVersion = talos13.MinimumKubernetesVersion, talos13.MaximumKubernetesVersion
 	case talos14.MajorMinor: // upgrades to 1.4.x

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -38,6 +38,35 @@ func runKubernetesVersionTest(t *testing.T, tt kubernetesVersionTest) {
 	})
 }
 
+func TestKubernetesCompatibility12(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.23.1",
+			target:            "1.2.0",
+		},
+		{
+			kubernetesVersion: "1.24.3",
+			target:            "1.2.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.25.0-rc.0",
+			target:            "1.2.7",
+		},
+		{
+			kubernetesVersion: "1.26.0-alpha.0",
+			target:            "1.2.0",
+			expectedError:     "version of Kubernetes 1.26.0-alpha.0 is too new to be used with Talos 1.2.0",
+		},
+		{
+			kubernetesVersion: "1.22.4",
+			target:            "1.2.0",
+			expectedError:     "version of Kubernetes 1.22.4 is too old to be used with Talos 1.2.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibility13(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
@@ -70,26 +99,26 @@ func TestKubernetesCompatibility13(t *testing.T) {
 func TestKubernetesCompatibility14(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
-			kubernetesVersion: "1.24.1",
+			kubernetesVersion: "1.25.1",
 			target:            "1.4.0",
 		},
 		{
-			kubernetesVersion: "1.25.3",
+			kubernetesVersion: "1.26.3",
 			target:            "1.4.0-beta.0",
 		},
 		{
-			kubernetesVersion: "1.26.0-rc.0",
+			kubernetesVersion: "1.27.0-rc.0",
 			target:            "1.4.7",
 		},
 		{
-			kubernetesVersion: "1.27.0-alpha.0",
+			kubernetesVersion: "1.28.0-alpha.0",
 			target:            "1.4.0",
-			expectedError:     "version of Kubernetes 1.27.0-alpha.0 is too new to be used with Talos 1.4.0",
+			expectedError:     "version of Kubernetes 1.28.0-alpha.0 is too new to be used with Talos 1.4.0",
 		},
 		{
-			kubernetesVersion: "1.23.4",
+			kubernetesVersion: "1.24.1",
 			target:            "1.4.0",
-			expectedError:     "version of Kubernetes 1.23.4 is too old to be used with Talos 1.4.0",
+			expectedError:     "version of Kubernetes 1.24.1 is too old to be used with Talos 1.4.0",
 		},
 	} {
 		runKubernetesVersionTest(t, tt)
@@ -105,8 +134,8 @@ func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 		},
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.2.0",
-			expectedError:     "compatibility with version 1.2.0 is not supported",
+			target:            "1.1.0",
+			expectedError:     "compatibility with version 1.1.0 is not supported",
 		},
 	} {
 		runKubernetesVersionTest(t, tt)

--- a/pkg/machinery/compatibility/talos12/talos12.go
+++ b/pkg/machinery/compatibility/talos12/talos12.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos12 provides compatibility constants for Talos 1.2.
+package talos12
+
+import "github.com/hashicorp/go-version"
+
+// MajorMinor is the major.minor version of Talos 1.2.
+var MajorMinor = [2]int{1, 2}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.2.
+var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.3.
+var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.3.0"))
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.2.
+var DeniedHostUpgradeVersions = []*version.Version{}
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.2.
+var MinimumKubernetesVersion = version.Must(version.NewVersion("1.23.0"))
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.2.
+var MaximumKubernetesVersion = version.Must(version.NewVersion("1.25.99"))

--- a/pkg/machinery/compatibility/talos14/talos14.go
+++ b/pkg/machinery/compatibility/talos14/talos14.go
@@ -20,7 +20,7 @@ var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.6.0"))
 var DeniedHostUpgradeVersions = []*version.Version{}
 
 // MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.4.
-var MinimumKubernetesVersion = version.Must(version.NewVersion("1.24.0"))
+var MinimumKubernetesVersion = version.Must(version.NewVersion("1.25.0"))
 
 // MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.4.
-var MaximumKubernetesVersion = version.Must(version.NewVersion("1.26.99"))
+var MaximumKubernetesVersion = version.Must(version.NewVersion("1.27.99"))

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
 )
@@ -45,6 +46,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	)
 
 	switch v.majorMinor {
+	case talos12.MajorMinor: // upgrades to 1.2.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos12.MinimumHostUpgradeVersion, talos12.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos12.DeniedHostUpgradeVersions
 	case talos13.MajorMinor: // upgrades to 1.3.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos13.MinimumHostUpgradeVersion, talos13.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos13.DeniedHostUpgradeVersions


### PR DESCRIPTION
This provides Kubernetes version compatibility for Talos 1.2.x, so that we have a unified source of data for Talos >= 1.2.x.

Also bump supported Kubernetes version for Talos 1.4.x to be 1.25-1.27, as Talos 1.4 is expected to ship with Kubernetes 1.27.
