### PR TITLE
fix: pre-create nftables chain to make kubelet use nftables

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -214,6 +214,16 @@ machine:
 Talos Linux now supports [Akamai Connected Cloud](https://www.linode.com/) provider (platform `akamai`).
 """
 
+    [notes.iptables]
+        title = "IPTables"
+        description = """\
+Talos Linux now forces `kubelet` and `kube-proxy` to use `iptables-nft` instead of `iptables-legacy` (`xtables`) which was the default
+before Talos 1.7.0.
+
+Container images based on `iptables-wrapper` should work without changes, but if there was a direct call to `legacy` mode of `iptables`, make sure
+to update to use `iptables-nft`.
+"""
+
 [make_deps]
 
     [make_deps.tools]


### PR DESCRIPTION
In Talos, kubelet (and kube-proxy) images use `iptables-wrapper` script to detect which version of `iptables` (legacy or NFT) to use.

The script assumes that `kubelet` runs on the host, and uses whatever version of `iptables` which is being used by the host. In Talos, `kubelet` runs in a container which has same `iptables-wrapper` script, and it defaults to `legacy` mode in our case.

We can't check the `kubelet` image, as it would affect all Talos version, so instead pre-create the chains/tables in `nftables` so that kubelet will pick up `nft` version of `iptables`, and `kube-proxy` will do the same.

Without this fix, the problem arises from the mix of `nft` used by Talos for the firewall and Kubernetes world relying on `legacy` (`xtables`).

Fixes https://github.com/siderolabs/kubelet/issues/77

See https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh#L102-L130
