### PR TITLE
fix: add uint32 type to Magic1 and Magic2

### DIFF
--- a/internal/pkg/meta/internal/adv/talos/talos.go
+++ b/internal/pkg/meta/internal/adv/talos/talos.go
@@ -27,8 +27,8 @@ const (
 
 // Magic constants.
 const (
-	Magic1 = 0x5a4b3c2d
-	Magic2 = 0xa5b4c3d2
+	Magic1 uint32 = 0x5a4b3c2d
+	Magic2 uint32 = 0xa5b4c3d2
 )
 
 // Tag is the key.


### PR DESCRIPTION
Discovered in #6971. Go compiler cannot deduce proper type on 32bit architectures for those constants,
in `fmt.Print(f)` functions. Since we only compare them with uint32 variables, it makes sense to add proper
types to them.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>