### PR TITLE
fix: properly GC images supplied with both tag and digest

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/export_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/export_test.go
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime
+
+// BuildExpectedImageNames is exported for testing.
+var BuildExpectedImageNames = buildExpectedImageNames


### PR DESCRIPTION
This is a follow-up fix for #7640

I noticed that image cleanup controller cleans up the images if specified with both tag and digest.

The problem was incorrectly building image references in the expected set of images, so they were incorrectly marked as unused.

Refactor the code to make the core part testable.
