### PR TITLE
chore: start containerd early in boot

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -80,6 +80,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 		).Append(
 			"machined",
 			StartMachined,
+			StartContainerd,
 		).Append(
 			"config",
 			LoadConfig,
@@ -105,6 +106,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			"earlyServices",
 			StartUdevd,
 			StartMachined,
+			StartContainerd,
 		).Append(
 			"usb",
 			WaitForUSB,
@@ -161,9 +163,6 @@ func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 			phases = phases.Append(
 				"env",
 				SetUserEnvVars,
-			).Append(
-				"containerd",
-				StartContainerd,
 			).Append(
 				"install",
 				Install,
@@ -227,9 +226,6 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).Append(
 		"env",
 		SetUserEnvVars,
-	).Append(
-		"containerd",
-		StartContainerd,
 	).Append(
 		"dbus",
 		StartDBus,
@@ -434,9 +430,6 @@ func (*Sequencer) MaintenanceUpgrade(r runtime.Runtime, in *machineapi.UpgradeRe
 		return nil
 	default:
 		phases = phases.Append(
-			"containerd",
-			StartContainerd,
-		).Append(
 			"verifyDisk",
 			VerifyDiskAvailability,
 		).Append(

--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -174,8 +174,14 @@ func (svc *Extension) Runner(r runtime.Runtime) (runner.Runner, error) {
 
 	ociSpecOpts := svc.getOCIOptions(envVars)
 
+	debug := false
+
+	if r.Config() != nil {
+		debug = r.Config().Debug()
+	}
+
 	return restart.New(containerd.NewRunner(
-		r.Config().Debug(),
+		debug,
 		&args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithNamespace(constants.SystemContainerdNamespace),


### PR DESCRIPTION
Start container early in the boot process so system extension services start in maintenance mode.

Fixes: #7083