### PR TITLE
docs: quickstart video and brew install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ TEXTLINT_FILTER_RULE_COMMENTS_VERSION ?= 1.2.2
 # renovate: datasource=npm depName=textlint-rule-one-sentence-per-line
 TEXTLINT_RULE_ONE_SENTENCE_PER_LINE_VERSION ?= 2.0.0
 # renovate: datasource=docker depName=klakegg/hugo
-HUGO_VERSION ?= 0.99.1-ext-alpine
+HUGO_VERSION ?= 0.111.3-ext-alpine
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)

--- a/website/content/v1.4/introduction/quickstart.md
+++ b/website/content/v1.4/introduction/quickstart.md
@@ -4,6 +4,8 @@ weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
 ---
 
+{{< youtube IO2Yo3N46nk >}}
+
 ## Local Docker Cluster
 
 The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluster on a machine with `docker` installed.
@@ -12,10 +14,10 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 #### `talosctl`
 
-Download `talosctl`:
+Download `talosctl` (macOS or Linux):
 
 ```bash
-curl -sL https://talos.dev/install | sh
+brew install siderolabs/tap/talosctl
 ```
 
 #### `kubectl`
@@ -30,6 +32,10 @@ Now run the following:
 talosctl cluster create
 ```
 
+{{% alert title="Note" color="info" %}}
+If you are using Docker Desktop on a macOS computer you will need to enable the default Docker socket in your settings.
+{{% /alert %}}
+
 You can explore using Talos API commands:
 
 ```bash
@@ -39,7 +45,7 @@ talosctl dashboard --nodes 10.5.0.2
 Verify that you can reach Kubernetes:
 
 ```bash
-$ kubectl get nodes -o wide
+kubectl get nodes -o wide
 NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
 talos-default-controlplane-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 talos-default-worker-1   Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5

--- a/website/content/v1.5/introduction/quickstart.md
+++ b/website/content/v1.5/introduction/quickstart.md
@@ -4,6 +4,8 @@ weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
 ---
 
+{{< youtube IO2Yo3N46nk >}}
+
 ## Local Docker Cluster
 
 The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluster on a machine with `docker` installed.
@@ -12,10 +14,10 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 #### `talosctl`
 
-Download `talosctl`:
+Download `talosctl` (macOS or Linux):
 
 ```bash
-curl -sL https://talos.dev/install | sh
+brew install siderolabs/tap/talosctl
 ```
 
 #### `kubectl`
@@ -30,6 +32,10 @@ Now run the following:
 talosctl cluster create
 ```
 
+{{% alert title="Note" color="info" %}}
+If you are using Docker Desktop on a macOS computer you will need to enable the default Docker socket in your settings.
+{{% /alert %}}
+
 You can explore using Talos API commands:
 
 ```bash
@@ -39,10 +45,10 @@ talosctl dashboard --nodes 10.5.0.2
 Verify that you can reach Kubernetes:
 
 ```bash
-$ kubectl get nodes -o wide
-NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
+kubectl get nodes -o wide
+NAME                           STATUS   ROLES    AGE    VERSION          INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                 KERNEL-VERSION   CONTAINER-RUNTIME
 talos-default-controlplane-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
-talos-default-worker-1   Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
+talos-default-worker-1         Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 ```
 
 ### Destroy the Cluster

--- a/website/content/v1.6/introduction/quickstart.md
+++ b/website/content/v1.6/introduction/quickstart.md
@@ -4,6 +4,8 @@ weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
 ---
 
+{{< youtube IO2Yo3N46nk >}}
+
 ## Local Docker Cluster
 
 The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluster on a machine with `docker` installed.
@@ -12,10 +14,10 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 #### `talosctl`
 
-Download `talosctl`:
+Download `talosctl` (macOS or Linux):
 
 ```bash
-curl -sL https://talos.dev/install | sh
+brew install siderolabs/tap/talosctl
 ```
 
 #### `kubectl`
@@ -30,6 +32,10 @@ Now run the following:
 talosctl cluster create
 ```
 
+{{% alert title="Note" color="info" %}}
+If you are using Docker Desktop on a macOS computer you will need to enable the default Docker socket in your settings.
+{{% /alert %}}
+
 You can explore using Talos API commands:
 
 ```bash
@@ -39,10 +45,10 @@ talosctl dashboard --nodes 10.5.0.2
 Verify that you can reach Kubernetes:
 
 ```bash
-$ kubectl get nodes -o wide
-NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
+kubectl get nodes -o wide
+NAME                           STATUS   ROLES    AGE    VERSION          INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                 KERNEL-VERSION   CONTAINER-RUNTIME
 talos-default-controlplane-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
-talos-default-worker-1   Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
+talos-default-worker-1         Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 ```
 
 ### Destroy the Cluster

--- a/website/content/v1.7/introduction/quickstart.md
+++ b/website/content/v1.7/introduction/quickstart.md
@@ -4,6 +4,8 @@ weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
 ---
 
+{{< youtube IO2Yo3N46nk >}}
+
 ## Local Docker Cluster
 
 The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluster on a machine with `docker` installed.
@@ -12,10 +14,10 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 #### `talosctl`
 
-Download `talosctl`:
+Download `talosctl` (macOS or Linux):
 
 ```bash
-curl -sL https://talos.dev/install | sh
+brew install siderolabs/tap/talosctl
 ```
 
 #### `kubectl`
@@ -30,6 +32,10 @@ Now run the following:
 talosctl cluster create
 ```
 
+{{% alert title="Note" color="info" %}}
+If you are using Docker Desktop on a macOS computer you will need to enable the default Docker socket in your settings.
+{{% /alert %}}
+
 You can explore using Talos API commands:
 
 ```bash
@@ -39,10 +45,10 @@ talosctl dashboard --nodes 10.5.0.2
 Verify that you can reach Kubernetes:
 
 ```bash
-$ kubectl get nodes -o wide
-NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
+kubectl get nodes -o wide
+NAME                           STATUS   ROLES    AGE    VERSION          INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                 KERNEL-VERSION   CONTAINER-RUNTIME
 talos-default-controlplane-1   Ready    master   115s   v{{< k8s_release >}}   10.5.0.2      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
-talos-default-worker-1   Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
+talos-default-worker-1         Ready    <none>   115s   v{{< k8s_release >}}   10.5.0.3      <none>        Talos ({{< release >}})   <host kernel>    containerd://1.5.5
 ```
 
 ### Destroy the Cluster


### PR DESCRIPTION
Bump hugo and change the quickstart guide to use brew install instructions. Updated command formatting and added warning for macOS Docker Desktop users.