### PR TITLE
chore: remove `cpu_manager_state` on `cpuManagerPolicy` change.

### DIFF
--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -54,8 +54,8 @@ func Services(runtime runtime.Runtime) *singleton {
 	once.Do(func() {
 		instance = &singleton{
 			runtime: runtime,
-			state:   make(map[string]*ServiceRunner),
-			running: make(map[string]struct{}),
+			state:   map[string]*ServiceRunner{},
+			running: map[string]struct{}{},
 		}
 	})
 
@@ -102,7 +102,7 @@ func (s *singleton) Unload(ctx context.Context, serviceIDs ...string) error {
 		return nil
 	}
 
-	servicesToRemove := []string{}
+	servicesToRemove := make([]string, 0, len(serviceIDs))
 
 	for _, id := range serviceIDs {
 		if _, exists := s.state[id]; exists {
@@ -264,7 +264,7 @@ func (s *singleton) StopWithRevDepenencies(ctx context.Context, serviceIDs ...st
 
 //nolint:gocyclo
 func (s *singleton) stopServices(ctx context.Context, services []string, waitForRevDependencies bool) error {
-	servicesToStop := make(map[string]*ServiceRunner)
+	servicesToStop := map[string]*ServiceRunner{}
 
 	if services == nil {
 		for name, svcrunner := range s.state {
@@ -282,7 +282,7 @@ func (s *singleton) stopServices(ctx context.Context, services []string, waitFor
 
 	// build reverse dependencies, and expand the list of services to stop
 	// with services which depend on the one being stopped
-	reverseDependencies := make(map[string][]string)
+	reverseDependencies := map[string][]string{}
 
 	if waitForRevDependencies {
 		// expand the list of services to stop with the list of services which depend
@@ -342,7 +342,7 @@ func (s *singleton) stopServices(ctx context.Context, services []string, waitFor
 	shutdownCtx, shutdownCtxCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer shutdownCtxCancel()
 
-	stoppedConds := []conditions.Condition{}
+	stoppedConds := make([]conditions.Condition, 0, len(servicesToStop))
 
 	for name, svcrunner := range servicesToStop {
 		shutdownWg.Add(1)

--- a/pkg/machinery/resources/k8s/deep_copy.generated.go
+++ b/pkg/machinery/resources/k8s/deep_copy.generated.go
@@ -224,7 +224,7 @@ func (o KubeletSpecSpec) DeepCopy() KubeletSpecSpec {
 		}
 	}
 	if o.Config != nil {
-		cp.Config = make(map[string]interface{}, len(o.Config))
+		cp.Config = make(map[string]any, len(o.Config))
 		for k2, v2 := range o.Config {
 			cp.Config[k2] = v2
 		}
@@ -302,7 +302,7 @@ func (o KubeletConfigSpec) DeepCopy() KubeletConfigSpec {
 		}
 	}
 	if o.ExtraConfig != nil {
-		cp.ExtraConfig = make(map[string]interface{}, len(o.ExtraConfig))
+		cp.ExtraConfig = make(map[string]any, len(o.ExtraConfig))
 		for k2, v2 := range o.ExtraConfig {
 			cp.ExtraConfig[k2] = v2
 		}

--- a/pkg/machinery/resources/k8s/kubelet_config.go
+++ b/pkg/machinery/resources/k8s/kubelet_config.go
@@ -27,18 +27,18 @@ type KubeletConfig = typed.Resource[KubeletConfigSpec, KubeletConfigExtension]
 //
 //gotagsrewrite:gen
 type KubeletConfigSpec struct {
-	Image                        string                 `yaml:"image" protobuf:"1"`
-	ClusterDNS                   []string               `yaml:"clusterDNS" protobuf:"2"`
-	ClusterDomain                string                 `yaml:"clusterDomain" protobuf:"3"`
-	ExtraArgs                    map[string]string      `yaml:"extraArgs,omitempty" protobuf:"4"`
-	ExtraMounts                  []specs.Mount          `yaml:"extraMounts,omitempty" protobuf:"5"`
-	ExtraConfig                  map[string]interface{} `yaml:"extraConfig,omitempty" protobuf:"6"`
-	CloudProviderExternal        bool                   `yaml:"cloudProviderExternal" protobuf:"7"`
-	DefaultRuntimeSeccompEnabled bool                   `yaml:"defaultRuntimeSeccompEnabled" protobuf:"8"`
-	SkipNodeRegistration         bool                   `yaml:"skipNodeRegistration" protobuf:"9"`
-	StaticPodListURL             string                 `yaml:"staticPodListURL" protobuf:"10"`
-	DisableManifestsDirectory    bool                   `yaml:"disableManifestsDirectory" protobuf:"11"`
-	EnableFSQuotaMonitoring      bool                   `yaml:"enableFSQuotaMonitoring" protobuf:"12"`
+	Image                        string            `yaml:"image" protobuf:"1"`
+	ClusterDNS                   []string          `yaml:"clusterDNS" protobuf:"2"`
+	ClusterDomain                string            `yaml:"clusterDomain" protobuf:"3"`
+	ExtraArgs                    map[string]string `yaml:"extraArgs,omitempty" protobuf:"4"`
+	ExtraMounts                  []specs.Mount     `yaml:"extraMounts,omitempty" protobuf:"5"`
+	ExtraConfig                  map[string]any    `yaml:"extraConfig,omitempty" protobuf:"6"`
+	CloudProviderExternal        bool              `yaml:"cloudProviderExternal" protobuf:"7"`
+	DefaultRuntimeSeccompEnabled bool              `yaml:"defaultRuntimeSeccompEnabled" protobuf:"8"`
+	SkipNodeRegistration         bool              `yaml:"skipNodeRegistration" protobuf:"9"`
+	StaticPodListURL             string            `yaml:"staticPodListURL" protobuf:"10"`
+	DisableManifestsDirectory    bool              `yaml:"disableManifestsDirectory" protobuf:"11"`
+	EnableFSQuotaMonitoring      bool              `yaml:"enableFSQuotaMonitoring" protobuf:"12"`
 }
 
 // NewKubeletConfig initializes an empty KubeletConfig resource.

--- a/pkg/machinery/resources/k8s/kubelet_spec.go
+++ b/pkg/machinery/resources/k8s/kubelet_spec.go
@@ -24,11 +24,11 @@ type KubeletSpec = typed.Resource[KubeletSpecSpec, KubeletSpecExtension]
 //
 //gotagsrewrite:gen
 type KubeletSpecSpec struct {
-	Image            string                 `yaml:"image" protobuf:"1"`
-	Args             []string               `yaml:"args,omitempty" protobuf:"2"`
-	ExtraMounts      []specs.Mount          `yaml:"extraMounts,omitempty" protobuf:"3"`
-	ExpectedNodename string                 `yaml:"expectedNodename,omitempty" protobuf:"4"`
-	Config           map[string]interface{} `yaml:"config" protobuf:"5"`
+	Image            string         `yaml:"image" protobuf:"1"`
+	Args             []string       `yaml:"args,omitempty" protobuf:"2"`
+	ExtraMounts      []specs.Mount  `yaml:"extraMounts,omitempty" protobuf:"3"`
+	ExpectedNodename string         `yaml:"expectedNodename,omitempty" protobuf:"4"`
+	Config           map[string]any `yaml:"config" protobuf:"5"`
 }
 
 // NewKubeletSpec initializes an empty KubeletSpec resource.


### PR DESCRIPTION
After we closed `kubelet`, remove `/var/lib/kubelet/cpu_manager_state` if there are any changes in `cpuManagerPolicy`. We do not add any other safeguards, so it's user responsibility to cordon/drain the node in advance.

Also minor fixes in other files.

Closes #7504