### PR TITLE
fix: allow `talosctl cp` to handle special files in `/proc`

### DIFF
--- a/pkg/archiver/tar.go
+++ b/pkg/archiver/tar.go
@@ -6,24 +6,27 @@ package archiver
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"syscall"
 
 	multierror "github.com/hashicorp/go-multierror"
 )
 
-// Tar creates .tar archive and writes it to output for every item in paths channel
-//
-//nolint:gocyclo
+// Tar creates .tar archive and writes it to output for every item in paths channel.
 func Tar(ctx context.Context, paths <-chan FileItem, output io.Writer) error {
 	tw := tar.NewWriter(output)
 	//nolint:errcheck
 	defer tw.Close()
 
 	var multiErr *multierror.Error
+
+	buf := make([]byte, 4096)
 
 	for fi := range paths {
 		if fi.Error != nil {
@@ -32,62 +35,9 @@ func Tar(ctx context.Context, paths <-chan FileItem, output io.Writer) error {
 			continue
 		}
 
-		header, err := tar.FileInfoHeader(fi.FileInfo, fi.Link)
+		err := processFile(ctx, tw, fi, buf)
 		if err != nil {
-			// not supported by tar
 			multiErr = multierror.Append(multiErr, fmt.Errorf("skipping %q: %s", fi.FullPath, err))
-
-			continue
-		}
-
-		header.Name = fi.RelPath
-		if fi.FileInfo.IsDir() {
-			header.Name += string(os.PathSeparator)
-		}
-
-		skipData := false
-
-		switch header.Typeflag {
-		case tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeDir, tar.TypeFifo:
-			// no data for these types, move on
-			skipData = true
-		}
-
-		if header.Size == 0 {
-			// skip files with zero length
-			//
-			// this might skip contents for special files in /proc, but
-			// anyways we can't archive them properly if we don't know size beforehand
-			skipData = true
-		}
-
-		var fp *os.File
-		if !skipData {
-			fp, err = os.Open(fi.FullPath)
-			if err != nil {
-				multiErr = multierror.Append(multiErr, fmt.Errorf("skipping %q: %s", fi.FullPath, err))
-
-				continue
-			}
-		}
-
-		err = tw.WriteHeader(header)
-		if err != nil {
-			//nolint:errcheck
-			fp.Close()
-
-			multiErr = multierror.Append(multiErr, err)
-
-			return multiErr
-		}
-
-		if !skipData {
-			err = archiveFile(ctx, tw, fi, fp)
-			if err != nil {
-				multiErr = multierror.Append(multiErr, err)
-
-				return multiErr
-			}
 		}
 	}
 
@@ -98,17 +48,88 @@ func Tar(ctx context.Context, paths <-chan FileItem, output io.Writer) error {
 	return multiErr.ErrorOrNil()
 }
 
-func archiveFile(ctx context.Context, tw io.Writer, fi FileItem, fp *os.File) error {
-	//nolint:errcheck
-	defer fp.Close()
+//nolint:gocyclo
+func processFile(ctx context.Context, tw *tar.Writer, fi FileItem, buf []byte) error {
+	header, err := tar.FileInfoHeader(fi.FileInfo, fi.Link)
+	if err != nil {
+		// not supported by tar
+		return err
+	}
 
-	buf := make([]byte, 4096)
+	header.Name = fi.RelPath
+	if fi.FileInfo.IsDir() {
+		header.Name += string(os.PathSeparator)
+	}
 
+	skipData := false
+
+	switch header.Typeflag {
+	case tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeDir, tar.TypeFifo:
+		// no data for these types, move on
+		skipData = true
+	}
+
+	var r io.Reader
+
+	if !skipData {
+		var fp *os.File
+
+		fp, err = os.Open(fi.FullPath)
+		if err != nil {
+			return err
+		}
+
+		defer fp.Close() //nolint:errcheck
+
+		r = fp
+	}
+
+	if !skipData && header.Size == 0 {
+		// Linux reports /proc files as zero length, but they might have data,
+		// so we try to read limited amount of data from it to determine the size
+		var n int
+
+		n, err = r.Read(buf)
+
+		switch {
+		case err == io.EOF:
+			// file is empty for real
+			skipData = true
+		case err != nil:
+			// error reading from the file
+			if errors.Is(err, syscall.EINVAL) {
+				// some files are not supported by os.Open, e.g. /proc/sys/net/ipv4/conf/all/accept_local
+				skipData = true
+			} else {
+				return err
+			}
+		case n < len(buf):
+			header.Size = int64(n)
+			r = bytes.NewReader(append([]byte(nil), buf[:n]...))
+		default:
+			// none matched so the file is bigger than we expected, ignore it and copy as zero size
+			skipData = true
+		}
+	}
+
+	err = tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	if skipData {
+		return nil
+	}
+
+	return archiveFile(ctx, tw, fi, r, buf)
+}
+
+func archiveFile(ctx context.Context, tw io.Writer, fi FileItem, r io.Reader, buf []byte) error {
 	for {
-		n, err := fp.Read(buf)
+		n, err := r.Read(buf)
 		if err != nil {
 			if err == io.EOF {
-				break
+				return nil
 			}
 
 			return err
@@ -131,6 +152,4 @@ func archiveFile(ctx context.Context, tw io.Writer, fi FileItem, fp *os.File) er
 			return err
 		}
 	}
-
-	return fp.Close()
 }


### PR DESCRIPTION
There is some refactoring to simplify things, but mostly handle files which report size 0 in `stat`, but actually contain data when read.

We try to read up to the small buffer, if we read whole file, we use that as contents, otherwise we still skip the file, as we need to write tar header with size _before_ we read the whole file.
