### PR TITLE
chore: add `/sbin/shutdown`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -541,6 +541,9 @@ COPY --from=machined-build-amd64 /machined /rootfs/sbin/init
 # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
 RUN ln /rootfs/sbin/init /rootfs/sbin/poweroff
 RUN chmod +x /rootfs/sbin/poweroff
+# some extensions like qemu-guest agent will call '/sbin/shutdown'
+RUN ln /rootfs/sbin/init /rootfs/sbin/shutdown
+RUN chmod +x /rootfs/sbin/shutdown
 RUN ln /rootfs/sbin/init /rootfs/sbin/wrapperd
 RUN chmod +x /rootfs/sbin/wrapperd
 RUN ln /rootfs/sbin/init /rootfs/sbin/dashboard
@@ -595,6 +598,9 @@ COPY --from=machined-build-arm64 /machined /rootfs/sbin/init
 # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
 RUN ln /rootfs/sbin/init /rootfs/sbin/poweroff
 RUN chmod +x /rootfs/sbin/poweroff
+# some extensions like qemu-guest agent will call '/sbin/shutdown'
+RUN ln /rootfs/sbin/init /rootfs/sbin/shutdown
+RUN chmod +x /rootfs/sbin/shutdown
 RUN ln /rootfs/sbin/init /rootfs/sbin/wrapperd
 RUN chmod +x /rootfs/sbin/wrapperd
 RUN ln /rootfs/sbin/init /rootfs/sbin/dashboard

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -297,7 +297,7 @@ func main() {
 
 		return
 	// Azure uses the hv_utils kernel module to shutdown the node in hyper-v by calling perform_shutdown which will call orderly_poweroff which will call /sbin/poweroff.
-	case "poweroff":
+	case "poweroff", "shutdown":
 		poweroff.Main()
 
 		return


### PR DESCRIPTION
Some tools like qemu-guest-agent when ran as a extension service calls `/sbin/shutdown` instead of `/sbin/poweroff`. This adds handling for the same.

Ref: https://github.com/siderolabs/extensions/pull/173