### PR TITLE
chore: talosctl: add openSUSE OVMF paths

### DIFF
--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -106,6 +106,7 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			"OVMF_CODE.secboot.fd",
 			"OVMF.secboot.fd",
 			"edk2-x86_64-secure-code.fd", // Alpine Linux
+			"ovmf-x86_64-ms-4m-code.bin",
 		}
 
 		// Non-secure boot firmware files
@@ -113,12 +114,14 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			"OVMF_CODE_4M.fd",
 			"OVMF_CODE.fd",
 			"OVMF.fd",
+			"ovmf-x86_64-4m-code.bin",
 		}
 
 		// Empty vars files
 		uefiVarsFiles := []string{
 			"OVMF_VARS_4M.fd",
 			"OVMF_VARS.fd",
+			"ovmf-x86_64-4m-vars.bin",
 		}
 
 		uefiSourceFiles = append(uefiSourceFiles, uefiSourceFilesInsecure...)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
add openSUSE OVMF paths

Tested both secureboot and non-secure code. Not enabled SB by default

## Why? (reasoning)
Avoid the need to copy those files to temp files

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
