### PR TITLE
fix: udevd rules trigger

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -164,7 +164,7 @@ func (g *GCP) Configuration(ctx context.Context, r state.State) ([]byte, error) 
 		return nil, err
 	}
 
-	log.Printf("fetching machine config from AWS")
+	log.Printf("fetching machine config from GCP metadata service")
 
 	userdata, err := netutils.RetryFetch(ctx, g.fetchConfiguration)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -782,6 +782,14 @@ func WriteUdevRules(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 			return fmt.Errorf("failed writing custom udev rules: %w", err)
 		}
 
+		if len(rules) > 0 {
+			if err := system.Services(r).Stop(ctx, "udevd"); err != nil {
+				return err
+			}
+
+			return system.Services(r).Start("udevd")
+		}
+
 		return nil
 	}, "writeUdevRules"
 }

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -43,6 +43,8 @@ func (c *Udevd) PreFunc(ctx context.Context, r runtime.Runtime) error {
 		"--update",
 	)
 
+	c.triggered = false
+
 	return err
 }
 


### PR DESCRIPTION
Restart udevd on adding custom rules where in the case the subsystems needs to be re-triggered.

Fixes: #7001