### PR TITLE
chore: faster dev cycle

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -193,7 +193,7 @@ local Pipeline(name, steps=[], depends_on=[], with_docker=true, disable_clone=fa
 
 local generate = Step('generate', target='generate docs', depends_on=[setup_ci]);
 local check_dirty = Step('check-dirty', depends_on=[generate]);
-local build = Step('build', target='talosctl-linux talosctl-darwin talosctl-freebsd talosctl-windows kernel initramfs installer imager talos _out/integration-test-linux-amd64', depends_on=[check_dirty], environment={ IMAGE_REGISTRY: local_registry, PUSH: true });
+local build = Step('build', target='talosctl-all kernel initramfs installer imager talos _out/integration-test-linux-amd64', depends_on=[check_dirty], environment={ IMAGE_REGISTRY: local_registry, PUSH: true });
 local lint = Step('lint', depends_on=[build]);
 local talosctl_cni_bundle = Step('talosctl-cni-bundle', depends_on=[build, lint]);
 local iso = Step('iso', target='iso', depends_on=[build], environment={ IMAGE_REGISTRY: local_registry });

--- a/Makefile
+++ b/Makefile
@@ -260,10 +260,32 @@ talos: ## Builds the Talos container image and outputs it to the registry.
 talosctl-image: ## Builds the talosctl container image and outputs it to the registry.
 	@$(MAKE) registry-talosctl TARGET_ARGS="--allow security.insecure"
 
-talosctl-%:
-	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PLATFORM=linux/amd64 PUSH=false NAME=Client
+talosctl-all:
+	@$(MAKE) local-talosctl-all DEST=$(ARTIFACTS) PUSH=false NAME=Client
 
-talosctl: $(TALOSCTL_DEFAULT_TARGET) ## Builds the talosctl binary for the local machine.
+talosctl-linux-amd64:
+	@$(MAKE) local-talosctl-linux-amd64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl-linux-arm64:
+	@$(MAKE) local-talosctl-linux-arm64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl-darwin-amd64:
+	@$(MAKE) local-talosctl-darwin-amd64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl-darwin-arm64:
+	@$(MAKE) local-talosctl-darwin-arm64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl-freebsd-amd64:
+	@$(MAKE) local-talosctl-freebsd-amd64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+taloscl-freebsd-arm64:
+	@$(MAKE) local-talosctl-freebsd-arm64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl-windows-amd64:
+	@$(MAKE) local-talosctl-windows-amd64 DEST=$(ARTIFACTS) PUSH=false NAME=Client
+
+talosctl:
+	@$(MAKE) local-talosctl-platform DEST=$(ARTIFACTS)
 
 image-%: ## Builds the specified image. Valid options are aws, azure, digital-ocean, gcp, and vmware (e.g. image-aws)
 	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG)


### PR DESCRIPTION
This cleans up `Dockerfile` and `Makefile` targets to be in similar parity with `kres` auto-generated targets.

Now `make talosctl` would only build the one for the specific local machine making development easier. Also added a `iso` docker target that builds iso for local development without having to push and pull the imager. (`make local-iso DEST=_out`)
