### PR TITLE
fix: update kubernetes library for 1.28 upgrade pre-checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/siderolabs/go-debug v0.2.3
 	github.com/siderolabs/go-kmsg v0.1.3
 	github.com/siderolabs/go-kubeconfig v0.1.0
-	github.com/siderolabs/go-kubernetes v0.2.2
+	github.com/siderolabs/go-kubernetes v0.2.3
 	github.com/siderolabs/go-loadbalancer v0.3.2
 	github.com/siderolabs/go-pcidb v0.2.0
 	github.com/siderolabs/go-pointer v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,8 @@ github.com/siderolabs/go-kmsg v0.1.3 h1:rYxuDCN52Y6XdTNnEe52f0NZa4F6GHDEAQoVMHME
 github.com/siderolabs/go-kmsg v0.1.3/go.mod h1:MrxoGwR6WNC7knaMlIKbQM3DFKqJ/flTQH9OtW7M3c8=
 github.com/siderolabs/go-kubeconfig v0.1.0 h1:t/2oMWkLSdWHXglKPMz8ySXnx6ZjHckeGY79NaDcBTo=
 github.com/siderolabs/go-kubeconfig v0.1.0/go.mod h1:eM3mO02Td6wYDvdi9zTbMrj1Q4WqEFN8XQ6pNjCUWkI=
-github.com/siderolabs/go-kubernetes v0.2.2 h1:rLkxNNL6IVYjm/nsLFaIFQegLhMZIvZ/gt70PumENS8=
-github.com/siderolabs/go-kubernetes v0.2.2/go.mod h1:iwv35xZkJrdQBjYxWiBL14YcSXVIPwFy/M6E8X/oF4Q=
+github.com/siderolabs/go-kubernetes v0.2.3 h1:/s3ncGbgc2D/B0U/saCK+NkOxEogXj/vmkjBXSDlXVc=
+github.com/siderolabs/go-kubernetes v0.2.3/go.mod h1:iwv35xZkJrdQBjYxWiBL14YcSXVIPwFy/M6E8X/oF4Q=
 github.com/siderolabs/go-loadbalancer v0.3.2 h1:R2jKq8ifWOARxJ5blXwOOkiWCA5/46stGxUR8+qV8GE=
 github.com/siderolabs/go-loadbalancer v0.3.2/go.mod h1:sKP/xSN4R+1fifcqIjnk1FtM5sSW20d+pi+0FV6CpVo=
 github.com/siderolabs/go-pcidb v0.2.0 h1:ZCkF1cz6UjoEIHpP7+aeTI5BwmSxE627Jl1Wy2VZAwU=


### PR DESCRIPTION
See https://github.com/siderolabs/go-kubernetes/pull/7

Fixes #7697
