### PR TITLE
docs: Update VMware Tools URL for VMware Guide

### DIFF
--- a/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware.md
@@ -39,7 +39,7 @@ It's contents should look like the following:
 - op: replace
   path: /cluster/extraManifests
   value:
-    - "https://raw.githubusercontent.com/mologie/talos-vmtoolsd/master/deploy/unstable.yaml"
+    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"
 ```
 
 With the patch in hand, generate machine configs with:

--- a/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
+++ b/website/content/v1.6/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
@@ -9,4 +9,4 @@
 - op: replace
   path: /cluster/extraManifests
   value:
-    - "https://raw.githubusercontent.com/mologie/talos-vmtoolsd/master/deploy/unstable.yaml"
+    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
@@ -39,7 +39,7 @@ It's contents should look like the following:
 - op: replace
   path: /cluster/extraManifests
   value:
-    - "https://raw.githubusercontent.com/mologie/talos-vmtoolsd/master/deploy/unstable.yaml"
+    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"
 ```
 
 With the patch in hand, generate machine configs with:

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
@@ -9,4 +9,4 @@
 - op: replace
   path: /cluster/extraManifests
   value:
-    - "https://raw.githubusercontent.com/mologie/talos-vmtoolsd/master/deploy/unstable.yaml"
+    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
The URL to the VMware tools manifest was no longer correct.

## Why? (reasoning)
The guide should link to a URL that works.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
