### PR TITLE
fix: make Talos work on Rockpi 4c boards again

### DIFF
--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -33,6 +33,8 @@ const (
 	SkipIfMounted
 	// SkipIfNoFilesystem is a flag for skipping formatting and mounting if the mountpoint has not filesystem.
 	SkipIfNoFilesystem
+	// SkipIfNoDevice is a flag for skipping errors when the device is not found.
+	SkipIfNoDevice
 )
 
 // Flags is the mount flags.

--- a/internal/pkg/mount/pseudo.go
+++ b/internal/pkg/mount/pseudo.go
@@ -35,7 +35,9 @@ func PseudoSubMountPoints() (mountpoints *Points, err error) {
 
 	if _, err := os.Stat(constants.EFIVarsMountPoint); err == nil {
 		// mount EFI vars if they exist
-		pseudo.Set("efivars", NewMountPoint("efivarfs", constants.EFIVarsMountPoint, "efivarfs", unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME|unix.MS_RDONLY, ""))
+		pseudo.Set("efivars", NewMountPoint("efivarfs", constants.EFIVarsMountPoint, "efivarfs", unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME|unix.MS_RDONLY, "",
+			WithFlags(SkipIfNoDevice),
+		))
 	}
 
 	return pseudo, nil


### PR DESCRIPTION
Suppress `efivars` `ENODEV` errors: skip mount and proceed with boot sequence.