### PR TITLE
feat: Add GOMEMLIMIT to k8s templates

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -167,6 +167,7 @@ func NewControlPlaneControllerManagerController() *ControlPlaneControllerManager
 					ExtraArgs:            cfgProvider.Cluster().ControllerManager().ExtraArgs(),
 					ExtraVolumes:         convertVolumes(cfgProvider.Cluster().ControllerManager().ExtraVolumes()),
 					EnvironmentVariables: cfgProvider.Cluster().ControllerManager().Env(),
+					Resources:            convertResources(cfgProvider.Cluster().ControllerManager().Resources()),
 				}
 
 				return nil
@@ -193,6 +194,7 @@ func NewControlPlaneSchedulerController() *ControlPlaneSchedulerController {
 					ExtraArgs:            cfgProvider.Cluster().Scheduler().ExtraArgs(),
 					ExtraVolumes:         convertVolumes(cfgProvider.Cluster().Scheduler().ExtraVolumes()),
 					EnvironmentVariables: cfgProvider.Cluster().Scheduler().Env(),
+					Resources:            convertResources(cfgProvider.Cluster().Scheduler().Resources()),
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
@@ -332,6 +332,38 @@ func (suite *K8sControlPlaneSuite) TestReconcileResources() {
 							},
 						},
 					},
+					ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{
+						ResourcesConfig: &v1alpha1.ResourcesConfig{
+							Requests: v1alpha1.Unstructured{
+								Object: map[string]interface{}{
+									"cpu":    "50m",
+									"memory": "500Mi",
+								},
+							},
+							Limits: v1alpha1.Unstructured{
+								Object: map[string]interface{}{
+									"cpu":    1,
+									"memory": "1000Mi",
+								},
+							},
+						},
+					},
+					SchedulerConfig: &v1alpha1.SchedulerConfig{
+						ResourcesConfig: &v1alpha1.ResourcesConfig{
+							Requests: v1alpha1.Unstructured{
+								Object: map[string]interface{}{
+									"cpu":    "150m",
+									"memory": "2Gi",
+								},
+							},
+							Limits: v1alpha1.Unstructured{
+								Object: map[string]interface{}{
+									"cpu":    3,
+									"memory": "2000Mi",
+								},
+							},
+						},
+					},
 				},
 			},
 		),
@@ -354,6 +386,44 @@ func (suite *K8sControlPlaneSuite) TestReconcileResources() {
 						"memory": "1500Mi",
 					},
 				}, apiServerCfg.Resources,
+			)
+		},
+	)
+
+	rtestutils.AssertResources(suite.Ctx(), suite.T(), suite.State(), []resource.ID{k8s.ControllerManagerConfigID},
+		func(controllerManager *k8s.ControllerManagerConfig, assert *assert.Assertions) {
+			controllerManagerCfg := controllerManager.TypedSpec()
+
+			assert.Equal(
+				k8s.Resources{
+					Requests: map[string]string{
+						"cpu":    "50m",
+						"memory": "500Mi",
+					},
+					Limits: map[string]string{
+						"cpu":    "1",
+						"memory": "1000Mi",
+					},
+				}, controllerManagerCfg.Resources,
+			)
+		},
+	)
+
+	rtestutils.AssertResources(suite.Ctx(), suite.T(), suite.State(), []resource.ID{k8s.SchedulerConfigID},
+		func(scheduler *k8s.SchedulerConfig, assert *assert.Assertions) {
+			schedulerCfg := scheduler.TypedSpec()
+
+			assert.Equal(
+				k8s.Resources{
+					Requests: map[string]string{
+						"cpu":    "150m",
+						"memory": "2Gi",
+					},
+					Limits: map[string]string{
+						"cpu":    "3",
+						"memory": "2000Mi",
+					},
+				}, schedulerCfg.Resources,
 			)
 		},
 	)

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -357,6 +357,9 @@ spec:
             requests:
               cpu: 100m
               memory: 70Mi
+          env:
+            - name: GOMEMLIMIT
+              value: "161MiB"
           args: [ "-conf", "/etc/coredns/Corefile" ]
           volumeMounts:
             - name: config-volume

--- a/pkg/flannel/gen.go
+++ b/pkg/flannel/gen.go
@@ -15,7 +15,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/siderolabs/gen/slices"
+	"github.com/siderolabs/gen/xslices"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -184,10 +184,10 @@ var Template = []byte(`+"`", url)
 
 			ds.Spec.Template.Spec.Containers[0].Image = "{{ .FlannelImage }}"
 
-			ds.Spec.Template.Spec.Volumes = slices.FilterInPlace(ds.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+			ds.Spec.Template.Spec.Volumes = xslices.FilterInPlace(ds.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
 				return v.Name != "xtables-lock"
 			})
-			ds.Spec.Template.Spec.Containers[0].VolumeMounts = slices.FilterInPlace(
+			ds.Spec.Template.Spec.Containers[0].VolumeMounts = xslices.FilterInPlace(
 				ds.Spec.Template.Spec.Containers[0].VolumeMounts, func(v corev1.VolumeMount) bool {
 					return v.Name != "xtables-lock"
 				})


### PR DESCRIPTION
# Pull Request
fixes #7874
<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
This commit integrates the GOMEMLIMIT environment variable into the shipped k8s manifests when resources.limits.memory are defined. It is set to 95% of the memory limit to optimize the performance of the Go garbage collector, mitigating the risk of OOMKills in containerized environments.
## Why? (reasoning)
see issue #7874 :
Addressing inefficiencies of Go's garbage collector in constrained memory environments, this PR introduces the GOMEMLIMIT environment variable to k8s manifests with defined resources.limits.memory. This optimizes garbage collection frequency, reducing OOMKill risk. The GOMEMLIMIT is set to 95% of the memory limit, ensuring efficient garbage collection while accommodating undetected memory usages.

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
