### PR TITLE
feat: generate secrets bundle from the machine config

### DIFF
--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -277,14 +276,14 @@ func (suite *GenSuite) TestConfigWithSecrets() {
 		base.StderrNotEmpty(),
 	)
 
-	config, err := configloader.NewFromFile("controlplane.yaml")
+	suite.RunCLI([]string{"gen", "secrets", "--from-controlplane-config", "controlplane.yaml", "--output-file", "secrets-from-config.yaml"},
+		base.StdoutEmpty(),
+	)
+
+	configSecretsBundle, err := os.ReadFile("secrets-from-config.yaml")
 	suite.Assert().NoError(err)
 
-	configSecretsBundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), config)
-	configSecretsBundleBytes, err := yaml.Marshal(configSecretsBundle)
-
-	suite.Assert().NoError(err)
-	suite.Assert().YAMLEq(string(secretsYaml), string(configSecretsBundleBytes))
+	suite.Assert().YAMLEq(string(secretsYaml), string(configSecretsBundle))
 }
 
 // TestGenConfigWithDeprecatedOutputDirFlag tests that gen config command still works with the deprecated --output-dir flag.

--- a/website/content/v1.6/introduction/getting-started.md
+++ b/website/content/v1.6/introduction/getting-started.md
@@ -178,7 +178,7 @@ install:
 
 to reflect `vda` instead of `sda`.
 
->For information on customizing your machine configurations (such as to  specify the version of Kubernetes), using [machine configuration patches]({{< relref "../talos-guides/configuration/patching" >}}), or customizing  configurations for individual machines (such as setting static IP addresses), see the [Production Notes]({{< relref "prodnotes#customizing-machine-configuration" >}}).
+> For information on customizing your machine configurations (such as to  specify the version of Kubernetes), using [machine configuration patches]({{< relref "../talos-guides/configuration/patching" >}}), or customizing  configurations for individual machines (such as setting static IP addresses), see the [Production Notes]({{< relref "prodnotes#customizing-machine-configuration" >}}).
 
 ## Understand talosctl, endpoints and nodes
 

--- a/website/content/v1.6/introduction/prodnotes.md
+++ b/website/content/v1.6/introduction/prodnotes.md
@@ -181,6 +181,9 @@ This bundle can be used to generate machine or client configurations at any time
 talosctl gen secrets -o secrets.yaml
 ```
 
+> The `secrets.yaml` can also be extracted from the existing controlplane machine configuration with
+> `talosctl gen secrets --from-controlplane-config controlplane.yaml -o secrets.yaml` command.
+
 Now, we can generate the machine configuration for each node:
 
 ```sh

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -1495,6 +1495,7 @@ talosctl gen secrets [flags]
 ### Options
 
 ```
+      --from-controlplane-config string     use the provided controlplane Talos machine configuration as input
   -p, --from-kubernetes-pki string          use a Kubernetes PKI directory (e.g. /etc/kubernetes/pki) as input
   -h, --help                                help for secrets
   -t, --kubernetes-bootstrap-token string   use the provided bootstrap token as input


### PR DESCRIPTION
This allows to "recover" secrets if the machine config was generated first without explicitly saving secrets bundle.

Fixes #7895
