### PR TITLE
fix: clear the encryption config in META when STATE is reset

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1625,6 +1625,31 @@ func ResetSystemDiskSpec(_ runtime.Sequence, data any) (runtime.TaskExecutionFun
 			}
 		}
 
+		stateWiped := slices.ContainsFunc(in.GetSystemDiskTargets(), func(t runtime.PartitionTarget) bool {
+			return t.GetLabel() == constants.StatePartitionLabel
+		})
+
+		metaWiped := slices.ContainsFunc(in.GetSystemDiskTargets(), func(t runtime.PartitionTarget) bool {
+			return t.GetLabel() == constants.MetaPartitionLabel
+		})
+
+		if stateWiped && !metaWiped {
+			var removed bool
+
+			removed, err = r.State().Machine().Meta().DeleteTag(ctx, meta.StateEncryptionConfig)
+			if err != nil {
+				return fmt.Errorf("failed to remove state encryption META config tag: %w", err)
+			}
+
+			if removed {
+				if err = r.State().Machine().Meta().Flush(); err != nil {
+					return fmt.Errorf("failed to flush META: %w", err)
+				}
+
+				logger.Printf("reset the state encryption META config tag")
+			}
+		}
+
 		logger.Printf("successfully reset system disk by the spec")
 
 		return nil


### PR DESCRIPTION
When STATE is reset, we need to make sure we wipe the META keys containing encryption config as well.

Fixes #7819
