### PR TITLE
chore: unify kexec phase

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -193,14 +193,8 @@ func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 				"stopEverything",
 				StopAllServices,
 			).Append(
-				"mountBoot",
-				MountBootPartition,
-			).Append(
 				"kexec",
 				KexecPrepare,
-			).Append(
-				"unmountBoot",
-				UnmountBootPartition,
 			).Append(
 				"reboot",
 				Reboot,
@@ -468,14 +462,8 @@ func (*Sequencer) MaintenanceUpgrade(r runtime.Runtime, _ *machineapi.UpgradeReq
 			"meta",
 			ReloadMeta,
 		).Append(
-			"mountBoot",
-			MountBootPartition,
-		).Append(
 			"kexec",
 			KexecPrepare,
-		).Append(
-			"unmountBoot",
-			UnmountBootPartition,
 		).Append(
 			"stopEverything",
 			StopAllServices,
@@ -542,14 +530,8 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			"meta",
 			ReloadMeta,
 		).Append(
-			"mountBoot",
-			MountBootPartition,
-		).Append(
 			"kexec",
 			KexecPrepare,
-		).Append(
-			"unmountBoot",
-			UnmountBootPartition,
 		).Append(
 			"stopEverything",
 			StopAllServices,
@@ -591,16 +573,8 @@ func stopAllPhaselist(r runtime.Runtime, enableKexec bool) PhaseList {
 			UnmountStatePartition,
 		).AppendWhen(
 			enableKexec,
-			"mountBoot",
-			MountBootPartition,
-		).AppendWhen(
-			enableKexec,
 			"kexec",
 			KexecPrepare,
-		).AppendWhen(
-			enableKexec,
-			"unmountBoot",
-			UnmountBootPartition,
 		).Append(
 			"stopEverything",
 			StopAllServices,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
@@ -51,9 +51,9 @@ func TestPhaseList_Append(t *testing.T) {
 			p:    PhaseList{},
 			args: args{
 				name:  "mount",
-				tasks: []runtime.TaskSetupFunc{MountBootPartition},
+				tasks: []runtime.TaskSetupFunc{KexecPrepare},
 			},
-			want: PhaseList{runtime.Phase{Name: "mount", Tasks: []runtime.TaskSetupFunc{MountBootPartition}}},
+			want: PhaseList{runtime.Phase{Name: "mount", Tasks: []runtime.TaskSetupFunc{KexecPrepare}}},
 		},
 	}
 
@@ -87,16 +87,16 @@ func TestPhaseList_AppendWhen(t *testing.T) {
 			args: args{
 				when:  true,
 				name:  "mount",
-				tasks: []runtime.TaskSetupFunc{MountBootPartition},
+				tasks: []runtime.TaskSetupFunc{KexecPrepare},
 			},
-			want: PhaseList{runtime.Phase{Name: "mount", Tasks: []runtime.TaskSetupFunc{MountBootPartition}}},
+			want: PhaseList{runtime.Phase{Name: "mount", Tasks: []runtime.TaskSetupFunc{KexecPrepare}}},
 		},
 		{
 			name: "false",
 			p:    PhaseList{},
 			args: args{
 				when:  false,
-				tasks: []runtime.TaskSetupFunc{MountBootPartition},
+				tasks: []runtime.TaskSetupFunc{KexecPrepare},
 			},
 			want: PhaseList{},
 		},


### PR DESCRIPTION
This changes the mounting/unmounting of `BOOT` partiton code into `kexecPrepare` phase. Also skips if `BOOT` partition cannot be found.