### PR TITLE
chore: unify semver under `github.com/blang/semver/v4`

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	hashiversion "github.com/hashicorp/go-version"
+	"github.com/blang/semver/v4"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -51,7 +51,7 @@ func ClientVersionCheck(ctx context.Context, c *client.Client) error {
 	// ignore the error, as we are only interested in the nodes which respond
 	serverVersions, _ := c.Version(ctx) //nolint:errcheck
 
-	clientVersion, err := hashiversion.NewVersion(version.NewVersion().Tag)
+	clientVersion, err := semver.ParseTolerant(version.NewVersion().Tag)
 	if err != nil {
 		return fmt.Errorf("error parsing client version: %w", err)
 	}
@@ -61,7 +61,7 @@ func ClientVersionCheck(ctx context.Context, c *client.Client) error {
 	for _, msg := range serverVersions.GetMessages() {
 		node := msg.GetMetadata().GetHostname()
 
-		serverVersion, err := hashiversion.NewVersion(msg.GetVersion().Tag)
+		serverVersion, err := semver.ParseTolerant(msg.GetVersion().Tag)
 		if err != nil {
 			return fmt.Errorf("%s: error parsing server version: %w", node, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/coreos/go-iptables v0.7.0
-	github.com/coreos/go-semver v0.3.1
 	github.com/cosi-project/runtime v0.3.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.5+incompatible
@@ -66,7 +65,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter/v2 v2.2.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-version v1.6.0
 	github.com/hetznercloud/hcloud-go/v2 v2.0.0
 	github.com/insomniacslk/dhcp v0.0.0-20230731140434-0f9eb93a696c
 	github.com/jsimonetti/rtnetlink v1.3.4
@@ -169,7 +167,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/briandowns/spinner v1.19.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
@@ -181,6 +179,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/containerd/ttrpc v1.1.2 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -217,6 +216,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.4 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/hack/cloud-image-uploader/azure.go
+++ b/hack/cloud-image-uploader/azure.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/hashicorp/go-version"
+	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/channel"
 	"github.com/ulikunitz/xz"
 	"golang.org/x/sync/errgroup"
@@ -51,12 +51,12 @@ type AzureUploader struct {
 
 // extractVersion extracts the version number in the format of int.int.int for Azure and assigns to the Options.AzureTag value.
 func (azu *AzureUploader) setVersion() error {
-	v, err := version.NewVersion(azu.Options.AzureAbbrevTag)
+	v, err := semver.ParseTolerant(azu.Options.AzureAbbrevTag)
 	if err != nil {
 		return err
 	}
 
-	versionCore := v.Core().String()
+	versionCore := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 
 	if fmt.Sprintf("v%s", versionCore) != azu.Options.AzureAbbrevTag {
 		azu.Options.AzureGalleryName = "SideroGalleryTest"

--- a/hack/cloud-image-uploader/go.mod
+++ b/hack/cloud-image-uploader/go.mod
@@ -7,14 +7,13 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.12
 	github.com/aws/aws-sdk-go v1.44.312
+	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-version v1.6.0
 	github.com/siderolabs/gen v0.4.5
 	github.com/siderolabs/go-retry v0.3.2
 	github.com/spf13/pflag v1.0.5

--- a/hack/cloud-image-uploader/go.sum
+++ b/hack/cloud-image-uploader/go.sum
@@ -9,9 +9,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aov
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0 h1:Sg/D8VuUQ+bw+FOYJF+xRKcwizCOP13HL0Se8pWNBzE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.1.0/go.mod h1:Kyqzdqq0XDoCm+o9aZ25wZBmBUBzPBzPAj1R5rYsT6I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.3.0 h1:LcJtQjCXJUm1s7JpUHZvu+bpgURhCatxVNbGADXniX0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.3.0/go.mod h1:+OgGVo0Httq7N5oayfvaLQ/Jq+2gJdqfp++Hyyl7Tws=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 h1:nVocQV40OQne5613EeLayJiRAJuKlBGy+m22qWG+WRg=
@@ -47,6 +45,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkM
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -59,8 +59,6 @@ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOW
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/pkg/cluster/kubernetes/detect.go
+++ b/pkg/cluster/kubernetes/detect.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/blang/semver/v4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,15 +52,15 @@ func DetectLowestVersion(ctx context.Context, cluster UpgradeProvider, options U
 				continue
 			}
 
-			v, err := semver.NewVersion(strings.TrimLeft(container.Image[idx+1:], "v"))
+			v, err := semver.ParseTolerant(strings.TrimLeft(container.Image[idx+1:], "v"))
 			if err != nil {
 				options.Log("failed to parse %s container version %s", app, err)
 
 				continue
 			}
 
-			if version == nil || v.LessThan(*version) {
-				version = v
+			if version == nil || v.LT(*version) {
+				version = &v
 			}
 		}
 	}

--- a/pkg/cluster/sonobuoy/sonobuoy.go
+++ b/pkg/cluster/sonobuoy/sonobuoy.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/blang/semver/v4"
 	"github.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app"
 	"github.com/vmware-tanzu/sonobuoy/pkg/client"
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
@@ -106,7 +106,7 @@ func CertifiedConformance(ctx context.Context, cluster cluster.K8sProvider) erro
 		RetrieveResults:   true,
 	}
 
-	k8sVersion, err := semver.NewVersion(options.KubernetesVersion)
+	k8sVersion, err := semver.ParseTolerant(options.KubernetesVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/machinery/compatibility/talos12/talos12.go
+++ b/pkg/machinery/compatibility/talos12/talos12.go
@@ -5,22 +5,24 @@
 // Package talos12 provides compatibility constants for Talos 1.2.
 package talos12
 
-import "github.com/hashicorp/go-version"
+import (
+	"github.com/blang/semver/v4"
+)
 
 // MajorMinor is the major.minor version of Talos 1.2.
-var MajorMinor = [2]int{1, 2}
+var MajorMinor = [2]uint64{1, 2}
 
 // MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.2.
-var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+var MinimumHostUpgradeVersion = semver.MustParse("1.0.0")
 
 // MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.3.
-var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.3.0"))
+var MaximumHostDowngradeVersion = semver.MustParse("1.3.0")
 
 // DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.2.
-var DeniedHostUpgradeVersions = []*version.Version{}
+var DeniedHostUpgradeVersions = []semver.Version{}
 
 // MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.2.
-var MinimumKubernetesVersion = version.Must(version.NewVersion("1.23.0"))
+var MinimumKubernetesVersion = semver.MustParse("1.23.0")
 
 // MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.2.
-var MaximumKubernetesVersion = version.Must(version.NewVersion("1.25.99"))
+var MaximumKubernetesVersion = semver.MustParse("1.25.99")

--- a/pkg/machinery/compatibility/talos13/talos13.go
+++ b/pkg/machinery/compatibility/talos13/talos13.go
@@ -5,22 +5,24 @@
 // Package talos13 provides compatibility constants for Talos 1.3.
 package talos13
 
-import "github.com/hashicorp/go-version"
+import (
+	"github.com/blang/semver/v4"
+)
 
 // MajorMinor is the major.minor version of Talos 1.3.
-var MajorMinor = [2]int{1, 3}
+var MajorMinor = [2]uint64{1, 3}
 
 // MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.3.
-var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+var MinimumHostUpgradeVersion = semver.MustParse("1.0.0")
 
 // MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.3.
-var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.5.0"))
+var MaximumHostDowngradeVersion = semver.MustParse("1.5.0")
 
 // DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.3.
-var DeniedHostUpgradeVersions = []*version.Version{}
+var DeniedHostUpgradeVersions = []semver.Version{}
 
 // MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.3.
-var MinimumKubernetesVersion = version.Must(version.NewVersion("1.24.0"))
+var MinimumKubernetesVersion = semver.MustParse("1.24.0")
 
 // MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.3.
-var MaximumKubernetesVersion = version.Must(version.NewVersion("1.26.99"))
+var MaximumKubernetesVersion = semver.MustParse("1.26.99")

--- a/pkg/machinery/compatibility/talos14/talos14.go
+++ b/pkg/machinery/compatibility/talos14/talos14.go
@@ -5,22 +5,24 @@
 // Package talos14 provides compatibility constants for Talos 1.4
 package talos14
 
-import "github.com/hashicorp/go-version"
+import (
+	"github.com/blang/semver/v4"
+)
 
 // MajorMinor is the major.minor version of Talos 1.4.
-var MajorMinor = [2]int{1, 4}
+var MajorMinor = [2]uint64{1, 4}
 
 // MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.4.
-var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.0.0"))
+var MinimumHostUpgradeVersion = semver.MustParse("1.0.0")
 
 // MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.4.
-var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.6.0"))
+var MaximumHostDowngradeVersion = semver.MustParse("1.6.0")
 
 // DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.4.
-var DeniedHostUpgradeVersions = []*version.Version{}
+var DeniedHostUpgradeVersions = []semver.Version{}
 
 // MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.4.
-var MinimumKubernetesVersion = version.Must(version.NewVersion("1.25.0"))
+var MinimumKubernetesVersion = semver.MustParse("1.25.0")
 
 // MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.4.
-var MaximumKubernetesVersion = version.Must(version.NewVersion("1.27.99"))
+var MaximumKubernetesVersion = semver.MustParse("1.27.99")

--- a/pkg/machinery/compatibility/talos15/talos15.go
+++ b/pkg/machinery/compatibility/talos15/talos15.go
@@ -5,22 +5,24 @@
 // Package talos15 provides compatibility constants for Talos 1.5.
 package talos15
 
-import "github.com/hashicorp/go-version"
+import (
+	"github.com/blang/semver/v4"
+)
 
 // MajorMinor is the major.minor version of Talos 1.5.
-var MajorMinor = [2]int{1, 5}
+var MajorMinor = [2]uint64{1, 5}
 
 // MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.5.
-var MinimumHostUpgradeVersion = version.Must(version.NewVersion("1.2.0"))
+var MinimumHostUpgradeVersion = semver.MustParse("1.2.0")
 
 // MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.5.
-var MaximumHostDowngradeVersion = version.Must(version.NewVersion("1.7.0"))
+var MaximumHostDowngradeVersion = semver.MustParse("1.7.0")
 
 // DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.5.
-var DeniedHostUpgradeVersions = []*version.Version{}
+var DeniedHostUpgradeVersions = []semver.Version{}
 
 // MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.5.
-var MinimumKubernetesVersion = version.Must(version.NewVersion("1.26.0"))
+var MinimumKubernetesVersion = semver.MustParse("1.26.0")
 
 // MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.5.
-var MaximumKubernetesVersion = version.Must(version.NewVersion("1.28.99"))
+var MaximumKubernetesVersion = semver.MustParse("1.28.99")

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -7,13 +7,13 @@ go 1.20
 replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20220527175918-f17b0f05cf2c
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/go-cni v1.1.9
 	github.com/cosi-project/runtime v0.3.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-version v1.6.0
 	github.com/jsimonetti/rtnetlink v1.3.4
 	github.com/mdlayher/ethtool v0.1.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -7,6 +7,8 @@ github.com/ProtonMail/gopenpgp/v2 v2.7.2/go.mod h1:IhkNEDaxec6NyzSI0PlxapinnwPVI
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/brianvoe/gofakeit/v6 v6.17.0 h1:obbQTJeHfktJtiZzq0Q1bEpsNUs+yHrYlPVWt7BtmJ4=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -61,8 +63,6 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=


### PR DESCRIPTION
Currently, we use `github.com/coreos/go-semver/semver` and `github.com/hashicorp/go-version` for version parsing. As we use `github.com/blang/semver/v4` in our other projects, and it has more features, it makes sense to use it across the projects. It also doesn't allocate like crazy in `KubernetesVersion.SupportedWith`.