### PR TITLE
chore: annotate installer errors

### DIFF
--- a/internal/app/machined/pkg/controllers/block/devices.go
+++ b/internal/app/machined/pkg/controllers/block/devices.go
@@ -230,7 +230,7 @@ func (ctrl *DevicesController) processEvent(ctx context.Context, r controller.Ru
 		}
 
 		if err := inotifyWatcher.Remove(devPath); err != nil {
-			return fmt.Errorf("failed to remove inotify watch for %q: %w", devPath, err)
+			logger.Debug("failed to remove inotify watch", zap.String("device", devPath), zap.Error(err))
 		}
 	default:
 		logger.Debug("skipped, as action is not supported")

--- a/internal/app/machined/pkg/controllers/block/internal/inotify/inotify.go
+++ b/internal/app/machined/pkg/controllers/block/internal/inotify/inotify.go
@@ -39,7 +39,10 @@ func (w *watches) remove(wd uint32) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	delete(w.path, w.wd[wd].path)
+	if _, ok := w.wd[wd]; ok {
+		delete(w.path, w.wd[wd].path)
+	}
+
 	delete(w.wd, wd)
 }
 
@@ -207,7 +210,7 @@ func (w *Watcher) Run() (<-chan string, <-chan error) {
 				}
 
 				// Send the events that are not ignored on the events channel
-				if mask&unix.IN_IGNORED == 0 {
+				if mask&unix.IN_IGNORED == 0 && mask&unix.IN_CLOSE_WRITE != 0 {
 					eventCh <- name
 				}
 

--- a/internal/app/machined/pkg/controllers/block/internal/inotify/inotify_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/inotify/inotify_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block/internal/inotify"
 )
 
+//nolint:gocyclo
 func TestWatcher(t *testing.T) {
 	watcher, err := inotify.NewWatcher()
 	require.NoError(t, err)
@@ -58,6 +59,17 @@ func TestWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, f2.Close())
+
+	select {
+	case path := <-watchCh:
+		require.FailNow(t, "unexpected path", "%s", path)
+	case err = <-errCh:
+		require.FailNow(t, "unexpected error", "%s", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// remove file2
+	require.NoError(t, os.Remove(filepath.Join(d, "file2")))
 
 	select {
 	case path := <-watchCh:

--- a/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
+++ b/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
@@ -6,11 +6,13 @@
 package kobject
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/mdlayher/kobject"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 const readBufferSize = 64 * 1024 * 1024
@@ -77,7 +79,9 @@ func (w *Watcher) Run(logger *zap.Logger) <-chan *Event {
 		for {
 			ev, err := w.cli.Receive()
 			if err != nil {
-				logger.Error("failed to receive kobject event", zap.Error(err))
+				if !errors.Is(err, unix.EBADF) {
+					logger.Error("failed to receive kobject event", zap.Error(err))
+				}
 
 				return
 			}

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -172,6 +172,11 @@ func (c *Client) LeaveCluster(ctx context.Context, st state.State) error {
 			return retry.ExpectedError(err)
 		}
 
+		if errors.Is(err, rpctypes.ErrStopped) {
+			// retry the stopped errors as the member might be in the process of shutting down
+			return retry.ExpectedError(err)
+		}
+
 		return err
 	}); err != nil {
 		return err


### PR DESCRIPTION
I want to catch a spurious error `ENODEV`, where exactly it comes from.
