### PR TITLE
fix: make static pods check output consistent

### DIFF
--- a/pkg/cluster/check/kubernetes.go
+++ b/pkg/cluster/check/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -420,7 +421,10 @@ func K8sControlPlaneStaticPods(ctx context.Context, cl ClusterInfo) error {
 		}
 
 		if len(expectedStaticPods) > 0 {
-			return fmt.Errorf("missing static pods on node %s: %v", node.InternalIP, maps.Keys(expectedStaticPods))
+			missingStaticPods := maps.Keys(expectedStaticPods)
+			slices.Sort(missingStaticPods)
+
+			return fmt.Errorf("missing static pods on node %s: %v", node.InternalIP, missingStaticPods)
 		}
 	}
 


### PR DESCRIPTION
Sort the pod names, so the check output doesn't re-print itself on no change to the list of pods.
