### PR TITLE
Add InstallConfig ignored notice to doc

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
+++ b/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
@@ -1808,9 +1808,9 @@
         "install": {
           "$ref": "#/$defs/InstallConfig",
           "title": "install",
-          "description": "Used to provide instructions for installations.\n",
-          "markdownDescription": "Used to provide instructions for installations.",
-          "x-intellij-html-description": "\u003cp\u003eUsed to provide instructions for installations.\u003c/p\u003e\n"
+          "description": "Used to provide instructions for installations.\n\nNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.\n",
+          "markdownDescription": "Used to provide instructions for installations.\n\nNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.",
+          "x-intellij-html-description": "\u003cp\u003eUsed to provide instructions for installations.\u003c/p\u003e\n\n\u003cp\u003eNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.\u003c/p\u003e\n"
         },
         "files": {
           "items": {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -747,6 +747,9 @@ type MachineConfig struct {
 	MachineDisks []*MachineDisk `yaml:"disks,omitempty"` // Note: `size` is in units of bytes.
 	//   description: |
 	//     Used to provide instructions for installations.
+	//
+	//     Note that this configuration section gets silently ignored by Talos images that are considered pre-installed.
+	//     To make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.
 	//   examples:
 	//     - name: MachineInstall config usage example.
 	//       value: machineInstallExample

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -215,7 +215,7 @@ func init() {
 	MachineConfigDoc.Fields[9].Name = "install"
 	MachineConfigDoc.Fields[9].Type = "InstallConfig"
 	MachineConfigDoc.Fields[9].Note = ""
-	MachineConfigDoc.Fields[9].Description = "Used to provide instructions for installations."
+	MachineConfigDoc.Fields[9].Description = "Used to provide instructions for installations.\n\nNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted."
 	MachineConfigDoc.Fields[9].Comments[encoder.LineComment] = "Used to provide instructions for installations."
 
 	MachineConfigDoc.Fields[9].AddExample("MachineInstall config usage example.", machineInstallExample)

--- a/website/content/v1.4/reference/configuration.md
+++ b/website/content/v1.4/reference/configuration.md
@@ -258,7 +258,7 @@ disks:
           # # Precise value in bytes.
           # size: 1073741824
 {{< /highlight >}}</details> | |
-|`install` |<a href="#installconfig">InstallConfig</a> |Used to provide instructions for installations. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`install` |<a href="#installconfig">InstallConfig</a> |<details><summary>Used to provide instructions for installations.</summary><br />Note that this configuration section gets silently ignored by Talos images that are considered pre-installed.<br />To make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 install:
     disk: /dev/sda # The disk used for installations.
     # Allows for supplying extra kernel args via the bootloader.

--- a/website/content/v1.4/schemas/v1alpha1_config.schema.json
+++ b/website/content/v1.4/schemas/v1alpha1_config.schema.json
@@ -1808,9 +1808,9 @@
         "install": {
           "$ref": "#/$defs/InstallConfig",
           "title": "install",
-          "description": "Used to provide instructions for installations.\n",
-          "markdownDescription": "Used to provide instructions for installations.",
-          "x-intellij-html-description": "\u003cp\u003eUsed to provide instructions for installations.\u003c/p\u003e\n"
+          "description": "Used to provide instructions for installations.\n\nNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.\n",
+          "markdownDescription": "Used to provide instructions for installations.\n\nNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.",
+          "x-intellij-html-description": "\u003cp\u003eUsed to provide instructions for installations.\u003c/p\u003e\n\n\u003cp\u003eNote that this configuration section gets silently ignored by Talos images that are considered pre-installed.\nTo make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted.\u003c/p\u003e\n"
         },
         "files": {
           "items": {


### PR DESCRIPTION
# Pull Request

## What? (description)

This PR adds a disclaimer to the 1.3 and 1.4 versions of the documentation regarding non-installable images. The reader is pointed towards ISO and PXE images as the only two kinds that acknowledge the `install` config

## Why? (reasoning)

As explained in #6865, I was pretty confused why the Talos metal image did not want to install. Since the original discussion did not lead to a clear answer, I want to make sure that the above-mentioned image types are indeed the only ones that follow the `install` config.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)  - Irrelevant for documentation
- [x] you ran conformance (`make conformance`) - Imperative Mood and Header Case checks fail with no apparent reason. A few other checks fail with vague errors. Please help me clear these up
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`) - Irrelevant for documentation

> See `make help` for a description of the available targets.
