### PR TITLE
fix: inhibit timer to follow kubelet timer

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -58,6 +58,7 @@ import (
 	"github.com/siderolabs/talos/internal/pkg/environment"
 	"github.com/siderolabs/talos/internal/pkg/etcd"
 	"github.com/siderolabs/talos/internal/pkg/install"
+	"github.com/siderolabs/talos/internal/pkg/logind"
 	"github.com/siderolabs/talos/internal/pkg/meta"
 	"github.com/siderolabs/talos/internal/pkg/mount"
 	"github.com/siderolabs/talos/internal/pkg/partition"
@@ -1604,7 +1605,7 @@ func stopAndRemoveAllPods(stopAction cri.StopAction) runtime.TaskExecutionFunc {
 
 		logger.Printf("shutting down kubelet gracefully")
 
-		shutdownCtx, shutdownCtxCancel := context.WithTimeout(ctx, constants.KubeletShutdownGracePeriod*2)
+		shutdownCtx, shutdownCtxCancel := context.WithTimeout(ctx, logind.InhibitMaxDelay)
 		defer shutdownCtxCancel()
 
 		if err = r.State().Machine().DBus().WaitShutdown(shutdownCtx); err != nil {

--- a/internal/pkg/logind/logind.go
+++ b/internal/pkg/logind/logind.go
@@ -20,9 +20,10 @@ const (
 	logindService   = "org.freedesktop.login1"
 	logindObject    = dbus.ObjectPath("/org/freedesktop/login1")
 	logindInterface = "org.freedesktop.login1.Manager"
-
-	inhibitMaxDelay = 40 * constants.KubeletShutdownGracePeriod
 )
+
+// InhibitMaxDelay is the maximum delay for graceful shutdown.
+const InhibitMaxDelay = 40 * constants.KubeletShutdownGracePeriod
 
 type logindMock struct {
 	mu          sync.Mutex
@@ -32,7 +33,7 @@ type logindMock struct {
 var logindProps = map[string]map[string]*prop.Prop{
 	logindInterface: {
 		"InhibitDelayMaxUSec": {
-			Value:    uint64(inhibitMaxDelay / time.Microsecond),
+			Value:    uint64(InhibitMaxDelay / time.Microsecond),
 			Writable: false,
 		},
 	},


### PR DESCRIPTION
Ensure to wait as long as possibly given to kubelet shutdown timers. Related to fix of siderolabs#7138
