### PR TITLE
feat: provide Kubernets/Talos version compatibility for 1.8

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos15"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos17"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos18"
 )
 
 // KubernetesVersion embeds Kubernetes version.
@@ -56,6 +57,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 		minK8sVersion, maxK8sVersion = talos16.MinimumKubernetesVersion, talos16.MaximumKubernetesVersion
 	case talos17.MajorMinor: // upgrades to 1.7.x
 		minK8sVersion, maxK8sVersion = talos17.MinimumKubernetesVersion, talos17.MaximumKubernetesVersion
+	case talos18.MajorMinor: // upgrades to 1.8.x
+		minK8sVersion, maxK8sVersion = talos18.MinimumKubernetesVersion, talos18.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -220,6 +220,39 @@ func TestKubernetesCompatibility17(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility18(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.27.1",
+			target:            "1.8.0",
+		},
+		{
+			kubernetesVersion: "1.26.1",
+			target:            "1.8.0",
+		},
+		{
+			kubernetesVersion: "1.30.3",
+			target:            "1.8.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.31.0-rc.0",
+			target:            "1.8.7",
+		},
+		{
+			kubernetesVersion: "1.32.0-alpha.0",
+			target:            "1.8.0",
+			expectedError:     "version of Kubernetes 1.32.0-alpha.0 is too new to be used with Talos 1.8.0",
+		},
+		{
+			kubernetesVersion: "1.25.1",
+			target:            "1.8.0",
+			expectedError:     "version of Kubernetes 1.25.1 is too old to be used with Talos 1.8.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{

--- a/pkg/machinery/compatibility/talos18/talos18.go
+++ b/pkg/machinery/compatibility/talos18/talos18.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos18 provides compatibility constants for Talos 1.8.
+package talos18
+
+import (
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinor is the major.minor version of Talos 1.8.
+var MajorMinor = [2]uint64{1, 8}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.8.
+var MinimumHostUpgradeVersion = semver.MustParse("1.5.0")
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.8.
+var MaximumHostDowngradeVersion = semver.MustParse("1.10.0")
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.8.
+var DeniedHostUpgradeVersions = []semver.Version{}
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.8.
+var MinimumKubernetesVersion = semver.MustParse("1.26.0")
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.8.
+var MaximumKubernetesVersion = semver.MustParse("1.31.99")

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos15"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos17"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos18"
 )
 
 // TalosVersion embeds Talos version.
@@ -79,6 +80,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	case talos17.MajorMinor: // upgrades to 1.7.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos17.MinimumHostUpgradeVersion, talos17.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos17.DeniedHostUpgradeVersions
+	case talos18.MajorMinor: // upgrades to 1.8.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos18.MinimumHostUpgradeVersion, talos18.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos18.DeniedHostUpgradeVersions
 	default:
 		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
 	}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -245,17 +245,58 @@ func TestTalosUpgradeCompatibility17(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility18(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.6.0",
+			target: "1.8.0",
+		},
+		{
+			host:   "1.5.0-alpha.0",
+			target: "1.8.0",
+		},
+		{
+			host:   "1.5.0",
+			target: "1.8.0-alpha.0",
+		},
+		{
+			host:   "1.7.0",
+			target: "1.8.1",
+		},
+		{
+			host:   "1.7.0-beta.0",
+			target: "1.8.0",
+		},
+		{
+			host:   "1.9.5",
+			target: "1.8.3",
+		},
+		{
+			host:          "1.4.0",
+			target:        "1.8.0",
+			expectedError: `host version 1.4.0 is too old to upgrade to Talos 1.8.0`,
+		},
+		{
+			host:          "1.10.0-alpha.0",
+			target:        "1.8.0",
+			expectedError: `host version 1.10.0-alpha.0 is too new to downgrade to Talos 1.8.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.8.0-alpha.0",
-			expectedError: `upgrades to version 1.8.0-alpha.0 are not supported`,
+			target:        "1.9.0-alpha.0",
+			expectedError: `upgrades to version 1.9.0-alpha.0 are not supported`,
 		},
 		{
 			host:          "1.4.0",
-			target:        "1.9.0-alpha.0",
-			expectedError: `upgrades to version 1.9.0-alpha.0 are not supported`,
+			target:        "1.10.0-alpha.0",
+			expectedError: `upgrades to version 1.10.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)


### PR DESCRIPTION
Fixes #8572

This allows to use 1.7 machinery with future 1.8 (e.g. alpha) versions.
