### PR TITLE
docs: mount bpffs to the cilium container

### DIFF
--- a/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
@@ -79,6 +79,9 @@ cilium install \
     --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --helm-set=cgroup.autoMount.enabled=false \
+    --helm-set=extraHostPathMounts[0].name=cilium-bpf \
+    --helm-set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --helm-set=extraHostPathMounts[0].hostPath=/sys/fs/bpf \
     --helm-set=cgroup.hostRoot=/sys/fs/cgroup
 ```
 
@@ -93,6 +96,9 @@ cilium install \
     --helm-set=bpf.autoMount.enabled=false \
     --helm-set=cgroup.autoMount.enabled=false \
     --helm-set=cgroup.hostRoot=/sys/fs/cgroup \
+    --helm-set=extraHostPathMounts[0].name=cilium-bpf \
+    --helm-set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --helm-set=extraHostPathMounts[0].hostPath=/sys/fs/bpf \
     --helm-set=k8sServiceHost=localhost \
     --helm-set=k8sServicePort=7445
 ```
@@ -128,7 +134,10 @@ helm install \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
-    --set=cgroup.hostRoot=/sys/fs/cgroup
+    --set=cgroup.hostRoot=/sys/fs/cgroup \
+    --set=extraHostPathMounts[0].name=cilium-bpf \
+    --set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --set=extraHostPathMounts[0].hostPath=/sys/fs/bpf
 ```
 
 Or if you want to deploy Cilium in strict mode without kube-proxy, also set some extra paramaters:
@@ -146,6 +155,9 @@ helm install \
     --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup \
+    --set=extraHostPathMounts[0].name=cilium-bpf \
+    --set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --set=extraHostPathMounts[0].hostPath=/sys/fs/bpf \
     --set=k8sServiceHost=localhost \
     --set=k8sServicePort=7445
 ```
@@ -168,7 +180,10 @@ helm template \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
-    --set=cgroup.hostRoot=/sys/fs/cgroup > cilium.yaml
+    --set=cgroup.hostRoot=/sys/fs/cgroup \
+    --set=extraHostPathMounts[0].name=cilium-bpf \
+    --set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --set=extraHostPathMounts[0].hostPath=/sys/fs/bpf > cilium.yaml
 
 kubectl apply -f cilium.yaml
 ```
@@ -191,6 +206,9 @@ helm template \
     --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup \
+    --set=extraHostPathMounts[0].name=cilium-bpf \
+    --set=extraHostPathMounts[0].mountPath=/sys/fs/bpf \
+    --set=extraHostPathMounts[0].hostPath=/sys/fs/bpf \
     --set=k8sServiceHost=localhost \
     --set=k8sServicePort=7445 > cilium.yaml
 


### PR DESCRIPTION
# Pull Request

## What? (description)
This commit adds a hostPath to ensure cilium functions correctly after a container restart.

## Why? (reasoning)
In commit 76fa45a, bpf automount was turned off because it's mounted on the host. This led to the removal of the init container's mounting. Helm doesn't automatically include the hostPath mount. Additionally, neither /sys nor /sys/fs were added to the container. As a result, cilium couldn't determine if /sys/fs/bpf was already mounted and mounts it anyway (only in the container).

More details: https://github.com/siderolabs/talos/pull/7565#issuecomment-1671063014

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
