### PR TITLE
fix: update the way secureboot signer fetches certificate (azure)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.0.1
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.0.1
 	github.com/BurntSushi/toml v1.3.2
 	github.com/aws/aws-sdk-go-v2/config v1.25.6
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.5

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,6 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.0.0 h1
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.0.0/go.mod h1:jYmTBxPYmbqUp5pCuTC58jMXVk/NxmqeYdoMbQGVUKo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.0.1 h1:MyVTgWR8qd/Jw1Le0NZebGBUCLbtak3bJ3z1OlqZBpw=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.0.1/go.mod h1:GpPjLhVR9dnUoJMyHWSPy71xY9/lcmpzIPZXmF0FCVY=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.0.1 h1:8TkzQBrN9PWIwo7ekdd696KpC6IfTltV2/F8qKKBWik=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.0.1/go.mod h1:aprFpXPQiTyG5Rkz6Ot5pvU6y6YKg/AKYOcLCoxN0bk=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0 h1:D3occbWoio4EBLkbkevetNMAVX197GkzbUMtqjGWn80=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0/go.mod h1:bTSOgj05NGRuHHhQwAdPnYr9TOdNmKlZTgGLL6nyAdI=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=

--- a/pkg/imager/profile/internal/signer/azure/azure.go
+++ b/pkg/imager/profile/internal/signer/azure/azure.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
-	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 )
 
 type authenticationMethod string
@@ -161,13 +160,4 @@ func getCertsClient(vaultURL string) (*azcertificates.Client, error) {
 	}
 
 	return azcertificates.NewClient(vaultURL, credAndError.cred, nil)
-}
-
-func getSecretsClient(vaultURL string) (*azsecrets.Client, error) {
-	credAndError := azureCredentialsOnce()
-	if credAndError.err != nil {
-		return nil, credAndError.err
-	}
-
-	return azsecrets.NewClient(vaultURL, credAndError.cred, nil)
 }

--- a/pkg/imager/profile/internal/signer/azure/azure_test.go
+++ b/pkg/imager/profile/internal/signer/azure/azure_test.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package azure_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/imager/profile/internal/signer/azure"
+)
+
+func TestIntegration(t *testing.T) {
+	for _, envVar := range []string{"AZURE_VAULT_URL", "AZURE_KEY_ID", "AZURE_CERT_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"} {
+		if os.Getenv(envVar) == "" {
+			t.Skipf("%s not set", envVar)
+		}
+	}
+
+	signer, err := azure.NewPCRSigner(context.TODO(), os.Getenv("AZURE_VAULT_URL"), os.Getenv("AZURE_KEY_ID"), "")
+	require.NoError(t, err)
+
+	digest := sha256.Sum256(nil)
+
+	_, err = signer.Sign(nil, digest[:], nil)
+	require.NoError(t, err)
+
+	sbSigner, err := azure.NewSecureBootSigner(context.TODO(), os.Getenv("AZURE_VAULT_URL"), os.Getenv("AZURE_CERT_ID"), "")
+	require.NoError(t, err)
+
+	_, err = sbSigner.Signer().Sign(nil, digest[:], nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The previous code was a mistake, the public part of the certificate is more easily available.
