### PR TITLE
fix: automatically change `rpi_4` board on upgrade

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -79,6 +79,11 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 	}
 
 	if opts.Board != constants.BoardNone {
+		// board 'rpi_4' was removed in Talos 1.5 in favor of `rpi_generic`
+		if opts.Board == "rpi_4" {
+			opts.Board = constants.BoardRPiGeneric
+		}
+
 		var b runtime.Board
 
 		b, err = board.NewBoard(opts.Board)


### PR DESCRIPTION
As `rpi_4` was removed in Talos 1.5, automatically migrate to `rpi_generic`.

Fixes #7632
