### PR TITLE
fix: capabilities including `ALL` should be uppercase

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -392,7 +392,7 @@ spec:
               add:
               - NET_BIND_SERVICE
               drop:
-              - all
+              - ALL
             readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)


## Why? (reasoning)

Pod security standard requires that ALL is in caps
See https://github.com/kyverno/policies/issues/413 for some discussion

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
