### PR TITLE
fix: efi fat32 compatibility with nvme 4KBn sector size

### DIFF
--- a/internal/pkg/partition/constants.go
+++ b/internal/pkg/partition/constants.go
@@ -30,7 +30,9 @@ const (
 const (
 	MiB = 1024 * 1024
 
-	EFISize      = 100 * MiB
+	// The actual minimum size is 65595 × 4 KB(NVME sector size)
+	// = 268677120 bytes = 256.23046875 MB.
+	EFISize      = 260 * MiB
 	BIOSGrubSize = 1 * MiB
 	BootSize     = 1000 * MiB
 	// EFIUKISize is the size of the EFI partition when UKI is enabled.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Fix the compatibility For Advanced Format 4K Native drives (4-KB-per-sector) drives, the minimum size is 260 MB, due to a limitation of the FAT32 file format.
## Why? (reasoning)
FAT32 spec :
- https://github.com/dosfstools/dosfstools/blob/master/src/mkfs.fat.c#L125
- https://www.cs.fsu.edu/~cop4610t/assignments/project3/spec/fatspec.pdf
- https://superuser.com/questions/1702331/what-is-the-minimum-size-of-a-4k-native-partition-when-formatted-with-fat32
- https://bbs.archlinux.org/viewtopic.php?id=168014

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
