### PR TITLE
chore: optimize image generation time

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -133,7 +133,6 @@ local setup_ci = {
 
   commands: [
     'setup-ci',
-    'make external-artifacts',
   ],
   environment: {
     BUILDKIT_FLAVOR: 'cross',
@@ -191,8 +190,9 @@ local Pipeline(name, steps=[], depends_on=[], with_docker=true, disable_clone=fa
 
 // Default pipeline.
 
+local external_artifacts = Step('external-artifacts', depends_on=[setup_ci]);
 local generate = Step('generate', target='generate docs', depends_on=[setup_ci]);
-local check_dirty = Step('check-dirty', depends_on=[generate]);
+local check_dirty = Step('check-dirty', depends_on=[generate, external_artifacts]);
 local build = Step('build', target='talosctl-all kernel initramfs installer imager talos _out/integration-test-linux-amd64', depends_on=[check_dirty], environment={ IMAGE_REGISTRY: local_registry, PUSH: true });
 local lint = Step('lint', depends_on=[build]);
 local talosctl_cni_bundle = Step('talosctl-cni-bundle', depends_on=[build, lint]);
@@ -355,6 +355,7 @@ local extensions_patch_manifest = {
 
 local default_steps = [
   setup_ci,
+  external_artifacts,
   generate,
   check_dirty,
   build,

--- a/Dockerfile
+++ b/Dockerfile
@@ -721,8 +721,10 @@ RUN apk add --no-cache --update --no-scripts \
     efibootmgr \
     kmod \
     mtools \
+    pigz \
     qemu-img \
     squashfs-tools \
+    tar \
     util-linux \
     xfsprogs \
     xorriso \

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -271,7 +271,7 @@ func finalize(platform runtime.Platform, img, arch string) (err error) {
 }
 
 func tar(filename, src, dir string) error {
-	if _, err := cmd.Run("tar", "-czvf", filepath.Join(outputArg, filename), src, "-C", dir); err != nil {
+	if _, err := cmd.Run("tar", "-cvf", filepath.Join(outputArg, filename), "-C", dir, "--sparse", "--use-compress-program=pigz -6", src); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use `pigz` and `--sparse` to handle more efficiently compression of the assets.

Also move tasks out of `setup-ci` step, as it runs always, including for the promoted pipelines.
