### PR TITLE
extensions: allow dtbs paths to open to extensions with device tree overlays

### DIFF
--- a/pkg/machinery/extensions/extensions.go
+++ b/pkg/machinery/extensions/extensions.go
@@ -17,4 +17,6 @@ var AllowedPaths = []string{
 	"/usr/share/glvnd",
 	"/usr/share/egl",
 	"/etc/vulkan",
+	"/dtb",
+	"/boot/dtb",
 }


### PR DESCRIPTION
# extensions: allow dtbs paths to open to extensions with device tree overlays

## What? (description)

Added the following paths to extensions AllowedPaths:
- `/dtb`: used by edk2
- `/boot/dtb`: used by U-Boot

## Why? (reasoning)

To allow extensions to add device tree overlays

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
