### PR TITLE
chore: allow uuid-based hostnames in talosctl cluster create

### DIFF
--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -100,6 +100,9 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	}
 
 	nodeUUID := uuid.New()
+	if nodeReq.UUID != nil {
+		nodeUUID = *nodeReq.UUID
+	}
 
 	apiPort, err := p.findBridgeListenPort(clusterReq)
 	if err != nil {

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
@@ -180,6 +181,11 @@ type NodeRequest struct {
 	//
 	// This doesn't apply to boots from ISO or from the disk image.
 	ExtraKernelArgs *procfs.Cmdline
+
+	// UUID allows to specify the UUID of the node (VMs only).
+	//
+	// If not specified, a random UUID will be generated.
+	UUID *uuid.UUID
 
 	// Testing features
 

--- a/website/content/v1.7/reference/cli.md
+++ b/website/content/v1.7/reference/cli.md
@@ -168,6 +168,7 @@ talosctl cluster create [flags]
       --with-network-packet-reorder float        specify percent of reordered packets on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
       --with-tpm2                                enable TPM2 emulation support using swtpm
       --with-uefi                                enable UEFI on x86_64 architecture (default true)
+      --with-uuid-hostnames                      use machine UUIDs as default hostnames (QEMU only)
       --workers int                              the number of workers to create (default 1)
 ```
 


### PR DESCRIPTION
This is useful when the VMs are booted without machine config, so default hostnames based on controlplanes/workers no longer make sense.
