### PR TITLE
feat: imager overlay

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -37,6 +37,8 @@ var cmdFlags struct {
 	OutputPath            string
 	OutputKind            string
 	TarToStdout           bool
+	OverlayName           string
+	OverlayImage          string
 }
 
 // rootCmd represents the base command when called without any subcommands.
@@ -72,6 +74,15 @@ var rootCmd = &cobra.Command{
 						ExtraKernelArgs: cmdFlags.ExtraKernelArgs,
 						MetaContents:    cmdFlags.MetaValues.GetMetaValues(),
 					},
+				}
+
+				if cmdFlags.OverlayName != "" || cmdFlags.OverlayImage != "" {
+					prof.Overlay = &profile.OverlayOptions{
+						Name: cmdFlags.OverlayName,
+						Image: profile.ContainerAsset{
+							ImageRef: cmdFlags.OverlayImage,
+						},
+					}
 				}
 
 				prof.Input.SystemExtensions = xslices.Map(
@@ -163,4 +174,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.OutputPath, "output", "/out", "The output directory path")
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.OutputKind, "output-kind", "", "Override output kind")
 	rootCmd.PersistentFlags().BoolVar(&cmdFlags.TarToStdout, "tar-to-stdout", false, "Tar output and send to stdout")
+	rootCmd.PersistentFlags().StringVar(&cmdFlags.OverlayName, "overlay-name", "", "The name of the overlay to use")
+	rootCmd.PersistentFlags().StringVar(&cmdFlags.OverlayImage, "overlay-image", "", "The image reference to the overlay")
+	rootCmd.MarkFlagsMutuallyExclusive("board", "overlay-name")
+	rootCmd.MarkFlagsMutuallyExclusive("board", "overlay-image")
 }

--- a/pkg/imager/internal/overlay/executor/executor.go
+++ b/pkg/imager/internal/overlay/executor/executor.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package executor implements overlay.Installer
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+)
+
+var _ overlay.Installer = (*Options)(nil)
+
+// Options executor options.
+type Options struct {
+	commandPath string
+}
+
+// New returns a new overlay installer executor.
+func New(commandPath string) *Options {
+	return &Options{
+		commandPath: commandPath,
+	}
+}
+
+// GetOptions returns the options for the overlay installer.
+func (o *Options) GetOptions(extra overlay.InstallExtraOptions) (overlay.Options, error) {
+	// parse extra as yaml
+	extraYAML, err := yaml.Marshal(extra)
+	if err != nil {
+		return overlay.Options{}, fmt.Errorf("failed to marshal extra: %w", err)
+	}
+
+	out, err := o.execute(bytes.NewReader(extraYAML), "get-options")
+	if err != nil {
+		return overlay.Options{}, fmt.Errorf("failed to run overlay installer: %w", err)
+	}
+
+	var options overlay.Options
+
+	if err := yaml.Unmarshal(out, &options); err != nil {
+		return overlay.Options{}, fmt.Errorf("failed to unmarshal overlay options: %w", err)
+	}
+
+	return options, nil
+}
+
+// Install installs the overlay.
+func (o *Options) Install(options overlay.InstallOptions) error {
+	optionsBytes, err := yaml.Marshal(&options)
+	if err != nil {
+		return fmt.Errorf("failed to marshal options: %w", err)
+	}
+
+	if _, err := o.execute(bytes.NewReader(optionsBytes), "install"); err != nil {
+		return fmt.Errorf("failed to run overlay installer: %w", err)
+	}
+
+	return nil
+}
+
+func (o *Options) execute(stdin io.Reader, args ...string) ([]byte, error) {
+	cmd := exec.Command(o.commandPath, args...)
+	cmd.Stdin = stdin
+
+	var stdOut, stdErr bytes.Buffer
+
+	cmd.Stdout = &stdOut
+	cmd.Stderr = &stdErr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run overlay installer: %w, stdErr: %s", err, stdErr.Bytes())
+	}
+
+	return stdOut.Bytes(), nil
+}

--- a/pkg/imager/profile/deep_copy.generated.go
+++ b/pkg/imager/profile/deep_copy.generated.go
@@ -33,6 +33,16 @@ func (o Profile) DeepCopy() Profile {
 		cp.Input.SystemExtensions = make([]ContainerAsset, len(o.Input.SystemExtensions))
 		copy(cp.Input.SystemExtensions, o.Input.SystemExtensions)
 	}
+	if o.Overlay != nil {
+		cp.Overlay = new(OverlayOptions)
+		*cp.Overlay = *o.Overlay
+		if o.Overlay.Options != nil {
+			cp.Overlay.Options = make(map[string]any, len(o.Overlay.Options))
+			for k4, v4 := range o.Overlay.Options {
+				cp.Overlay.Options[k4] = v4
+			}
+		}
+	}
 	if o.Output.ImageOptions != nil {
 		cp.Output.ImageOptions = new(ImageOptions)
 		*cp.Output.ImageOptions = *o.Output.ImageOptions

--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -26,6 +26,7 @@ import (
 	"github.com/siderolabs/talos/pkg/imager/profile/internal/signer/aws"
 	"github.com/siderolabs/talos/pkg/imager/profile/internal/signer/azure"
 	"github.com/siderolabs/talos/pkg/imager/profile/internal/signer/file"
+	"github.com/siderolabs/talos/pkg/imager/quirks"
 	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -166,7 +167,7 @@ const defaultSecureBootPrefix = "/secureboot"
 
 // FillDefaults fills default values for the input.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (i *Input) FillDefaults(arch, version string, secureboot bool) {
 	var (
 		zeroFileAsset      FileAsset
@@ -181,7 +182,7 @@ func (i *Input) FillDefaults(arch, version string, secureboot bool) {
 		i.Initramfs.Path = fmt.Sprintf(constants.InitramfsAssetPath, arch)
 	}
 
-	if arch == arm64 {
+	if arch == arm64 && !quirks.New(version).SupportsOverlay() {
 		if i.DTB == zeroFileAsset {
 			i.DTB.Path = fmt.Sprintf(constants.DTBAssetPath, arch)
 		}

--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -37,8 +37,20 @@ type Profile struct {
 
 	// Input describes inputs for image generation.
 	Input Input `yaml:"input"`
+	// Overlay describes overlay options for image generation.
+	Overlay *OverlayOptions `yaml:"overlay,omitempty"`
 	// Output describes image generation result.
 	Output Output `yaml:"output"`
+}
+
+// OverlayOptions describes overlay options for image generation.
+type OverlayOptions struct {
+	// Name of the overlay installer, defaults to `default` if not set.
+	Name string `yaml:"name"`
+	// Image to use for the overlay.
+	Image ContainerAsset `yaml:"image"`
+	// Options for the overlay.
+	Options map[string]any `yaml:"options,omitempty"`
 }
 
 // CustomizationProfile describes customizations that can be applied to the image.
@@ -67,7 +79,11 @@ func (p *Profile) Validate() error {
 	}
 
 	if p.Board != "" {
-		if !(p.Arch == arm64 && p.Platform == "metal") {
+		if p.Overlay != nil {
+			return errors.New("overlay is not supported with board options")
+		}
+
+		if p.Arch != arm64 || p.Platform != "metal" {
 			return errors.New("board is only supported for metal arm64")
 		}
 	}

--- a/pkg/imager/quirks/quirks.go
+++ b/pkg/imager/quirks/quirks.go
@@ -45,3 +45,15 @@ func (q Quirks) SupportsCompressedEncodedMETA() bool {
 
 	return q.v.GTE(minVersionCompressedMETA)
 }
+
+var minVersionOverlay = semver.MustParse("1.7.0")
+
+// SupportsOverlay returns true if the Talos imager version supports overlay.
+func (q Quirks) SupportsOverlay() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minVersionOverlay)
+}

--- a/pkg/machinery/overlay/adapter/adapter.go
+++ b/pkg/machinery/overlay/adapter/adapter.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package adapter provides an adapter for the overlay installer.
+package adapter
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+)
+
+// Execute executes the overlay installer.
+func Execute(installer overlay.Installer) {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, "missing command")
+
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "install":
+		install(installer)
+	case "get-options":
+		getOptions(installer)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s", os.Args[1])
+
+		os.Exit(1)
+	}
+}
+
+func getOptions(installer overlay.Installer) {
+	var opts overlay.InstallExtraOptions
+
+	withErrorHandler(yaml.NewDecoder(os.Stdin).Decode(&opts))
+
+	opt, err := installer.GetOptions(opts)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+
+		os.Exit(1)
+	}
+
+	withErrorHandler(yaml.NewEncoder(os.Stdout).Encode(opt))
+}
+
+func install(installer overlay.Installer) {
+	var opts overlay.InstallOptions
+
+	withErrorHandler(yaml.NewDecoder(os.Stdin).Decode(&opts))
+
+	withErrorHandler(installer.Install(opts))
+}
+
+func withErrorHandler(err error) {
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+
+		os.Exit(1)
+	}
+}

--- a/pkg/machinery/overlay/overlay.go
+++ b/pkg/machinery/overlay/overlay.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package overlay provides an interface for overlay installers.
+package overlay
+
+// Installer is an interface for overlay installers.
+type Installer interface {
+	GetOptions(extra InstallExtraOptions) (Options, error)
+	Install(options InstallOptions) error
+}
+
+// Options for the overlay installer.
+type Options struct {
+	Name             string   `yaml:"name"`
+	KernelArgs       []string `yaml:"kernelArgs,omitempty"`
+	PartitionOptions struct {
+		Offset uint64
+	} `yaml:"partitionOptions,omitempty"`
+}
+
+// InstallOptions for the overlay installer.
+type InstallOptions struct {
+	InstallDisk   string              `yaml:"installDisk"`
+	MountPrefix   string              `yaml:"mountPrefix"`
+	ArtifactsPath string              `yaml:"artifactsPath"`
+	ExtraOptions  InstallExtraOptions `yaml:"extraOptions,omitempty"`
+}
+
+// InstallExtraOptions for the overlay installer.
+type InstallExtraOptions map[string]any


### PR DESCRIPTION
Support overlays for imager.
The `Install` interface is not wired yet, it will be done as a different PR.

This should be a no-op for existing imager.

Part of: #8350