### PR TITLE
fix: make encryption config provider default to `luks2` if not set

### DIFF
--- a/internal/pkg/encryption/encryption.go
+++ b/internal/pkg/encryption/encryption.go
@@ -37,7 +37,7 @@ const (
 func NewHandler(device *blockdevice.BlockDevice, partition *gpt.Partition, encryptionConfig config.Encryption, getSystemInformation helpers.SystemInformationGetter) (*Handler, error) {
 	var provider encryption.Provider
 
-	switch encryptionConfig.Kind() {
+	switch encryptionConfig.Provider() {
 	case encryption.LUKS2:
 		cipher, err := luks.ParseCipherKind(encryptionConfig.Cipher())
 		if err != nil {
@@ -68,7 +68,7 @@ func NewHandler(device *blockdevice.BlockDevice, partition *gpt.Partition, encry
 			opts...,
 		)
 	default:
-		return nil, fmt.Errorf("unknown encryption kind %s", encryptionConfig.Kind())
+		return nil, fmt.Errorf("unknown encryption kind %s", encryptionConfig.Provider())
 	}
 
 	return &Handler{
@@ -116,7 +116,7 @@ func (h *Handler) Open(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-	} else if sb.Type() != h.encryptionConfig.Kind() {
+	} else if sb.Type() != h.encryptionConfig.Provider() {
 		return "", fmt.Errorf("failed to encrypt the partition %s, because it is not empty", partPath)
 	}
 

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -379,7 +379,7 @@ type EncryptionKeyTPM interface{}
 
 // Encryption defines settings for the partition encryption.
 type Encryption interface {
-	Kind() string
+	Provider() string
 	Cipher() string
 	KeySize() uint
 	BlockSize() uint64

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -15,6 +15,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/slices"
+	"github.com/siderolabs/go-blockdevice/blockdevice/encryption"
 	"github.com/siderolabs/go-blockdevice/blockdevice/util/disk"
 	"github.com/siderolabs/go-pointer"
 
@@ -1313,8 +1314,12 @@ func (p *DiskPartition) MountPoint() string {
 	return p.DiskMountPoint
 }
 
-// Kind implements the config.Provider interface.
-func (e *EncryptionConfig) Kind() string {
+// Provider implements the config.Provider interface.
+func (e *EncryptionConfig) Provider() string {
+	if e.EncryptionProvider == "" {
+		return encryption.LUKS2
+	}
+
 	return e.EncryptionProvider
 }
 


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/talos/issues/7515

Rename `Kind` to `Provider` in the `v1alpha1_provider`.