### PR TITLE
chore: update CoreDNS renovate source

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/siderolabs/go-blockdevice/blockdevice"
 	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/siderolabs/go-retry/retry"
-	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board"
@@ -385,7 +385,7 @@ func retryBlockdeviceOpen(device string) (*blockdevice.BlockDevice, error) {
 		switch {
 		case os.IsNotExist(openErr):
 			return retry.ExpectedError(openErr)
-		case errors.Is(openErr, unix.ENODEV):
+		case errors.Is(openErr, syscall.ENODEV):
 			return retry.ExpectedError(openErr)
 		default:
 			return nil

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -371,7 +371,7 @@ const (
 	CoreDNSImage = "registry.k8s.io/coredns/coredns"
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
-	// renovate: datasource=github-releases depName=coredns/coredns
+	// renovate: datasource=docker depName=registry.k8s.io/coredns/coredns
 	DefaultCoreDNSVersion = "v1.11.1"
 
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.


### PR DESCRIPTION
As we're using a mirrored image from `registry.k8s.io`, use that as a source instead of GitHub. Mirrored image appears with some delay after an official CoreDNS release.
