### PR TITLE
docs: fix outdated Kubernetes version in 1.5 what is new page

### DIFF
--- a/website/content/v1.5/introduction/what-is-new/index.md
+++ b/website/content/v1.5/introduction/what-is-new/index.md
@@ -143,7 +143,7 @@ rolling component update.
 * containerd: 1.6.23
 * runc: 1.1.9
 * etcd: 3.5.9
-* Kubernetes: 1.28.0
+* Kubernetes: {{< k8s_release >}}
 * Flannel: 0.22.1
 
 Talos is built with Go 1.20.7.


### PR DESCRIPTION
# Pull Request
## What? (description)
Fixes outdated Kubernetes version in 1.5 docs

Screenshot with change running locally:
![Screenshot from 2023-11-16 13-46-25](https://github.com/siderolabs/talos/assets/1570691/3efb7e38-25ac-454f-b8fb-6f85e5f0b094)

Screenshot [from current docs](https://www.talos.dev/v1.5/introduction/what-is-new/#component-updates):
![Screenshot from 2023-11-16 13-46-10](https://github.com/siderolabs/talos/assets/1570691/9c4e84f9-20b0-4e9b-9dcf-a07f081ab6f7)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
