### PR TITLE
feat: allow writing initial META values into the image

### DIFF
--- a/cmd/installer/pkg/install/meta_value.go
+++ b/cmd/installer/pkg/install/meta_value.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// MetaValues is a list of MetaValue.
+type MetaValues struct {
+	values  []MetaValue
+	changed bool
+}
+
+// MetaValue represents a key/value pair for META.
+type MetaValue struct {
+	Key   uint8
+	Value string
+}
+
+func (v MetaValue) String() string {
+	return fmt.Sprintf("0x%x=%s", v.Key, v.Value)
+}
+
+// Parse k=v expression.
+func (v *MetaValue) Parse(s string) error {
+	k, vv, ok := strings.Cut(s, "=")
+	if !ok {
+		return fmt.Errorf("invalid value %q", s)
+	}
+
+	key, err := strconv.ParseUint(k, 0, 8)
+	if err != nil {
+		return fmt.Errorf("invalid key %q", k)
+	}
+
+	v.Key = uint8(key)
+	v.Value = vv
+
+	return nil
+}
+
+// Interface check.
+var (
+	_ pflag.Value      = &MetaValues{}
+	_ pflag.SliceValue = &MetaValues{}
+)
+
+// Set implements pflag.Value.
+func (s *MetaValues) Set(val string) error {
+	var v MetaValue
+
+	if err := v.Parse(val); err != nil {
+		return err
+	}
+
+	if !s.changed {
+		s.values = []MetaValue{v}
+	} else {
+		s.values = append(s.values, v)
+	}
+
+	s.changed = true
+
+	return nil
+}
+
+// Type implements pflag.Value.
+func (s *MetaValues) Type() string {
+	return "metaValueSlice"
+}
+
+// String implements pflag.Value.
+func (s *MetaValues) String() string {
+	return "[" + strings.Join(s.GetSlice(), ",") + "]"
+}
+
+// Append implements pflag.SliceValue.
+func (s *MetaValues) Append(val string) error {
+	var v MetaValue
+
+	if err := v.Parse(val); err != nil {
+		return err
+	}
+
+	s.values = append(s.values, v)
+
+	return nil
+}
+
+// Replace implements pflag.SliceValue.
+func (s *MetaValues) Replace(val []string) error {
+	out := make([]MetaValue, len(val))
+
+	for i, pair := range val {
+		var v MetaValue
+
+		if err := v.Parse(pair); err != nil {
+			return err
+		}
+
+		out[i] = v
+	}
+
+	s.values = out
+
+	return nil
+}
+
+// GetSlice implements pflag.SliceValue.
+func (s *MetaValues) GetSlice() []string {
+	out := make([]string, len(s.values))
+
+	for i, v := range s.values {
+		out[i] = v.String()
+	}
+
+	return out
+}

--- a/cmd/installer/pkg/install/meta_value_test.go
+++ b/cmd/installer/pkg/install/meta_value_test.go
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/installer/pkg/install"
+)
+
+func TestMetaValue(t *testing.T) {
+	t.Parallel()
+
+	var v install.MetaValue
+
+	require.NoError(t, v.Parse("10=foo"))
+
+	assert.Equal(t, uint8(10), v.Key)
+	assert.Equal(t, "foo", v.Value)
+
+	assert.Equal(t, "0xa=foo", v.String())
+
+	var v2 install.MetaValue
+
+	require.NoError(t, v2.Parse(v.String()))
+
+	assert.Equal(t, v, v2)
+}
+
+func TestMetaValues(t *testing.T) {
+	t.Parallel()
+
+	var s install.MetaValues
+
+	require.NoError(t, s.Set("10=foo"))
+	require.NoError(t, s.Append("20=bar"))
+
+	assert.Equal(t, "[0xa=foo,0x14=bar]", s.String())
+}


### PR DESCRIPTION
E.g. with the command:

```
make image-metal IMAGER_ARGS="--meta 0xc=abc --meta 0xd=abc"
```

This doesn't support ISO/PXE boot yet, it's going to come into the next PR.

Fixes #6999 
