### PR TITLE
fix: oracle integration fixes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/expected.yaml
@@ -1,6 +1,18 @@
 addresses: []
 links: []
-routes: []
+routes:
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: fe80::a:b:c:d
+      outLinkName: eth0
+      table: main
+      priority: 2048
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
 hostnames:
     - hostname: talos
       domainname: ""

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/metadatanetwork.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/testdata/metadatanetwork.json
@@ -7,6 +7,9 @@
         "virtualRouterIp": "172.16.1.1",
         "subnetCidrBlock": "172.16.1.0/24",
         "ipv6SubnetCidrBlock": "2603:a:b:c::/64",
-        "ipv6VirtualRouterIp": "fe80::a:b:c:d"
+        "ipv6VirtualRouterIp": "fe80::a:b:c:d",
+        "ipv6Addresses": [
+            "2603:a:b:c::1234"
+        ]
     }
 ]

--- a/website/content/v1.4/talos-guides/install/cloud-platforms/oracle.md
+++ b/website/content/v1.4/talos-guides/install/cloud-platforms/oracle.md
@@ -1,7 +1,7 @@
 ---
 title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
-aliases: 
+aliases:
   - ../../../cloud-platforms/oracle
 ---
 
@@ -70,7 +70,7 @@ cat <<EOF > controlplane-health-checker.json
   "intervalInMillis": 10000,
   "port": 6443,
   "protocol": "HTTPS",
-  "returnCode": 200,
+  "returnCode": 401,
   "urlPath": "/readyz"
 }
 EOF

--- a/website/content/v1.5/talos-guides/install/cloud-platforms/oracle.md
+++ b/website/content/v1.5/talos-guides/install/cloud-platforms/oracle.md
@@ -1,7 +1,7 @@
 ---
 title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
-aliases: 
+aliases:
   - ../../../cloud-platforms/oracle
 ---
 
@@ -70,7 +70,7 @@ cat <<EOF > controlplane-health-checker.json
   "intervalInMillis": 10000,
   "port": 6443,
   "protocol": "HTTPS",
-  "returnCode": 200,
+  "returnCode": 401,
   "urlPath": "/readyz"
 }
 EOF

--- a/website/content/v1.6/talos-guides/install/cloud-platforms/oracle.md
+++ b/website/content/v1.6/talos-guides/install/cloud-platforms/oracle.md
@@ -1,7 +1,7 @@
 ---
 title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
-aliases: 
+aliases:
   - ../../../cloud-platforms/oracle
 ---
 
@@ -70,7 +70,7 @@ cat <<EOF > controlplane-health-checker.json
   "intervalInMillis": 10000,
   "port": 6443,
   "protocol": "HTTPS",
-  "returnCode": 200,
+  "returnCode": 401,
   "urlPath": "/readyz"
 }
 EOF


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Update oracle platform:

* Set static gateway IPv6 if it possible. Some cni do not work properly with ipv6, so we will fix it. (We already did the same in gcp/azure)
* Disable Talos dashboard. Oracle cloud does not have screen interface.

close #7528

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
