### PR TITLE
fix: patch correctly config in `talosctl upgrade-k8s`

### DIFF
--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -25,7 +25,6 @@ import (
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -285,10 +284,9 @@ func (suite *ApplyConfigSuite) TestApplyConfigRotateEncryptionSecrets() {
 	}
 
 	for _, keys := range keySets {
-		cfg.EncryptionKeys = keys
-
-		data, err := container.NewV1Alpha1(machineConfig).Bytes()
-		suite.Require().NoError(err)
+		data := suite.PatchV1Alpha1Config(provider, func(cfg *v1alpha1.Config) {
+			cfg.MachineConfig.MachineSystemDiskEncryption.EphemeralPartition.EncryptionKeys = keys
+		})
 
 		suite.AssertRebooted(
 			suite.ctx, node, func(nodeCtx context.Context) error {

--- a/pkg/cluster/kubernetes/patch.go
+++ b/pkg/cluster/kubernetes/patch.go
@@ -6,14 +6,12 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/safe"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
-	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	v1alpha1config "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -33,16 +31,14 @@ func patchNodeConfig(ctx context.Context, cluster UpgradeProvider, node string, 
 		return fmt.Errorf("error fetching config resource: %w", err)
 	}
 
-	cfg := mc.Container().RawV1Alpha1()
-	if cfg == nil {
-		return errors.New("config is not v1alpha1 config")
-	}
+	provider := mc.Provider()
 
-	if err = patchFunc(cfg); err != nil {
+	newProvider, err := provider.PatchV1Alpha1(patchFunc)
+	if err != nil {
 		return fmt.Errorf("error patching config: %w", err)
 	}
 
-	cfgBytes, err := container.NewV1Alpha1(cfg).EncodeBytes(encoderOpt)
+	cfgBytes, err := newProvider.EncodeBytes(encoderOpt)
 	if err != nil {
 		return fmt.Errorf("error serializing config: %w", err)
 	}

--- a/pkg/machinery/config/container/container_test.go
+++ b/pkg/machinery/config/container/container_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime/extensions"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -87,6 +88,35 @@ func TestNewDuplicate(t *testing.T) {
 
 	_, err = container.New(siderolink1, siderolink2)
 	assert.EqualError(t, err, "duplicate document: SideroLinkConfig/")
+}
+
+func TestPatchV1Alpha1(t *testing.T) {
+	t.Parallel()
+
+	v1alpha1Cfg := &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineType: "worker",
+		},
+	}
+
+	sideroLinkCfg := siderolink.NewConfigV1Alpha1()
+	sideroLinkCfg.APIUrlConfig.URL = must.Value(url.Parse("https://siderolink.api/?jointoken=secret&user=alice"))(t)
+
+	cfg, err := container.New(v1alpha1Cfg, sideroLinkCfg)
+	require.NoError(t, err)
+
+	patchedCfg, err := cfg.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		cfg.MachineConfig.MachineType = "controlplane"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, machine.TypeWorker, cfg.Machine().Type())
+	assert.Equal(t, machine.TypeControlPlane, patchedCfg.Machine().Type())
+
+	assert.Equal(t, "https://siderolink.api/?jointoken=secret&user=alice", cfg.SideroLink().APIUrl().String())
+	assert.Equal(t, "https://siderolink.api/?jointoken=secret&user=alice", patchedCfg.SideroLink().APIUrl().String())
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -42,6 +42,9 @@ type Provider interface {
 	// Clone returns a copy of the Provider.
 	Clone() Provider
 
+	// PatchV1Alpha1 patches the container's v1alpha1.Config while preserving other config documents.
+	PatchV1Alpha1(patcher func(*v1alpha1.Config) error) (Provider, error)
+
 	// RedactSecrets returns a copy of the Provider with all secrets replaced with the given string.
 	RedactSecrets(string) Provider
 


### PR DESCRIPTION
The current code was stipping non-`v1alpha1.Config` documents. Provide a proper method in the config provider, and update places using it.
