### PR TITLE
feat: clean up (garbage collect) system images which are not referenced

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/cri_image_gc.go
+++ b/internal/app/machined/pkg/controllers/runtime/cri_image_gc.go
@@ -1,0 +1,272 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/docker/distribution/reference"
+	"github.com/siderolabs/gen/slices"
+	"github.com/siderolabs/go-pointer"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+)
+
+// ImageCleanupInterval is the interval at which the image GC controller runs.
+const ImageCleanupInterval = 15 * time.Minute
+
+// ImageGCGracePeriod is the minimum age of an image before it can be deleted.
+const ImageGCGracePeriod = 4 * ImageCleanupInterval
+
+// CRIImageGCController renders manifests based on templates and config/secrets.
+type CRIImageGCController struct {
+	ImageServiceProvider func() (ImageServiceProvider, error)
+	Clock                clock.Clock
+}
+
+// ImageServiceProvider wraps the containerd image service.
+type ImageServiceProvider interface {
+	ImageService() images.Store
+	Close() error
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *CRIImageGCController) Name() string {
+	return "runtime.CRIImageGCController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *CRIImageGCController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: v1alpha1.NamespaceName,
+			Type:      v1alpha1.ServiceType,
+			ID:        pointer.To("cri"),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: k8s.NamespaceName,
+			Type:      k8s.KubeletSpecType,
+			ID:        pointer.To(k8s.KubeletID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: etcd.NamespaceName,
+			Type:      etcd.SpecType,
+			ID:        pointer.To(etcd.SpecID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *CRIImageGCController) Outputs() []controller.Output {
+	return nil
+}
+
+func defaultImageServiceProvider() (ImageServiceProvider, error) {
+	criClient, err := containerd.New(constants.CRIContainerdAddress)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CRI containerd client: %w", err)
+	}
+
+	return &containerdImageServiceProvider{
+		criClient: criClient,
+	}, nil
+}
+
+type containerdImageServiceProvider struct {
+	criClient *containerd.Client
+}
+
+func (s *containerdImageServiceProvider) ImageService() images.Store {
+	return s.criClient.ImageService()
+}
+
+func (s *containerdImageServiceProvider) Close() error {
+	return s.criClient.Close()
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo,cyclop
+func (ctrl *CRIImageGCController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if ctrl.ImageServiceProvider == nil {
+		ctrl.ImageServiceProvider = defaultImageServiceProvider
+	}
+
+	if ctrl.Clock == nil {
+		ctrl.Clock = clock.New()
+	}
+
+	var (
+		criIsUp              bool
+		expectedImages       []string
+		imageServiceProvider ImageServiceProvider
+	)
+
+	ticker := ctrl.Clock.Ticker(ImageCleanupInterval)
+	defer ticker.Stop()
+
+	defer func() {
+		if imageServiceProvider != nil {
+			imageServiceProvider.Close() //nolint:errcheck
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if !criIsUp || len(expectedImages) == 0 {
+				continue
+			}
+
+			if imageServiceProvider == nil {
+				var err error
+
+				imageServiceProvider, err = ctrl.ImageServiceProvider()
+				if err != nil {
+					return fmt.Errorf("error creating image service provider: %w", err)
+				}
+			}
+
+			if err := ctrl.cleanup(ctx, logger, imageServiceProvider.ImageService(), expectedImages); err != nil {
+				return fmt.Errorf("error running image cleanup: %w", err)
+			}
+		case <-r.EventCh():
+			criService, err := safe.ReaderGet[*v1alpha1.Service](ctx, r, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, "cri", resource.VersionUndefined))
+			if err != nil && !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting CRI service: %w", err)
+			}
+
+			criIsUp = criService != nil && criService.TypedSpec().Running && criService.TypedSpec().Healthy
+
+			expectedImages = nil
+
+			etcdSpec, err := safe.ReaderGet[*etcd.Spec](ctx, r, resource.NewMetadata(etcd.NamespaceName, etcd.SpecType, etcd.SpecID, resource.VersionUndefined))
+			if err != nil && !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting etcd spec: %w", err)
+			}
+
+			if etcdSpec != nil {
+				expectedImages = append(expectedImages, etcdSpec.TypedSpec().Image)
+			}
+
+			kubeletSpec, err := safe.ReaderGet[*k8s.KubeletSpec](ctx, r, resource.NewMetadata(k8s.NamespaceName, k8s.KubeletSpecType, k8s.KubeletID, resource.VersionUndefined))
+			if err != nil && !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting etcd spec: %w", err)
+			}
+
+			if kubeletSpec != nil {
+				expectedImages = append(expectedImages, kubeletSpec.TypedSpec().Image)
+			}
+		}
+
+		r.ResetRestartBackoff()
+	}
+}
+
+//nolint:gocyclo
+func (ctrl *CRIImageGCController) cleanup(ctx context.Context, logger *zap.Logger, imageService images.Store, expectedImages []string) error {
+	logger.Info("running image cleanup")
+
+	ctx = namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
+
+	actualImages, err := imageService.List(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing images: %w", err)
+	}
+
+	var parseErrors []error
+
+	expectedReferences := slices.Map(expectedImages, func(ref string) reference.Named {
+		res, parseErr := reference.ParseNamed(ref)
+
+		parseErrors = append(parseErrors, parseErr)
+
+		return res
+	})
+
+	if err = errors.Join(parseErrors...); err != nil {
+		return fmt.Errorf("error parsing expected images: %w", err)
+	}
+
+	for _, image := range actualImages {
+		imageRef, err := reference.ParseNamed(image.Name)
+		if err != nil {
+			logger.Info("failed to parse image name", zap.String("image", image.Name), zap.Error(err))
+
+			continue
+		}
+
+		shouldDelete := true
+
+		for _, expectedRef := range expectedReferences {
+			if imageRef.Name() != expectedRef.Name() {
+				continue
+			}
+
+			imageTagged, ok1 := imageRef.(reference.Tagged)
+			expectedTagged, ok2 := expectedRef.(reference.Tagged)
+
+			if ok1 && ok2 {
+				if imageTagged.Tag() == expectedTagged.Tag() {
+					shouldDelete = false
+
+					break
+				}
+			}
+
+			imageDigested, ok1 := imageRef.(reference.Digested)
+			expectedDigested, ok2 := expectedRef.(reference.Digested)
+
+			if ok1 && ok2 {
+				if imageDigested.Digest().Encoded() == expectedDigested.Digest().Encoded() {
+					shouldDelete = false
+
+					break
+				}
+			}
+		}
+
+		if !shouldDelete {
+			logger.Debug("image is referenced, skipping garbage collection", zap.String("image", image.Name))
+
+			continue
+		}
+
+		imageAge := ctrl.Clock.Since(image.CreatedAt)
+		if imageAge < ImageGCGracePeriod {
+			logger.Debug("skipping image cleanup, as it's below minimum age", zap.String("image", image.Name), zap.Duration("age", imageAge))
+
+			continue
+		}
+
+		if err = imageService.Delete(ctx, image.Name); err != nil {
+			return fmt.Errorf("failed to delete an image %s: %w", image.Name, err)
+		}
+
+		logger.Info("deleted an image", zap.String("image", image.Name))
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/controllers/runtime/cri_image_gc_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/cri_image_gc_test.go
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime_test
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/containerd/containerd/images"
+	"github.com/siderolabs/gen/slices"
+	"github.com/siderolabs/go-retry/retry"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
+	runtimectrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+)
+
+func TestCRIImageGC(t *testing.T) {
+	mockImageService := &mockImageService{}
+	fakeClock := clock.NewMock()
+
+	suite.Run(t, &CRIImageGCSuite{
+		mockImageService: mockImageService,
+		fakeClock:        fakeClock,
+		DefaultSuite: ctest.DefaultSuite{
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(&runtimectrl.CRIImageGCController{
+					ImageServiceProvider: func() (runtimectrl.ImageServiceProvider, error) {
+						return mockImageService, nil
+					},
+					Clock: fakeClock,
+				}))
+			},
+		},
+	})
+}
+
+type mockImageService struct {
+	mu sync.Mutex
+
+	images []images.Image
+}
+
+func (m *mockImageService) ImageService() images.Store {
+	return m
+}
+
+func (m *mockImageService) Close() error {
+	return nil
+}
+
+func (m *mockImageService) Get(ctx context.Context, name string) (images.Image, error) {
+	panic("not implemented")
+}
+
+func (m *mockImageService) List(ctx context.Context, filters ...string) ([]images.Image, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]images.Image(nil), m.images...), nil
+}
+
+func (m *mockImageService) Create(ctx context.Context, image images.Image) (images.Image, error) {
+	panic("not implemented")
+}
+
+func (m *mockImageService) Update(ctx context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
+	panic("not implemented")
+}
+
+func (m *mockImageService) Delete(ctx context.Context, name string, opts ...images.DeleteOpt) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.images = slices.FilterInPlace(m.images, func(i images.Image) bool { return i.Name != name })
+
+	return nil
+}
+
+type CRIImageGCSuite struct {
+	ctest.DefaultSuite
+
+	mockImageService *mockImageService
+	fakeClock        *clock.Mock
+}
+
+func (suite *CRIImageGCSuite) TestReconcile() {
+	storedImages := []images.Image{
+		{
+			Name:      "registry.io/org/image1:v1.3.5@sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a",
+			CreatedAt: suite.fakeClock.Now().Add(-2 * runtimectrl.ImageGCGracePeriod),
+		}, // ok to be gc'd
+		{
+			Name:      "registry.io/org/image1:v1.3.7",
+			CreatedAt: suite.fakeClock.Now().Add(-2 * runtimectrl.ImageGCGracePeriod),
+		}, // current image
+		{
+			Name:      "registry.io/org/image1:v1.3.8",
+			CreatedAt: suite.fakeClock.Now(),
+		}, // not ok to clean up, too new
+		{
+			Name:      "registry.io/org/image2@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8",
+			CreatedAt: suite.fakeClock.Now().Add(-2 * runtimectrl.ImageGCGracePeriod),
+		}, // current image
+	}
+
+	suite.mockImageService.images = storedImages
+
+	criService := v1alpha1.NewService("cri")
+	criService.TypedSpec().Healthy = true
+	criService.TypedSpec().Running = true
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), criService))
+
+	kubelet := k8s.NewKubeletSpec(k8s.NamespaceName, k8s.KubeletID)
+	kubelet.TypedSpec().Image = "registry.io/org/image1:v1.3.7"
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), kubelet))
+
+	etcd := etcd.NewSpec(etcd.NamespaceName, etcd.SpecID)
+	etcd.TypedSpec().Image = "registry.io/org/image2@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8"
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), etcd))
+
+	expectedImages := slices.Map(storedImages[1:4], func(i images.Image) string { return i.Name })
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(func() error {
+		suite.fakeClock.Add(runtimectrl.ImageCleanupInterval)
+
+		imageList, _ := suite.mockImageService.List(suite.Ctx()) //nolint:errcheck
+		actualImages := slices.Map(imageList, func(i images.Image) string { return i.Name })
+
+		if reflect.DeepEqual(expectedImages, actualImages) {
+			return nil
+		}
+
+		return retry.ExpectedErrorf("images don't match: expected %v actual %v", expectedImages, actualImages)
+	}))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -212,6 +212,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&network.TimeServerMergeController{},
 		&network.TimeServerSpecController{},
 		&perf.StatsController{},
+		&runtimecontrollers.CRIImageGCController{},
 		&runtimecontrollers.EventsSinkController{
 			V1Alpha1Events: ctrl.v1alpha1Runtime.Events(),
 			Cmdline:        procfs.ProcCmdline(),


### PR DESCRIPTION
Fixes #7121

Talos pulls some images on its own (without CRI/kubelet) to the `system` namespace of the CRI containerd. These images are not visible to the CRI/kubelet, so we need to clean them up manually.

