### PR TITLE
fix: validate that workers don't get cluster CA key

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -374,6 +374,10 @@ func (c *ClusterConfig) Validate(isControlPlane bool) error {
 		}
 	}
 
+	if c.ClusterCA != nil && !isControlPlane && len(c.ClusterCA.Key) > 0 {
+		result = multierror.Append(result, errors.New("cluster CA key is not allowed on non-controlplane nodes (.cluster.ca)"))
+	}
+
 	result = multierror.Append(
 		result,
 		c.ClusterInlineManifests.Validate(),


### PR DESCRIPTION
Only the cert should be present on worker nodes, enforce this via validation.
