### PR TITLE
docs: fix talosctl dashboard cli docs

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -26,14 +26,14 @@ var dashboardCmd = &cobra.Command{
 
 Keyboard shortcuts:
 
- - h, <Left>: switch one node to the left
- - l, <Right>: switch one node to the right
- - j, <Down>: scroll logs/process list down
- - k, <Up>: scroll logs/process list up
- - <C-d>: scroll logs/process list half page down
- - <C-u>: scroll logs/process list half page up
- - <C-f>: scroll logs/process list one page down
- - <C-b>: scroll logs/process list one page up
+ - h, &lt;Left&gt; - switch one node to the left
+ - l, &lt;Right&gt; - switch one node to the right
+ - j, &lt;Down&gt; - scroll logs/process list down
+ - k, &lt;Up&gt; - scroll logs/process list up
+ - &lt;C-d&gt; - scroll logs/process list half page down
+ - &lt;C-u&gt; - scroll logs/process list half page up
+ - &lt;C-f&gt; - scroll logs/process list one page down
+ - &lt;C-b&gt; - scroll logs/process list one page up
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -778,14 +778,14 @@ Provide a text-based UI to navigate node overview, logs and real-time metrics.
 
 Keyboard shortcuts:
 
- - h, <Left>: switch one node to the left
- - l, <Right>: switch one node to the right
- - j, <Down>: scroll logs/process list down
- - k, <Up>: scroll logs/process list up
- - <C-d>: scroll logs/process list half page down
- - <C-u>: scroll logs/process list half page up
- - <C-f>: scroll logs/process list one page down
- - <C-b>: scroll logs/process list one page up
+ - h, &lt;Left&gt; - switch one node to the left
+ - l, &lt;Right&gt; - switch one node to the right
+ - j, &lt;Down&gt; - scroll logs/process list down
+ - k, &lt;Up&gt; - scroll logs/process list up
+ - &lt;C-d&gt; - scroll logs/process list half page down
+ - &lt;C-u&gt; - scroll logs/process list half page up
+ - &lt;C-f&gt; - scroll logs/process list one page down
+ - &lt;C-b&gt; - scroll logs/process list one page up
 
 
 ```


### PR DESCRIPTION
# Pull Request
## What? (description)
Fixes the shortcuts for the dashboard command by encoding < and >

Current docs: https://www.talos.dev/v1.6/reference/cli/#talosctl-dashboard
![Screenshot from 2023-11-23 10-21-51](https://github.com/siderolabs/talos/assets/1570691/1ee6d824-7e8d-4968-94a8-92be0b0a7bad)



With commit:
![Screenshot from 2023-11-23 10-37-45](https://github.com/siderolabs/talos/assets/1570691/5d2d1c8a-4fd4-4bae-8ab6-57130b04c5d4)



## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
