### PR TITLE
chore: remove k8s master label

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -247,10 +247,6 @@ func getDiscoveryMemberList(ctx context.Context, runtime runtime.Runtime) ([]*cl
 
 func isControlPlaneNode(node *corev1.Node) bool {
 	for key := range node.Labels {
-		if key == constants.LabelNodeRoleMaster {
-			return true
-		}
-
 		if key == constants.LabelNodeRoleControlPlane {
 			return true
 		}

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -341,9 +341,6 @@ spec:
       serviceAccountName: coredns
       priorityClassName: system-cluster-critical
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -678,7 +678,7 @@ func (suite *UpgradeSuite) untaint(name string) {
 	k := 0
 
 	for _, taint := range n.Spec.Taints {
-		if taint.Key != constants.LabelNodeRoleMaster && taint.Key != constants.LabelNodeRoleControlPlane {
+		if taint.Key != constants.LabelNodeRoleControlPlane {
 			n.Spec.Taints[k] = taint
 			k++
 		}

--- a/pkg/cluster/check/kubernetes.go
+++ b/pkg/cluster/check/kubernetes.go
@@ -97,7 +97,7 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cl ClusterInfo) error {
 
 	for _, node := range nodes.Items {
 		for label := range node.Labels {
-			if label == constants.LabelNodeRoleMaster || label == constants.LabelNodeRoleControlPlane {
+			if label == constants.LabelNodeRoleControlPlane {
 				var internalIP netip.Addr
 
 				var ips []netip.Addr

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -334,9 +334,6 @@ const (
 	// renovate: datasource=github-releases depName=coredns/coredns
 	DefaultCoreDNSVersion = "1.10.1"
 
-	// LabelNodeRoleMaster is the node label required by a control plane node.
-	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
-
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
 


### PR DESCRIPTION
Since talos now defaults to k8s 1.27, remove the handling of `master` label for controlplane nodes.