### PR TITLE
fix: Increase EFI partition size to 200 MiB.

### DIFF
--- a/internal/pkg/partition/constants.go
+++ b/internal/pkg/partition/constants.go
@@ -30,7 +30,7 @@ const (
 const (
 	MiB = 1024 * 1024
 
-	EFISize      = 100 * MiB
+	EFISize      = 200 * MiB
 	BIOSGrubSize = 1 * MiB
 	BootSize     = 1000 * MiB
 	MetaSize     = 1 * MiB


### PR DESCRIPTION
Fixes: #7066

# Pull Request

## What? (description)

This PR increases the fixed EFI partition size to 200MiB. Apparently some EFI environments, including at least T2 Intel Macs, don't like sizes smaller than this; ref:

* https://www.linux.org/threads/efi-partition-sizes.35741/
* https://www.ctrl.blog/entry/esp-size-guide.html

## Why? (reasoning)

1. T2 Intel Macs can boot most Linuxes, but not Talos. I was able to boot the Talos v1.3.7 and v1.4.0 ISOs on a 2017 iMac Pro using a USB flash drive, and `kexec` reboots also worked, but warm & cold reboots did not: the Mac does not recognize the EFI partition. During debugging, I noted that the Mac's recovery mode Disk Utility reported that the EFI partition size (100MiB) was too small. After bumping the size to 200MiB and re-installing using the modified installer, Talos v1.4.0 now boots fine on the iMac Pro.
2. Anecdotally, there are also reports of issues with 100MiB EFI partitions on at least some other PCs, though I haven't personally experienced this (except on the 2017 iMac Pro as described above).
3. An additional 100MiB for better compatibility seems like a good tradeoff.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)


