### PR TITLE
chore: add output flag for talosctl config info

### DIFF
--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -475,7 +475,8 @@ talosctl config info [flags]
 ### Options
 
 ```
-  -h, --help   help for info
+  -h, --help            help for info
+  -o, --output string   output format (json|yaml|text). Default text. (default "text")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Add output flag for `talosctl config info`.

This allows to programatically gather endpoints for CI tests.

Eg:

```bash
_out/talosctl-linux-amd64 config info --output json | jq '.Contexts[].Endpoints[0]'
```