### PR TITLE
Preserve bond and ip kernel params

### DIFF
--- a/api/resource/definitions/cluster/cluster.proto
+++ b/api/resource/definitions/cluster/cluster.proto
@@ -66,4 +66,3 @@ message MemberSpec {
   string operating_system = 5;
   ControlPlane control_plane = 6;
 }
-

--- a/api/resource/definitions/cri/cri.proto
+++ b/api/resource/definitions/cri/cri.proto
@@ -11,4 +11,3 @@ message SeccompProfileSpec {
   string name = 1;
   google.protobuf.Struct value = 2;
 }
-

--- a/api/resource/definitions/enums/enums.proto
+++ b/api/resource/definitions/enums/enums.proto
@@ -330,4 +330,3 @@ enum RuntimeMachineStage {
   MACHINE_STAGE_RESETTING = 7;
   MACHINE_STAGE_UPGRADING = 8;
 }
-

--- a/api/resource/definitions/etcd/etcd.proto
+++ b/api/resource/definitions/etcd/etcd.proto
@@ -36,4 +36,3 @@ message SpecSpec {
   repeated common.NetIP listen_peer_addresses = 5;
   repeated common.NetIP listen_client_addresses = 6;
 }
-

--- a/api/resource/definitions/extensions/extensions.proto
+++ b/api/resource/definitions/extensions/extensions.proto
@@ -28,4 +28,3 @@ message Metadata {
   string description = 4;
   Compatibility compatibility = 5;
 }
-

--- a/api/resource/definitions/files/files.proto
+++ b/api/resource/definitions/files/files.proto
@@ -14,4 +14,3 @@ message EtcFileSpecSpec {
 message EtcFileStatusSpec {
   string spec_version = 1;
 }
-

--- a/api/resource/definitions/hardware/hardware.proto
+++ b/api/resource/definitions/hardware/hardware.proto
@@ -42,4 +42,3 @@ message SystemInformationSpec {
   string wake_up_type = 6;
   string sku_number = 7;
 }
-

--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -236,4 +236,3 @@ message StaticPodSpec {
 message StaticPodStatusSpec {
   google.protobuf.Struct pod_status = 1;
 }
-

--- a/api/resource/definitions/kubeaccess/kubeaccess.proto
+++ b/api/resource/definitions/kubeaccess/kubeaccess.proto
@@ -10,4 +10,3 @@ message ConfigSpec {
   repeated string allowed_api_roles = 2;
   repeated string allowed_kubernetes_namespaces = 3;
 }
-

--- a/api/resource/definitions/kubespan/kubespan.proto
+++ b/api/resource/definitions/kubespan/kubespan.proto
@@ -55,4 +55,3 @@ message PeerStatusSpec {
   common.NetIPPort last_used_endpoint = 7;
   google.protobuf.Timestamp last_endpoint_change = 8;
 }
-

--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -322,4 +322,3 @@ message WireguardSpec {
   int64 firewall_mark = 4;
   repeated WireguardPeer peers = 5;
 }
-

--- a/api/resource/definitions/perf/perf.proto
+++ b/api/resource/definitions/perf/perf.proto
@@ -81,4 +81,3 @@ message MemorySpec {
   uint64 direct_map2m = 47;
   uint64 direct_map1g = 48;
 }
-

--- a/api/resource/definitions/proto/proto.proto
+++ b/api/resource/definitions/proto/proto.proto
@@ -11,4 +11,3 @@ message Mount {
   string source = 3;
   repeated string options = 4;
 }
-

--- a/api/resource/definitions/runtime/runtime.proto
+++ b/api/resource/definitions/runtime/runtime.proto
@@ -83,4 +83,3 @@ message UnmetCondition {
   string name = 1;
   string reason = 2;
 }
-

--- a/api/resource/definitions/secrets/secrets.proto
+++ b/api/resource/definitions/secrets/secrets.proto
@@ -86,4 +86,3 @@ message TrustdCertsSpec {
   common.PEMEncodedCertificateAndKey ca = 1;
   common.PEMEncodedCertificateAndKey server = 2;
 }
-

--- a/api/resource/definitions/siderolink/siderolink.proto
+++ b/api/resource/definitions/siderolink/siderolink.proto
@@ -8,4 +8,3 @@ option go_package = "github.com/siderolabs/talos/pkg/machinery/api/resource/defi
 message ConfigSpec {
   string api_endpoint = 1;
 }
-

--- a/api/resource/definitions/time/time.proto
+++ b/api/resource/definitions/time/time.proto
@@ -10,4 +10,3 @@ message StatusSpec {
   int64 epoch = 2;
   bool sync_disabled = 3;
 }
-

--- a/api/resource/definitions/v1alpha1/v1alpha1.proto
+++ b/api/resource/definitions/v1alpha1/v1alpha1.proto
@@ -10,4 +10,3 @@ message ServiceSpec {
   bool healthy = 2;
   bool unknown = 3;
 }
-

--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -116,7 +116,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 	}
 
 	// standard ip=
-	ipSettings := cmdline.Get("ip")
+	ipSettings := cmdline.Get(constants.KernelParamIP)
 
 	for idx := 0; ipSettings.Get(idx) != nil; idx++ {
 		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -181,6 +181,8 @@ func RunInstallerContainer(disk, platform, ref string, cfg configcore.Config, cf
 		constants.KernelParamEquinixMetalEvents,
 		constants.KernelParamDashboardDisabled,
 		constants.KernelParamNetIfnames,
+		constants.KernelParamBonding,
+		constants.KernelParamIP,
 	} {
 		if c := procfs.ProcCmdline().Get(preservedArg).First(); c != nil {
 			args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", preservedArg, *c))

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -37,6 +37,9 @@ const (
 	// events sink server.
 	KernelParamEventsSink = "talos.events.sink"
 
+	// KernelParamIP is the kernel parameter name for network interface configuration
+	KernelParamIP = "ip"
+
 	// KernelParamLoggingKernel is the kernel parameter name for specifying the
 	// kernel log delivery destination.
 	KernelParamLoggingKernel = "talos.logging.kernel"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

The bond and ip kernel params are typically used to configure networking on the host and should be preserved when Talos is installed

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
