### PR TITLE
docs: fix link in what is new page

### DIFF
--- a/website/content/v1.5/introduction/what-is-new/index.md
+++ b/website/content/v1.5/introduction/what-is-new/index.md
@@ -77,7 +77,7 @@ The extension waits for the file to be present before starting the service.
 
 ### TPM-based Disk Encryption
 
-Talos now supports encrypting `STATE`/`EPHEMERAL` with [keys bound to a TPM device]{{< relref "../../talos-guides/install/bare-metal-platforms/secureboot" >}}().
+Talos now supports encrypting `STATE`/`EPHEMERAL` with [keys bound to a TPM device]({{< relref "../../talos-guides/install/bare-metal-platforms/secureboot" >}}).
 The TPM device must be TPM2.0 compatible.
 This type of disk encryption should be used when booting Talos in SecureBoot mode.
 


### PR DESCRIPTION
# Pull Request

## What? (description)
Fixes a broken link in the documentation.
https://www.talos.dev/v1.5/introduction/what-is-new/#tpm-based-disk-encryption

Verified with `make docs-preview`

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
