### PR TITLE
Update deploy-metrics-server.md

### DIFF
--- a/website/content/v1.5/kubernetes-guides/configuration/deploy-metrics-server.md
+++ b/website/content/v1.5/kubernetes-guides/configuration/deploy-metrics-server.md
@@ -21,6 +21,13 @@ machine:
       rotate-server-certificates: true
 ```
 
+This may require manually approving the kubelets certificate signing requests in the cluster PKI:
+
+```shell
+kubectl get csr --sort-by=.metadata.creationTimestamp
+kubectl certificate approve csr-xxxxx
+```
+
 ## Install During Bootstrap
 
 We will want to ensure that new certificates for the kubelets are approved automatically.


### PR DESCRIPTION
# Pull Request

## What

Add hint about csr pki approval.

## Why? (reasoning)

Enabling certificate rotation on a freshly installed cluster requires the kublet CSRs  to be manually approved. This requirement may not be obvious to people new to kubernetes like me who wonder, why for example `kubectl logs` fails after enabling certificate rotation. 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
