### PR TITLE
fix: disable LVM backups/archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -562,6 +562,7 @@ COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml
 COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
 COPY --chmod=0644 hack/cri-plugin.part /rootfs/etc/cri/conf.d/00-base.part
 COPY --chmod=0644 hack/udevd/80-net-name-slot.rules /rootfs/usr/lib/udev/rules.d/
+COPY --chmod=0644 hack/lvm.conf /rootfs/etc/lvm/lvm.conf
 RUN touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,os-release,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part}
 RUN ln -s ca-certificates /rootfs/etc/ssl/certs/ca-certificates.crt
 RUN ln -s /etc/ssl /rootfs/etc/pki
@@ -619,6 +620,7 @@ COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml
 COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
 COPY --chmod=0644 hack/cri-plugin.part /rootfs/etc/cri/conf.d/00-base.part
 COPY --chmod=0644 hack/udevd/80-net-name-slot.rules /rootfs/usr/lib/udev/rules.d/
+COPY --chmod=0644 hack/lvm.conf /rootfs/etc/lvm/lvm.conf
 RUN touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,os-release,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part}
 RUN ln -s /etc/ssl /rootfs/etc/pki
 RUN ln -s ca-certificates /rootfs/etc/ssl/certs/ca-certificates.crt

--- a/hack/lvm.conf
+++ b/hack/lvm.conf
@@ -1,0 +1,8 @@
+# Disable LVM backups as Talos rootfs is read-only, and ephemeral partition is not a safe place to store
+# metadata backups.
+#
+# See https://github.com/siderolabs/talos/issues/3129
+backup {
+    backup = 0
+    archive = 0
+}


### PR DESCRIPTION
Fixes #3129

Talos does not have a good location to keep LVM metadata backups.
