### PR TITLE
fix: be more tolerant to error handling in Mounts API

### DIFF
--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -31,7 +31,7 @@ var mountsCmd = &cobra.Command{
 			resp, err := c.Mounts(ctx, grpc.Peer(&remotePeer))
 			if err != nil {
 				if resp == nil {
-					return fmt.Errorf("error getting interfaces: %s", err)
+					return fmt.Errorf("error getting mount information: %s", err)
 				}
 
 				cli.Warning("%s", err)


### PR DESCRIPTION
Fixes #8202

If some mountpoint can't be queried successfully for 'diskfree' information, don't treat that as an error, and report zero values for disk usage/size instead.
