### PR TITLE
docs: fix table formatting for machineservice api

### DIFF
--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -14,9 +14,7 @@ import "google/protobuf/timestamp.proto";
 service MachineService {
   rpc ApplyConfiguration(ApplyConfigurationRequest) returns (ApplyConfigurationResponse);
   // Bootstrap method makes control plane node enter etcd bootstrap mode.
-  //
   // Node aborts etcd join sequence and creates single-node etcd cluster.
-  //
   // If recover_etcd argument is specified, etcd is recovered from a snapshot
   // uploaded with EtcdRecover.
   rpc Bootstrap(BootstrapRequest) returns (BootstrapResponse);
@@ -28,14 +26,12 @@ service MachineService {
   rpc Events(EventsRequest) returns (stream Event);
   rpc EtcdMemberList(EtcdMemberListRequest) returns (EtcdMemberListResponse);
   // EtcdRemoveMember removes a member from the etcd cluster by hostname.
-  //
   // Please use EtcdRemoveMemberByID instead.
   rpc EtcdRemoveMember(EtcdRemoveMemberRequest) returns (EtcdRemoveMemberResponse) {
     option (common.remove_deprecated_method) = "v1.7";
     option deprecated = true;
   }
   // EtcdRemoveMemberByID removes a member from the etcd cluster identified by member ID.
-  //
   // This API should be used to remove members which don't have an associated Talos node anymore.
   // To remove a member with a running Talos node, use EtcdLeaveCluster API on the node to be removed.
   rpc EtcdRemoveMemberByID(EtcdRemoveMemberByIDRequest) returns (EtcdRemoveMemberByIDResponse);
@@ -43,31 +39,24 @@ service MachineService {
   rpc EtcdForfeitLeadership(EtcdForfeitLeadershipRequest) returns (EtcdForfeitLeadershipResponse);
   // EtcdRecover method uploads etcd data snapshot created with EtcdSnapshot
   // to the node.
-  //
   // Snapshot can be later used to recover the cluster via Bootstrap method.
   rpc EtcdRecover(stream common.Data) returns (EtcdRecoverResponse);
   // EtcdSnapshot method creates etcd data snapshot (backup) from the local etcd instance
   // and streams it back to the client.
-  //
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdSnapshot(EtcdSnapshotRequest) returns (stream common.Data);
   // EtcdAlarmList lists etcd alarms for the current node.
-  //
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdAlarmList(google.protobuf.Empty) returns (EtcdAlarmListResponse);
   // EtcdAlarmDisarm disarms etcd alarms for the current node.
-  //
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdAlarmDisarm(google.protobuf.Empty) returns (EtcdAlarmDisarmResponse);
   // EtcdDefragment defragments etcd data directory for the current node.
-  //
   // Defragmentation is a resource-heavy operation, so it should only run on a specific
   // node.
-  //
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdDefragment(google.protobuf.Empty) returns (EtcdDefragmentResponse);
   // EtcdStatus returns etcd status for the current member.
-  //
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdStatus(google.protobuf.Empty) returns (EtcdStatusResponse);
   rpc GenerateConfiguration(GenerateConfigurationRequest) returns (GenerateConfigurationResponse);

--- a/pkg/machinery/api/machine/machine_grpc.pb.go
+++ b/pkg/machinery/api/machine/machine_grpc.pb.go
@@ -82,9 +82,7 @@ const (
 type MachineServiceClient interface {
 	ApplyConfiguration(ctx context.Context, in *ApplyConfigurationRequest, opts ...grpc.CallOption) (*ApplyConfigurationResponse, error)
 	// Bootstrap method makes control plane node enter etcd bootstrap mode.
-	//
 	// Node aborts etcd join sequence and creates single-node etcd cluster.
-	//
 	// If recover_etcd argument is specified, etcd is recovered from a snapshot
 	// uploaded with EtcdRecover.
 	Bootstrap(ctx context.Context, in *BootstrapRequest, opts ...grpc.CallOption) (*BootstrapResponse, error)
@@ -97,11 +95,9 @@ type MachineServiceClient interface {
 	EtcdMemberList(ctx context.Context, in *EtcdMemberListRequest, opts ...grpc.CallOption) (*EtcdMemberListResponse, error)
 	// Deprecated: Do not use.
 	// EtcdRemoveMember removes a member from the etcd cluster by hostname.
-	//
 	// Please use EtcdRemoveMemberByID instead.
 	EtcdRemoveMember(ctx context.Context, in *EtcdRemoveMemberRequest, opts ...grpc.CallOption) (*EtcdRemoveMemberResponse, error)
 	// EtcdRemoveMemberByID removes a member from the etcd cluster identified by member ID.
-	//
 	// This API should be used to remove members which don't have an associated Talos node anymore.
 	// To remove a member with a running Talos node, use EtcdLeaveCluster API on the node to be removed.
 	EtcdRemoveMemberByID(ctx context.Context, in *EtcdRemoveMemberByIDRequest, opts ...grpc.CallOption) (*EtcdRemoveMemberByIDResponse, error)
@@ -109,31 +105,24 @@ type MachineServiceClient interface {
 	EtcdForfeitLeadership(ctx context.Context, in *EtcdForfeitLeadershipRequest, opts ...grpc.CallOption) (*EtcdForfeitLeadershipResponse, error)
 	// EtcdRecover method uploads etcd data snapshot created with EtcdSnapshot
 	// to the node.
-	//
 	// Snapshot can be later used to recover the cluster via Bootstrap method.
 	EtcdRecover(ctx context.Context, opts ...grpc.CallOption) (MachineService_EtcdRecoverClient, error)
 	// EtcdSnapshot method creates etcd data snapshot (backup) from the local etcd instance
 	// and streams it back to the client.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdSnapshot(ctx context.Context, in *EtcdSnapshotRequest, opts ...grpc.CallOption) (MachineService_EtcdSnapshotClient, error)
 	// EtcdAlarmList lists etcd alarms for the current node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdAlarmList(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*EtcdAlarmListResponse, error)
 	// EtcdAlarmDisarm disarms etcd alarms for the current node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdAlarmDisarm(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*EtcdAlarmDisarmResponse, error)
 	// EtcdDefragment defragments etcd data directory for the current node.
-	//
 	// Defragmentation is a resource-heavy operation, so it should only run on a specific
 	// node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdDefragment(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*EtcdDefragmentResponse, error)
 	// EtcdStatus returns etcd status for the current member.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdStatus(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*EtcdStatusResponse, error)
 	GenerateConfiguration(ctx context.Context, in *GenerateConfigurationRequest, opts ...grpc.CallOption) (*GenerateConfigurationResponse, error)
@@ -929,9 +918,7 @@ func (c *machineServiceClient) ImagePull(ctx context.Context, in *ImagePullReque
 type MachineServiceServer interface {
 	ApplyConfiguration(context.Context, *ApplyConfigurationRequest) (*ApplyConfigurationResponse, error)
 	// Bootstrap method makes control plane node enter etcd bootstrap mode.
-	//
 	// Node aborts etcd join sequence and creates single-node etcd cluster.
-	//
 	// If recover_etcd argument is specified, etcd is recovered from a snapshot
 	// uploaded with EtcdRecover.
 	Bootstrap(context.Context, *BootstrapRequest) (*BootstrapResponse, error)
@@ -944,11 +931,9 @@ type MachineServiceServer interface {
 	EtcdMemberList(context.Context, *EtcdMemberListRequest) (*EtcdMemberListResponse, error)
 	// Deprecated: Do not use.
 	// EtcdRemoveMember removes a member from the etcd cluster by hostname.
-	//
 	// Please use EtcdRemoveMemberByID instead.
 	EtcdRemoveMember(context.Context, *EtcdRemoveMemberRequest) (*EtcdRemoveMemberResponse, error)
 	// EtcdRemoveMemberByID removes a member from the etcd cluster identified by member ID.
-	//
 	// This API should be used to remove members which don't have an associated Talos node anymore.
 	// To remove a member with a running Talos node, use EtcdLeaveCluster API on the node to be removed.
 	EtcdRemoveMemberByID(context.Context, *EtcdRemoveMemberByIDRequest) (*EtcdRemoveMemberByIDResponse, error)
@@ -956,31 +941,24 @@ type MachineServiceServer interface {
 	EtcdForfeitLeadership(context.Context, *EtcdForfeitLeadershipRequest) (*EtcdForfeitLeadershipResponse, error)
 	// EtcdRecover method uploads etcd data snapshot created with EtcdSnapshot
 	// to the node.
-	//
 	// Snapshot can be later used to recover the cluster via Bootstrap method.
 	EtcdRecover(MachineService_EtcdRecoverServer) error
 	// EtcdSnapshot method creates etcd data snapshot (backup) from the local etcd instance
 	// and streams it back to the client.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdSnapshot(*EtcdSnapshotRequest, MachineService_EtcdSnapshotServer) error
 	// EtcdAlarmList lists etcd alarms for the current node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdAlarmList(context.Context, *emptypb.Empty) (*EtcdAlarmListResponse, error)
 	// EtcdAlarmDisarm disarms etcd alarms for the current node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdAlarmDisarm(context.Context, *emptypb.Empty) (*EtcdAlarmDisarmResponse, error)
 	// EtcdDefragment defragments etcd data directory for the current node.
-	//
 	// Defragmentation is a resource-heavy operation, so it should only run on a specific
 	// node.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdDefragment(context.Context, *emptypb.Empty) (*EtcdDefragmentResponse, error)
 	// EtcdStatus returns etcd status for the current member.
-	//
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdStatus(context.Context, *emptypb.Empty) (*EtcdStatusResponse, error)
 	GenerateConfiguration(context.Context, *GenerateConfigurationRequest) (*GenerateConfigurationResponse, error)

--- a/website/content/v1.6/reference/api.md
+++ b/website/content/v1.6/reference/api.md
@@ -7251,11 +7251,7 @@ The machine service definition.
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | ApplyConfiguration | [ApplyConfigurationRequest](#machine.ApplyConfigurationRequest) | [ApplyConfigurationResponse](#machine.ApplyConfigurationResponse) |  |
-| Bootstrap | [BootstrapRequest](#machine.BootstrapRequest) | [BootstrapResponse](#machine.BootstrapResponse) | Bootstrap method makes control plane node enter etcd bootstrap mode.
-
-Node aborts etcd join sequence and creates single-node etcd cluster.
-
-If recover_etcd argument is specified, etcd is recovered from a snapshot uploaded with EtcdRecover. |
+| Bootstrap | [BootstrapRequest](#machine.BootstrapRequest) | [BootstrapResponse](#machine.BootstrapResponse) | Bootstrap method makes control plane node enter etcd bootstrap mode. Node aborts etcd join sequence and creates single-node etcd cluster. If recover_etcd argument is specified, etcd is recovered from a snapshot uploaded with EtcdRecover. |
 | Containers | [ContainersRequest](#machine.ContainersRequest) | [ContainersResponse](#machine.ContainersResponse) |  |
 | Copy | [CopyRequest](#machine.CopyRequest) | [.common.Data](#common.Data) stream |  |
 | CPUInfo | [.google.protobuf.Empty](#google.protobuf.Empty) | [CPUInfoResponse](#machine.CPUInfoResponse) |  |
@@ -7263,34 +7259,16 @@ If recover_etcd argument is specified, etcd is recovered from a snapshot uploade
 | Dmesg | [DmesgRequest](#machine.DmesgRequest) | [.common.Data](#common.Data) stream |  |
 | Events | [EventsRequest](#machine.EventsRequest) | [Event](#machine.Event) stream |  |
 | EtcdMemberList | [EtcdMemberListRequest](#machine.EtcdMemberListRequest) | [EtcdMemberListResponse](#machine.EtcdMemberListResponse) |  |
-| EtcdRemoveMember | [EtcdRemoveMemberRequest](#machine.EtcdRemoveMemberRequest) | [EtcdRemoveMemberResponse](#machine.EtcdRemoveMemberResponse) | EtcdRemoveMember removes a member from the etcd cluster by hostname.
-
-Please use EtcdRemoveMemberByID instead. |
-| EtcdRemoveMemberByID | [EtcdRemoveMemberByIDRequest](#machine.EtcdRemoveMemberByIDRequest) | [EtcdRemoveMemberByIDResponse](#machine.EtcdRemoveMemberByIDResponse) | EtcdRemoveMemberByID removes a member from the etcd cluster identified by member ID.
-
-This API should be used to remove members which don't have an associated Talos node anymore. To remove a member with a running Talos node, use EtcdLeaveCluster API on the node to be removed. |
+| EtcdRemoveMember | [EtcdRemoveMemberRequest](#machine.EtcdRemoveMemberRequest) | [EtcdRemoveMemberResponse](#machine.EtcdRemoveMemberResponse) | EtcdRemoveMember removes a member from the etcd cluster by hostname. Please use EtcdRemoveMemberByID instead. |
+| EtcdRemoveMemberByID | [EtcdRemoveMemberByIDRequest](#machine.EtcdRemoveMemberByIDRequest) | [EtcdRemoveMemberByIDResponse](#machine.EtcdRemoveMemberByIDResponse) | EtcdRemoveMemberByID removes a member from the etcd cluster identified by member ID. This API should be used to remove members which don't have an associated Talos node anymore. To remove a member with a running Talos node, use EtcdLeaveCluster API on the node to be removed. |
 | EtcdLeaveCluster | [EtcdLeaveClusterRequest](#machine.EtcdLeaveClusterRequest) | [EtcdLeaveClusterResponse](#machine.EtcdLeaveClusterResponse) |  |
 | EtcdForfeitLeadership | [EtcdForfeitLeadershipRequest](#machine.EtcdForfeitLeadershipRequest) | [EtcdForfeitLeadershipResponse](#machine.EtcdForfeitLeadershipResponse) |  |
-| EtcdRecover | [.common.Data](#common.Data) stream | [EtcdRecoverResponse](#machine.EtcdRecoverResponse) | EtcdRecover method uploads etcd data snapshot created with EtcdSnapshot to the node.
-
-Snapshot can be later used to recover the cluster via Bootstrap method. |
-| EtcdSnapshot | [EtcdSnapshotRequest](#machine.EtcdSnapshotRequest) | [.common.Data](#common.Data) stream | EtcdSnapshot method creates etcd data snapshot (backup) from the local etcd instance and streams it back to the client.
-
-This method is available only on control plane nodes (which run etcd). |
-| EtcdAlarmList | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdAlarmListResponse](#machine.EtcdAlarmListResponse) | EtcdAlarmList lists etcd alarms for the current node.
-
-This method is available only on control plane nodes (which run etcd). |
-| EtcdAlarmDisarm | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdAlarmDisarmResponse](#machine.EtcdAlarmDisarmResponse) | EtcdAlarmDisarm disarms etcd alarms for the current node.
-
-This method is available only on control plane nodes (which run etcd). |
-| EtcdDefragment | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdDefragmentResponse](#machine.EtcdDefragmentResponse) | EtcdDefragment defragments etcd data directory for the current node.
-
-Defragmentation is a resource-heavy operation, so it should only run on a specific node.
-
-This method is available only on control plane nodes (which run etcd). |
-| EtcdStatus | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdStatusResponse](#machine.EtcdStatusResponse) | EtcdStatus returns etcd status for the current member.
-
-This method is available only on control plane nodes (which run etcd). |
+| EtcdRecover | [.common.Data](#common.Data) stream | [EtcdRecoverResponse](#machine.EtcdRecoverResponse) | EtcdRecover method uploads etcd data snapshot created with EtcdSnapshot to the node. Snapshot can be later used to recover the cluster via Bootstrap method. |
+| EtcdSnapshot | [EtcdSnapshotRequest](#machine.EtcdSnapshotRequest) | [.common.Data](#common.Data) stream | EtcdSnapshot method creates etcd data snapshot (backup) from the local etcd instance and streams it back to the client. This method is available only on control plane nodes (which run etcd). |
+| EtcdAlarmList | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdAlarmListResponse](#machine.EtcdAlarmListResponse) | EtcdAlarmList lists etcd alarms for the current node. This method is available only on control plane nodes (which run etcd). |
+| EtcdAlarmDisarm | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdAlarmDisarmResponse](#machine.EtcdAlarmDisarmResponse) | EtcdAlarmDisarm disarms etcd alarms for the current node. This method is available only on control plane nodes (which run etcd). |
+| EtcdDefragment | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdDefragmentResponse](#machine.EtcdDefragmentResponse) | EtcdDefragment defragments etcd data directory for the current node. Defragmentation is a resource-heavy operation, so it should only run on a specific node. This method is available only on control plane nodes (which run etcd). |
+| EtcdStatus | [.google.protobuf.Empty](#google.protobuf.Empty) | [EtcdStatusResponse](#machine.EtcdStatusResponse) | EtcdStatus returns etcd status for the current member. This method is available only on control plane nodes (which run etcd). |
 | GenerateConfiguration | [GenerateConfigurationRequest](#machine.GenerateConfigurationRequest) | [GenerateConfigurationResponse](#machine.GenerateConfigurationResponse) |  |
 | Hostname | [.google.protobuf.Empty](#google.protobuf.Empty) | [HostnameResponse](#machine.HostnameResponse) |  |
 | Kubeconfig | [.google.protobuf.Empty](#google.protobuf.Empty) | [.common.Data](#common.Data) stream |  |


### PR DESCRIPTION


# Pull Request
## What? (description)
Fixes formatting for https://www.talos.dev/v1.6/reference/api/#machineservice

Formatting with change:
![Screenshot from 2023-11-19 14-47-55](https://github.com/siderolabs/talos/assets/1570691/d36f5a5b-b9ab-4fc7-8637-4ad0c08637d9)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
