### PR TITLE
fix: set correct (1 year) talosconfig expiration

### DIFF
--- a/cmd/talosctl/cmd/talos/config_test.go
+++ b/cmd/talosctl/cmd/talos/config_test.go
@@ -66,7 +66,6 @@ contexts:
 Current context:     no-roles
 Nodes:               not defined
 Endpoints:           172.20.1.2
-Roles:               not defined
 Certificate expires: 10 years from now (2031-07-03)
 `) + "\n",
 		},

--- a/internal/app/machined/pkg/adapters/cluster/identity_test.go
+++ b/internal/app/machined/pkg/adapters/cluster/identity_test.go
@@ -25,7 +25,7 @@ func TestIdentityGenerate(t *testing.T) {
 	length := len(spec1.NodeID)
 
 	assert.GreaterOrEqual(t, length, 43)
-	assert.LessOrEqual(t, length, 44)
+	assert.LessOrEqual(t, length, 45)
 }
 
 func TestIdentityConvertMachineID(t *testing.T) {

--- a/internal/app/machined/pkg/controllers/runtime/maintenance_service_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/maintenance_service_test.go
@@ -78,7 +78,11 @@ func (suite *MaintenanceServiceSuite) TestRunService() {
 
 	// wait for the service to be up
 	suite.AssertWithin(time.Second, 10*time.Millisecond, func() error {
-		c, err := net.Dial("tcp", maintenanceConfig.TypedSpec().ListenAddress)
+		c, err := tls.Dial("tcp", maintenanceConfig.TypedSpec().ListenAddress,
+			&tls.Config{
+				InsecureSkipVerify: true,
+			},
+		)
 
 		if c != nil {
 			c.Close() //nolint:errcheck

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -35,6 +35,12 @@ func (suite *TalosconfigSuite) TestList() {
 		base.StdoutShouldMatch(regexp.MustCompile(`CURRENT`)))
 }
 
+// TestInfo checks `talosctl config info`.
+func (suite *TalosconfigSuite) TestInfo() {
+	suite.RunCLI([]string{"config", "info"}, // TODO: remove 10 years once the CABPT & TF providers are updated to 1.5.2+
+		base.StdoutShouldMatch(regexp.MustCompile(`(1 year|10 years) from now`)))
+}
+
 // TestMerge checks `talosctl config merge`.
 func (suite *TalosconfigSuite) TestMerge() {
 	tempDir := suite.T().TempDir()

--- a/pkg/machinery/config/generate/secrets/bundle.go
+++ b/pkg/machinery/config/generate/secrets/bundle.go
@@ -351,6 +351,6 @@ func (bundle *Bundle) GenerateTalosAPIClientCertificate(roles role.Set) (*x509.P
 		bundle.Clock.Now(),
 		bundle.Certs.OS,
 		roles,
-		CAValidityTime,
+		constants.TalosAPIDefaultCertificateValidityDuration,
 	)
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -911,6 +911,9 @@ const (
 
 	// KubePrismHealthCheckTimeout is the timeout for health checks for the KubePrism loadbalancer.
 	KubePrismHealthCheckTimeout = 15 * time.Second
+
+	// TalosAPIDefaultCertificateValidityDuration specifies default certificate duration for Talos API generated client certificates.
+	TalosAPIDefaultCertificateValidityDuration = time.Hour * 24 * 365
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Fixes #7698

Also fix `talosctl config info` for `talosconfig` without a client certificate (e.g. Omni-generated one).
