### PR TITLE
fix: retry in the fixed amount of time if grpc relay failed

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -243,10 +243,8 @@ func (suite *AddressMergeSuite) TestMergeFlapping() {
 						resource.VersionUndefined,
 					),
 					"foo",
-				); err != nil {
-					if err != nil && !state.IsNotFoundError(err) {
-						return err
-					}
+				); err != nil && !state.IsNotFoundError(err) {
+					return err
 				}
 			}
 

--- a/internal/app/machined/pkg/controllers/network/link_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge_test.go
@@ -267,10 +267,8 @@ func (suite *LinkMergeSuite) TestMergeFlapping() {
 						resource.VersionUndefined,
 					),
 					"foo",
-				); err != nil {
-					if err != nil && !state.IsNotFoundError(err) {
-						return err
-					}
+				); err != nil && !state.IsNotFoundError(err) {
+					return err
 				}
 			}
 

--- a/internal/app/machined/pkg/controllers/network/operator_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_merge_test.go
@@ -266,10 +266,8 @@ func (suite *OperatorMergeSuite) TestMergeFlapping() {
 						resource.VersionUndefined,
 					),
 					"foo",
-				); err != nil {
-					if err != nil && !state.IsNotFoundError(err) {
-						return err
-					}
+				); err != nil && !state.IsNotFoundError(err) {
+					return err
 				}
 			}
 

--- a/internal/app/machined/pkg/controllers/network/route_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge_test.go
@@ -309,10 +309,8 @@ func (suite *RouteMergeSuite) TestMergeFlapping() {
 						resource.VersionUndefined,
 					),
 					"foo",
-				); err != nil {
-					if err != nil && !state.IsNotFoundError(err) {
-						return err
-					}
+				); err != nil && !state.IsNotFoundError(err) {
+					return err
 				}
 			}
 


### PR DESCRIPTION
Before this commit, if tunnel failed with error, it would never restart again until `siderolink.TunnelType` event happen. For most of the time it's a good idea, because it might mean that destination has changed.

But tunnel can also fail because allowed peer list is not yet loaded on newly started Omni instance.

Because of that, we want to try again and not be tied to the runtime event channel.