### PR TITLE
fix: provide stashed META values before installation

### DIFF
--- a/cmd/installer/cmd/iso.go
+++ b/cmd/installer/cmd/iso.go
@@ -7,13 +7,11 @@ package cmd
 import (
 	"bytes"
 	_ "embed"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/siderolabs/go-procfs/procfs"
@@ -134,8 +132,7 @@ func createISO(out string) error {
 
 	if metaValues := options.MetaValues.GetSlice(); len(metaValues) > 0 {
 		// pass META values as kernel talos.environment args which will be passed via the environment to the installer
-		metaBase64 := base64.StdEncoding.EncodeToString([]byte(strings.Join(metaValues, ";")))
-		cmdline.Append(constants.KernelParamEnvironment, metaValueEnvVariable+"="+metaBase64)
+		cmdline.Append(constants.KernelParamEnvironment, constants.MetaValuesEnvVar+"="+options.MetaValues.Encode())
 	}
 
 	var grubCfg bytes.Buffer

--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -6,11 +6,9 @@
 package cmd
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,19 +23,10 @@ var rootCmd = &cobra.Command{
 	Long:  ``,
 }
 
-const metaValueEnvVariable = "INSTALLER_META_BASE64"
-
 func setFlagsFromEnvironment() error {
-	if metaEnvBase64 := os.Getenv(metaValueEnvVariable); metaEnvBase64 != "" {
-		metaEnv, err := base64.StdEncoding.DecodeString(metaEnvBase64)
-		if err != nil {
+	if metaEnvBase64 := os.Getenv(constants.MetaValuesEnvVar); metaEnvBase64 != "" {
+		if err := options.MetaValues.Decode(metaEnvBase64); err != nil {
 			return err
-		}
-
-		for _, val := range strings.Split(string(metaEnv), ";") {
-			if err := options.MetaValues.Set(val); err != nil {
-				return err
-			}
 		}
 	}
 

--- a/cmd/installer/pkg/install/meta_value_test.go
+++ b/cmd/installer/pkg/install/meta_value_test.go
@@ -13,25 +13,6 @@ import (
 	"github.com/siderolabs/talos/cmd/installer/pkg/install"
 )
 
-func TestMetaValue(t *testing.T) {
-	t.Parallel()
-
-	var v install.MetaValue
-
-	require.NoError(t, v.Parse("10=foo"))
-
-	assert.Equal(t, uint8(10), v.Key)
-	assert.Equal(t, "foo", v.Value)
-
-	assert.Equal(t, "0xa=foo", v.String())
-
-	var v2 install.MetaValue
-
-	require.NoError(t, v2.Parse(v.String()))
-
-	assert.Equal(t, v, v2)
-}
-
 func TestMetaValues(t *testing.T) {
 	t.Parallel()
 
@@ -41,4 +22,11 @@ func TestMetaValues(t *testing.T) {
 	require.NoError(t, s.Append("20=bar"))
 
 	assert.Equal(t, "[0xa=foo,0x14=bar]", s.String())
+
+	encoded := s.Encode()
+
+	var s2 install.MetaValues
+
+	require.NoError(t, s2.Decode(encoded))
+	assert.Equal(t, s.String(), s2.String())
 }

--- a/internal/pkg/meta/meta.go
+++ b/internal/pkg/meta/meta.go
@@ -75,11 +75,8 @@ func New(ctx context.Context, st state.State, opts ...Option) (*Meta, error) {
 	}
 
 	err = meta.Reload(ctx)
-	if err != nil && !os.IsNotExist(err) {
-		return meta, err
-	}
 
-	return meta, nil
+	return meta, err
 }
 
 func (meta *Meta) getPath() (string, error) {

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -863,6 +863,9 @@ const (
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"
+
+	// MetaValuesEnvVar is the name of the environment variable to store encoded meta values for the disk image (installer).
+	MetaValuesEnvVar = "INSTALLER_META_BASE64"
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/machinery/meta/meta.go
+++ b/pkg/machinery/meta/meta.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package meta provides interfaces for encoding and decoding META values.
+package meta
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/siderolabs/gen/slices"
+)
+
+// Value represents a key/value pair for META.
+type Value struct {
+	Key   uint8
+	Value string
+}
+
+func (v Value) String() string {
+	return fmt.Sprintf("0x%x=%s", v.Key, v.Value)
+}
+
+// Parse k=v expression.
+func (v *Value) Parse(s string) error {
+	k, vv, ok := strings.Cut(s, "=")
+	if !ok {
+		return fmt.Errorf("invalid value %q", s)
+	}
+
+	key, err := strconv.ParseUint(k, 0, 8)
+	if err != nil {
+		return fmt.Errorf("invalid key %q", k)
+	}
+
+	v.Key = uint8(key)
+	v.Value = vv
+
+	return nil
+}
+
+// Values is a collection of Value.
+type Values []Value
+
+// Encode returns a string representation of Values for the environment variable.
+//
+// Each Value is encoded a k=v, split by ';' character.
+// The result is base64 encoded.
+func (v Values) Encode() string {
+	return base64.StdEncoding.EncodeToString([]byte(strings.Join(slices.Map(v, Value.String), ";")))
+}
+
+// DecodeValues parses a string representation of Values for the environment variable.
+//
+// See Encode for the details of the encoding.
+func DecodeValues(s string) (Values, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		return nil, nil
+	}
+
+	parts := strings.Split(string(b), ";")
+
+	result := make(Values, 0, len(parts))
+
+	for _, v := range parts {
+		var vv Value
+
+		if err := vv.Parse(v); err != nil {
+			return nil, err
+		}
+
+		result = append(result, vv)
+	}
+
+	return result, nil
+}

--- a/pkg/machinery/meta/meta_test.go
+++ b/pkg/machinery/meta/meta_test.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/meta"
+)
+
+func TestValue(t *testing.T) {
+	t.Parallel()
+
+	var v meta.Value
+
+	require.NoError(t, v.Parse("10=foo"))
+
+	assert.Equal(t, uint8(10), v.Key)
+	assert.Equal(t, "foo", v.Value)
+
+	assert.Equal(t, "0xa=foo", v.String())
+
+	var v2 meta.Value
+
+	require.NoError(t, v2.Parse(v.String()))
+
+	assert.Equal(t, v, v2)
+}
+
+func TestEncodeDecodeValues(t *testing.T) {
+	t.Parallel()
+
+	values := make(meta.Values, 2)
+
+	require.NoError(t, values[0].Parse("10=foo"))
+	require.NoError(t, values[1].Parse("0xb=bar"))
+
+	encoded := values.Encode()
+
+	decoded, err := meta.DecodeValues(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, values, decoded)
+}


### PR DESCRIPTION
Previously, if META values were supplied to the Talos ISO via environment variable, they will be written down and available after the install. With this fix, values are also readable and available before the installation runs (in maintenance mode).

Most of the PR is refactoring `meta.Value(s)` to be a shared library which is used by the installer/imager and (now) Talos.

Also fixes an issue with not returning properly `NotExist` error when META is not yet available as a partition on disk.
