### PR TITLE
docs: copy generated JSON schema to host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -300,6 +300,7 @@ COPY --from=generate-build /api/inspect/*.pb.go /pkg/machinery/api/inspect/
 COPY --from=go-generate /src/pkg/flannel/ /pkg/flannel/
 COPY --from=go-generate /src/pkg/imager/profile/ /pkg/imager/profile/
 COPY --from=go-generate /src/pkg/machinery/resources/ /pkg/machinery/resources/
+COPY --from=go-generate /src/pkg/machinery/config/schemas/ /pkg/machinery/config/schemas/
 COPY --from=go-generate /src/pkg/machinery/config/types/ /pkg/machinery/config/types/
 COPY --from=go-generate /src/pkg/machinery/nethelpers/ /pkg/machinery/nethelpers/
 COPY --from=go-generate /src/pkg/machinery/extensions/ /pkg/machinery/extensions/

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2604,6 +2604,13 @@
           "description": "Kernel driver, supports matching by wildcard.\n",
           "markdownDescription": "Kernel driver, supports matching by wildcard.",
           "x-intellij-html-description": "\u003cp\u003eKernel driver, supports matching by wildcard.\u003c/p\u003e\n"
+        },
+        "physical": {
+          "type": "boolean",
+          "title": "physical",
+          "description": "Select only physical devices.\n",
+          "markdownDescription": "Select only physical devices.",
+          "x-intellij-html-description": "\u003cp\u003eSelect only physical devices.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/website/content/v1.7/schemas/config.schema.json
+++ b/website/content/v1.7/schemas/config.schema.json
@@ -2604,6 +2604,13 @@
           "description": "Kernel driver, supports matching by wildcard.\n",
           "markdownDescription": "Kernel driver, supports matching by wildcard.",
           "x-intellij-html-description": "\u003cp\u003eKernel driver, supports matching by wildcard.\u003c/p\u003e\n"
+        },
+        "physical": {
+          "type": "boolean",
+          "title": "physical",
+          "description": "Select only physical devices.\n",
+          "markdownDescription": "Select only physical devices.",
+          "x-intellij-html-description": "\u003cp\u003eSelect only physical devices.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
After the JSON schema is generated in a build container, copy it over to the host, so it becomes a part of the codebase.

This is required as the location of the schema changed recently from being under `pkg/machinery/config/types/` to be under `pkg/machinery/config/schemas/`.
