### PR TITLE
Small corrections for 1.4 docs

### DIFF
--- a/website/content/v1.4/_index.md
+++ b/website/content/v1.4/_index.md
@@ -4,7 +4,7 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.4.0-alpha.3
+lastRelease: v1.4.0-beta.1
 kubernetesRelease: "1.27.0-rc.1"
 prevKubernetesRelease: "1.26.2"
 theilaRelease: "v0.2.1"

--- a/website/content/v1.4/introduction/what-is-new.md
+++ b/website/content/v1.4/introduction/what-is-new.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in Talos 1.3
+title: What's New in Talos 1.4
 weight: 50
 description: "List of new and shiny features in Talos Linux."
 ---

--- a/website/content/v1.4/learn-more/philosophy.md
+++ b/website/content/v1.4/learn-more/philosophy.md
@@ -70,7 +70,6 @@ it forms.
 
 This is achievable because Talos is tightly focused to do one thing: run
 Kubernetes, in the easiest, most secure, most reliable way it can.
-/Users/stevefrancis/workspace/talos/website/content/v1.3/learn-more
 
 ## Not based on X distro
 

--- a/website/content/v1.4/reference/cli.md
+++ b/website/content/v1.4/reference/cli.md
@@ -96,7 +96,7 @@ talosctl cluster create [flags]
       --bad-rtc                                  launch VM with bad RTC state (QEMU only)
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                     search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                    URL to download CNI bundle from (VM only) (default "https://github.com/siderolabs/talos/releases/download/v1.4.0-alpha.4/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                    URL to download CNI bundle from (VM only) (default "https://github.com/siderolabs/talos/releases/download/v1.4.0-beta.1/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                     CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
@@ -2622,7 +2622,7 @@ talosctl upgrade [flags]
       --debug              debug operation from kernel logs. --wait is set to true when this flag is set
   -f, --force              force the upgrade (skip checks on etcd health and members, might lead to data loss)
   -h, --help               help for upgrade
-  -i, --image string       the container image to use for performing the install (default "ghcr.io/siderolabs/installer:v1.4.0-alpha.4")
+  -i, --image string       the container image to use for performing the install (default "ghcr.io/siderolabs/installer:v1.4.0-beta.1")
       --insecure           upgrade using the insecure (encrypted with no auth) maintenance service
   -p, --preserve           preserve data
   -s, --stage              stage the upgrade to perform it after a reboot


### PR DESCRIPTION
# Pull Request

## What? (description)
I corrected some version references in the v1.4 doc tree

## Why? (reasoning)
I stumbled upon references to v1.3 in the v1.4 docs when I wanted to upgrade my homelab to `v1.4.0-beta.1`, so I `git grep`'d myself through the v1.4 docs.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`) **yes, but it had some complaints about code I did not change**
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
