### PR TITLE
doc: warning about secretboxEncryptionSecret in kubeadm migration guide

### DIFF
--- a/website/content/v1.5/advanced/migrating-from-kubeadm.md
+++ b/website/content/v1.5/advanced/migrating-from-kubeadm.md
@@ -90,7 +90,8 @@ you can do the following:
     - `.cluster.network.serviceSubnets[0]` with the value of the `networking.serviceSubnet` from the previous step
     - `.cluster.network.dnsDomain` with the value of the `networking.dnsDomain` from the previous step
 
-7. Go through the rest of `controlplane.yaml` and `worker.yaml` to customize them according to your needs.
+7. Go through the rest of `controlplane.yaml` and `worker.yaml` to customize them according to your needs, especially :
+    - `.cluster.secretboxEncryptionSecret` should be either removed if you don't currently use `EncryptionConfig` on your `kube-apiserver` or set to the correct value
 
 8. Bring up a Talos node to be the initial Talos control plane node.
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Warning about EncryptionConfig when migrating from an existing kubeadm cluster in documentation.
## Why? (reasoning)
If you don't know about this config, you risk having a split configuration between kubeadm controlplane and talos controlplane, it **will** lead to unusable Secrets and to a dysfunctional cluster.

https://github.com/siderolabs/talos/issues/7475

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
