### PR TITLE
feat: enforce kernel lockdown for UKI

### DIFF
--- a/cmd/ukify/main.go
+++ b/cmd/ukify/main.go
@@ -34,6 +34,10 @@ func run() error {
 		return err
 	}
 
+	if err := defaultCmdline.AppendAll(kernelpkg.SecureBootArgs); err != nil {
+		return err
+	}
+
 	if err := defaultCmdline.AppendAll(metal.KernelArgs().Strings()); err != nil {
 		return err
 	}

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -31,6 +31,11 @@ var DefaultArgs = []string{
 	"ima_hash=sha512",
 }
 
+// SecureBootArgs returns the kernel commandline options required for secure boot.
+var SecureBootArgs = []string{
+	"lockdown=confidentiality",
+}
+
 // Param represents a kernel system property.
 type Param struct {
 	Key   string


### PR DESCRIPTION
UKI is meant to be for UEFI Secure Boot, so it's expected to enforce kernel lockdown. We might reconsider in the future to use a kernel patch instead: https://github.com/SUSE/kernel/commit/b1a0314b0827ea781c13a27abcc3c3b96fc0e946
