### PR TITLE
fix: properly overwrite files on install

### DIFF
--- a/pkg/imager/iso/loader.conf
+++ b/pkg/imager/iso/loader.conf
@@ -1,0 +1,5 @@
+# systemd-boot configuration
+
+timeout 10
+
+secure-boot-enroll if-safe

--- a/pkg/imager/utils/copy.go
+++ b/pkg/imager/utils/copy.go
@@ -40,7 +40,7 @@ func CopyFiles(printf func(string, ...any), instructions ...CopyInstruction) err
 			//nolint:errcheck
 			defer from.Close()
 
-			to, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0o666)
+			to, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Without truncate the file was not overwritten properly if the file with the same name already exists and has smaller size.

Fixes #8097

Also add a 10 second timeout on UEFI ISO boot, so that boot menu can be seen without pressing `Esc` many times.
