### PR TITLE
docs: retain cilium autoMount pending upstream hostPath fix

### DIFF
--- a/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
@@ -90,7 +90,6 @@ cilium install \
     --helm-set=kubeProxyReplacement=strict \
     --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-    --helm-set=bpf.autoMount.enabled=false \
     --helm-set=cgroup.autoMount.enabled=false \
     --helm-set=cgroup.hostRoot=/sys/fs/cgroup \
     --helm-set=k8sServiceHost=localhost \
@@ -126,7 +125,6 @@ helm install \
     --set=kubeProxyReplacement=disabled \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-    --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup
 ```
@@ -143,7 +141,6 @@ helm install \
     --set=kubeProxyReplacement=strict \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-    --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup \
     --set=k8sServiceHost=localhost \
@@ -166,7 +163,6 @@ helm template \
     --set=kubeProxyReplacement=disabled \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-    --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup > cilium.yaml
 
@@ -188,7 +184,6 @@ helm template \
     --set=kubeProxyReplacement=strict \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-    --set=bpf.autoMount.enabled=false \
     --set=cgroup.autoMount.enabled=false \
     --set=cgroup.hostRoot=/sys/fs/cgroup \
     --set=k8sServiceHost=localhost \


### PR DESCRIPTION




# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Partial rollback of 76fa45a.

## Why? (reasoning)
The cilium helm chart requires an fix to handle the hostPath at /sys/fs/bpf when bpf.autoMount.enabled=false. The earlier commit disabled bpf automount, removing the init container's mount. Helm missed adding the hostPath, and neither /sys nor /sys/fs got added. This made cilium wrongly mount /sys/fs/bpf.

Fixes error message at: https://github.com/siderolabs/talos/pull/7565#issuecomment-1671063014

Continuation of PR https://github.com/siderolabs/talos/pull/7593 which i was unuable to reopen as I forced pushed in between

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
