### PR TITLE
refactor: drop the dependency link platform -> network ctrl

### DIFF
--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -16,9 +16,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
-// DefaultRouteMetric is the default route metric if no metric was specified explicitly.
-const DefaultRouteMetric = 1024
-
 // SetBondSlave sets the bond slave spec.
 func SetBondSlave(link *network.LinkSpecSpec, bond ordered.Pair[string, int]) {
 	link.BondSlave = network.BondSlave{

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -111,7 +111,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 					LinkName:  linkConfig.LinkName,
 					RequireUp: true,
 					DHCP4: network.DHCP4OperatorSpec{
-						RouteMetric: DefaultRouteMetric,
+						RouteMetric: network.DefaultRouteMetric,
 					},
 					ConfigLayer: network.ConfigCmdline,
 				})
@@ -136,7 +136,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 				if device.DHCP() && device.DHCPOptions().IPv4() {
 					routeMetric := device.DHCPOptions().RouteMetric()
 					if routeMetric == 0 {
-						routeMetric = DefaultRouteMetric
+						routeMetric = network.DefaultRouteMetric
 					}
 
 					specs = append(specs, network.OperatorSpecSpec{
@@ -153,7 +153,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 				if device.DHCP() && device.DHCPOptions().IPv6() {
 					routeMetric := device.DHCPOptions().RouteMetric()
 					if routeMetric == 0 {
-						routeMetric = DefaultRouteMetric
+						routeMetric = network.DefaultRouteMetric
 					}
 
 					specs = append(specs, network.OperatorSpecSpec{
@@ -172,7 +172,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 					if vlan.DHCP() && vlan.DHCPOptions().IPv4() {
 						routeMetric := vlan.DHCPOptions().RouteMetric()
 						if routeMetric == 0 {
-							routeMetric = DefaultRouteMetric
+							routeMetric = network.DefaultRouteMetric
 						}
 
 						specs = append(specs, network.OperatorSpecSpec{
@@ -189,7 +189,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 					if vlan.DHCP() && vlan.DHCPOptions().IPv6() {
 						routeMetric := vlan.DHCPOptions().RouteMetric()
 						if routeMetric == 0 {
-							routeMetric = DefaultRouteMetric
+							routeMetric = network.DefaultRouteMetric
 						}
 
 						specs = append(specs, network.OperatorSpecSpec{
@@ -248,7 +248,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 							LinkName:  linkStatus.Metadata().ID(),
 							RequireUp: true,
 							DHCP4: network.DHCP4OperatorSpec{
-								RouteMetric: DefaultRouteMetric,
+								RouteMetric: network.DefaultRouteMetric,
 							},
 							ConfigLayer: network.ConfigDefault,
 						})

--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -124,7 +124,7 @@ func (suite *OperatorConfigSuite) TestDefaultDHCP() {
 		}, func(r *network.OperatorSpec, asrt *assert.Assertions) {
 			asrt.Equal(network.OperatorDHCP4, r.TypedSpec().Operator)
 			asrt.True(r.TypedSpec().RequireUp)
-			asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+			asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 
 			switch r.Metadata().ID() {
 			case "default/dhcp4/eth0":
@@ -163,7 +163,7 @@ func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 		}, func(r *network.OperatorSpec, asrt *assert.Assertions) {
 			asrt.Equal(network.OperatorDHCP4, r.TypedSpec().Operator)
 			asrt.True(r.TypedSpec().RequireUp)
-			asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+			asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 
 			switch r.Metadata().ID() {
 			case "default/dhcp4/eth0":
@@ -304,16 +304,16 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 			switch r.Metadata().ID() {
 			case "configuration/dhcp4/eth1":
 				asrt.Equal("eth1", r.TypedSpec().LinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 			case "configuration/dhcp4/eth3":
 				asrt.Equal("eth3", r.TypedSpec().LinkName)
 				asrt.EqualValues(256, r.TypedSpec().DHCP4.RouteMetric)
 			case "configuration/dhcp4/eth4.25":
 				asrt.Equal("eth4.25", r.TypedSpec().LinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 			case "configuration/dhcp4/eth4.26":
 				asrt.Equal("eth4.26", r.TypedSpec().LinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 			case "configuration/dhcp4/eth4.27":
 				asrt.Equal("eth4.27", r.TypedSpec().LinkName)
 				asrt.EqualValues(256, r.TypedSpec().DHCP4.RouteMetric)
@@ -402,7 +402,7 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP6() {
 			switch r.Metadata().ID() {
 			case "configuration/dhcp6/eth2":
 				asrt.Equal("eth2", r.TypedSpec().LinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().DHCP6.RouteMetric)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP6.RouteMetric)
 			case "configuration/dhcp6/eth3":
 				asrt.Equal("eth3", r.TypedSpec().LinkName)
 				asrt.EqualValues(512, r.TypedSpec().DHCP6.RouteMetric)

--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -197,7 +197,7 @@ func (ctrl *RouteConfigController) parseCmdline(logger *zap.Logger) (routes []ne
 			Gateway:     linkConfig.Gateway,
 			Scope:       nethelpers.ScopeGlobal,
 			Table:       nethelpers.TableMain,
-			Priority:    DefaultRouteMetric + uint32(idx), // set different priorities to avoid a conflict
+			Priority:    network.DefaultRouteMetric + uint32(idx), // set different priorities to avoid a conflict
 			Protocol:    nethelpers.ProtocolBoot,
 			Type:        nethelpers.TypeUnicast,
 			OutLinkName: linkConfig.LinkName,
@@ -262,7 +262,7 @@ func (ctrl *RouteConfigController) processDevicesConfiguration(logger *zap.Logge
 
 		route.Priority = in.Metric()
 		if route.Priority == 0 {
-			route.Priority = DefaultRouteMetric
+			route.Priority = network.DefaultRouteMetric
 		}
 
 		route.MTU = in.MTU()

--- a/internal/app/machined/pkg/controllers/network/route_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_config_test.go
@@ -93,10 +93,10 @@ func (suite *RouteConfigSuite) TestCmdline() {
 			switch r.Metadata().ID() {
 			case "cmdline/inet4/172.20.0.1//1024":
 				asrt.Equal("eth1", r.TypedSpec().OutLinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 			case "cmdline/inet4/10.3.5.1//1025":
 				asrt.Equal("eth4", r.TypedSpec().OutLinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric+2, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric+2, r.TypedSpec().Priority)
 			}
 		},
 	)
@@ -124,12 +124,12 @@ func (suite *RouteConfigSuite) TestCmdlineNotReachable() {
 			switch r.Metadata().ID() {
 			case "cmdline/inet4/172.20.0.1//1024":
 				asrt.Equal("eth1", r.TypedSpec().OutLinkName)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 			case "cmdline/inet4//172.20.0.1/32/1024":
 				asrt.Equal("eth1", r.TypedSpec().OutLinkName)
 				asrt.Equal(netip.Addr{}, r.TypedSpec().Gateway)
 				asrt.Equal(netip.MustParsePrefix("172.20.0.1/32"), r.TypedSpec().Destination)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 			}
 		},
 	)
@@ -240,11 +240,11 @@ func (suite *RouteConfigSuite) TestMachineConfiguration() {
 			case "configuration/inet6/2001:470:6d:30e:8ed2:b60c:9d2f:803b//1024":
 				asrt.Equal("eth2", r.TypedSpec().OutLinkName)
 				asrt.Equal(nethelpers.FamilyInet6, r.TypedSpec().Family)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 			case "configuration/inet4/10.0.3.1/10.0.3.0/24/1024":
 				asrt.Equal("eth0.24", r.TypedSpec().OutLinkName)
 				asrt.Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 			case "configuration/inet4/192.168.0.25/192.168.0.0/18/25":
 				asrt.Equal("eth3", r.TypedSpec().OutLinkName)
 				asrt.Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
@@ -252,12 +252,12 @@ func (suite *RouteConfigSuite) TestMachineConfiguration() {
 			case "configuration/inet4/192.244.0.1/192.244.0.0/24/1024":
 				asrt.Equal("eth1", r.TypedSpec().OutLinkName)
 				asrt.Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 				asrt.EqualValues(netip.MustParseAddr("192.244.0.10"), r.TypedSpec().Source)
 			case "configuration/inet4//169.254.254.254/32/1024":
 				asrt.Equal("eth3", r.TypedSpec().OutLinkName)
 				asrt.Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
-				asrt.EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().Priority)
 				asrt.Equal(nethelpers.ScopeLink, r.TypedSpec().Scope)
 				asrt.Equal("169.254.254.254/32", r.TypedSpec().Destination.String())
 			}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -22,7 +22,6 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
-	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
@@ -280,11 +279,11 @@ func (p *EquinixMetal) ParseMetadata(ctx context.Context, equinixMetadata *Metad
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      family,
-				Priority:    networkctrl.DefaultRouteMetric,
+				Priority:    network.DefaultRouteMetric,
 			}
 
 			if addr.Family == 6 {
-				route.Priority = 2 * networkctrl.DefaultRouteMetric
+				route.Priority = 2 * network.DefaultRouteMetric
 			}
 
 			route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -16,7 +16,6 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"gopkg.in/yaml.v3"
 
-	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
@@ -76,7 +75,7 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 					Operator: network.OperatorDHCP4,
 					LinkName: ntwrk.Interfaces,
 					DHCP4: network.DHCP4OperatorSpec{
-						RouteMetric: networkctrl.DefaultRouteMetric,
+						RouteMetric: network.DefaultRouteMetric,
 					},
 					ConfigLayer: network.ConfigPlatform,
 				})
@@ -121,7 +120,7 @@ func (h *Hcloud) ParseMetadata(unmarshalledNetworkConfig *NetworkConfig, metadat
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      nethelpers.FamilyInet6,
-					Priority:    networkctrl.DefaultRouteMetric,
+					Priority:    network.DefaultRouteMetric,
 				}
 
 				route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
@@ -26,7 +26,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
-	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
@@ -389,11 +388,11 @@ func (n *Nocloud) applyNetworkConfigV1(config *NetworkConfig, st state.State, ne
 							Protocol:    nethelpers.ProtocolStatic,
 							Type:        nethelpers.TypeUnicast,
 							Family:      family,
-							Priority:    networkctrl.DefaultRouteMetric,
+							Priority:    network.DefaultRouteMetric,
 						}
 
 						if family == nethelpers.FamilyInet6 {
-							route.Priority = 2 * networkctrl.DefaultRouteMetric
+							route.Priority = 2 * network.DefaultRouteMetric
 						}
 
 						route.Normalize()
@@ -426,7 +425,7 @@ func applyNetworkConfigV2Ethernet(name string, eth Ethernet, networkConfig *runt
 			LinkName:  name,
 			RequireUp: true,
 			DHCP4: network.DHCP4OperatorSpec{
-				RouteMetric: uint32(networkctrl.DefaultRouteMetric),
+				RouteMetric: network.DefaultRouteMetric,
 			},
 			ConfigLayer: network.ConfigPlatform,
 		})
@@ -438,7 +437,7 @@ func applyNetworkConfigV2Ethernet(name string, eth Ethernet, networkConfig *runt
 			LinkName:  name,
 			RequireUp: true,
 			DHCP6: network.DHCP6OperatorSpec{
-				RouteMetric: uint32(networkctrl.DefaultRouteMetric),
+				RouteMetric: network.DefaultRouteMetric,
 			},
 			ConfigLayer: network.ConfigPlatform,
 		})
@@ -482,7 +481,7 @@ func applyNetworkConfigV2Ethernet(name string, eth Ethernet, networkConfig *runt
 			Protocol:    nethelpers.ProtocolStatic,
 			Type:        nethelpers.TypeUnicast,
 			Family:      nethelpers.FamilyInet4,
-			Priority:    networkctrl.DefaultRouteMetric,
+			Priority:    network.DefaultRouteMetric,
 		}
 
 		route.Normalize()
@@ -504,7 +503,7 @@ func applyNetworkConfigV2Ethernet(name string, eth Ethernet, networkConfig *runt
 			Protocol:    nethelpers.ProtocolStatic,
 			Type:        nethelpers.TypeUnicast,
 			Family:      nethelpers.FamilyInet6,
-			Priority:    2 * networkctrl.DefaultRouteMetric,
+			Priority:    2 * network.DefaultRouteMetric,
 		}
 
 		route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-procfs/procfs"
 
-	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
@@ -72,7 +71,7 @@ func (o *Oracle) ParseMetadata(interfaceAddresses []NetworkConfig, metadata *Met
 				LinkName:  ifname,
 				RequireUp: true,
 				DHCP6: network.DHCP6OperatorSpec{
-					RouteMetric: networkctrl.DefaultRouteMetric,
+					RouteMetric: network.DefaultRouteMetric,
 				},
 				ConfigLayer: network.ConfigPlatform,
 			})
@@ -90,7 +89,7 @@ func (o *Oracle) ParseMetadata(interfaceAddresses []NetworkConfig, metadata *Met
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      nethelpers.FamilyInet6,
-				Priority:    2 * networkctrl.DefaultRouteMetric,
+				Priority:    2 * network.DefaultRouteMetric,
 			}
 
 			route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/metadata.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 
-	networkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -132,7 +131,7 @@ func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, confi
 		})
 
 		if eth.DHCPv4 {
-			routeMetric := uint32(networkctrl.DefaultRouteMetric)
+			routeMetric := uint32(network.DefaultRouteMetric)
 
 			if eth.DHCP4Overrides.RouteMetric != 0 {
 				routeMetric = eth.DHCP4Overrides.RouteMetric
@@ -150,7 +149,7 @@ func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, confi
 		}
 
 		if eth.DHCPv6 {
-			routeMetric := uint32(2 * networkctrl.DefaultRouteMetric)
+			routeMetric := uint32(2 * network.DefaultRouteMetric)
 
 			if eth.DHCP4Overrides.RouteMetric != 0 {
 				routeMetric = eth.DHCP6Overrides.RouteMetric
@@ -205,7 +204,7 @@ func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, confi
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      nethelpers.FamilyInet4,
-				Priority:    networkctrl.DefaultRouteMetric,
+				Priority:    network.DefaultRouteMetric,
 			}
 
 			route.Normalize()
@@ -227,7 +226,7 @@ func (v *VMware) ApplyNetworkConfigV2(ctx context.Context, st state.State, confi
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      nethelpers.FamilyInet6,
-				Priority:    2 * networkctrl.DefaultRouteMetric,
+				Priority:    2 * network.DefaultRouteMetric,
 			}
 
 			route.Normalize()

--- a/pkg/machinery/resources/network/network.go
+++ b/pkg/machinery/resources/network/network.go
@@ -22,6 +22,9 @@ const NamespaceName resource.Namespace = "network"
 // Resources in the ConfigNamespaceName namespace are merged to produce final versions in the NamespaceName namespace.
 const ConfigNamespaceName resource.Namespace = "network-config"
 
+// DefaultRouteMetric is the default route metric if no metric was specified explicitly.
+const DefaultRouteMetric = 1024
+
 // AddressID builds ID (primary key) for the address.
 func AddressID(linkName string, addr netip.Prefix) string {
 	return fmt.Sprintf("%s/%s", linkName, addr)


### PR DESCRIPTION
This leads to lots of unneccesary improts, as the chain from network controllers is pretty long.
