### PR TITLE
fix: report unsupported x86_64 microarchitecture level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -356,8 +356,7 @@ FROM base AS init-build-amd64
 WORKDIR /src/internal/app/init
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
-ARG GOAMD64
-RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=amd64 GOAMD64=${GOAMD64} go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /init
+RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=amd64 GOAMD64=v1 go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /init
 RUN chmod +x /init
 
 FROM base AS init-build-arm64

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/jeromer/syslogparser v1.1.0
 	github.com/jsimonetti/rtnetlink v1.4.1
 	github.com/jxskiss/base62 v1.1.0
+	github.com/klauspost/cpuid/v2 v2.2.7
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
 github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
+github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
+++ b/internal/app/machined/pkg/controllers/block/internal/kobject/kobject.go
@@ -77,7 +77,7 @@ func (w *Watcher) Run(logger *zap.Logger) <-chan *Event {
 		for {
 			ev, err := w.cli.Receive()
 			if err != nil {
-				if err.Error() == "use of closed file" { // unfortunately not an exported error, just errors.New()
+				if err.Error() != "use of closed file" { // unfortunately not an exported error, just errors.New()
 					logger.Error("failed to receive kobject event", zap.Error(err))
 				}
 

--- a/internal/integration/api/rotate.go
+++ b/internal/integration/api/rotate.go
@@ -116,6 +116,8 @@ func (suite *RotateCASuite) TestTalos() {
 	suite.Require().NoError(err)
 
 	suite.AssertClusterHealthy(suite.ctx)
+
+	suite.ClearConnectionRefused(suite.ctx, suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)...)
 }
 
 // TestKubernetes updates Kubernetes CA in the cluster.

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -398,7 +398,7 @@ func (apiSuite *APISuite) ClearConnectionRefused(ctx context.Context, nodes ...s
 				continue
 			}
 
-			if client.StatusCode(err) == codes.Unavailable {
+			if client.StatusCode(err) == codes.Unavailable || client.StatusCode(err) == codes.Canceled {
 				return retry.ExpectedError(err)
 			}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -992,6 +992,9 @@ const (
 
 	// SyslogListenSocketPath is the path to the syslog socket.
 	SyslogListenSocketPath = "/dev/log"
+
+	// MinimumGOAMD64Level is the minimum x86_64 microarchitecture level required by Talos.
+	MinimumGOAMD64Level = 2
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/rotate/pki/kubernetes/kubernetes.go
+++ b/pkg/rotate/pki/kubernetes/kubernetes.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/go-retry/retry"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
Fixes #8361

Talos requires v2 (circa 2008), but VMs are often configured to limit the exposed features to the baseline (v1).

```
[    0.779218] [talos] [initramfs] booting Talos v1.7.0-alpha.1-35-gef5bbe728-dirty
[    0.779806] [talos] [initramfs] CPU: QEMU Virtual CPU version 2.5+, 4 core(s), 1 thread(s) per core
[    0.780529] [talos] [initramfs] x86_64 microarchitecture level: 1
[    0.781018] [talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
[    0.782346] [talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
```
