### PR TITLE
fix: set the static pod priority as values

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -31,6 +31,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 )
 
+// systemCriticalPriority is copied from scheduling.SystemCriticalPriority in Kubernetes internals.
+const systemCriticalPriority int32 = 2000000000
+
 // ControlPlaneStaticPodController manages k8s.StaticPod based on control plane configuration.
 type ControlPlaneStaticPodController struct{}
 
@@ -387,6 +390,7 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 				},
 			},
 			Spec: v1.PodSpec{
+				Priority:          pointer.To(systemCriticalPriority),
 				PriorityClassName: "system-cluster-critical",
 				Containers: []v1.Container{
 					{
@@ -555,6 +559,7 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 				},
 			},
 			Spec: v1.PodSpec{
+				Priority:          pointer.To(systemCriticalPriority),
 				PriorityClassName: "system-cluster-critical",
 				Containers: []v1.Container{
 					{
@@ -688,6 +693,7 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 				},
 			},
 			Spec: v1.PodSpec{
+				Priority:          pointer.To(systemCriticalPriority),
 				PriorityClassName: "system-cluster-critical",
 				Containers: []v1.Container{
 					{

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
@@ -158,6 +158,8 @@ func (ctrl *StaticPodServerController) createServer(ctx context.Context, r contr
 		staticPodList := ctrl.podList
 		ctrl.podListMu.Unlock()
 
+		logger.Debug("serving static pod manifests", zap.Int("size", len(staticPodList)))
+
 		if staticPodList == nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 

--- a/internal/app/machined/pkg/controllers/runtime/cri_image_gc.go
+++ b/internal/app/machined/pkg/controllers/runtime/cri_image_gc.go
@@ -187,7 +187,7 @@ func (ctrl *CRIImageGCController) Run(ctx context.Context, r controller.Runtime,
 
 //nolint:gocyclo
 func (ctrl *CRIImageGCController) cleanup(ctx context.Context, logger *zap.Logger, imageService images.Store, expectedImages []string) error {
-	logger.Info("running image cleanup")
+	logger.Debug("running image cleanup")
 
 	ctx = namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
 
@@ -213,7 +213,7 @@ func (ctrl *CRIImageGCController) cleanup(ctx context.Context, logger *zap.Logge
 	for _, image := range actualImages {
 		imageRef, err := reference.ParseNamed(image.Name)
 		if err != nil {
-			logger.Info("failed to parse image name", zap.String("image", image.Name), zap.Error(err))
+			logger.Error("failed to parse image name", zap.String("image", image.Name), zap.Error(err))
 
 			continue
 		}


### PR DESCRIPTION
API server takes care of setting priority for "regular" pods from priorityClassName, but nothing does that for static pods, so we have to specify the priotity explicitly for static pods.

This fixes the graceful node shutdown (kubelet) to stop non-critical pods before the api-server and friends (critical pods).

Also some logging fixes.
