### PR TITLE
fix: do not show control plane status for workers on dashboard

### DIFF
--- a/internal/pkg/dashboard/components/talosinfo.go
+++ b/internal/pkg/dashboard/components/talosinfo.go
@@ -79,10 +79,11 @@ func (widget *TalosInfo) updateNodeData(data resourcedata.Data) {
 			nodeData.uuid = res.TypedSpec().UUID
 		}
 	case *cluster.Info:
-		if data.Deleted {
+		clusterName := res.TypedSpec().ClusterName
+		if data.Deleted || clusterName == "" {
 			nodeData.clusterName = notAvailable
 		} else {
-			nodeData.clusterName = res.TypedSpec().ClusterName
+			nodeData.clusterName = clusterName
 		}
 	case *runtime.MachineStatus:
 		if data.Deleted {


### PR DESCRIPTION
Hide kube-apiserver, kube-controller-manager and kube-scheduler statuses on the dashboard for the worker nodes, instead of showing them as n/a.

Also display the cluster name as n/a for workers (instead of an empty string), as that information is not available to them.

Closes siderolabs/talos#7103.
