### PR TITLE
chore: add version compatibility for Talos 1.6

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos15"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 )
 
 // KubernetesVersion embeds Kubernetes version.
@@ -50,6 +51,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 		minK8sVersion, maxK8sVersion = talos14.MinimumKubernetesVersion, talos14.MaximumKubernetesVersion
 	case talos15.MajorMinor: // upgrades to 1.5.x
 		minK8sVersion, maxK8sVersion = talos15.MinimumKubernetesVersion, talos15.MaximumKubernetesVersion
+	case talos16.MajorMinor: // upgrades to 1.6.x
+		minK8sVersion, maxK8sVersion = talos16.MinimumKubernetesVersion, talos16.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -154,12 +154,41 @@ func TestKubernetesCompatibility15(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility16(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.27.1",
+			target:            "1.6.0",
+		},
+		{
+			kubernetesVersion: "1.28.3",
+			target:            "1.6.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.29.0-rc.0",
+			target:            "1.6.7",
+		},
+		{
+			kubernetesVersion: "1.30.0-alpha.0",
+			target:            "1.6.0",
+			expectedError:     "version of Kubernetes 1.30.0-alpha.0 is too new to be used with Talos 1.6.0",
+		},
+		{
+			kubernetesVersion: "1.26.1",
+			target:            "1.6.0",
+			expectedError:     "version of Kubernetes 1.26.1 is too old to be used with Talos 1.6.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.6.0-alpha.0",
-			expectedError:     "compatibility with version 1.6.0-alpha.0 is not supported",
+			target:            "1.7.0-alpha.0",
+			expectedError:     "compatibility with version 1.7.0-alpha.0 is not supported",
 		},
 		{
 			kubernetesVersion: "1.25.0",

--- a/pkg/machinery/compatibility/talos16/talos16.go
+++ b/pkg/machinery/compatibility/talos16/talos16.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos16 provides compatibility constants for Talos 1.6.
+package talos16
+
+import (
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinor is the major.minor version of Talos 1.6.
+var MajorMinor = [2]uint64{1, 6}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.6.
+var MinimumHostUpgradeVersion = semver.MustParse("1.3.0")
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.6.
+var MaximumHostDowngradeVersion = semver.MustParse("1.8.0")
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.6.
+var DeniedHostUpgradeVersions = []semver.Version{}
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.6.
+var MinimumKubernetesVersion = semver.MustParse("1.27.0")
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.6.
+var MaximumKubernetesVersion = semver.MustParse("1.29.99")

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos15"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 )
 
 // TalosVersion embeds Talos version.
@@ -69,6 +70,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	case talos15.MajorMinor: // upgrades to 1.5.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos15.MinimumHostUpgradeVersion, talos15.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos15.DeniedHostUpgradeVersions
+	case talos16.MajorMinor: // upgrades to 1.6.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos16.MinimumHostUpgradeVersion, talos16.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos16.DeniedHostUpgradeVersions
 	default:
 		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
 	}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -163,17 +163,58 @@ func TestTalosUpgradeCompatibility15(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility16(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.4.0",
+			target: "1.6.0",
+		},
+		{
+			host:   "1.3.0-alpha.0",
+			target: "1.6.0",
+		},
+		{
+			host:   "1.3.0",
+			target: "1.6.0-alpha.0",
+		},
+		{
+			host:   "1.6.0",
+			target: "1.6.1",
+		},
+		{
+			host:   "1.6.0-beta.0",
+			target: "1.6.0",
+		},
+		{
+			host:   "1.7.5",
+			target: "1.6.3",
+		},
+		{
+			host:          "1.2.0",
+			target:        "1.6.0",
+			expectedError: `host version 1.2.0 is too old to upgrade to Talos 1.6.0`,
+		},
+		{
+			host:          "1.8.0-alpha.0",
+			target:        "1.6.0",
+			expectedError: `host version 1.8.0-alpha.0 is too new to downgrade to Talos 1.6.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.7.0-alpha.0",
-			expectedError: `upgrades to version 1.7.0-alpha.0 are not supported`,
+			target:        "1.8.0-alpha.0",
+			expectedError: `upgrades to version 1.8.0-alpha.0 are not supported`,
 		},
 		{
 			host:          "1.4.0",
-			target:        "1.6.0-alpha.0",
-			expectedError: `upgrades to version 1.6.0-alpha.0 are not supported`,
+			target:        "1.7.0-alpha.0",
+			expectedError: `upgrades to version 1.7.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)
@@ -199,6 +240,10 @@ func TestDisablePredictableNetworkInterfaces(t *testing.T) {
 		},
 		{
 			host:     "1.6.0",
+			expected: false,
+		},
+		{
+			host:     "1.7.0",
 			expected: false,
 		},
 	} {

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion1_6     = &VersionContract{1, 6}
 	TalosVersion1_5     = &VersionContract{1, 5}
 	TalosVersion1_4     = &VersionContract{1, 4}
 	TalosVersion1_3     = &VersionContract{1, 3}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -68,6 +68,30 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.DiskQuotaSupportEnabled())
 }
 
+func TestContract1_6(t *testing.T) {
+	contract := config.TalosVersion1_6
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.False(t, contract.PodSecurityPolicyEnabled())
+	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.True(t, contract.StableHostnameEnabled())
+	assert.True(t, contract.KubeletDefaultRuntimeSeccompProfileEnabled())
+	assert.False(t, contract.KubernetesAlternateImageRegistries())
+	assert.True(t, contract.KubernetesAllowSchedulingOnControlPlanes())
+	assert.True(t, contract.KubernetesDiscoveryBackendDisabled())
+	assert.True(t, contract.ApidExtKeyUsageCheckEnabled())
+	assert.True(t, contract.APIServerAuditPolicySupported())
+	assert.True(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.True(t, contract.SecretboxEncryptionSupported())
+	assert.True(t, contract.DiskQuotaSupportEnabled())
+}
+
 func TestContract1_5(t *testing.T) {
 	contract := config.TalosVersion1_5
 


### PR DESCRIPTION
This will be backported to 1.5, so that Talos 1.5 machinery will still provide compatibility for (future) Talos 1.6.
