### PR TITLE
Update Cilium Install Docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ HELM_VERSION ?= v3.12.3
 # renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
 CLUSTERCTL_VERSION ?= 1.5.0
 # renovate: datasource=github-releases depName=cilium/cilium-cli
-CILIUM_CLI_VERSION ?= v0.14.8
+CILIUM_CLI_VERSION ?= v0.15.7
 KUBECTL_URL ?= https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OPERATING_SYSTEM)/amd64/kubectl
 KUBESTR_URL ?= https://github.com/kastenhq/kubestr/releases/download/$(KUBESTR_VERSION)/kubestr_$(subst v,,$(KUBESTR_VERSION))_Linux_amd64.tar.gz
 HELM_URL ?= https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -245,31 +245,29 @@ function install_and_run_cilium_cni_tests {
   case "${CILIUM_INSTALL_TYPE:-none}" in
     strict)
       ${CILIUM_CLI} install \
-        --helm-set=ipam.mode=kubernetes \
-        --helm-set=kubeProxyReplacement=strict \
-        --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
-        --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-        --helm-set=cgroup.autoMount.enabled=false \
-        --helm-set=cgroup.hostRoot=/sys/fs/cgroup \
-        --helm-set=k8sServiceHost=localhost \
-        --helm-set=k8sServicePort=13336 \
-        --wait-duration=10m
+        --set=ipam.mode=kubernetes \
+        --set=kubeProxyReplacement=true \
+        --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
+        --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
+        --set=cgroup.autoMount.enabled=false \
+        --set=cgroup.hostRoot=/sys/fs/cgroup \
+        --set=k8sServiceHost=localhost \
+        --set=k8sServicePort=13336
       ;;
     *)
       # explicitly setting kubeProxyReplacement=disabled since by the time cilium cli runs talos
       # has not yet applied the kube-proxy manifests
       ${CILIUM_CLI} install \
-        --helm-set=ipam.mode=kubernetes \
-        --helm-set=kubeProxyReplacement=disabled \
-        --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
-        --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
-        --helm-set=cgroup.autoMount.enabled=false \
-        --helm-set=cgroup.hostRoot=/sys/fs/cgroup \
-        --wait-duration=10m
+        --set=ipam.mode=kubernetes \
+        --set=kubeProxyReplacement=false \
+        --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
+        --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
+        --set=cgroup.autoMount.enabled=false \
+        --set=cgroup.hostRoot=/sys/fs/cgroup
       ;;
   esac
 
-  ${CILIUM_CLI} status
+  ${CILIUM_CLI} status --wait --wait-duration=10m
 
   ${KUBECTL} delete ns --ignore-not-found cilium-test
 

--- a/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
@@ -40,7 +40,7 @@ talosctl gen config \
     --config-patch @patch.yaml
 ```
 
-Or if you want to deploy Cilium in strict mode without kube-proxy, you also need to disable kube proxy:
+Or if you want to deploy Cilium without kube-proxy, you also need to disable kube proxy:
 
 Create a `patch.yaml` file with the following contents:
 
@@ -87,7 +87,7 @@ cilium install \
 ```bash
 cilium install \
     --helm-set=ipam.mode=kubernetes \
-    --helm-set=kubeProxyReplacement=strict \
+    --helm-set=kubeProxyReplacement=true \
     --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --helm-set=cgroup.autoMount.enabled=false \
@@ -129,7 +129,7 @@ helm install \
     --set=cgroup.hostRoot=/sys/fs/cgroup
 ```
 
-Or if you want to deploy Cilium in strict mode without kube-proxy, also set some extra paramaters:
+Or if you want to deploy Cilium without kube-proxy, also set some extra paramaters:
 
 ```bash
 helm install \
@@ -138,7 +138,7 @@ helm install \
     --version 1.14.0 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set=kubeProxyReplacement=strict \
+    --set=kubeProxyReplacement=true \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=cgroup.autoMount.enabled=false \
@@ -181,7 +181,7 @@ helm template \
     --version 1.14.0 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set=kubeProxyReplacement=strict \
+    --set=kubeProxyReplacement=true \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=cgroup.autoMount.enabled=false \

--- a/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
@@ -40,7 +40,7 @@ talosctl gen config \
     --config-patch @patch.yaml
 ```
 
-Or if you want to deploy Cilium in strict mode without kube-proxy, you also need to disable kube proxy:
+Or if you want to deploy Cilium without kube-proxy, you also need to disable kube proxy:
 
 Create a `patch.yaml` file with the following contents:
 
@@ -87,7 +87,7 @@ cilium install \
 ```bash
 cilium install \
     --helm-set=ipam.mode=kubernetes \
-    --helm-set=kubeProxyReplacement=strict \
+    --helm-set=kubeProxyReplacement=true \
     --helm-set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --helm-set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --helm-set=cgroup.autoMount.enabled=false \
@@ -129,7 +129,7 @@ helm install \
     --set=cgroup.hostRoot=/sys/fs/cgroup
 ```
 
-Or if you want to deploy Cilium in strict mode without kube-proxy, also set some extra paramaters:
+Or if you want to deploy Cilium without kube-proxy, also set some extra paramaters:
 
 ```bash
 helm install \
@@ -138,7 +138,7 @@ helm install \
     --version 1.14.0 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set=kubeProxyReplacement=strict \
+    --set=kubeProxyReplacement=true \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=cgroup.autoMount.enabled=false \
@@ -181,7 +181,7 @@ helm template \
     --version 1.14.0 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set=kubeProxyReplacement=strict \
+    --set=kubeProxyReplacement=true \
     --set=securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set=securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set=cgroup.autoMount.enabled=false \


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Update cilium setup doc with latest info

## Why? (reasoning)
`kubeProxyReplacement=strict` The value strict is now deprecated. From Cilium helm char values:
```
# Valid options are "true", "false", "disabled" (deprecated), "partial" (deprecated), "strict" (deprecated).
# ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
#kubeProxyReplacement: "false"
```


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
