### PR TITLE
feat: add Pine64 SOQuartz SBC on CM4 I/O board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,11 +317,11 @@ images-essential: image-aws image-gcp image-metal secureboot-installer ## Builds
 
 images: image-aws image-azure image-digital-ocean image-exoscale image-gcp image-hcloud image-iso image-metal image-nocloud image-openstack image-oracle image-scaleway image-upcloud image-vmware image-vultr ## Builds all known images (AWS, Azure, DigitalOcean, Exoscale, GCP, HCloud, Metal, NoCloud, Openstack, Oracle, Scaleway, UpCloud, Vultr and VMware).
 
-sbc-%: ## Builds the specified SBC image. Valid options are rpi_generic, rock64, bananapi_m64, libretech_all_h3_cc_h5, rockpi_4, rockpi_4c, pine64, jetson_nano and nanopi_r4s (e.g. sbc-rpi_generic)
+sbc-%: ## Builds the specified SBC image. Valid options are rpi_generic, rock64, bananapi_m64, libretech_all_h3_cc_h5, rockpi_4, rockpi_4c, pine64, jetson_nano, nanopi_r4s and soquartz_cm4 (e.g. sbc-rpi_generic)
 	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG)
 	@docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/out --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch arm64 $(IMAGER_ARGS)
 
-sbcs: sbc-rpi_generic sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 sbc-rockpi_4c sbc-pine64 sbc-jetson_nano sbc-nanopi_r4s ## Builds all known SBC images (Raspberry Pi 4, Rock64, Banana Pi M64, Radxa ROCK Pi 4, Radxa ROCK Pi 4c, Pine64, Libre Computer Board ALL-H3-CC, Jetson Nano and Nano Pi R4S).
+sbcs: sbc-rpi_generic sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 sbc-rockpi_4c sbc-pine64 sbc-jetson_nano sbc-nanopi_r4s sbc-soquartz_cm4 ## Builds all known SBC images (Raspberry Pi 4, Rock64, Banana Pi M64, Radxa ROCK Pi 4, Radxa ROCK Pi 4c, Pine64, Libre Computer Board ALL-H3-CC, Jetson Nano, Nano Pi R4S, and SOQuartz CM4).
 
 .PHONY: iso
 iso: image-iso ## Builds the ISO and outputs it to the artifact directory.

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
@@ -22,6 +22,7 @@ import (
 	rockpi4 "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4"
 	rockpi4c "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c"
 	rpigeneric "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic"
+	soquartzcm4 "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/soquartz_cm4"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -70,6 +71,8 @@ func newBoard(board string) (b runtime.Board, err error) {
 		b = &jetsonnano.JetsonNano{}
 	case constants.BoardNanoPiR4S:
 		b = &nanopir4s.NanoPiR4S{}
+	case constants.BoardSOQuartzCM4:
+		b = &soquartzcm4.SOQuartzCM4{}
 	default:
 		return nil, fmt.Errorf("unsupported board: %q", board)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/soquartz_cm4/soquartz_cm4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/soquartz_cm4/soquartz_cm4.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package soquartzcm4 provides the Pine64 SOQuartz board implementation on a CM4 carrier board.
+package soquartzcm4
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-procfs/procfs"
+	"golang.org/x/sys/unix"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/copy"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+var (
+	bin       = constants.BoardSOQuartzCM4 + "/u-boot-rockchip.bin"
+	off int64 = 512 * 64
+	dtb       = "rockchip/rk3566-soquartz-cm4.dtb"
+)
+
+// SOQuartzCM4 represents the Pine64 SOQuartz board on a CM4 carrier board.
+//
+// Reference: https://wiki.pine64.org/wiki/SOQuartz
+type SOQuartzCM4 struct{}
+
+// Name implements the runtime.Board.
+func (b *SOQuartzCM4) Name() string {
+	return constants.BoardSOQuartzCM4
+}
+
+// Install implements the runtime.Board.
+func (b *SOQuartzCM4) Install(options runtime.BoardInstallOptions) (err error) {
+	var f *os.File
+
+	if f, err = os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666); err != nil {
+		return err
+	}
+	//nolint:errcheck
+	defer f.Close()
+
+	var uboot []byte
+
+	uboot, err = os.ReadFile(filepath.Join(options.UBootPath, bin))
+	if err != nil {
+		return err
+	}
+
+	options.Printf("writing %s at offset %d", bin, off)
+
+	var n int
+
+	n, err = f.WriteAt(uboot, off)
+	if err != nil {
+		return err
+	}
+
+	options.Printf("wrote %d bytes", n)
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.DTBPath, dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	err = copy.File(src, dst)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// KernelArgs implements the runtime.Board.
+func (b *SOQuartzCM4) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("tty0").Append("ttyS2,115200n8"),
+		procfs.NewParameter(constants.KernelParamDashboardDisabled).Append("1"),
+	}
+}
+
+// PartitionOptions implements the runtime.Board.
+func (b *SOQuartzCM4) PartitionOptions() *runtime.PartitionOptions {
+	return &runtime.PartitionOptions{PartitionsOffset: 2048 * 10}
+}

--- a/pkg/imager/profile/default.go
+++ b/pkg/imager/profile/default.go
@@ -367,4 +367,18 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	constants.BoardSOQuartzCM4: {
+		Arch:       "arm64",
+		Platform:   constants.PlatformMetal,
+		Board:      constants.BoardSOQuartzCM4,
+		SecureBoot: pointer.To(false),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatXZ,
+			ImageOptions: &ImageOptions{
+				DiskSize:   MinRAWDiskSize,
+				DiskFormat: DiskFormatRaw,
+			},
+		},
+	},
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -112,6 +112,9 @@ const (
 	// BoardNanoPiR4S is the name of the Friendlyelec Nano Pi R4S.
 	BoardNanoPiR4S = "nanopi_r4s"
 
+	// BoardSOQuartzCM4 is the name of the SOQuartz on a CM4 carrier board.
+	BoardSOQuartzCM4 = "soquartz_cm4"
+
 	// KernelParamHostname is the kernel parameter name for specifying the
 	// hostname.
 	KernelParamHostname = "talos.hostname"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Adds support for the [Pine64 SOQuartz](https://wiki.pine64.org/wiki/SOQuartz) SBC when mounted on a CM4 I/O board. This will likely be rebased against the upcoming community SBC repo, rather than the main Talos tree.

## Why? (reasoning)

Fixes #7112. CM4-compatible SBCs are common in lab k8s clusters like the Turing Pi 2.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] ~~you included tests (if applicable)~~
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

## Dependencies

- [ ] siderolabs/pkgs#860
- [ ] #8065
