### PR TITLE
fix: set max msg recv size when proxying

### DIFF
--- a/internal/app/apid/pkg/backend/apid.go
+++ b/internal/app/apid/pkg/backend/apid.go
@@ -101,6 +101,9 @@ func (a *APID) GetConnection(ctx context.Context, fullMethodName string) (contex
 			// see: https://github.com/grpc/grpc-go/blob/d5dee5fdbdeb52f6ea10b37b2cc7ce37814642d7/clientconn.go#L55-L56
 			MinConnectTimeout: 20 * time.Second,
 		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
+		),
 		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
 		grpc.WithSharedWriteBuffer(true),
 	)

--- a/pkg/grpc/proxy/backend/local.go
+++ b/pkg/grpc/proxy/backend/local.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/siderolabs/talos/pkg/grpc/middleware/authz"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var _ proxy.Backend = (*Local)(nil)
@@ -60,6 +61,9 @@ func (l *Local) GetConnection(ctx context.Context, fullMethodName string) (conte
 		ctx,
 		"unix:"+l.socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
+		),
 		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
 		grpc.WithSharedWriteBuffer(true),
 	)


### PR DESCRIPTION
Previously a fix was deployed in the Talos API client, but when the request passes through `apid`, we need to make sure that proxy doesn't reject large responses.
