### PR TITLE
feat: coredns node uninitialized toleration

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -345,8 +345,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: coredns
           image: {{ .CoreDNSImage }}


### PR DESCRIPTION
Launch CoreDNS even if the node is not initialized. Network is ready already, but CCM didn't finish their job.
CCM needs the dns resolver to reach the talos-api, but CoreDNS stack in toleration condition.
I didn't catch this lock before, because I used my own coredns deploy....

I remove the `CriticalAddonsOnly` key. It was from kubeadm bootstrap process. 
We do not use it.




# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
