### PR TITLE
feat: support ephemeral partition size

### DIFF
--- a/cmd/installer/cmd/install.go
+++ b/cmd/installer/cmd/install.go
@@ -78,6 +78,8 @@ func runInstallCmd() (err error) {
 		if config.Machine().Install().LegacyBIOSSupport() {
 			options.LegacyBIOSSupport = true
 		}
+
+		options.EphemeralSize = config.Machine().Install().EphemeralSize()
 	}
 
 	return install.Install(p, seq, options)

--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -37,6 +37,7 @@ var options = &install.Options{}
 func init() {
 	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
 	rootCmd.PersistentFlags().StringVar(&options.Disk, "disk", "", "The path to the disk to install to")
+	rootCmd.PersistentFlags().StringVar(&options.EphemeralSize, "ephemeral-size", "", "Size for ephemeral disk partition")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringVar(&options.Arch, "arch", runtime.GOARCH, "The target architecture")
 	rootCmd.PersistentFlags().StringVar(&options.Board, "board", constants.BoardNone, "The value of "+constants.KernelParamBoard)

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -28,6 +28,7 @@ import (
 type Options struct {
 	ConfigSource      string
 	Disk              string
+	EphemeralSize     string
 	Platform          string
 	Arch              string
 	Board             string

--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/siderolabs/go-blockdevice/blockdevice"
 	"github.com/siderolabs/go-blockdevice/blockdevice/partition/gpt"
 	"github.com/siderolabs/go-retry/retry"
@@ -148,6 +149,13 @@ func NewManifest(label string, sequence runtime.Sequence, bootPartitionFound boo
 	})
 
 	ephemeralTarget := EphemeralTarget(opts.Disk, NoFilesystem)
+	if opts.EphemeralSize != "" {
+		size, err := humanize.ParseBytes(opts.EphemeralSize)
+		if err != nil {
+			return nil, err
+		}
+		ephemeralTarget.FormatOptions.Size = size
+	}
 
 	targets := []*Target{efiTarget, biosTarget, bootTarget, metaTarget, stateTarget, ephemeralTarget}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -2141,6 +2141,13 @@ func MountEphemeralPartition(runtime.Sequence, any) (runtime.TaskExecutionFunc, 
 	}, "mountEphemeralPartition"
 }
 
+// MountEphemeralPartition mounts the ephemeral partition without resizing.
+func MountEphemeralPartitionWithoutResize(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+		return mount.SystemPartitionMount(r, logger, constants.EphemeralPartitionLabel)
+	}, "mountEphemeralPartition"
+}
+
 // UnmountEphemeralPartition unmounts the ephemeral partition.
 func UnmountEphemeralPartition(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {

--- a/internal/pkg/install/options.go
+++ b/internal/pkg/install/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	Upgrade         bool
 	Zero            bool
 	ExtraKernelArgs []string
+	EphemeralSize   string
 }
 
 // DefaultInstallOptions returns default options.

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -118,6 +118,7 @@ type Install interface {
 	Zero() bool
 	LegacyBIOSSupport() bool
 	WithBootloader() bool
+	EphemeralSize() string
 }
 
 // Extension defines the system extension.

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -81,6 +81,7 @@ type Input struct {
 
 	InstallDisk            string
 	InstallImage           string
+	InstallEphemeralSize   string
 	InstallExtraKernelArgs []string
 
 	NetworkConfigOptions []v1alpha1.NetworkConfigOption
@@ -671,6 +672,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		InstallDisk:                    options.InstallDisk,
 		InstallImage:                   options.InstallImage,
 		InstallExtraKernelArgs:         options.InstallExtraKernelArgs,
+		InstallEphemeralSize:           options.InstallEphemeralSize,
 		NetworkConfigOptions:           options.NetworkConfigOptions,
 		CNIConfig:                      options.CNIConfig,
 		RegistryMirrors:                options.RegistryMirrors,

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -46,6 +46,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			InstallBootloader:      pointer.To(true),
 			InstallWipe:            pointer.To(false),
 			InstallExtraKernelArgs: in.InstallExtraKernelArgs,
+			InstallEphemeralSize:   in.InstallEphemeralSize,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -72,6 +72,15 @@ func WithInstallExtraKernelArgs(args []string) GenOption {
 	}
 }
 
+// WithInstallEphemeralSize specifies the ephemeral size to use
+func WithInstallEphemeralSize(size string) GenOption {
+	return func(o *GenOptions) error {
+		o.InstallEphemeralSize = size
+
+		return nil
+	}
+}
+
 // WithNetworkOptions adds network config generation option.
 func WithNetworkOptions(opts ...v1alpha1.NetworkConfigOption) GenOption {
 	return func(o *GenOptions) error {
@@ -270,6 +279,7 @@ type GenOptions struct {
 	InstallDisk                    string
 	InstallImage                   string
 	InstallExtraKernelArgs         []string
+	InstallEphemeralSize           string
 	AdditionalSubjectAltNames      []string
 	NetworkConfigOptions           []v1alpha1.NetworkConfigOption
 	CNIConfig                      *v1alpha1.CNIConfig

--- a/pkg/machinery/config/types/v1alpha1/generate/worker.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/worker.go
@@ -47,6 +47,7 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			InstallBootloader:      pointer.To(true),
 			InstallWipe:            pointer.To(false),
 			InstallExtraKernelArgs: in.InstallExtraKernelArgs,
+			InstallEphemeralSize:   in.InstallEphemeralSize,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
+++ b/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
@@ -1398,6 +1398,13 @@
           "description": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn’t support GPT partitioning scheme.\n",
           "markdownDescription": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.",
           "x-intellij-html-description": "\u003cp\u003eIndicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn\u0026rsquo;t support GPT partitioning scheme.\u003c/p\u003e\n"
+        },
+        "ephemeralSize": {
+          "type": "string",
+          "title": "ephemeralSize",
+          "description": "description: |\n    Configure ephemeral partition size.\n  examples:\n    - value: 15GB\n",
+          "markdownDescription": "description: |\n    Configure ephemeral partition size.\n  examples:\n    - value: 15GB",
+          "x-intellij-html-description": "\u003cp\u003edescription: |\n    Configure ephemeral partition size.\n  examples:\n    - value: 15GB\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1217,6 +1217,11 @@ func (i *InstallConfig) WithBootloader() bool {
 	return pointer.SafeDeref(i.InstallBootloader)
 }
 
+// EphemeralSize implements the config.Provider interface.
+func (i *InstallConfig) EphemeralSize() string {
+	return i.InstallEphemeralSize
+}
+
 // Image implements the config.Provider interface.
 func (i InstallExtensionConfig) Image() string {
 	return i.ExtensionImage

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -187,6 +187,7 @@ var (
 		InstallDisk:            "/dev/sda",
 		InstallExtraKernelArgs: []string{"console=ttyS1", "panic=10"},
 		InstallImage:           "ghcr.io/siderolabs/installer:latest",
+		InstallEphemeralSize:   "15GB",
 		InstallBootloader:      pointer.To(true),
 		InstallWipe:            pointer.To(false),
 	}
@@ -1333,6 +1334,11 @@ type InstallConfig struct {
 	//     Indicates if MBR partition should be marked as bootable (active).
 	//     Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.
 	InstallLegacyBIOSSupport *bool `yaml:"legacyBIOSSupport,omitempty"`
+	// 	 description: |
+	//     Configure ephemeral partition size.
+	//   examples:
+	//     - value: 15GB
+	InstallEphemeralSize string `yaml:"ephemeralSize,omitempty"`
 }
 
 // InstallDiskSizeMatcher disk size condition parser.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -785,7 +785,7 @@ func init() {
 			FieldName: "install",
 		},
 	}
-	InstallConfigDoc.Fields = make([]encoder.Doc, 8)
+	InstallConfigDoc.Fields = make([]encoder.Doc, 9)
 	InstallConfigDoc.Fields[0].Name = "disk"
 	InstallConfigDoc.Fields[0].Type = "string"
 	InstallConfigDoc.Fields[0].Note = ""
@@ -850,6 +850,11 @@ func init() {
 	InstallConfigDoc.Fields[7].Note = ""
 	InstallConfigDoc.Fields[7].Description = "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme."
 	InstallConfigDoc.Fields[7].Comments[encoder.LineComment] = "Indicates if MBR partition should be marked as bootable (active)."
+	InstallConfigDoc.Fields[8].Name = "ephemeralSize"
+	InstallConfigDoc.Fields[8].Type = "string"
+	InstallConfigDoc.Fields[8].Note = ""
+	InstallConfigDoc.Fields[8].Description = "description: |\n    Configure ephemeral partition size.\n  examples:\n    - value: 15GB\n"
+	InstallConfigDoc.Fields[8].Comments[encoder.LineComment] = "description: |"
 
 	InstallDiskSelectorDoc.Type = "InstallDiskSelector"
 	InstallDiskSelectorDoc.Comments[encoder.LineComment] = "InstallDiskSelector represents a disk query parameters for the install disk lookup."


### PR DESCRIPTION
Allow ephemeral partition size to be specified in configuration. Users can limit the size of their ephemeral partition and partition the rest of the disk for other tools such as rook OSDs.

# Pull Request

Partially addresses: https://github.com/siderolabs/talos/issues/4721

This solution was what worked best for my use case (running a Rook OSD on the same drive as my Talos install) by making the partition size and subsequent partition resizing of the ephemeral partition configurable.

The default behavior remains the same, where the ephemeral partition will resize to the maximum remaining size of the drive.

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Allow ephemeral partition size to be specified in configuration. 

## Why? (reasoning)
Users can limit the size of their ephemeral partition and partition the rest of the disk for other tools such as rook OSDs.
## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
