### PR TITLE
fix: ignore kernel command line in container mode

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/events_sink_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/events_sink_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"go.uber.org/zap"
 
+	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -22,7 +23,8 @@ import (
 
 // EventsSinkConfigController generates configuration for kmsg log delivery.
 type EventsSinkConfigController struct {
-	Cmdline *procfs.Cmdline
+	Cmdline      *procfs.Cmdline
+	V1Alpha1Mode v1alpha1runtime.Mode
 }
 
 // Name implements controller.Controller interface.
@@ -65,7 +67,7 @@ func (ctrl *EventsSinkConfigController) Run(ctx context.Context, r controller.Ru
 
 		var endpoint string
 
-		if ctrl.Cmdline != nil {
+		if ctrl.Cmdline != nil && ctrl.V1Alpha1Mode != v1alpha1runtime.ModeContainer {
 			if val := ctrl.Cmdline.Get(constants.KernelParamEventsSink).First(); val != nil {
 				endpoint = *val
 			}

--- a/internal/app/machined/pkg/controllers/siderolink/config.go
+++ b/internal/app/machined/pkg/controllers/siderolink/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"go.uber.org/zap"
 
+	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/siderolink"
@@ -22,7 +23,8 @@ import (
 
 // ConfigController interacts with SideroLink API and brings up the SideroLink Wireguard interface.
 type ConfigController struct {
-	Cmdline *procfs.Cmdline
+	Cmdline      *procfs.Cmdline
+	V1Alpha1Mode v1alpha1runtime.Mode
 }
 
 // Name implements controller.Controller interface.
@@ -87,6 +89,10 @@ func (ctrl *ConfigController) Run(ctx context.Context, r controller.Runtime, _ *
 func (ctrl *ConfigController) apiEndpoint(machineConfig *config.MachineConfig) string {
 	if machineConfig != nil && machineConfig.Config().SideroLink() != nil && machineConfig.Config().SideroLink().APIUrl() != nil {
 		return machineConfig.Config().SideroLink().APIUrl().String()
+	}
+
+	if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
+		return ""
 	}
 
 	if ctrl.Cmdline == nil || ctrl.Cmdline.Get(constants.KernelParamSideroLink).First() == nil {

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -244,7 +244,8 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			MetaProvider: ctrl.v1alpha1Runtime.State().Machine(),
 		},
 		&runtimecontrollers.EventsSinkConfigController{
-			Cmdline: procfs.ProcCmdline(),
+			Cmdline:      procfs.ProcCmdline(),
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
 		&runtimecontrollers.EventsSinkController{
 			V1Alpha1Events: ctrl.v1alpha1Runtime.Events(),
@@ -297,7 +298,8 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		secrets.NewRootOSController(),
 		&secrets.TrustdController{},
 		&siderolink.ConfigController{
-			Cmdline: procfs.ProcCmdline(),
+			Cmdline:      procfs.ProcCmdline(),
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
 		&siderolink.ManagerController{},
 		&timecontrollers.AdjtimeStatusController{


### PR DESCRIPTION
Ignore kernel command line for `SideroLink` and `EventsSink` config when running in container mode. Otherwise when running Talos as a docker container in Talos it picks up the host kernel cmdline and try to configure SideroLink/EventsSink.