### PR TITLE
fix: terminate dashboard gracefully on & switch back to tty1

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -49,7 +49,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/events"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services"
-	"github.com/siderolabs/talos/internal/pkg/console"
 	"github.com/siderolabs/talos/internal/pkg/cri"
 	"github.com/siderolabs/talos/internal/pkg/environment"
 	"github.com/siderolabs/talos/internal/pkg/etcd"
@@ -620,13 +619,9 @@ func StartMachined(_ runtime.Sequence, _ any) (runtime.TaskExecutionFunc, string
 // StartDashboard represents the task to start dashboard.
 func StartDashboard(_ runtime.Sequence, _ interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(_ context.Context, _ *log.Logger, r runtime.Runtime) error {
-		ttyNumber := constants.DashboardTTY
+		system.Services(r).LoadAndStart(&services.Dashboard{})
 
-		system.Services(r).LoadAndStart(&services.Dashboard{
-			TTYNumber: ttyNumber,
-		})
-
-		return console.Switch(ttyNumber)
+		return nil
 	}, "startDashboard"
 }
 

--- a/internal/app/machined/pkg/system/services/dashboard.go
+++ b/internal/app/machined/pkg/system/services/dashboard.go
@@ -15,15 +15,14 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/siderolabs/talos/internal/pkg/capability"
+	"github.com/siderolabs/talos/internal/pkg/console"
 	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 // Dashboard implements the Service interface. It serves as the concrete type with
 // the required methods.
-type Dashboard struct {
-	TTYNumber int
-}
+type Dashboard struct{}
 
 // ID implements the Service interface.
 func (d *Dashboard) ID(_ runtime.Runtime) string {
@@ -32,12 +31,12 @@ func (d *Dashboard) ID(_ runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (d *Dashboard) PreFunc(_ context.Context, _ runtime.Runtime) error {
-	return nil
+	return console.Switch(constants.DashboardTTY)
 }
 
 // PostFunc implements the Service interface.
 func (d *Dashboard) PostFunc(_ runtime.Runtime, _ events.ServiceState) error {
-	return nil
+	return console.Switch(constants.KernelLogsTTY)
 }
 
 // Condition implements the Service interface.
@@ -52,7 +51,7 @@ func (d *Dashboard) DependsOn(_ runtime.Runtime) []string {
 
 // Runner implements the Service interface.
 func (d *Dashboard) Runner(r runtime.Runtime) (runner.Runner, error) {
-	tty := fmt.Sprintf("/dev/tty%d", d.TTYNumber)
+	tty := fmt.Sprintf("/dev/tty%d", constants.DashboardTTY)
 
 	return restart.New(process.NewRunner(false, &runner.Args{
 		ID:          d.ID(r),

--- a/internal/pkg/console/console.go
+++ b/internal/pkg/console/console.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 const (
@@ -28,9 +30,9 @@ const (
 
 // Switch switches the active console to the specified tty.
 func Switch(ttyNumber int) error {
-	// redirect the kernel logs to tty1 instead of the currently used one,
-	// so that dashboard on tty2 does not get flooded with kernel logs
-	if err := redirectKernelLogs(1); err != nil {
+	// redirect the kernel logs to their own TTY instead of the currently used one,
+	// so that other TTYs (e.g., dashboard on tty2) do not get flooded with kernel logs
+	if err := redirectKernelLogs(constants.KernelLogsTTY); err != nil {
 		return err
 	}
 
@@ -40,7 +42,7 @@ func Switch(ttyNumber int) error {
 		return err
 	}
 
-	defer tty0.Close() //nolint: errcheck
+	defer tty0.Close() //nolint:errcheck
 
 	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, tty0.Fd(), vtActivate, uintptr(ttyNumber)); errno != 0 {
 		return fmt.Errorf("failed to activate console: %w", errno)

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -867,6 +867,9 @@ const (
 	// APIAuthzRoleMetadataKey is the gRPC metadata key used to submit a role with os:impersonator.
 	APIAuthzRoleMetadataKey = "talos-role"
 
+	// KernelLogsTTY is the number of the TTY device (/dev/ttyN) to redirect Kernel logs to.
+	KernelLogsTTY = 1
+
 	// DashboardTTY is the number of the TTY device (/dev/ttyN) for dashboard.
 	DashboardTTY = 2
 


### PR DESCRIPTION
- Make dashboard SIGTERM-aware
- Handle panics on dashboard and terminate it gracefully, so it resets the terminal properly
- Switch to TTY2 when it starts and back to TTY1 when it stops.

Closes siderolabs/talos#7516.
