### PR TITLE
chore: deprecate `environmentFile` for extensions

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -96,6 +96,9 @@ environment:
 ```
 
 For documentation, see [Extension Services Config Files](https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/).
+
+**Note**: The use of `environmentFile` in extension service spec is now deprecated and will be removed in a future release of Talos.
+Use `ExtensionServiceConfig` instead.
 """
 
     [notes.k8supgrade]

--- a/website/content/v1.7/advanced/extension-services.md
+++ b/website/content/v1.7/advanced/extension-services.md
@@ -27,8 +27,6 @@ Format of the extension service config:
 name: hello-world
 container:
   entrypoint: ./hello-world
-  # an optional path to a file containing environment variables
-  environmentFile: /var/etc/hello-world/env
   environment:
     - XDG_RUNTIME_DIR=/run
   args:
@@ -57,8 +55,10 @@ The extension service will be registered as a Talos service under an `ext-<name>
 ### `container`
 
 * `entrypoint` defines the container entrypoint relative to the container root filesystem (`/usr/local/lib/containers/<name>`)
-* `environmentFile` defines the path to a file containing environment variables, the service waits for the file to exist before starting
-* `environment` defines the container environment variables, overrides the variables from `environmentFile`
+* `environmentFile` (**deprecated**) defines the path to a file containing environment variables, the service waits for the file to
+  exist before starting.
+  Use `ExtensionServiceConfig` instead.
+* `environment` defines the container environment variables.
 * `args` defines the additional arguments to pass to the entrypoint
 * `mounts` defines the volumes to be mounted into the container root
 

--- a/website/content/v1.7/talos-guides/upgrading-talos.md
+++ b/website/content/v1.7/talos-guides/upgrading-talos.md
@@ -36,7 +36,23 @@ For example, if upgrading from Talos 1.0 to Talos 1.2.4, the recommended upgrade
 
 ## Before Upgrade to {{% release %}}
 
-There are no specific actions to be taken before an upgrade.
+If running `tailscale` or `nut-client` extension, follow the below steps for upgrade.
+
+### nut-client
+
+First start by editing the machine config in `staged` mode (`talosctl edit mc --mode=staged`) and remove the `.machine.files` section that adds the `nut-client` config.
+
+Now upgrade talos to `{{% release %}}`, the `nut-client` service would now be waiting for the `ExtensionServiceConfig` document.
+
+Create a config document as described in the `nut-client` [README](https://github.com/siderolabs/extensions/blob/main/power/nut-client/README.md#usage) and apply the patch.
+
+### tailscale
+
+First start by editing the machine config in `staged` mode (`talosctl edit mc --mode=staged`) and remove the `.machine.files` section that adds the `tailscale` auth key file.
+
+Upgrade talos to `{{% release %}}`, the `tailscale` service would now be waiting for the `ExtensionServiceConfig` document.
+
+Create a config document as described in the `tailscale` [README](https://github.com/siderolabs/extensions/blob/main/network/tailscale/README.md#usage) and apply the patch.
 
 Please review the [release notes]({{< relref "../introduction/what-is-new" >}}) for any changes that may affect your cluster.
 


### PR DESCRIPTION
Deprecate `environmentFile` for extension services in favor of `ExtensionServiceConfig`.