### PR TITLE
Update vmware.sh

### DIFF
--- a/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware/vmware.sh
+++ b/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware/vmware.sh
@@ -10,6 +10,7 @@ set -e
 # export GOVC_INSECURE=true
 # export GOVC_URL='https://172.16.199.151'
 # export GOVC_DATASTORE='xxx'
+# export GOVC_NETWORK='PortGroup Name'
 
 CLUSTER_NAME=${CLUSTER_NAME:=vmware-test}
 TALOS_VERSION=v1.1.0
@@ -55,6 +56,13 @@ create () {
 
         govc vm.disk.change -vm ${CLUSTER_NAME}-control-plane-${i} -disk.name disk-1000-0 -size ${CONTROL_PLANE_DISK}
 
+        if [ -z "${GOVC_NETWORK+x}" ]; then
+             echo "GOVC_NETWORK is unset, assuming default VM Network";
+        else
+            echo "GOVC_NETWORK set to ${GOVC_NETWORK}";
+            govc vm.network.change -vm ${CLUSTER_NAME}-control-plane-${i} -net ${GOVC_NETWORK} ethernet-0
+        fi
+
         govc vm.power -on ${CLUSTER_NAME}-control-plane-${i}
     done
 
@@ -74,6 +82,14 @@ create () {
         -vm ${CLUSTER_NAME}-worker-${i}
 
         govc vm.disk.change -vm ${CLUSTER_NAME}-worker-${i} -disk.name disk-1000-0 -size ${WORKER_DISK}
+
+        if [ -z "${GOVC_NETWORK+x}" ]; then
+             echo "GOVC_NETWORK is unset, assuming default VM Network";
+        else
+            echo "GOVC_NETWORK set to ${GOVC_NETWORK}";
+            govc vm.network.change -vm ${CLUSTER_NAME}-worker-${i} -net ${GOVC_NETWORK} ethernet-0
+        fi
+
 
         govc vm.power -on ${CLUSTER_NAME}-worker-${i}
     done

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/vmware.sh
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/vmware.sh
@@ -10,6 +10,7 @@ set -e
 # export GOVC_INSECURE=true
 # export GOVC_URL='https://172.16.199.151'
 # export GOVC_DATASTORE='xxx'
+# export GOVC_NETWORK='PortGroup Name'
 
 CLUSTER_NAME=${CLUSTER_NAME:=vmware-test}
 TALOS_VERSION=v1.1.0
@@ -55,6 +56,13 @@ create () {
 
         govc vm.disk.change -vm ${CLUSTER_NAME}-control-plane-${i} -disk.name disk-1000-0 -size ${CONTROL_PLANE_DISK}
 
+        if [ -z "${GOVC_NETWORK+x}" ]; then
+             echo "GOVC_NETWORK is unset, assuming default VM Network";
+        else
+            echo "GOVC_NETWORK set to ${GOVC_NETWORK}";
+            govc vm.network.change -vm ${CLUSTER_NAME}-control-plane-${i} -net ${GOVC_NETWORK} ethernet-0
+        fi
+
         govc vm.power -on ${CLUSTER_NAME}-control-plane-${i}
     done
 
@@ -74,6 +82,14 @@ create () {
         -vm ${CLUSTER_NAME}-worker-${i}
 
         govc vm.disk.change -vm ${CLUSTER_NAME}-worker-${i} -disk.name disk-1000-0 -size ${WORKER_DISK}
+
+        if [ -z "${GOVC_NETWORK+x}" ]; then
+             echo "GOVC_NETWORK is unset, assuming default VM Network";
+        else
+            echo "GOVC_NETWORK set to ${GOVC_NETWORK}";
+            govc vm.network.change -vm ${CLUSTER_NAME}-worker-${i} -net ${GOVC_NETWORK} ethernet-0
+        fi
+
 
         govc vm.power -on ${CLUSTER_NAME}-worker-${i}
     done


### PR DESCRIPTION
Add support for using the GOVC_NETWORK environment variable to determine which vSphere vSwitch PortGroup to use.

This checks if the GOVC_NETWORK environment variable is set, if that's the case, use that value. If not, continue with the default PortGroup (VM Network) as before.

Checks added for both control plane and worker nodes.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
