### PR TITLE
docs: cap max heading level

### DIFF
--- a/pkg/machinery/config/encoder/markdown.go
+++ b/pkg/machinery/config/encoder/markdown.go
@@ -43,6 +43,7 @@ func (fd *FileDoc) Encode(root *Doc, frontmatter func(title, description string)
 			"trimPrefix":  strings.TrimPrefix,
 			"add":         func(a, b int) int { return a + b },
 			"frontmatter": frontmatter,
+			"min":         minInt,
 		}).
 		Parse(markdownTemplate))
 
@@ -188,4 +189,8 @@ func tmplDict(vals ...any) (map[string]any, error) {
 	}
 
 	return res, nil
+}
+
+func minInt(a, b int) int {
+	return min(a, b)
 }

--- a/pkg/machinery/config/encoder/markdown.tmpl
+++ b/pkg/machinery/config/encoder/markdown.tmpl
@@ -1,7 +1,7 @@
 {{ frontmatter .Root.Type .Root.Description }}
 
 {{ block "struct" dict "Struct" .Root "Level" 1 "Name" .Root.Type "Path" .Root.Type  "Types" .Types }}
-{{ if gt .Level 1 }}{{ repeat "#" .Level }} {{ .Name }} {#{{ .Path }}}{{ end }}
+{{ if gt .Level 1 }}{{ repeat "#" (min .Level 6) }} {{ .Name }} {#{{ .Path }}}{{ end }}
 
 {{ if and .Struct.Description (gt .Level 1) -}}
 {{ .Struct.Description }}

--- a/website/content/v1.6/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.6/reference/configuration/v1alpha1/config.md
@@ -1454,7 +1454,7 @@ machine:
 
 
 
-####### equinixMetal {#Config.machine.network.interfaces..vlans..vip.equinixMetal}
+###### equinixMetal {#Config.machine.network.interfaces..vlans..vip.equinixMetal}
 
 VIPEquinixMetalConfig contains settings for Equinix Metal VIP management.
 
@@ -1470,7 +1470,7 @@ VIPEquinixMetalConfig contains settings for Equinix Metal VIP management.
 
 
 
-####### hcloud {#Config.machine.network.interfaces..vlans..vip.hcloud}
+###### hcloud {#Config.machine.network.interfaces..vlans..vip.hcloud}
 
 VIPHCloudConfig contains settings for Hetzner Cloud VIP management.
 


### PR DESCRIPTION
Markdown/HTML can't have headings after level 6, so make sure the maximum heading level is capped at 6.

We have just a single place with such deep nesting.
