### PR TITLE
chore: clean up the output of the `imager`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ image-%: ## Builds the specified image. Valid options are aws, azure, digital-oc
 	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG)
 	@for platform in $(subst $(,),$(space),$(PLATFORM)); do \
 		arch=$$(basename "$${platform}") && \
-		docker run --rm -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/secureboot:ro --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch $$arch --tar-to-stdout $(IMAGER_ARGS) | tar xz -C $(ARTIFACTS) ; \
+		docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/secureboot:ro -v $(PWD)/$(ARTIFACTS):/out --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch $$arch $(IMAGER_ARGS) ; \
 	done
 
 images-essential: image-aws image-gcp image-metal secureboot-installer ## Builds only essential images used in the CI (AWS, GCP, and Metal).
@@ -309,7 +309,7 @@ images: image-aws image-azure image-digital-ocean image-exoscale image-gcp image
 
 sbc-%: ## Builds the specified SBC image. Valid options are rpi_generic, rock64, bananapi_m64, libretech_all_h3_cc_h5, rockpi_4, rockpi_4c, pine64, jetson_nano and nanopi_r4s (e.g. sbc-rpi_generic)
 	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG)
-	@docker run --rm -v /dev:/dev --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch arm64 --tar-to-stdout $(IMAGER_ARGS) | tar xz -C $(ARTIFACTS)
+	@docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/out --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch arm64 $(IMAGER_ARGS)
 
 sbcs: sbc-rpi_generic sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 sbc-rockpi_4c sbc-pine64 sbc-jetson_nano sbc-nanopi_r4s ## Builds all known SBC images (Raspberry Pi 4, Rock64, Banana Pi M64, Radxa ROCK Pi 4, Radxa ROCK Pi 4c, Pine64, Libre Computer Board ALL-H3-CC, Jetson Nano and Nano Pi R4S).
 

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -42,6 +42,7 @@ type Options struct {
 	ImageSecureboot bool
 	Version         string
 	BootAssets      bootloaderoptions.BootAssets
+	Printf          func(string, ...any)
 }
 
 // Mode is the install mode.
@@ -107,7 +108,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		return err
 	}
 
-	log.Printf("installation of %s complete", version.Tag)
+	i.options.Printf("installation of %s complete", version.Tag)
 
 	return nil
 }
@@ -130,6 +131,10 @@ func NewInstaller(ctx context.Context, cmdline *procfs.Cmdline, mode Mode, opts 
 
 	if i.options.Version == "" {
 		i.options.Version = version.Tag
+	}
+
+	if i.options.Printf == nil {
+		i.options.Printf = log.Printf
 	}
 
 	if !i.options.Zero {
@@ -258,6 +263,7 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 		Version:    i.options.Version,
 		ImageMode:  mode.IsImage(),
 		BootAssets: i.options.BootAssets,
+		Printf:     i.options.Printf,
 	}); err != nil {
 		return err
 	}
@@ -270,7 +276,7 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 			return err
 		}
 
-		log.Printf("installing U-Boot for %q", b.Name())
+		i.options.Printf("installing U-Boot for %q", b.Name())
 
 		if err = b.Install(i.options.Disk); err != nil {
 			return err

--- a/cmd/installer/pkg/install/manifest_test.go
+++ b/cmd/installer/pkg/install/manifest_test.go
@@ -229,9 +229,10 @@ func (suite *manifestSuite) TestExecuteManifestClean() {
 	suite.skipUnderBuildkit()
 
 	manifest, err := install.NewManifest(install.ModeInstall, false, false, &install.Options{
-		Disk:  suite.loopbackDevice.Name(),
-		Force: true,
-		Board: constants.BoardNone,
+		Disk:   suite.loopbackDevice.Name(),
+		Force:  true,
+		Board:  constants.BoardNone,
+		Printf: suite.T().Logf,
 	})
 	suite.Require().NoError(err)
 
@@ -249,9 +250,10 @@ func (suite *manifestSuite) TestExecuteManifestForce() {
 	suite.skipUnderBuildkit()
 
 	manifest, err := install.NewManifest(install.ModeInstall, false, false, &install.Options{
-		Disk:  suite.loopbackDevice.Name(),
-		Force: true,
-		Board: constants.BoardNone,
+		Disk:   suite.loopbackDevice.Name(),
+		Force:  true,
+		Board:  constants.BoardNone,
+		Printf: suite.T().Logf,
 	})
 	suite.Require().NoError(err)
 
@@ -267,10 +269,11 @@ func (suite *manifestSuite) TestExecuteManifestForce() {
 	// reinstall
 
 	manifest, err = install.NewManifest(install.ModeUpgrade, false, true, &install.Options{
-		Disk:  suite.loopbackDevice.Name(),
-		Force: true,
-		Zero:  true,
-		Board: constants.BoardNone,
+		Disk:   suite.loopbackDevice.Name(),
+		Force:  true,
+		Zero:   true,
+		Board:  constants.BoardNone,
+		Printf: suite.T().Logf,
 	})
 	suite.Require().NoError(err)
 
@@ -288,9 +291,10 @@ func (suite *manifestSuite) TestExecuteManifestPreserve() {
 	suite.skipUnderBuildkit()
 
 	manifest, err := install.NewManifest(install.ModeInstall, false, false, &install.Options{
-		Disk:  suite.loopbackDevice.Name(),
-		Force: true,
-		Board: constants.BoardNone,
+		Disk:   suite.loopbackDevice.Name(),
+		Force:  true,
+		Board:  constants.BoardNone,
+		Printf: suite.T().Logf,
 	})
 	suite.Require().NoError(err)
 
@@ -306,9 +310,10 @@ func (suite *manifestSuite) TestExecuteManifestPreserve() {
 	// reinstall
 
 	manifest, err = install.NewManifest(install.ModeUpgrade, false, true, &install.Options{
-		Disk:  suite.loopbackDevice.Name(),
-		Force: false,
-		Board: constants.BoardNone,
+		Disk:   suite.loopbackDevice.Name(),
+		Force:  false,
+		Board:  constants.BoardNone,
+		Printf: suite.T().Logf,
 	})
 	suite.Require().NoError(err)
 

--- a/cmd/installer/pkg/install/target.go
+++ b/cmd/installer/pkg/install/target.go
@@ -200,11 +200,11 @@ func (t *Target) Locate(pt *gpt.GPT) (*gpt.Partition, error) {
 }
 
 // partition creates a new partition on the specified device.
-func (t *Target) partition(pt *gpt.GPT, pos int) (err error) {
+func (t *Target) partition(pt *gpt.GPT, pos int, printf func(string, ...any)) (err error) {
 	if t.Skip {
 		part := pt.Partitions().FindByName(t.Label)
 		if part != nil {
-			log.Printf("skipped %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
+			printf("skipped %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
 
 			t.PartitionName, err = part.Path()
 			if err != nil {
@@ -220,7 +220,7 @@ func (t *Target) partition(pt *gpt.GPT, pos int) (err error) {
 		PartitionType:      t.PartitionType,
 		Size:               t.Size,
 		LegacyBIOSBootable: t.LegacyBIOSBootable,
-	})
+	}, printf)
 	if err != nil {
 		return err
 	}
@@ -231,12 +231,12 @@ func (t *Target) partition(pt *gpt.GPT, pos int) (err error) {
 }
 
 // Format creates a filesystem on the device/partition.
-func (t *Target) Format() error {
+func (t *Target) Format(printf func(string, ...any)) error {
 	if t.Skip {
 		return nil
 	}
 
-	return partition.Format(t.PartitionName, t.FormatOptions)
+	return partition.Format(t.PartitionName, t.FormatOptions, printf)
 }
 
 // GetLabel returns the underlaying partition label.

--- a/internal/app/machined/pkg/runtime/sequencer.go
+++ b/internal/app/machined/pkg/runtime/sequencer.go
@@ -136,7 +136,7 @@ type ResetOptions interface {
 // PartitionTarget provides interface to the disk partition.
 type PartitionTarget interface {
 	fmt.Stringer
-	Format() error
+	Format(func(string, ...any)) error
 	GetLabel() string
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/encode.go
@@ -7,7 +7,6 @@ package grub
 import (
 	"bytes"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -43,7 +42,7 @@ menuentry "Reset Talos installation and return to maintenance mode" {
 `
 
 // Write the grub configuration to the given file.
-func (c *Config) Write(path string) error {
+func (c *Config) Write(path string, printf func(string, ...any)) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, os.ModeDir); err != nil {
 		return err
@@ -56,7 +55,7 @@ func (c *Config) Write(path string) error {
 		return err
 	}
 
-	log.Printf("writing %s to disk", path)
+	printf("writing %s to disk", path)
 
 	return os.WriteFile(path, wr.Bytes(), 0o600)
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub_test.go
@@ -103,7 +103,7 @@ func TestWrite(t *testing.T) {
 	config := grub.NewConfig()
 	require.NoError(t, config.Put(grub.BootA, "cmdline A", "v0.0.1"))
 
-	err := config.Write(tempFile.Name())
+	err := config.Write(tempFile.Name(), t.Logf)
 	assert.NoError(t, err)
 
 	written, _ := os.ReadFile(tempFile.Name())

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/revert.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/revert.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -69,7 +70,7 @@ func (c *Config) Revert(ctx context.Context) error {
 		return fmt.Errorf("cannot rollback to %q, label does not exist", "")
 	}
 
-	if err := c.Write(ConfigPath); err != nil {
+	if err := c.Write(ConfigPath, log.Printf); err != nil {
 		return fmt.Errorf("failed to revert bootloader: %v", err)
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
@@ -27,6 +27,9 @@ type InstallOptions struct {
 
 	// Boot assets to install.
 	BootAssets BootAssets
+
+	// Printf-like function to use.
+	Printf func(format string, v ...any)
 }
 
 // BootAssets describes the assets to be installed by the booloader.

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
@@ -157,7 +157,7 @@ func (c *Config) Install(options options.InstallOptions) error {
 			continue
 		}
 
-		log.Printf("removing old UKI: %s", file)
+		options.Printf("removing old UKI: %s", file)
 
 		if err = os.Remove(file); err != nil {
 			return err
@@ -167,6 +167,7 @@ func (c *Config) Install(options options.InstallOptions) error {
 	options.BootAssets.FillDefaults(options.Arch)
 
 	if err := utils.CopyFiles(
+		options.Printf,
 		utils.SourceDestination(options.BootAssets.UKIPath, filepath.Join(constants.EFIMountPoint, "EFI", "Linux", ukiPath)),
 		utils.SourceDestination(options.BootAssets.SDBootPath, filepath.Join(constants.EFIMountPoint, "EFI", "boot", sdbootFilename)),
 	); err != nil {
@@ -175,6 +176,8 @@ func (c *Config) Install(options options.InstallOptions) error {
 
 	// don't update EFI variables if we're installing to a loop device
 	if !options.ImageMode {
+		options.Printf("updating EFI variables")
+
 		efiCtx := efivario.NewDefaultContext()
 
 		// set the new entry as a default one

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -822,6 +822,7 @@ func partitionAndFormatDisks(logger *log.Logger, r runtime.Runtime) error {
 	m := &installer.Manifest{
 		Devices: map[string]installer.Device{},
 		Targets: map[string][]*installer.Target{},
+		Printf:  logger.Printf,
 	}
 
 	for _, disk := range r.Config().Machine().Disks() {
@@ -1618,7 +1619,7 @@ func ResetSystemDiskSpec(_ runtime.Sequence, data any) (runtime.TaskExecutionFun
 		}
 
 		for _, target := range in.GetSystemDiskTargets() {
-			if err = target.Format(); err != nil {
+			if err = target.Format(logger.Printf); err != nil {
 				return fmt.Errorf("failed wiping partition %s: %w", target, err)
 			}
 		}

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -167,7 +167,7 @@ func SystemMountPointForLabel(ctx context.Context, device *blockdevice.BlockDevi
 		if !o.MountFlags.Check(SkipIfNoFilesystem) {
 			p.fstype = opts.FileSystemType
 
-			return partition.Format(p.source, opts)
+			return partition.Format(p.source, opts, log.Printf)
 		}
 
 		return nil

--- a/internal/pkg/partition/format.go
+++ b/internal/pkg/partition/format.go
@@ -7,7 +7,6 @@ package partition
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/siderolabs/go-blockdevice/blockdevice"
 
@@ -28,13 +27,13 @@ func NewFormatOptions(label string) *FormatOptions {
 }
 
 // Format zeroes the device and formats it using filesystem type provided.
-func Format(devname string, t *FormatOptions) error {
+func Format(devname string, t *FormatOptions, printf func(string, ...any)) error {
 	if t.FileSystemType == FilesystemTypeNone {
-		return zeroPartition(devname)
+		return zeroPartition(devname, printf)
 	}
 
 	opts := []makefs.Option{makefs.WithForce(t.Force), makefs.WithLabel(t.Label)}
-	log.Printf("formatting the partition %q as %q with label %q\n", devname, t.FileSystemType, t.Label)
+	printf("formatting the partition %q as %q with label %q\n", devname, t.FileSystemType, t.Label)
 
 	switch t.FileSystemType {
 	case FilesystemTypeVFAT:
@@ -47,8 +46,8 @@ func Format(devname string, t *FormatOptions) error {
 }
 
 // zeroPartition fills the partition with zeroes.
-func zeroPartition(devname string) (err error) {
-	log.Printf("zeroing out %q", devname)
+func zeroPartition(devname string, printf func(string, ...any)) (err error) {
+	printf("zeroing out %q", devname)
 
 	part, err := blockdevice.Open(devname, blockdevice.WithExclusiveLock(true))
 	if err != nil {

--- a/internal/pkg/partition/format_test.go
+++ b/internal/pkg/partition/format_test.go
@@ -137,7 +137,7 @@ func (suite *manifestSuite) TestZeroPartition() {
 
 	err = partition.Format(part, &partition.FormatOptions{
 		FileSystemType: partition.FilesystemTypeNone,
-	})
+	}, suite.T().Logf)
 	suite.Require().NoError(err)
 
 	// reading 10 times more than what we wrote should still return 0 since the partition is wiped

--- a/internal/pkg/partition/partition.go
+++ b/internal/pkg/partition/partition.go
@@ -6,8 +6,6 @@
 package partition
 
 import (
-	"log"
-
 	"github.com/dustin/go-humanize"
 	"github.com/siderolabs/go-blockdevice/blockdevice/partition/gpt"
 
@@ -40,8 +38,8 @@ func Locate(pt *gpt.GPT, label string) (*gpt.Partition, error) {
 
 // Partition creates a new partition on the specified device.
 // Returns the path to the newly created partition.
-func Partition(pt *gpt.GPT, pos int, device string, partitionOpts Options) (string, error) {
-	log.Printf("partitioning %s - %s %q\n", device, partitionOpts.PartitionLabel, humanize.Bytes(partitionOpts.Size))
+func Partition(pt *gpt.GPT, pos int, device string, partitionOpts Options, printf func(string, ...any)) (string, error) {
+	printf("partitioning %s - %s %q\n", device, partitionOpts.PartitionLabel, humanize.Bytes(partitionOpts.Size))
 
 	opts := []gpt.PartitionOption{
 		gpt.WithPartitionType(partitionOpts.PartitionType),
@@ -66,7 +64,7 @@ func Partition(pt *gpt.GPT, pos int, device string, partitionOpts Options) (stri
 		return "", err
 	}
 
-	log.Printf("created %s (%s) size %d blocks", partitionName, partitionOpts.PartitionLabel, part.Length())
+	printf("created %s (%s) size %d blocks", partitionName, partitionOpts.PartitionLabel, part.Length())
 
 	return partitionName, nil
 }

--- a/internal/pkg/secureboot/uki/sbat.go
+++ b/internal/pkg/secureboot/uki/sbat.go
@@ -7,7 +7,6 @@ package uki
 import (
 	"debug/pe"
 	"fmt"
-	"log"
 
 	"github.com/siderolabs/talos/internal/pkg/secureboot"
 )
@@ -23,8 +22,6 @@ func GetSBAT(path string) ([]byte, error) {
 
 	for _, section := range pefile.Sections {
 		if section.Name == string(secureboot.SBAT) {
-			log.Printf("section size: %d", section.Size)
-
 			data, err := section.Data()
 			if err != nil {
 				return nil, err

--- a/pkg/imager/extensions/rebuild.go
+++ b/pkg/imager/extensions/rebuild.go
@@ -29,7 +29,7 @@ func (builder *Builder) rebuildInitramfs(tempDir string) error {
 	defer pipeW.Close() //nolint:errcheck
 
 	// build cpio image which contains .sqsh images and extensions.yaml
-	cmd1 := exec.Command("cpio", "-H", "newc", "--create", "--reproducible")
+	cmd1 := exec.Command("cpio", "-H", "newc", "--create", "--reproducible", "--quiet")
 	cmd1.Dir = tempDir
 	cmd1.Stdin = listing
 	cmd1.Stdout = pipeW
@@ -51,7 +51,7 @@ func (builder *Builder) rebuildInitramfs(tempDir string) error {
 	defer destination.Close() //nolint:errcheck
 
 	// append compressed initramfs.sysext to the original initramfs.xz, kernel can read such format
-	cmd2 := exec.Command("xz", "-v", "-C", "crc32", "-0", "-e", "-T", "0", "-z")
+	cmd2 := exec.Command("xz", "-v", "-C", "crc32", "-0", "-e", "-T", "0", "-z", "--quiet")
 	cmd2.Dir = tempDir
 	cmd2.Stdin = pipeR
 	cmd2.Stdout = destination

--- a/pkg/imager/iso/grub.go
+++ b/pkg/imager/iso/grub.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -37,15 +36,16 @@ var grubCfgTemplate string
 // CreateGRUB creates a GRUB-based ISO image.
 //
 // This iso supports both BIOS and UEFI booting.
-func CreateGRUB(options GRUBOptions) error {
+func CreateGRUB(printf func(string, ...any), options GRUBOptions) error {
 	if err := utils.CopyFiles(
+		printf,
 		utils.SourceDestination(options.KernelPath, filepath.Join(options.ScratchDir, "boot", "vmlinuz")),
 		utils.SourceDestination(options.InitramfsPath, filepath.Join(options.ScratchDir, "boot", "initramfs.xz")),
 	); err != nil {
 		return err
 	}
 
-	log.Println("creating grub.cfg")
+	printf("creating grub.cfg")
 
 	var grubCfg bytes.Buffer
 
@@ -76,11 +76,11 @@ func CreateGRUB(options GRUBOptions) error {
 		return err
 	}
 
-	if err = utils.TouchFiles(options.ScratchDir); err != nil {
+	if err = utils.TouchFiles(printf, options.ScratchDir); err != nil {
 		return err
 	}
 
-	log.Println("creating ISO")
+	printf("creating ISO image")
 
 	return grubMkrescue(options.OutPath, options.ScratchDir)
 }

--- a/pkg/imager/iso/uefi.go
+++ b/pkg/imager/iso/uefi.go
@@ -47,7 +47,7 @@ const (
 // The ISO created supports only booting in UEFI mode, and supports SecureBoot.
 //
 //nolint:gocyclo,cyclop
-func CreateUEFI(options UEFIOptions) error {
+func CreateUEFI(printf func(string, ...any), options UEFIOptions) error {
 	if err := os.MkdirAll(options.ScratchDir, 0o755); err != nil {
 		return err
 	}
@@ -60,9 +60,11 @@ func CreateUEFI(options UEFIOptions) error {
 		isoSize = UKIISOSizeARM64
 	}
 
-	if err := utils.CreateRawDisk(efiBootImg, isoSize); err != nil {
+	if err := utils.CreateRawDisk(printf, efiBootImg, isoSize); err != nil {
 		return err
 	}
+
+	printf("creating vFAT EFI image")
 
 	fopts := []makefs.Option{
 		makefs.WithLabel(constants.EFIPartitionLabel),
@@ -130,9 +132,11 @@ func CreateUEFI(options UEFIOptions) error {
 	}
 
 	// fixup directory timestamps recursively
-	if err := utils.TouchFiles(options.ScratchDir); err != nil {
+	if err := utils.TouchFiles(printf, options.ScratchDir); err != nil {
 		return err
 	}
+
+	printf("creating ISO image")
 
 	if _, err := cmd.Run(
 		"xorriso",

--- a/pkg/imager/ova/ova.go
+++ b/pkg/imager/ova/ova.go
@@ -141,18 +141,18 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
 // CreateOVAFromRAW creates an OVA from a RAW disk.
 //
 //nolint:gocyclo
-func CreateOVAFromRAW(name, path, arch, scratchPath string, diskSize int64) error {
+func CreateOVAFromRAW(name, path, arch, scratchPath string, diskSize int64, printf func(string, ...any)) error {
 	if err := os.MkdirAll(scratchPath, 0o755); err != nil {
 		return err
 	}
 
 	vmdkPath := filepath.Join(scratchPath, name+".vmdk")
 
-	if err := utils.CopyFiles(utils.SourceDestination(path, vmdkPath)); err != nil {
+	if err := utils.CopyFiles(printf, utils.SourceDestination(path, vmdkPath)); err != nil {
 		return err
 	}
 
-	if err := qemuimg.Convert("raw", "vmdk", "compat6,subformat=streamOptimized,adapter_type=lsilogic", vmdkPath); err != nil {
+	if err := qemuimg.Convert("raw", "vmdk", "compat6,subformat=streamOptimized,adapter_type=lsilogic", vmdkPath, printf); err != nil {
 		return err
 	}
 

--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -144,8 +143,8 @@ func fileExists(path string) bool {
 }
 
 // Pull the container asset to the path.
-func (c *ContainerAsset) Pull(ctx context.Context, arch string) (v1.Image, error) {
-	log.Printf("pulling %s...", c.ImageRef)
+func (c *ContainerAsset) Pull(ctx context.Context, arch string, printf func(string, ...any)) (v1.Image, error) {
+	printf("pulling %s...", c.ImageRef)
 
 	img, err := crane.Pull(c.ImageRef, crane.WithPlatform(&v1.Platform{
 		Architecture: arch,
@@ -159,8 +158,8 @@ func (c *ContainerAsset) Pull(ctx context.Context, arch string) (v1.Image, error
 }
 
 // Extract the container asset to the path.
-func (c *ContainerAsset) Extract(ctx context.Context, destination, arch string) error {
-	img, err := c.Pull(ctx, arch)
+func (c *ContainerAsset) Extract(ctx context.Context, destination, arch string, printf func(string, ...any)) error {
+	img, err := c.Pull(ctx, arch, printf)
 	if err != nil {
 		return err
 	}

--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -102,7 +102,7 @@ func (p *Profile) Validate() error {
 			return fmt.Errorf("customization of meta partition is not supported for %s output", p.Output.Kind)
 		}
 	case OutKindUKI:
-		if p.SecureBootEnabled() {
+		if !p.SecureBootEnabled() {
 			return fmt.Errorf("!secureboot is not supported for %s output", p.Output.Kind)
 		}
 	}

--- a/pkg/imager/progress.go
+++ b/pkg/imager/progress.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package imager
+
+import (
+	"fmt"
+
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+// progressPrintf wraps a reporter.Reporter to report progress via Printf logging.
+func progressPrintf(report *reporter.Reporter, status reporter.Update) func(format string, args ...any) {
+	return func(format string, args ...any) {
+		msg := status.Message
+		extra := fmt.Sprintf(format, args...)
+
+		if extra != "" {
+			msg += "\n\t" + extra
+		}
+
+		report.Report(reporter.Update{
+			Message: msg,
+			Status:  status.Status,
+		})
+	}
+}

--- a/pkg/imager/qemuimg/qemuimg.go
+++ b/pkg/imager/qemuimg/qemuimg.go
@@ -12,9 +12,11 @@ import (
 )
 
 // Convert converts an image from one format to another.
-func Convert(inputFmt, outputFmt, options, path string) error {
+func Convert(inputFmt, outputFmt, options, path string, printf func(string, ...any)) error {
 	src := path + ".in"
 	dest := path
+
+	printf("converting %s to %s", inputFmt, outputFmt)
 
 	if err := os.Rename(path, src); err != nil {
 		return err

--- a/pkg/imager/utils/copy.go
+++ b/pkg/imager/utils/copy.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -23,7 +22,7 @@ func SourceDestination(src, dest string) CopyInstruction {
 }
 
 // CopyFiles copies files according to the given instructions.
-func CopyFiles(instructions ...CopyInstruction) error {
+func CopyFiles(printf func(string, ...any), instructions ...CopyInstruction) error {
 	for _, instruction := range instructions {
 		if err := func(instruction CopyInstruction) error {
 			src, dest := instruction.F1, instruction.F2
@@ -32,7 +31,7 @@ func CopyFiles(instructions ...CopyInstruction) error {
 				return err
 			}
 
-			log.Printf("copying %s to %s", src, dest)
+			printf("copying %s to %s", src, dest)
 
 			from, err := os.Open(src)
 			if err != nil {
@@ -52,7 +51,7 @@ func CopyFiles(instructions ...CopyInstruction) error {
 
 			return err
 		}(instruction); err != nil {
-			return fmt.Errorf("error copying %s -> %s", instruction.F1, instruction.F2)
+			return fmt.Errorf("error copying %s -> %s: %w", instruction.F1, instruction.F2, err)
 		}
 	}
 

--- a/pkg/imager/utils/raw.go
+++ b/pkg/imager/utils/raw.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"syscall"
 
@@ -14,8 +13,8 @@ import (
 )
 
 // CreateRawDisk creates a raw disk image of the specified size.
-func CreateRawDisk(path string, diskSize int64) error {
-	log.Printf("creating raw disk of size %s", humanize.Bytes(uint64(diskSize)))
+func CreateRawDisk(printf func(string, ...any), path string, diskSize int64) error {
+	printf("creating raw disk of size %s", humanize.Bytes(uint64(diskSize)))
 
 	f, err := os.Create(path)
 	if err != nil {

--- a/pkg/imager/utils/touch.go
+++ b/pkg/imager/utils/touch.go
@@ -6,14 +6,13 @@ package utils
 
 import (
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"time"
 )
 
 // TouchFiles updates mtime for all the files under root if SOURCE_DATE_EPOCH is set.
-func TouchFiles(root string) error {
+func TouchFiles(printf func(string, ...any), root string) error {
 	epochInt, ok, err := SourceDateEpoch()
 	if err != nil {
 		return err
@@ -25,7 +24,7 @@ func TouchFiles(root string) error {
 
 	timestamp := time.Unix(epochInt, 0)
 
-	log.Printf("changing timestamps under %q to %s", root, timestamp)
+	printf("changing timestamps under %q to %s", root, timestamp)
 
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
Use `Progress`, and options to pass around the way messages are written.

Fixed some tiny issues in the code, but otherwise no functional changes.

To make colored output work with `docker run`, switched back image generation to use volume mount for output (old mode is still functioning, but it's not the default, and it works when docker is not running on the same host).
