### PR TITLE
chore: fix cilium e2e tests

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -120,10 +120,10 @@ esac
 case "${WITH_CONFIG_PATCH_WORKER:-false}" in
   # using arrays here to preserve spaces properly in WITH_CONFIG_PATCH_WORKER
   false)
-      CONFIG_PATCH_FLAG=()
+      CONFIG_PATCH_FLAG_WORKER=()
       ;;
   *)
-      CONFIG_PATCH_FLAG=(--config-patch-worker "${WITH_CONFIG_PATCH_WORKER}")
+      CONFIG_PATCH_FLAG_WORKER=(--config-patch-worker "${WITH_CONFIG_PATCH_WORKER}")
       ;;
 esac
 
@@ -166,6 +166,7 @@ function create_cluster {
     ${QEMU_FLAGS} \
     ${CUSTOM_CNI_FLAG} \
     "${CONFIG_PATCH_FLAG[@]}" \
+    "${CONFIG_PATCH_FLAG_WORKER[@]}" \
     "${SKIP_BOOT_PHASE_FINISHED_CHECK_FLAG}"
 
   "${TALOSCTL}" config node 172.20.1.2

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -340,7 +340,5 @@ function install_and_run_cilium_cni_tests {
   ${KUBECTL} label ns cilium-test pod-security.kubernetes.io/enforce=privileged
 
   # --external-target added, as default 'one.one.one.one' is buggy, and CloudFlare status is of course "all healthy"
-  ${CILIUM_CLI} connectivity test --test-namespace cilium-test --external-target google.com
-
-  ${KUBECTL} delete ns cilium-test
+  ${CILIUM_CLI} connectivity test --test-namespace cilium-test --external-target google.com; ${KUBECTL} delete ns cilium-test
 }

--- a/internal/integration/cli/jsonpath.go
+++ b/internal/integration/cli/jsonpath.go
@@ -42,7 +42,6 @@ func (suite *JSONPathSuite) TestGetWithJSONPathWildcard() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	suite.RunCLI([]string{"get", "--nodes", node, "manifests", "--output", `jsonpath='{.spec[*].metadata.name}'`},
-		base.StdoutShouldMatch(regexp.MustCompile("kube-proxy")),
 		base.StdoutShouldMatch(regexp.MustCompile("coredns")),
 		base.StdoutShouldMatch(regexp.MustCompile("kube-dns")),
 		base.StdoutShouldMatch(regexp.MustCompile("kubeconfig-in-cluster")),


### PR DESCRIPTION
`WITH_CONFIG_PATCH_WORKER` check result was overriding any value set in `CONFIG_PATCH_FLAG` variable. Move it to the different variable.