### PR TITLE
chore: load all external artifacts earlier

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -133,7 +133,7 @@ local setup_ci = {
 
   commands: [
     'setup-ci',
-    'make ./_out/kubectl ./_out/kubestr ./_out/clusterctl',
+    'make external-artifacts',
   ],
   environment: {
     BUILDKIT_FLAVOR: 'cross',

--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,9 @@ $(ARTIFACTS)/cilium:
 	@curl -L "$(CILIUM_CLI_URL)" | tar xzf - -C $(ARTIFACTS) cilium
 	@chmod +x $(ARTIFACTS)/cilium
 
-e2e-%: $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 $(ARTIFACTS)/kubectl $(ARTIFACTS)/clusterctl $(ARTIFACTS)/kubestr $(ARTIFACTS)/helm $(ARTIFACTS)/cilium ## Runs the E2E test for the specified platform (e.g. e2e-docker).
+external-artifacts: $(ARTIFACTS)/kubectl $(ARTIFACTS)/clusterctl $(ARTIFACTS)/kubestr $(ARTIFACTS)/helm $(ARTIFACTS)/cilium
+
+e2e-%: $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 external-artifacts ## Runs the E2E test for the specified platform (e.g. e2e-docker).
 	@$(MAKE) hack-test-$@ \
 		PLATFORM=$* \
 		TAG=$(TAG) \


### PR DESCRIPTION
Load all external artifacts early in the build process so that the binaries are available for e2e tests.