### PR TITLE
chore: remove <-errCh where possible in grpc methods

### DIFF
--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -48,22 +47,10 @@ captures ownership and permission bits.`,
 				return err
 			}
 
-			r, errCh, err := c.Copy(ctx, args[0])
+			r, err := c.Copy(ctx, args[0])
 			if err != nil {
 				return fmt.Errorf("error copying: %w", err)
 			}
-
-			var wg sync.WaitGroup
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for err := range errCh {
-					fmt.Fprintln(os.Stderr, err.Error())
-				}
-			}()
-
-			defer wg.Wait()
 
 			localPath := args[1]
 

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"text/tabwriter"
 
 	"github.com/dustin/go-humanize"
@@ -350,24 +349,12 @@ var etcdSnapshotCmd = &cobra.Command{
 
 			defer dest.Close() //nolint:errcheck
 
-			r, errCh, err := c.EtcdSnapshot(ctx, &machine.EtcdSnapshotRequest{})
+			r, err := c.EtcdSnapshot(ctx, &machine.EtcdSnapshotRequest{})
 			if err != nil {
 				return fmt.Errorf("error reading file: %w", err)
 			}
 
 			defer r.Close() //nolint:errcheck
-
-			var wg sync.WaitGroup
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for err := range errCh {
-					fmt.Fprintln(os.Stderr, err.Error())
-				}
-			}()
-
-			defer wg.Wait()
 
 			size, err := io.Copy(dest, r)
 			if err != nil {

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/mattn/go-isatty"
 	"github.com/siderolabs/go-kubeconfig"
@@ -92,22 +91,11 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				}
 			}
 
-			r, errCh, err := c.KubeconfigRaw(ctx)
+			r, err := c.KubeconfigRaw(ctx)
 			if err != nil {
 				return fmt.Errorf("error copying: %w", err)
 			}
 
-			var wg sync.WaitGroup
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for err := range errCh {
-					fmt.Fprintln(os.Stderr, err.Error())
-				}
-			}()
-
-			defer wg.Wait()
 			defer r.Close() //nolint:errcheck
 
 			data, err := helpers.ExtractFileFromTarGz("kubeconfig", r)

--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gopacket/gopacket"
@@ -90,26 +89,10 @@ e.g. by excluding packets with the port 50000.
 				return err
 			}
 
-			r, errCh, err := c.PacketCapture(ctx, &req)
+			r, err := c.PacketCapture(ctx, &req)
 			if err != nil {
 				return fmt.Errorf("error copying: %w", err)
 			}
-
-			var wg sync.WaitGroup
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for err := range errCh {
-					if client.StatusCode(err) == codes.DeadlineExceeded {
-						continue
-					}
-
-					fmt.Fprintln(os.Stderr, err.Error())
-				}
-			}()
-
-			defer wg.Wait()
 
 			if pcapCmdFlags.output == "" {
 				return dumpPackets(r)

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -320,7 +320,7 @@ func (a *Tracker) processNodeUpdate(update nodeUpdate) reporter.Update {
 // getBootID reads the boot ID from the node.
 // It returns the node as the first return value and the boot ID as the second.
 func getBootID(ctx context.Context, c *client.Client) (string, error) {
-	reader, errCh, err := c.Read(ctx, "/proc/sys/kernel/random/boot_id")
+	reader, err := c.Read(ctx, "/proc/sys/kernel/random/boot_id")
 	if err != nil {
 		return "", err
 	}
@@ -333,12 +333,6 @@ func getBootID(ctx context.Context, c *client.Client) (string, error) {
 	}
 
 	bootID := strings.TrimSpace(string(body))
-
-	for err = range errCh {
-		if err != nil {
-			return "", err
-		}
-	}
 
 	return bootID, reader.Close()
 }

--- a/internal/integration/api/cgroups.go
+++ b/internal/integration/api/cgroups.go
@@ -128,7 +128,7 @@ func (suite *CGroupsSuite) TestCGroupsVersion() {
 
 //nolint:gocyclo
 func (suite *CGroupsSuite) readCmdline(ctx context.Context) (string, error) {
-	reader, errCh, err := suite.Client.Read(ctx, "/proc/cmdline")
+	reader, err := suite.Client.Read(ctx, "/proc/cmdline")
 	if err != nil {
 		return "", err
 	}
@@ -145,12 +145,6 @@ func (suite *CGroupsSuite) readCmdline(ctx context.Context) (string, error) {
 	_, err = io.Copy(io.Discard, reader)
 	if err != nil {
 		return "", err
-	}
-
-	for err = range errCh {
-		if err != nil {
-			return "", err
-		}
 	}
 
 	return bootID, reader.Close()

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -51,13 +51,11 @@ func (suite *DmesgSuite) TestNodeHasDmesg() {
 	)
 	suite.Require().NoError(err)
 
-	logReader, errCh, err := client.ReadStream(dmesgStream)
+	logReader, err := client.ReadStream(dmesgStream)
 	suite.Require().NoError(err)
 
 	n, err := io.Copy(io.Discard, logReader)
 	suite.Require().NoError(err)
-
-	suite.Require().NoError(<-errCh)
 
 	// dmesg shouldn't be empty
 	suite.Require().Greater(n, int64(1024))

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -69,15 +69,13 @@ func (suite *LogsSuite) TestServicesHaveLogs() {
 		)
 		suite.Require().NoError(err)
 
-		logReader, errCh, err := client.ReadStream(logsStream)
+		logReader, err := client.ReadStream(logsStream)
 		suite.Require().NoError(err)
 
 		n, err := io.Copy(io.Discard, logReader)
 		suite.Require().NoError(err)
 
 		logsSize += n
-
-		suite.Require().NoError(<-errCh)
 	}
 
 	// overall logs shouldn't be empty
@@ -104,7 +102,7 @@ func (suite *LogsSuite) TestTail() {
 		)
 		suite.Require().NoError(err)
 
-		logReader, errCh, err := client.ReadStream(logsStream)
+		logReader, err := client.ReadStream(logsStream)
 		suite.Require().NoError(err)
 
 		scanner := bufio.NewScanner(logReader)
@@ -115,8 +113,6 @@ func (suite *LogsSuite) TestTail() {
 		}
 
 		suite.Require().NoError(scanner.Err())
-
-		suite.Require().NoError(<-errCh)
 
 		suite.Assert().EqualValues(tailLines, lines)
 	}

--- a/pkg/cluster/crashdump.go
+++ b/pkg/cluster/crashdump.go
@@ -75,7 +75,7 @@ func (s *APICrashDumper) CrashDump(ctx context.Context, out io.Writer) {
 						continue
 					}
 
-					r, errCh, err := client.ReadStream(stream)
+					r, err := client.ReadStream(stream)
 					if err != nil {
 						fmt.Fprintf(out, "error getting service logs for %s: %s\n", svc.Id, err)
 
@@ -85,11 +85,6 @@ func (s *APICrashDumper) CrashDump(ctx context.Context, out io.Writer) {
 					fmt.Fprintf(out, "\n> %s\n%s\n\n", svc.Id, strings.Repeat("-", len(svc.Id)+2))
 
 					_, err = io.Copy(out, r)
-					if err != nil {
-						fmt.Fprintf(out, "error streaming service logs: %s\n", err)
-					}
-
-					err = <-errCh
 					if err != nil {
 						fmt.Fprintf(out, "error streaming service logs: %s\n", err)
 					}

--- a/pkg/cluster/support.go
+++ b/pkg/cluster/support.go
@@ -627,7 +627,7 @@ func mounts(ctx context.Context, options *BundleOptions) ([]byte, error) {
 func devices(ctx context.Context, options *BundleOptions) ([]byte, error) {
 	options.Log("reading devices")
 
-	r, _, err := options.Client.Read(ctx, "/proc/bus/pci/devices")
+	r, err := options.Client.Read(ctx, "/proc/bus/pci/devices")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Simplify code by passing error directly into the pipe closer.