### PR TITLE
fix: image build for nanopi_4s

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/nanopi_r4s/nanopi_r4s.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/nanopi_r4s/nanopi_r4s.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	bin       = constants.BoardNanoPiR4S + "u-boot-rockchip.bin"
+	bin       = constants.BoardNanoPiR4S + "/u-boot-rockchip.bin"
 	off int64 = 512 * 64
 	dtb       = "rockchip/rk3399-nanopi-r4s.dtb"
 )


### PR DESCRIPTION
Path was missing a slash.
