### PR TITLE
feat: add support for multi-doc strategic merge patching

### DIFF
--- a/pkg/machinery/config/config/document.go
+++ b/pkg/machinery/config/config/document.go
@@ -8,6 +8,16 @@ package config
 type Document interface {
 	// Clone returns a deep copy of the document.
 	Clone() Document
+	// Kind returns the kind of the document.
+	Kind() string
+	// APIVersion returns the API version of the document.
+	APIVersion() string
+}
+
+// NamedDocument is a configuration document which has a name.
+type NamedDocument interface {
+	// Name of the document.
+	Name() string
 }
 
 // SecretDocument is a configuration document that contains secrets.

--- a/pkg/machinery/config/configloader/internal/decoder/decoder.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder.go
@@ -20,8 +20,8 @@ import (
 var ErrMissingKind = errors.New("missing kind")
 
 const (
-	// ManifestVersionKey is the string indicating a manifest's version.
-	ManifestVersionKey = "version"
+	// ManifestAPIVersionKey is the string indicating a manifest's version.
+	ManifestAPIVersionKey = "apiVersion"
 	// ManifestKindKey is the string indicating a manifest's kind.
 	ManifestKindKey = "kind"
 	// ManifestDeprecatedKeyMachine represents the deprecated v1alpha1 manifest.
@@ -106,7 +106,7 @@ func decode(manifest *yaml.Node) (target config.Document, err error) {
 			if err = manifest.Content[i+1].Decode(&kind); err != nil {
 				return nil, fmt.Errorf("kind decode: %w", err)
 			}
-		case ManifestVersionKey:
+		case ManifestAPIVersionKey:
 			if len(manifest.Content) < i+1 {
 				return nil, fmt.Errorf("missing manifest content")
 			}

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -20,8 +20,16 @@ import (
 )
 
 type Meta struct {
-	Kind    string `yaml:"kind"`
-	Version string `yaml:"version,omitempty"`
+	MetaKind       string `yaml:"kind"`
+	MetaAPIVersion string `yaml:"apiVersion,omitempty"`
+}
+
+func (m Meta) Kind() string {
+	return m.MetaKind
+}
+
+func (m Meta) APIVersion() string {
+	return m.MetaAPIVersion
 }
 
 type Mock struct {
@@ -104,7 +112,7 @@ func TestDecoder(t *testing.T) {
 			name: "valid",
 			source: []byte(`---
 kind: mock
-version: v1alpha1
+apiVersion: v1alpha1
 test: true
 `),
 			expected: []config.Document{
@@ -117,7 +125,7 @@ test: true
 		{
 			name: "missing kind",
 			source: []byte(`---
-version: v1alpha2
+apiVersion: v1alpha2
 test: true
 `),
 			expected:    nil,
@@ -127,7 +135,7 @@ test: true
 			name: "empty kind",
 			source: []byte(`---
 kind:
-version: v1alpha2
+apiVersion: v1alpha2
 test: true
 `),
 			expected:    nil,
@@ -137,7 +145,7 @@ test: true
 			name: "tab instead of spaces",
 			source: []byte(`---
 kind: mock
-version: v1alpha1
+apiVersion: v1alpha1
 spec:
 	test: true
 `),
@@ -148,7 +156,7 @@ spec:
 			name: "extra field",
 			source: []byte(`---
 kind: mock
-version: v1alpha1
+apiVersion: v1alpha1
 test: true
 extra: fail
 `),
@@ -159,7 +167,7 @@ extra: fail
 			name: "extra fields in map",
 			source: []byte(`---
 kind: mock
-version: v1alpha2
+apiVersion: v1alpha2
 map:
   first:
     test: true
@@ -172,7 +180,7 @@ map:
 			name: "extra fields in slice",
 			source: []byte(`---
 kind: mock
-version: v1alpha2
+apiVersion: v1alpha2
 slice:
   - test: true
     not: working
@@ -186,7 +194,7 @@ slice:
 			name: "extra zero fields in map",
 			source: []byte(`---
 kind: mock
-version: v1alpha2
+apiVersion: v1alpha2
 map:
   second:
     a:
@@ -199,7 +207,7 @@ map:
 			name: "valid nested",
 			source: []byte(`---
 kind: mock
-version: v1alpha2
+apiVersion: v1alpha2
 slice:
   - test: true
 map:
@@ -229,7 +237,7 @@ map:
 			name: "kubelet config",
 			source: []byte(`---
 kind: kubelet
-version: v1alpha1
+apiVersion: v1alpha1
 extraMounts:
  - destination: /var/local
    options:
@@ -245,7 +253,7 @@ extraMounts:
 			name: "omit empty test",
 			source: []byte(`---
 kind: mock
-version: v1alpha3
+apiVersion: v1alpha3
 omit: false
 `),
 			expected:    nil,
@@ -261,7 +269,7 @@ omit: false
 			name: "unstructured config",
 			source: []byte(`---
 kind: unstructured
-version: v1alpha1
+apiVersion: v1alpha1
 pods:
  - destination: /var/local
    options:
@@ -277,7 +285,7 @@ pods:
 			name: "omit empty test",
 			source: []byte(`---
 kind: mock
-version: v1alpha3
+apiVersion: v1alpha3
 omit: false
 `),
 		},

--- a/pkg/machinery/config/configpatcher/apply_test.go
+++ b/pkg/machinery/config/configpatcher/apply_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package configpatcher_test
 
 import (
@@ -20,6 +21,12 @@ var config []byte
 
 //go:embed testdata/apply/expected.yaml
 var expected []byte
+
+//go:embed testdata/multidoc/config.yaml
+var configMultidoc []byte
+
+//go:embed testdata/multidoc/expected.yaml
+var expectedMultidoc []byte
 
 func TestApply(t *testing.T) {
 	patches, err := configpatcher.LoadPatches([]string{
@@ -54,7 +61,72 @@ func TestApply(t *testing.T) {
 			bytes, err := out.Bytes()
 			require.NoError(t, err)
 
-			assert.Equal(t, expected, bytes)
+			assert.Equal(t, string(expected), string(bytes))
+		})
+	}
+}
+
+func TestApplyMultiDocFail(t *testing.T) {
+	patches, err := configpatcher.LoadPatches([]string{
+		"@testdata/multidoc/jsonpatch.yaml",
+		"@testdata/multidoc/strategic1.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := configloader.NewFromBytes(configMultidoc)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		input configpatcher.Input
+	}{
+		{
+			name:  "WithConfig",
+			input: configpatcher.WithConfig(cfg),
+		},
+		{
+			name:  "WithBytes",
+			input: configpatcher.WithBytes(configMultidoc),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := configpatcher.Apply(tt.input, patches)
+			assert.EqualError(t, err, "JSON6902 patches are not supported for multi-document machine configuration")
+		})
+	}
+}
+
+func TestApplyMultiDoc(t *testing.T) {
+	patches, err := configpatcher.LoadPatches([]string{
+		"@testdata/multidoc/strategic1.yaml",
+		"@testdata/multidoc/strategic2.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := configloader.NewFromBytes(configMultidoc)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		input configpatcher.Input
+	}{
+		{
+			name:  "WithConfig",
+			input: configpatcher.WithConfig(cfg),
+		},
+		{
+			name:  "WithBytes",
+			input: configpatcher.WithBytes(configMultidoc),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := configpatcher.Apply(tt.input, patches)
+			require.NoError(t, err)
+
+			bytes, err := out.Bytes()
+			require.NoError(t, err)
+
+			assert.Equal(t, string(expectedMultidoc), string(bytes))
 		})
 	}
 }

--- a/pkg/machinery/config/configpatcher/json6902.go
+++ b/pkg/machinery/config/configpatcher/json6902.go
@@ -5,14 +5,28 @@
 package configpatcher
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	ghodssyaml "github.com/ghodss/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // JSON6902 is responsible for applying a JSON 6902 patch to the bootstrap data.
 func JSON6902(talosMachineConfig []byte, patch jsonpatch.Patch) ([]byte, error) {
+	// check number of input documents
+	numDocuments, err := countYAMLDocuments(talosMachineConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if numDocuments != 1 {
+		return nil, fmt.Errorf("JSON6902 patches are not supported for multi-document machine configuration")
+	}
+
+	// apply JSON patch
 	jsonDecodedData, err := ghodssyaml.YAMLToJSON(talosMachineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failure converting talos machine config to json: %s", err)
@@ -29,4 +43,31 @@ func JSON6902(talosMachineConfig []byte, patch jsonpatch.Patch) ([]byte, error) 
 	}
 
 	return talosMachineConfig, nil
+}
+
+func countYAMLDocuments(talosMachineConfig []byte) (int, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(talosMachineConfig))
+
+	numDocuments := 0
+
+	for {
+		var docs yaml.Node
+
+		err := decoder.Decode(&docs)
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return 0, fmt.Errorf("failure decoding talos machine config: %s", err)
+		}
+
+		if docs.Kind != yaml.DocumentNode {
+			return 0, fmt.Errorf("talos machine config is not a yaml document")
+		}
+
+		numDocuments++
+	}
+
+	return numDocuments, nil
 }

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/config.yaml
@@ -1,0 +1,11 @@
+version: v1alpha1
+machine:
+  network:
+    hostname: hostname1
+    interfaces:
+      - interface: eth0
+        dhcp: true
+---
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: https://siderolink.api/join?jointoken=secret&user=alice

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/expected.yaml
@@ -1,0 +1,15 @@
+version: v1alpha1
+machine:
+    type: ""
+    token: ""
+    certSANs: []
+    network:
+        hostname: hostname1
+        interfaces:
+            - interface: eth0
+              dhcp: false
+cluster: null
+---
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: https://siderolink.api/join?jointoken=secret&user=bob

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/jsonpatch.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/jsonpatch.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /machine/network/interfaces/0/addresses
+  value:
+     - 10.1.2.3/24

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/strategic1.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/strategic1.yaml
@@ -1,0 +1,5 @@
+machine:
+  network:
+    interfaces:
+      - interface: eth0
+        dhcp: false

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/strategic2.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/strategic2.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: https://siderolink.api/join?jointoken=secret&user=bob

--- a/pkg/machinery/config/container/container_test.go
+++ b/pkg/machinery/config/container/container_test.go
@@ -57,6 +57,20 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "https://siderolink.api/join?jointoken=REDACTED&user=alice", cfgRedacted.SideroLink().APIUrl().String())
 }
 
+func TestNewDuplicate(t *testing.T) {
+	v1alpha1Cfg1 := &v1alpha1.Config{}
+	v1alpha1Cfg2 := &v1alpha1.Config{}
+
+	siderolink1 := siderolink.NewConfigV1Alpha1()
+	siderolink2 := siderolink.NewConfigV1Alpha1()
+
+	_, err := container.New(v1alpha1Cfg1, siderolink1, v1alpha1Cfg2)
+	assert.EqualError(t, err, "duplicate v1alpha1.Config")
+
+	_, err = container.New(siderolink1, siderolink2)
+	assert.EqualError(t, err, "duplicate document: SideroLinkConfig/")
+}
+
 func must[T any](t T, err error) T {
 	if err != nil {
 		panic(err)

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -27,6 +27,11 @@ type Container interface {
 
 	// RawV1Alpha1 returns internal config representation.
 	RawV1Alpha1() *v1alpha1.Config
+
+	// Documents returns a list of config documents.
+	//
+	// Documents should be not be modified.
+	Documents() []config.Document
 }
 
 // Provider defines the configuration consumption interface combining access and encoding/decoding.

--- a/pkg/machinery/config/types/meta/meta.go
+++ b/pkg/machinery/config/types/meta/meta.go
@@ -7,6 +7,16 @@ package meta
 
 // Meta is a shared meta information for config documents.
 type Meta struct {
-	Kind    string `yaml:"kind"`
-	Version string `yaml:"version,omitempty"`
+	MetaAPIVersion string `yaml:"apiVersion,omitempty"`
+	MetaKind       string `yaml:"kind"`
+}
+
+// Kind implements config.Document interface.
+func (m Meta) Kind() string {
+	return m.MetaKind
+}
+
+// APIVersion implements config.Document interface.
+func (m Meta) APIVersion() string {
+	return m.MetaAPIVersion
 }

--- a/pkg/machinery/config/types/siderolink/siderolink.go
+++ b/pkg/machinery/config/types/siderolink/siderolink.go
@@ -42,8 +42,8 @@ type ConfigV1Alpha1 struct {
 func NewConfigV1Alpha1() *ConfigV1Alpha1 {
 	return &ConfigV1Alpha1{
 		Meta: meta.Meta{
-			Kind:    Kind,
-			Version: "v1alpha1",
+			MetaKind:       Kind,
+			MetaAPIVersion: "v1alpha1",
 		},
 	}
 }

--- a/pkg/machinery/config/types/siderolink/siderolink_test.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_test.go
@@ -5,11 +5,14 @@
 package siderolink_test
 
 import (
+	_ "embed"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 )
 
@@ -22,6 +25,19 @@ func TestRedact(t *testing.T) {
 	cfg.Redact("REDACTED")
 
 	assert.Equal(t, "https://siderolink.api/join?jointoken=REDACTED&user=alice", cfg.APIUrlConfig.String())
+}
+
+//go:embed testdata/document.yaml
+var expectedDocument []byte
+
+func TestMarshalStability(t *testing.T) {
+	cfg := siderolink.NewConfigV1Alpha1()
+	cfg.APIUrlConfig.URL = must(url.Parse("https://siderolink.api/join?jointoken=secret&user=alice"))
+
+	marshaled, err := encoder.NewEncoder(cfg).Encode()
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedDocument, marshaled)
 }
 
 func must[T any](t T, err error) T {

--- a/pkg/machinery/config/types/siderolink/testdata/document.yaml
+++ b/pkg/machinery/config/types/siderolink/testdata/document.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: https://siderolink.api/join?jointoken=secret&user=alice

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -40,6 +40,16 @@ func (c *Config) Clone() config.Document {
 	return c.DeepCopy()
 }
 
+// Kind returns the kind of the document.
+func (c *Config) Kind() string {
+	return Version // legacy document
+}
+
+// APIVersion returns the API version of the document.
+func (c *Config) APIVersion() string {
+	return "" // legacy document
+}
+
 // Debug implements the config.Provider interface.
 func (c *Config) Debug() bool {
 	return pointer.SafeDeref(c.ConfigDebug)

--- a/website/content/v1.5/talos-guides/configuration/patching.md
+++ b/website/content/v1.5/talos-guides/configuration/patching.md
@@ -16,6 +16,9 @@ Talos supports two configuration patch formats:
 
 Strategic merge patches are the easiest to use, but JSON patches allow more precise configuration adjustments.
 
+> Note: Talos 1.5 introduces experimental support for multi-document machine configuration.
+> JSON patches don't support multi-document machine configuration, while strategic merge patches do.
+
 ### Strategic Merge patches
 
 Strategic merge patches look like incomplete machine configuration files:
@@ -46,6 +49,11 @@ There are some special rules:
   - values of the fields `cluster.network.podSubnets` and `cluster.network.serviceSubnets` are overwritten on merge
   - `network.interfaces` section is merged with the value in the machine config if there is a match on `interface:` or `deviceSelector:` keys
   - `network.interfaces.vlans` section is merged with the value in the machine config if there is a match on the `vlanId:` key
+
+When patching a multi-document machine configuration, following rules apply:
+
+- for each document in the patch, the document is merged with the respective document in the machine configuration (matching by `kind`, `apiVersion` and `name` for named documentes)
+- if the patch document doesn't exist in the machine configuration, it is appended to the machine configuration
 
 ### RFC6902 (JSON Patches)
 


### PR DESCRIPTION
Other changes:

* renamed `version:` to `apiVersion:` in the multi-doc format, as this better matches Kubernetes objects
* introduced (not used at the moment) a concept of `NamedDocuments` (many documents for the same type)
* added container validation on not having duplicate documents
* JSON6902 now denies multi-doc config

Fixes #7312
