### PR TITLE
docs: fix broken link to powershell module

### DIFF
--- a/website/content/v1.0/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.0/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 

--- a/website/content/v1.1/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.1/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 

--- a/website/content/v1.2/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.2/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 

--- a/website/content/v1.3/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.3/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 

--- a/website/content/v1.4/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.4/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 

--- a/website/content/v1.5/talos-guides/install/virtualized-platforms/hyper-v.md
+++ b/website/content/v1.5/talos-guides/install/virtualized-platforms/hyper-v.md
@@ -8,7 +8,7 @@ aliases:
 ## Pre-requisities
 
 1. Download the latest `talos-amd64.iso` ISO from github [releases page](https://github.com/siderolabs/talos/releases)
-2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/New-TalosVM.psm1) there
+2. Create a New-TalosVM folder in any of your PS Module Path folders `$env:PSModulePath -split ';'` and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there
 
 ## Plan Overview
 


### PR DESCRIPTION
- Small update to documentation, basically looks like the maintainer of another [referenced project](https://github.com/nebula-it/New-TalosVM) changed their folder structure, thus resulting in a broken link in your documentation.

- Just trying to provide a better documentation experience to the lowly Windows users out there 😄

- Very small change, love the project and your docs to just happy to keep them clean.

Re-submitted with conventional commit.