### PR TITLE
fix: the node IP for kubelet shouldn't change if nothing matches

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/nodeip.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip.go
@@ -111,6 +111,8 @@ func (ctrl *NodeIPController) Run(ctx context.Context, r controller.Runtime, log
 
 		if len(ips) == 0 {
 			logger.Warn("no suitable node IP found, please make sure .machine.kubelet.nodeIP filters and pod/service subnets are set up correctly")
+
+			continue
 		}
 
 		// filter down to make sure only one IPv4 and one IPv6 address stays

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_test.go
@@ -94,11 +94,19 @@ func (suite *KmsgLogDeliverySuite) SetupTest() {
 	suite.srv2, err = logreceiver.NewServer(logger, suite.listener2, suite.handler2.HandleLog)
 	suite.Require().NoError(err)
 
+	suite.wg.Add(1)
+
 	go func() {
+		defer suite.wg.Done()
+
 		suite.srv1.Serve() //nolint:errcheck
 	}()
 
+	suite.wg.Add(1)
+
 	go func() {
+		defer suite.wg.Done()
+
 		suite.srv2.Serve() //nolint:errcheck
 	}()
 


### PR DESCRIPTION
This was a fix some time ago, but it was incorrect (missing `continue`), which was failing the unit-tests.

Also fix a data race in another unit-test (which is unit-test only, not affecting production).
