### PR TITLE
fix: platform opennebula - only set gateway if is set in context

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
@@ -127,26 +127,28 @@ func (o *OpenNebula) ParseMetadata(st state.State, oneContextPlain []byte) (*run
 						},
 					)
 
-					// Parse gateway address and create RouteSpecSpec entry
-					gateway, err := netip.ParseAddr(oneContext[ifaceName+"_GATEWAY"])
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse gateway ip: %w", err)
+					if oneContext[ifaceName+"_GATEWAY"] != "" {
+						// Parse gateway address and create RouteSpecSpec entry
+						gateway, err := netip.ParseAddr(oneContext[ifaceName+"_GATEWAY"])
+						if err != nil {
+							return nil, fmt.Errorf("failed to parse gateway ip: %w", err)
+						}
+
+						route := network.RouteSpecSpec{
+							ConfigLayer: network.ConfigPlatform,
+							Gateway:     gateway,
+							OutLinkName: ifaceNameLower,
+							Table:       nethelpers.TableMain,
+							Protocol:    nethelpers.ProtocolStatic,
+							Type:        nethelpers.TypeUnicast,
+							Family:      nethelpers.FamilyInet4,
+							Priority:    network.DefaultRouteMetric,
+						}
+
+						route.Normalize()
+
+						networkConfig.Routes = append(networkConfig.Routes, route)
 					}
-
-					route := network.RouteSpecSpec{
-						ConfigLayer: network.ConfigPlatform,
-						Gateway:     gateway,
-						OutLinkName: ifaceNameLower,
-						Table:       nethelpers.TableMain,
-						Protocol:    nethelpers.ProtocolStatic,
-						Type:        nethelpers.TypeUnicast,
-						Family:      nethelpers.FamilyInet4,
-						Priority:    network.DefaultRouteMetric,
-					}
-
-					route.Normalize()
-
-					networkConfig.Routes = append(networkConfig.Routes, route)
 
 					// Parse DNS servers
 					dnsServers := strings.Fields(oneContext[ifaceName+"_DNS"])


### PR DESCRIPTION
# Pull Request

fix for feature https://github.com/siderolabs/talos/pull/8249 

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Fix for the platform OpenNebula to only set gateway if is set in context.

## Why? (reasoning)
to resolve error when you attach a second nic to the vm without gateway

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
