### PR TITLE
chore: use 8GiB instead of 10GiB for cloud images

### DIFF
--- a/cmd/installer/pkg/raw.go
+++ b/cmd/installer/pkg/raw.go
@@ -18,7 +18,7 @@ const (
 	MinRAWDiskSize = 1246
 
 	// DefaultRAWDiskSize is the value we use for any non-metal images by default.
-	DefaultRAWDiskSize = 10240
+	DefaultRAWDiskSize = 8192
 )
 
 // CreateRawDisk creates a raw disk by invoking the `dd` command.


### PR DESCRIPTION
This PR changes the default disk size for cloud images to be 8GiB instead. This was prompted b/c the disk price in azure between tiers is doubled and the cutoff for the tier is 8GiB.
