### PR TITLE
chore: workaround AWS AMI failures, disable Azure uploader

### DIFF
--- a/hack/cloud-image-uploader/aws.go
+++ b/hack/cloud-image-uploader/aws.go
@@ -243,7 +243,9 @@ func (au *AWSUploader) registerAMIArch(ctx context.Context, region string, svc *
 		return retry.ExpectedError(fmt.Errorf("task status not found"))
 	})
 	if err != nil {
-		return err
+		log.Printf("WARNING: aws: ignoring failure to import snapshot into %s/%s: %s", region, arch, err)
+
+		return nil //nolint:nilerr
 	}
 
 	log.Printf("aws: import into %s/%s, snapshot ID %q", region, arch, snapshotID)

--- a/hack/cloud-image-uploader/main.go
+++ b/hack/cloud-image-uploader/main.go
@@ -92,13 +92,14 @@ func run() error {
 		return aws.Upload(ctx)
 	})
 
-	g.Go(func() error {
-		azure := AzureUploader{
-			Options: DefaultOptions,
-		}
+	// disabled until https://github.com/siderolabs/talos/issues/7512 is resolved
+	// g.Go(func() error {
+	// 	azure := AzureUploader{
+	// 		Options: DefaultOptions,
+	// 	}
 
-		return azure.AzureGalleryUpload(ctx)
-	})
+	// 	return azure.AzureGalleryUpload(ctx)
+	// })
 
 	if err = g.Wait(); err != nil {
 		return fmt.Errorf("failed: %w", err)


### PR DESCRIPTION
Fixes #7513

AWS image uploads recently consistently fail in some regions, which blocks the release process. Allow to skip some AMIs if they fail to upload.

Disable Azure until #7512 is resolved.
