### PR TITLE
fix: typos inteface -> interface (docs and tests) 

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_status_test.go
@@ -287,7 +287,7 @@ func (suite *LinkStatusSuite) TestDummyInterface() {
 }
 
 func (suite *LinkStatusSuite) TestBridgeInterface() {
-	bridgeInteface := suite.uniqueDummyInterface()
+	bridgeInterface := suite.uniqueDummyInterface()
 
 	conn, err := rtnetlink.Dial(nil)
 	suite.Require().NoError(err)
@@ -302,7 +302,7 @@ func (suite *LinkStatusSuite) TestBridgeInterface() {
 			&rtnetlink.LinkMessage{
 				Type: unix.ARPHRD_ETHER,
 				Attributes: &rtnetlink.LinkAttributes{
-					Name: bridgeInteface,
+					Name: bridgeInterface,
 					Info: &rtnetlink.LinkInfo{
 						Kind: "bridge",
 						Data: bridgeData,
@@ -312,7 +312,7 @@ func (suite *LinkStatusSuite) TestBridgeInterface() {
 		),
 	)
 
-	bridgeIface, err := net.InterfaceByName(bridgeInteface)
+	bridgeIface, err := net.InterfaceByName(bridgeInterface)
 	suite.Require().NoError(err)
 
 	defer conn.Link.Delete(uint32(bridgeIface.Index)) //nolint:errcheck
@@ -321,7 +321,7 @@ func (suite *LinkStatusSuite) TestBridgeInterface() {
 		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			func() error {
 				return suite.assertInterfaces(
-					[]string{bridgeInteface}, func(r *network.LinkStatus) error {
+					[]string{bridgeInterface}, func(r *network.LinkStatus) error {
 						suite.Assert().Equal("ether", r.TypedSpec().Type.String())
 						suite.Assert().True(r.TypedSpec().BridgeMaster.STP.Enabled)
 

--- a/website/content/v1.2/talos-guides/configuration/patching.md
+++ b/website/content/v1.2/talos-guides/configuration/patching.md
@@ -80,7 +80,7 @@ Base machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24
@@ -122,7 +122,7 @@ Patched machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24

--- a/website/content/v1.3/talos-guides/configuration/patching.md
+++ b/website/content/v1.3/talos-guides/configuration/patching.md
@@ -80,7 +80,7 @@ Base machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24
@@ -122,7 +122,7 @@ Patched machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24

--- a/website/content/v1.4/talos-guides/configuration/patching.md
+++ b/website/content/v1.4/talos-guides/configuration/patching.md
@@ -81,7 +81,7 @@ Base machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24
@@ -123,7 +123,7 @@ Patched machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24

--- a/website/content/v1.4/talos-guides/network/device-selector.md
+++ b/website/content/v1.4/talos-guides/network/device-selector.md
@@ -47,7 +47,7 @@ Device selectors can be used to configure bonded interfaces:
 machine:
   ...
   network:
-    intefaces:
+    interfaces:
       - interface: bond0
         bond:
           mode: balance-rr

--- a/website/content/v1.5/talos-guides/configuration/patching.md
+++ b/website/content/v1.5/talos-guides/configuration/patching.md
@@ -81,7 +81,7 @@ Base machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24
@@ -123,7 +123,7 @@ Patched machine configuration:
 machine:
   network:
     interfaces:
-      - inteface: eth0
+      - interface: eth0
         dhcp: false
         addresses:
           - 192.168.10.3/24

--- a/website/content/v1.5/talos-guides/network/device-selector.md
+++ b/website/content/v1.5/talos-guides/network/device-selector.md
@@ -47,7 +47,7 @@ Device selectors can be used to configure bonded interfaces:
 machine:
   ...
   network:
-    intefaces:
+    interfaces:
       - interface: bond0
         bond:
           mode: balance-rr


### PR DESCRIPTION
# Pull Request


## What? (description)
Fixing typo in the documentation and tests

Fixes #7157

## Why? (reasoning)


## Acceptance

I did not run the`make conformance`, looks like there is no docker image available for arm64/v8
```
Unable to find image 'ghcr.io/siderolabs/conform:latest' locally
latest: Pulling from siderolabs/conform
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
```

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
