### PR TITLE
feat: qemu secureboot

### DIFF
--- a/cmd/installer/pkg/iso.go
+++ b/cmd/installer/pkg/iso.go
@@ -97,7 +97,7 @@ func CreateUKIISO(iso, dir, arch string) error {
 		return err
 	}
 
-	efiBootPath := "::EFI/BOOT/BOOTX64.efi"
+	efiBootPath := "::EFI/BOOT/BOOTX64.EFI"
 
 	if arch == "arm64" {
 		efiBootPath = "::EFI/BOOT/BOOTAA64.EFI"

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -81,6 +81,9 @@ const (
 	bootloaderEnabledFlag         = "with-bootloader"
 	forceEndpointFlag             = "endpoint"
 	controlPlanePortFlag          = "control-plane-port"
+	tpm2EnabledFlag               = "with-tpm2"
+	secureBootEnabledFlag         = "with-secureboot"
+	secureBootEnrollCertFlag      = "secureboot-enroll-cert"
 )
 
 var (
@@ -97,6 +100,9 @@ var (
 	applyConfigEnabled         bool
 	bootloaderEnabled          bool
 	uefiEnabled                bool
+	secureBootEnabled          bool
+	secureBootEnrollmentCert   string
+	tpm2Enabled                bool
 	extraUEFISearchPaths       []string
 	configDebug                bool
 	networkCIDR                string
@@ -306,6 +312,9 @@ func create(ctx context.Context, flags *pflag.FlagSet) (err error) {
 		provision.WithDockerPortsHostIP(dockerHostIP),
 		provision.WithBootlader(bootloaderEnabled),
 		provision.WithUEFI(uefiEnabled),
+		provision.WithTPM2(tpm2Enabled),
+		provision.WithSecureBoot(secureBootEnabled),
+		provision.WithSecureBootEnrollmentCert(secureBootEnrollmentCert),
 		provision.WithExtraUEFISearchPaths(extraUEFISearchPaths),
 		provision.WithTargetArch(targetArch),
 	}
@@ -871,6 +880,9 @@ func init() {
 	createCmd.Flags().BoolVar(&applyConfigEnabled, "with-apply-config", false, "enable apply config when the VM is starting in maintenance mode")
 	createCmd.Flags().BoolVar(&bootloaderEnabled, bootloaderEnabledFlag, true, "enable bootloader to load kernel and initramfs from disk image after install")
 	createCmd.Flags().BoolVar(&uefiEnabled, "with-uefi", true, "enable UEFI on x86_64 architecture")
+	createCmd.Flags().BoolVar(&tpm2Enabled, tpm2EnabledFlag, false, "enable TPM2 emulation support using swtpm")
+	createCmd.Flags().BoolVar(&secureBootEnabled, secureBootEnabledFlag, false, "enforce secure boot")
+	createCmd.Flags().StringVar(&secureBootEnrollmentCert, secureBootEnrollCertFlag, "_out/uki-certs/uki-signing-cert.pem", "path to certificate to enroll in PK, KEK and DB")
 	createCmd.Flags().StringSliceVar(&extraUEFISearchPaths, "extra-uefi-search-paths", []string{}, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 	createCmd.Flags().StringSliceVar(&registryMirrors, registryMirrorFlag, []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
 	createCmd.Flags().StringSliceVar(&registryInsecure, registryInsecureFlag, []string{}, "list of registry hostnames to skip TLS verification for")

--- a/hack/ukify/main.go
+++ b/hack/ukify/main.go
@@ -30,10 +30,8 @@ import (
 	"github.com/siderolabs/talos/pkg/version"
 )
 
-var (
-	//go:embed assets/sidero.bmp
-	splashBMP []byte
-)
+//go:embed assets/sidero.bmp
+var splashBMP []byte
 
 var (
 	sdStub         string
@@ -149,7 +147,7 @@ func Measure(tempDir, kernel, signingKey string, sections []section) ([]section,
 		return nil, err
 	}
 
-	if err = os.WriteFile(pcrpsigFile, pcrSignatureData, 0644); err != nil {
+	if err = os.WriteFile(pcrpsigFile, pcrSignatureData, 0o644); err != nil {
 		return nil, err
 	}
 

--- a/hack/ukify/measure/measure_test.go
+++ b/hack/ukify/measure/measure_test.go
@@ -28,10 +28,8 @@ const (
 	ExpectedSignatureHex = "12e432978d18c9f720b3fb922cab180ca025ecd5f918966d1f878ae93f1eedbc6b20885d5a9f1c4ffdd4bf2dc3c25dc1097b6c5109d9c9a90128eff20056ace7"
 )
 
-var (
-	//go:embed testdata/pcr-signing-key.pem
-	pcrSigningKeyPEM []byte
-)
+//go:embed testdata/pcr-signing-key.pem
+var pcrSigningKeyPEM []byte
 
 func TestMeasureMatchesExpectedOutput(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -70,6 +70,33 @@ func WithUEFI(enabled bool) Option {
 	}
 }
 
+// WithTPM2 enables or disables TPM2 emulation.
+func WithTPM2(enabled bool) Option {
+	return func(o *Options) error {
+		o.TPM2Enabled = enabled
+
+		return nil
+	}
+}
+
+// WithSecureBoot enables or disables secure boot.
+func WithSecureBoot(enabled bool) Option {
+	return func(o *Options) error {
+		o.SecureBootEnabled = enabled
+
+		return nil
+	}
+}
+
+// WithSecureBootEnrollmentCert specifies secure boot enrollment certificate.
+func WithSecureBootEnrollmentCert(cert string) Option {
+	return func(o *Options) error {
+		o.SecureBootEnrollmentCert = cert
+
+		return nil
+	}
+}
+
 // WithExtraUEFISearchPaths configures additional search paths to look for UEFI firmware.
 func WithExtraUEFISearchPaths(extraUEFISearchPaths []string) Option {
 	return func(o *Options) error {
@@ -128,6 +155,12 @@ type Options struct {
 
 	// Enable UEFI (for amd64), arm64 can only boot UEFI
 	UEFIEnabled bool
+	// Enable TPM2 emulation using swtpm.
+	TPM2Enabled bool
+	// Enforce Secure Boot.
+	SecureBootEnabled bool
+	// Path to Secure Boot enrollment certificate.
+	SecureBootEnrollmentCert string
 	// Configure additional search paths to look for UEFI firmware.
 	ExtraUEFISearchPaths []string
 

--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -71,7 +71,7 @@ type PFlash struct {
 }
 
 // PFlash returns settings for parallel flash.
-func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlash {
+func (arch Arch) PFlash(uefiEnabled, secureBootEnabled bool, extraUEFISearchPaths []string) []PFlash {
 	switch arch {
 	case ArchArm64:
 		uefiSourcePaths := []string{"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd", "/usr/share/OVMF/QEMU_EFI.fd"}
@@ -93,9 +93,14 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			return nil
 		}
 
-		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd", "/usr/share/OVMF/OVMF_CODE.fd", "/usr/share/OVMF/OVMF_CODE.secboot.fd"}
+		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd", "/usr/share/OVMF/OVMF_CODE_4M.fd", "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd"}
 		for _, p := range extraUEFISearchPaths {
 			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "OVMF.fd"))
+		}
+
+		if secureBootEnabled {
+			// picking exactly the last one, as it's the one having secure boot enabled
+			uefiSourcePaths = uefiSourcePaths[len(uefiSourcePaths)-1:]
 		}
 
 		return []PFlash{

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -49,6 +49,10 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
+	if err := p.destroyVirtualTPM2s(cluster.Info()); err != nil {
+		return err
+	}
+
 	state, ok := cluster.(*vm.State)
 	if !ok {
 		return fmt.Errorf("error inspecting QEMU state, %#+v", cluster)

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -34,10 +34,10 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	var pflashImages []string
 
-	if pflashSpec := arch.PFlash(opts.UEFIEnabled, opts.ExtraUEFISearchPaths); pflashSpec != nil {
+	if pflashSpec := arch.PFlash(opts.UEFIEnabled, opts.SecureBootEnabled, opts.ExtraUEFISearchPaths); pflashSpec != nil {
 		var err error
 
-		if pflashImages, err = p.createPFlashImages(state, nodeReq.Name, pflashSpec); err != nil {
+		if pflashImages, err = p.createPFlashImages(state, nodeReq.Name, pflashSpec, opts.SecureBootEnabled, opts.SecureBootEnrollmentCert); err != nil {
 			return provision.NodeInfo{}, fmt.Errorf("error creating flash images: %w", err)
 		}
 	}
@@ -139,6 +139,31 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		APIPort:           apiPort,
 	}
 
+	nodeInfo := provision.NodeInfo{
+		ID:   pidPath,
+		UUID: nodeUUID,
+		Name: nodeReq.Name,
+		Type: nodeReq.Type,
+
+		NanoCPUs: nodeReq.NanoCPUs,
+		Memory:   nodeReq.Memory,
+		DiskSize: nodeReq.Disks[0].Size,
+
+		IPs: nodeReq.IPs,
+
+		APIPort: apiPort,
+	}
+
+	if opts.TPM2Enabled {
+		tpm2, tpm2Err := p.createVirtualTPM2State(state, nodeReq.Name)
+		if tpm2Err != nil {
+			return provision.NodeInfo{}, tpm2Err
+		}
+
+		launchConfig.TPM2Config = tpm2
+		nodeInfo.TPM2StateDir = tpm2.StateDir
+	}
+
 	if !clusterReq.Network.DHCPSkipHostname {
 		launchConfig.Hostname = nodeReq.Name
 	}
@@ -186,21 +211,6 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	}
 
 	// no need to wait here, as cmd has all the Stdin/out/err via *os.File
-
-	nodeInfo := provision.NodeInfo{
-		ID:   pidPath,
-		UUID: nodeUUID,
-		Name: nodeReq.Name,
-		Type: nodeReq.Type,
-
-		NanoCPUs: nodeReq.NanoCPUs,
-		Memory:   nodeReq.Memory,
-		DiskSize: nodeReq.Disks[0].Size,
-
-		IPs: nodeReq.IPs,
-
-		APIPort: apiPort,
-	}
 
 	return nodeInfo, nil
 }

--- a/pkg/provision/providers/qemu/pflash.go
+++ b/pkg/provision/providers/qemu/pflash.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
 
 //nolint:gocyclo
-func (p *provisioner) createPFlashImages(state *vm.State, nodeName string, pflashSpec []PFlash) ([]string, error) {
+func (p *provisioner) createPFlashImages(state *vm.State, nodeName string, pflashSpec []PFlash, secureBootEnabled bool, secureBootEnrollCert string) ([]string, error) {
 	var images []string
 
 	for i, pflash := range pflashSpec {
@@ -64,6 +65,35 @@ func (p *provisioner) createPFlashImages(state *vm.State, nodeName string, pflas
 		}(i, pflash); err != nil {
 			return nil, err
 		}
+	}
+
+	if secureBootEnabled {
+		flashVarsPath := state.GetRelativePath(fmt.Sprintf("%s-flash_vars.fd", nodeName))
+
+		cmd := exec.Command("ovmfctl", []string{
+			"--no-microsoft",
+			"--secure-boot",
+			"--set-pk",
+			// OEM value from here: https://bugzilla.tianocore.org/show_bug.cgi?id=1747#c2
+			"4e32566d-8e9e-4f52-81d3-5bb9715f9727",
+			secureBootEnrollCert,
+			"--add-kek",
+			"4e32566d-8e9e-4f52-81d3-5bb9715f9727",
+			secureBootEnrollCert,
+			"--add-db",
+			"4e32566d-8e9e-4f52-81d3-5bb9715f9727",
+			secureBootEnrollCert,
+			"--input",
+			"/usr/share/OVMF/OVMF_VARS_4M.fd",
+			"--output",
+			flashVarsPath,
+		}...)
+
+		if err := cmd.Run(); err != nil {
+			return nil, err
+		}
+
+		images = append(images, flashVarsPath)
 	}
 
 	return images, nil

--- a/pkg/provision/providers/qemu/tpm2.go
+++ b/pkg/provision/providers/qemu/tpm2.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers/vm"
+)
+
+func (p *provisioner) createVirtualTPM2State(state *vm.State, nodeName string) (tpm2Config, error) {
+	tpm2StateDir := state.GetRelativePath(fmt.Sprintf("%s-tpm2", nodeName))
+
+	if err := os.MkdirAll(tpm2StateDir, 0o755); err != nil {
+		return tpm2Config{}, err
+	}
+
+	return tpm2Config{
+		NodeName: nodeName,
+		StateDir: tpm2StateDir,
+	}, nil
+}
+
+func (p *provisioner) destroyVirtualTPM2s(cluster provision.ClusterInfo) error {
+	errCh := make(chan error)
+
+	nodes := append([]provision.NodeInfo{}, cluster.Nodes...)
+
+	for _, node := range nodes {
+		if node.TPM2StateDir == "" {
+			continue
+		}
+
+		tpm2PidPath := filepath.Join(node.TPM2StateDir, "swtpm.pid")
+
+		go func() {
+			errCh <- p.destroyVirtualTPM2(tpm2PidPath)
+		}()
+	}
+
+	var multiErr *multierror.Error
+
+	for _, node := range nodes {
+		if node.TPM2StateDir == "" {
+			continue
+		}
+
+		multiErr = multierror.Append(multiErr, <-errCh)
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+func (p *provisioner) destroyVirtualTPM2(pid string) error {
+	return vm.StopProcessByPidfile(pid)
+}

--- a/pkg/provision/providers/vm/dhcpd.go
+++ b/pkg/provision/providers/vm/dhcpd.go
@@ -317,5 +317,5 @@ func (p *Provisioner) CreateDHCPd(state *State, clusterReq provision.ClusterRequ
 func (p *Provisioner) DestroyDHCPd(state *State) error {
 	pidPath := state.GetRelativePath(dhcpPid)
 
-	return stopProcessByPidfile(pidPath)
+	return StopProcessByPidfile(pidPath)
 }

--- a/pkg/provision/providers/vm/loadbalancer.go
+++ b/pkg/provision/providers/vm/loadbalancer.go
@@ -68,5 +68,5 @@ func (p *Provisioner) CreateLoadBalancer(state *State, clusterReq provision.Clus
 func (p *Provisioner) DestroyLoadBalancer(state *State) error {
 	pidPath := state.GetRelativePath(lbPid)
 
-	return stopProcessByPidfile(pidPath)
+	return StopProcessByPidfile(pidPath)
 }

--- a/pkg/provision/providers/vm/node.go
+++ b/pkg/provision/providers/vm/node.go
@@ -38,5 +38,5 @@ func (p *Provisioner) DestroyNodes(cluster provision.ClusterInfo, options *provi
 
 // DestroyNode destroys VM.
 func (p *Provisioner) DestroyNode(node provision.NodeInfo) error {
-	return stopProcessByPidfile(node.ID) // node.ID stores PID path for control process
+	return StopProcessByPidfile(node.ID) // node.ID stores PID path for control process
 }

--- a/pkg/provision/providers/vm/process.go
+++ b/pkg/provision/providers/vm/process.go
@@ -11,7 +11,8 @@ import (
 	"syscall"
 )
 
-func stopProcessByPidfile(pidPath string) error {
+// StopProcessByPidfile stops a process by reading its PID from a file.
+func StopProcessByPidfile(pidPath string) error {
 	pidFile, err := os.Open(pidPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -57,5 +57,6 @@ type NodeInfo struct {
 
 	IPs []netip.Addr
 
-	APIPort int
+	APIPort      int
+	TPM2StateDir string
 }

--- a/website/content/v1.5/reference/cli.md
+++ b/website/content/v1.5/reference/cli.md
@@ -138,6 +138,7 @@ talosctl cluster create [flags]
       --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --secureboot-enroll-cert string            path to certificate to enroll in PK, KEK and DB (default "_out/uki-certs/uki-signing-cert.pem")
       --skip-boot-phase-finished-check           skip waiting for node to finish boot phase
       --skip-injecting-config                    skip injecting config from embedded metadata server, write config files to current directory
       --skip-kubeconfig                          skip merging kubeconfig from the created cluster
@@ -155,6 +156,8 @@ talosctl cluster create [flags]
       --with-debug                               enable debug in Talos config to send service logs to the console
       --with-init-node                           create the cluster with an init node
       --with-kubespan                            enable KubeSpan system
+      --with-secureboot                          enforce secure boot
+      --with-tpm2                                enable TPM2 emulation support using swtpm
       --with-uefi                                enable UEFI on x86_64 architecture (default true)
       --workers int                              the number of workers to create (default 1)
 ```


### PR DESCRIPTION
Add qemu support for secureboot testing via `talosctl cluster create`.

Can be tested via:

```bash
sudo -E _out/talosctl-linux-amd64 cluster create --provisioner=qemu $REGISTRY_MIRROR_FLAGS --controlplanes=1 --workers=1 --iso-path=_out/talos-uki-amd64.iso --with-secureboot=true --with-tpm2=true --skip-injecting-config --with-apply-config
```

This currently only supports just booting Talos in SecureBoot mode. Installation and Upgrade comes as extra PRs.

Fixes: #7324