### PR TITLE
refactor: bootloader interface, labels

### DIFF
--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -47,11 +47,7 @@ type Device struct {
 // NewManifest initializes and returns a Manifest.
 //
 //nolint:gocyclo
-func NewManifest(label string, sequence runtime.Sequence, bootLoaderPresent bool, opts *Options) (manifest *Manifest, err error) {
-	if label == "" {
-		return nil, fmt.Errorf("a label is required, got \"\"")
-	}
-
+func NewManifest(sequence runtime.Sequence, bootLoaderPresent bool, opts *Options) (manifest *Manifest, err error) {
 	manifest = &Manifest{
 		Devices:           map[string]Device{},
 		Targets:           map[string][]*Target{},
@@ -116,16 +112,6 @@ func NewManifest(label string, sequence runtime.Sequence, bootLoaderPresent bool
 
 	bootTarget := BootTarget(opts.Disk, &Target{
 		PreserveContents: bootLoaderPresent,
-		Assets: []*Asset{
-			{
-				Source:      fmt.Sprintf(constants.KernelAssetPath, opts.Arch),
-				Destination: filepath.Join(constants.BootMountPoint, label, constants.KernelAsset),
-			},
-			{
-				Source:      fmt.Sprintf(constants.InitramfsAssetPath, opts.Arch),
-				Destination: filepath.Join(constants.BootMountPoint, label, constants.InitramfsAsset),
-			},
-		},
 	})
 
 	metaTarget := MetaTarget(opts.Disk, &Target{

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -337,14 +337,15 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 		return nil, err
 	}
 
+	systemDisk := s.Controller.Runtime().State().Machine().Disk()
+	if systemDisk == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "system disk not found")
+	}
+
 	if err := func() error {
-		config, err := bootloader.Probe(false)
+		config, err := bootloader.Probe(systemDisk.Device().Name())
 		if err != nil {
 			return err
-		}
-
-		if !config.Installed() {
-			return fmt.Errorf("grub configuration not found, nothing to rollback")
 		}
 
 		return config.Revert()

--- a/internal/app/machined/pkg/controllers/k8s/node_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_apply.go
@@ -229,7 +229,7 @@ func (ctrl *NodeApplyController) sync(
 	return retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(ctx, func(ctx context.Context) error {
 		err := ctrl.syncOnce(ctx, logger, k8sClient, nodeName, nodeLabelSpecs, nodeTaintSpecs, nodeShouldCordon)
 
-		if err != nil && apierrors.IsConflict(err) {
+		if err != nil && (apierrors.IsConflict(err) || apierrors.IsForbidden(err)) {
 			return retry.ExpectedError(err)
 		}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/assets/assets.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/assets/assets.go
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package assets provides bootloader assets.
+package assets
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// Assets is a list of assets.
+type Assets []Asset
+
+// Asset represents a file required by a target.
+type Asset struct {
+	Source      string
+	Destination string
+}
+
+// Install copies the assets to the bootloader partition.
+func (assets Assets) Install() error {
+	for _, asset := range assets {
+		asset := asset
+
+		if assetErr := func() error {
+			var (
+				sourceFile *os.File
+				destFile   *os.File
+			)
+
+			sourceFile, err := os.Open(asset.Source)
+			if err != nil {
+				return err
+			}
+			//nolint:errcheck
+			defer sourceFile.Close()
+
+			if err = os.MkdirAll(filepath.Dir(asset.Destination), os.ModeDir); err != nil {
+				return err
+			}
+
+			if destFile, err = os.Create(asset.Destination); err != nil {
+				return err
+			}
+
+			//nolint:errcheck
+			defer destFile.Close()
+
+			log.Printf("copying %s to %s\n", sourceFile.Name(), destFile.Name())
+
+			if _, err = io.Copy(destFile, sourceFile); err != nil {
+				log.Printf("failed to copy %s to %s\n", sourceFile.Name(), destFile.Name())
+
+				return err
+			}
+
+			if err = destFile.Close(); err != nil {
+				log.Printf("failed to close %s", destFile.Name())
+
+				return err
+			}
+
+			if err = sourceFile.Close(); err != nil {
+				log.Printf("failed to close %s", sourceFile.Name())
+
+				return err
+			}
+
+			return nil
+		}(); assetErr != nil {
+			return assetErr
+		}
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
@@ -5,36 +5,40 @@
 // Package bootloader provides bootloader implementation.
 package bootloader
 
-import "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
+import (
+	"os"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
+)
 
 // Bootloader describes a bootloader.
 type Bootloader interface {
 	// Install installs the bootloader
 	Install(bootDisk, arch, cmdline string) error
-	// Flip flips the bootloader entry to the next state.
-	Flip() error
 	// Revert reverts the bootloader entry to the previous state.
 	Revert() error
-	// NextLabel returns the next bootloader label.
-	NextLabel() string
 	// PreviousLabel returns the previous bootloader label.
 	PreviousLabel() string
-	// Installed returns true if the bootloader is installed.
-	Installed() bool
 }
 
 // Probe checks if any supported bootloaders are installed.
+//
+// If 'disk' is empty, it will probe all disks.
 // Returns nil if it cannot detect any supported bootloader.
-func Probe(skipProbe bool) (Bootloader, error) {
-	// skipProbe skips bootloader probing.
-	if skipProbe {
-		return nil, nil
-	}
-
-	bootloader, err := grub.Probe()
+func Probe(disk string) (Bootloader, error) {
+	grubBootloader, err := grub.Probe(disk)
 	if err != nil {
 		return nil, err
 	}
 
-	return bootloader, nil
+	if grubBootloader == nil {
+		return nil, os.ErrNotExist
+	}
+
+	return grubBootloader, nil
+}
+
+// New returns a new bootloader.
+func New() (Bootloader, error) {
+	return grub.NewConfig(), nil
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/boot_label.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/boot_label.go
@@ -12,41 +12,26 @@ import (
 )
 
 // Flip flips the default boot label.
-func (c *Config) Flip() error {
-	if c == nil {
-		return fmt.Errorf("cannot flip bootloader: %w", bootloaderNotInstalledError{})
+func (c *Config) flip() error {
+	if _, exists := c.Entries[c.Default]; !exists {
+		return nil
 	}
 
-	current := c.Next
+	current := c.Default
 
-	next, err := bootloader.FlipBootLabel(c.Next)
+	next, err := bootloader.FlipBootLabel(c.Default)
 	if err != nil {
 		return err
 	}
 
-	c.Next = next
+	c.Default = next
 	c.Fallback = current
 
 	return nil
 }
 
-// NextLabel returns the next bootloader label.
-func (c *Config) NextLabel() string {
-	// If the bootloader is not installed, return the default label.
-	if c == nil {
-		return string(bootloader.BootA)
-	}
-
-	return string(c.Next)
-}
-
 // PreviousLabel returns the previous bootloader label.
 func (c *Config) PreviousLabel() string {
-	// If the bootloader is not installed, empty.
-	if c == nil {
-		return ""
-	}
-
 	return string(c.Fallback)
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/decode.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/decode.go
@@ -77,7 +77,7 @@ func Decode(c []byte) (*Config, error) {
 	}
 
 	conf := Config{
-		Next:     defaultEntry,
+		Default:  defaultEntry,
 		Fallback: fallbackEntry,
 		Entries:  entries,
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 )
 
-const confTemplate = `set default="{{ (index .Entries .Next).Name }}"
+const confTemplate = `set default="{{ (index .Entries .Default).Name }}"
 {{ with (index .Entries .Fallback).Name -}}
 set fallback="{{ . }}"
 {{- end }}
@@ -33,7 +33,7 @@ menuentry "{{ $entry.Name }}" {
 }
 {{ end -}}
 
-{{ $defaultEntry := index .Entries .Next -}}
+{{ $defaultEntry := index .Entries .Default -}}
 menuentry "Reset Talos installation and return to maintenance mode" {
   set gfxmode=auto
   set gfxpayload=text

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -16,7 +16,7 @@ import (
 
 // Config represents a grub configuration file (grub.cfg).
 type Config struct {
-	Next     bootloader.BootLabel
+	Default  bootloader.BootLabel
 	Fallback bootloader.BootLabel
 	Entries  map[bootloader.BootLabel]MenuEntry
 }
@@ -34,18 +34,11 @@ func (e bootloaderNotInstalledError) Error() string {
 }
 
 // NewConfig creates a new grub configuration (nothing is written to disk).
-func NewConfig(cmdline string) *Config {
+func NewConfig() *Config {
 	return &Config{
-		Next: bootloader.BootA,
-		Entries: map[bootloader.BootLabel]MenuEntry{
-			bootloader.BootA: buildMenuEntry(bootloader.BootA, cmdline),
-		},
+		Default: bootloader.BootA,
+		Entries: map[bootloader.BootLabel]MenuEntry{},
 	}
-}
-
-// Installed returns true if the bootloader is installed.
-func (c *Config) Installed() bool {
-	return c != nil
 }
 
 // Put puts a new menu entry to the grub config (nothing is written to disk).
@@ -56,8 +49,8 @@ func (c *Config) Put(entry bootloader.BootLabel, cmdline string) error {
 }
 
 func (c *Config) validate() error {
-	if _, ok := c.Entries[c.Next]; !ok {
-		return fmt.Errorf("invalid default entry: %s", c.Next)
+	if _, ok := c.Entries[c.Default]; !ok {
+		return fmt.Errorf("invalid default entry: %s", c.Default)
 	}
 
 	if c.Fallback != "" {
@@ -66,7 +59,7 @@ func (c *Config) validate() error {
 		}
 	}
 
-	if c.Next == c.Fallback {
+	if c.Default == c.Fallback {
 		return fmt.Errorf("default and fallback entries must not be the same")
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/revert.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/revert.go
@@ -24,7 +24,7 @@ func (c *Config) Revert() error {
 		return fmt.Errorf("cannot revert bootloader: %w", bootloaderNotInstalledError{})
 	}
 
-	if err := c.Flip(); err != nil {
+	if err := c.flip(); err != nil {
 		return err
 	}
 
@@ -64,7 +64,7 @@ func (c *Config) Revert() error {
 		defer mp.Unmount() //nolint:errcheck
 	}
 
-	if _, err = os.Stat(filepath.Join(constants.BootMountPoint, string(c.Next))); errors.Is(err, os.ErrNotExist) {
+	if _, err = os.Stat(filepath.Join(constants.BootMountPoint, string(c.Default))); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("cannot rollback to %q, label does not exist", "")
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -2242,7 +2242,7 @@ func KexecPrepare(_ runtime.Sequence, data any) (runtime.TaskExecutionFunc, stri
 			return nil
 		}
 
-		defaultEntry, ok := conf.Entries[conf.Next]
+		defaultEntry, ok := conf.Entries[conf.Default]
 		if !ok {
 			return nil
 		}

--- a/internal/app/machined/revert.go
+++ b/internal/app/machined/revert.go
@@ -47,14 +47,14 @@ func revertBootloadInternal() error {
 	log.Printf("reverting failed upgrade, switching to %q", label)
 
 	if err = func() error {
-		config, probeErr := bootloader.Probe(false)
+		config, probeErr := bootloader.Probe("")
 		if probeErr != nil {
-			return probeErr
-		}
+			if os.IsNotExist(probeErr) {
+				// no bootloader found, nothing to do
+				return nil
+			}
 
-		// not bootloader found, nothing to do
-		if !config.Installed() {
-			return nil
+			return probeErr
 		}
 
 		return config.Revert()

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -72,21 +72,21 @@ func WithPrefix(o string) Option {
 // WithFlags is a functional option to set up mount flags.
 func WithFlags(flags Flags) Option {
 	return func(args *Options) {
-		args.MountFlags = flags
+		args.MountFlags |= flags
 	}
 }
 
 // WithPreMountHooks adds functions to be called before mounting the partition.
 func WithPreMountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.PreMountHooks = hooks
+		args.PreMountHooks = append(args.PreMountHooks, hooks...)
 	}
 }
 
 // WithPostUnmountHooks adds functions to be called after unmounting the partition.
 func WithPostUnmountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.PostUnmountHooks = hooks
+		args.PostUnmountHooks = append(args.PostUnmountHooks, hooks...)
 	}
 }
 


### PR DESCRIPTION
Move labels out of the bootloader interface, while moving copying assets into the bootloader interface. GRUB is using one set of assets, `sd-boot` will be using another one.

Fix the problem with `bootloader.Probe()` finding boot partition on the host when it runs in a priv container, fixing issues with image creation in the CI.
