### PR TITLE
fix: easier upgrade to Talos 1.3 with custom CRI config

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1080,6 +1080,10 @@ func WriteUserFiles(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 				continue
 			}
 
+			if f.Path() == filepath.Join("/etc", constants.CRICustomizationConfigPart) {
+				continue
+			}
+
 			// Determine if supplied path is in /var or not.
 			// If not, we'll write it to /var anyways and bind mount below
 			p := f.Path()

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -433,6 +433,9 @@ const (
 	// CRIRegistryConfigPart is the path to the CRI generated registry configuration relative to /etc.
 	CRIRegistryConfigPart = "cri/conf.d/01-registries.part"
 
+	// CRICustomizationConfigPart is the path to the CRI generated registry configuration relative to /etc.
+	CRICustomizationConfigPart = "cri/conf.d/20-customization.part"
+
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 


### PR DESCRIPTION
This makes Talos 1.2 accept but ignore Talos 1.3 specific `/etc/cri/conf.d/20-customization.part` file, so that new config can be injected into running Talos 1.2 before upgrading to Talos 1.3.

Talos 1.3 will ignore the customization under `/var`, so it can be safely removed after the upgrade.

Fixes #6882
