### PR TITLE
fix: assign different priority to IPv6 default gateway on OpenStack

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -275,6 +275,12 @@ func (o *Openstack) ParseMetadata(
 					return nil, fmt.Errorf("failed to parse gateway ip: %w", err)
 				}
 
+				priority := uint32(network.DefaultRouteMetric)
+
+				if family == nethelpers.FamilyInet6 {
+					priority *= 2
+				}
+
 				route := network.RouteSpecSpec{
 					ConfigLayer: network.ConfigPlatform,
 					Gateway:     gw,
@@ -283,7 +289,7 @@ func (o *Openstack) ParseMetadata(
 					Protocol:    nethelpers.ProtocolStatic,
 					Type:        nethelpers.TypeUnicast,
 					Family:      family,
-					Priority:    network.DefaultRouteMetric,
+					Priority:    priority,
 				}
 
 				route.Normalize()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -99,7 +99,7 @@ routes:
       gateway: 2000:0:100:2fff:ff:ff:ff:ff
       outLinkName: eth0
       table: main
-      priority: 1024
+      priority: 2048
       scope: global
       type: unicast
       flags: ""


### PR DESCRIPTION
Fixes #8558

Similar fix is done for other platforms, but not OpenStack.
