### PR TITLE
feat: multiple docker clusters

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -87,6 +87,7 @@ const (
 	bootloaderEnabledFlag         = "with-bootloader"
 	forceEndpointFlag             = "endpoint"
 	controlPlanePortFlag          = "control-plane-port"
+	apiPortFlag                   = "api-port"
 	kubePrismFlag                 = "kubeprism-port"
 	tpm2EnabledFlag               = "with-tpm2"
 	diskEncryptionKeyTypesFlag    = "disk-encryption-key-types"
@@ -159,6 +160,7 @@ var (
 	extraBootKernelArgs        string
 	dockerDisableIPv6          bool
 	controlPlanePort           int
+	apiPort                    int
 	kubePrismPort              int
 	dhcpSkipHostname           bool
 	skipBootPhaseFinishedCheck bool
@@ -650,7 +652,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 			}
 		}
 
-		endpointList = []string{forceEndpoint + ":50050"}
+		endpointList = []string{fmt.Sprintf("%s:%d", forceEndpoint, apiPort)}
 		genOptions = append(genOptions, generate.WithEndpointList(endpointList))
 		configBundleOpts = append(configBundleOpts,
 			bundle.WithInputOptions(
@@ -779,7 +781,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 		}
 
 		if i == 0 {
-			nodeReq.Ports = []string{"50050:50000/tcp", fmt.Sprintf("%d:%d/tcp", controlPlanePort, controlPlanePort)}
+			nodeReq.Ports = []string{fmt.Sprintf("%d:50000/tcp", apiPort), fmt.Sprintf("%d:%d/tcp", controlPlanePort, controlPlanePort)}
 		}
 
 		if withInitNode && i == 0 {
@@ -1144,6 +1146,7 @@ func init() {
 	createCmd.Flags().StringVar(&extraBootKernelArgs, "extra-boot-kernel-args", "", "add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)")
 	createCmd.Flags().BoolVar(&dockerDisableIPv6, "docker-disable-ipv6", false, "skip enabling IPv6 in containers (Docker only)")
 	createCmd.Flags().IntVar(&controlPlanePort, controlPlanePortFlag, constants.DefaultControlPlanePort, "control plane port (load balancer and local API port)")
+	createCmd.Flags().IntVar(&apiPort, apiPortFlag, constants.ApidPort, "API port (local Talos management API port)")
 	createCmd.Flags().IntVar(&kubePrismPort, kubePrismFlag, constants.DefaultKubePrismPort, "KubePrism port (set to 0 to disable)")
 	createCmd.Flags().BoolVar(&dhcpSkipHostname, "disable-dhcp-hostname", false, "skip announcing hostname via DHCP (QEMU only)")
 	createCmd.Flags().BoolVar(&skipBootPhaseFinishedCheck, "skip-boot-phase-finished-check", false, "skip waiting for node to finish boot phase")
@@ -1186,6 +1189,7 @@ func checkForDefinedGenFlag(flags *pflag.FlagSet) string {
 		bootloaderEnabledFlag,
 		forceEndpointFlag,
 		controlPlanePortFlag,
+		apiPortFlag,
 		kubePrismFlag,
 		firewallFlag,
 	}

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -646,6 +646,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 			}
 		}
 
+		endpointList = []string{forceEndpoint + ":50050"}
 		genOptions = append(genOptions, generate.WithEndpointList(endpointList))
 		configBundleOpts = append(configBundleOpts,
 			bundle.WithInputOptions(
@@ -774,7 +775,7 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 		}
 
 		if i == 0 {
-			nodeReq.Ports = []string{"50000:50000/tcp", fmt.Sprintf("%d:%d/tcp", controlPlanePort, controlPlanePort)}
+			nodeReq.Ports = []string{"50050:50000/tcp", fmt.Sprintf("%d:%d/tcp", controlPlanePort, controlPlanePort)}
 		}
 
 		if withInitNode && i == 0 {

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -625,6 +625,10 @@ func create(ctx context.Context, flags *pflag.FlagSet) error {
 
 		var endpointList []string
 
+		if controlPlanePort != 0 {
+			provisionOptions = append(provisionOptions, provision.WithPort(controlPlanePort))
+		}
+
 		switch {
 		case defaultEndpoint != "":
 			if forceEndpoint == "" {

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -15,7 +15,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	k8s "github.com/siderolabs/talos/pkg/kubernetes"
-	// "github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 // KubernetesClient provides Kubernetes client built via Talos API Kubeconfig.
@@ -25,6 +25,8 @@ type KubernetesClient struct {
 
 	// ForceEndpoint overrides default Kubernetes API endpoint.
 	ForceEndpoint string
+	// ForcePort overrides default Kubernetes API port
+	ForcePort int
 
 	KubeHelper *k8s.Client
 
@@ -68,7 +70,11 @@ func (k *KubernetesClient) K8sRestConfig(ctx context.Context) (*rest.Config, err
 	config.Timeout = time.Minute
 
 	if k.ForceEndpoint != "" {
-		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, 7444 /*constants.DefaultControlPlanePort*/)
+		port := k.ForcePort
+		if port == 0 {
+			port = constants.DefaultControlPlanePort
+		}
+		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, port)
 	}
 
 	return config, nil

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -15,7 +15,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	k8s "github.com/siderolabs/talos/pkg/kubernetes"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
+	// "github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 // KubernetesClient provides Kubernetes client built via Talos API Kubeconfig.
@@ -68,7 +68,7 @@ func (k *KubernetesClient) K8sRestConfig(ctx context.Context) (*rest.Config, err
 	config.Timeout = time.Minute
 
 	if k.ForceEndpoint != "" {
-		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, constants.DefaultControlPlanePort)
+		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, 7444 /*constants.DefaultControlPlanePort*/)
 	}
 
 	return config, nil

--- a/pkg/provision/access/adapter.go
+++ b/pkg/provision/access/adapter.go
@@ -72,6 +72,7 @@ func NewAdapter(clusterInfo provision.Cluster, opts ...provision.Option) *Adapte
 		KubernetesClient: cluster.KubernetesClient{
 			ClientProvider: &configProvider,
 			ForceEndpoint:  options.ForceEndpoint,
+			ForcePort:      options.ForcePort,
 		},
 		APICrashDumper: cluster.APICrashDumper{
 			ClientProvider: &configProvider,

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -34,6 +34,15 @@ func WithEndpoint(endpoint string) Option {
 	}
 }
 
+// WithPort specifies k8s port to use when acessing Talos cluster.
+func WithPort(port int) Option {
+	return func(o *Options) error {
+		o.ForcePort = port
+
+		return nil
+	}
+}
+
 // WithTalosConfig specifies talosconfig to use when acessing Talos cluster.
 func WithTalosConfig(talosConfig *clientconfig.Config) Option {
 	return func(o *Options) error {
@@ -139,6 +148,7 @@ type Options struct {
 	TalosConfig   *clientconfig.Config
 	TalosClient   *client.Client
 	ForceEndpoint string
+	ForcePort     int
 	TargetArch    string
 
 	// Enable bootloader by booting from disk image after install.

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -85,11 +85,11 @@ func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (int
 	case "darwin", "windows":
 		return "", "127.0.0.1"
 	case "linux":
-		if detectWSL() {
-			return "", "127.0.0.1"
-		}
+		// if detectWSL() {
+		return "", "127.0.0.1"
+		// }
 
-		fallthrough
+		// fallthrough
 	default:
 		return "", ""
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Making talosctl capable of creating multiple Docker clusters in case port forwarding is being used (Docker Desktop or WSL). Currently WIP

## Why? (reasoning)
Fixes #8141

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
