### PR TITLE
chore: allow non preallocated disks for QEMU cluster

### DIFF
--- a/pkg/provision/providers/vm/disk.go
+++ b/pkg/provision/providers/vm/disk.go
@@ -42,8 +42,10 @@ func (p *Provisioner) CreateDisks(state *State, nodeReq provision.NodeRequest) (
 			return nil, err
 		}
 
-		if err = syscall.Fallocate(int(diskF.Fd()), 0, 0, int64(disk.Size)); err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: failed to preallocate disk space for %q (size %d): %s", diskPath, disk.Size, err)
+		if !disk.SkipPreallocate {
+			if err = syscall.Fallocate(int(diskF.Fd()), 0, 0, int64(disk.Size)); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: failed to preallocate disk space for %q (size %d): %s", diskPath, disk.Size, err)
+			}
 		}
 
 		diskPaths[i] = diskPath

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -150,6 +150,8 @@ func (reqs NodeRequests) PXENodes() (nodes []NodeRequest) {
 type Disk struct {
 	// Size in bytes.
 	Size uint64
+	// Whether to skip preallocating the disk space.
+	SkipPreallocate bool
 	// Partitions represents the list of partitions.
 	Partitions []*v1alpha1.DiskPartition
 }

--- a/website/content/v1.7/reference/cli.md
+++ b/website/content/v1.7/reference/cli.md
@@ -112,6 +112,7 @@ talosctl cluster create [flags]
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
       --disk-encryption-key-types stringArray    encryption key types to use for disk encryption (uuid, kms) (default [uuid])
       --disk-image-path string                   disk image to use
+      --disk-preallocate                         whether disk space should be preallocated (default true)
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
       --docker-disable-ipv6                      skip enabling IPv6 in containers (Docker only)
       --docker-host-ip string                    Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Added an option to disable `fallocate` calls on QEMU images

## Why? (reasoning)
Preallocation is still done by default for correct max usage estimates, but in development environment it could be beneficial not to use up that space, so I added a flag to disable preallocation and provision the image thinly.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
