### PR TITLE
docs: fix wrong capability name

### DIFF
--- a/website/content/v1.4/learn-more/process-capabilities.md
+++ b/website/content/v1.4/learn-more/process-capabilities.md
@@ -9,7 +9,7 @@ Linux defines a set of [process capabilities](https://man7.org/linux/man-pages/m
 Talos Linux for security reasons restricts any process from gaining the following capabilities:
 
 * `CAP_SYS_MODULE` (loading kernel modules)
-* `CAP_BOOT` (rebooting the system)
+* `CAP_SYS_BOOT` (rebooting the system)
 
 This means that any process including privileged Kubernetes pods will not be able to get these capabilities.
 

--- a/website/content/v1.5/learn-more/process-capabilities.md
+++ b/website/content/v1.5/learn-more/process-capabilities.md
@@ -9,7 +9,7 @@ Linux defines a set of [process capabilities](https://man7.org/linux/man-pages/m
 Talos Linux for security reasons restricts any process from gaining the following capabilities:
 
 * `CAP_SYS_MODULE` (loading kernel modules)
-* `CAP_BOOT` (rebooting the system)
+* `CAP_SYS_BOOT` (rebooting the system)
 
 This means that any process including privileged Kubernetes pods will not be able to get these capabilities.
 


### PR DESCRIPTION
It's CAP_SYS_BOOT, not CAP_BOOT.

# Pull Request


## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
