### PR TITLE
chore: fix markdown-lint call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -959,7 +959,7 @@ RUN markdownlint \
     --ignore '**/hack/chglog/**' \
     --ignore 'website/content/*/reference/*' \
     --ignore 'website/themes/**' \
-    --disable MD045 MD056 \
+    --disable MD045 MD056 -- \
     .
 RUN find . \
     -name '*.md' \


### PR DESCRIPTION
Don't ask me why this weird syntax for flags.

Don't ask me why it fails with exit code zero (success) on invalid flags.
