### PR TITLE
docs: fix table formatting for bootstraprequest

### DIFF
--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -154,11 +154,9 @@ message RebootResponse {
 // rpc Bootstrap
 message BootstrapRequest {
   // Enable etcd recovery from the snapshot.
-  //
   // Snapshot should be uploaded before this call via EtcdRecover RPC.
   bool recover_etcd = 1;
   // Skip hash check on the snapshot (etcd).
-  //
   // Enable this when recovering from data directory copy to skip integrity check.
   bool recover_skip_hash_check = 2;
 }

--- a/pkg/machinery/api/machine/machine.pb.go
+++ b/pkg/machinery/api/machine/machine.pb.go
@@ -1183,11 +1183,9 @@ type BootstrapRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Enable etcd recovery from the snapshot.
-	//
 	// Snapshot should be uploaded before this call via EtcdRecover RPC.
 	RecoverEtcd bool `protobuf:"varint,1,opt,name=recover_etcd,json=recoverEtcd,proto3" json:"recover_etcd,omitempty"`
 	// Skip hash check on the snapshot (etcd).
-	//
 	// Enable this when recovering from data directory copy to skip integrity check.
 	RecoverSkipHashCheck bool `protobuf:"varint,2,opt,name=recover_skip_hash_check,json=recoverSkipHashCheck,proto3" json:"recover_skip_hash_check,omitempty"`
 }

--- a/website/content/v1.6/reference/api.md
+++ b/website/content/v1.6/reference/api.md
@@ -4300,12 +4300,8 @@ rpc Bootstrap
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| recover_etcd | [bool](#bool) |  | Enable etcd recovery from the snapshot.
-
-Snapshot should be uploaded before this call via EtcdRecover RPC. |
-| recover_skip_hash_check | [bool](#bool) |  | Skip hash check on the snapshot (etcd).
-
-Enable this when recovering from data directory copy to skip integrity check. |
+| recover_etcd | [bool](#bool) |  | Enable etcd recovery from the snapshot. Snapshot should be uploaded before this call via EtcdRecover RPC. |
+| recover_skip_hash_check | [bool](#bool) |  | Skip hash check on the snapshot (etcd). Enable this when recovering from data directory copy to skip integrity check. |
 
 
 


### PR DESCRIPTION
# Pull Request
## What? (description)
Fixes formatting for https://www.talos.dev/v1.6/reference/api/#bootstraprequest

Before:
![Screenshot from 2023-11-20 15-26-18](https://github.com/siderolabs/talos/assets/1570691/1af896a0-7289-4571-8412-d6b0b581f7f0)

With this change:
![Screenshot from 2023-11-20 15-26-06](https://github.com/siderolabs/talos/assets/1570691/ddacab9a-c36e-4695-9a4d-aba80eae66fc)



## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
