### PR TITLE
fix: present all accepted CAs to the kube-apiserver

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/optional"
+	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -184,7 +185,11 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 						keyFilename:  "etcd-client.key",
 					},
 					{
-						getter:       func() *x509.PEMEncodedCertificateAndKey { return rootK8sSecrets.IssuingCA },
+						getter: func() *x509.PEMEncodedCertificateAndKey {
+							return &x509.PEMEncodedCertificateAndKey{
+								Crt: bytes.Join(xslices.Map(rootK8sSecrets.AcceptedCAs, func(ca *x509.PEMEncodedCertificate) []byte { return ca.Crt }), nil),
+							}
+						},
 						certFilename: "ca.crt",
 					},
 					{

--- a/internal/integration/api/rotate.go
+++ b/internal/integration/api/rotate.go
@@ -156,6 +156,8 @@ func (suite *RotateCASuite) TestKubernetes() {
 
 	suite.Require().NoError(kubernetes.Rotate(suite.ctx, options))
 
+	suite.AssertClusterHealthy(suite.ctx)
+
 	suite.T().Logf("rotating back new CA -> old CA")
 
 	options = kubernetes.Options{


### PR DESCRIPTION
This fixes an issue with a single controlplane cluster.

Properly present all accepted CAs to the apiserver, in the test let the cluster fully recovery between two CA rotations performed.
