### PR TITLE
fix: extension base folder permission

### DIFF
--- a/internal/pkg/extensions/kernel_modules.go
+++ b/internal/pkg/extensions/kernel_modules.go
@@ -144,6 +144,11 @@ func GenerateKernelModuleDependencyTreeExtension(extensionsPathWithKernelModules
 		return nil, err
 	}
 
+	// we want to make sure the root directory has the right permissions.
+	if err := os.Chmod(kernelModulesDependencyTreeStagingDir, 0o755); err != nil {
+		return nil, err
+	}
+
 	kernelModulesDepenencyTreeDirectory := filepath.Join(kernelModulesDependencyTreeStagingDir, constants.DefaultKernelModulesPath)
 
 	if err := os.MkdirAll(kernelModulesDepenencyTreeDirectory, 0o755); err != nil {


### PR DESCRIPTION
The `modules.dep` kernel module dependency tree extension root path was previously created with a permission of `0o700` which means the talos root go a permission of `0o700` when the kernel module tree was re-built when extensions providing kernel modules was enabled. This means that any binaries lost the executable permission when ran as non-root creating an `EACCES` error. Fix by making sure the temporary directory created for building kernel modules tree has `0o755` permission explicitly.