### PR TITLE
Improve catch-all network interface `deviceSelector`.

### DIFF
--- a/website/content/v1.6/talos-guides/network/predictable-interface-names.md
+++ b/website/content/v1.6/talos-guides/network/predictable-interface-names.md
@@ -32,7 +32,9 @@ There are two ways to solve this:
     network:
       interfaces:
         - deviceSelector:
-            busPath: "0*" # should select any hardware network device, if you have just one, it will be selected
-          # any configuration can follow, e.g:
+            # This should select any hardware ethernet interface. If you have just one, it will be selected.
+            type: ether
+            kind: ''
+          # Any configuration can follow, e.g.:
           addresses: [10.3.4.5/24]
   ```

--- a/website/content/v1.6/talos-guides/network/predictable-interface-names.md
+++ b/website/content/v1.6/talos-guides/network/predictable-interface-names.md
@@ -32,7 +32,7 @@ There are two ways to solve this:
     network:
       interfaces:
         - deviceSelector:
-            # This should select any hardware ethernet interface. If you have just one, it will be selected.
+            # This should select any hardware Ethernet interface. If you have just one, it will be selected.
             type: ether
             kind: ''
           # Any configuration can follow, e.g.:

--- a/website/content/v1.6/talos-guides/network/vip.md
+++ b/website/content/v1.6/talos-guides/network/vip.md
@@ -95,7 +95,7 @@ machine:
   network:
     interfaces:
       - deviceSelector:
-          # This should select any hardware ethernet interface. If you have just one, it will be selected.
+          # This should select any hardware Ethernet interface. If you have just one, it will be selected.
           type: ether
           kind: ''
       dhcp: true

--- a/website/content/v1.6/talos-guides/network/vip.md
+++ b/website/content/v1.6/talos-guides/network/vip.md
@@ -95,7 +95,9 @@ machine:
   network:
     interfaces:
       - deviceSelector:
-          busPath: "0*" # should select any hardware network device, if you have just one, it will be selected
+          # This should select any hardware ethernet interface. If you have just one, it will be selected.
+          type: ether
+          kind: ''
       dhcp: true
       vip:
         ip: 192.168.0.15


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Change example for catch-all network interface `deviceSelector`.

## Why? (reasoning)

The existing example does not work on Raspberry Pi, I assume since the network interface is not a PCIe device but connected to the USB controller.

I am using Raspberry Pis (Hardware PHY) and Proxmox VMs (VirtIO PHY). The common attributes of the ethernet interfaces seem to be `type: ether` and `kind: ''`.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
