### PR TITLE
fix: use a mount prefix when installing a bootloader

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -43,6 +43,7 @@ type Options struct {
 	Version         string
 	BootAssets      bootloaderoptions.BootAssets
 	Printf          func(string, ...any)
+	MountPrefix     string
 }
 
 // Mode is the install mode.
@@ -234,7 +235,7 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 
 			var mountpoint *mount.Point
 
-			mountpoint, err = mount.SystemMountPointForLabel(ctx, bd, label)
+			mountpoint, err = mount.SystemMountPointForLabel(ctx, bd, label, mount.WithPrefix(i.options.MountPrefix))
 			if err != nil {
 				return err
 			}
@@ -262,13 +263,14 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 
 	// Install the bootloader.
 	if err = i.bootloader.Install(bootloaderoptions.InstallOptions{
-		BootDisk:   i.options.Disk,
-		Arch:       i.options.Arch,
-		Cmdline:    i.cmdline.String(),
-		Version:    i.options.Version,
-		ImageMode:  mode.IsImage(),
-		BootAssets: i.options.BootAssets,
-		Printf:     i.options.Printf,
+		BootDisk:    i.options.Disk,
+		Arch:        i.options.Arch,
+		Cmdline:     i.cmdline.String(),
+		Version:     i.options.Version,
+		ImageMode:   mode.IsImage(),
+		MountPrefix: i.options.MountPrefix,
+		BootAssets:  i.options.BootAssets,
+		Printf:      i.options.Printf,
 	}); err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
@@ -35,8 +35,14 @@ func (c *Config) Install(options options.InstallOptions) error {
 
 	if err := utils.CopyFiles(
 		options.Printf,
-		utils.SourceDestination(options.BootAssets.KernelPath, filepath.Join(constants.BootMountPoint, string(c.Default), constants.KernelAsset)),
-		utils.SourceDestination(options.BootAssets.InitramfsPath, filepath.Join(constants.BootMountPoint, string(c.Default), constants.InitramfsAsset)),
+		utils.SourceDestination(
+			options.BootAssets.KernelPath,
+			filepath.Join(options.MountPrefix, constants.BootMountPoint, string(c.Default), constants.KernelAsset),
+		),
+		utils.SourceDestination(
+			options.BootAssets.InitramfsPath,
+			filepath.Join(options.MountPrefix, constants.BootMountPoint, string(c.Default), constants.InitramfsAsset),
+		),
 	); err != nil {
 		return err
 	}
@@ -45,7 +51,7 @@ func (c *Config) Install(options options.InstallOptions) error {
 		return err
 	}
 
-	if err := c.Write(ConfigPath, options.Printf); err != nil {
+	if err := c.Write(filepath.Join(options.MountPrefix, ConfigPath), options.Printf); err != nil {
 		return err
 	}
 
@@ -69,8 +75,11 @@ func (c *Config) Install(options options.InstallOptions) error {
 	}
 
 	for _, platform := range platforms {
-		args := []string{"--boot-directory=" + constants.BootMountPoint, "--efi-directory=" +
-			constants.EFIMountPoint, "--removable"}
+		args := []string{
+			"--boot-directory=" + filepath.Join(options.MountPrefix, constants.BootMountPoint),
+			"--efi-directory=" + filepath.Join(options.MountPrefix, constants.EFIMountPoint),
+			"--removable",
+		}
 
 		if options.ImageMode {
 			args = append(args, "--no-nvram")

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
@@ -25,6 +25,9 @@ type InstallOptions struct {
 	// Are we running in image mode?
 	ImageMode bool
 
+	// Mount prefix for /boot-like partitions.
+	MountPrefix string
+
 	// Boot assets to install.
 	BootAssets BootAssets
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
@@ -140,7 +140,7 @@ func (c *Config) Install(options options.InstallOptions) error {
 	}
 
 	// list existing UKIs, and clean up all but the current one (used to boot)
-	files, err := filepath.Glob(filepath.Join(constants.EFIMountPoint, "EFI", "Linux", "Talos-*.efi"))
+	files, err := filepath.Glob(filepath.Join(options.MountPrefix, constants.EFIMountPoint, "EFI", "Linux", "Talos-*.efi"))
 	if err != nil {
 		return err
 	}
@@ -169,8 +169,14 @@ func (c *Config) Install(options options.InstallOptions) error {
 
 	if err := utils.CopyFiles(
 		options.Printf,
-		utils.SourceDestination(options.BootAssets.UKIPath, filepath.Join(constants.EFIMountPoint, "EFI", "Linux", ukiPath)),
-		utils.SourceDestination(options.BootAssets.SDBootPath, filepath.Join(constants.EFIMountPoint, "EFI", "boot", sdbootFilename)),
+		utils.SourceDestination(
+			options.BootAssets.UKIPath,
+			filepath.Join(options.MountPrefix, constants.EFIMountPoint, "EFI", "Linux", ukiPath),
+		),
+		utils.SourceDestination(
+			options.BootAssets.SDBootPath,
+			filepath.Join(options.MountPrefix, constants.EFIMountPoint, "EFI", "boot", sdbootFilename),
+		),
 	); err != nil {
 		return err
 	}

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -175,6 +175,8 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 
 	cmdline := procfs.NewCmdline(i.cmdline)
 
+	scratchSpace := filepath.Join(i.tempDir, "image")
+
 	opts := &install.Options{
 		Disk:       loDevice,
 		Platform:   i.prof.Platform,
@@ -190,7 +192,8 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 			UKIPath:       i.ukiPath,
 			SDBootPath:    i.sdBootPath,
 		},
-		Printf: printf,
+		MountPrefix: scratchSpace,
+		Printf:      printf,
 	}
 
 	if opts.Board == "" {


### PR DESCRIPTION
This is not a problem in general, but when running multiple image generation procedures using the same mount point is a problem.

This is a no-op if `MountPrefix` is not set (when installing/upgrading vs. creating an image).
