### PR TITLE
fix: disk UUID & WWID always empty in `talosctl disks`

### DIFF
--- a/internal/app/storaged/server.go
+++ b/internal/app/storaged/server.go
@@ -40,6 +40,8 @@ func (s *Server) Disks(ctx context.Context, in *emptypb.Empty) (reply *storage.D
 			Name:       d.Name,
 			Serial:     d.Serial,
 			Modalias:   d.Modalias,
+			Uuid:       d.UUID,
+			Wwid:       d.WWID,
 			Type:       storage.Disk_DiskType(d.Type),
 			BusPath:    d.BusPath,
 			SystemDisk: systemDisk != nil && d.DeviceName == systemDisk.Device().Name(),


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

`talosctl disks` always show empty UUID and WWID which is annoying if you want to select an install disk by a stable hardware attribute.

https://github.com/siderolabs/omni-feedback/issues/54#issuecomment-1712956202

## Why? (reasoning)

Missing UUID and WWID attributes during conversion from go-blockdevice Disk to protobuf Disk

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
