### PR TITLE
fix: enforce nolock option for all NFS mounts by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -495,6 +495,7 @@ RUN cleanup.sh /rootfs
 RUN mkdir -pv /rootfs/{boot,etc/cri/conf.d/hosts,lib/firmware,usr/local/share,usr/share/zoneinfo/Etc,mnt,system,opt}
 COPY --chmod=0644 hack/zoneinfo/Etc/UTC /rootfs/usr/share/zoneinfo/Etc/UTC
 RUN ln -s /usr/share/zoneinfo/Etc/UTC /rootfs/etc/localtime
+COPY --chmod=0644 hack/nfsmount.conf /rootfs/etc/nfsmount.conf
 RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
 RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}
 COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml
@@ -547,6 +548,7 @@ RUN cleanup.sh /rootfs
 RUN mkdir -pv /rootfs/{boot,etc/cri/conf.d/hosts,lib/firmware,usr/local/share,usr/share/zoneinfo/Etc,mnt,system,opt}
 COPY --chmod=0644 hack/zoneinfo/Etc/UTC /rootfs/usr/share/zoneinfo/Etc/UTC
 RUN ln -s /usr/share/zoneinfo/Etc/UTC /rootfs/etc/localtime
+COPY --chmod=0644 hack/nfsmount.conf /rootfs/etc/nfsmount.conf
 RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
 RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}
 COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml

--- a/hack/nfsmount.conf
+++ b/hack/nfsmount.conf
@@ -1,0 +1,2 @@
+[ NFSMount_Global_Options ]
+    nolock=true

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -119,6 +119,7 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: constants.CgroupMountPath, Source: constants.CgroupMountPath, Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/lib/modules", Source: "/lib/modules", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"bind", "rshared", "rw"}},
+		{Type: "bind", Destination: "/etc/nfsmount.conf", Source: "/etc/nfsmount.conf", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/machine-id", Source: "/etc/machine-id", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/os-release", Source: "/etc/os-release", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/cni", Source: "/etc/cni", Options: []string{"rbind", "rshared", "rw"}},


### PR DESCRIPTION
Talos doesn't have `rpc.statsd` running, so mounting without locking is the only option. Some places in Kubernetes don't allow to set mount options for NFS, so setting defaults is the only way.

Fixes #6582
