### PR TITLE
chore: add dm_multipath module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.5.0-alpha.0-19-gdc7dd9e
-PKGS ?= v1.5.0-alpha.0-43-ga65ac0d
+PKGS ?= v1.5.0-alpha.0-44-gcb97daf
 EXTRAS ?= v1.5.0-alpha.0-2-gf415aac
 # renovate: datasource=github-tags depName=golang/go
 GO_VERSION ?= 1.20

--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -7,7 +7,9 @@ kernel/crypto/async_tx/async_raid6_recov.ko
 kernel/crypto/async_tx/async_tx.ko
 kernel/crypto/async_tx/async_xor.ko
 kernel/crypto/xor.ko
+kernel/drivers/md/dm-multipath.ko
 kernel/drivers/md/dm-raid.ko
+kernel/drivers/md/dm-round-robin.ko
 kernel/drivers/md/raid456.ko
 kernel/drivers/infiniband/sw/rxe/rdma_rxe.ko
 kernel/drivers/net/ethernet/aquantia/atlantic/atlantic.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -7,7 +7,9 @@ kernel/crypto/async_tx/async_raid6_recov.ko
 kernel/crypto/async_tx/async_tx.ko
 kernel/crypto/async_tx/async_xor.ko
 kernel/crypto/xor.ko
+kernel/drivers/md/dm-multipath.ko
 kernel/drivers/md/dm-raid.ko
+kernel/drivers/md/dm-round-robin.ko
 kernel/drivers/md/raid456.ko
 kernel/drivers/infiniband/sw/rxe/rdma_rxe.ko
 kernel/drivers/irqchip/irq-imx-mu-msi.ko

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.5.0-alpha.0-43-ga65ac0d
+v1.5.0-alpha.0-44-gcb97daf


### PR DESCRIPTION
This PR pulls in the latest pkgs commit to enable dm_multipath as a module.
