### PR TITLE
fix: populate routes to BGP neighbors (Equinix Metal)

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/metadata.go
@@ -6,11 +6,12 @@ package equinixmetal
 
 // MetadataConfig holds equinixmetal metadata info.
 type MetadataConfig struct {
-	ID             string   `json:"id"`
-	Hostname       string   `json:"hostname"`
-	Plan           string   `json:"plan"`
-	Metro          string   `json:"metro"`
-	Facility       string   `json:"facility"`
-	Network        Network  `json:"network"`
-	PrivateSubnets []string `json:"private_subnets"`
+	ID             string        `json:"id"`
+	Hostname       string        `json:"hostname"`
+	Plan           string        `json:"plan"`
+	Metro          string        `json:"metro"`
+	Facility       string        `json:"facility"`
+	Network        Network       `json:"network"`
+	BGPNeighbors   []BGPNeighbor `json:"bgp_neighbors"`
+	PrivateSubnets []string      `json:"private_subnets"`
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
@@ -95,6 +95,28 @@ routes:
       flags: ""
       protocol: static
       layer: platform
+    - family: inet4
+      dst: 169.254.255.1/32
+      src: ""
+      gateway: 10.66.142.16
+      outLinkName: bond0
+      table: main
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: 169.254.255.2/32
+      src: ""
+      gateway: 10.66.142.16
+      outLinkName: bond0
+      table: main
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
 hostnames:
     - hostname: infra-green-ci
       domainname: ""

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/metadata.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/metadata.json
@@ -111,6 +111,38 @@
         ],
         "metal_gateways": []
     },
+    "bgp_neighbors": [
+        {
+          "address_family": 4,
+          "customer_as": 65000,
+          "customer_ip": "10.67.50.1",
+          "md5_enabled": false,
+          "md5_password": null,
+          "multihop": true,
+          "peer_as": 65530,
+          "peer_ips": [
+            "169.254.255.1",
+            "169.254.255.2"
+          ],
+          "routes_in": [],
+          "routes_out": []
+        },
+        {
+          "address_family": 6,
+          "customer_as": 65000,
+          "customer_ip": "2604:1380:45e1:5000::1",
+          "md5_enabled": false,
+          "md5_password": null,
+          "multihop": true,
+          "peer_as": 65530,
+          "peer_ips": [
+            "fc00:0000:0000:0000:0000:0000:0000:000e",
+            "fc00:0000:0000:0000:0000:0000:0000:000f"
+          ],
+          "routes_in": [],
+          "routes_out": []
+        }
+    ],
     "api_url": "https://metadata.packet.net",
     "phone_home_url": "http://tinkerbell.ny5.packet.net/phone-home",
     "user_state_url": "http://tinkerbell.ny5.packet.net/events"

--- a/website/content/v1.6/_index.md
+++ b/website/content/v1.6/_index.md
@@ -4,8 +4,8 @@ no_list: true
 linkTitle: "Documentation"
 cascade:
   type: docs
-lastRelease: v1.6.4
-kubernetesRelease: "1.29.1"
+lastRelease: v1.6.7
+kubernetesRelease: "1.29.3"
 prevKubernetesRelease: "1.28.3"
 nvidiaContainerToolkitRelease: "v1.13.5"
 nvidiaDriverRelease: "535.129.03"


### PR DESCRIPTION
Fixes #8267

Also refactor the code so that we don't fail hard on mutiple bonds, but it's not clear still how to attach addresses, as they don't have a interface name field, so for now attaching to the first bond.

Fixes #8411
