### PR TITLE
docs: include `allowSchedulingOnControlPlanes` on `talosctl gen config` output

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1051,6 +1051,8 @@ type ClusterConfig struct {
 	//     - yes
 	//     - false
 	//     - no
+	//   examples:
+	//     - value: true
 	AllowSchedulingOnControlPlanes *bool `yaml:"allowSchedulingOnControlPlanes,omitempty"`
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -523,6 +523,8 @@ func init() {
 	ClusterConfigDoc.Fields[24].Note = ""
 	ClusterConfigDoc.Fields[24].Description = "Allows running workload on control-plane nodes."
 	ClusterConfigDoc.Fields[24].Comments[encoder.LineComment] = "Allows running workload on control-plane nodes."
+
+	ClusterConfigDoc.Fields[24].AddExample("", true)
 	ClusterConfigDoc.Fields[24].Values = []string{
 		"true",
 		"yes",

--- a/website/content/v1.5/reference/configuration.md
+++ b/website/content/v1.5/reference/configuration.md
@@ -642,7 +642,9 @@ inlineManifests:
 adminKubeconfig:
     certLifetime: 1h0m0s # Admin kubeconfig certificate lifetime (default is 1 year).
 {{< /highlight >}}</details> | |
-|`allowSchedulingOnControlPlanes` |bool |Allows running workload on control-plane nodes.  |`true`<br />`yes`<br />`false`<br />`no`<br /> |
+|`allowSchedulingOnControlPlanes` |bool |Allows running workload on control-plane nodes. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+allowSchedulingOnControlPlanes: true
+{{< /highlight >}}</details> |`true`<br />`yes`<br />`false`<br />`no`<br /> |
 
 
 


### PR DESCRIPTION
Include a description and a commented-out example for the `cluster.allowSchedulingOnControlPlanes` field on `talosctl gen config ...` output.

Closes siderolabs/talos#7313.
