### PR TITLE
fix: allow http:// for discovery service URL

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1121,7 +1121,6 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/siderolabs/go-debug"
 	sideronet "github.com/siderolabs/net"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -443,17 +442,8 @@ func (c *ClusterDiscoveryConfig) Validate(clusterCfg *ClusterConfig) error {
 		url, err := url.ParseRequestURI(c.Registries().Service().Endpoint())
 		if err != nil {
 			result = multierror.Append(result, fmt.Errorf("cluster discovery service registry endpoint is invalid: %w", err))
-		} else {
-			// allow insecure discovery service for easier local development
-			if !debug.Enabled {
-				if url.Scheme != "https" {
-					result = multierror.Append(result, fmt.Errorf("cluster discovery service should use TLS"))
-				}
-			}
-
-			if url.Path != "" && url.Path != "/" {
-				result = multierror.Append(result, fmt.Errorf("cluster discovery service path should be empty"))
-			}
+		} else if url.Path != "" && url.Path != "/" {
+			result = multierror.Append(result, fmt.Errorf("cluster discovery service path should be empty"))
 		}
 
 		if clusterCfg.ID() == "" {

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/siderolabs/gen v0.4.5
 	github.com/siderolabs/go-api-signature v0.2.4
 	github.com/siderolabs/go-blockdevice v0.4.5
-	github.com/siderolabs/go-debug v0.2.2
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/siderolabs/net v0.4.0
 	github.com/siderolabs/protoenc v0.2.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -115,8 +115,6 @@ github.com/siderolabs/go-api-signature v0.2.4 h1:s+K0GtaPHql4LdZzL72QvwPMzffY+KB
 github.com/siderolabs/go-api-signature v0.2.4/go.mod h1:rLIKzbDhKewI3MdztyntS1apH6EC8ccU2TF5S0/O2yg=
 github.com/siderolabs/go-blockdevice v0.4.5 h1:NgpR9XTl/N7WeL59QHBsseDD0Nb8Y2nel+W3u7xHIvY=
 github.com/siderolabs/go-blockdevice v0.4.5/go.mod h1:4PeOuk71pReJj1JQEXDE7kIIQJPVe8a+HZQa+qjxSEA=
-github.com/siderolabs/go-debug v0.2.2 h1:c8styCvp+MO0oPO8q4N1CKSF3fVuAT0qnuUIeZ/BiW0=
-github.com/siderolabs/go-debug v0.2.2/go.mod h1:c/wMqY6+djxwrwEg1eg3kaTeZIfq6OUlEHAMreo1VV0=
 github.com/siderolabs/go-pointer v1.0.0 h1:6TshPKep2doDQJAAtHUuHWXbca8ZfyRySjSBT/4GsMU=
 github.com/siderolabs/go-pointer v1.0.0/go.mod h1:HTRFUNYa3R+k0FFKNv11zgkaCLzEkWVzoYZ433P3kHc=
 github.com/siderolabs/go-retry v0.3.2 h1:FzWslFm4y8RY1wU0gIskm0oZHOpsSibZqlR8N8/k4Eo=


### PR DESCRIPTION
Fixes #7333

Also fixed the discovery service controller to reconnect the client on config changes (previously it wasn't reactive on e.g. URL changes).
