### PR TITLE
test: fix misprint in e2e scripts

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -115,7 +115,7 @@ case "${WITH_CONFIG_PATCH_WORKER:-false}" in
       CONFIG_PATCH_FLAG=()
       ;;
   *)
-      CONFIG_PATCH_FLAG=(--config-patch-worker "${WITH_CONFIG_PATCH_FILE}")
+      CONFIG_PATCH_FLAG=(--config-patch-worker "${WITH_CONFIG_PATCH_WORKER}")
       ;;
 esac
 


### PR DESCRIPTION
This bug breaks `e2e-extensions`.
