### PR TITLE
fix: apply small fixes on dashboard

### DIFF
--- a/internal/pkg/dashboard/apidata/source.go
+++ b/internal/pkg/dashboard/apidata/source.go
@@ -92,27 +92,6 @@ func (source *Source) gather() *Data {
 
 	gatherFuncs := []func() error{
 		func() error {
-			resp, err := source.MachineClient.Hostname(source.ctx, &emptypb.Empty{})
-			if err != nil {
-				return err
-			}
-
-			resultLock.Lock()
-			defer resultLock.Unlock()
-
-			for _, msg := range resp.GetMessages() {
-				node := msg.GetMetadata().GetHostname()
-
-				if _, ok := result.Nodes[node]; !ok {
-					result.Nodes[node] = &Node{}
-				}
-
-				result.Nodes[node].Hostname = msg
-			}
-
-			return nil
-		},
-		func() error {
 			resp, err := source.MachineClient.LoadAvg(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err

--- a/internal/pkg/dashboard/components/header.go
+++ b/internal/pkg/dashboard/components/header.go
@@ -13,17 +13,37 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/siderolabs/talos/internal/pkg/dashboard/apidata"
+	"github.com/siderolabs/talos/internal/pkg/dashboard/resourcedata"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
+
+const noHostname = "(no hostname)"
+
+type headerData struct {
+	hostname        string
+	version         string
+	uptime          string
+	numCPUs         string
+	cpuFreq         string
+	totalMem        string
+	numProcesses    string
+	cpuUsagePercent string
+	memUsagePercent string
+}
 
 // Header represents the top bar with host info.
 type Header struct {
 	tview.TextView
+
+	selectedNode string
+	nodeMap      map[string]*headerData
 }
 
 // NewHeader initializes Header.
 func NewHeader() *Header {
 	header := &Header{
 		TextView: *tview.NewTextView(),
+		nodeMap:  make(map[string]*headerData),
 	}
 
 	header.SetDynamicColors(true).SetText(noData)
@@ -31,67 +51,42 @@ func NewHeader() *Header {
 	return header
 }
 
+// OnNodeSelect implements the NodeSelectListener interface.
+func (widget *Header) OnNodeSelect(node string) {
+	if node != widget.selectedNode {
+		widget.selectedNode = node
+
+		widget.redraw()
+	}
+}
+
+// OnResourceDataChange implements the ResourceDataListener interface.
+func (widget *Header) OnResourceDataChange(data resourcedata.Data) {
+	nodeData := widget.getOrCreateNodeData(data.Node)
+
+	switch res := data.Resource.(type) { //nolint:gocritic
+	case *network.HostnameStatus:
+		if data.Deleted {
+			nodeData.hostname = noHostname
+		} else {
+			nodeData.hostname = res.TypedSpec().Hostname
+		}
+	}
+
+	if data.Node == widget.selectedNode {
+		widget.redraw()
+	}
+}
+
 // OnAPIDataChange implements the APIDataListener interface.
 func (widget *Header) OnAPIDataChange(node string, data *apidata.Data) {
-	nodeData := data.Nodes[node]
-	_ = nodeData
+	nodeAPIData := data.Nodes[node]
 
-	if nodeData == nil {
-		widget.SetText(notAvailable)
+	widget.updateNodeAPIData(node, nodeAPIData)
 
-		return
+	if node == widget.selectedNode {
+		widget.redraw()
 	}
-
-	hostname := notAvailable
-	uptime := notAvailable
-	version := notAvailable
-	numCPUs := notAvailable
-	cpuFreq := notAvailable
-	totalMem := notAvailable
-	numProcesses := notAvailable
-
-	cpuUsagePercent := fmt.Sprintf("%.1f%%", nodeData.CPUUsageByName("usage")*100.0)
-	memUsagePercent := fmt.Sprintf("%.1f%%", nodeData.MemUsage()*100.0)
-
-	if nodeData.Hostname != nil {
-		hostname = nodeData.Hostname.GetHostname()
-	}
-
-	if nodeData.Version != nil {
-		version = nodeData.Version.GetVersion().GetTag()
-	}
-
-	if nodeData.SystemStat != nil {
-		uptime = time.Since(time.Unix(int64(nodeData.SystemStat.GetBootTime()), 0)).Round(time.Second).String()
-	}
-
-	if nodeData.CPUsInfo != nil {
-		numCPUs = fmt.Sprintf("%d", len(nodeData.CPUsInfo.GetCpuInfo()))
-		cpuFreq = widget.humanizeCPUFrequency(nodeData.CPUsInfo.GetCpuInfo()[0].GetCpuMhz())
-	}
-
-	if nodeData.Processes != nil {
-		numProcesses = fmt.Sprintf("%d", len(nodeData.Processes.GetProcesses()))
-	}
-
-	if nodeData.Memory != nil {
-		totalMem = humanize.IBytes(nodeData.Memory.GetMeminfo().GetMemtotal() << 10)
-	}
-
-	text := fmt.Sprintf(
-		"[yellow::b]%s[-:-:-] (%s): uptime %s, %sx%s, %s RAM, PROCS %s, CPU %s, RAM %s",
-		hostname,
-		version,
-		uptime,
-		numCPUs,
-		cpuFreq,
-		totalMem,
-		numProcesses,
-		cpuUsagePercent,
-		memUsagePercent,
-	)
-
-	widget.SetText(text)
 }
 
 func (widget *Header) humanizeCPUFrequency(mhz float64) string {
@@ -105,4 +100,80 @@ func (widget *Header) humanizeCPUFrequency(mhz float64) string {
 	}
 
 	return fmt.Sprintf("%s%s", humanize.Ftoa(value), unit)
+}
+
+func (widget *Header) redraw() {
+	data := widget.getOrCreateNodeData(widget.selectedNode)
+
+	text := fmt.Sprintf(
+		"[yellow::b]%s[-:-:-] (%s): uptime %s, %sx%s, %s RAM, PROCS %s, CPU %s, RAM %s",
+		data.hostname,
+		data.version,
+		data.uptime,
+		data.numCPUs,
+		data.cpuFreq,
+		data.totalMem,
+		data.numProcesses,
+		data.cpuUsagePercent,
+		data.memUsagePercent,
+	)
+
+	widget.SetText(text)
+}
+
+func (widget *Header) updateNodeAPIData(node string, data *apidata.Node) {
+	sss := widget.getOrCreateNodeData(node)
+
+	if data == nil {
+		return
+	}
+
+	sss.cpuUsagePercent = fmt.Sprintf("%.1f%%", data.CPUUsageByName("usage")*100.0)
+	sss.memUsagePercent = fmt.Sprintf("%.1f%%", data.MemUsage()*100.0)
+
+	if data.Hostname != nil {
+		sss.hostname = data.Hostname.GetHostname()
+	}
+
+	if data.Version != nil {
+		sss.version = data.Version.GetVersion().GetTag()
+	}
+
+	if data.SystemStat != nil {
+		sss.uptime = time.Since(time.Unix(int64(data.SystemStat.GetBootTime()), 0)).Round(time.Second).String()
+	}
+
+	if data.CPUsInfo != nil {
+		sss.numCPUs = fmt.Sprintf("%d", len(data.CPUsInfo.GetCpuInfo()))
+		sss.cpuFreq = widget.humanizeCPUFrequency(data.CPUsInfo.GetCpuInfo()[0].GetCpuMhz())
+	}
+
+	if data.Processes != nil {
+		sss.numProcesses = fmt.Sprintf("%d", len(data.Processes.GetProcesses()))
+	}
+
+	if data.Memory != nil {
+		sss.totalMem = humanize.IBytes(data.Memory.GetMeminfo().GetMemtotal() << 10)
+	}
+}
+
+func (widget *Header) getOrCreateNodeData(node string) *headerData {
+	data, ok := widget.nodeMap[node]
+	if !ok {
+		data = &headerData{
+			hostname:        notAvailable,
+			version:         notAvailable,
+			uptime:          notAvailable,
+			numCPUs:         notAvailable,
+			cpuFreq:         notAvailable,
+			totalMem:        notAvailable,
+			numProcesses:    notAvailable,
+			cpuUsagePercent: notAvailable,
+			memUsagePercent: notAvailable,
+		}
+
+		widget.nodeMap[node] = data
+	}
+
+	return data
 }

--- a/internal/pkg/dashboard/components/kubernetesinfo.go
+++ b/internal/pkg/dashboard/components/kubernetesinfo.go
@@ -65,7 +65,7 @@ func (widget *KubernetesInfo) OnNodeSelect(node string) {
 func (widget *KubernetesInfo) OnResourceDataChange(data resourcedata.Data) {
 	widget.updateNodeData(data)
 
-	if data.Node != widget.selectedNode {
+	if data.Node == widget.selectedNode {
 		widget.redraw()
 	}
 }

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -155,7 +155,7 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 
 	dashboard.summaryGrid = NewSummaryGrid(dashboard.app)
 	dashboard.monitorGrid = NewMonitorGrid(dashboard.app)
-	dashboard.networkConfigGrid = NewNetworkConfigGrid(ctx, dashboard.app, dashboard.pages, cli)
+	dashboard.networkConfigGrid = NewNetworkConfigGrid(ctx, dashboard)
 
 	err := dashboard.initScreenConfigs(defOptions.screens)
 	if err != nil {
@@ -210,6 +210,7 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 	}
 
 	dashboard.resourceDataListeners = []ResourceDataListener{
+		header,
 		dashboard.summaryGrid,
 		dashboard.networkConfigGrid,
 	}
@@ -219,6 +220,7 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 	}
 
 	dashboard.nodeSelectListeners = []NodeSelectListener{
+		header,
 		dashboard.summaryGrid,
 		dashboard.networkConfigGrid,
 		dashboard.footer,

--- a/internal/pkg/dashboard/resourcedata/resourcedata.go
+++ b/internal/pkg/dashboard/resourcedata/resourcedata.go
@@ -143,6 +143,14 @@ func (source *Source) runResourceWatch(ctx context.Context, node string) error {
 		return err
 	}
 
+	if err := source.COSI.Watch(ctx, network.NewStatus(network.NamespaceName, network.StatusID).Metadata(), eventCh); err != nil {
+		return err
+	}
+
+	if err := source.COSI.Watch(ctx, network.NewHostnameStatus(network.NamespaceName, network.HostnameID).Metadata(), eventCh); err != nil {
+		return err
+	}
+
 	if err := source.COSI.WatchKind(ctx, k8s.NewStaticPodStatus(k8s.NamespaceName, "").Metadata(), eventCh, state.WithBootstrapContents(true)); err != nil {
 		return err
 	}
@@ -156,6 +164,10 @@ func (source *Source) runResourceWatch(ctx context.Context, node string) error {
 	}
 
 	if err := source.COSI.WatchKind(ctx, cluster.NewMember(cluster.NamespaceName, "").Metadata(), eventCh, state.WithBootstrapContents(true)); err != nil {
+		return err
+	}
+
+	if err := source.COSI.WatchKind(ctx, network.NewNodeAddress(network.NamespaceName, "").Metadata(), eventCh, state.WithBootstrapContents(true)); err != nil {
 		return err
 	}
 

--- a/internal/pkg/dashboard/summary.go
+++ b/internal/pkg/dashboard/summary.go
@@ -38,8 +38,7 @@ func NewSummaryGrid(app *tview.Application) *SummaryGrid {
 		logViewers: make(map[string]*components.LogViewer),
 	}
 
-	widget.SetRows(8, 0).
-		SetColumns(0, 0, 0)
+	widget.SetRows(8, 0).SetColumns(-3, -2, -3)
 
 	talosInfo := components.NewTalosInfo()
 	widget.AddItem(talosInfo, 0, 0, 1, 1, 0, 0, false)


### PR DESCRIPTION
* Clear the input form and switch to summary tab after the network config is saved.
* Use nodeaddress resource for detecting and displaying IPs. Improve the IP filtering logic.
* Fix the logic of gateway detection. Display all gateways instead of a single one.
* Use hostnamestatus resource to detect the hostname instead of an API call.
* Add hostname entry to the network info section on summary tab (as `HOST`).
* Enable `OUTBOUND` entry in network info section on summary tab.
* Display only the physical network interfaces in the interface dropdown on network config tab.
* Improve form input handling.
* Additional minor fixes & improvements.

Closes siderolabs/talos#6992.
