### PR TITLE
fix: set default route priority for hcloud platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"gopkg.in/yaml.v3"
 
+	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
@@ -75,7 +76,7 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 					Operator: network.OperatorDHCP4,
 					LinkName: ntwrk.Interfaces,
 					DHCP4: network.DHCP4OperatorSpec{
-						RouteMetric: 1024,
+						RouteMetric: networkctrl.DefaultRouteMetric,
 					},
 					ConfigLayer: network.ConfigPlatform,
 				})
@@ -120,6 +121,7 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      nethelpers.FamilyInet6,
+					Priority:    networkctrl.DefaultRouteMetric,
 				}
 
 				route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/testdata/expected.yaml
@@ -20,6 +20,7 @@ routes:
       gateway: fe80::1
       outLinkName: eth0
       table: main
+      priority: 1024
       scope: global
       type: unicast
       flags: ""


### PR DESCRIPTION
Otherwise route gets created with priority '0' and it seems to get into conflict with what Cilium tries to add.
