### PR TITLE
docs: update lastRelease to v1.5.5 in _index.md

### DIFF
--- a/website/content/v1.5/_index.md
+++ b/website/content/v1.5/_index.md
@@ -4,8 +4,8 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.5.4
-kubernetesRelease: "1.28.2"
+lastRelease: v1.5.5
+kubernetesRelease: "1.28.3"
 prevKubernetesRelease: "1.27.4"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.13.5"

--- a/website/content/v1.6/_index.md
+++ b/website/content/v1.6/_index.md
@@ -6,7 +6,7 @@ cascade:
   type: docs
 lastRelease: v1.6.0-alpha.1
 kubernetesRelease: "1.29.0"
-prevKubernetesRelease: "1.28.2"
+prevKubernetesRelease: "1.28.3"
 theilaRelease: "v0.2.1"
 nvidiaContainerToolkitRelease: "v1.13.5"
 nvidiaDriverRelease: "535.54.03"


### PR DESCRIPTION
# Pull Request

## What? (description)
In the getting ["Getting Started" section](https://www.talos.dev/v1.5/introduction/getting-started/#acquire-the-talos-linux-image-and-boot-machines) the iso images are both for the previous release. Right now the links are:

```
    X86: https://github.com/siderolabs/talos/releases/download/v1.5.4/metal-amd64.iso
    ARM64: https://github.com/siderolabs/talos/releases/download/v1.5.4/metal-arm64.iso
```

But they should point to the latest `v1.5.5`.

## Why? (reasoning)
I believe `lastRelease` in `_index.md` also needs to be bumped. 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
