### PR TITLE
fix: handle errors to watch apid/trustd certs

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -81,7 +81,7 @@ func apidMain() error {
 	stateClient := v1alpha1.NewStateClient(runtimeConn)
 	resources := state.WrapCore(client.NewAdapter(stateClient))
 
-	tlsConfig, err := provider.NewTLSConfig(resources)
+	tlsConfig, err := provider.NewTLSConfig(ctx, resources)
 	if err != nil {
 		return fmt.Errorf("failed to create remote certificate provider: %w", err)
 	}
@@ -223,6 +223,10 @@ func apidMain() error {
 
 	errGroup.Go(func() error {
 		return socketServer.Serve(socketListener)
+	})
+
+	errGroup.Go(func() error {
+		return tlsConfig.Watch(ctx)
 	})
 
 	errGroup.Go(func() error {

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// Package trustd implements trustd functionality.
 package trustd
 
 import (
@@ -78,7 +79,7 @@ func trustdMain() error {
 	stateClient := v1alpha1.NewStateClient(runtimeConn)
 	resources := state.WrapCore(client.NewAdapter(stateClient))
 
-	tlsConfig, err := provider.NewTLSConfig(resources)
+	tlsConfig, err := provider.NewTLSConfig(ctx, resources)
 	if err != nil {
 		return fmt.Errorf("failed to create remote certificate provider: %w", err)
 	}
@@ -112,6 +113,10 @@ func trustdMain() error {
 
 	errGroup.Go(func() error {
 		return networkServer.Serve(networkListener)
+	})
+
+	errGroup.Go(func() error {
+		return tlsConfig.Watch(ctx)
 	})
 
 	errGroup.Go(func() error {


### PR DESCRIPTION
Fixes #8345

Both `apid` and `trustd` services use a gRPC connection back to `machined` to watch changes to the certificates (new certificates being issued).

This refactors the code to follow regular conventions, so that a failure to watch will crash the process, and they have a way to restart and re-establish the watch.

Use the context and errgroup consistently.
