### PR TITLE
feat: link support matrix in k8s update doc

### DIFF
--- a/website/content/v1.4/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.4/kubernetes-guides/upgrading-kubernetes.md
@@ -6,6 +6,9 @@ aliases:
 ---
 
 This guide covers upgrading Kubernetes on Talos Linux clusters.
+
+For a list of Kubernetes versions compatible with each Talos release, see the [Support Matrix]({{< relref "../introduction/support-matrix" >}}).
+
 For upgrading the Talos Linux operating system, see [Upgrading Talos]({{< relref "../talos-guides/upgrading-talos" >}})
 
 ## Video Walkthrough

--- a/website/content/v1.5/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.5/kubernetes-guides/upgrading-kubernetes.md
@@ -6,6 +6,9 @@ aliases:
 ---
 
 This guide covers upgrading Kubernetes on Talos Linux clusters.
+
+For a list of Kubernetes versions compatible with each Talos release, see the [Support Matrix]({{< relref "../introduction/support-matrix" >}}).
+
 For upgrading the Talos Linux operating system, see [Upgrading Talos]({{< relref "../talos-guides/upgrading-talos" >}})
 
 ## Video Walkthrough


### PR DESCRIPTION
# Pull Request

## What? (description)

Add a link to the support matrix page in the upgrading Kubernetes guide.

## Why? (reasoning)

I was working on my Talos update procedure, and it wasn't immediately obvious to me how I should upgrade K8S. I [opened a discussion to ask](https://github.com/siderolabs/talos/discussions/7242#discussioncomment-5942386). I think this small change will make it easier for others.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
