### PR TITLE
fix: support 'List' type manifests

### DIFF
--- a/internal/app/machined/pkg/adapters/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/adapters/k8s/manifest_test.go
@@ -5,6 +5,7 @@
 package k8s_test
 
 import (
+	_ "embed"
 	"strings"
 	"testing"
 
@@ -49,4 +50,20 @@ rules:
 
 	assert.Len(t, adapter.Objects(), 1)
 	assert.Equal(t, adapter.Objects()[0].GetKind(), "Policy")
+}
+
+//go:embed testdata/list.yaml
+var listManifest []byte
+
+func TestManifestSetYAMLList(t *testing.T) {
+	manifest := k8s.NewManifest(k8s.ControlPlaneNamespaceName, "test")
+	adapter := k8sadapter.Manifest(manifest)
+
+	require.NoError(t, adapter.SetYAML(listManifest))
+
+	assert.Len(t, adapter.Objects(), 2)
+	assert.Equal(t, "ClusterRoleBinding", adapter.Objects()[0].GetKind())
+	assert.Equal(t, "system:cloud-node-controller", adapter.Objects()[0].GetName())
+	assert.Equal(t, "ClusterRoleBinding", adapter.Objects()[1].GetKind())
+	assert.Equal(t, "system:cloud-controller-manager", adapter.Objects()[1].GetName())
 }

--- a/internal/app/machined/pkg/adapters/k8s/testdata/list.yaml
+++ b/internal/app/machined/pkg/adapters/k8s/testdata/list.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-node-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-node-controller
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-node-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+kind: List
+metadata: {}


### PR DESCRIPTION
Fixes #7636

This support a `List`-type manifests by unwrapping them into individual objects.
