### PR TITLE
chore: allow custom registry to build installer/imager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,90 +7,91 @@ ARG PKGS
 ARG PKG_KERNEL
 ARG EXTRAS
 ARG INSTALLER_ARCH
+ARG PKGS_PREFIX
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
-FROM ghcr.io/siderolabs/fhs:${PKGS} AS pkg-fhs
-FROM ghcr.io/siderolabs/ca-certificates:${PKGS} AS pkg-ca-certificates
+FROM ${PKGS_PREFIX}/fhs:${PKGS} AS pkg-fhs
+FROM ${PKGS_PREFIX}/ca-certificates:${PKGS} AS pkg-ca-certificates
 
-FROM --platform=amd64 ghcr.io/siderolabs/cryptsetup:${PKGS} AS pkg-cryptsetup-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/cryptsetup:${PKGS} AS pkg-cryptsetup-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/cryptsetup:${PKGS} AS pkg-cryptsetup-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/cryptsetup:${PKGS} AS pkg-cryptsetup-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/containerd:${PKGS} AS pkg-containerd-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/containerd:${PKGS} AS pkg-containerd-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/containerd:${PKGS} AS pkg-containerd-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/containerd:${PKGS} AS pkg-containerd-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/dosfstools:${PKGS} AS pkg-dosfstools-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/dosfstools:${PKGS} AS pkg-dosfstools-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/dosfstools:${PKGS} AS pkg-dosfstools-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/dosfstools:${PKGS} AS pkg-dosfstools-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/eudev:${PKGS} AS pkg-eudev-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/eudev:${PKGS} AS pkg-eudev-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/eudev:${PKGS} AS pkg-eudev-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/eudev:${PKGS} AS pkg-eudev-arm64
 
-FROM ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub
-FROM --platform=amd64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/grub:${PKGS} AS pkg-grub-arm64
+FROM ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub
+FROM --platform=amd64 ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub-arm64
 
-FROM ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot
-FROM --platform=amd64 ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/sd-boot:${PKGS} AS pkg-sd-boot-arm64
+FROM ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot
+FROM --platform=amd64 ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/iptables:${PKGS} AS pkg-iptables-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/iptables:${PKGS} AS pkg-iptables-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/iptables:${PKGS} AS pkg-iptables-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/iptables:${PKGS} AS pkg-iptables-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/ipxe:${PKGS} AS pkg-ipxe-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/ipxe:${PKGS} AS pkg-ipxe-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/ipxe:${PKGS} AS pkg-ipxe-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/ipxe:${PKGS} AS pkg-ipxe-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/libinih:${PKGS} AS pkg-libinih-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/libinih:${PKGS} AS pkg-libinih-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/libinih:${PKGS} AS pkg-libinih-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/libinih:${PKGS} AS pkg-libinih-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/libjson-c:${PKGS} AS pkg-libjson-c-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/libjson-c:${PKGS} AS pkg-libjson-c-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/libjson-c:${PKGS} AS pkg-libjson-c-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/libjson-c:${PKGS} AS pkg-libjson-c-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/libpopt:${PKGS} AS pkg-libpopt-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/libpopt:${PKGS} AS pkg-libpopt-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/libpopt:${PKGS} AS pkg-libpopt-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/libpopt:${PKGS} AS pkg-libpopt-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/liburcu:${PKGS} AS pkg-liburcu-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/liburcu:${PKGS} AS pkg-liburcu-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/liburcu:${PKGS} AS pkg-liburcu-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/liburcu:${PKGS} AS pkg-liburcu-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/openssl:${PKGS} AS pkg-openssl-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/openssl:${PKGS} AS pkg-openssl-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/openssl:${PKGS} AS pkg-openssl-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/openssl:${PKGS} AS pkg-openssl-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/libseccomp:${PKGS} AS pkg-libseccomp-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/libseccomp:${PKGS} AS pkg-libseccomp-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/libseccomp:${PKGS} AS pkg-libseccomp-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/libseccomp:${PKGS} AS pkg-libseccomp-arm64
 
 # linux-firmware is not arch-specific
-FROM --platform=amd64 ghcr.io/siderolabs/linux-firmware:${PKGS} AS pkg-linux-firmware
+FROM --platform=amd64 ${PKGS_PREFIX}/linux-firmware:${PKGS} AS pkg-linux-firmware
 
-FROM --platform=amd64 ghcr.io/siderolabs/lvm2:${PKGS} AS pkg-lvm2-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/lvm2:${PKGS} AS pkg-lvm2-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/lvm2:${PKGS} AS pkg-lvm2-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/lvm2:${PKGS} AS pkg-lvm2-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/libaio:${PKGS} AS pkg-libaio-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/libaio:${PKGS} AS pkg-libaio-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/libaio:${PKGS} AS pkg-libaio-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/libaio:${PKGS} AS pkg-libaio-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/musl:${PKGS} AS pkg-musl-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/musl:${PKGS} AS pkg-musl-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/runc:${PKGS} AS pkg-runc-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/runc:${PKGS} AS pkg-runc-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/runc:${PKGS} AS pkg-runc-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/runc:${PKGS} AS pkg-runc-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/xfsprogs:${PKGS} AS pkg-xfsprogs-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/xfsprogs:${PKGS} AS pkg-xfsprogs-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/xfsprogs:${PKGS} AS pkg-xfsprogs-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/xfsprogs:${PKGS} AS pkg-xfsprogs-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/util-linux:${PKGS} AS pkg-util-linux-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/util-linux:${PKGS} AS pkg-util-linux-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/util-linux:${PKGS} AS pkg-util-linux-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/util-linux:${PKGS} AS pkg-util-linux-arm64
 
-FROM --platform=amd64 ghcr.io/siderolabs/kmod:${PKGS} AS pkg-kmod-amd64
-FROM --platform=arm64 ghcr.io/siderolabs/kmod:${PKGS} AS pkg-kmod-arm64
+FROM --platform=amd64 ${PKGS_PREFIX}/kmod:${PKGS} AS pkg-kmod-amd64
+FROM --platform=arm64 ${PKGS_PREFIX}/kmod:${PKGS} AS pkg-kmod-arm64
 
 FROM ${PKG_KERNEL} AS pkg-kernel
 FROM --platform=amd64 ${PKG_KERNEL} AS pkg-kernel-amd64
 FROM --platform=arm64 ${PKG_KERNEL} AS pkg-kernel-arm64
 
-FROM --platform=arm64 ghcr.io/siderolabs/u-boot:${PKGS} AS pkg-u-boot-arm64
-FROM --platform=arm64 ghcr.io/siderolabs/raspberrypi-firmware:${PKGS} AS pkg-raspberrypi-firmware-arm64
+FROM --platform=arm64 ${PKGS_PREFIX}/u-boot:${PKGS} AS pkg-u-boot-arm64
+FROM --platform=arm64 ${PKGS_PREFIX}/raspberrypi-firmware:${PKGS} AS pkg-raspberrypi-firmware-arm64
 
 # Resolve package images using ${EXTRAS} to be used later in COPY --from=.
 
-FROM ghcr.io/siderolabs/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
+FROM ${PKGS_PREFIX}/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
 
 # The tools target provides base toolchain for the build.
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ CLOUD_IMAGES_EXTRA_ARGS ?= ""
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.7.0-alpha.0
+PKGS_PREFIX ?= ghcr.io/siderolabs
 PKGS ?= v1.7.0-alpha.0-11-g2d3ca68
-PKG_KERNEL ?= ghcr.io/siderolabs/kernel:$(PKGS)
+PKG_KERNEL ?= $(PKGS_PREFIX)/kernel:$(PKGS)
 EXTRAS ?= v1.7.0-alpha.0
 # renovate: datasource=github-tags depName=golang/go
 GO_VERSION ?= 1.21
@@ -144,6 +145,7 @@ COMMON_ARGS += --build-arg=NAME=$(NAME)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
+COMMON_ARGS += --build-arg=PKGS_PREFIX=$(PKGS_PREFIX)
 COMMON_ARGS += --build-arg=ABBREV_TAG=$(ABBREV_TAG)
 
 CI_ARGS ?=


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

use registry and username inside Dockerfile to allow build with custom registry

## Why? (reasoning)

impossible to `make imager` with specific kernel built and pkgs version

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
