### PR TITLE
fix: fall back to external IP when discovering nodes in upgrade-k8s

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -126,6 +126,8 @@ func upgradeKubeProxy(ctx context.Context, cluster UpgradeProvider, options Upgr
 	options.Log("updating kube-proxy to version %q", options.Path.ToVersion())
 
 	for _, node := range options.controlPlaneNodes {
+		options.Log(" > %q: starting update", node)
+
 		if err := patchNodeConfig(ctx, cluster, node, patchKubeProxy(options)); err != nil {
 			return fmt.Errorf("error updating node %q: %w", node, err)
 		}
@@ -136,6 +138,12 @@ func upgradeKubeProxy(ctx context.Context, cluster UpgradeProvider, options Upgr
 
 func patchKubeProxy(options UpgradeOptions) func(config *v1alpha1config.Config) error {
 	return func(config *v1alpha1config.Config) error {
+		if options.DryRun {
+			options.Log(" > skipped in dry-run")
+
+			return nil
+		}
+
 		if config.ClusterConfig == nil {
 			config.ClusterConfig = &v1alpha1config.ClusterConfig{}
 		}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -171,8 +171,18 @@ func (h *Client) NodeIPs(ctx context.Context, machineType machine.Type) (addrs [
 			continue
 		}
 
+		// try to get the internal IP address
 		for _, nodeAddress := range node.Status.Addresses {
 			if nodeAddress.Type == corev1.NodeInternalIP {
+				addrs = append(addrs, nodeAddress.Address)
+
+				break
+			}
+		}
+
+		// no internal IP, fallback to external IP
+		for _, nodeAddress := range node.Status.Addresses {
+			if nodeAddress.Type == corev1.NodeExternalIP {
 				addrs = append(addrs, nodeAddress.Address)
 
 				break


### PR DESCRIPTION
Fixes #7253

Also fix the case that `kube-proxy` version was updated in the machine config in `--dry-run` mode.
