### PR TITLE
test: fix 'talosctl gen' tests

### DIFF
--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -225,39 +225,26 @@ func (suite *GenSuite) TestSecrets() {
 
 	suite.RunCLI([]string{"gen", "secrets", "--force"}, base.StdoutEmpty())
 
-	defer os.Remove("secrets.yaml") //nolint:errcheck
-
-	suite.RunCLI([]string{"gen", "secrets", "--output-file", "/tmp/secrets2.yaml"}, base.StdoutEmpty())
-	suite.Assert().FileExists("/tmp/secrets2.yaml")
-
-	defer os.Remove("/tmp/secrets2.yaml") //nolint:errcheck
+	suite.RunCLI([]string{"gen", "secrets", "--output-file", "secrets2.yaml"}, base.StdoutEmpty())
+	suite.Assert().FileExists("secrets2.yaml")
 
 	suite.RunCLI([]string{"gen", "secrets", "-o", "secrets3.yaml", "--talos-version", "v0.8"}, base.StdoutEmpty())
 	suite.Assert().FileExists("secrets3.yaml")
-
-	defer os.Remove("secrets3.yaml") //nolint:errcheck
 }
 
 // TestSecretsWithPKIDirAndToken ...
 func (suite *GenSuite) TestSecretsWithPKIDirAndToken() {
-	path := "/tmp/secrets-with-pki-dir-and-token.yaml"
+	path := "secrets-with-pki-dir-and-token.yaml"
 
-	tempDir := suite.T().TempDir()
-
-	dir, err := writeKubernetesPKIFiles(tempDir)
-	suite.Assert().NoError(err)
-
-	defer os.RemoveAll(dir) //nolint:errcheck
+	suite.Require().NoError(writeKubernetesPKIFiles("k8s-pki/"))
 
 	suite.RunCLI([]string{
-		"gen", "secrets", "--from-kubernetes-pki", dir,
+		"gen", "secrets", "--from-kubernetes-pki", "k8s-pki/",
 		"--kubernetes-bootstrap-token", "test-token",
 		"--output-file", path,
 	}, base.StdoutEmpty())
 
 	suite.Assert().FileExists(path)
-
-	defer os.Remove(path) //nolint:errcheck
 
 	secretsYaml, err := os.ReadFile(path)
 	suite.Assert().NoError(err)

--- a/internal/integration/cli/pki.go
+++ b/internal/integration/cli/pki.go
@@ -27,41 +27,39 @@ var (
 	pkiEtcdCAKey []byte
 )
 
-func writeKubernetesPKIFiles(dir string) (string, error) {
-	var err error
-
-	if err = os.WriteFile(filepath.Join(dir, "ca.crt"), pkiCACrt, 0o777); err != nil {
-		return "", err
+func writeKubernetesPKIFiles(dir string) error {
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "ca.key"), pkiCAKey, 0o777); err != nil {
-		return "", err
+	if err := os.WriteFile(filepath.Join(dir, "ca.crt"), pkiCACrt, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "front-proxy-ca.crt"), pkiFrontProxyCACrt, 0o777); err != nil {
-		return "", err
+	if err := os.WriteFile(filepath.Join(dir, "ca.key"), pkiCAKey, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "front-proxy-ca.key"), pkiFrontProxyCAKey, 0o777); err != nil {
-		return "", err
+	if err := os.WriteFile(filepath.Join(dir, "front-proxy-ca.crt"), pkiFrontProxyCACrt, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "sa.key"), pkiSAKey, 0o777); err != nil {
-		return "", err
+	if err := os.WriteFile(filepath.Join(dir, "front-proxy-ca.key"), pkiFrontProxyCAKey, 0o777); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "sa.key"), pkiSAKey, 0o777); err != nil {
+		return err
 	}
 
 	etcdDir := filepath.Join(dir, "etcd")
-	if err = os.Mkdir(etcdDir, 0o777); err != nil {
-		return "", err
+	if err := os.Mkdir(etcdDir, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(etcdDir, "ca.crt"), pkiEtcdCACrt, 0o777); err != nil {
-		return "", err
+	if err := os.WriteFile(filepath.Join(etcdDir, "ca.crt"), pkiEtcdCACrt, 0o777); err != nil {
+		return err
 	}
 
-	if err = os.WriteFile(filepath.Join(etcdDir, "ca.key"), pkiEtcdCAKey, 0o777); err != nil {
-		return "", err
-	}
-
-	return dir, nil
+	return os.WriteFile(filepath.Join(etcdDir, "ca.key"), pkiEtcdCAKey, 0o777)
 }


### PR DESCRIPTION
There were weird hacks put into the tests, while each test already runs in a temporary directory as 'working directory', so no hacks are needed.

Moreover, using fixed `/tmp/...` paths leads to test failures, as CI runs docker & QEMU tests in parallel conflicting with each other.
