### PR TITLE
fix: support user disks via symlinks

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -130,6 +130,12 @@ cluster:
 ```
 """
 
+    [notes.user-disks]
+        title = "User Disks"
+        description = """\
+Talos Linux now supports specifying user disks in `.machine.disks` machine configuration links via `udev` symlinks, e.g. `/dev/disk/by-id/XXXX`.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -279,8 +279,14 @@ func launchVM(config *LaunchConfig) error {
 		"virtserialport,chardev=qga0,name=org.qemu.guest_agent.0",
 	}
 
-	for _, disk := range config.DiskPaths {
-		args = append(args, "-drive", fmt.Sprintf("format=raw,if=virtio,file=%s,cache=unsafe", disk))
+	for i, disk := range config.DiskPaths {
+		driver := "virtio"
+
+		if i > 0 {
+			driver = "ide"
+		}
+
+		args = append(args, "-drive", fmt.Sprintf("format=raw,if=%s,file=%s,cache=unsafe", driver, disk))
 	}
 
 	machineArg := config.MachineType

--- a/pkg/provision/providers/vm/disk.go
+++ b/pkg/provision/providers/vm/disk.go
@@ -14,24 +14,11 @@ import (
 
 // UserDiskName returns disk device path.
 func (p *Provisioner) UserDiskName(index int) string {
-	res := "/dev/vd"
-
-	var convert func(i int) string
-
-	convert = func(i int) string {
-		remainder := i % 26
-		divider := i / 26
-
-		prefix := ""
-
-		if divider != 0 {
-			prefix = convert(divider - 1)
-		}
-
-		return fmt.Sprintf("%s%s", prefix, string(rune('a'+remainder)))
-	}
-
-	return res + convert(index)
+	// the disk IDs are assigned in the following way:
+	// * ata-QEMU_HARDDISK_QM00001
+	// * ata-QEMU_HARDDISK_QM00003
+	// * ata-QEMU_HARDDISK_QM00005
+	return fmt.Sprintf("/dev/disk/by-id/ata-QEMU_HARDDISK_QM%05d", (index-1)*2+1)
 }
 
 // CreateDisks creates empty disk files for each disk.


### PR DESCRIPTION
The core blockdevice library already supported resolving symlinks, we just need to get the raw block device name from it, and use it afterwards.

In QEMU provisioner, leave the first (system) disk as virtio (for performance), and mount user disks as 'ata', which allows `udevd` to pick up the disk IDs (not available for `virtio`), and use the symlink path in the tests.
