### PR TITLE
chore: bump go-api-signature dependency to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/sethgrid/pester v1.2.0 // indirect
-	github.com/siderolabs/go-api-signature v0.3.0 // indirect
+	github.com/siderolabs/go-api-signature v0.3.1 // indirect
 	github.com/siderolabs/protoenc v0.2.0 // indirect
 	github.com/siderolabs/tcpproxy v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/siderolabs/discovery-client v0.1.5 h1:CyaOOynanZdB29v46lyEOaNfPoBnKjj
 github.com/siderolabs/discovery-client v0.1.5/go.mod h1:XFSNX7ADu+4r3j/m299V6pP7f4vEDnSJJhgc5yZE73g=
 github.com/siderolabs/gen v0.4.7 h1:lM69UYggT7yzpubf7hEFaNujPdY55Y9zvQf/NC18GvA=
 github.com/siderolabs/gen v0.4.7/go.mod h1:4PBYMdXxTg292IDRq4CGn5AymyDxJVEDvobVKDqFBEA=
-github.com/siderolabs/go-api-signature v0.3.0 h1:RSJ210iLD6p2FouRvRvkB6FMvz8ZltXvt9+g+5EGbC4=
-github.com/siderolabs/go-api-signature v0.3.0/go.mod h1:RZQFRiZ4midsdC9XCGhhWyS8QcIWtpEFeigvqoDPYJY=
+github.com/siderolabs/go-api-signature v0.3.1 h1:ePXOxBT2fxRICsDntXed9kivmVK269nZe5UXvOxgtnM=
+github.com/siderolabs/go-api-signature v0.3.1/go.mod h1:RZQFRiZ4midsdC9XCGhhWyS8QcIWtpEFeigvqoDPYJY=
 github.com/siderolabs/go-blockdevice v0.4.6 h1:yfxFYzXezzszB0mSF2ZG8jPPampoNXa9r8W8nM0IoZI=
 github.com/siderolabs/go-blockdevice v0.4.6/go.mod h1:4PeOuk71pReJj1JQEXDE7kIIQJPVe8a+HZQa+qjxSEA=
 github.com/siderolabs/go-circular v0.1.0 h1:zpBJNUbCZSh0odZxA4Dcj0d3ShLLR2WxKW6hTdAtoiE=

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1
 	github.com/siderolabs/crypto v0.4.1
 	github.com/siderolabs/gen v0.4.7
-	github.com/siderolabs/go-api-signature v0.3.0
+	github.com/siderolabs/go-api-signature v0.3.1
 	github.com/siderolabs/go-blockdevice v0.4.6
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/siderolabs/net v0.4.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -112,8 +112,8 @@ github.com/siderolabs/crypto v0.4.1 h1:PP84WSDDyCCbjYKePcc0IaMSPXDndz8V3cQ9hMRSv
 github.com/siderolabs/crypto v0.4.1/go.mod h1:nJmvkqWy1Hngbzw3eg2TdtJ/ZYHHofQK1NbmmYywW8k=
 github.com/siderolabs/gen v0.4.7 h1:lM69UYggT7yzpubf7hEFaNujPdY55Y9zvQf/NC18GvA=
 github.com/siderolabs/gen v0.4.7/go.mod h1:4PBYMdXxTg292IDRq4CGn5AymyDxJVEDvobVKDqFBEA=
-github.com/siderolabs/go-api-signature v0.3.0 h1:RSJ210iLD6p2FouRvRvkB6FMvz8ZltXvt9+g+5EGbC4=
-github.com/siderolabs/go-api-signature v0.3.0/go.mod h1:RZQFRiZ4midsdC9XCGhhWyS8QcIWtpEFeigvqoDPYJY=
+github.com/siderolabs/go-api-signature v0.3.1 h1:ePXOxBT2fxRICsDntXed9kivmVK269nZe5UXvOxgtnM=
+github.com/siderolabs/go-api-signature v0.3.1/go.mod h1:RZQFRiZ4midsdC9XCGhhWyS8QcIWtpEFeigvqoDPYJY=
 github.com/siderolabs/go-blockdevice v0.4.6 h1:yfxFYzXezzszB0mSF2ZG8jPPampoNXa9r8W8nM0IoZI=
 github.com/siderolabs/go-blockdevice v0.4.6/go.mod h1:4PeOuk71pReJj1JQEXDE7kIIQJPVe8a+HZQa+qjxSEA=
 github.com/siderolabs/go-pointer v1.0.0 h1:6TshPKep2doDQJAAtHUuHWXbca8ZfyRySjSBT/4GsMU=


### PR DESCRIPTION
Bring in the fix in https://github.com/siderolabs/go-api-signature/pull/31
