### PR TITLE
test: bump CAPI components versions

### DIFF
--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -4,9 +4,9 @@ set -eou pipefail
 
 source ./hack/test/e2e.sh
 
-export CAPI_VERSION="${CAPI_VERSION:-1.1.3}"
-export CAPA_VERSION="${CAPA_VERSION:-1.2.0}"
-export CAPG_VERSION="${CAPG_VERSION:-1.0.0}"
+export CAPI_VERSION="${CAPI_VERSION:-1.4.0}"
+export CAPA_VERSION="${CAPA_VERSION:-1.5.2}"
+export CAPG_VERSION="${CAPG_VERSION:-1.3.0}"
 
 # We need to override this here since e2e.sh will set it to ${TMP}/capi/kubeconfig.
 export KUBECONFIG="/tmp/e2e/docker/kubeconfig"


### PR DESCRIPTION
Bringing up to the latest version in 1.x series.
