### PR TITLE
feat: hostname configuration improvements on the NoCloud platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -33,12 +33,17 @@ func (n *Nocloud) Name() string {
 func (n *Nocloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, st state.State, metadata *MetadataConfig) (*runtime.PlatformNetworkConfig, error) {
 	networkConfig := &runtime.PlatformNetworkConfig{}
 
-	if metadata.Hostname != "" {
+	hostname := metadata.Hostname
+	if hostname == "" {
+		hostname = metadata.LocalHostname
+	}
+
+	if hostname != "" {
 		hostnameSpec := network.HostnameSpecSpec{
 			ConfigLayer: network.ConfigPlatform,
 		}
 
-		if err := hostnameSpec.ParseFQDN(metadata.Hostname); err != nil {
+		if err := hostnameSpec.ParseFQDN(hostname); err != nil {
 			return nil, err
 		}
 
@@ -60,7 +65,7 @@ func (n *Nocloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, st sta
 
 	networkConfig.Metadata = &runtimeres.PlatformMetadataSpec{
 		Platform:     n.Name(),
-		Hostname:     metadata.Hostname,
+		Hostname:     hostname,
 		InstanceID:   metadata.InstanceID,
 		InstanceType: metadata.InstanceType,
 		ProviderID:   metadata.ProviderID,

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -74,16 +74,25 @@ func TestParseMetadata(t *testing.T) {
 				Hostname:   "talos.fqdn",
 				InstanceID: "0",
 			}
+			mc2 := nocloud.MetadataConfig{
+				LocalHostname: "talos.fqdn",
+				InstanceID:    "0",
+			}
 
 			networkConfig, err := n.ParseMetadata(&m, st, &mc)
 			require.NoError(t, err)
+			networkConfig2, err := n.ParseMetadata(&m, st, &mc2)
+			require.NoError(t, err)
 
 			marshaled, err := yaml.Marshal(networkConfig)
+			require.NoError(t, err)
+			marshaled2, err := yaml.Marshal(networkConfig2)
 			require.NoError(t, err)
 
 			fmt.Print(string(marshaled))
 
 			assert.Equal(t, tt.expected, string(marshaled))
+			assert.Equal(t, tt.expected, string(marshaled2))
 		})
 	}
 }


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

* support for local-hostname parameter
* support for hostnames passed via user-data (for Proxmox VE)

## Why? (reasoning)

Official documentation shows examples how to use `local-hostname` with `NoCloud`:
* https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html
* https://www.talos.dev/v1.5/talos-guides/install/cloud-platforms/nocloud/#example-qemu

Proxmox VE writes `hostname` to `user-data` instead of `meta-data`.
Until `user-data` in not used for machine config it can still be used to parse the hostname from user's `cloud-config`

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
