### PR TITLE
chore: machined socket for `shutdown`, `poweroff`

### DIFF
--- a/internal/app/poweroff/main.go
+++ b/internal/app/poweroff/main.go
@@ -27,7 +27,7 @@ func Main() {
 	authz.SetMetadata(md, role.MakeSet(role.Admin))
 	adminCtx := metadata.NewOutgoingContext(ctx, md)
 
-	client, err := client.New(adminCtx, client.WithUnixSocket(constants.APISocketPath), client.WithGRPCDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())))
+	client, err := client.New(adminCtx, client.WithUnixSocket(constants.MachineSocketPath), client.WithGRPCDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	if err != nil {
 		log.Fatalf(fmt.Errorf("error while creating machinery client: %w", err).Error())
 	}


### PR DESCRIPTION
Use the `machined` socket for `shutdown` and `poweroff` aliases. This ensures that worker nodes does not have to wait on apid to start.
