### PR TITLE
feat: add pod ip to kube-proxy spec

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -134,6 +134,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Exposes the pod IP as the `POD_IP` environment variable via the downward API in the kube-proxy pod for use in e.g. metrics-bind-addr.