### PR TITLE
feat: enables imager to use private registry for pulling extensions

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -37,6 +39,7 @@ var cmdFlags struct {
 	OutputPath            string
 	OutputKind            string
 	TarToStdout           bool
+	RegistryCredentials   string
 }
 
 // rootCmd represents the base command when called without any subcommands.
@@ -74,11 +77,25 @@ var rootCmd = &cobra.Command{
 					},
 				}
 
+				var auth *authn.AuthConfig
+
+				if cmdFlags.RegistryCredentials != "" {
+					userpass := strings.Split(cmdFlags.RegistryCredentials, ":")
+					if len(userpass) != 2 {
+						return fmt.Errorf("please use format username:password for registry credential")
+					}
+					auth = &authn.AuthConfig{
+						Username: userpass[0],
+						Password: userpass[1],
+					}
+				}
+
 				prof.Input.SystemExtensions = xslices.Map(
 					cmdFlags.SystemExtensionImages,
 					func(imageRef string) profile.ContainerAsset {
 						return profile.ContainerAsset{
-							ImageRef: imageRef,
+							ImageRef:   imageRef,
+							AuthConfig: auth,
 						}
 					},
 				)
@@ -163,4 +180,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.OutputPath, "output", "/out", "The output directory path")
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.OutputKind, "output-kind", "", "Override output kind")
 	rootCmd.PersistentFlags().BoolVar(&cmdFlags.TarToStdout, "tar-to-stdout", false, "Tar output and send to stdout")
+	rootCmd.PersistentFlags().StringVar(&cmdFlags.RegistryCredentials, "registry-credentials", "", "username:password for pulling extensions from private registry")
 }


### PR DESCRIPTION
# Pull Request

## What? (description)
Adds registry-credentials option to imager.

## Why? (reasoning)
When building Talos image with private extensions and access to registry is protected by authentication there is need for providing imager with credentials

## Acceptance

Without providing credentials:
```
docker run -t ghcr.io/nwik/imager:v1.6.0-alpha.1-195-g67ac6933d-dirty iso --system-extension-image MASKED/hardware-watchdog:1.27
profile ready:
arch: amd64
platform: metal
secureboot: false
version: v1.6.0-alpha.1-195-g67ac6933d-dirty
input:
  kernel:
    path: /usr/install/amd64/vmlinuz
  initramfs:
    path: /usr/install/amd64/initramfs.xz
  baseInstaller:
    imageRef: ghcr.io/nwik/installer:v1.6.0-alpha.1-195-g67ac6933d-dirty
    authconfig: null
  systemExtensions:
    - imageRef: MASKED/hardware-watchdog:1.27
      authconfig:
        username: ""
        password: ""
        auth: ""
        identitytoken: ""
        registrytoken: ""
output:
  kind: iso
  outFormat: raw
◱ error pulling image MASKED/hardware-watchdog:1.27: GET https://MASED/hardware-watchdog/manifests/1.27: UNAUTHORIZED: unauthorized to access repository: hardware-watchdog, action: pull: unauthorized to access repository: hardware-watchdog, action: pull
Error: error pulling image MASKED/hardware-watchdog:1.27: GET https://MASKED/hardware-watchdog/manifests/1.27: UNAUTHORIZED: unauthorized to access repository: hardware-watchdog, action: pull: unauthorized to access repository: hardware-watchdog, action: pull
```

When using credentials:
```
docker run -t ghcr.io/nwik/imager:v1.6.0-alpha.1-195-g67ac6933d-dirty iso --registry-credentials USER:PASS --system-extension-image MASKED/hardware-watchdog:1.27
profile ready:
arch: amd64
platform: metal
secureboot: false
version: v1.6.0-alpha.1-195-g67ac6933d-dirty
input:
  kernel:
    path: /usr/install/amd64/vmlinuz
  initramfs:
    path: /usr/install/amd64/initramfs.xz
  baseInstaller:
    imageRef: ghcr.io/nwik/installer:v1.6.0-alpha.1-195-g67ac6933d-dirty
    authconfig: null
  systemExtensions:
    - imageRef: MASKED/hardware-watchdog:1.27
      authconfig:
        username: MASKED
        password: MASKED
        auth: ""
        identitytoken: ""
        registrytoken: ""
output:
  kind: iso
  outFormat: raw
initramfs ready
kernel command line: talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512
ISO ready
output asset path: /out/metal-amd64.iso
```

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.