### PR TITLE
chore: add machine config version contract for v1.4

### DIFF
--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion1_4     = &VersionContract{1, 4}
 	TalosVersion1_3     = &VersionContract{1, 3}
 	TalosVersion1_2     = &VersionContract{1, 2}
 	TalosVersion1_1     = &VersionContract{1, 1}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -67,6 +67,29 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 }
 
+func TestContract1_4(t *testing.T) {
+	contract := config.TalosVersion1_4
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.False(t, contract.PodSecurityPolicyEnabled())
+	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.True(t, contract.StableHostnameEnabled())
+	assert.True(t, contract.KubeletDefaultRuntimeSeccompProfileEnabled())
+	assert.False(t, contract.KubernetesAlternateImageRegistries())
+	assert.True(t, contract.KubernetesAllowSchedulingOnControlPlanes())
+	assert.True(t, contract.KubernetesDiscoveryBackendDisabled())
+	assert.True(t, contract.ApidExtKeyUsageCheckEnabled())
+	assert.True(t, contract.APIServerAuditPolicySupported())
+	assert.True(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.True(t, contract.SecretboxEncryptionSupported())
+}
+
 func TestContract1_3(t *testing.T) {
 	contract := config.TalosVersion1_3
 


### PR DESCRIPTION
No changes vs. v1.3, so mostly no-op change just to keep things consistent.
