### PR TITLE
fix: fast-wipe the system disk on talosctl reset

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1520,7 +1520,7 @@ func ResetSystemDisk(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) 
 
 		defer dev.Close() //nolint:errcheck
 
-		return dev.Reset()
+		return dev.FastWipe()
 	}, "resetSystemDisk"
 }
 


### PR DESCRIPTION
Fixes #7558

I see no reason to keep old behavior (removing all partitions on the disk), as it's only compatible with Talos itself.
