### PR TITLE
fix: decoding config document with wrong apiVersion

### DIFF
--- a/pkg/machinery/config/configloader/configloader_fuzz_test.go
+++ b/pkg/machinery/config/configloader/configloader_fuzz_test.go
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build go1.18
-
 package configloader_test
 
 import (

--- a/pkg/machinery/config/configloader/configloader_test.go
+++ b/pkg/machinery/config/configloader/configloader_test.go
@@ -48,6 +48,8 @@ func callMethods(t testing.TB, obj reflect.Value, chain ...string) {
 			fallthrough
 		case "Doc":
 			fallthrough
+		case "APIUrl":
+			fallthrough
 		case "Endpoint":
 			// t.Logf("Skipping %v", nextChain)
 			continue

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -289,6 +289,19 @@ apiVersion: v1alpha3
 omit: false
 `),
 		},
+		{
+			name: "misspelled apiVersion",
+			source: []byte(`---
+apiversion: v1alpha1
+kind: ExtensionServicesConfig
+config:
+    - name: nut-client
+      configFiles:
+          - content: MONITOR ${upsmonHost} 1 remote pass foo
+            mountPath: /usr/local/etc/nut/upsmon.conf
+`),
+			expectedErr: "\"ExtensionServicesConfig\" \"\": not registered",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/machinery/config/configloader/testdata/fuzz/FuzzConfigLoader/dfd1adfe630cffc2
+++ b/pkg/machinery/config/configloader/testdata/fuzz/FuzzConfigLoader/dfd1adfe630cffc2
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("apiVersion: v1alpha1\nkind: SideroLinkConfig")

--- a/pkg/machinery/config/configloader/testdata/multidoc2.test
+++ b/pkg/machinery/config/configloader/testdata/multidoc2.test
@@ -1,0 +1,7 @@
+apiVersion: v1alpha1
+kind: ExtensionServicesConfig
+config:
+    - name: foo
+      configFiles:
+        - content: hello
+          mountPath: /etc/foo

--- a/pkg/machinery/config/configloader/testdata/multidoc3.test
+++ b/pkg/machinery/config/configloader/testdata/multidoc3.test
@@ -1,0 +1,26 @@
+apiVersion: v1alpha1
+kind: NetworkDefaultActionConfig
+ingress: block
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: test
+portSelector:
+    ports:
+        - 53
+        - 8000-9000
+    protocol: udp
+ingress:
+    - subnet: 192.168.0.0/16
+      except: 192.168.0.3/32
+    - subnet: 2001::/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: www
+portSelector:
+    ports:
+        - 80
+    protocol: tcp
+ingress:
+    - subnet: 192.168.0.0/16

--- a/pkg/machinery/config/internal/registry/registry_test.go
+++ b/pkg/machinery/config/internal/registry/registry_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/internal/registry"
+)
+
+type mockDocument struct {
+	kind, version string
+}
+
+func (d mockDocument) Clone() config.Document {
+	return d
+}
+
+func (d mockDocument) Kind() string {
+	return d.kind
+}
+
+func (d mockDocument) APIVersion() string {
+	return d.version
+}
+
+func mockFactory(kind, version string) registry.NewDocumentFunc {
+	return func(requestedVersion string) config.Document {
+		if requestedVersion == version {
+			return mockDocument{kind, version}
+		}
+
+		return nil
+	}
+}
+
+func TestRegistry(t *testing.T) {
+	r := registry.NewRegistry()
+
+	// register document types
+	r.Register("kind1", mockFactory("kind1", "v1alpha1"))
+	r.Register("kind2", mockFactory("kind2", "v1alpha1"))
+
+	// register duplicate kind
+	assert.Panics(t, func() {
+		r.Register("kind1", mockFactory("kind1", "v1alpha3"))
+	})
+
+	// attempt to get unregistered kind
+	_, err := r.New("unknownKind", "unknownVersion")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, registry.ErrNotRegistered)
+	assert.EqualError(t, err, "\"unknownKind\" \"unknownVersion\": not registered")
+
+	// successful creation of documents
+	d, err := r.New("kind1", "v1alpha1")
+	require.NoError(t, err)
+	assert.Equal(t, "kind1", d.Kind())
+	assert.Equal(t, "v1alpha1", d.APIVersion())
+
+	d, err = r.New("kind2", "v1alpha1")
+	require.NoError(t, err)
+	assert.Equal(t, "kind2", d.Kind())
+	assert.Equal(t, "v1alpha1", d.APIVersion())
+
+	// attempt get registered kind, but wrong version
+	_, err = r.New("kind1", "unknownVersion")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, registry.ErrNotRegistered)
+	assert.EqualError(t, err, "\"kind1\" \"unknownVersion\": not registered")
+}


### PR DESCRIPTION
Fixes #8270

The base bug was that the registry will return `nil` `ConfigDocument` if the version is not registered for a kind, which would result into weird config decoding errors.

Add more unit-tests, while at it, also add more fuzzing samples.
