### PR TITLE
feat: update default Kubernetes version to 1.28.0-beta.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ INTEGRATION_TEST_DEFAULT_TARGET := integration-test-$(OPERATING_SYSTEM)
 MODULE_SIG_VERIFY_DEFAULT_TARGET := module-sig-verify-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_PROVISION_DEFAULT_TARGET := integration-test-provision-$(OPERATING_SYSTEM)
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
-KUBECTL_VERSION ?= v1.28.0-alpha.4
+KUBECTL_VERSION ?= v1.28.0-beta.0
 # renovate: datasource=github-releases depName=kastenhq/kubestr
 KUBESTR_VERSION ?= v0.4.37
 # renovate: datasource=github-releases depName=helm/helm

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,7 +22,7 @@ preface = """\
 * containerd: 1.6.21
 * runc: 1.1.8
 * etcd: 3.5.9
-* Kubernetes: 1.28.0-alpha.4
+* Kubernetes: 1.28.0-beta.0
 * Flannel: 0.22.0
 
 Talos is built with Go 1.20.6.

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -40,7 +40,7 @@ export TALOS_VERSION=v1.1
 # Kubernetes
 
 export KUBECONFIG="${TMP}/kubeconfig"
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.28.0-alpha.4}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.28.0-beta.0}
 
 export NAME_PREFIX="talos-e2e-${SHA}-${PLATFORM}"
 export TIMEOUT=1200

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -311,7 +311,7 @@ const (
 
 	// DefaultKubernetesVersion is the default target version of the control plane.
 	// renovate: datasource=github-releases depName=kubernetes/kubernetes
-	DefaultKubernetesVersion = "1.28.0-alpha.4"
+	DefaultKubernetesVersion = "1.28.0-beta.0"
 
 	// DefaultControlPlanePort is the default port to use for the control plane.
 	DefaultControlPlanePort = 6443

--- a/website/content/v1.5/reference/cli.md
+++ b/website/content/v1.5/reference/cli.md
@@ -133,7 +133,7 @@ talosctl cluster create [flags]
       --ipv6                                     enable IPv6 network in the cluster (QEMU provisioner only)
       --iso-path string                          the ISO path to use for the initial boot (VM only)
       --kubeprism-port int                       KubePrism port (defaults to 0 - disabled)
-      --kubernetes-version string                desired kubernetes version to run (default "1.28.0-alpha.4")
+      --kubernetes-version string                desired kubernetes version to run (default "1.28.0-beta.0")
       --memory int                               the limit on memory usage in MB (each control plane/VM) (default 2048)
       --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
       --mtu int                                  MTU of the cluster network (default 1500)
@@ -1329,7 +1329,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
       --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")
-      --kubernetes-version string                desired kubernetes version to run (default "1.28.0-alpha.4")
+      --kubernetes-version string                desired kubernetes version to run (default "1.28.0-beta.0")
   -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
   -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
   -p, --persist                                  the desired persist value for configs (default true)
@@ -2887,7 +2887,7 @@ talosctl upgrade-k8s [flags]
       --from string       the Kubernetes control plane version to upgrade from
   -h, --help              help for upgrade-k8s
       --pre-pull-images   pre-pull images before upgrade (default true)
-      --to string         the Kubernetes control plane version to upgrade to (default "1.28.0-alpha.4")
+      --to string         the Kubernetes control plane version to upgrade to (default "1.28.0-beta.0")
       --upgrade-kubelet   upgrade kubelet service (default true)
 ```
 

--- a/website/content/v1.5/reference/configuration.md
+++ b/website/content/v1.5/reference/configuration.md
@@ -101,7 +101,7 @@ controlPlane:
 {{< /highlight >}}</details> | |
 |`kubelet` |<a href="#kubeletconfig">KubeletConfig</a> |Used to provide additional options to the kubelet. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.28.0-alpha.4 # The `image` field is an optional reference to an alternative kubelet image.
+    image: ghcr.io/siderolabs/kubelet:v1.28.0-beta.0 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -523,7 +523,7 @@ serviceAccount:
 {{< /highlight >}}</details> | |
 |`apiServer` |<a href="#apiserverconfig">APIServerConfig</a> |API server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.28.0-alpha.4 # The container image used in the API server manifest.
+    image: registry.k8s.io/kube-apiserver:v1.28.0-beta.0 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -562,14 +562,14 @@ apiServer:
 {{< /highlight >}}</details> | |
 |`controllerManager` |<a href="#controllermanagerconfig">ControllerManagerConfig</a> |Controller manager server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.28.0-alpha.4 # The container image used in the controller manager manifest.
+    image: registry.k8s.io/kube-controller-manager:v1.28.0-beta.0 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
         feature-gates: ServerSideApply=true
 {{< /highlight >}}</details> | |
 |`proxy` |<a href="#proxyconfig">ProxyConfig</a> |Kube-proxy server-specific configuration options <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 proxy:
-    image: registry.k8s.io/kube-proxy:v1.28.0-alpha.4 # The container image used in the kube-proxy manifest.
+    image: registry.k8s.io/kube-proxy:v1.28.0-beta.0 # The container image used in the kube-proxy manifest.
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
@@ -580,7 +580,7 @@ proxy:
 {{< /highlight >}}</details> | |
 |`scheduler` |<a href="#schedulerconfig">SchedulerConfig</a> |Scheduler server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.28.0-alpha.4 # The container image used in the scheduler manifest.
+    image: registry.k8s.io/kube-scheduler:v1.28.0-beta.0 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
         feature-gates: AllBeta=true
@@ -747,7 +747,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: ghcr.io/siderolabs/kubelet:v1.28.0-alpha.4 # The `image` field is an optional reference to an alternative kubelet image.
+image: ghcr.io/siderolabs/kubelet:v1.28.0-beta.0 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -784,7 +784,7 @@ extraArgs:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The `image` field is an optional reference to an alternative kubelet image. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: ghcr.io/siderolabs/kubelet:v1.28.0-alpha.4
+image: ghcr.io/siderolabs/kubelet:v1.28.0-beta.0
 {{< /highlight >}}</details> | |
 |`clusterDNS` |[]string |The `ClusterDNS` field is an optional reference to an alternative kubelet clusterDNS ip list. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 clusterDNS:
@@ -1401,7 +1401,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: registry.k8s.io/kube-apiserver:v1.28.0-alpha.4 # The container image used in the API server manifest.
+image: registry.k8s.io/kube-apiserver:v1.28.0-beta.0 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -1443,7 +1443,7 @@ certSANs:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the API server manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-apiserver:v1.28.0-alpha.4
+image: registry.k8s.io/kube-apiserver:v1.28.0-beta.0
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the API server.  | |
 |`extraVolumes` |[]<a href="#volumemountconfig">VolumeMountConfig</a> |Extra volumes to mount to the API server static pod.  | |
@@ -1530,7 +1530,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: registry.k8s.io/kube-controller-manager:v1.28.0-alpha.4 # The container image used in the controller manager manifest.
+image: registry.k8s.io/kube-controller-manager:v1.28.0-beta.0 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -1540,7 +1540,7 @@ extraArgs:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the controller manager manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-controller-manager:v1.28.0-alpha.4
+image: registry.k8s.io/kube-controller-manager:v1.28.0-beta.0
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the controller manager.  | |
 |`extraVolumes` |[]<a href="#volumemountconfig">VolumeMountConfig</a> |Extra volumes to mount to the controller manager static pod.  | |
@@ -1560,7 +1560,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: registry.k8s.io/kube-proxy:v1.28.0-alpha.4 # The container image used in the kube-proxy manifest.
+image: registry.k8s.io/kube-proxy:v1.28.0-beta.0 # The container image used in the kube-proxy manifest.
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
@@ -1577,7 +1577,7 @@ extraArgs:
 disabled: false
 {{< /highlight >}}</details> | |
 |`image` |string |The container image used in the kube-proxy manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-proxy:v1.28.0-alpha.4
+image: registry.k8s.io/kube-proxy:v1.28.0-beta.0
 {{< /highlight >}}</details> | |
 |`mode` |string |<details><summary>proxy mode of kube-proxy.</summary>The default is 'iptables'.</details>  | |
 |`extraArgs` |map[string]string |Extra arguments to supply to kube-proxy.  | |
@@ -1595,7 +1595,7 @@ Appears in:
 
 
 {{< highlight yaml >}}
-image: registry.k8s.io/kube-scheduler:v1.28.0-alpha.4 # The container image used in the scheduler manifest.
+image: registry.k8s.io/kube-scheduler:v1.28.0-beta.0 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
     feature-gates: AllBeta=true
@@ -1605,7 +1605,7 @@ extraArgs:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the scheduler manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-scheduler:v1.28.0-alpha.4
+image: registry.k8s.io/kube-scheduler:v1.28.0-beta.0
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the scheduler.  | |
 |`extraVolumes` |[]<a href="#volumemountconfig">VolumeMountConfig</a> |Extra volumes to mount to the scheduler static pod.  | |


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/releases/tag/v1.28.0-beta.0

Go modules are not tagged yet, so skipped updating them.
