### PR TITLE
fix: correct upgrade Talos version check

### DIFF
--- a/cmd/installer/pkg/install/preflight.go
+++ b/cmd/installer/pkg/install/preflight.go
@@ -109,7 +109,7 @@ func (checks *PreflightChecks) talosVersion(ctx context.Context) error {
 		return fmt.Errorf("error parsing installer Talos version: %w", err)
 	}
 
-	return checks.hostTalosVersion.UpgradeableFrom(checks.installerTalosVersion)
+	return checks.installerTalosVersion.UpgradeableFrom(checks.hostTalosVersion)
 }
 
 type k8sVersions struct {


### PR DESCRIPTION
This was discovered during 1.5.0-alpha.0 release, backporting it to release-1.4.
