### PR TITLE
feat: add network chaos to qemu development environment

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -80,6 +80,14 @@ case "${DISABLE_DHCP_HOSTNAME:-false}" in
     ;;
 esac
 
+case "${WITH_NETWORK_CHAOS:-false}" in
+  false)
+    ;;
+  *)
+    QEMU_FLAGS="${QEMU_FLAGS} --with-network-chaos --with-network-packet-loss=0.01 --with-network-latency=15ms --with-network-jitter=5ms"
+    ;;
+esac
+
 case "${USE_DISK_IMAGE:-false}" in
   false)
     DISK_IMAGE_FLAG=

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -54,8 +54,8 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 
 	fmt.Fprintln(out, "waiting for API")
 
-	err = retry.Constant(5*time.Minute, retry.WithUnits(500*time.Millisecond)).RetryWithContext(nodeCtx, func(nodeCtx context.Context) error {
-		retryCtx, cancel := context.WithTimeout(nodeCtx, 500*time.Millisecond)
+	err = retry.Constant(10*time.Minute, retry.WithUnits(500*time.Millisecond)).RetryWithContext(nodeCtx, func(nodeCtx context.Context) error {
+		retryCtx, cancel := context.WithTimeout(nodeCtx, 2*time.Second)
 		defer cancel()
 
 		if _, err = cli.Version(retryCtx); err != nil {
@@ -72,7 +72,7 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 	fmt.Fprintln(out, "bootstrapping cluster")
 
 	return retry.Constant(backoff.DefaultConfig.MaxDelay, retry.WithUnits(100*time.Millisecond)).RetryWithContext(nodeCtx, func(nodeCtx context.Context) error {
-		retryCtx, cancel := context.WithTimeout(nodeCtx, 500*time.Millisecond)
+		retryCtx, cancel := context.WithTimeout(nodeCtx, 2*time.Second)
 		defer cancel()
 
 		if err = cli.Bootstrap(retryCtx, &machineapi.BootstrapRequest{}); err != nil {

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -49,7 +49,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating network", request.Network.Name)
 
-	if err = p.CreateNetwork(ctx, state, request.Network); err != nil {
+	if err = p.CreateNetwork(ctx, state, request.Network, options); err != nil {
 		return nil, fmt.Errorf("unable to provision CNI network: %w", err)
 	}
 

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -7,6 +7,7 @@ package provision
 import (
 	"fmt"
 	"net/netip"
+	"time"
 
 	"github.com/siderolabs/go-procfs/procfs"
 
@@ -62,6 +63,15 @@ type NetworkRequest struct {
 
 	// Docker-specific parameters.
 	DockerDisableIPv6 bool
+
+	// Network chaos parameters.
+	NetworkChaos  bool
+	Jitter        time.Duration
+	Latency       time.Duration
+	PacketLoss    float64
+	PacketReorder float64
+	PacketCorrupt float64
+	Bandwidth     int
 }
 
 // NodeRequests is a list of NodeRequest.

--- a/website/content/v1.5/reference/cli.md
+++ b/website/content/v1.5/reference/cli.md
@@ -156,6 +156,13 @@ talosctl cluster create [flags]
       --with-debug                               enable debug in Talos config to send service logs to the console
       --with-init-node                           create the cluster with an init node
       --with-kubespan                            enable KubeSpan system
+      --with-network-bandwidth int               specify bandwidth restriction (in kbps) on the bridge interface when creating a qemu cluster
+      --with-network-chaos                       enable to use network chaos parameters when creating a qemu cluster
+      --with-network-jitter duration             specify jitter on the bridge interface when creating a qemu cluster
+      --with-network-latency duration            specify latency on the bridge interface when creating a qemu cluster
+      --with-network-packet-corrupt float        specify percent of corrupt packets on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
+      --with-network-packet-loss float           specify percent of packet loss on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
+      --with-network-packet-reorder float        specify percent of reordered packets on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
       --with-secureboot                          enforce secure boot
       --with-tpm2                                enable TPM2 emulation support using swtpm
       --with-uefi                                enable UEFI on x86_64 architecture (default true)


### PR DESCRIPTION
Add flags for configuring the qemu bridge interface with chaos options:
- network-chaos-enabled
- network-jitter
- network-latency
- network-packet-loss
- network-packet-reorder
- network-packet-corrupt
- network-bandwidth

These flags are used in /pkg/provision/providers/vm/network.go at the end of the CreateNetwork function to first see if the network-chaos-enabled flag is set, and then check if bandwidth is set.  This will allow developers to simulate clusters having a degraded WAN connection in the development environment and testing pipelines.

If bandwidth is not set, it will then enable the other options.
- Note that if bandwidth is set, the other options such as jitter, latency, packet loss, reordering and corruption will not be used.  This is for two reasons:
	- Restriction the bandwidth can often intoduce many of the other issues being set by the other options.
	- Setting the bandwidth uses a separate queuing discipline (Token Bucket Filter) from the other options (Network Emulator) and requires a much more complex configuration using a Heirarchial Token Bucket Filter which cannot be configured at a granular enough level using the vishvananda/netlink library.

Adding both queuing disciplines to the same interface may be an option to look into in the future, but would take more extensive testing and control over many more variables which I believe is out of the scope of this PR.  It is also possible to add custom profiles, but will also take more research to develop common scenarios which combine different options in a realistic manner.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
