### PR TITLE
fix: merge PodSecurity admission configs without duplicate exemptions

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/expected.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/expected.yaml
@@ -69,8 +69,15 @@ cluster:
                     namespaces:
                         - kube-system
                         - rook-system
-                    runtimeClasses: []
-                    usernames: []
+                    runtimeClasses:
+                        - rc-1
+                        - rc-2
+                        - rc-3
+                    usernames:
+                        - user-1
+                        - user-2
+                        - user-3
+                        - user-4
                 kind: PodSecurityConfiguration
     controllerManager:
         image: k8s.gcr.io/kube-controller-manager:v1.24.2

--- a/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/left.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/left.yaml
@@ -68,8 +68,12 @@ cluster:
                 exemptions:
                     namespaces:
                         - kube-system
-                    runtimeClasses: []
-                    usernames: []
+                    runtimeClasses:
+                        - rc-1
+                        - rc-2
+                    usernames:
+                        - user-1
+                        - user-2
                 kind: PodSecurityConfiguration
     controllerManager:
         image: k8s.gcr.io/kube-controller-manager:v1.24.2

--- a/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/right.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/strategic/004/right.yaml
@@ -8,4 +8,13 @@ cluster:
                     enforce: restricted
                 exemptions:
                     namespaces:
+                        - kube-system
                         - rook-system
+                    runtimeClasses:
+                      - rc-2
+                      - rc-3
+                    usernames:
+                      - user-3
+                      - user-1
+                      - user-2
+                      - user-4


### PR DESCRIPTION
When we strategically merge admission plugin configs of type "PodSecurity", we were concatenating the fields `namespaces`, `runtimeClasses` and `usernames`, which are string slices.

This did not pass the validation in the kube-apiserver and put it into a crash loop with errors like:
```
run.go:74] "command failed" err="failed to apply admission: failed to initialize admission plugin \"PodSecurity\": PodSecurity invalid: exemptions.namespaces[1]: Duplicate value: \"kube-system\"
```

Fix it by treating `PodSecurity` specially and not duplicating the elements in these fields while merging.