### PR TITLE
Compare only basename of `os.Args[0]`.

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -286,25 +287,25 @@ func run() error {
 }
 
 func main() {
-	switch os.Args[0] {
-	case "/apid":
+	switch filepath.Base(os.Args[0]) {
+	case "apid":
 		apid.Main()
 
 		return
-	case "/trustd":
+	case "trustd":
 		trustd.Main()
 
 		return
 	// Azure uses the hv_utils kernel module to shutdown the node in hyper-v by calling perform_shutdown which will call orderly_poweroff which will call /sbin/poweroff.
-	case "/sbin/poweroff":
+	case "poweroff":
 		poweroff.Main()
 
 		return
-	case "/sbin/wrapperd":
+	case "wrapperd":
 		wrapperd.Main()
 
 		return
-	case "/sbin/dashboard":
+	case "dashboard":
 		dashboard.Main()
 
 		return


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Only compare the basename of the 0th argument.

## Why? (reasoning)

Took me more than a day to debug why

```c
execl("/sbin/poweroff", "poweroff", (char *)NULL);
```

was not working in https://github.com/siderolabs/extensions/pull/173, only to discover that 

```c
execl("/sbin/poweroff", "/sbin/poweroff", (char *)NULL);
```

does work.


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
