### PR TITLE
feat: nocloud platform prefer mac address

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -52,7 +52,7 @@ func (n *Nocloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, st sta
 
 	switch unmarshalledNetworkConfig.Version {
 	case 1:
-		if err := n.applyNetworkConfigV1(unmarshalledNetworkConfig, networkConfig); err != nil {
+		if err := n.applyNetworkConfigV1(unmarshalledNetworkConfig, st, networkConfig); err != nil {
 			return nil, err
 		}
 	case 2:

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -58,6 +58,10 @@ func TestParseMetadata(t *testing.T) {
 
 			st := state.WrapCore(namespaced.NewState(inmem.Build))
 
+			eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+			eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf7}
+			require.NoError(t, st.Create(context.TODO(), eth0))
+
 			eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
 			eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf8}
 			require.NoError(t, st.Create(context.TODO(), eth1))

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1.yaml
@@ -5,14 +5,33 @@ addresses:
       scope: global
       flags: permanent
       layer: platform
-    - address: 2001:2:3:4:5:6:7:8/64
+    - address: 2001:2:3:4:5:6:7:f7/64
       linkName: eth0
+      family: inet6
+      scope: global
+      flags: permanent
+      layer: platform
+    - address: 192.168.2.11/24
+      linkName: eth2
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+    - address: 2001:2:3:4:5:6:7:f9/64
+      linkName: eth2
       family: inet6
       scope: global
       flags: permanent
       layer: platform
 links:
     - name: eth0
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      layer: platform
+    - name: eth2
       logical: false
       up: true
       mtu: 0
@@ -37,6 +56,30 @@ routes:
       src: ""
       gateway: fe80::1
       outLinkName: eth0
+      table: main
+      priority: 2048
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 192.168.2.1
+      outLinkName: eth2
+      table: main
+      priority: 1024
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: fe80::2
+      outLinkName: eth2
       table: main
       priority: 2048
       scope: global

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v1.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v1.yaml
@@ -2,15 +2,26 @@ version: 1
 config:
   - type: physical
     name: eth0
-    mac_address: 'ae:71:9e:61:d0:ad'
+    mac_address: '68:05:ca:b8:f1:f7'
     subnets:
     - type: static
       address: '192.168.1.11'
       netmask: '255.255.255.0'
       gateway: '192.168.1.1'
     - type: static6
-      address: '2001:2:3:4:5:6:7:8/64'
+      address: '2001:2:3:4:5:6:7:f7/64'
       gateway: 'fe80::1'
+  - type: physical
+    name: eth1
+    mac_address: '68:05:ca:b8:f1:f9'
+    subnets:
+    - type: static
+      address: '192.168.2.11'
+      netmask: '255.255.255.0'
+      gateway: '192.168.2.1'
+    - type: static6
+      address: '2001:2:3:4:5:6:7:f9/64'
+      gateway: 'fe80::2'
   - type: nameserver
     address:
     - '192.168.1.1'


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Use MAC address over network interface name.
This helps to use SR-IOV and paravirtualization network devices together.

Also I've added `WaitInterfaces` func. 
The kernel has not yet initialized the network devices, when the platform is attempting to identify the device by its MAC address.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
