### PR TITLE
fix: force KubePrism to connect using IPv4

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -243,7 +243,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 
 				var server string
 				if cfgProvider.Machine().Features().KubePrism().Enabled() {
-					server = fmt.Sprintf("https://localhost:%d", cfgProvider.Machine().Features().KubePrism().Port())
+					server = fmt.Sprintf("https://127.0.0.1:%d", cfgProvider.Machine().Features().KubePrism().Port())
 				} else {
 					server = cfgProvider.Cluster().Endpoint().String()
 				}

--- a/internal/app/machined/pkg/controllers/k8s/kubeprism_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubeprism_config.go
@@ -55,7 +55,7 @@ func NewKubePrismConfigController() *KubePrismConfigController {
 
 				spec := res.TypedSpec()
 				spec.Endpoints = endpt.TypedSpec().Endpoints
-				spec.Host = "localhost"
+				spec.Host = "127.0.0.1"
 				spec.Port = cfg.Config().Machine().Features().KubePrism().Port()
 
 				return nil

--- a/internal/app/machined/pkg/controllers/k8s/kubeprism_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubeprism_config_test.go
@@ -61,7 +61,7 @@ func (suite *KubePrismConfigControllerSuite) TestGeneration() {
 	ctest.AssertResource(suite, k8s.KubePrismConfigID, func(e *k8s.KubePrismConfig, asrt *assert.Assertions) {
 		asrt.Equal(
 			&k8s.KubePrismConfigSpec{
-				Host: "localhost",
+				Host: "127.0.0.1",
 				Port: 7445,
 				Endpoints: []k8s.KubePrismEndpoint{
 					{Host: "example.com", Port: 443},
@@ -94,7 +94,7 @@ func (suite *KubePrismConfigControllerSuite) TestGeneration() {
 	ctest.AssertResource(suite, k8s.KubePrismConfigID, func(e *k8s.KubePrismConfig, asrt *assert.Assertions) {
 		asrt.Equal(
 			&k8s.KubePrismConfigSpec{
-				Host: "localhost",
+				Host: "127.0.0.1",
 				Port: 7446,
 				Endpoints: []k8s.KubePrismEndpoint{
 					{Host: "example.com", Port: 443},
@@ -115,7 +115,7 @@ func (suite *KubePrismConfigControllerSuite) TestGeneration() {
 	ctest.AssertResource(suite, k8s.KubePrismConfigID, func(e *k8s.KubePrismConfig, asrt *assert.Assertions) {
 		asrt.Equal(
 			&k8s.KubePrismConfigSpec{
-				Host: "localhost",
+				Host: "127.0.0.1",
 				Port: 7445,
 				Endpoints: []k8s.KubePrismEndpoint{
 					{Host: "example.com", Port: 443},

--- a/internal/app/machined/pkg/controllers/secrets/kubelet.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubelet.go
@@ -44,7 +44,7 @@ func NewKubeletController() *KubeletController {
 				switch {
 				case cfgProvider.Machine().Features().KubePrism().Enabled():
 					// use cluster endpoint for controlplane nodes with loadbalancer support
-					localEndpoint, err := url.Parse(fmt.Sprintf("https://localhost:%d", cfgProvider.Machine().Features().KubePrism().Port()))
+					localEndpoint, err := url.Parse(fmt.Sprintf("https://127.0.0.1:%d", cfgProvider.Machine().Features().KubePrism().Port()))
 					if err != nil {
 						return err
 					}

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -135,6 +136,7 @@ func (ctrl *KubernetesCertSANsController) Run(ctx context.Context, r controller.
 
 			spec.AppendIPs(k8sRoot.APIServerIPs...)
 			spec.AppendIPs(nodeAddresses.IPs()...)
+			spec.AppendIPs(netip.MustParseAddr("127.0.0.1"))
 
 			spec.Sort()
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
@@ -101,7 +101,7 @@ func (suite *KubernetesCertSANsSuite) TestReconcile() {
 				"some.url",
 			}, spec.DNSNames,
 		)
-		suite.Assert().Equal("[10.2.1.3 10.4.3.2 172.16.0.1]", fmt.Sprintf("%v", spec.IPs))
+		suite.Assert().Equal("[10.2.1.3 10.4.3.2 127.0.0.1 172.16.0.1]", fmt.Sprintf("%v", spec.IPs))
 
 		return nil
 	})

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -83,7 +83,7 @@ func NewRootKubernetesController() *RootKubernetesController {
 				)
 
 				if cfgProvider.Machine().Features().KubePrism().Enabled() {
-					localEndpoint, err = url.Parse(fmt.Sprintf("https://localhost:%d", cfgProvider.Machine().Features().KubePrism().Port()))
+					localEndpoint, err = url.Parse(fmt.Sprintf("https://127.0.0.1:%d", cfgProvider.Machine().Features().KubePrism().Port()))
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Before this change KubePrism used hardcoded "localhost" as destination which Go could resolve to IPv6 destination and then fail to connect to. This change forces KubePrism to connect using IPv4 and uses hardcoded "127.0.0.1" destination so it will always use IPv4.

For #8112