### PR TITLE
test: update e2e-aws to use worker groups

### DIFF
--- a/hack/test/tfvars/aws.jq
+++ b/hack/test/tfvars/aws.jq
@@ -1,16 +1,10 @@
 {
     "cluster_name": .cluster_name,
-    "num_control_planes": 3,
-    "num_workers": (if .worker_group == "nvidia" then 0 else 3 end),
-    "ami_id": .ami_id,
     "ccm": true,
     "kubernetes_version": .kubernetes_version,
-    "instance_type_control_plane": "t3.large",
-    "instance_type_worker": "t3.large",
-    "extra_tags": {
-        "Name": .cluster_name,
-        "Project": "talos-e2e-ci",
-        "Environment": "ci"
+    "control_plane": {
+        "ami_id": .ami_id,
+        "instance_type": "t3.large"
     },
     "worker_groups": (if .worker_group == "nvidia" then [
         {
@@ -24,5 +18,18 @@
                 "Type": "nvidia-t4"
             }
         }
-    ] else [] end)
+    ] else [
+        {
+            "name": "default",
+            "num_instances": 3,
+            "ami_id": .ami_id,
+            "instance_type": "t3.large"
+        }
+    ] end),
+    "extra_tags": {
+        "Cluster Name": .cluster_name,
+        "Project": "talos-e2e-ci",
+        "Environment": "ci"
+    },
+
 }


### PR DESCRIPTION
This PR updates the e2e-aws flow to use worker groups and an updated control plane variable setup.