### PR TITLE
feat: provide platform network config for 'metal' in META

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -447,10 +447,6 @@ func (ctrl *PlatformConfigController) apply(ctx context.Context, r controller.Ru
 			},
 		},
 	} {
-		if specType.length == 0 {
-			continue
-		}
-
 		touchedIDs := make(map[resource.ID]struct{}, specType.length)
 
 		resourceEmpty := specType.resourceBuilder("")

--- a/internal/pkg/meta/constants.go
+++ b/internal/pkg/meta/constants.go
@@ -13,4 +13,6 @@ const (
 	StagedUpgradeInstallOptions
 	// StateEncryptionConfig stores JSON-serialized v1alpha1.Encryption.
 	StateEncryptionConfig
+	// MetalNetworkPlatformConfig stores serialized NetworkPlatformConfig for the `metal` platform.
+	MetalNetworkPlatformConfig
 )

--- a/internal/pkg/meta/meta.go
+++ b/internal/pkg/meta/meta.go
@@ -148,7 +148,7 @@ func (meta *Meta) syncState(ctx context.Context) error {
 	existingTags := make(map[resource.ID]struct{})
 
 	for _, t := range meta.talos.ListTags() {
-		existingTags[tagToID(t)] = struct{}{}
+		existingTags[runtime.MetaKeyTagToID(t)] = struct{}{}
 		val, _ := meta.talos.ReadTag(t)
 
 		if err := updateTagResource(ctx, meta.state, t, val); err != nil {
@@ -303,7 +303,7 @@ func (meta *Meta) DeleteTag(ctx context.Context, t uint8) (bool, error) {
 		return ok, nil
 	}
 
-	err := meta.state.Destroy(ctx, runtime.NewMetaKey(runtime.NamespaceName, tagToID(t)).Metadata()) //nolint:errcheck
+	err := meta.state.Destroy(ctx, runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(t)).Metadata()) //nolint:errcheck
 	if state.IsNotFoundError(err) {
 		err = nil
 	}
@@ -311,16 +311,12 @@ func (meta *Meta) DeleteTag(ctx context.Context, t uint8) (bool, error) {
 	return ok, err
 }
 
-func tagToID(t uint8) resource.ID {
-	return fmt.Sprintf("0x%02x", t)
-}
-
 func updateTagResource(ctx context.Context, st state.State, t uint8, val string) error {
 	if st == nil {
 		return nil
 	}
 
-	_, err := safe.StateUpdateWithConflicts(ctx, st, runtime.NewMetaKey(runtime.NamespaceName, tagToID(t)).Metadata(), func(r *runtime.MetaKey) error {
+	_, err := safe.StateUpdateWithConflicts(ctx, st, runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(t)).Metadata(), func(r *runtime.MetaKey) error {
 		r.TypedSpec().Value = val
 
 		return nil
@@ -331,7 +327,7 @@ func updateTagResource(ctx context.Context, st state.State, t uint8, val string)
 	}
 
 	if state.IsNotFoundError(err) {
-		r := runtime.NewMetaKey(runtime.NamespaceName, tagToID(t))
+		r := runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(t))
 		r.TypedSpec().Value = val
 
 		return st.Create(ctx, r)

--- a/pkg/machinery/resources/runtime/meta_key.go
+++ b/pkg/machinery/resources/runtime/meta_key.go
@@ -5,6 +5,8 @@
 package runtime
 
 import (
+	"fmt"
+
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
@@ -50,6 +52,11 @@ func (MetaKeyExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 			},
 		},
 	}
+}
+
+// MetaKeyTagToID converts a tag to ID for MetaKey resource.
+func MetaKeyTagToID(t uint8) resource.ID {
+	return fmt.Sprintf("0x%02x", t)
 }
 
 func init() {


### PR DESCRIPTION
A special META key might contain optional platform network config for the `METAL` platform.

It is completely optional, but if present, it works same way as in the clouds: it is applied with low priority (can be overriden with machine config), but provides some initial defaults for the machine.
