### PR TITLE
test: fix cilium integration tests

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -334,6 +334,13 @@ function install_and_run_cilium_cni_tests {
 
   ${CILIUM_CLI} status
 
-  # use kube-system namespace since it doesn't have a PSS restriction
-  ${CILIUM_CLI} connectivity test --test-namespace kube-system
+  ${KUBECTL} delete ns --ignore-not-found cilium-test
+
+  ${KUBECTL} create ns cilium-test
+  ${KUBECTL} label ns cilium-test pod-security.kubernetes.io/enforce=privileged
+
+  # --external-target added, as default 'one.one.one.one' is buggy, and CloudFlare status is of course "all healthy"
+  ${CILIUM_CLI} connectivity test --test-namespace cilium-test --external-target google.com
+
+  ${KUBECTL} delete ns cilium-test
 }


### PR DESCRIPTION
Due to a bug (?) cilium tests don't clean up all the deployments & pods, leaving one pod in 'Pending' state.

Kubernetes e2e tests check for !Runing pods in `kube-system` namespace.

Fix by moving cilium tests to a separate namespace.
