### PR TITLE
docs: update config patch in cilium docs

### DIFF
--- a/website/content/v1.0/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.0/kubernetes-guides/network/deploying-cilium.md
@@ -150,7 +150,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.1/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.1/kubernetes-guides/network/deploying-cilium.md
@@ -150,7 +150,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.2/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.2/kubernetes-guides/network/deploying-cilium.md
@@ -150,7 +150,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.3/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.3/kubernetes-guides/network/deploying-cilium.md
@@ -150,7 +150,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.4/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.4/kubernetes-guides/network/deploying-cilium.md
@@ -253,7 +253,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
@@ -275,7 +275,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
@@ -251,7 +251,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --

--- a/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
@@ -251,7 +251,8 @@ talosctl gen config \
 To do so patch this into your machine configuration:
 
 ``` yaml
-inlineManifests:
+cluster:
+  inlineManifests:
     - name: cilium
       contents: |
         --


### PR DESCRIPTION
We missed the `cluster` key in the config patch. Fixed to avoid user confusion.
