### PR TITLE
fix: fail quickly if upgrade-k8s is used with multiple nodes

### DIFF
--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -46,6 +46,10 @@ func init() {
 }
 
 func upgradeKubernetes(ctx context.Context, c *client.Client) error {
+	if err := helpers.FailIfMultiNodes(ctx, "upgrade-k8s"); err != nil {
+		return err
+	}
+
 	if err := helpers.ClientVersionCheck(ctx, c); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #7283
