### PR TITLE
feat: implement `Install` for imager overlays

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -640,7 +640,6 @@ local integration_qemu_csi = Step('e2e-csi', target='e2e-qemu', privileged=true,
 });
 
 local integration_images = Step('images', target='images', depends_on=[load_artifacts], environment={ IMAGE_REGISTRY: local_registry });
-local integration_sbcs = Step('sbcs', target='sbcs', depends_on=[integration_images], environment={ IMAGE_REGISTRY: local_registry });
 local integration_cloud_images = Step('cloud-images', depends_on=[integration_images], environment=creds_env_vars);
 
 local integration_reproducibility_test = Step('reproducibility-test', target='reproducibility-test', depends_on=[load_artifacts], environment={ IMAGE_REGISTRY: local_registry });
@@ -704,7 +703,7 @@ local integration_pipelines = [
   Pipeline('integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip]) + integration_trigger(['integration-qemu-encrypted-vip']),
   Pipeline('integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race]) + integration_trigger(['integration-qemu-race']),
   Pipeline('integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi]) + integration_trigger(['integration-qemu-csi']),
-  Pipeline('integration-images', default_pipeline_steps + [integration_images, integration_sbcs]) + integration_trigger(['integration-images']),
+  Pipeline('integration-images', default_pipeline_steps + [integration_images]) + integration_trigger(['integration-images']),
   Pipeline('integration-reproducibility-test', default_pipeline_steps + [integration_reproducibility_test]) + integration_trigger(['integration-reproducibility']),
   Pipeline('integration-cloud-images', default_pipeline_steps + [integration_images, integration_cloud_images]) + literal_trigger(['integration-cloud-images']),
   Pipeline('image-factory', default_pipeline_steps + [
@@ -738,7 +737,7 @@ local integration_pipelines = [
   Pipeline('cron-integration-qemu-encrypted-vip', default_pipeline_steps + [integration_qemu_encrypted_vip], [default_cron_pipeline]) + cron_trigger(['thrice-daily', 'nightly']),
   Pipeline('cron-integration-qemu-race', default_pipeline_steps + [build_race, integration_qemu_race], [default_cron_pipeline]) + cron_trigger(['nightly']),
   Pipeline('cron-integration-qemu-csi', default_pipeline_steps + [integration_qemu_csi], [default_cron_pipeline]) + cron_trigger(['nightly']),
-  Pipeline('cron-integration-images', default_pipeline_steps + [integration_images, integration_sbcs], [default_cron_pipeline]) + cron_trigger(['nightly']),
+  Pipeline('cron-integration-images', default_pipeline_steps + [integration_images], [default_cron_pipeline]) + cron_trigger(['nightly']),
   Pipeline('cron-integration-reproducibility-test', default_pipeline_steps + [integration_reproducibility_test], [default_cron_pipeline]) + cron_trigger(['nightly']),
   Pipeline('cron-image-factory', default_pipeline_steps + [
     integration_factory_16_iso,
@@ -891,7 +890,6 @@ local conformance_pipelines = [
 
 local cloud_images = Step('cloud-images', depends_on=[e2e_docker, e2e_qemu], environment=creds_env_vars);
 local images = Step('images', target='images', depends_on=[iso, images_essential, save_artifacts], environment={ IMAGE_REGISTRY: local_registry });
-local sbcs = Step('sbcs', target='sbcs', depends_on=[images], environment={ IMAGE_REGISTRY: local_registry });
 
 // TODO(andrewrynhard): We should run E2E tests on a release.
 local release = {
@@ -921,15 +919,6 @@ local release = {
       '_out/metal-arm64.iso',
       '_out/metal-amd64.raw.xz',
       '_out/metal-arm64.raw.xz',
-      '_out/metal-rpi_generic-arm64.raw.xz',
-      '_out/metal-rockpi_4-arm64.raw.xz',
-      '_out/metal-rockpi_4c-arm64.raw.xz',
-      '_out/metal-rock64-arm64.raw.xz',
-      '_out/metal-pine64-arm64.raw.xz',
-      '_out/metal-bananapi_m64-arm64.raw.xz',
-      '_out/metal-libretech_all_h3_cc_h5-arm64.raw.xz',
-      '_out/metal-jetson_nano-arm64.raw.xz',
-      '_out/metal-nanopi_r4s-arm64.raw.xz',
       '_out/nocloud-amd64.raw.xz',
       '_out/nocloud-arm64.raw.xz',
       '_out/opennebula-amd64.raw.xz',
@@ -973,7 +962,6 @@ local release = {
     cloud_images.name,
     talosctl_cni_bundle.name,
     images.name,
-    sbcs.name,
     iso.name,
     push.name,
     release_notes.name,
@@ -982,7 +970,6 @@ local release = {
 
 local release_steps = default_steps + [
   images,
-  sbcs,
   cloud_images,
   release,
 ];

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ ARG PKG_RUNC
 ARG PKG_XFSPROGS
 ARG PKG_UTIL_LINUX
 ARG PKG_KMOD
-ARG PKG_U_BOOT
-ARG PKG_RASPBERYPI_FIRMWARE
 ARG PKG_KERNEL
 ARG PKG_TALOSCTL_CNI_BUNDLE_INSTALL
 
@@ -113,9 +111,6 @@ FROM --platform=arm64 ${PKG_KMOD} AS pkg-kmod-arm64
 FROM ${PKG_KERNEL} AS pkg-kernel
 FROM --platform=amd64 ${PKG_KERNEL} AS pkg-kernel-amd64
 FROM --platform=arm64 ${PKG_KERNEL} AS pkg-kernel-arm64
-
-FROM --platform=arm64 ${PKG_U_BOOT} AS pkg-u-boot-arm64
-FROM --platform=arm64 ${PKG_RASPBERYPI_FIRMWARE} AS pkg-raspberrypi-firmware-arm64
 
 # Resolve package images using ${EXTRAS} to be used later in COPY --from=.
 
@@ -780,8 +775,6 @@ COPY --from=pkg-kernel-arm64 /dtb /usr/install/arm64/dtb
 COPY --from=initramfs-archive-arm64 /initramfs.xz /usr/install/arm64/initramfs.xz
 COPY --from=pkg-sd-boot-arm64 /linuxaa64.efi.stub /usr/install/arm64/systemd-stub.efi
 COPY --from=pkg-sd-boot-arm64 /systemd-bootaa64.efi /usr/install/arm64/systemd-boot.efi
-COPY --from=pkg-u-boot-arm64 / /usr/install/arm64/u-boot
-COPY --from=pkg-raspberrypi-firmware-arm64 / /usr/install/arm64/raspberrypi-firmware
 
 FROM scratch AS install-artifacts-all
 COPY --from=install-artifacts-amd64 / /

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,6 @@ PKG_RUNC ?= $(PKGS_PREFIX)/runc:$(PKGS)
 PKG_XFSPROGS ?= $(PKGS_PREFIX)/xfsprogs:$(PKGS)
 PKG_UTIL_LINUX ?= $(PKGS_PREFIX)/util-linux:$(PKGS)
 PKG_KMOD ?= $(PKGS_PREFIX)/kmod:$(PKGS)
-PKG_U_BOOT ?= $(PKGS_PREFIX)/u-boot:$(PKGS)
-PKG_RASPBERYPI_FIRMWARE ?= $(PKGS_PREFIX)/raspberrypi-firmware:$(PKGS)
 PKG_KERNEL ?= $(PKGS_PREFIX)/kernel:$(PKGS)
 PKG_TALOSCTL_CNI_BUNDLE_INSTALL ?= $(PKGS_PREFIX)/talosctl-cni-bundle-install:$(EXTRAS)
 
@@ -375,12 +373,6 @@ image-%: ## Builds the specified image. Valid options are aws, azure, digital-oc
 images-essential: image-aws image-gcp image-metal secureboot-installer ## Builds only essential images used in the CI (AWS, GCP, and Metal).
 
 images: image-aws image-azure image-digital-ocean image-exoscale image-gcp image-hcloud image-iso image-metal image-nocloud image-opennebula image-openstack image-oracle image-scaleway image-upcloud image-vmware image-vultr ## Builds all known images (AWS, Azure, DigitalOcean, Exoscale, GCP, HCloud, Metal, NoCloud, OpenNebula, Openstack, Oracle, Scaleway, UpCloud, Vultr and VMware).
-
-sbc-%: ## Builds the specified SBC image. Valid options are rpi_generic, rock64, bananapi_m64, libretech_all_h3_cc_h5, rockpi_4, rockpi_4c, pine64, jetson_nano and nanopi_r4s (e.g. sbc-rpi_generic)
-	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG)
-	@docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/out --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG) $* --arch arm64 $(IMAGER_ARGS)
-
-sbcs: sbc-rpi_generic sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 sbc-rockpi_4c sbc-pine64 sbc-jetson_nano sbc-nanopi_r4s ## Builds all known SBC images (Raspberry Pi 4, Rock64, Banana Pi M64, Radxa ROCK Pi 4, Radxa ROCK Pi 4c, Pine64, Libre Computer Board ALL-H3-CC, Jetson Nano and Nano Pi R4S).
 
 .PHONY: iso
 iso: image-iso ## Builds the ISO and outputs it to the artifact directory.

--- a/cmd/installer/cmd/installer/root.go
+++ b/cmd/installer/cmd/installer/root.go
@@ -52,13 +52,12 @@ var options = &install.Options{}
 
 var bootloader bool
 
-//nolint:goconst
 func init() {
 	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
 	rootCmd.PersistentFlags().StringVar(&options.Disk, "disk", "", "The path to the disk to install to")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringVar(&options.Arch, "arch", runtime.GOARCH, "The target architecture")
-	rootCmd.PersistentFlags().StringVar(&options.Board, "board", constants.BoardNone, "The value of "+constants.KernelParamBoard)
+	rootCmd.PersistentFlags().StringVar(&options.Board, "board", constants.BoardNone, "Deprecated: no op")
 	rootCmd.PersistentFlags().StringArrayVar(&options.ExtraKernelArgs, "extra-kernel-arg", []string{}, "Extra argument to pass to the kernel")
 	rootCmd.PersistentFlags().BoolVar(&bootloader, "bootloader", true, "Deprecated: no op")
 	rootCmd.PersistentFlags().BoolVar(&options.Upgrade, "upgrade", false, "Indicates that the install is being performed by an upgrade")

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -124,6 +124,13 @@ machine:
 ```
 """
 
+    [notes.sbc]
+        title = "SBC"
+        description = """\
+Talos core will drop support for SBC's and will not include the SBC binaries in the release.
+*Overlays* are being developed to support SBC's.
+"""
+
     [notes.syslog]
         title = "Syslog"
         description = """\

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
@@ -6,11 +6,7 @@
 package board
 
 import (
-	"errors"
 	"fmt"
-	"os"
-
-	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	bananapim64 "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64"
@@ -25,26 +21,8 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
-// CurrentBoard is a helper func for discovering the current board.
-func CurrentBoard() (b runtime.Board, err error) {
-	var board string
-
-	if p := procfs.ProcCmdline().Get(constants.KernelParamBoard).First(); p != nil {
-		board = *p
-	}
-
-	if p, ok := os.LookupEnv("BOARD"); ok {
-		board = p
-	}
-
-	if board == "" {
-		return nil, errors.New("failed to determine board")
-	}
-
-	return newBoard(board)
-}
-
 // NewBoard initializes and returns a runtime.Board.
+// Deprecated: Not supported anymore, use overlays instead.
 func NewBoard(board string) (b runtime.Board, err error) {
 	return newBoard(board)
 }

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -173,10 +173,6 @@ func RunInstallerContainer(disk, platform, ref string, cfg configcore.Config, cf
 		"--zero=" + zero,
 	}
 
-	if c := procfs.ProcCmdline().Get(constants.KernelParamBoard).First(); c != nil {
-		args = append(args, "--board="+*c)
-	}
-
 	for _, arg := range options.ExtraKernelArgs {
 		args = append(args, "--extra-kernel-arg", arg)
 	}

--- a/pkg/imager/overlay/executor/executor.go
+++ b/pkg/imager/overlay/executor/executor.go
@@ -40,7 +40,7 @@ func (o *Options) GetOptions(extra overlay.ExtraOptions) (overlay.Options, error
 
 	out, err := o.execute(bytes.NewReader(extraYAML), "get-options")
 	if err != nil {
-		return overlay.Options{}, fmt.Errorf("failed to run overlay installer: %w", err)
+		return overlay.Options{}, err
 	}
 
 	var options overlay.Options
@@ -60,7 +60,7 @@ func (o *Options) Install(options overlay.InstallOptions[overlay.ExtraOptions]) 
 	}
 
 	if _, err := o.execute(bytes.NewReader(optionsBytes), "install"); err != nil {
-		return fmt.Errorf("failed to run overlay installer: %w", err)
+		return err
 	}
 
 	return nil

--- a/pkg/imager/profile/deep_copy.generated.go
+++ b/pkg/imager/profile/deep_copy.generated.go
@@ -36,10 +36,10 @@ func (o Profile) DeepCopy() Profile {
 	if o.Overlay != nil {
 		cp.Overlay = new(OverlayOptions)
 		*cp.Overlay = *o.Overlay
-		if o.Overlay.Options != nil {
-			cp.Overlay.Options = make(map[string]any, len(o.Overlay.Options))
-			for k4, v4 := range o.Overlay.Options {
-				cp.Overlay.Options[k4] = v4
+		if o.Overlay.ExtraOptions != nil {
+			cp.Overlay.ExtraOptions = make(map[string]any, len(o.Overlay.ExtraOptions))
+			for k4, v4 := range o.Overlay.ExtraOptions {
+				cp.Overlay.ExtraOptions[k4] = v4
 			}
 		}
 	}

--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/talos/pkg/machinery/meta"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
 )
 
 //go:generate deep-copy -type Profile -header-file ../../../hack/boilerplate.txt -o deep_copy.generated.go .
@@ -50,7 +51,7 @@ type OverlayOptions struct {
 	// Image to use for the overlay.
 	Image ContainerAsset `yaml:"image"`
 	// Options for the overlay.
-	Options map[string]any `yaml:"options,omitempty"`
+	overlay.ExtraOptions `yaml:"options,omitempty"`
 }
 
 // CustomizationProfile describes customizations that can be applied to the image.

--- a/pkg/imager/quirks/quirks.go
+++ b/pkg/imager/quirks/quirks.go
@@ -19,7 +19,12 @@ func New(talosVersion string) Quirks {
 		return Quirks{}
 	}
 
-	return Quirks{v: &v}
+	// we only care about major, minor, and patch, so that alpha, beta, etc. are ignored
+	return Quirks{v: &semver.Version{
+		Major: v.Major,
+		Minor: v.Minor,
+		Patch: v.Patch,
+	}}
 }
 
 var minVersionResetOption = semver.MustParse("1.4.0")

--- a/pkg/imager/quirks/quirks_test.go
+++ b/pkg/imager/quirks/quirks_test.go
@@ -63,3 +63,39 @@ func TestSupportsCompressedEncodedMETA(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsOverlay(t *testing.T) {
+	for _, test := range []struct {
+		version string
+
+		expected bool
+	}{
+		{
+			version:  "1.6.3",
+			expected: false,
+		},
+		{
+			version:  "1.7.0",
+			expected: true,
+		},
+		{
+			expected: true,
+		},
+		{
+			version:  "1.6.2",
+			expected: false,
+		},
+		{
+			version:  "1.7.0-alpha.0",
+			expected: true,
+		},
+		{
+			version:  "v1.7.0-alpha.0-75-gff08e2821",
+			expected: true,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			assert.Equal(t, test.expected, quirks.New(test.version).SupportsOverlay())
+		})
+	}
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -574,6 +574,21 @@ const (
 	// RPiFirmwareAssetPath is the path to the raspberrypi firmware in the installer.
 	RPiFirmwareAssetPath = "/usr/install/%s/raspberrypi-firmware"
 
+	// ImagerOverlayBasePath is the base path for the imager overlay.
+	ImagerOverlayBasePath = "/overlay"
+	// ImagerOverlayArtifactsPath is the path to the artifacts in the imager overlay.
+	ImagerOverlayArtifactsPath = ImagerOverlayBasePath + "/" + "artifacts"
+	// ImagerOverlayInstallersPath is the path to the installers in the imager overlay.
+	ImagerOverlayInstallersPath = ImagerOverlayBasePath + "/" + "installers"
+	// ImagerOverlayProfilesPath is the path to the profiles in the imager overlay.
+	ImagerOverlayProfilesPath = ImagerOverlayBasePath + "/" + "profiles"
+	// ImagerOverlayInstallerDefault is the default installer name.
+	ImagerOverlayInstallerDefault = "default"
+	// ImagerOverlayInstallerDefaultPath is the path to the default installer in the imager overlay.
+	ImagerOverlayInstallerDefaultPath = ImagerOverlayInstallersPath + "/" + ImagerOverlayInstallerDefault
+	// ImagerOverlayExtraOptionsPath is the path to the generated extra options file in the imager overlay.
+	ImagerOverlayExtraOptionsPath = ImagerOverlayBasePath + "/" + "extra-options"
+
 	// PlatformKeyAsset defines a well known name for the platform key filename used for auto-enrolling.
 	PlatformKeyAsset = "PK.auth"
 

--- a/pkg/machinery/overlay/adapter/adapter.go
+++ b/pkg/machinery/overlay/adapter/adapter.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Execute executes the overlay installer.
-func Execute(installer overlay.Installer) {
+func Execute[T any](installer overlay.Installer[T]) {
 	if len(os.Args) < 2 {
 		fmt.Fprint(os.Stderr, "missing command")
 
@@ -34,8 +34,8 @@ func Execute(installer overlay.Installer) {
 	}
 }
 
-func getOptions(installer overlay.Installer) {
-	var opts overlay.InstallExtraOptions
+func getOptions[T any](installer overlay.Installer[T]) {
+	var opts T
 
 	withErrorHandler(yaml.NewDecoder(os.Stdin).Decode(&opts))
 
@@ -49,8 +49,8 @@ func getOptions(installer overlay.Installer) {
 	withErrorHandler(yaml.NewEncoder(os.Stdout).Encode(opt))
 }
 
-func install(installer overlay.Installer) {
-	var opts overlay.InstallOptions
+func install[T any](installer overlay.Installer[T]) {
+	var opts overlay.InstallOptions[T]
 
 	withErrorHandler(yaml.NewDecoder(os.Stdin).Decode(&opts))
 

--- a/pkg/machinery/overlay/overlay.go
+++ b/pkg/machinery/overlay/overlay.go
@@ -6,9 +6,9 @@
 package overlay
 
 // Installer is an interface for overlay installers.
-type Installer interface {
-	GetOptions(extra InstallExtraOptions) (Options, error)
-	Install(options InstallOptions) error
+type Installer[T any] interface {
+	GetOptions(extra T) (Options, error)
+	Install(options InstallOptions[T]) error
 }
 
 // Options for the overlay installer.
@@ -21,12 +21,12 @@ type Options struct {
 }
 
 // InstallOptions for the overlay installer.
-type InstallOptions struct {
-	InstallDisk   string              `yaml:"installDisk"`
-	MountPrefix   string              `yaml:"mountPrefix"`
-	ArtifactsPath string              `yaml:"artifactsPath"`
-	ExtraOptions  InstallExtraOptions `yaml:"extraOptions,omitempty"`
+type InstallOptions[T any] struct {
+	InstallDisk   string `yaml:"installDisk"`
+	MountPrefix   string `yaml:"mountPrefix"`
+	ArtifactsPath string `yaml:"artifactsPath"`
+	ExtraOptions  T      `yaml:"extraOptions,omitempty"`
 }
 
-// InstallExtraOptions for the overlay installer.
-type InstallExtraOptions map[string]any
+// ExtraOptions for the overlay installer.
+type ExtraOptions map[string]any


### PR DESCRIPTION
Implement `Install` for imager overlays.
Also add support for generating installers.

Depends on: #8377

Fixes: #8350
Fixes: #8351
Fixes: #8350