### PR TITLE
docs: fix talosctl pcap argument

### DIFF
--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -43,7 +43,7 @@ Default behavior is to decode the packets with internal decoder to stdout:
 
     talosctl pcap -i eth0
 
-Raw pcap file can be saved with --output flag:
+Raw pcap file can be saved with ` + "`--output`" + ` flag:
 
     talosctl pcap -i eth0 --output eth0.pcap
 

--- a/website/content/v1.6/reference/cli.md
+++ b/website/content/v1.6/reference/cli.md
@@ -2423,7 +2423,7 @@ Default behavior is to decode the packets with internal decoder to stdout:
 
     talosctl pcap -i eth0
 
-Raw pcap file can be saved with --output flag:
+Raw pcap file can be saved with `--output` flag:
 
     talosctl pcap -i eth0 --output eth0.pcap
 


### PR DESCRIPTION
# Pull Request
## What? (description)
Fixes a formatting issue on the website. The `--output` argument is shown with a single dash and without code formatting. 

Current docs: https://www.talos.dev/v1.6/reference/cli/#talosctl-pcap
![Screenshot from 2023-11-23 17-05-35](https://github.com/siderolabs/talos/assets/1570691/b4fc83a5-5ca7-4832-98c3-fefabe8f2600)


With change:
![Screenshot from 2023-11-23 17-05-14](https://github.com/siderolabs/talos/assets/1570691/fd64199d-f724-4a00-9a73-5cd215e6d955)


## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
