### PR TITLE
fix: allow META encoded values to be compressed

### DIFF
--- a/cmd/installer/pkg/install/meta_value.go
+++ b/cmd/installer/pkg/install/meta_value.go
@@ -103,7 +103,7 @@ func (s *MetaValues) GetSlice() []string {
 
 // Encode returns the encoded values.
 func (s *MetaValues) Encode() string {
-	return s.values.Encode()
+	return s.values.Encode(false)
 }
 
 // Decode the values from the given string.

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/internal/pkg/secureboot/uki"
 	"github.com/siderolabs/talos/pkg/imager/extensions"
 	"github.com/siderolabs/talos/pkg/imager/profile"
+	"github.com/siderolabs/talos/pkg/imager/quirks"
 	"github.com/siderolabs/talos/pkg/imager/utils"
 	"github.com/siderolabs/talos/pkg/machinery/config/merge"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -276,7 +277,10 @@ func (i *Imager) buildCmdline() error {
 	// meta values can be written only to the "image" output
 	if len(i.prof.Customization.MetaContents) > 0 && i.prof.Output.Kind != profile.OutKindImage {
 		// pass META values as kernel talos.environment args which will be passed via the environment to the installer
-		cmdline.Append(constants.KernelParamEnvironment, constants.MetaValuesEnvVar+"="+i.prof.Customization.MetaContents.Encode())
+		cmdline.Append(
+			constants.KernelParamEnvironment,
+			constants.MetaValuesEnvVar+"="+i.prof.Customization.MetaContents.Encode(quirks.New(i.prof.Version).SupportsCompressedEncodedMETA()),
+		)
 	}
 
 	// apply customization

--- a/pkg/imager/quirks/quirks.go
+++ b/pkg/imager/quirks/quirks.go
@@ -33,3 +33,15 @@ func (q Quirks) SupportsResetGRUBOption() bool {
 
 	return q.v.GTE(minVersionResetOption)
 }
+
+var minVersionCompressedMETA = semver.MustParse("1.6.3")
+
+// SupportsCompressedEncodedMETA returns true if the Talos version supports compressed and encoded META as an environment variable.
+func (q Quirks) SupportsCompressedEncodedMETA() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minVersionCompressedMETA)
+}

--- a/pkg/imager/quirks/quirks_test.go
+++ b/pkg/imager/quirks/quirks_test.go
@@ -35,3 +35,31 @@ func TestSupportsResetOption(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsCompressedEncodedMETA(t *testing.T) {
+	for _, test := range []struct {
+		version string
+
+		expected bool
+	}{
+		{
+			version:  "1.6.3",
+			expected: true,
+		},
+		{
+			version:  "1.7.0",
+			expected: true,
+		},
+		{
+			expected: true,
+		},
+		{
+			version:  "1.6.2",
+			expected: false,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			assert.Equal(t, test.expected, quirks.New(test.version).SupportsCompressedEncodedMETA())
+		})
+	}
+}

--- a/website/content/v1.7/advanced/metal-network-configuration.md
+++ b/website/content/v1.7/advanced/metal-network-configuration.md
@@ -403,7 +403,7 @@ kernel command line: ... talos.environment=INSTALLER_META_BASE64=MHhhPWZvbw==
 When PXE booting, the value of `INSTALLER_META_BASE64` should be set manually:
 
 ```bash
-echo -n "0xa=$(cat network.yaml)" | base64
+echo -n "0xa=$(cat network.yaml)" | gzip -9 | base64
 ```
 
 The resulting base64 string should be passed as an environment variable `INSTALLER_META_BASE64` to the initial boot of Talos: `talos.environment=INSTALLER_META_BASE64=<base64-encoded value>`.


### PR DESCRIPTION
Fixes #8186

This is planned to be backported to Talos 1.6.3.

This allows to pass large META values (YAML for platform network configuration) which might otherwise exceed the limit for kernel command line params.
