### PR TITLE
chore: update default image sizes to 10GB for all "cloud" images

### DIFF
--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -61,9 +61,7 @@ func runImageCmd() (err error) {
 
 	log.Printf("creating image for %s", p.Name())
 
-	log.Print("creating RAW disk")
-
-	img, err := pkg.CreateRawDisk()
+	img, err := pkg.CreateRawDisk(p, options.DiskSize)
 	if err != nil {
 		return err
 	}

--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -64,6 +64,7 @@ var options = &install.Options{}
 func init() {
 	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
 	rootCmd.PersistentFlags().StringVar(&options.Disk, "disk", "", "The path to the disk to install to")
+	rootCmd.PersistentFlags().IntVar(&options.DiskSize, "disk-size", 0, "The size of the disk to install to in MB")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringVar(&options.Arch, "arch", runtime.GOARCH, "The target architecture")
 	rootCmd.PersistentFlags().StringVar(&options.Board, "board", constants.BoardNone, "The value of "+constants.KernelParamBoard)

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -28,6 +28,7 @@ import (
 type Options struct {
 	ConfigSource      string
 	Disk              string
+	DiskSize          int
 	Platform          string
 	Arch              string
 	Board             string

--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -160,7 +160,7 @@ func CreateOVAFromRAW(name, src, out, arch string) (err error) {
 
 	size := f.Size()
 
-	ovf, err := renderOVF(name, size, pkg.RAWDiskSize)
+	ovf, err := renderOVF(name, size, pkg.DefaultRAWDiskSize)
 	if err != nil {
 		return err
 	}

--- a/cmd/installer/pkg/raw.go
+++ b/cmd/installer/pkg/raw.go
@@ -6,20 +6,44 @@ package pkg
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/siderolabs/go-cmd/pkg/cmd"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 )
 
 const (
-	// RAWDiskSize is the minimum size disk we can create.
-	RAWDiskSize = 1246
+	// MinRAWDiskSize is the minimum size disk we can create. Used for metal images.
+	MinRAWDiskSize = 1246
+
+	// DefaultRAWDiskSize is the value we use for any non-metal images by default.
+	DefaultRAWDiskSize = 10240
 )
 
 // CreateRawDisk creates a raw disk by invoking the `dd` command.
-func CreateRawDisk() (img string, err error) {
+func CreateRawDisk(p runtime.Platform, diskSize int) (img string, err error) {
 	img = "/tmp/disk.raw"
 
-	seek := fmt.Sprintf("seek=%d", RAWDiskSize)
+	// In the case that no disk size is specified, determine if we should use the min size (metal images)
+	// or the default for all other images.
+	if diskSize == 0 {
+		if p.Name() == "metal" {
+			diskSize = MinRAWDiskSize
+		} else {
+			diskSize = DefaultRAWDiskSize
+		}
+	}
+
+	// Protect against users creating a disk that's too small
+	if diskSize < MinRAWDiskSize {
+		log.Printf("specified disk size too small, using minimum value of %d MB", MinRAWDiskSize)
+		diskSize = MinRAWDiskSize
+	}
+
+	log.Printf("creating raw disk of size %d MB", diskSize)
+
+	seek := fmt.Sprintf("seek=%d", diskSize)
 
 	if _, err = cmd.Run("dd", "if=/dev/zero", "of="+img, "bs=1M", "count=0", seek); err != nil {
 		return "", fmt.Errorf("failed to create RAW disk: %w", err)


### PR DESCRIPTION
This PR adds a flag to imager that allows for tweaking the size of the created disk. Additionally, it sets the default value of that created disk to 10GB, as most images are cloud images that fail when uploaded b/c it only picks up a 1GB disk currently. Also adds some conditionals to the makefile to make sure we set the default small value for metal images and SBCs.