### PR TITLE
fix: do not fail cluster create when `--input-dir` does not contain talosconfig

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -443,7 +443,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 	if inputDir != "" {
 		definedGenFlag := checkForDefinedGenFlag(flags)
 		if definedGenFlag != "" {
-			return fmt.Errorf("flag --%s is not supported with generated configs(--%s)", definedGenFlag, inputDirFlag)
+			return fmt.Errorf("flag --%s is not supported with generated configs (--%s)", definedGenFlag, inputDirFlag)
 		}
 
 		configBundleOpts = append(configBundleOpts, bundle.WithExistingConfigs(inputDir))
@@ -1169,7 +1169,6 @@ func checkForDefinedGenFlag(flags *pflag.FlagSet) string {
 		networkIPv4Flag,
 		networkIPv6Flag,
 		networkMTUFlag,
-		networkCIDRFlag,
 		nameserversFlag,
 		clusterDiskSizeFlag,
 		clusterDisksFlag,

--- a/pkg/machinery/config/bundle/bundle.go
+++ b/pkg/machinery/config/bundle/bundle.go
@@ -85,6 +85,10 @@ func NewBundle(opts ...Option) (*Bundle, error) {
 
 		// Pull existing talosconfig
 		talosConfig, err := os.Open(filepath.Join(options.ExistingConfigs, "talosconfig"))
+		if os.IsNotExist(err) { // talosconfig is optional
+			return bundle, nil
+		}
+
 		if err != nil {
 			return bundle, err
 		}


### PR DESCRIPTION
As `--input-dir` flag now supports partial configs, it should not fail when there is no talosconfig in the directory.

This was the missing part in siderolabs/talos#8333.
