### PR TITLE
fix: skip over tpm2 1.2 devices

### DIFF
--- a/internal/pkg/rng/tpm.go
+++ b/internal/pkg/rng/tpm.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/go-tpm/tpm2"
@@ -20,7 +21,8 @@ import (
 func TPMSeed() error {
 	t, err := transport.OpenTPM()
 	if err != nil {
-		if os.IsNotExist(err) {
+		// if the TPM is not available or not a TPM 2.0, we can skip the PCR extension
+		if os.IsNotExist(err) || strings.Contains(err.Error(), "device is not a TPM 2.0") {
 			log.Printf("TPM device is not available")
 
 			return nil

--- a/internal/pkg/secureboot/tpm2/pcr.go
+++ b/internal/pkg/secureboot/tpm2/pcr.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpm2/transport"
@@ -66,7 +67,8 @@ func ReadPCR(t transport.TPM, pcr int) ([]byte, error) {
 func PCRExtent(pcr int, data []byte) error {
 	t, err := transport.OpenTPM()
 	if err != nil {
-		if os.IsNotExist(err) {
+		// if the TPM is not available or not a TPM 2.0, we can skip the PCR extension
+		if os.IsNotExist(err) || strings.Contains(err.Error(), "device is not a TPM 2.0") {
 			log.Printf("TPM device is not available, skipping PCR extension")
 
 			return nil


### PR DESCRIPTION
For rng seed and pcr extend, let's ignore if the device is not TPM2.0 based. Seal/Unseal operations would still error out since it's explicitly user enabled feature.