### PR TITLE
There is no need that the value of err is assigned to itself. So removes this self assignment.

### DIFF
--- a/cmd/installer/cmd/install.go
+++ b/cmd/installer/cmd/install.go
@@ -18,18 +18,15 @@ import (
 	"github.com/siderolabs/talos/pkg/version"
 )
 
-// installCmd represents the install command.
+// installCmd represents the installation command.
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		if err := runInstallCmd(); err != nil {
-			if err = (err); err != nil {
-				return err
-			}
+			return err
 		}
-
 		return nil
 	},
 }


### PR DESCRIPTION
There is no need that the value of err is assigned to itself. 

So removes this self assignment.


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
