### PR TITLE
fix: ignore 'no such device' in addition to 'no such file'

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -148,7 +148,7 @@ func mountRetry(f RetryFunc, p *Point, isUnmount bool) (err error) {
 			switch err {
 			case unix.EBUSY:
 				return retry.ExpectedError(err)
-			case unix.ENOENT:
+			case unix.ENOENT, unix.ENODEV:
 				// if udevd triggers BLKRRPART ioctl, partition device entry might disappear temporarily
 				return retry.ExpectedError(err)
 			case unix.EUCLEAN:


### PR DESCRIPTION
This errors pops up when `udevd` rescans the partition table with Talos trying to mount a device concurrently.

This feels to be something new with Linux 6.6 probably.
