### PR TITLE
fix: send 'STOP' event on phase end

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -266,7 +266,7 @@ func (c *Controller) runPhase(ctx context.Context, phase runtime.Phase, seq runt
 
 	defer c.Runtime().Events().Publish(ctx, &machine.PhaseEvent{
 		Phase:  phase.Name,
-		Action: machine.PhaseEvent_START,
+		Action: machine.PhaseEvent_STOP,
 	})
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Previously 'START' was sent for both start and finish.
