### PR TITLE
fix: use fast wipe for upgrade

### DIFF
--- a/internal/pkg/partition/format.go
+++ b/internal/pkg/partition/format.go
@@ -57,9 +57,7 @@ func zeroPartition(devname string) (err error) {
 
 	defer part.Close() //nolint:errcheck
 
-	_, err = part.Wipe()
-
-	return err
+	return part.FastWipe()
 }
 
 func systemPartitionsFormatOptions(label string) *FormatOptions {


### PR DESCRIPTION
As part of bootloader refactoring `go-blockdevice` was used for wiping partitions in #7329, but used standard wipe which could be fast/slow depending on the blockdevice support. Switch to using fast-wipe for partitions. This should not affect `wipe` option in machineconfig.

Fixes: #7531