### PR TITLE
feat: upgrade-k8s  without comments

### DIFF
--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -38,6 +38,7 @@ import (
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -699,6 +700,8 @@ func (suite *UpgradeSuite) upgradeKubernetes(fromVersion, toVersion string, skip
 
 		UpgradeKubelet: !skipKubeletUpgrade,
 		PrePullImages:  true,
+
+		EncoderOpt: encoder.WithComments(encoder.CommentsAll),
 	}
 
 	suite.Require().NoError(kubernetes.Upgrade(suite.ctx, suite.clusterAccess, options))

--- a/pkg/cluster/kubernetes/kubelet.go
+++ b/pkg/cluster/kubernetes/kubelet.go
@@ -98,7 +98,7 @@ func upgradeKubeletOnNode(ctx context.Context, cluster UpgradeProvider, options 
 
 	skipWait := false
 
-	err = patchNodeConfig(ctx, cluster, node, upgradeKubeletPatcher(options, kubeletSpec))
+	err = patchNodeConfig(ctx, cluster, node, options.EncoderOpt, upgradeKubeletPatcher(options, kubeletSpec))
 	if err != nil {
 		if errors.Is(err, errUpdateSkipped) {
 			skipWait = true

--- a/pkg/cluster/kubernetes/patch.go
+++ b/pkg/cluster/kubernetes/patch.go
@@ -13,12 +13,13 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	v1alpha1config "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 // patchNodeConfig updates node configuration by means of patch function.
-func patchNodeConfig(ctx context.Context, cluster UpgradeProvider, node string, patchFunc func(config *v1alpha1config.Config) error) error {
+func patchNodeConfig(ctx context.Context, cluster UpgradeProvider, node string, encoderOpt encoder.Option, patchFunc func(config *v1alpha1config.Config) error) error {
 	c, err := cluster.Client()
 	if err != nil {
 		return fmt.Errorf("error building Talos API client: %w", err)
@@ -44,7 +45,7 @@ func patchNodeConfig(ctx context.Context, cluster UpgradeProvider, node string, 
 		return fmt.Errorf("error patching config: %w", err)
 	}
 
-	cfgBytes, err := container.NewV1Alpha1(cfg).EncodeBytes()
+	cfgBytes, err := container.NewV1Alpha1(cfg).EncodeBytes(encoderOpt)
 	if err != nil {
 		return fmt.Errorf("error serializing config: %w", err)
 	}

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -179,7 +179,7 @@ func upgradeKubeProxy(ctx context.Context, cluster UpgradeProvider, options Upgr
 	for _, node := range options.controlPlaneNodes {
 		options.Log(" > %q: starting update", node)
 
-		if err := patchNodeConfig(ctx, cluster, node, patchKubeProxy(options)); err != nil {
+		if err := patchNodeConfig(ctx, cluster, node, options.EncoderOpt, patchKubeProxy(options)); err != nil {
 			return fmt.Errorf("error updating node %q: %w", node, err)
 		}
 	}
@@ -261,7 +261,7 @@ func upgradeStaticPodOnNode(ctx context.Context, cluster UpgradeProvider, option
 
 	skipConfigWait := false
 
-	err = patchNodeConfig(ctx, cluster, node, upgradeStaticPodPatcher(options, service, initialConfig))
+	err = patchNodeConfig(ctx, cluster, node, options.EncoderOpt, upgradeStaticPodPatcher(options, service, initialConfig))
 	if err != nil {
 		if errors.Is(err, errUpdateSkipped) {
 			skipConfigWait = true

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -9,6 +9,8 @@ import (
 	"io"
 
 	"github.com/siderolabs/go-kubernetes/kubernetes/upgrade"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 )
 
 const (
@@ -28,6 +30,7 @@ type UpgradeOptions struct {
 	PrePullImages        bool
 	UpgradeKubelet       bool
 	DryRun               bool
+	EncoderOpt           encoder.Option
 
 	controlPlaneNodes []string
 	workerNodes       []string

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -2889,6 +2889,8 @@ talosctl upgrade-k8s [flags]
       --pre-pull-images   pre-pull images before upgrade (default true)
       --to string         the Kubernetes control plane version to upgrade to (default "1.28.1")
       --upgrade-kubelet   upgrade kubelet service (default true)
+      --with-docs         patch all machine configs adding the documentation for each field (default true)
+      --with-examples     patch all machine configs with the commented examples (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Hello.

the command `talosctl gen config --with-docs=false --with-examples=false` can generate machineConfig without documentation inside. But during upgrade-k8s, talosctl adds them.

This feature allows us to remove any comments from the machineconfig after upgrading Kubernetes.

Thanks.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
