### PR TITLE
feat: set environment variables early in the boot

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -79,6 +79,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			"etc",
 			CreateSystemCgroups,
 			CreateOSReleaseFile,
+			SetUserEnvVars,
 		).Append(
 			"machined",
 			StartMachined,
@@ -105,6 +106,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			"etc",
 			CreateSystemCgroups,
 			CreateOSReleaseFile,
+			SetUserEnvVars,
 		).Append(
 			"earlyServices",
 			StartUdevd,


### PR DESCRIPTION
Fixes #7696

This allows to set env variables from `talos.environment=` command line arg.
