### PR TITLE
fix: use correct TTL for talosconfig in `talosctl config new`

### DIFF
--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -31,6 +31,7 @@ import (
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
@@ -617,7 +618,7 @@ func init() {
 	)
 
 	configNewCmd.Flags().StringSliceVar(&configNewCmdFlags.roles, "roles", role.MakeSet(role.Admin).Strings(), "roles")
-	configNewCmd.Flags().DurationVar(&configNewCmdFlags.crtTTL, "crt-ttl", 87600*time.Hour, "certificate TTL")
+	configNewCmd.Flags().DurationVar(&configNewCmdFlags.crtTTL, "crt-ttl", constants.TalosAPIDefaultCertificateValidityDuration, "certificate TTL")
 
 	configInfoCmd.Flags().StringVarP(&configInfoCmdFlags.output, "output", "o", "text", "output format (json|yaml|text). Default text.")
 

--- a/website/content/v1.7/reference/cli.md
+++ b/website/content/v1.7/reference/cli.md
@@ -538,7 +538,7 @@ talosctl config new [<path>] [flags]
 ### Options
 
 ```
-      --crt-ttl duration   certificate TTL (default 87600h0m0s)
+      --crt-ttl duration   certificate TTL (default 8760h0m0s)
   -h, --help               help for new
       --roles strings      roles (default [os:admin])
 ```


### PR DESCRIPTION
See #8152
