### PR TITLE
fix: use correct prefix when installing SBC files

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -290,6 +290,7 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 
 		if err = b.Install(runtime.BoardInstallOptions{
 			InstallDisk:     i.options.Disk,
+			MountPrefix:     i.options.MountPrefix,
 			UBootPath:       i.options.BootAssets.UBootPath,
 			DTBPath:         i.options.BootAssets.DTBPath,
 			RPiFirmwarePath: i.options.BootAssets.RPiFirmwarePath,

--- a/internal/app/machined/pkg/runtime/board.go
+++ b/internal/app/machined/pkg/runtime/board.go
@@ -15,6 +15,7 @@ type PartitionOptions struct {
 // BoardInstallOptions are the board specific options for installation of various boot assets.
 type BoardInstallOptions struct {
 	InstallDisk     string
+	MountPrefix     string
 	DTBPath         string
 	UBootPath       string
 	RPiFirmwarePath string

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
@@ -73,7 +73,7 @@ func (b *BananaPiM64) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/jetson_nano/jetson_nano.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/jetson_nano/jetson_nano.go
@@ -53,7 +53,7 @@ func (b JetsonNano) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
@@ -70,7 +70,7 @@ func (l *LibretechAllH3CCH5) Install(options runtime.BoardInstallOptions) (err e
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/nanopi_r4s/nanopi_r4s.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/nanopi_r4s/nanopi_r4s.go
@@ -64,7 +64,7 @@ func (n *NanoPiR4S) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o600); err != nil {
 		return err

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
@@ -71,7 +71,7 @@ func (b Pine64) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rock64/rock64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rock64/rock64.go
@@ -70,7 +70,7 @@ func (r *Rock64) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4/rockpi4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4/rockpi4.go
@@ -70,7 +70,7 @@ func (r *Rockpi4) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c/rockpi4c.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c/rockpi4c.go
@@ -69,7 +69,7 @@ func (r *Rockpi4c) Install(options runtime.BoardInstallOptions) (err error) {
 	}
 
 	src := filepath.Join(options.DTBPath, dtb)
-	dst := filepath.Join("/boot/EFI/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic/rpi_generic.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic/rpi_generic.go
@@ -32,17 +32,17 @@ func (r *RPiGeneric) Name() string {
 
 // Install implements the runtime.Board.
 func (r *RPiGeneric) Install(options runtime.BoardInstallOptions) (err error) {
-	err = copy.Dir(filepath.Join(options.RPiFirmwarePath, "boot"), "/boot/EFI")
+	err = copy.Dir(filepath.Join(options.RPiFirmwarePath, "boot"), filepath.Join(options.MountPrefix, "/boot/EFI"))
 	if err != nil {
 		return err
 	}
 
-	err = copy.File(filepath.Join(options.UBootPath, "rpi_generic/u-boot.bin"), "/boot/EFI/u-boot.bin")
+	err = copy.File(filepath.Join(options.UBootPath, "rpi_generic/u-boot.bin"), filepath.Join(options.MountPrefix, "/boot/EFI/u-boot.bin"))
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile("/boot/EFI/config.txt", configTxt, 0o600)
+	return os.WriteFile(filepath.Join(options.MountPrefix, "/boot/EFI/config.txt"), configTxt, 0o600)
 }
 
 // KernelArgs implements the runtime.Board.


### PR DESCRIPTION
When creating an image under non-default mount prefix, it should be explictly used when copying SBC files.

See https://github.com/siderolabs/image-factory/issues/65
