### PR TITLE
fix: update providerid prefix for aws

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -85,7 +85,7 @@ func (a *AWS) ParseMetadata(metadata *MetadataConfig) (*runtime.PlatformNetworkC
 		Zone:         metadata.Zone,
 		InstanceType: metadata.InstanceType,
 		InstanceID:   metadata.InstanceID,
-		ProviderID:   fmt.Sprintf("aws://%s/%s", metadata.Zone, metadata.InstanceID),
+		ProviderID:   fmt.Sprintf("aws:///%s/%s", metadata.Zone, metadata.InstanceID),
 		Spot:         metadata.InstanceLifeCycle == "spot",
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/testdata/expected.yaml
@@ -16,4 +16,4 @@ metadata:
     region: us-east-1
     zone: us-east-1a
     instanceId: i-0a0a0a0a0a0a0a0a0
-    providerId: aws://us-east-1a/i-0a0a0a0a0a0a0a0a0
+    providerId: aws:///us-east-1a/i-0a0a0a0a0a0a0a0a0


### PR DESCRIPTION
This PR updates the ProviderID format for aws resources. There seems to be a bug when using Talos CCM (which consumes this value from Talos) because the format is `aws://x/y` (two slashes) vs. the expected `aws:///x/y` (three slashes) that is set with the AWS CCM code [here](https://github.com/kubernetes/cloud-provider-aws/blob/d0551093673e8c355db17249b8f069767c014748/pkg/providers/v1/instances.go#L47-L53).

Setting only two slashes causes important software in the workload cluster to fail, specifically cluster-autoscaler. The regex they use for pulling providerID is [here](https://github.com/kubernetes/autoscaler/blob/702e9685d6c1d002f4a448f2d88007141dfa6d56/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go#L195).

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
(cherry picked from commit bcf2845307ad2c4395967cbb8e756d6a0d8caf2c)
