### PR TITLE
fix: proper logging in machined on startup

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -70,9 +70,6 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 	switch r.State().Platform().Mode() { //nolint:exhaustive
 	case runtime.ModeContainer:
 		phases = phases.Append(
-			"logger",
-			SetupLogger,
-		).Append(
 			"systemRequirements",
 			SetupSystemDirectory,
 		).Append(
@@ -89,9 +86,6 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 		)
 	default:
 		phases = phases.Append(
-			"logger",
-			SetupLogger,
-		).Append(
 			"systemRequirements",
 			EnforceKSPPRequirements,
 			SetupSystemDirectory,
@@ -111,6 +105,9 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			"earlyServices",
 			StartUdevd,
 			StartMachined,
+		).Append(
+			"usb",
+			WaitForUSB,
 		).Append(
 			"meta",
 			ReloadMeta,


### PR DESCRIPTION
Move `setupLogging` inside the controller, so that logger is set up correctly before Talos starts printing first messages.

This fixes an inconsistency that first messages are printed using "default" logger, while after that the proper logger is set up, and format of the messages matches kernel log.

Also move `waitForUSBDelay` into the sequencer after `udevd` was started (this is when blockdevices including USB ones are discovered).
