### PR TITLE
docs: update replicated-local-storage-with-openebs-jiva.md

### DIFF
--- a/website/content/v1.7/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva.md
+++ b/website/content/v1.7/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva.md
@@ -26,9 +26,9 @@ Create a machine config patch with the contents below and save as `patch.yaml`
 machine:
   kubelet:
     extraMounts:
-      - destination: /var/openebs/local
+      - destination: /var/local/openebs
         type: bind
-        source: /var/openebs/local
+        source: /var/local/openebs
         options:
           - bind
           - rshared


### PR DESCRIPTION
# Pull Request

## What? (description)

Changed the documentation for the configuration of Mayastor.

## Why? (reasoning)

Trying to install the Mayastor deployment led to MountVolume.NewMounter errors. At least for my case the issue resided in the path of the patch being incorrect.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
