### PR TITLE
chore: registry.k8s.io for coredns image

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -325,11 +325,11 @@ const (
 	KubernetesSchedulerImage = "registry.k8s.io/kube-scheduler"
 
 	// CoreDNSImage is the enforced CoreDNS image to use.
-	CoreDNSImage = "docker.io/coredns/coredns"
+	CoreDNSImage = "registry.k8s.io/coredns/coredns"
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
 	// renovate: datasource=github-releases depName=coredns/coredns
-	DefaultCoreDNSVersion = "1.10.1"
+	DefaultCoreDNSVersion = "v1.10.1"
 
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"

--- a/website/content/v1.5/reference/configuration.md
+++ b/website/content/v1.5/reference/configuration.md
@@ -611,7 +611,7 @@ etcd:
 {{< /highlight >}}</details> | |
 |`coreDNS` |<a href="#coredns">CoreDNS</a> |Core DNS specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 coreDNS:
-    image: docker.io/coredns/coredns:1.10.1 # The `image` field is an override to the default coredns image.
+    image: registry.k8s.io/coredns/coredns:v1.10.1 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}</details> | |
 |`externalCloudProvider` |<a href="#externalcloudproviderconfig">ExternalCloudProviderConfig</a> |External cloud provider configuration. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 externalCloudProvider:
@@ -1319,7 +1319,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: docker.io/coredns/coredns:1.10.1 # The `image` field is an override to the default coredns image.
+image: registry.k8s.io/coredns/coredns:v1.10.1 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}
 
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Replace docker.io with registry.k8s.io for the coredns image.

## Why? (reasoning)

registry.k8s.io is the official kubernetes registry. Dockerhub has a pull limit for unauthenticated image pulls and this can cause outages if you spend your entire quota.

For these reasons I think registry.k8s.io is a better default for most Talos users.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
