### PR TITLE
feat: support multiple Docker cluster in talosctl cluster create

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -63,6 +63,7 @@ func showCluster(cluster provision.Cluster) error {
 
 	fmt.Fprintf(w, "NETWORK GATEWAY\t%s\n", strings.Join(gateways, ","))
 	fmt.Fprintf(w, "NETWORK MTU\t%d\n", cluster.Info().Network.MTU)
+	fmt.Fprintf(w, "KUBERNETES ENDPOINT\t%s\n", cluster.Info().KubernetesEndpoint)
 
 	if err := w.Flush(); err != nil {
 		return err

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -21,8 +21,6 @@ function create_cluster {
     --memory=2048 \
     --cpus=2.0 \
     --with-init-node=false \
-    --docker-host-ip=127.0.0.1 \
-    --endpoint=127.0.0.1 \
     ${REGISTRY_MIRROR_FLAGS} \
     --crashdump
 

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -171,7 +171,7 @@ function run_talos_integration_test_docker {
       ;;
   esac
 
-  "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.kubectlpath "${KUBECTL}" -talos.k8sendpoint 127.0.0.1:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" -talos.image "${REGISTRY}/siderolabs/talos" "${EXTRA_TEST_ARGS[@]}" "${TEST_RUN[@]}" "${TEST_SHORT[@]}"
+  "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.kubectlpath "${KUBECTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" -talos.image "${REGISTRY}/siderolabs/talos" "${EXTRA_TEST_ARGS[@]}" "${TEST_RUN[@]}" "${TEST_SHORT[@]}"
 }
 
 function run_kubernetes_conformance_test {

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -81,7 +80,7 @@ func (suite *HealthSuite) testClientSide(extraArgs ...string) {
 	args := append([]string{"--server=false"}, extraArgs...)
 
 	if suite.K8sEndpoint != "" {
-		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])
+		args = append(args, "--k8s-endpoint", suite.K8sEndpoint)
 	}
 
 	suite.RunCLI(append([]string{"health"}, args...),

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -82,6 +82,10 @@ func TestIntegration(t *testing.T) {
 		if err != nil {
 			t.Error("error reflecting cluster via provisioner", err)
 		}
+
+		if k8sEndpoint == "" {
+			k8sEndpoint = cluster.Info().KubernetesEndpoint
+		}
 	}
 
 	provision_test.DefaultSettings.CurrentVersion = expectedVersion

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -43,7 +43,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/access"
@@ -494,8 +493,7 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 		StateDirectory: suite.stateDir,
 	}
 
-	defaultInternalLB, _ := suite.provisioner.GetLoadBalancers(request.Network)
-	suite.controlPlaneEndpoint = fmt.Sprintf("https://%s", nethelpers.JoinHostPort(defaultInternalLB, constants.DefaultControlPlanePort))
+	suite.controlPlaneEndpoint = suite.provisioner.GetExternalKubernetesControlPlaneEndpoint(request.Network, constants.DefaultControlPlanePort)
 
 	genOptions := suite.provisioner.GenOptions(request.Network)
 

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -6,7 +6,9 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -68,7 +70,15 @@ func (k *KubernetesClient) K8sRestConfig(ctx context.Context) (*rest.Config, err
 	config.Timeout = time.Minute
 
 	if k.ForceEndpoint != "" {
-		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, constants.DefaultControlPlanePort)
+		forceEndpoint, _ := strings.CutPrefix(k.ForceEndpoint, "https://")
+
+		host, port, err := net.SplitHostPort(forceEndpoint)
+		if err != nil {
+			host = forceEndpoint
+			port = strconv.Itoa(constants.DefaultControlPlanePort)
+		}
+
+		config.Host = net.JoinHostPort(host, port)
 	}
 
 	return config, nil

--- a/pkg/machinery/config/generate/options.go
+++ b/pkg/machinery/config/generate/options.go
@@ -59,7 +59,7 @@ func WithInstallDisk(disk string) Option {
 // WithAdditionalSubjectAltNames specifies additional SANs.
 func WithAdditionalSubjectAltNames(sans []string) Option {
 	return func(o *Options) error {
-		o.AdditionalSubjectAltNames = sans
+		o.AdditionalSubjectAltNames = append(o.AdditionalSubjectAltNames, sans...)
 
 		return nil
 	}

--- a/pkg/provision/access/adapter.go
+++ b/pkg/provision/access/adapter.go
@@ -71,7 +71,7 @@ func NewAdapter(clusterInfo provision.Cluster, opts ...provision.Option) *Adapte
 		ConfigClientProvider: configProvider,
 		KubernetesClient: cluster.KubernetesClient{
 			ClientProvider: &configProvider,
-			ForceEndpoint:  options.ForceEndpoint,
+			ForceEndpoint:  options.KubernetesEndpoint,
 		},
 		APICrashDumper: cluster.APICrashDumper{
 			ClientProvider: &configProvider,

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -25,10 +25,10 @@ func WithLogWriter(w io.Writer) Option {
 	}
 }
 
-// WithEndpoint specifies endpoint to use when acessing Talos cluster.
-func WithEndpoint(endpoint string) Option {
+// WithKubernetesEndpoint specifies full external Kubernetes API endpoint to use when accessing Talos cluster.
+func WithKubernetesEndpoint(endpoint string) Option {
 	return func(o *Options) error {
-		o.ForceEndpoint = endpoint
+		o.KubernetesEndpoint = endpoint
 
 		return nil
 	}
@@ -144,11 +144,11 @@ func WithSiderolinkAgent(v bool) Option {
 
 // Options describes Provisioner parameters.
 type Options struct {
-	LogWriter     io.Writer
-	TalosConfig   *clientconfig.Config
-	TalosClient   *client.Client
-	ForceEndpoint string
-	TargetArch    string
+	LogWriter          io.Writer
+	TalosConfig        *clientconfig.Config
+	TalosClient        *client.Client
+	KubernetesEndpoint string
+	TargetArch         string
 
 	// Enable bootloader by booting from disk image after install.
 	BootloaderEnabled bool

--- a/pkg/provision/providers/docker/create.go
+++ b/pkg/provision/providers/docker/create.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
@@ -37,7 +38,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating controlplane nodes")
 
-	if nodeInfo, err = p.createNodes(ctx, request, request.Nodes.ControlPlaneNodes(), &options); err != nil {
+	if nodeInfo, err = p.createNodes(ctx, request, request.Nodes.ControlPlaneNodes(), &options, true); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +46,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	var workerNodeInfo []provision.NodeInfo
 
-	if workerNodeInfo, err = p.createNodes(ctx, request, request.Nodes.WorkerNodes(), &options); err != nil {
+	if workerNodeInfo, err = p.createNodes(ctx, request, request.Nodes.WorkerNodes(), &options, false); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +61,8 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 				GatewayAddrs: request.Network.GatewayAddrs[:1],
 				MTU:          request.Network.MTU,
 			},
-			Nodes: nodeInfo,
+			Nodes:              nodeInfo,
+			KubernetesEndpoint: p.GetExternalKubernetesControlPlaneEndpoint(request.Network, constants.DefaultControlPlanePort),
 		},
 	}
 

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -120,8 +120,9 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 			GatewayAddrs: request.Network.GatewayAddrs,
 			MTU:          request.Network.MTU,
 		},
-		Nodes:      nodeInfo,
-		ExtraNodes: pxeNodeInfo,
+		Nodes:              nodeInfo,
+		ExtraNodes:         pxeNodeInfo,
+		KubernetesEndpoint: p.GetExternalKubernetesControlPlaneEndpoint(request.Network, request.Network.LoadBalancerPorts[0]),
 	}
 
 	err = state.Save()

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -14,6 +14,8 @@ import (
 )
 
 // Provisioner is an interface each provisioner should implement.
+//
+//nolint:interfacebloat
 type Provisioner interface {
 	Create(context.Context, ClusterRequest, ...Option) (Cluster, error)
 	Destroy(context.Context, Cluster, ...Option) error
@@ -23,7 +25,11 @@ type Provisioner interface {
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
 
 	GenOptions(NetworkRequest) []generate.Option
-	GetLoadBalancers(NetworkRequest) (internalEndpoint, externalEndpoint string)
+
+	GetInClusterKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string
+	GetExternalKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string
+	GetTalosAPIEndpoints(NetworkRequest) []string
+
 	GetFirstInterface() v1alpha1.IfaceSelector
 
 	Close() error

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -31,6 +31,9 @@ type ClusterInfo struct {
 
 	// ExtraNodes are not part of the cluster.
 	ExtraNodes []NodeInfo
+
+	// KubernetesEndpoint is the endpoint of the Kubernetes API server.
+	KubernetesEndpoint string
 }
 
 // NetworkInfo describes cluster network.

--- a/website/content/v1.7/reference/cli.md
+++ b/website/content/v1.7/reference/cli.md
@@ -102,7 +102,7 @@ talosctl cluster create [flags]
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
       --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
-      --control-plane-port int                   control plane port (load balancer and local API port) (default 6443)
+      --control-plane-port int                   control plane port (load balancer and local API port, QEMU only) (default 6443)
       --controlplanes int                        the number of controlplanes to create (default 1)
       --cpus string                              the share of CPUs as fraction (each control plane/VM) (default "2.0")
       --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")


### PR DESCRIPTION
Dynamically map Kubernetes and Talos API ports to an available port on the host, so every cluster gets its own unique set of parts.

As part of the changes, refactor the provision library and interfaces, dropping old weird interfaces replacing with (hopefully) much more descriprive names.
