### PR TITLE
chore: allow custom pkgs to build talos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,94 +4,122 @@
 
 ARG TOOLS
 ARG PKGS
-ARG PKG_KERNEL
 ARG EXTRAS
 ARG INSTALLER_ARCH
+
 ARG PKGS_PREFIX
+ARG PKG_FHS
+ARG PKG_CA_CERTIFICATES
+ARG PKG_CRYPTSETUP
+ARG PKG_CONTAINERD
+ARG PKG_DOSFSTOOLS
+ARG PKG_EUDEV
+ARG PKG_GRUB
+ARG PKG_SD_BOOT
+ARG PKG_IPTABLES
+ARG PKG_IPXE
+ARG PKG_LIBINIH
+ARG PKG_LIBJSON_C
+ARG PKG_LIBPOPT
+ARG PKG_LIBURCU
+ARG PKG_OPENSSL
+ARG PKG_LIBSECCOMP
+ARG PKG_LINUX_FIRMWARE
+ARG PKG_LVM2
+ARG PKG_LIBAIO
+ARG PKG_MUSL
+ARG PKG_RUNC
+ARG PKG_XFSPROGS
+ARG PKG_UTIL_LINUX
+ARG PKG_KMOD
+ARG PKG_U_BOOT
+ARG PKG_RASPBERY_PI_FIRMWARE
+ARG PKG_KERNEL
+ARG PKG_TALOSCTL_CNI_BUNDLE_INSTALL
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
-FROM ${PKGS_PREFIX}/fhs:${PKGS} AS pkg-fhs
-FROM ${PKGS_PREFIX}/ca-certificates:${PKGS} AS pkg-ca-certificates
+FROM ${PKG_FHS} AS pkg-fhs
+FROM ${PKG_CA_CERTIFICATES} AS pkg-ca-certificates
 
-FROM --platform=amd64 ${PKGS_PREFIX}/cryptsetup:${PKGS} AS pkg-cryptsetup-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/cryptsetup:${PKGS} AS pkg-cryptsetup-arm64
+FROM --platform=amd64 ${PKG_CRYPTSETUP} AS pkg-cryptsetup-amd64
+FROM --platform=arm64 ${PKG_CRYPTSETUP} AS pkg-cryptsetup-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/containerd:${PKGS} AS pkg-containerd-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/containerd:${PKGS} AS pkg-containerd-arm64
+FROM --platform=amd64 ${PKG_CONTAINERD} AS pkg-containerd-amd64
+FROM --platform=arm64 ${PKG_CONTAINERD} AS pkg-containerd-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/dosfstools:${PKGS} AS pkg-dosfstools-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/dosfstools:${PKGS} AS pkg-dosfstools-arm64
+FROM --platform=amd64 ${PKG_DOSFSTOOLS} AS pkg-dosfstools-amd64
+FROM --platform=arm64 ${PKG_DOSFSTOOLS} AS pkg-dosfstools-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/eudev:${PKGS} AS pkg-eudev-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/eudev:${PKGS} AS pkg-eudev-arm64
+FROM --platform=amd64 ${PKG_EUDEV} AS pkg-eudev-amd64
+FROM --platform=arm64 ${PKG_EUDEV} AS pkg-eudev-arm64
 
-FROM ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub
-FROM --platform=amd64 ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub-arm64
+FROM ${PKG_GRUB} AS pkg-grub
+FROM --platform=amd64 ${PKG_GRUB} AS pkg-grub-amd64
+FROM --platform=arm64 ${PKG_GRUB} AS pkg-grub-arm64
 
-FROM ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot
-FROM --platform=amd64 ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/sd-boot:${PKGS} AS pkg-sd-boot-arm64
+FROM ${PKG_SD_BOOT} AS pkg-sd-boot
+FROM --platform=amd64 ${PKG_SD_BOOT} AS pkg-sd-boot-amd64
+FROM --platform=arm64 ${PKG_SD_BOOT} AS pkg-sd-boot-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/iptables:${PKGS} AS pkg-iptables-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/iptables:${PKGS} AS pkg-iptables-arm64
+FROM --platform=amd64 ${PKG_IPTABLES} AS pkg-iptables-amd64
+FROM --platform=arm64 ${PKG_IPTABLES} AS pkg-iptables-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/ipxe:${PKGS} AS pkg-ipxe-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/ipxe:${PKGS} AS pkg-ipxe-arm64
+FROM --platform=amd64 ${PKG_IPXE} AS pkg-ipxe-amd64
+FROM --platform=arm64 ${PKG_IPXE} AS pkg-ipxe-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/libinih:${PKGS} AS pkg-libinih-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/libinih:${PKGS} AS pkg-libinih-arm64
+FROM --platform=amd64 ${PKG_LIBINIH} AS pkg-libinih-amd64
+FROM --platform=arm64 ${PKG_LIBINIH} AS pkg-libinih-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/libjson-c:${PKGS} AS pkg-libjson-c-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/libjson-c:${PKGS} AS pkg-libjson-c-arm64
+FROM --platform=amd64 ${PKG_LIBJSON_C} AS pkg-libjson-c-amd64
+FROM --platform=arm64 ${PKG_LIBJSON_C} AS pkg-libjson-c-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/libpopt:${PKGS} AS pkg-libpopt-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/libpopt:${PKGS} AS pkg-libpopt-arm64
+FROM --platform=amd64 ${PKG_LIBPOPT} AS pkg-libpopt-amd64
+FROM --platform=arm64 ${PKG_LIBPOPT} AS pkg-libpopt-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/liburcu:${PKGS} AS pkg-liburcu-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/liburcu:${PKGS} AS pkg-liburcu-arm64
+FROM --platform=amd64 ${PKG_LIBURCU} AS pkg-liburcu-amd64
+FROM --platform=arm64 ${PKG_LIBURCU} AS pkg-liburcu-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/openssl:${PKGS} AS pkg-openssl-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/openssl:${PKGS} AS pkg-openssl-arm64
+FROM --platform=amd64 ${PKG_OPENSSL} AS pkg-openssl-amd64
+FROM --platform=arm64 ${PKG_OPENSSL} AS pkg-openssl-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/libseccomp:${PKGS} AS pkg-libseccomp-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/libseccomp:${PKGS} AS pkg-libseccomp-arm64
+FROM --platform=amd64 ${PKG_LIBSECCOMP} AS pkg-libseccomp-amd64
+FROM --platform=arm64 ${PKG_LIBSECCOMP} AS pkg-libseccomp-arm64
 
 # linux-firmware is not arch-specific
-FROM --platform=amd64 ${PKGS_PREFIX}/linux-firmware:${PKGS} AS pkg-linux-firmware
+FROM --platform=amd64 ${PKG_LINUX_FIRMWARE} AS pkg-linux-firmware
 
-FROM --platform=amd64 ${PKGS_PREFIX}/lvm2:${PKGS} AS pkg-lvm2-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/lvm2:${PKGS} AS pkg-lvm2-arm64
+FROM --platform=amd64 ${PKG_LVM2} AS pkg-lvm2-amd64
+FROM --platform=arm64 ${PKG_LVM2} AS pkg-lvm2-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/libaio:${PKGS} AS pkg-libaio-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/libaio:${PKGS} AS pkg-libaio-arm64
+FROM --platform=amd64 ${PKG_LIBAIO} AS pkg-libaio-amd64
+FROM --platform=arm64 ${PKG_LIBAIO} AS pkg-libaio-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/musl:${PKGS} AS pkg-musl-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/musl:${PKGS} AS pkg-musl-arm64
+FROM --platform=amd64 ${PKG_MUSL} AS pkg-musl-amd64
+FROM --platform=arm64 ${PKG_MUSL} AS pkg-musl-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/runc:${PKGS} AS pkg-runc-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/runc:${PKGS} AS pkg-runc-arm64
+FROM --platform=amd64 ${PKG_RUNC} AS pkg-runc-amd64
+FROM --platform=arm64 ${PKG_RUNC} AS pkg-runc-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/xfsprogs:${PKGS} AS pkg-xfsprogs-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/xfsprogs:${PKGS} AS pkg-xfsprogs-arm64
+FROM --platform=amd64 ${PKG_XFSPROGS} AS pkg-xfsprogs-amd64
+FROM --platform=arm64 ${PKG_XFSPROGS} AS pkg-xfsprogs-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/util-linux:${PKGS} AS pkg-util-linux-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/util-linux:${PKGS} AS pkg-util-linux-arm64
+FROM --platform=amd64 ${PKG_UTIL_LINUX} AS pkg-util-linux-amd64
+FROM --platform=arm64 ${PKG_UTIL_LINUX} AS pkg-util-linux-arm64
 
-FROM --platform=amd64 ${PKGS_PREFIX}/kmod:${PKGS} AS pkg-kmod-amd64
-FROM --platform=arm64 ${PKGS_PREFIX}/kmod:${PKGS} AS pkg-kmod-arm64
+FROM --platform=amd64 ${PKG_KMOD} AS pkg-kmod-amd64
+FROM --platform=arm64 ${PKG_KMOD} AS pkg-kmod-arm64
 
 FROM ${PKG_KERNEL} AS pkg-kernel
 FROM --platform=amd64 ${PKG_KERNEL} AS pkg-kernel-amd64
 FROM --platform=arm64 ${PKG_KERNEL} AS pkg-kernel-arm64
 
-FROM --platform=arm64 ${PKGS_PREFIX}/u-boot:${PKGS} AS pkg-u-boot-arm64
-FROM --platform=arm64 ${PKGS_PREFIX}/raspberrypi-firmware:${PKGS} AS pkg-raspberrypi-firmware-arm64
+FROM --platform=arm64 ${PKG_U_BOOT} AS pkg-u-boot-arm64
+FROM --platform=arm64 ${PKG_RASPBERY_PI_FIRMWARE} AS pkg-raspberrypi-firmware-arm64
 
 # Resolve package images using ${EXTRAS} to be used later in COPY --from=.
 
-FROM ${PKGS_PREFIX}/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
+FROM ${PKG_TALOSCTL_CNI_BUNDLE_INSTALL} AS extras-talosctl-cni-bundle-install
 
 # The tools target provides base toolchain for the build.
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,40 @@ CLOUD_IMAGES_EXTRA_ARGS ?= ""
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.7.0-alpha.0-5-gf4b41d1
+
 PKGS_PREFIX ?= ghcr.io/siderolabs
 PKGS ?= v1.7.0-alpha.0-19-g96cc841
-PKG_KERNEL ?= $(PKGS_PREFIX)/kernel:$(PKGS)
 EXTRAS ?= v1.7.0-alpha.0
+
+PKG_FHS ?= $(PKGS_PREFIX)/fhs:$(PKGS)
+PKG_CA_CERTIFICATES ?= $(PKGS_PREFIX)/ca-certificates:$(PKGS)
+PKG_CRYPTSETUP ?= $(PKGS_PREFIX)/cryptsetup:$(PKGS)
+PKG_CONTAINERD ?= $(PKGS_PREFIX)/containerd:$(PKGS)
+PKG_DOSFSTOOLS ?= $(PKGS_PREFIX)/dosfstools:$(PKGS)
+PKG_EUDEV ?= $(PKGS_PREFIX)/eudev:$(PKGS)
+PKG_GRUB ?= $(PKGS_PREFIX)/grub:$(PKGS)
+PKG_SD_BOOT ?= $(PKGS_PREFIX)/sd-boot:$(PKGS)
+PKG_IPTABLES ?= $(PKGS_PREFIX)/iptables:$(PKGS)
+PKG_IPXE ?= $(PKGS_PREFIX)/ipxe:$(PKGS)
+PKG_LIBINIH ?= $(PKGS_PREFIX)/libinih:$(PKGS)
+PKG_LIBJSON_C ?= $(PKGS_PREFIX)/libjson-c:$(PKGS)
+PKG_LIBPOPT ?= $(PKGS_PREFIX)/libpopt:$(PKGS)
+PKG_LIBURCU ?= $(PKGS_PREFIX)/liburcu:$(PKGS)
+PKG_OPENSSL ?= $(PKGS_PREFIX)/openssl:$(PKGS)
+PKG_LIBSECCOMP ?= $(PKGS_PREFIX)/libseccomp:$(PKGS)
+PKG_LINUX_FIRMWARE ?= $(PKGS_PREFIX)/linux-firmware:$(PKGS)
+PKG_LVM2 ?= $(PKGS_PREFIX)/lvm2:$(PKGS)
+PKG_LIBAIO ?= $(PKGS_PREFIX)/libaio:$(PKGS)
+PKG_MUSL ?= $(PKGS_PREFIX)/musl:$(PKGS)
+PKG_RUNC ?= $(PKGS_PREFIX)/runc:$(PKGS)
+PKG_XFSPROGS ?= $(PKGS_PREFIX)/xfsprogs:$(PKGS)
+PKG_UTIL_LINUX ?= $(PKGS_PREFIX)/util-linux:$(PKGS)
+PKG_KMOD ?= $(PKGS_PREFIX)/kmod:$(PKGS)
+PKG_U_BOOT ?= $(PKGS_PREFIX)/u-boot:$(PKGS)
+PKG_RASPBERY_PI_FIRMWARE ?= $(PKGS_PREFIX)/raspberry-pi-firmware:$(PKGS)
+PKG_KERNEL ?= $(PKGS_PREFIX)/kernel:$(PKGS)
+PKG_TALOSCTL_CNI_BUNDLE_INSTALL ?= $(PKGS_PREFIX)/talosctl-cni-bundle-install:$(EXTRA)
+
 # renovate: datasource=github-tags depName=golang/go
 GO_VERSION ?= 1.21
 # renovate: datasource=go depName=golang.org/x/tools


### PR DESCRIPTION
# Pull Request

## What? (description)

Use provided pkgs inside Dockerfile to allow build with custom pkgs from any registry

## Why? (reasoning)

Following on from #8164, impossible to `make imager` or `make installer` with specific u-boot build
It would be nice to be able to customise all of the components so that we could more easily test, fork and contribute to certain packages while remaining based on Talos releases for unaffected elements.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
