### PR TITLE
docs: make Talos 1.5 documentation the default one

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -108,7 +108,7 @@ version_menu = "Releases"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/v1.4"
+url_latest_version = "/v1.5"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 # github_repo = "https://github.com/googley-example"
@@ -137,11 +137,11 @@ prism_syntax_highlighting = false
 
 [[params.versions]]
 url = "/v1.5/"
-version = "v1.5 (pre-release)"
+version = "v1.5 (latest)"
 
 [[params.versions]]
 url = "/v1.4/"
-version = "v1.4 (latest)"
+version = "v1.4"
 
 [[params.versions]]
 url = "/v1.3/"

--- a/website/content/v1.4/_index.md
+++ b/website/content/v1.4/_index.md
@@ -4,14 +4,13 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.4.7
+lastRelease: v1.4.8
 kubernetesRelease: "1.27.4"
 prevKubernetesRelease: "1.26.3"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.12.1"
 nvidiaDriverRelease: "530.41.03"
 iscsiToolsRelease: "v0.1.4"
-menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.5/_index.md
+++ b/website/content/v1.5/_index.md
@@ -4,14 +4,14 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.5.0-beta.0
+lastRelease: v1.5.0
 kubernetesRelease: "1.28.0"
-prevKubernetesRelease: "1.27.1"
+prevKubernetesRelease: "1.27.4"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.13.5"
 nvidiaDriverRelease: "535.54.03"
 iscsiToolsRelease: "v0.1.4"
-preRelease: true
+menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.5/introduction/support-matrix.md
+++ b/website/content/v1.5/introduction/support-matrix.md
@@ -6,8 +6,8 @@ description: "Table of supported Talos Linux versions and respective platforms."
 
 | Talos Version                                                                                                  | 1.5                                | 1.4                                |
 |----------------------------------------------------------------------------------------------------------------|------------------------------------|------------------------------------|
-| Release Date                                                                                                   | 2023-08-17, TBD                    | 2023-04-18 (1.4.0)                 |
-| End of Community Support                                                                                       | 1.6.0 release (2023-12-15, TBD)    | 1.5.0 release (2023-08-17, TBD)    |
+| Release Date                                                                                                   | 2023-08-17                         | 2023-04-18 (1.4.0)                 |
+| End of Community Support                                                                                       | 1.6.0 release (2023-12-15, TBD)    | 1.5.0 release (2023-08-17)         |
 | Enterprise Support                                                                                             | [offered by Sidero Labs Inc.](https://www.siderolabs.com/support/) | [offered by Sidero Labs Inc.](https://www.siderolabs.com/support/) |
 | Kubernetes                                                                                                     | 1.28, 1.27, 1.26                   | 1.27, 1.26, 1.25                   |
 | Architecture                                                                                                   | amd64, arm64                       | amd64, arm64                       |

--- a/website/content/v1.5/introduction/what-is-new/index.md
+++ b/website/content/v1.5/introduction/what-is-new/index.md
@@ -139,11 +139,11 @@ rolling component update.
 
 ## Component Updates
 
-* Linux: 6.1.42
-* containerd: 1.6.22
-* runc: 1.1.8
+* Linux: 6.1.45
+* containerd: 1.6.23
+* runc: 1.1.9
 * etcd: 3.5.9
-* Kubernetes: 1.28.0-rc.1
+* Kubernetes: 1.28.0
 * Flannel: 0.22.1
 
 Talos is built with Go 1.20.7.


### PR DESCRIPTION
This matches upcoming Talos 1.5.0 release.
