### PR TITLE
docs: fix talosctl inspect dependencies example indentation

### DIFF
--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -36,7 +36,7 @@ var inspectDependenciesCmd = &cobra.Command{
 Pipe the output of the command through the "dot" program (part of graphviz package)
 to render the graph:
 
-  talosctl inspect dependencies | dot -Tpng > graph.png
+    talosctl inspect dependencies | dot -Tpng > graph.png
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -1937,7 +1937,7 @@ Inspect controller-resource dependencies as graphviz graph.
 Pipe the output of the command through the "dot" program (part of graphviz package)
 to render the graph:
 
-  talosctl inspect dependencies | dot -Tpng > graph.png
+    talosctl inspect dependencies | dot -Tpng > graph.png
 
 
 ```


### PR DESCRIPTION
# Pull Request
## What? (description)
Adds missing whitespace to ensure correct rendering on web

Current docs https://www.talos.dev/v1.6/reference/cli/#talosctl-inspect-dependencies
![Screenshot from 2023-11-23 11-11-59](https://github.com/siderolabs/talos/assets/1570691/7b7e1cf2-4e3e-4e42-ace3-f63651ee3eb8)


With change:
![Screenshot from 2023-11-23 11-12-11](https://github.com/siderolabs/talos/assets/1570691/ec93e480-db0a-477b-8cd8-12b5c7c5c03f)


## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
