### PR TITLE
docs: fix typo in word governor

### DIFF
--- a/website/content/v1.2/learn-more/knowledge-base.md
+++ b/website/content/v1.2/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 

--- a/website/content/v1.3/learn-more/knowledge-base.md
+++ b/website/content/v1.3/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 

--- a/website/content/v1.4/learn-more/knowledge-base.md
+++ b/website/content/v1.4/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 

--- a/website/content/v1.5/learn-more/knowledge-base.md
+++ b/website/content/v1.5/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 

--- a/website/content/v1.6/learn-more/knowledge-base.md
+++ b/website/content/v1.6/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 

--- a/website/content/v1.7/learn-more/knowledge-base.md
+++ b/website/content/v1.7/learn-more/knowledge-base.md
@@ -68,9 +68,9 @@ promtail:
                 __path__: /var/log/audit/kube/*.log
 ```
 
-## Setting CPU scaling governer
+## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governer](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 


### PR DESCRIPTION
Docs typo.

Forked from #8375