### PR TITLE
chore: support http downloads for assets in talosctl cluster create

### DIFF
--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+# shellcheck source=/dev/null
+source ./hack/test/e2e.sh
+
+PROVISIONER=qemu
+CLUSTER_NAME="e2e-${PROVISIONER}"
+
+FACTORY_HOSTNAME=${FACTORY_HOSTNAME:-factory.talos.dev}
+PXE_FACTORY_HOSTNAME=${PXE_FACTORY_HOSTNAME:-pxe.factory.talos.dev}
+FACTORY_SCHEME=${FACTORY_SCHEME:-https}
+INSTALLER_IMAGE_NAME=${INSTALLER_IMAGE_NAME:-installer}
+
+case "${FACTORY_BOOT_METHOD:-iso}" in
+  iso)
+    QEMU_FLAGS+=("--iso-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64.iso")
+    ;;
+  disk-image)
+    QEMU_FLAGS+=("--disk-image-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64.raw.xz")
+    ;;
+  ipxe)
+    QEMU_FLAGS+=("--ipxe-boot-script=${FACTORY_SCHEME}://${PXE_FACTORY_HOSTNAME}/pxe/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64")
+    ;;
+  secureboot-iso)
+    QEMU_FLAGS+=("--iso-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64-secureboot.iso" "--with-tpm2" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
+    INSTALLER_IMAGE_NAME=installer-secureboot
+    ;;
+esac
+
+function assert_secureboot {
+  if [[ "${FACTORY_BOOT_METHOD:-iso}" != "secureboot-iso" ]]; then
+    return
+  fi
+
+  ${TALOSCTL} get securitystate -o json
+  ${TALOSCTL} get securitystate -o json | jq -e '.spec.secureBoot == true'
+}
+
+function create_cluster {
+  build_registry_mirrors
+
+  "${TALOSCTL}" cluster create \
+    --provisioner="${PROVISIONER}" \
+    --name="${CLUSTER_NAME}" \
+    --kubernetes-version="${KUBERNETES_VERSION}" \
+    --controlplanes=3 \
+    --workers="${QEMU_WORKERS:-1}" \
+    --disk=15360 \
+    --mtu=1450 \
+    --memory=2048 \
+    --memory-workers="${QEMU_MEMORY_WORKERS:-2048}" \
+    --cpus="${QEMU_CPUS:-2}" \
+    --cpus-workers="${QEMU_CPUS_WORKERS:-2}" \
+    --cidr=172.20.1.0/24 \
+    --cni-bundle-url="${ARTIFACTS}/talosctl-cni-bundle-\${ARCH}.tar.gz" \
+    --skip-injecting-config \
+    --with-apply-config \
+    --talos-version="${FACTORY_VERSION}" \
+    --install-image="${FACTORY_HOSTNAME}/${INSTALLER_IMAGE_NAME}/${FACTORY_SCHEMATIC}:${FACTORY_VERSION}" \
+    --crashdump \
+    "${REGISTRY_MIRROR_FLAGS[@]}" \
+    "${QEMU_FLAGS[@]}"
+
+    ${TALOSCTL} config node 172.20.1.2
+}
+
+function destroy_cluster() {
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+}
+
+create_cluster
+
+${TALOSCTL} health --run-e2e
+${TALOSCTL} version | grep "${FACTORY_VERSION}"
+${TALOSCTL} get extensions | grep "${FACTORY_SCHEMATIC}"
+assert_secureboot
+
+if [[ "${FACTORY_UPGRADE:-false}" == "true" ]]; then
+    ${TALOSCTL} upgrade -i "${FACTORY_HOSTNAME}/${INSTALLER_IMAGE_NAME}/${FACTORY_UPGRADE_SCHEMATIC:-$FACTORY_SCHEMATIC}:${FACTORY_UPGRADE_VERSION:-$FACTORY_VERSION}"
+    ${TALOSCTL} version | grep "${FACTORY_UPGRADE_VERSION:-$FACTORY_VERSION}"
+    ${TALOSCTL} get extensions | grep "${FACTORY_UPGRADE_SCHEMATIC:-$FACTORY_SCHEMATIC}"
+    assert_secureboot
+fi
+
+destroy_cluster

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -217,7 +217,7 @@ function build_registry_mirrors {
     done
   else
     # use the value from the environment, if present
-    REGISTRY_MIRROR_FLAGS=("${REGISTRY_MIRROR_FLAGS:-}")
+    REGISTRY_MIRROR_FLAGS=(${REGISTRY_MIRROR_FLAGS:-})
   fi
 }
 


### PR DESCRIPTION
This allows to pass direct URLs to Image Factory assets for disk image/ISO/vmlinuz/initramfs, so that we can test Image Factory with Talos.

Also add an integration test for Image Factory.

Fixes #8110 
