### PR TITLE
chore: publish systemd-boot and systemd-stub assets

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -211,7 +211,7 @@ local external_artifacts = Step('external-artifacts', depends_on=[setup_ci]);
 local generate = Step('generate', target='generate docs', depends_on=[setup_ci]);
 local uki_certs = Step('uki-certs', depends_on=[generate], environment={ PLATFORM: 'linux/amd64' });
 local check_dirty = Step('check-dirty', depends_on=[generate, external_artifacts, uki_certs]);
-local build = Step('build', target='talosctl-all kernel initramfs installer imager talos _out/integration-test-linux-amd64', depends_on=[check_dirty], environment={ IMAGE_REGISTRY: local_registry, PUSH: true });
+local build = Step('build', target='talosctl-all kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64', depends_on=[check_dirty], environment={ IMAGE_REGISTRY: local_registry, PUSH: true });
 local lint = Step('lint', depends_on=[build]);
 local talosctl_cni_bundle = Step('talosctl-cni-bundle', depends_on=[build, lint]);
 local iso = Step('iso', target='iso secureboot-iso', depends_on=[build], environment={ IMAGE_REGISTRY: local_registry });
@@ -735,6 +735,10 @@ local release = {
       '_out/oracle-arm64.qcow2.xz',
       '_out/scaleway-amd64.raw.xz',
       '_out/scaleway-arm64.raw.xz',
+      '_out/sd-boot-amd64.efi',
+      '_out/sd-boot-arm64.efi',
+      '_out/sd-stub-amd64.efi',
+      '_out/sd-stub-arm64.efi',
       '_out/talosctl-cni-bundle-amd64.tar.gz',
       '_out/talosctl-cni-bundle-arm64.tar.gz',
       '_out/talosctl-darwin-amd64',

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub
 FROM --platform=amd64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-amd64
 FROM --platform=arm64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-arm64
 
+FROM ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot
 FROM --platform=amd64 ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot-amd64
 FROM --platform=arm64 ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot-arm64
 
@@ -474,6 +475,16 @@ ENTRYPOINT ["/talosctl"]
 FROM scratch AS kernel
 ARG TARGETARCH
 COPY --from=pkg-kernel /boot/vmlinuz /vmlinuz-${TARGETARCH}
+
+# The sd-boot target is the systemd-boot asset.
+FROM scratch AS sd-boot
+ARG TARGETARCH
+COPY --from=pkg-sd-boot /*.efi /sd-boot-${TARGETARCH}.efi
+
+# The sd-stub target is the systemd-stub asset.
+FROM scratch AS sd-stub
+ARG TARGETARCH
+COPY --from=pkg-sd-boot /*.efi.stub /sd-stub-${TARGETARCH}.efi
 
 FROM tools AS depmod-amd64
 WORKDIR /staging

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,14 @@ kernel: ## Outputs the kernel package contents (vmlinuz) to the artifact directo
 initramfs: ## Builds the compressed initramfs and outputs it to the artifact directory.
 	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PUSH=false
 
+.PHONY: sd-boot
+sd-boot: ## Outputs the systemd-boot to the artifact directory.
+	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PUSH=false
+
+.PHONY: sd-stub
+sd-stub: ## Outputs the systemd-stub to the artifact directory.
+	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PUSH=false
+
 .PHONY: installer
 installer: ## Builds the container image for the installer and outputs it to the registry.
 	@INSTALLER_ARCH=targetarch  \


### PR DESCRIPTION
These assets are required to build a UKI, so publish them as part of the release.
