### PR TITLE
feat: add network config screen to dashboard

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -38,16 +38,11 @@ Keyboard shortcuts:
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
-			d, err := dashboard.New(c,
+			return dashboard.Run(ctx, c,
 				dashboard.WithInterval(dashboardCmdFlags.interval),
 				dashboard.WithScreens(dashboard.ScreenSummary, dashboard.ScreenMonitor),
 				dashboard.WithAllowExitKeys(true),
 			)
-			if err != nil {
-				return err
-			}
-
-			return d.Run(ctx)
 		})
 	},
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -40,7 +40,7 @@ type Metal struct{}
 
 // Name implements the platform.Platform interface.
 func (m *Metal) Name() string {
-	return "metal"
+	return constants.PlatformMetal
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/metal"
 	"github.com/siderolabs/talos/internal/pkg/meta"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -51,7 +52,7 @@ outerLoop:
 		case <-ctx.Done():
 			require.FailNow(t, "timed out waiting for network config")
 		case cfg := <-ch:
-			assert.Equal(t, "metal", cfg.Metadata.Platform)
+			assert.Equal(t, constants.PlatformMetal, cfg.Metadata.Platform)
 
 			if cfg.Metadata.InstanceID == "" {
 				continue
@@ -74,7 +75,7 @@ outerLoop2:
 		case <-ctx.Done():
 			require.FailNow(t, "timed out waiting for network config")
 		case cfg := <-ch:
-			assert.Equal(t, "metal", cfg.Metadata.Platform)
+			assert.Equal(t, constants.PlatformMetal, cfg.Metadata.Platform)
 			assert.Equal(t, uuid.TypedSpec().UUID, cfg.Metadata.InstanceID)
 
 			if len(cfg.ExternalIPs) == 0 {
@@ -94,7 +95,7 @@ outerLoop2:
 	case <-ctx.Done():
 		require.FailNow(t, "timed out waiting for network config")
 	case cfg := <-ch:
-		assert.Equal(t, "metal", cfg.Metadata.Platform)
+		assert.Equal(t, constants.PlatformMetal, cfg.Metadata.Platform)
 		assert.Equal(t, uuid.TypedSpec().UUID, cfg.Metadata.InstanceID)
 
 		assert.Equal(t, "[]", fmt.Sprintf("%v", cfg.ExternalIPs))
@@ -107,7 +108,7 @@ outerLoop2:
 	case <-ctx.Done():
 		require.FailNow(t, "timed out waiting for network config")
 	case cfg := <-ch:
-		assert.Equal(t, "metal", cfg.Metadata.Platform)
+		assert.Equal(t, constants.PlatformMetal, cfg.Metadata.Platform)
 		assert.Equal(t, uuid.TypedSpec().UUID, cfg.Metadata.InstanceID)
 
 		assert.Equal(t, "[]", fmt.Sprintf("%v", cfg.ExternalIPs))

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -101,7 +101,7 @@ func newPlatform(platform string) (p runtime.Platform, err error) {
 		p = &gcp.GCP{}
 	case "hcloud":
 		p = &hcloud.Hcloud{}
-	case "metal":
+	case constants.PlatformMetal:
 		p = &metal.Metal{}
 	case "openstack":
 		p = &openstack.Openstack{}

--- a/internal/pkg/dashboard/resourcedata/resourcedata.go
+++ b/internal/pkg/dashboard/resourcedata/resourcedata.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/siderolabs/talos/internal/pkg/meta"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -135,6 +136,10 @@ func (source *Source) runResourceWatch(ctx context.Context, node string) error {
 	}
 
 	if err := source.COSI.Watch(ctx, cluster.NewInfo().Metadata(), eventCh); err != nil {
+		return err
+	}
+
+	if err := source.COSI.Watch(ctx, runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(meta.MetalNetworkPlatformConfig)).Metadata(), eventCh); err != nil {
 		return err
 	}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -820,6 +820,9 @@ const (
 
 	// FlannelVersion is the version of flannel to use.
 	FlannelVersion = "v0.21.4"
+
+	// PlatformMetal is the name of the metal platform.
+	PlatformMetal = "metal"
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 
 	"github.com/google/uuid"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -79,7 +79,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	cmdline.Append("talos.shutdown", "halt")
 
 	// Talos config
-	cmdline.Append("talos.platform", "metal")
+	cmdline.Append("talos.platform", constants.PlatformMetal)
 
 	// add overrides
 	if nodeReq.ExtraKernelArgs != nil {


### PR DESCRIPTION
Implement the network config screen with input forms to configure the initial node networking by writing a config to the META partition.

Closes siderolabs/talos#6961.

Preview:
![dashboard-edit-network-config](https://user-images.githubusercontent.com/1465819/226072737-90f16ba1-12ed-40dc-b311-0d1a691aa5d5.gif)
