### PR TITLE
fix: parse errors correctly

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -38,7 +38,7 @@ func CheckErrors[T interface{ GetMetadata() *common.Metadata }](messages ...T) e
 
 	for _, msg := range messages {
 		md := msg.GetMetadata()
-		if md.Error != "" {
+		if md != nil && md.Error != "" {
 			err = AppendErrors(err, fmt.Errorf(md.Error))
 		}
 	}


### PR DESCRIPTION
Message metadata might be missing, the easiest usecase is contacting worker directly using it both as an endpoint and a node.

Fixes https://github.com/siderolabs/talos/issues/7108
