### PR TITLE
chore: modify some usages that are not recommended

### DIFF
--- a/cmd/installer/pkg/install/meta_value.go
+++ b/cmd/installer/pkg/install/meta_value.go
@@ -24,7 +24,7 @@ type MetaValue struct {
 	Value string
 }
 
-func (v MetaValue) String() string {
+func (v *MetaValue) String() string {
 	return fmt.Sprintf("0x%x=%s", v.Key, v.Value)
 }
 

--- a/cmd/installer/pkg/install/preflight.go
+++ b/cmd/installer/pkg/install/preflight.go
@@ -34,7 +34,7 @@ type PreflightChecks struct {
 	hostTalosVersion      *compatibility.TalosVersion
 }
 
-// NewPreflightChecks initializes and returns the install PreflightChecks.
+// NewPreflightChecks initializes and returns the installation PreflightChecks.
 func NewPreflightChecks(ctx context.Context) (*PreflightChecks, error) {
 	if _, err := os.Stat(constants.MachineSocketPath); err != nil {
 		log.Printf("pre-flight checks disabled, as host Talos version is too old")


### PR DESCRIPTION
Struct MetaValue has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation. Modifies the receiver usage.

Variable config collides with imported package name. Renames the variable config.

Removes a redundant alias.

Empty slice declaration uses a literal. Replaces with nil slice declaration.


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
