### PR TITLE
fix: restore compatibility with Kubernetes 1.26

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
@@ -110,7 +110,8 @@ func (ctrl *KubeletSpecController) Run(ctx context.Context, r controller.Runtime
 
 			"cert-dir": constants.KubeletPKIDir,
 
-			"hostname-override": expectedNodename,
+			"hostname-override":          expectedNodename,
+			"container-runtime-endpoint": "unix://" + constants.CRIContainerdAddress,
 		}
 
 		if !cfgSpec.SkipNodeRegistration {
@@ -264,7 +265,6 @@ func NewKubeletConfiguration(cfgSpec *k8s.KubeletConfigSpec) (*kubeletconfig.Kub
 	config.KubeletCgroups = constants.CgroupKubelet
 	config.RotateCertificates = true
 	config.ProtectKernelDefaults = true
-	config.ContainerRuntimeEndpoint = "unix://" + constants.CRIContainerdAddress
 
 	// SeccompDefault feature gate is enabled by default Kubernetes 1.25+, GA in 1.27
 	if cfgSpec.DefaultRuntimeSeccompEnabled {

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec_test.go
@@ -128,6 +128,7 @@ func (suite *KubeletSpecSuite) TestReconcileDefault() {
 						"--cert-dir=/var/lib/kubelet/pki",
 						"--cloud-provider=external",
 						"--config=/etc/kubernetes/kubelet.yaml",
+						"--container-runtime-endpoint=unix://" + constants.CRIContainerdAddress,
 						"--foo=bar",
 						"--hostname-override=example.com",
 						"--kubeconfig=/etc/kubernetes/kubeconfig-kubelet",
@@ -187,6 +188,7 @@ func (suite *KubeletSpecSuite) TestReconcileWithExplicitNodeIP() {
 						"--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubeconfig",
 						"--cert-dir=/var/lib/kubelet/pki",
 						"--config=/etc/kubernetes/kubelet.yaml",
+						"--container-runtime-endpoint=unix://" + constants.CRIContainerdAddress,
 						"--hostname-override=example.com",
 						"--kubeconfig=/etc/kubernetes/kubeconfig-kubelet",
 						"--node-ip=10.0.0.1",
@@ -316,6 +318,7 @@ func (suite *KubeletSpecSuite) TestReconcileWithSkipNodeRegistration() {
 				suite.Assert().Equal([]string{
 					"--cert-dir=/var/lib/kubelet/pki",
 					"--config=/etc/kubernetes/kubelet.yaml",
+					"--container-runtime-endpoint=unix://" + constants.CRIContainerdAddress,
 					"--hostname-override=foo.com",
 					"--node-ip=172.20.0.3",
 				}, spec.Args)
@@ -449,7 +452,6 @@ func TestNewKubeletConfigurationMerge(t *testing.T) {
 		StreamingConnectionIdleTimeout:  metav1.Duration{Duration: 5 * time.Minute},
 		TLSMinVersion:                   "VersionTLS13",
 		StaticPodPath:                   constants.ManifestsDirectory,
-		ContainerRuntimeEndpoint:        "unix://" + constants.CRIContainerdAddress,
 	}
 
 	for _, tt := range []struct {


### PR DESCRIPTION
The `--container-runtime-endpoint` flag was moved to the kubelet config only in Kubernetes 1.27.

Kubernetes 1.27 and 1.28 still support the flag (even though 1.28 shows the warning that the flag is deprecated).

This is direct commit to `release-1.5`, as `main` is going to use Kubernetes 1.27-1.29, so it should be using a config file.

Fixes #7648
