### PR TITLE
BUGFIX: Added cancel method to fix context leak

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/discovery_service.go
+++ b/internal/app/machined/pkg/controllers/cluster/discovery_service.go
@@ -246,7 +246,8 @@ func (ctrl *DiscoveryServiceController) Run(ctx context.Context, r controller.Ru
 
 			var clientCtx context.Context
 
-			clientCtx, clientCtxCancel = context.WithCancel(ctx) //nolint:govet
+			clientCtx, clientCtxCancel = context.WithCancel(ctx)
+			defer clientCtxCancel()
 
 			ctrl.discoveryConfigVersion = discoveryConfig.Metadata().Version()
 

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
@@ -138,7 +138,8 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 
 		if notifyCh == nil {
 			var watchCtx context.Context
-			watchCtx, watchCtxCancel = context.WithCancel(ctx) //nolint:govet
+			watchCtx, watchCtxCancel = context.WithCancel(ctx)
+			defer watchCtxCancel()
 
 			notifyCh, notifyCloser, err = kubernetesRegistry.Watch(watchCtx, logger)
 			if err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/node_status.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_status.go
@@ -135,7 +135,8 @@ func (ctrl *NodeStatusController) Run(ctx context.Context, r controller.Runtime,
 
 		if notifyCh == nil {
 			var watchCtx context.Context
-			watchCtx, watchCtxCancel = context.WithCancel(ctx) //nolint:govet
+			watchCtx, watchCtxCancel = context.WithCancel(ctx)
+			defer watchCtxCancel()
 
 			notifyCh, notifyCloser, err = nodewatcher.Watch(watchCtx, logger)
 			if err != nil {

--- a/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount.go
+++ b/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount.go
@@ -166,7 +166,8 @@ func (ctrl *CRDController) Run(ctx context.Context, r controller.Runtime, logger
 
 		var crdControllerCtx context.Context
 
-		crdControllerCtx, crdControllerCtxCancel = context.WithCancel(ctx) //nolint:govet
+		crdControllerCtx, crdControllerCtxCancel = context.WithCancel(ctx)
+		defer crdControllerCtxCancel()
 
 		go func() {
 			crdControllerErrCh <- ctrl.runCRDController(

--- a/internal/app/machined/pkg/controllers/time/sync.go
+++ b/internal/app/machined/pkg/controllers/time/sync.go
@@ -208,7 +208,8 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 
 			timeSynced = false
 
-			syncCtx, syncCtxCancel = context.WithCancel(ctx) //nolint:govet
+			syncCtx, syncCtxCancel = context.WithCancel(ctx)
+			defer syncCtxCancel()
 
 			syncWg.Add(1)
 


### PR DESCRIPTION
## What? (description)
This PR fixes context leak bugs in your code.


## Why? (reasoning)
While triaging your project, our bug fixing tool generated a few warnings-
> Possible context leak. The returned cancel function should be called in all paths.

When using context in Go, it's suggested that the returned `cancelFunc` be called using a `defer` statement. I have fixed these by calling the cancel handlers in defer statements.

## Acceptance
Please use the following checklist:
- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.