### PR TITLE
feat: enables imager to use private registry for pulling extensions

### DIFF
--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -77,6 +78,9 @@ type ContainerAsset struct {
 	//
 	// If OCIPath is set, ImageRef is ignored.
 	OCIPath string `yaml:"ociPath,omitempty"`
+
+	// AuthConfig is a authentication config to access private registry.
+	*authn.AuthConfig
 }
 
 // SecureBootAssets describes secureboot assets.
@@ -264,6 +268,7 @@ func (c *ContainerAsset) Pull(ctx context.Context, arch string, printf func(stri
 			Architecture: arch,
 			OS:           "linux",
 		}),
+		crane.WithAuth(c),
 		crane.WithContext(ctx),
 	}
 
@@ -277,6 +282,11 @@ func (c *ContainerAsset) Pull(ctx context.Context, arch string, printf func(stri
 	}
 
 	return img, nil
+}
+
+// Authorization fullfils container registry Authorization interface.
+func (c *ContainerAsset) Authorization() (*authn.AuthConfig, error) {
+	return c.AuthConfig, nil
 }
 
 func (c *ContainerAsset) pullFromOCI(arch string) (v1.Image, error) {


### PR DESCRIPTION
# Pull Request

## What? (description)
Adds registry-credentials option to imager.

## Why? (reasoning)
When building Talos image with private extensions and access to registry is protected by authentication there is need for providing imager with credentials

## Acceptance

Without providing credentials:
```
docker run -t ghcr.io/nwik/imager:v1.6.0-alpha.1-195-g67ac6933d-dirty iso --system-extension-image MASKED/hardware-watchdog:1.27
profile ready:
arch: amd64
platform: metal
secureboot: false
version: v1.6.0-alpha.1-195-g67ac6933d-dirty
input:
  kernel:
    path: /usr/install/amd64/vmlinuz
  initramfs:
    path: /usr/install/amd64/initramfs.xz
  baseInstaller:
    imageRef: ghcr.io/nwik/installer:v1.6.0-alpha.1-195-g67ac6933d-dirty
    authconfig: null
  systemExtensions:
    - imageRef: MASKED/hardware-watchdog:1.27
      authconfig:
        username: ""
        password: ""
        auth: ""
        identitytoken: ""
        registrytoken: ""
output:
  kind: iso
  outFormat: raw
◱ error pulling image MASKED/hardware-watchdog:1.27: GET https://MASED/hardware-watchdog/manifests/1.27: UNAUTHORIZED: unauthorized to access repository: hardware-watchdog, action: pull: unauthorized to access repository: hardware-watchdog, action: pull
Error: error pulling image MASKED/hardware-watchdog:1.27: GET https://MASKED/hardware-watchdog/manifests/1.27: UNAUTHORIZED: unauthorized to access repository: hardware-watchdog, action: pull: unauthorized to access repository: hardware-watchdog, action: pull
```

When using credentials:
```
docker run -t ghcr.io/nwik/imager:v1.6.0-alpha.1-195-g67ac6933d-dirty iso --registry-credentials USER:PASS --system-extension-image MASKED/hardware-watchdog:1.27
profile ready:
arch: amd64
platform: metal
secureboot: false
version: v1.6.0-alpha.1-195-g67ac6933d-dirty
input:
  kernel:
    path: /usr/install/amd64/vmlinuz
  initramfs:
    path: /usr/install/amd64/initramfs.xz
  baseInstaller:
    imageRef: ghcr.io/nwik/installer:v1.6.0-alpha.1-195-g67ac6933d-dirty
    authconfig: null
  systemExtensions:
    - imageRef: MASKED/hardware-watchdog:1.27
      authconfig:
        username: MASKED
        password: MASKED
        auth: ""
        identitytoken: ""
        registrytoken: ""
output:
  kind: iso
  outFormat: raw
initramfs ready
kernel command line: talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512
ISO ready
output asset path: /out/metal-amd64.iso
```

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
