### PR TITLE
fix: do not probe kernel args in dashboard if not needed

### DIFF
--- a/internal/pkg/dashboard/configurl.go
+++ b/internal/pkg/dashboard/configurl.go
@@ -119,7 +119,13 @@ func NewConfigURLGrid(ctx context.Context, dashboard *Dashboard) *ConfigURLGrid 
 	return grid
 }
 
-func (widget *ConfigURLGrid) readTemplateFromKernelArgs() string {
+func (widget *ConfigURLGrid) readTemplateFromKernelArgs() (val string) {
+	defer func() { // catch potential panic from procfs.ProcCmdline()
+		if r := recover(); r != nil {
+			val = "error reading kernel args"
+		}
+	}()
+
 	option := procfs.ProcCmdline().Get(constants.KernelParamConfig).First()
 	if option == nil {
 		return unset


### PR DESCRIPTION
If the dashboard is run without the "Config URL" screen, do not initialize it, and do not probe the kernel args for the code parameter.

Refactor the dashboard to do not construct the unused screens at all.

Closes siderolabs/talos#7300.
