### PR TITLE
feat: report Docker node resources in cluster show

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/coreos/go-iptables v0.7.0
 	github.com/cosi-project/runtime v0.4.0-alpha.9
 	github.com/distribution/reference v0.5.0
-	github.com/docker/docker v25.0.4+incompatible
+	github.com/docker/docker v25.0.5+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ecks/uefi v0.0.0-20221116212947-caef65d070eb

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/docker/cli v24.0.0+incompatible h1:0+1VshNwBQzQAx9lOl+OYCTCEAD8fKs/qe
 github.com/docker/cli v24.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.4+incompatible h1:XITZTrq+52tZyZxUOtFIahUf3aH367FLxJzt9vZeAF8=
-github.com/docker/docker v25.0.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
+github.com/docker/docker v25.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/pkg/provision/providers/docker/reflect.go
+++ b/pkg/provision/providers/docker/reflect.go
@@ -68,6 +68,11 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory s
 			return nil, err
 		}
 
+		container, err := p.client.ContainerInspect(ctx, node.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		var ips []netip.Addr
 
 		if network, ok := node.NetworkSettings.Networks[res.clusterInfo.Network.Name]; ok {
@@ -91,6 +96,9 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory s
 				Type: t,
 
 				IPs: ips,
+
+				NanoCPUs: container.HostConfig.Resources.NanoCPUs,
+				Memory:   container.HostConfig.Resources.Memory,
 			})
 	}
 


### PR DESCRIPTION
# Pull Request

## What? (description)

For consistency with `talosctl cluster create`, this commit fetches the missing information through an inspect call for each node so that this information are available from a `Reflect` initialization.

## Why? (reasoning)

`talosctl cluster show` currently reports '-' in the CPU and RAM columns because this information are not available directly from the container list API call.

## Open questions

➡️ Placing a call to Docker inspect in this location does not feel right from an architecture point of view. It should probably be in `listNodes` instead, but it would change the signature from `[]types.Container` to `[]types.Container`. While this type is mostly a superset of the former, it will require adaptations to the existing callers. Let me know if you want me to do this.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)... But it complains with "openpgp: signature made by unknown entity"
- [x] you formatted your code (`make fmt`) --> Fails on 'api/*'
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
