### PR TITLE
fix: fix .der output in `talosctl gen secureboot`

### DIFF
--- a/website/content/v1.6/talos-guides/install/bare-metal-platforms/secureboot.md
+++ b/website/content/v1.6/talos-guides/install/bare-metal-platforms/secureboot.md
@@ -136,10 +136,12 @@ Talos provides a utility to generate the keys, but existing PKI infrastructure c
 ```shell
 $ talosctl gen secureboot uki --common-name "SecureBoot Key"
 writing _out/uki-signing-cert.pem
+writing _out/uki-signing-cert.der
 writing _out/uki-signing-key.pem
 ```
 
 The generated certificate and private key are written to disk in PEM-encoded format (RSA 4096-bit key).
+The certificate is also written in DER format for the systems which expect the certificate in DER format.
 
 PCR signing key can be generated with:
 


### PR DESCRIPTION
PEM was converted to DER incorrectly when the output was a X509 certificate and not a public key.

Skip unnecessary parsing of it to an RSA public key before writing it in DER format as output.

Simplify the code as we do not generate `*-signing-public-key.pem` anymore.
