### PR TITLE
fix: pass TTL when generating client certificate

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -2092,7 +2092,7 @@ func (s *Server) GenerateClientConfiguration(ctx context.Context, in *machine.Ge
 
 	secretsBundle := secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), s.Controller.Runtime().Config())
 
-	cert, err := secretsBundle.GenerateTalosAPIClientCertificate(roles)
+	cert, err := secretsBundle.GenerateTalosAPIClientCertificateWithTTL(roles, crtTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -125,6 +125,20 @@ func (suite *TalosconfigSuite) TestMerge() {
 	suite.Require().NotNil(c.Contexts["foo-1"])
 }
 
+// TestNewTTL checks `talosctl config new --crt-ttl`.
+func (suite *TalosconfigSuite) TestNewTTL() {
+	tempDir := suite.T().TempDir()
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+
+	talosconfig := filepath.Join(tempDir, "talosconfig")
+	suite.RunCLI([]string{"--nodes", node, "config", "new", "--roles", "os:reader", talosconfig, "--crt-ttl", "17520h"},
+		base.StdoutEmpty())
+
+	suite.RunCLI([]string{"config", "info", "--talosconfig", talosconfig},
+		base.StdoutShouldMatch(regexp.MustCompile(`2 years from now`)))
+}
+
 // TestNew checks `talosctl config new`.
 func (suite *TalosconfigSuite) TestNew() {
 	stdout, _ := suite.RunCLI([]string{"version", "--json", "--nodes", suite.RandomDiscoveredNodeInternalIP()})

--- a/pkg/machinery/config/generate/secrets/bundle.go
+++ b/pkg/machinery/config/generate/secrets/bundle.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/siderolabs/crypto/x509"
 	"gopkg.in/yaml.v3"
@@ -358,10 +359,15 @@ func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
 
 // GenerateTalosAPIClientCertificate generates the admin certificate.
 func (bundle *Bundle) GenerateTalosAPIClientCertificate(roles role.Set) (*x509.PEMEncodedCertificateAndKey, error) {
+	return bundle.GenerateTalosAPIClientCertificateWithTTL(roles, constants.TalosAPIDefaultCertificateValidityDuration)
+}
+
+// GenerateTalosAPIClientCertificateWithTTL generates the admin certificate with specified TTL.
+func (bundle *Bundle) GenerateTalosAPIClientCertificateWithTTL(roles role.Set, crtTTL time.Duration) (*x509.PEMEncodedCertificateAndKey, error) {
 	return NewAdminCertificateAndKey(
 		bundle.Clock.Now(),
 		bundle.Certs.OS,
 		roles,
-		constants.TalosAPIDefaultCertificateValidityDuration,
+		crtTTL,
 	)
 }


### PR DESCRIPTION
# Pull Request

## What?
This PR adds a TTL argument to the `GenerateTalosAPIClientCertificate` function.

Fixes #8250.

## Why?

The value of the `--crt-ttl` argument of the `talosctl config new` command did not get passed to the `GenerateTalosAPIClientCertificate` function which generates a new client certificate, causing the default of one year to always be used.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

