### PR TITLE
chore: bump golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -190,6 +190,7 @@ issues:
   exclude:
     - package comment should be of the form "Package services ..." # revive
     - ^ST1000 # ST1000: at least one file in a package should have a package comment (stylecheck)
+    - parameter '\w+' seems to be unused, consider removing or renaming it as _ # noisy check, especially when the usage is an interface implementation
 
   exclude-rules:
     - path: cmd/talosctl/cmd

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOIMPORTS_VERSION ?= v0.7.0
 # renovate: datasource=go depName=mvdan.cc/gofumpt
 GOFUMPT_VERSION ?= v0.4.0
 # renovate: datasource=go depName=github.com/golangci/golangci-lint
-GOLANGCILINT_VERSION ?= v1.51.2
+GOLANGCILINT_VERSION ?= v1.52.1
 # renovate: datasource=go depName=golang.org/x/tools
 STRINGER_VERSION ?= v0.7.0
 # renovate: datasource=go depName=github.com/alvaroloes/enumer

--- a/cmd/installer/pkg/install/extensions.go
+++ b/cmd/installer/pkg/install/extensions.go
@@ -67,11 +67,7 @@ func (i *Installer) installExtensions() error {
 		return err
 	}
 
-	if err = i.rebuildInitramfs(tempDir); err != nil {
-		return err
-	}
-
-	return nil
+	return i.rebuildInitramfs(tempDir)
 }
 
 func printExtensions(extensions []*extensions.Extension) error {

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -184,11 +184,7 @@ func getResources(args []string) func(ctx context.Context, c *client.Client) err
 				return nil
 			}
 
-			if err := out.WriteResource(hostname, r, 0); err != nil {
-				return err
-			}
-
-			return nil
+			return out.WriteResource(hostname, r, 0)
 		}
 
 		callbackRD := func(definition *meta.ResourceDefinition) error {

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -81,7 +81,7 @@ var supportCmd = &cobra.Command{
 
 		eg.Go(func() error {
 			if supportCmdFlags.verbose {
-				for range progress {
+				for range progress { //nolint:revive
 				}
 			} else {
 				showProgress(progress)

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -171,11 +171,7 @@ func mountRootFS() error {
 		return err
 	}
 
-	if err := unix.Mount(constants.ExtensionsConfigFile, filepath.Join(constants.NewRoot, constants.ExtensionsRuntimeConfigFile), "", unix.MS_BIND|unix.MS_RDONLY, ""); err != nil {
-		return err
-	}
-
-	return nil
+	return unix.Mount(constants.ExtensionsConfigFile, filepath.Join(constants.NewRoot, constants.ExtensionsRuntimeConfigFile), "", unix.MS_BIND|unix.MS_RDONLY, "")
 }
 
 func bindMountFirmware() error {

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
@@ -239,11 +239,7 @@ func (ctrl *KubeletServiceController) writePKI(secretSpec *secrets.KubeletSpec) 
 		return err
 	}
 
-	if err := os.WriteFile(constants.KubernetesCACert, secretSpec.CA.Crt, 0o400); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(constants.KubernetesCACert, secretSpec.CA.Crt, 0o400)
 }
 
 var kubeletKubeConfigTemplate = []byte(`apiVersion: v1

--- a/internal/app/machined/pkg/controllers/k8s/node_label_spec_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_label_spec_test.go
@@ -173,7 +173,7 @@ func (suite *NodeLabelsSuite) assertLabel(expectedLabel, oldValue, expectedValue
 	suite.Assert().NoError(
 		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			func() error {
-				if err := suite.assertResource(
+				return suite.assertResource(
 					resource.NewMetadata(
 						k8s.NamespaceName,
 						k8s.NodeLabelSpecType,
@@ -199,11 +199,7 @@ func (suite *NodeLabelsSuite) assertLabel(expectedLabel, oldValue, expectedValue
 
 						return nil
 					},
-				)(); err != nil {
-					return err
-				}
-
-				return nil
+				)()
 			},
 		),
 	)

--- a/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
+++ b/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
@@ -248,7 +248,7 @@ func (t *CRDController) Run(ctx context.Context, workers int) error {
 }
 
 func (t *CRDController) runWorker(ctx context.Context) {
-	for t.processNextWorkItem(ctx) {
+	for t.processNextWorkItem(ctx) { //nolint:revive
 	}
 }
 

--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -230,9 +230,8 @@ func (suite *AddressMergeSuite) TestMergeFlapping() {
 					}
 
 					continue
-				} else {
-					suite.T().Log("finalizer added")
 				}
+				suite.T().Log("finalizer added")
 
 				time.Sleep(10 * time.Millisecond)
 

--- a/internal/app/machined/pkg/controllers/network/link_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge_test.go
@@ -254,9 +254,8 @@ func (suite *LinkMergeSuite) TestMergeFlapping() {
 					}
 
 					continue
-				} else {
-					suite.T().Log("finalizer added")
 				}
+				suite.T().Log("finalizer added")
 
 				time.Sleep(10 * time.Millisecond)
 

--- a/internal/app/machined/pkg/controllers/network/operator_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_merge_test.go
@@ -252,9 +252,8 @@ func (suite *OperatorMergeSuite) TestMergeFlapping() {
 					}
 
 					continue
-				} else {
-					suite.T().Log("finalizer added")
 				}
+				suite.T().Log("finalizer added")
 
 				time.Sleep(10 * time.Millisecond)
 

--- a/internal/app/machined/pkg/controllers/network/route_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge_test.go
@@ -295,9 +295,8 @@ func (suite *RouteMergeSuite) TestMergeFlapping() {
 					}
 
 					continue
-				} else {
-					suite.T().Log("finalizer added")
 				}
+				suite.T().Log("finalizer added")
 
 				time.Sleep(10 * time.Millisecond)
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils/netutils.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils/netutils.go
@@ -21,11 +21,7 @@ import (
 func Wait(ctx context.Context, r state.State) error {
 	log.Printf("waiting for network to be ready")
 
-	if err := network.NewReadyCondition(r, network.AddressReady).Wait(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return network.NewReadyCondition(r, network.AddressReady).Wait(ctx)
 }
 
 // RetryFetch retries fetching from metadata service.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
@@ -115,9 +115,9 @@ func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, confi
 					macAddressMatched = true
 
 					break
-				} else {
-					availableMACAddresses = append(availableMACAddresses, macAddress)
 				}
+
+				availableMACAddresses = append(availableMACAddresses, macAddress)
 			}
 
 			if !macAddressMatched {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1727,11 +1727,7 @@ func ResetUserDisks(_ runtime.Sequence, data any) (runtime.TaskExecutionFunc, st
 
 			logger.Printf("wiping user disk %s", deviceName)
 
-			if err = dev.FastWipe(); err != nil {
-				return err
-			}
-
-			return nil
+			return dev.FastWipe()
 		}
 
 		for _, deviceName := range in.GetUserDisksToWipe() {

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -95,7 +95,7 @@ func (suite *DmesgSuite) TestStreaming() {
 	defer func() {
 		suite.ctxCancel()
 		// drain respCh
-		for range respCh {
+		for range respCh { //nolint:revive
 		}
 	}()
 

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -207,7 +207,7 @@ func (suite *LogsSuite) testStreaming(tailLines int32) {
 	defer func() {
 		suite.ctxCancel()
 		// drain respCh
-		for range respCh {
+		for range respCh { //nolint:revive
 		}
 	}()
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -459,7 +459,7 @@ func copyFromReaderWithErrChan(out io.Writer, in io.Reader, errCh <-chan error) 
 		defer wg.Done()
 
 		// StreamReader is only singly-buffered, so we need to process any errors as we get them.
-		for chanErr = range errCh {
+		for chanErr = range errCh { //nolint:revive
 		}
 	}()
 

--- a/internal/pkg/extensions/kernel_modules.go
+++ b/internal/pkg/extensions/kernel_modules.go
@@ -183,7 +183,7 @@ func logErr(f func() error) {
 func extractRootfsFromInitramfs(input bytes.Buffer, rootfsFilePath string) error {
 	recReader := cpio.Newc.Reader(bytes.NewReader(input.Bytes()))
 
-	if err := cpio.ForEachRecord(recReader, func(r cpio.Record) error {
+	return cpio.ForEachRecord(recReader, func(r cpio.Record) error {
 		if r.Name != constants.RootfsAsset {
 			return nil
 		}
@@ -204,11 +204,7 @@ func extractRootfsFromInitramfs(input bytes.Buffer, rootfsFilePath string) error
 		}
 
 		return f.Close()
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func depmod(kernelModulesPath string) error {

--- a/internal/pkg/extensions/validate.go
+++ b/internal/pkg/extensions/validate.go
@@ -23,11 +23,7 @@ func (ext *Extension) Validate() error {
 		return err
 	}
 
-	if err := ext.validateContents(); err != nil {
-		return err
-	}
-
-	return nil
+	return ext.validateContents()
 }
 
 func (ext *Extension) validateConstraints() error {

--- a/pkg/machinery/client/config/config.go
+++ b/pkg/machinery/client/config/config.go
@@ -182,11 +182,7 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 
-	if err = os.WriteFile(c.path.Path, configBytes, 0o600); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(c.path.Path, configBytes, 0o600)
 }
 
 // Bytes gets yaml encoded config data.

--- a/pkg/machinery/config/decoder/unknown_keys.go
+++ b/pkg/machinery/config/decoder/unknown_keys.go
@@ -120,7 +120,8 @@ func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown interf
 
 			switch typ.Kind() { //nolint:exhaustive
 			case reflect.Struct:
-				if fieldIndex, ok := availableKeys[key]; !ok {
+				fieldIndex, ok := availableKeys[key]
+				if !ok {
 					if unknown == nil {
 						unknown = map[string]interface{}{}
 					}
@@ -128,9 +129,9 @@ func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown interf
 					unknown.(map[string]interface{})[key] = spec.Content[i+1]
 
 					continue
-				} else {
-					elemType = typ.FieldByIndex(fieldIndex).Type
 				}
+
+				elemType = typ.FieldByIndex(fieldIndex).Type
 			case reflect.Map:
 				elemType = typ.Elem()
 			}


### PR DESCRIPTION
Bump golangci-lint and fixup new warnings. Ignore check that checks for used function parameters, it's kind of noisy and makes it confusing to read interface implementations.