### PR TITLE
chore: bump timeout in acquire tests

### DIFF
--- a/internal/app/machined/pkg/controllers/config/acquire_test.go
+++ b/internal/app/machined/pkg/controllers/config/acquire_test.go
@@ -132,7 +132,7 @@ func TestAcquireSuite(t *testing.T) {
 
 	s := &AcquireSuite{
 		DefaultSuite: ctest.DefaultSuite{
-			Timeout: 5 * time.Second,
+			Timeout: 15 * time.Second,
 		},
 	}
 

--- a/internal/app/machined/pkg/controllers/secrets/root_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/root_test.go
@@ -27,7 +27,7 @@ func TestRootSuite(t *testing.T) {
 
 	suite.Run(t, &RootSuite{
 		DefaultSuite: ctest.DefaultSuite{
-			Timeout: 5 * time.Second,
+			Timeout: 10 * time.Second,
 			AfterSetup: func(suite *ctest.DefaultSuite) {
 				suite.Require().NoError(suite.Runtime().RegisterController(secretsctrl.NewRootEtcdController()))
 				suite.Require().NoError(suite.Runtime().RegisterController(secretsctrl.NewRootKubernetesController()))


### PR DESCRIPTION
With switching to RSA service account, machine config generation time is considerably higher now, so the test might not make it in time.
