### PR TITLE
fix: allow platform cmdline args to be platform-specific

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -92,7 +92,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		cmdline.Append(constants.KernelParamConfig, opts.ConfigSource)
 	}
 
-	cmdline.SetAll(p.KernelArgs().Strings())
+	cmdline.SetAll(p.KernelArgs(opts.Arch).Strings())
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
 	if err := cmdline.AppendAll(kernel.DefaultArgs); err != nil {

--- a/internal/app/machined/pkg/controllers/block/devices_test.go
+++ b/internal/app/machined/pkg/controllers/block/devices_test.go
@@ -5,6 +5,7 @@
 package block_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
@@ -25,6 +26,10 @@ func TestDevicesSuite(t *testing.T) {
 }
 
 func (suite *DevicesSuite) TestDiscover() {
+	if os.Geteuid() != 0 {
+		suite.T().Skip("skipping test; must be root to use inotify")
+	}
+
 	suite.Require().NoError(suite.Runtime().RegisterController(&blockctrls.DevicesController{}))
 
 	// these devices should always exist on Linux

--- a/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
+++ b/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
@@ -6,13 +6,11 @@
 package kobject
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/mdlayher/kobject"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 )
 
 const readBufferSize = 64 * 1024 * 1024
@@ -79,7 +77,7 @@ func (w *Watcher) Run(logger *zap.Logger) <-chan *Event {
 		for {
 			ev, err := w.cli.Receive()
 			if err != nil {
-				if !errors.Is(err, unix.EBADF) {
+				if err.Error() == "use of closed file" { // unfortunately not an exported error, just errors.New()
 					logger.Error("failed to receive kobject event", zap.Error(err))
 				}
 

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -715,7 +715,7 @@ func (mock *platformMock) Mode() v1alpha1runtime.Mode {
 	return v1alpha1runtime.ModeCloud
 }
 
-func (mock *platformMock) KernelArgs() procfs.Parameters {
+func (mock *platformMock) KernelArgs(string) procfs.Parameters {
 	return nil
 }
 

--- a/internal/app/machined/pkg/runtime/platform.go
+++ b/internal/app/machined/pkg/runtime/platform.go
@@ -30,7 +30,7 @@ type Platform interface {
 	Configuration(context.Context, state.State) ([]byte, error)
 
 	// KernelArgs returns additional kernel arguments which should be injected for the kernel boot.
-	KernelArgs() procfs.Parameters
+	KernelArgs(arch string) procfs.Parameters
 
 	// NetworkConfiguration fetches network configuration from the platform metadata.
 	//

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -140,7 +140,7 @@ func (a *AWS) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *AWS) KernelArgs() procfs.Parameters {
+func (a *AWS) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -211,7 +211,7 @@ func (a *Azure) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *Azure) KernelArgs() procfs.Parameters {
+func (a *Azure) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0,115200n8"),
 		procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -52,7 +52,7 @@ func (c *Container) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (c *Container) KernelArgs() procfs.Parameters {
+func (c *Container) KernelArgs(string) procfs.Parameters {
 	return nil
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -256,7 +256,7 @@ func (d *DigitalOcean) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (d *DigitalOcean) KernelArgs() procfs.Parameters {
+func (d *DigitalOcean) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0").Append("tty0").Append("tty1"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -110,9 +110,18 @@ func (p *EquinixMetal) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (p *EquinixMetal) KernelArgs() procfs.Parameters {
-	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS1,115200n8"),
+func (p *EquinixMetal) KernelArgs(arch string) procfs.Parameters {
+	switch arch {
+	case "amd64":
+		return []*procfs.Parameter{
+			procfs.NewParameter("console").Append("ttyS1,115200n8"),
+		}
+	case "arm64":
+		return []*procfs.Parameter{
+			procfs.NewParameter("console").Append("ttyAMA0,115200"),
+		}
+	default:
+		return nil
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
@@ -86,7 +86,7 @@ func (e *Exoscale) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (e *Exoscale) KernelArgs() procfs.Parameters {
+func (e *Exoscale) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -199,7 +199,7 @@ func (g *GCP) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (g *GCP) KernelArgs() procfs.Parameters {
+func (g *GCP) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -167,7 +167,7 @@ func (h *Hcloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (h *Hcloud) KernelArgs() procfs.Parameters {
+func (h *Hcloud) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -154,9 +154,18 @@ func readConfigFromISO() ([]byte, error) {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (m *Metal) KernelArgs() procfs.Parameters {
-	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS0").Append("tty0"),
+func (m *Metal) KernelArgs(arch string) procfs.Parameters {
+	switch arch {
+	case "amd64":
+		return []*procfs.Parameter{
+			procfs.NewParameter("console").Append("ttyS0").Append("tty0"),
+		}
+	case "arm64":
+		return []*procfs.Parameter{
+			procfs.NewParameter("console").Append("ttyAMA0").Append("tty0"),
+		}
+	default:
+		return nil
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -96,7 +96,7 @@ func (n *Nocloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (n *Nocloud) KernelArgs() procfs.Parameters {
+func (n *Nocloud) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
@@ -225,7 +225,7 @@ func (o *OpenNebula) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *OpenNebula) KernelArgs() procfs.Parameters {
+func (o *OpenNebula) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -344,7 +344,7 @@ func (o *Openstack) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *Openstack) KernelArgs() procfs.Parameters {
+func (o *Openstack) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
@@ -159,7 +159,7 @@ func (o *Oracle) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *Oracle) KernelArgs() procfs.Parameters {
+func (o *Oracle) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -182,7 +182,7 @@ func (s *Scaleway) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (s *Scaleway) KernelArgs() procfs.Parameters {
+func (s *Scaleway) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -195,7 +195,7 @@ func (u *UpCloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (u *UpCloud) KernelArgs() procfs.Parameters {
+func (u *UpCloud) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -220,7 +220,7 @@ func (v *VMware) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (v *VMware) KernelArgs() procfs.Parameters {
+func (v *VMware) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter(constants.KernelParamConfig).Append(constants.ConfigGuestInfo),
 		procfs.NewParameter("console").Append("tty0").Append("ttyS0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -35,7 +35,7 @@ func (v *VMware) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (v *VMware) KernelArgs() procfs.Parameters {
+func (v *VMware) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
@@ -176,7 +176,7 @@ func (v *Vultr) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (v *Vultr) KernelArgs() procfs.Parameters {
+func (v *Vultr) KernelArgs(string) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 	}

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -322,7 +322,7 @@ func (i *Imager) buildCmdline() error {
 
 	// platform kernel args
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
-	cmdline.SetAll(p.KernelArgs().Strings())
+	cmdline.SetAll(p.KernelArgs(i.prof.Arch).Strings())
 
 	// board kernel args
 	if i.prof.Board != "" && !quirks.New(i.prof.Version).SupportsOverlay() {


### PR DESCRIPTION
Fix Equnix Metal (where proper arm64 args are known) and metal platform (using generic arm64 console arg).

Other platforms might need to be updated, but correct settings are not known at the moment.

Fixes #8529
