### PR TITLE
fix: fix error output of cli action tracker

### DIFF
--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -56,8 +55,6 @@ var rebootCmd = &cobra.Command{
 				return nil
 			})
 		}
-
-		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -13,7 +13,6 @@ import (
 	"github.com/siderolabs/gen/maps"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -139,8 +138,6 @@ var resetCmd = &cobra.Command{
 				return action.BootIDChangedPostCheckFn(ctx, c, preActionBootID)
 			}
 		}
-
-		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -49,8 +48,6 @@ var shutdownCmd = &cobra.Command{
 				return nil
 			})
 		}
-
-		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
@@ -72,8 +71,6 @@ var upgradeCmd = &cobra.Command{
 		if !upgradeCmdFlags.wait {
 			return runUpgradeNoWait(opts)
 		}
-
-		common.SuppressErrors = true
 
 		return action.NewTracker(
 			&GlobalArgs,

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -154,6 +155,10 @@ func (a *Tracker) Run() error {
 		eg.Go(func() error {
 			return a.runReporter(ctx)
 		})
+
+		// Reporter is started, it will print the errors if there is any.
+		// So from here on we can suppress the command error to be printed to avoid it being printed twice.
+		common.SuppressErrors = true
 
 		var trackEg errgroup.Group
 


### PR DESCRIPTION
Before we started a reboot/shutdown/reset/upgrade action with the action tracker (`--wait`), we were setting a flag to prevent cobra from printing the returned error from the command.

This was to prevent the error from being printed twice, as the reporter of the action tracker already prints any errors occurred during the action execution.

But if the error happens too early - i.e. before we even started the status printer goroutine, then that error wouldn't be printed at all, as we have suppressed the errors.

This PR moves the suppression flag to be set after the status printer is started - so we still do not double-print the errors, but neither do we suppress any early-stage error from being printed.

Closes siderolabs/talos#7900.
