### PR TITLE
chore: drop firmware from initramfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -680,12 +680,6 @@ FROM build AS initramfs-archive-arm64
 WORKDIR /initramfs
 COPY --from=squashfs-arm64 /rootfs.sqsh .
 COPY --from=init-build-arm64 /init .
-# copying over firmware binary blobs to initramfs
-COPY --from=pkg-linux-firmware /lib/firmware/rtl_nic ./lib/firmware/rtl_nic
-COPY --from=pkg-linux-firmware /lib/firmware/nvidia/tegra210 ./lib/firmware/nvidia/tegra210
-# the intel ice pkg file from linux-firmware has the version appended to it, but kernel only looks up ice.pkg
-# ref: https://github.com/torvalds/linux/blob/v5.15/Documentation/networking/device_drivers/ethernet/intel/ice.rst#dynamic-device-personalization
-COPY --from=pkg-linux-firmware /lib/firmware/intel/ice/ddp/ice-*.pkg ./lib/firmware/intel/ice/ddp/ice.pkg
 RUN find . -print0 \
     | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
 RUN set -o pipefail \
@@ -699,12 +693,6 @@ FROM build AS initramfs-archive-amd64
 WORKDIR /initramfs
 COPY --from=squashfs-amd64 /rootfs.sqsh .
 COPY --from=init-build-amd64 /init .
-# copying over firmware binary blobs to initramfs
-COPY --from=pkg-linux-firmware /lib/firmware/bnx2 ./lib/firmware/bnx2
-COPY --from=pkg-linux-firmware /lib/firmware/bnx2x ./lib/firmware/bnx2x
-# the intel ice pkg file from linux-firmware has the version appended to it, but kernel only looks up ice.pkg
-# ref: https://github.com/torvalds/linux/blob/v5.15/Documentation/networking/device_drivers/ethernet/intel/ice.rst#dynamic-device-personalization
-COPY --from=pkg-linux-firmware /lib/firmware/intel/ice/ddp/ice-*.pkg ./lib/firmware/intel/ice/ddp/ice.pkg
 RUN find . -print0 \
     | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
 RUN set -o pipefail \

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -14,6 +14,14 @@ preface = """\
 """
 
 [notes]
+    [notes.firmware]
+        title = "Linux Firmware"
+        description = """\
+Starting with Talos 1.6, there is no Linux firmware included in the initramfs.
+Customers who need Linux firmware can pull them as extension during install time using the image service.
+If the initial boot requires firmware, a custom iso can be built with the firmware included using the imager service.
+This also ensures that the linux-firmware is not tied to a specific Talos version.
+"""
 
     [notes.updates]
         title = "Component Updates"


### PR DESCRIPTION
Drop firmware from initramfs. Extra firmware can be added as system extensions enabled through imager service.

Before:

```bash
❯ du -sh _out/initramfs-amd64.xz
58M	_out/initramfs-amd64.xz
```

After:

```bash
❯ du -sh _out/initramfs-amd64.xz
56M	_out/initramfs-amd64.xz
```