### PR TITLE
docs: fix talosctl pcap example indentation

### DIFF
--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -41,23 +41,23 @@ var pcapCmd = &cobra.Command{
 
 Default behavior is to decode the packets with internal decoder to stdout:
 
-  talosctl pcap -i eth0
+    talosctl pcap -i eth0
 
 Raw pcap file can be saved with --output flag:
 
-  talosctl pcap -i eth0 --output eth0.pcap
+    talosctl pcap -i eth0 --output eth0.pcap
 
 Output can be piped to tcpdump:
 
-  talosctl pcap -i eth0 -o - | tcpdump -vvv -r -
+    talosctl pcap -i eth0 -o - | tcpdump -vvv -r -
 
- BPF filter can be applied, but it has to compiled to BPF instructions first using tcpdump.
- Correct link type should be specified for the tcpdump: EN10MB for Ethernet links and RAW
- for e.g. Wireguard tunnels:
+BPF filter can be applied, but it has to compiled to BPF instructions first using tcpdump.
+Correct link type should be specified for the tcpdump: EN10MB for Ethernet links and RAW
+for e.g. Wireguard tunnels:
 
-   talosctl pcap -i eth0 --bpf-filter "$(tcpdump -dd -y EN10MB 'tcp and dst port 80')"
+    talosctl pcap -i eth0 --bpf-filter "$(tcpdump -dd -y EN10MB 'tcp and dst port 80')"
 
-   talosctl pcap -i kubespan --bpf-filter "$(tcpdump -dd -y RAW 'port 50000')"
+    talosctl pcap -i kubespan --bpf-filter "$(tcpdump -dd -y RAW 'port 50000')"
 
 As packet capture is transmitted over the network, it is recommended to filter out the Talos API traffic,
 e.g. by excluding packets with the port 50000.

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -2421,23 +2421,23 @@ The command launches packet capture on the node and streams back the packets as 
 
 Default behavior is to decode the packets with internal decoder to stdout:
 
-  talosctl pcap -i eth0
+    talosctl pcap -i eth0
 
 Raw pcap file can be saved with --output flag:
 
-  talosctl pcap -i eth0 --output eth0.pcap
+    talosctl pcap -i eth0 --output eth0.pcap
 
 Output can be piped to tcpdump:
 
-  talosctl pcap -i eth0 -o - | tcpdump -vvv -r -
+    talosctl pcap -i eth0 -o - | tcpdump -vvv -r -
 
- BPF filter can be applied, but it has to compiled to BPF instructions first using tcpdump.
- Correct link type should be specified for the tcpdump: EN10MB for Ethernet links and RAW
- for e.g. Wireguard tunnels:
+BPF filter can be applied, but it has to compiled to BPF instructions first using tcpdump.
+Correct link type should be specified for the tcpdump: EN10MB for Ethernet links and RAW
+for e.g. Wireguard tunnels:
 
-   talosctl pcap -i eth0 --bpf-filter "$(tcpdump -dd -y EN10MB 'tcp and dst port 80')"
+    talosctl pcap -i eth0 --bpf-filter "$(tcpdump -dd -y EN10MB 'tcp and dst port 80')"
 
-   talosctl pcap -i kubespan --bpf-filter "$(tcpdump -dd -y RAW 'port 50000')"
+    talosctl pcap -i kubespan --bpf-filter "$(tcpdump -dd -y RAW 'port 50000')"
 
 As packet capture is transmitted over the network, it is recommended to filter out the Talos API traffic,
 e.g. by excluding packets with the port 50000.


### PR DESCRIPTION
# Pull Request
## What? (description)
Fixes whitespaces in talosctl pcap examples. With change:
![Screenshot from 2023-11-16 15-51-15](https://github.com/siderolabs/talos/assets/1570691/7a6dbb92-8647-4bbb-919a-e73c10e4bf41)

Before change (current docs): https://www.talos.dev/v1.5/reference/cli/#synopsis-15

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
