### PR TITLE
Fix #8190 - vmware.md - add missing talos-config option to the vmtools-secret step

### DIFF
--- a/website/content/v1.0/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.0/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.1/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.2/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.2/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.3/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.3/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.4/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.4/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.5/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.5/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
-aliases: 
+aliases:
   - ../../../virtualized-platforms/vmware
 ---
 
@@ -296,7 +296,7 @@ The talos-vmtoolsd application was deployed as a daemonset as part of the cluste
 Create a new talosconfig with:
 
 ```bash
-talosctl -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
+talosctl --talosconfig talosconfig -n <control plane IP> config new vmtoolsd-secret.yaml --roles os:admin
 ```
 
 Create a secret from the talosconfig:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Fixes #8190 - a documentation bug.

## Why? (reasoning)

Better documentation.

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
