### PR TITLE
fix: improve action tracking post checks

### DIFF
--- a/cmd/talosctl/cmd/common/common.go
+++ b/cmd/talosctl/cmd/common/common.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package common provides common functionality for talosctl commands.
+package common
+
+// SuppressErrors is a flag to suppress printing errors after the command was run.
+var SuppressErrors = false

--- a/cmd/talosctl/cmd/root.go
+++ b/cmd/talosctl/cmd/root.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
 	"github.com/siderolabs/talos/pkg/cli"
@@ -48,8 +50,8 @@ func Execute() error {
 	cli.Should(rootCmd.RegisterFlagCompletionFunc("nodes", talos.CompleteNodes))
 	rootCmd.PersistentFlags().StringVar(&talos.GlobalArgs.Cluster, "cluster", "", "Cluster to connect to if a proxy endpoint is used.")
 
-	cmd, err := rootCmd.ExecuteC()
-	if err != nil {
+	cmd, err := rootCmd.ExecuteContextC(context.Background())
+	if err != nil && !common.SuppressErrors {
 		fmt.Fprintln(os.Stderr, err.Error())
 
 		errorString := err.Error()

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -56,19 +57,13 @@ var rebootCmd = &cobra.Command{
 			})
 		}
 
-		cmd.SilenceErrors = true
-
-		postCheckFn := func(ctx context.Context, c *client.Client) error {
-			_, err := c.Disks(ctx)
-
-			return err
-		}
+		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,
 			action.MachineReadyEventFn,
 			rebootGetActorID(opts...),
-			action.WithPostCheck(postCheckFn),
+			action.WithPostCheck(action.BootIDChangedPostCheckFn),
 			action.WithDebug(rebootCmdFlags.debug),
 			action.WithTimeout(rebootCmdFlags.timeout),
 		).Run()

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -49,7 +50,7 @@ var shutdownCmd = &cobra.Command{
 			})
 		}
 
-		cmd.SilenceErrors = true
+		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
@@ -51,19 +52,13 @@ var upgradeCmd = &cobra.Command{
 			return runUpgradeNoWait()
 		}
 
-		cmd.SilenceErrors = true
-
-		postCheckFn := func(ctx context.Context, c *client.Client) error {
-			_, err := c.Disks(ctx)
-
-			return err
-		}
+		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,
 			action.MachineReadyEventFn,
 			upgradeGetActorID,
-			action.WithPostCheck(postCheckFn),
+			action.WithPostCheck(action.BootIDChangedPostCheckFn),
 			action.WithDebug(upgradeCmdFlags.debug),
 			action.WithTimeout(upgradeCmdFlags.timeout),
 		).Run()


### PR DESCRIPTION
In the tracking of the `reset --reboot`, `reboot` and `upgrade` lifecycle commands, verify that the node was actually rebooted in the post check by comparing the pre- and post-check boot IDs.

In the `reset --reboot` post-check, try both maintenance and normal mode, since the reset might be issued to only remove `EPHEMERAL` partition, which will not put the node into the maintenance mode.

Fixes https://github.com/siderolabs/talos/issues/7009.

Additionally, if an action tracking fails, return the error instead of swallowing it. This way the command erminates with a non-zero exit code. Suppress the re-printing this error after the command was run.

Fixes https://github.com/siderolabs/talos/issues/6966.