### PR TITLE
fix: handle more OpenStack link types

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -146,8 +146,31 @@ func (o *Openstack) ParseMetadata(
 	// Interfaces
 
 	for idx, netLink := range unmarshalledNetworkConfig.Links {
+		// OpenStack network metadata schema:
+		// "type": {
+		// 	"$id": "#/definitions/l2_link/properties/type",
+		// 	"type": "string",
+		// 	"enum": [
+		// 	  "bridge",
+		// 	  "dvs",
+		// 	  "hw_veb",
+		// 	  "hyperv",
+		// 	  "ovs",
+		// 	  "tap",
+		// 	  "vhostuser",
+		// 	  "vif",
+		// 	  "phy"
+		// 	],
+		// 	"title": "Interface type",
+		// 	"examples": [
+		// 	  "bridge"
+		// 	]
+		//   },
+		//   "vif_id": {
+		// 	"$ref": "#/definitions/l2_vif_id"
+		//   }
 		switch netLink.Type {
-		case "phy", "vif", "ovs":
+		case "phy", "vif", "ovs", "bridge", "tap", "vhostuser", "hw_veb":
 			linkName := ""
 
 			for hostInterfaceIter := hostInterfaces.Iterator(); hostInterfaceIter.Next(); {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
@@ -36,7 +36,7 @@
         },
         {
             "id": "411f3980-d8f9-4bf0-a09a-9c01c81e1022",
-            "type": "phy",
+            "type": "bridge",
             "ethernet_mac_address": "4c:d9:8f:b3:34:f8"
         },
         {


### PR DESCRIPTION
Fixes #8531 

The issue was that the link 'bridge' was skipped, so Talos default was applied to run DHCP and use the DHCP hostname (instead of using platform's hostname).
