### PR TITLE
fix: race with `udevd` and `mountUserDisks`

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1037,7 +1037,7 @@ func partitionAndFormatDisks(logger *log.Logger, r runtime.Runtime) error {
 		disk := disk
 
 		if err := func() error {
-			bd, err := blockdevice.Open(disk.Device())
+			bd, err := blockdevice.Open(disk.Device(), blockdevice.WithMode(blockdevice.ReadonlyMode))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #7246

The problem was that `udevd` watches via `inotify` any attempts to open blockdevices with 'write' access.

Talos was opening with write access, but actually accessing as read-only, so the fix is to open as read-only.
