### PR TITLE
fix: usage of custom kernels

### DIFF
--- a/website/content/v1.5/advanced/customizing-the-kernel.md
+++ b/website/content/v1.5/advanced/customizing-the-kernel.md
@@ -30,6 +30,9 @@ Using a multi-stage `Dockerfile` we can define the `customization` stage and bui
 
 ```docker
 FROM scratch AS customization
+# this is needed so that Talos copies base kernel modules info and default modules shipped with Talos
+COPY --from=<custom kernel image> /lib/modules /kernel/lib/modules
+# this copies over the custom modules
 COPY --from=<custom kernel image> /lib/modules /lib/modules
 
 FROM ghcr.io/siderolabs/installer:latest

--- a/website/content/v1.5/talos-guides/configuration/nvidia-gpu-proprietary.md
+++ b/website/content/v1.5/talos-guides/configuration/nvidia-gpu-proprietary.md
@@ -55,6 +55,8 @@ Start by creating a `Dockerfile` with the following content:
 
 ```Dockerfile
 FROM scratch as customization
+# this is needed so that Talos copies base kernel modules info and default modules shipped with Talos
+COPY --from=ghcr.io/talos-user/kernel:{{< release >}}-nvidia /lib/modules /kernel/lib/modules
 COPY --from=ghcr.io/talos-user/nonfree-kmod-nvidia:{{< release >}}-nvidia /lib/modules /lib/modules
 
 FROM ghcr.io/siderolabs/installer:{{< release >}}


### PR DESCRIPTION
This fixes usage of custom kernel images to copy over the modules info list and the default set of modules shipped with Talos.