### PR TITLE
fix: inhibit timer to follow kubelet timer

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1604,7 +1604,7 @@ func stopAndRemoveAllPods(stopAction cri.StopAction) runtime.TaskExecutionFunc {
 
 		logger.Printf("shutting down kubelet gracefully")
 
-		shutdownCtx, shutdownCtxCancel := context.WithTimeout(ctx, constants.KubeletShutdownGracePeriod*2)
+		shutdownCtx, shutdownCtxCancel := context.WithTimeout(ctx, constants.KubeletShutdownGracePeriod*40)
 		defer shutdownCtxCancel()
 
 		if err = r.State().Machine().DBus().WaitShutdown(shutdownCtx); err != nil {


### PR DESCRIPTION
ensure to wait as long as possibly given to kubelet shutdown timers. Related to fix of siderolabs#7138

