### PR TITLE
fix: allow extra kernel args for secureboot installer

### DIFF
--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -84,8 +84,8 @@ func (p *Profile) Validate() error {
 			return fmt.Errorf("disk size is required for image output")
 		}
 	case OutKindInstaller:
-		if len(p.Customization.ExtraKernelArgs) > 0 {
-			return fmt.Errorf("customization of kernel args is not supported for %s output", p.Output.Kind)
+		if !p.SecureBootEnabled() && len(p.Customization.ExtraKernelArgs) > 0 {
+			return fmt.Errorf("customization of kernel args is not supported for %s output in !secureboot mode", p.Output.Kind)
 		}
 
 		if len(p.Customization.MetaContents) > 0 {


### PR DESCRIPTION
With SecureBoot, kernel args are part of the UKI (and signed), so we need to allow kernel args when building an installer, as this is the only way to allow updating kernel args in SecureBoot mode.
