### PR TITLE
fix: don't announce the VIP on acquire failure

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/vip.go
+++ b/internal/app/machined/pkg/controllers/network/operator/vip.go
@@ -366,6 +366,12 @@ func (vip *VIP) markAsLeader(ctx context.Context, notifyCh chan<- struct{}, lead
 
 	if leader {
 		handlerErr = vip.handler.Acquire(ctx)
+
+		if handlerErr != nil {
+			// if failed to acquire, we are not a leader, we will resign from the election
+			// so don't mark as leader, so that Talos doesn't announce IPs on the host
+			leader = false
+		}
 	} else {
 		handlerErr = vip.handler.Release(ctx)
 	}


### PR DESCRIPTION
I noticed that while looking at #8493, but I don't know if this problem actually happened in real life.

If acquiring a VIP fails (which can only fail for Equinix/HCloud, not L2 ARP announce), we should not set the leader flag, as it would make the controller announce the IP, while it shouldn't do that.

If this call fails, there's no matching call to de-announce on failure.

The bug would show up as two nodes having same VIP assigned on the host.
