### PR TITLE
fix: allow time skew for generated kubeconfig

### DIFF
--- a/pkg/kubeconfig/generate.go
+++ b/pkg/kubeconfig/generate.go
@@ -83,6 +83,8 @@ type GenerateInput struct {
 	ContextName string
 }
 
+const allowedTimeSkew = 10 * time.Second
+
 // Generate a kubeconfig for the cluster from the given Input.
 func Generate(in *GenerateInput, out io.Writer) error {
 	tpl, err := template.New("kubeconfig").Funcs(template.FuncMap{
@@ -100,6 +102,7 @@ func Generate(in *GenerateInput, out io.Writer) error {
 	clientCert, err := x509.NewKeyPair(k8sCA,
 		x509.CommonName(in.CommonName),
 		x509.Organization(in.Organization),
+		x509.NotBefore(time.Now().Add(-allowedTimeSkew)),
 		x509.NotAfter(time.Now().Add(in.CertificateLifetime)),
 		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),
 		x509.ExtKeyUsage([]stdlibx509.ExtKeyUsage{


### PR DESCRIPTION
The `kubeconfig` can be fetched from one Talos node, while Kubernetes API request might land on `kube-apiserver` on a different node which might have time slightly out of sync.

The minimum time diff between the two might lead to `Unauthorized` error on first use:

```
1 authentication.go:70] "Unable to authenticate the request" err="[x509: certificate has expired or is not yet valid: current time 2023-06-13T15:30:51Z is before 2023-06-13T15:30:52Z, verifying certificate SN=314179687645609956480346926163236202072, SKID=, AKID=E9:9E:A8:1E:0B:6C:8B:AB:1B:2B:7E:17:14:CF:A4:0A:82:6B:42:67 failed: x509: certificate has expired or is not yet valid: current time 2023-06-13T15:30:51Z is before 2023-06-13T15:30:52Z]"
```
