### PR TITLE
fix: remove maintenance config when maintenance service is shut down

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
+++ b/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
@@ -111,6 +111,12 @@ func (ctrl *MaintenanceServiceController) Run(ctx context.Context, r controller.
 			lastReachableAddresses = nil
 			lastListenAddress = ""
 		}
+
+		// clean up maintenance machine config, as we are done with the maintenance service
+		err := r.Destroy(ctx, config.NewMachineConfigWithID(nil, config.MaintenanceID).Metadata())
+		if err != nil && !state.IsNotFoundError(err) {
+			logger.Error("failed to destroy maintenance machine config", zap.String("id", config.MaintenanceID), zap.Error(err))
+		}
 	}
 
 	defer shutdownServer(context.Background())


### PR DESCRIPTION
We now remove the machine config with the id `maintenance` when we are done with it - when the maintenance service is shut down.

Closes siderolabs/talos#8424, where in some configurations there would be machine configs with both `v1alpha1` and `maintenance` IDs present, causing the `talosctl edit machineconfig` to loop twice and causing confusion.
