### PR TITLE
fix: initial assignment of alias IP in hcloud (Hetzner)

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator_vip_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_vip_config.go
@@ -229,7 +229,7 @@ func handleVIP(ctx context.Context, vlanConfig talosconfig.VIPConfig, deviceName
 		spec.VIP.GratuitousARP = false
 		spec.VIP.HCloud.APIToken = vlanConfig.HCloud().APIToken()
 
-		if err = vip.GetNetworkAndDeviceIDs(ctx, &spec.VIP.HCloud, sharedIP); err != nil {
+		if err = vip.GetNetworkAndDeviceIDs(ctx, &spec.VIP.HCloud, sharedIP, logger); err != nil {
 			return network.OperatorSpecSpec{}, err
 		}
 	// Regular layer 2 VIP


### PR DESCRIPTION
# Pull Request

## What? (description)
As described in https://github.com/siderolabs/talos/issues/3599, assigning an alias IP in Hetzner Cloud at bootstrap of the cluster does (sometimes) not work. 

The assignment of private networks happens in the hetzner cloud after starting the server and therefore often after querying the network information when assigning VIPs.

If an alias IP is to be set but no private network is yet available, an error message is now thrown, until the private network is assigned.

Previously, no error message was thrown and the network ID was set to 0, which means that the VIP is regarded as a public floating IP in the further code and not as a private alias IP.

In addition, some logs are added that make it much easier to find out what is happening.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`) -> GPG Identity failed
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
