### PR TITLE
feat: custom image settings for k8s upgrade

### DIFF
--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -49,6 +49,13 @@ func init() {
 	upgradeK8sCmd.Flags().BoolVar(&upgradeOptions.DryRun, "dry-run", false, "skip the actual upgrade and show the upgrade plan instead")
 	upgradeK8sCmd.Flags().BoolVar(&upgradeOptions.PrePullImages, "pre-pull-images", true, "pre-pull images before upgrade")
 	upgradeK8sCmd.Flags().BoolVar(&upgradeOptions.UpgradeKubelet, "upgrade-kubelet", true, "upgrade kubelet service")
+
+	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.KubeletImage, "kubelet-image", constants.KubeletImage, "kubelet image to use")
+	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.APIServerImage, "apiserver-image", constants.KubernetesAPIServerImage, "kube-apiserver image to use")
+	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.ControllerManagerImage, "controller-manager-image", constants.KubernetesControllerManagerImage, "kube-controller-manager image to use")
+	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.SchedulerImage, "scheduler-image", constants.KubernetesSchedulerImage, "kube-scheduler image to use")
+	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.ProxyImage, "proxy-image", constants.KubeProxyImage, "kube-proxy image to use")
+
 	addCommand(upgradeK8sCmd)
 }
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -95,6 +95,13 @@ config:
 ```
 """
 
+    [notes.k8supgrade]
+        title = "Kubernetes Upgrade"
+        description = """\
+The command `talosctl upgrade-k8s` now supports specifying custom image references for Kubernetes components via `--*-image` flags.
+The default behavior is unchanged, and the flags are optional.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -417,6 +417,12 @@ func (suite *BaseSuite) upgradeKubernetes(fromVersion, toVersion string, skipKub
 		UpgradeKubelet: !skipKubeletUpgrade,
 		PrePullImages:  true,
 
+		KubeletImage:           constants.KubeletImage,
+		APIServerImage:         constants.KubernetesAPIServerImage,
+		ControllerManagerImage: constants.KubernetesControllerManagerImage,
+		SchedulerImage:         constants.KubernetesSchedulerImage,
+		ProxyImage:             constants.KubeProxyImage,
+
 		EncoderOpt: encoder.WithComments(encoder.CommentsAll),
 	}
 

--- a/pkg/cluster/kubernetes/kubelet.go
+++ b/pkg/cluster/kubernetes/kubelet.go
@@ -22,7 +22,6 @@ import (
 	"github.com/siderolabs/talos/pkg/kubernetes"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	v1alpha1config "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -199,7 +198,7 @@ func upgradeKubeletPatcher(
 			}
 		}
 
-		image := fmt.Sprintf("%s:v%s", constants.KubeletImage, options.Path.ToVersion())
+		image := fmt.Sprintf("%s:v%s", options.KubeletImage, options.Path.ToVersion())
 
 		if oldImage == image {
 			return errUpdateSkipped

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -32,6 +32,12 @@ type UpgradeOptions struct {
 	DryRun               bool
 	EncoderOpt           encoder.Option
 
+	KubeletImage           string
+	APIServerImage         string
+	ControllerManagerImage string
+	SchedulerImage         string
+	ProxyImage             string
+
 	controlPlaneNodes []string
 	workerNodes       []string
 }

--- a/website/content/v1.7/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.7/kubernetes-guides/upgrading-kubernetes.md
@@ -106,6 +106,8 @@ This command runs in several phases:
 
 If the command fails for any reason, it can be safely restarted to continue the upgrade process from the moment of the failure.
 
+> Note: When using custom/overridden Kubernetes component images, use flags `--*-image` to override the default image names.
+
 ## Manual Kubernetes Upgrade
 
 Kubernetes can be upgraded manually by following the steps outlined below.

--- a/website/content/v1.7/reference/cli.md
+++ b/website/content/v1.7/reference/cli.md
@@ -2887,15 +2887,20 @@ talosctl upgrade-k8s [flags]
 ### Options
 
 ```
-      --dry-run           skip the actual upgrade and show the upgrade plan instead
-      --endpoint string   the cluster control plane endpoint
-      --from string       the Kubernetes control plane version to upgrade from
-  -h, --help              help for upgrade-k8s
-      --pre-pull-images   pre-pull images before upgrade (default true)
-      --to string         the Kubernetes control plane version to upgrade to (default "1.29.1")
-      --upgrade-kubelet   upgrade kubelet service (default true)
-      --with-docs         patch all machine configs adding the documentation for each field (default true)
-      --with-examples     patch all machine configs with the commented examples (default true)
+      --apiserver-image string            kube-apiserver image to use (default "registry.k8s.io/kube-apiserver")
+      --controller-manager-image string   kube-controller-manager image to use (default "registry.k8s.io/kube-controller-manager")
+      --dry-run                           skip the actual upgrade and show the upgrade plan instead
+      --endpoint string                   the cluster control plane endpoint
+      --from string                       the Kubernetes control plane version to upgrade from
+  -h, --help                              help for upgrade-k8s
+      --kubelet-image string              kubelet image to use (default "ghcr.io/siderolabs/kubelet")
+      --pre-pull-images                   pre-pull images before upgrade (default true)
+      --proxy-image string                kube-proxy image to use (default "registry.k8s.io/kube-proxy")
+      --scheduler-image string            kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
+      --to string                         the Kubernetes control plane version to upgrade to (default "1.29.1")
+      --upgrade-kubelet                   upgrade kubelet service (default true)
+      --with-docs                         patch all machine configs adding the documentation for each field (default true)
+      --with-examples                     patch all machine configs with the commented examples (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->
Fixes: #8275 
## What? (description)
* Adding management of private registries for k8s upgrades
* set image before condition
* format

Due to the usage of authentication for image pullin adding this in the pre-pull feature was to big that is why we enable the feature only on --pre-pull=false.
It could be another feature. 

## Why? (reasoning)
The cli patch MachineConfig using public registries. This break automatic upgrade because of public registries overwriting.
 
## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

Co-author : @g3offrey