### PR TITLE
chore: optimize image compression

### DIFF
--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -279,7 +279,7 @@ func tar(filename, src, dir string) error {
 }
 
 func gz(filename string) error {
-	if _, err := cmd.Run("gzip", "-6", filename); err != nil {
+	if _, err := cmd.Run("pigz", "-6", filename); err != nil {
 		return err
 	}
 
@@ -287,7 +287,7 @@ func gz(filename string) error {
 }
 
 func xz(filename string) error {
-	if _, err := cmd.Run("xz", "-6", "-T", "0", filename); err != nil {
+	if _, err := cmd.Run("xz", "-0", "-T", "0", filename); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use `pigz` (parallel) instead of `gzip`.

Use `xz` compression `-0` instead of `-6`.

This has pros and cons:

* image size goes up (77M -> 79M) (+2.5%)
* image generation goes down 19s -> 10s (-50%).
