### PR TITLE
feat: support sanitized kernel args

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -101,6 +101,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		opts.ExtraKernelArgs,
 		procfs.WithOverwriteArgs("console"),
 		procfs.WithOverwriteArgs(constants.KernelParamPlatform),
+		procfs.WithDeleteNegatedArgs(),
 	); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/siderolabs/go-loadbalancer v0.3.2
 	github.com/siderolabs/go-pcidb v0.2.0
 	github.com/siderolabs/go-pointer v1.0.0
-	github.com/siderolabs/go-procfs v0.1.1
+	github.com/siderolabs/go-procfs v0.1.2
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-smbios v0.3.2
 	github.com/siderolabs/go-tail v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -675,8 +675,8 @@ github.com/siderolabs/go-pcidb v0.2.0 h1:ZCkF1cz6UjoEIHpP7+aeTI5BwmSxE627Jl1Wy2V
 github.com/siderolabs/go-pcidb v0.2.0/go.mod h1:XstZrp8xnganxzIc3UQKfCs1fQFgYWH2lqtWeqBwRok=
 github.com/siderolabs/go-pointer v1.0.0 h1:6TshPKep2doDQJAAtHUuHWXbca8ZfyRySjSBT/4GsMU=
 github.com/siderolabs/go-pointer v1.0.0/go.mod h1:HTRFUNYa3R+k0FFKNv11zgkaCLzEkWVzoYZ433P3kHc=
-github.com/siderolabs/go-procfs v0.1.1 h1:GkKjnDfFkupcuLN0w6A/Oy58/8FPAHcmlgiHIaw6M+g=
-github.com/siderolabs/go-procfs v0.1.1/go.mod h1:byGwc3MfF65wg1mz8t3qQ1zlrYhMngEYh1eDzaFAYq0=
+github.com/siderolabs/go-procfs v0.1.2 h1:bDs9hHyYGE2HO1frpmUsD60yg80VIEDrx31fkbi4C8M=
+github.com/siderolabs/go-procfs v0.1.2/go.mod h1:dBzQXobsM7+TWRRI3DS9X7vAuj8Nkfgu3Z/U9iY3ZTY=
 github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9oCEg=
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/siderolabs/go-smbios v0.3.2 h1:/9MCz1h3HYFcNdFG9rIL9EKwtQJsHRPuGuM2ESdao3A=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -39,6 +39,19 @@ Talos now supports specifying the kube-scheduler configuration in the Talos conf
 It can be set under `cluster.scheduler.config` and kube-scheduler will be automatically configured to with the correct flags.
 """
 
+    [notes.extensions]
+        title = "Extension Services"
+        description = """\
+Talos now starts Extension Services early in the boot process, this allows guest agents to be started in maintenance mode.
+"""
+
+    [notes.kernel-args]
+        title = "Kernel Arguments"
+        description = """\
+Talos and Imager now supports dropping kernel arguments specified in `.machine.install.extraKernelArgs` or as `--extra-kernel-arg` to imager.
+Any kernel argument that starts with a `-` is dropped. Kernel arguments to be dropped can be specified either as `-<key>` which would remove all arguments that start with `<key>` or as `-<key>=<value>` which would remove the exact argument.
+"""
+
     [notes.updates]
         title = "Component Updates"
         description = """\

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -284,6 +284,7 @@ func (i *Imager) buildCmdline() error {
 		i.prof.Customization.ExtraKernelArgs,
 		procfs.WithOverwriteArgs("console"),
 		procfs.WithOverwriteArgs(constants.KernelParamPlatform),
+		procfs.WithDeleteNegatedArgs(),
 	); err != nil {
 		return err
 	}

--- a/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
+++ b/pkg/machinery/config/types/v1alpha1/schemas/v1alpha1_config.schema.json
@@ -1478,9 +1478,9 @@
           },
           "type": "array",
           "title": "extraKernelArgs",
-          "description": "Allows for supplying extra kernel args via the bootloader.\n",
-          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.",
-          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\u003c/p\u003e\n"
+          "description": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a -.\nFor example -console removes all console=\u0026lt;value\u0026gt; arguments, whereas -console=tty0 removes the console=tty0 default argument.\n",
+          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=\u003cvalue\u003e` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.",
+          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a \u003ccode\u003e-\u003c/code\u003e.\nFor example \u003ccode\u003e-console\u003c/code\u003e removes all \u003ccode\u003econsole=\u0026lt;value\u0026gt;\u003c/code\u003e arguments, whereas \u003ccode\u003e-console=tty0\u003c/code\u003e removes the \u003ccode\u003econsole=tty0\u003c/code\u003e default argument.\u003c/p\u003e\n"
         },
         "image": {
           "type": "string",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -758,6 +758,8 @@ type InstallConfig struct {
 	InstallDiskSelector *InstallDiskSelector `yaml:"diskSelector,omitempty"`
 	//   description: |
 	//     Allows for supplying extra kernel args via the bootloader.
+	//     Existing kernel args can be removed by prefixing the argument with a `-`.
+	//     For example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.
 	//   examples:
 	//     - value: '[]string{"talos.platform=metal", "reboot=k"}'
 	InstallExtraKernelArgs []string `yaml:"extraKernelArgs,omitempty"`

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1003,7 +1003,7 @@ func (InstallConfig) Doc() *encoder.Doc {
 				Name:        "extraKernelArgs",
 				Type:        "[]string",
 				Note:        "",
-				Description: "Allows for supplying extra kernel args via the bootloader.",
+				Description: "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Allows for supplying extra kernel args via the bootloader." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{

--- a/website/content/v1.6/reference/configuration.md
+++ b/website/content/v1.6/reference/configuration.md
@@ -1213,7 +1213,7 @@ diskSelector:
     # busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0
     # busPath: /pci0000:00/*
 {{< /highlight >}}</details> | |
-|`extraKernelArgs` |[]string |Allows for supplying extra kernel args via the bootloader. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`extraKernelArgs` |[]string |<details><summary>Allows for supplying extra kernel args via the bootloader.</summary>Existing kernel args can be removed by prefixing the argument with a `-`.<br />For example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 extraKernelArgs:
     - talos.platform=metal
     - reboot=k

--- a/website/content/v1.6/schemas/v1alpha1_config.schema.json
+++ b/website/content/v1.6/schemas/v1alpha1_config.schema.json
@@ -1478,9 +1478,9 @@
           },
           "type": "array",
           "title": "extraKernelArgs",
-          "description": "Allows for supplying extra kernel args via the bootloader.\n",
-          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.",
-          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\u003c/p\u003e\n"
+          "description": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a -.\nFor example -console removes all console=\u0026lt;value\u0026gt; arguments, whereas -console=tty0 removes the console=tty0 default argument.\n",
+          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=\u003cvalue\u003e` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.",
+          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a \u003ccode\u003e-\u003c/code\u003e.\nFor example \u003ccode\u003e-console\u003c/code\u003e removes all \u003ccode\u003econsole=\u0026lt;value\u0026gt;\u003c/code\u003e arguments, whereas \u003ccode\u003e-console=tty0\u003c/code\u003e removes the \u003ccode\u003econsole=tty0\u003c/code\u003e default argument.\u003c/p\u003e\n"
         },
         "image": {
           "type": "string",

--- a/website/content/v1.6/talos-guides/install/boot-assets.md
+++ b/website/content/v1.6/talos-guides/install/boot-assets.md
@@ -165,13 +165,15 @@ The base profile can be customized with the additional flags to the imager:
 
 * `--arch` specifies the architecture of the image to be generated (default: host architecture)
 * `--meta` allows to set initial `META` values
-* `--extra-kernel-arg` allows to customize the kernel command line arguments
+* `--extra-kernel-arg` allows to customize the kernel command line arguments.
+  Default kernel arg can be removed by prefixing the argument with a `-`.
+  For example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.
 * `--system-extension-image` allows to install a system extension into the image
 
 ### Example: Bare-metal with Imager
 
 Let's assume we want to boot Talos on a bare-metal machine with Intel CPU and add a `gvisor` container runtime to the image.
-Also we want to disable predictable network interface names with `net.ifnames=0` kernel argument.
+Also we want to disable predictable network interface names with `net.ifnames=0` kernel argument and replace the Talos default `console` arguments and add a custom `console` arg.
 
 First, let's lookup extension images for Intel CPU microcode updates and `gvisor` container runtime in the [extensions repository](https://github.com/siderolabs/extensions):
 
@@ -183,7 +185,7 @@ ghcr.io/siderolabs/intel-ucode:20230613
 Now we can generate the ISO image with the following command:
 
 ```shell
-$ docker run --rm -t -v $PWD/_out:/out ghcr.io/siderolabs/imager:{{< release >}} iso --system-extension-image ghcr.io/siderolabs/gvisor:20231214.0-v1.5.0-beta.0 --system-extension-image ghcr.io/siderolabs/intel-ucode:20230613 --extra-kernel-arg net.ifnames=0
+$ docker run --rm -t -v $PWD/_out:/out ghcr.io/siderolabs/imager:{{< release >}} iso --system-extension-image ghcr.io/siderolabs/gvisor:20231214.0-v1.5.0-beta.0 --system-extension-image ghcr.io/siderolabs/intel-ucode:20230613 --extra-kernel-arg net.ifnames=0 --extra-kernel-arg=-console --extra-kernel-arg=console=ttyS1
 profile ready:
 arch: amd64
 platform: metal
@@ -206,7 +208,7 @@ output:
   kind: iso
   outFormat: raw
 initramfs ready
-kernel command line: talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 net.ifnames=0
+kernel command line: talos.platform=metal console=ttyS1 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 net.ifnames=0
 ISO ready
 output asset path: /out/metal-amd64.iso
 ```


### PR DESCRIPTION
Support dropping kernel args that start with `-`.

Fixes: #7613