### PR TITLE
fix: trim file path in the container image

### DIFF
--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -260,22 +261,22 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 	if i.prof.SecureBootEnabled() {
 		artifacts = append(artifacts,
 			filemap.File{
-				ImagePath:  fmt.Sprintf(constants.UKIAssetPath, i.prof.Arch),
+				ImagePath:  strings.TrimLeft(fmt.Sprintf(constants.UKIAssetPath, i.prof.Arch), "/"),
 				SourcePath: i.ukiPath,
 			},
 			filemap.File{
-				ImagePath:  fmt.Sprintf(constants.SDBootAssetPath, i.prof.Arch),
+				ImagePath:  strings.TrimLeft(fmt.Sprintf(constants.SDBootAssetPath, i.prof.Arch), "/"),
 				SourcePath: i.sdBootPath,
 			},
 		)
 	} else {
 		artifacts = append(artifacts,
 			filemap.File{
-				ImagePath:  fmt.Sprintf(constants.KernelAssetPath, i.prof.Arch),
+				ImagePath:  strings.TrimLeft(fmt.Sprintf(constants.KernelAssetPath, i.prof.Arch), "/"),
 				SourcePath: i.prof.Input.Kernel.Path,
 			},
 			filemap.File{
-				ImagePath:  fmt.Sprintf(constants.InitramfsAssetPath, i.prof.Arch),
+				ImagePath:  strings.TrimLeft(fmt.Sprintf(constants.InitramfsAssetPath, i.prof.Arch), "/"),
 				SourcePath: i.initramfsPath,
 			},
 		)


### PR DESCRIPTION
When imager generates `installer` image, it should generate a layer without `/` in front, e.g. `/usr/install` -> `usr/install`.

It works either way, but this seems to be cleaner.
