### PR TITLE
docs: Added information about KubeSpan ports and topology.

### DIFF
--- a/website/content/v1.5/talos-guides/discovery.md
+++ b/website/content/v1.5/talos-guides/discovery.md
@@ -42,9 +42,9 @@ cluster:
         disabled: true
 ```
 
-Disabling all registries effectively disables member discovery altogether.
+Disabling all registries effectively disables member discovery.
 
-> An enabled discovery service is required for [KubeSpan]({{< relref "../kubernetes-guides/network/kubespan/" >}}) to function correctly.
+> Note: An enabled discovery service is required for [KubeSpan]({{< relref "../talos-guides/network/kubespan/" >}}) to function correctly.
 
 The `Kubernetes` registry uses Kubernetes `Node` resource data and additional Talos annotations:
 
@@ -83,7 +83,7 @@ In order for nodes to communicate to the discovery service, they must be able to
 
 ## Resource Definitions
 
-Talos provides seven resources that can be used to introspect the new discovery and KubeSpan features.
+Talos provides resources that can be used to introspect the discovery and KubeSpan features.
 
 ### Discovery
 
@@ -107,7 +107,7 @@ Node identity is preserved across reboots and upgrades, but it is regenerated if
 
 #### Affiliates
 
-An affiliate is a proposed member attributed to the fact that the node has the same cluster ID and secret.
+An affiliate is a proposed member: the node has the same cluster ID and secret.
 
 ```sh
 $ talosctl get affiliates


### PR DESCRIPTION
# Pull Request
Update KubeSpan Docs
<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Closes #5234

Adds documentation around KubeSpan ports and supported topologies.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
