### PR TITLE
chore: modernize machined/pkg/controllers/k8s

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
@@ -319,13 +319,13 @@ func (suite *K8sControlPlaneSuite) TestReconcileResources() {
 					APIServerConfig: &v1alpha1.APIServerConfig{
 						ResourcesConfig: &v1alpha1.ResourcesConfig{
 							Requests: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    "100m",
 									"memory": "1Gi",
 								},
 							},
 							Limits: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    2,
 									"memory": "1500Mi",
 								},
@@ -335,13 +335,13 @@ func (suite *K8sControlPlaneSuite) TestReconcileResources() {
 					ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{
 						ResourcesConfig: &v1alpha1.ResourcesConfig{
 							Requests: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    "50m",
 									"memory": "500Mi",
 								},
 							},
 							Limits: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    1,
 									"memory": "1000Mi",
 								},
@@ -351,13 +351,13 @@ func (suite *K8sControlPlaneSuite) TestReconcileResources() {
 					SchedulerConfig: &v1alpha1.SchedulerConfig{
 						ResourcesConfig: &v1alpha1.ResourcesConfig{
 							Requests: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    "150m",
 									"memory": "2Gi",
 								},
 							},
 							Limits: v1alpha1.Unstructured{
-								Object: map[string]interface{}{
+								Object: map[string]any{
 									"cpu":    3,
 									"memory": "2000Mi",
 								},

--- a/internal/app/machined/pkg/controllers/k8s/internal/nodewatch/nodewatch.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/nodewatch/nodewatch.go
@@ -60,7 +60,7 @@ func (r *NodeWatcher) Watch(ctx context.Context, logger *zap.Logger) (<-chan str
 
 	notifyCh := make(chan struct{}, 1)
 
-	notify := func(_ interface{}) {
+	notify := func(_ any) {
 		select {
 		case notifyCh <- struct{}{}:
 		default:
@@ -78,7 +78,7 @@ func (r *NodeWatcher) Watch(ctx context.Context, logger *zap.Logger) (<-chan str
 	if _, err := r.nodes.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    notify,
 		DeleteFunc: notify,
-		UpdateFunc: func(_, _ interface{}) { notify(nil) },
+		UpdateFunc: func(_, _ any) { notify(nil) },
 	}); err != nil {
 		return nil, nil, fmt.Errorf("failed to add event handler: %w", err)
 	}

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
@@ -102,7 +102,7 @@ func (suite *KubeletConfigSuite) TestReconcile() {
 							},
 						},
 						KubeletExtraConfig: v1alpha1.Unstructured{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"serverTLSBootstrap": true,
 							},
 						},
@@ -170,7 +170,7 @@ func (suite *KubeletConfigSuite) TestReconcile() {
 					spec.ExtraMounts,
 				)
 				suite.Assert().Equal(
-					map[string]interface{}{
+					map[string]any{
 						"serverTLSBootstrap": true,
 					},
 					spec.ExtraConfig,

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
@@ -213,7 +213,7 @@ func (ctrl *KubeletSpecController) Run(ctx context.Context, r controller.Runtime
 	}
 }
 
-func prepareExtraConfig(extraConfig map[string]interface{}) (*kubeletconfig.KubeletConfiguration, error) {
+func prepareExtraConfig(extraConfig map[string]any) (*kubeletconfig.KubeletConfiguration, error) {
 	// check for fields that can't be overridden via extraConfig
 	var multiErr *multierror.Error
 

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec_test.go
@@ -78,7 +78,7 @@ func (suite *KubeletSpecSuite) TestReconcileDefault() {
 		)
 		asrt.Equal(cfg.TypedSpec().ExtraMounts, spec.ExtraMounts)
 
-		asrt.Equal([]interface{}{"10.96.0.10"}, spec.Config["clusterDNS"])
+		asrt.Equal([]any{"10.96.0.10"}, spec.Config["clusterDNS"])
 		asrt.Equal("cluster.local", spec.Config["clusterDomain"])
 	})
 }
@@ -164,7 +164,7 @@ func (suite *KubeletSpecSuite) TestReconcileWithExtraConfig() {
 	cfg.TypedSpec().Image = "kubelet:v2.0.0"
 	cfg.TypedSpec().ClusterDNS = []string{"10.96.0.11"}
 	cfg.TypedSpec().ClusterDomain = "some.local"
-	cfg.TypedSpec().ExtraConfig = map[string]interface{}{
+	cfg.TypedSpec().ExtraConfig = map[string]any{
 		"serverTLSBootstrap": true,
 	}
 
@@ -270,7 +270,7 @@ func TestNewKubeletConfigurationFail(t *testing.T) {
 			cfgSpec: &k8s.KubeletConfigSpec{
 				ClusterDNS:    []string{"10.96.0.10"},
 				ClusterDomain: "cluster.svc",
-				ExtraConfig: map[string]interface{}{
+				ExtraConfig: map[string]any{
 					"API":  "v1",
 					"foo":  "bar",
 					"Port": "xyz",
@@ -283,7 +283,7 @@ func TestNewKubeletConfigurationFail(t *testing.T) {
 			cfgSpec: &k8s.KubeletConfigSpec{
 				ClusterDNS:    []string{"10.96.0.10"},
 				ClusterDomain: "cluster.svc",
-				ExtraConfig: map[string]interface{}{
+				ExtraConfig: map[string]any{
 					"oomScoreAdj": "v1",
 				},
 			},
@@ -294,7 +294,7 @@ func TestNewKubeletConfigurationFail(t *testing.T) {
 			cfgSpec: &k8s.KubeletConfigSpec{
 				ClusterDNS:    []string{"10.96.0.10"},
 				ClusterDomain: "cluster.svc",
-				ExtraConfig: map[string]interface{}{
+				ExtraConfig: map[string]any{
 					"oomScoreAdj":    -300,
 					"port":           81,
 					"authentication": nil,
@@ -380,7 +380,7 @@ func TestNewKubeletConfigurationMerge(t *testing.T) {
 			cfgSpec: &k8s.KubeletConfigSpec{
 				ClusterDNS:    []string{"10.0.0.5"},
 				ClusterDomain: "cluster.local",
-				ExtraConfig: map[string]interface{}{
+				ExtraConfig: map[string]any{
 					"oomScoreAdj":             -300,
 					"enableDebuggingHandlers": true,
 				},
@@ -396,7 +396,7 @@ func TestNewKubeletConfigurationMerge(t *testing.T) {
 			cfgSpec: &k8s.KubeletConfigSpec{
 				ClusterDNS:    []string{"10.0.0.5"},
 				ClusterDomain: "cluster.local",
-				ExtraConfig: map[string]interface{}{
+				ExtraConfig: map[string]any{
 					"shutdownGracePeriod":             "0s",
 					"shutdownGracePeriodCriticalPods": "0s",
 				},

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod.go
@@ -210,8 +210,8 @@ func (ctrl *KubeletStaticPodController) refreshPodStatus(ctx context.Context, r 
 
 		podsSeen[statusID] = struct{}{}
 
-		if err = r.Modify(ctx, k8s.NewStaticPodStatus(k8s.NamespaceName, statusID), func(r resource.Resource) error {
-			return k8sadapter.StaticPodStatus(r.(*k8s.StaticPodStatus)).SetStatus(&pod.Status)
+		if err = safe.WriterModify(ctx, r, k8s.NewStaticPodStatus(k8s.NamespaceName, statusID), func(r *k8s.StaticPodStatus) error {
+			return k8sadapter.StaticPodStatus(r).SetStatus(&pod.Status)
 		}); err != nil {
 			return fmt.Errorf("error updating pod status: %w", err)
 		}

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -225,8 +225,8 @@ func (suite *ManifestSuite) TestReconcileKubeProxyExtraArgs() {
 	suite.Assert().Equal("DaemonSet", k8sadapter.Manifest(manifest).Objects()[0].GetKind())
 
 	ds := k8sadapter.Manifest(manifest).Objects()[0].Object
-	containerSpec := ds["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})[0]
-	args := containerSpec.(map[string]interface{})["command"].([]interface{}) //nolint:errcheck,forcetypeassert
+	containerSpec := ds["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)[0]
+	args := containerSpec.(map[string]any)["command"].([]any) //nolint:errcheck,forcetypeassert
 
 	suite.Assert().Equal("--bind-address=\"::\"", args[len(args)-1])
 }

--- a/internal/app/machined/pkg/controllers/k8s/node_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_apply.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -258,7 +258,7 @@ func umarshalOwnedAnnotation(node *v1.Node, annotation string) (map[string]struc
 
 func marshalOwnedAnnotation(node *v1.Node, annotation string, ownedMap map[string]struct{}) error {
 	owned := maps.Keys(ownedMap)
-	sort.Strings(owned)
+	slices.Sort(owned)
 
 	if len(owned) > 0 {
 		ownedJSON, err := json.Marshal(owned)

--- a/internal/app/machined/pkg/controllers/k8s/node_apply_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_apply_test.go
@@ -5,7 +5,7 @@
 package k8s_test
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/siderolabs/gen/maps"
@@ -132,7 +132,7 @@ func TestApplyLabels(t *testing.T) {
 				newOwnedLabels = []string{}
 			}
 
-			sort.Strings(newOwnedLabels)
+			slices.Sort(newOwnedLabels)
 
 			assert.Equal(t, tt.expectedLabels, node.Labels)
 			assert.Equal(t, tt.expectedOwnedLabels, newOwnedLabels)
@@ -317,7 +317,7 @@ func TestApplyTaints(t *testing.T) {
 				newOwnedTaints = []string{}
 			}
 
-			sort.Strings(newOwnedTaints)
+			slices.Sort(newOwnedTaints)
 
 			assert.Equal(t, tt.expectedTaints, node.Spec.Taints)
 			assert.Equal(t, tt.expectedOwnedTaints, newOwnedTaints)

--- a/internal/app/machined/pkg/controllers/k8s/nodeip.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip.go
@@ -139,11 +139,12 @@ func (ctrl *NodeIPController) Run(ctx context.Context, r controller.Runtime, log
 			}
 		}
 
-		if err = r.Modify(
+		if err = safe.WriterModify(
 			ctx,
+			r,
 			k8s.NewNodeIP(k8s.NamespaceName, k8s.KubeletID),
-			func(r resource.Resource) error {
-				spec := r.(*k8s.NodeIP).TypedSpec()
+			func(r *k8s.NodeIP) error {
+				spec := r.TypedSpec()
 
 				spec.Addresses = nodeIPs
 

--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -327,9 +327,9 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 			}
 		}
 
-		if err = r.Modify(ctx, k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID), func(r resource.Resource) error {
-			r.(*k8s.SecretsStatus).TypedSpec().Ready = true
-			r.(*k8s.SecretsStatus).TypedSpec().Version = secretsRes.Metadata().Version().String()
+		if err = safe.WriterModify(ctx, r, k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID), func(r *k8s.SecretsStatus) error {
+			r.TypedSpec().Ready = true
+			r.TypedSpec().Version = secretsRes.Metadata().Version().String()
 
 			return nil
 		}); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_config.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
@@ -100,8 +99,8 @@ func (ctrl *StaticPodConfigController) Run(ctx context.Context, r controller.Run
 
 				id := fmt.Sprintf("%s-%s", namespace, name)
 
-				if err = r.Modify(ctx, k8s.NewStaticPod(k8s.NamespaceName, id), func(r resource.Resource) error {
-					r.(*k8s.StaticPod).TypedSpec().Pod = pod
+				if err = safe.WriterModify(ctx, r, k8s.NewStaticPod(k8s.NamespaceName, id), func(r *k8s.StaticPod) error {
+					r.TypedSpec().Pod = pod
 
 					return nil
 				}); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_config_test.go
@@ -107,15 +107,15 @@ func (suite *StaticPodConfigSuite) TestReconcile() {
 				MachineConfig: &v1alpha1.MachineConfig{
 					MachinePods: []v1alpha1.Unstructured{
 						{
-							Object: map[string]interface{}{
+							Object: map[string]any{
 								"apiVersion": "v1",
 								"kind":       "pod",
-								"metadata": map[string]interface{}{
+								"metadata": map[string]any{
 									"name": "nginx",
 								},
-								"spec": map[string]interface{}{
-									"containers": []interface{}{
-										map[string]interface{}{
+								"spec": map[string]any{
+									"containers": []any{
+										map[string]any{
 											"name":  "nginx",
 											"image": "nginx",
 										},
@@ -148,7 +148,7 @@ func (suite *StaticPodConfigSuite) TestReconcile() {
 	)
 
 	// update the pod changing the namespace
-	cfg.Container().RawV1Alpha1().MachineConfig.MachinePods[0].Object["metadata"].(map[string]interface{})["namespace"] = "custom"
+	cfg.Container().RawV1Alpha1().MachineConfig.MachinePods[0].Object["metadata"].(map[string]any)["namespace"] = "custom"
 	suite.Require().NoError(suite.state.Update(suite.ctx, cfg))
 
 	suite.Assert().NoError(

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_server.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -54,7 +53,7 @@ func (ctrl *StaticPodServerController) Outputs() []controller.Output {
 	}
 }
 
-type pod map[string]interface{}
+type pod map[string]any
 
 type podList struct {
 	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
@@ -191,10 +190,10 @@ func (ctrl *StaticPodServerController) createServer(ctx context.Context, r contr
 		shutdownServer()
 	}()
 
-	if err := r.Modify(ctx, k8s.NewStaticPodServerStatus(k8s.NamespaceName, k8s.StaticPodServerStatusResourceID), func(r resource.Resource) error {
+	if err := safe.WriterModify(ctx, r, k8s.NewStaticPodServerStatus(k8s.NamespaceName, k8s.StaticPodServerStatusResourceID), func(r *k8s.StaticPodServerStatus) error {
 		url := fmt.Sprintf("http://%s", listener.Addr().String())
 
-		r.(*k8s.StaticPodServerStatus).TypedSpec().URL = url
+		r.TypedSpec().URL = url
 
 		return nil
 	}); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_server_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_server_test.go
@@ -110,7 +110,7 @@ func (suite *StaticPodListSuite) getResource(
 func newTestPod(name string) *k8s.StaticPod {
 	testPod := k8s.NewStaticPod(k8s.NamespaceName, name)
 
-	testPod.TypedSpec().Pod = map[string]interface{}{
+	testPod.TypedSpec().Pod = map[string]any{
 		"metadata": name,
 		"spec":     "testSpec",
 	}


### PR DESCRIPTION
This is going to be multipart effort to finally use safe.* wrappers in the production code. Quick regexp search shows that there are around 150 direct type assertions on resources (excluding the ones in this commit).

Also - migrate from `interface{}` to `any` and use `slices.Sort` instead of `sort.*` where possible.