### PR TITLE
fix: nil pointer exception in syncLink

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -225,6 +225,16 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 		if existing != nil && link.TypedSpec().Logical {
 			replace := false
 
+			if existing.Attributes.Info == nil {
+				logger.Warn("requested logical link has no info, skipping sync",
+					zap.String("name", existing.Attributes.Name),
+					zap.Stringer("type", nethelpers.LinkType(existing.Type)),
+					zap.Uint32("index", existing.Index),
+				)
+
+				return nil
+			}
+
 			// if type/kind doesn't match, recreate the link to change it
 			if existing.Type != uint16(link.TypedSpec().Type) || existing.Attributes.Info.Kind != link.TypedSpec().Kind {
 				logger.Info("replacing logical link",

--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -290,6 +290,7 @@ func (ctrl *LinkStatusController) reconcile(
 			status.DriverVersion = driverInfo.Version
 			status.FirmwareVersion = driverInfo.FwVersion
 
+			// link.Attributes.Info will be non-nil, because we set status.Kind above using link.Attributes.Info.Kind
 			switch status.Kind {
 			case network.LinkKindVLAN:
 				if err = networkadapter.VLANSpec(&status.VLAN).Decode(link.Attributes.Info.Data); err != nil {


### PR DESCRIPTION
If link has no `Info` field we can't do anything meaningful, so we'll just log and skip.
Also fix race in test.

For #6956

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>