### PR TITLE
chore: optimize memory usage of `tcell` library on init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -344,14 +344,14 @@ WORKDIR /src/internal/app/machined
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
 ARG GOAMD64
-RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=amd64 GOAMD64=${GOAMD64} go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /machined
+RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=amd64 GOAMD64=${GOAMD64} go build ${GO_BUILDFLAGS} -tags tcell_minimal -ldflags "${GO_LDFLAGS}" -o /machined
 RUN chmod +x /machined
 
 FROM base AS machined-build-arm64
 WORKDIR /src/internal/app/machined
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
-RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=arm64 go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /machined
+RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=arm64 go build ${GO_BUILDFLAGS} -tags tcell_minimal -ldflags "${GO_LDFLAGS}" -o /machined
 RUN chmod +x /machined
 
 FROM machined-build-${TARGETARCH} AS machined-build

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -159,7 +159,9 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: filepath.Dir(constants.APISocketPath), Source: filepath.Dir(constants.APISocketPath), Options: []string{"rbind", "rw"}},
 	}
 
-	env := []string{}
+	env := []string{
+		constants.TcellMinimizeEnvironment,
+	}
 
 	for _, value := range environment.Get(r.Config()) {
 		key, _, _ := strings.Cut(value, "=")

--- a/internal/app/machined/pkg/system/services/dashboard.go
+++ b/internal/app/machined/pkg/system/services/dashboard.go
@@ -58,7 +58,10 @@ func (d *Dashboard) Runner(r runtime.Runtime) (runner.Runner, error) {
 		ProcessArgs: []string{"/sbin/dashboard"},
 	},
 		runner.WithLoggingManager(r.Logging()),
-		runner.WithEnv([]string{"TERM=linux"}),
+		runner.WithEnv([]string{
+			"TERM=linux",
+			constants.TcellMinimizeEnvironment,
+		}),
 		runner.WithStdinFile(tty),
 		runner.WithStdoutFile(tty),
 		runner.WithCtty(1),

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -140,6 +140,7 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	env := environment.Get(r.Config())
+	env = append(env, constants.TcellMinimizeEnvironment)
 
 	if debug.RaceEnabled {
 		env = append(env, "GORACE=halt_on_error=1")

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v2"
+	_ "github.com/gdamore/tcell/v2/terminfo/l/linux" // linux terminal is used when running on the machine, but not included with tcell_minimal
 	"github.com/gizak/termui/v3"
 	"github.com/rivo/tview"
 	"github.com/siderolabs/gen/maps"

--- a/internal/pkg/mount/switchroot/switchroot.go
+++ b/internal/pkg/mount/switchroot/switchroot.go
@@ -77,7 +77,9 @@ func Switch(prefix string, mountpoints *mount.Points) (err error) {
 	// convention.
 	log.Println("executing /sbin/init")
 
-	envv := []string{}
+	envv := []string{
+		constants.TcellMinimizeEnvironment,
+	}
 
 	if debug.RaceEnabled {
 		envv = append(envv, "GORACE=halt_on_error=1")

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -893,6 +893,9 @@ const (
 
 	// GRPCMaxMessageSize is the maximum message size for Talos API.
 	GRPCMaxMessageSize = 32 * 1024 * 1024
+
+	// TcellMinimizeEnvironment is the environment variable to minimize tcell library memory usage (skips rune width calculation).
+	TcellMinimizeEnvironment = "TCELL_MINIMIZE=1"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
There are two changes here:

* build `machined` binary with `tcell_minimal` tag (which disables loading some parts of the terminfo database), which also affects `apid`, `trustd` and `dashboard` processes, as they run from the same executable; in `dashboard` explicitly import `linux` terminal we're using when the `dashboard` runs on the machine
* pass `TCELL_MINIMIZE=1` environment variable to each Talos process which removes 0.5MiB of runewdith allocation for a lookup table

See #7578
