### PR TITLE
fix: default priority for ipv6

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
@@ -1,6 +1,18 @@
 addresses: []
 links: []
-routes: []
+routes:
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: fe80::1234:5678:9abc
+      outLinkName: eth0
+      table: main
+      priority: 4096
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
 hostnames:
     - hostname: some
       domainname: fqdn
@@ -12,7 +24,7 @@ operators:
       linkName: eth0
       requireUp: true
       dhcp6:
-        routeMetric: 1024
+        routeMetric: 2048
       layer: default
 externalIPs:
     - 1.2.3.4

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -109,7 +109,7 @@ func (d *DigitalOcean) ParseMetadata(metadata *MetadataConfig) (*runtime.Platfor
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      nethelpers.FamilyInet4,
-					Priority:    1024,
+					Priority:    network.DefaultRouteMetric,
 				}
 
 				route.Normalize()
@@ -164,7 +164,7 @@ func (d *DigitalOcean) ParseMetadata(metadata *MetadataConfig) (*runtime.Platfor
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      nethelpers.FamilyInet6,
-					Priority:    1024,
+					Priority:    2 * network.DefaultRouteMetric,
 				}
 
 				route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/testdata/expected.yaml
@@ -69,7 +69,7 @@ routes:
       gateway: 2a03:b0c0:2:d0::1
       outLinkName: eth0
       table: main
-      priority: 1024
+      priority: 2048
       scope: global
       type: unicast
       flags: ""

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -85,7 +85,7 @@ func (g *GCP) ParseMetadata(metadata *MetadataConfig, interfaces []NetworkInterf
 			Operator: network.OperatorDHCP4,
 			LinkName: ifname,
 			DHCP4: network.DHCP4OperatorSpec{
-				RouteMetric: 1024,
+				RouteMetric: network.DefaultRouteMetric,
 			},
 			RequireUp:   true,
 			ConfigLayer: network.ConfigPlatform,
@@ -125,6 +125,7 @@ func (g *GCP) ParseMetadata(metadata *MetadataConfig, interfaces []NetworkInterf
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      nethelpers.FamilyInet6,
+				Priority:    2 * network.DefaultRouteMetric,
 			}
 
 			route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/testdata/expected.yaml
@@ -20,6 +20,7 @@ routes:
       gateway: fe80::4001:acff:fe10:1
       outLinkName: eth0
       table: main
+      priority: 2048
       scope: global
       type: unicast
       flags: ""

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -200,7 +200,7 @@ func (o *Openstack) ParseMetadata(
 				LinkName:  iface,
 				RequireUp: true,
 				DHCP4: network.DHCP4OperatorSpec{
-					RouteMetric:         1024,
+					RouteMetric:         network.DefaultRouteMetric,
 					SkipHostnameRequest: true,
 				},
 				ConfigLayer: network.ConfigPlatform,
@@ -211,7 +211,7 @@ func (o *Openstack) ParseMetadata(
 				LinkName:  iface,
 				RequireUp: true,
 				DHCP6: network.DHCP6OperatorSpec{
-					RouteMetric:         1024,
+					RouteMetric:         2 * network.DefaultRouteMetric,
 					SkipHostnameRequest: true,
 				},
 				ConfigLayer: network.ConfigPlatform,
@@ -260,7 +260,7 @@ func (o *Openstack) ParseMetadata(
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      family,
-					Priority:    1024,
+					Priority:    network.DefaultRouteMetric,
 				}
 
 				route.Normalize()
@@ -294,7 +294,7 @@ func (o *Openstack) ParseMetadata(
 				Protocol:    nethelpers.ProtocolStatic,
 				Type:        nethelpers.TypeUnicast,
 				Family:      family,
-				Priority:    1024,
+				Priority:    network.DefaultRouteMetric,
 			}
 
 			route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -187,7 +187,7 @@ operators:
       linkName: eth2
       requireUp: true
       dhcp6:
-        routeMetric: 1024
+        routeMetric: 2048
         skipHostnameRequest: true
       layer: platform
 externalIPs:

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -74,7 +74,7 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 		Protocol:    nethelpers.ProtocolStatic,
 		Type:        nethelpers.TypeUnicast,
 		Family:      nethelpers.FamilyInet4,
-		Priority:    1024,
+		Priority:    network.DefaultRouteMetric,
 	}
 
 	route.Normalize()
@@ -85,7 +85,7 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 		LinkName:  "eth0",
 		RequireUp: true,
 		DHCP4: network.DHCP4OperatorSpec{
-			RouteMetric: 1024,
+			RouteMetric: network.DefaultRouteMetric,
 		},
 		ConfigLayer: network.ConfigPlatform,
 	})
@@ -128,7 +128,7 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 			Protocol:    nethelpers.ProtocolStatic,
 			Type:        nethelpers.TypeUnicast,
 			Family:      nethelpers.FamilyInet6,
-			Priority:    1024,
+			Priority:    2 * network.DefaultRouteMetric,
 		}
 
 		route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected.yaml
@@ -32,7 +32,7 @@ routes:
       gateway: '2001:111:222:3333::'
       outLinkName: eth0
       table: main
-      priority: 1024
+      priority: 2048
       scope: global
       type: unicast
       flags: ""

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -89,7 +89,7 @@ func (u *UpCloud) ParseMetadata(metadata *MetadataConfig) (*runtime.PlatformNetw
 					LinkName:  iface,
 					RequireUp: true,
 					DHCP4: network.DHCP4OperatorSpec{
-						RouteMetric: 1024,
+						RouteMetric: network.DefaultRouteMetric,
 					},
 					ConfigLayer: network.ConfigPlatform,
 				})
@@ -141,7 +141,7 @@ func (u *UpCloud) ParseMetadata(metadata *MetadataConfig) (*runtime.PlatformNetw
 						Protocol:    nethelpers.ProtocolStatic,
 						Type:        nethelpers.TypeUnicast,
 						Family:      family,
-						Priority:    1024,
+						Priority:    network.DefaultRouteMetric,
 					}
 
 					route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
@@ -125,7 +125,7 @@ func (v *Vultr) ParseMetadata(metadata *metadata.MetaData) (*runtime.PlatformNet
 				LinkName:  iface,
 				RequireUp: true,
 				DHCP4: network.DHCP4OperatorSpec{
-					RouteMetric: 1024,
+					RouteMetric: network.DefaultRouteMetric,
 				},
 				ConfigLayer: network.ConfigPlatform,
 			})


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

We will use the default IPv6 gateway priority as 2048. The RA default is 1024, which leads to verbose messages such as 'error adding route: netlink receive: file exists.'

Azure uses DHCPv6 and RA for configuring IPv6 on the node. The platform sets the default gateway as a fallback in case 'accept_ra' is not set to 2.

PS. @smira can we backport it to 1.6.x?  Thanks.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
