### PR TITLE
fix: correctly handle partial configs in `DNSUpstreamController`

### DIFF
--- a/internal/app/machined/pkg/controllers/network/dns_upstream.go
+++ b/internal/app/machined/pkg/controllers/network/dns_upstream.go
@@ -90,7 +90,8 @@ func (ctrl *DNSUpstreamController) run(ctx context.Context, r controller.Runtime
 		return err
 	}
 
-	if !mc.Config().Machine().Features().LocalDNSEnabled() {
+	machineConfig := mc.Config().Machine()
+	if machineConfig == nil || !machineConfig.Features().LocalDNSEnabled() {
 		return nil
 	}
 


### PR DESCRIPTION
Prevent `DNSUpstreamController` from panicking by checking if the `machine` section in the config is `nil`. This is the case when a machine has partial configuration, e.g., when the machine has only a `SideroLinkConfig` in its config.
