### PR TITLE
fix: set rlimit explicitly in wrapperd

### DIFF
--- a/internal/app/wrapperd/main.go
+++ b/internal/app/wrapperd/main.go
@@ -50,6 +50,13 @@ func Main() {
 		}
 	}
 
+	// set the rlimit for the process before we drop privileges
+	// TODO: frezbo: see if we need to drop Rlimit from the boot sequence, the only downside maybe that some very early process might
+	// not have the higher rlimit set, but it seems we always use the wrapper to start processes.
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{Max: 1048576, Cur: 1048576}); err != nil {
+		log.Fatalf("failed to set rlimit: %v", err)
+	}
+
 	// load the cgroup and put the process into the cgroup
 	if cgroupPath != "" {
 		if cgroups.Mode() == cgroups.Unified {


### PR DESCRIPTION
Now Go only sets the rlimit for the parent and any fork/exec'ed process gets the rlimit that was the default before fork/exec. Ref: https://github.com/golang/go/issues/46279

This fix got backported to [Go 1.20.4](https://github.com/golang/go/commit/ecf7e00db8b8f5fff622f232bd8c515814c2ecc6) breaking Talos. Talos used to set rlimit in the [`SetRLimit`](https://github.com/siderolabs/talos/blob/v1.4.2/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go#L302) sequencer task. This means any process started by `wrapperd` gets the default Rlimit (1024). Fix this by explicitly setting `rlimit` in `wrapperd` before we drop any capabilities.

Fixes: #7198