### PR TITLE
fix: Update Dockerfile to include TARGETARCH in installer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -707,6 +707,8 @@ LABEL org.opencontainers.image.source https://github.com/siderolabs/talos
 ENTRYPOINT ["/bin/installer"]
 
 FROM installer-image-squashed AS installer
+ARG TARGETARCH
+ENV TARGETARCH ${TARGETARCH}
 ONBUILD RUN apk add --no-cache --update \
     cpio \
     squashfs-tools \


### PR DESCRIPTION
Fixes https://github.com/siderolabs/pkgs/issues/717
Fixes #7155

# Pull Request

## What? (description)

Adds back in the required TARGETARCH for installer so extensions can be built off installer again.

## Why? (reasoning)

nvidia extension build breaking. 

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

