### PR TITLE
docs: update Cilium docs

### DIFF
--- a/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
@@ -288,6 +288,12 @@ For more details: [GCP ILB support / support scope local routes to be configured
 
 ## Other things to know
 
+- After installing Cilium, `cilium connectivity test` might hang and/or fail with errors similar to
+
+    ```Error creating: pods "client-69748f45d8-9b9jg" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "client" must not include "NET_RAW" in securityContext.capabilities.add)```
+
+  This is expected, you can workaround it by adding the `pod-security.kubernetes.io/enforce=priviledged` [label on the namespace level]({{< relref "../configuration/pod-security">}}).
+
 - Talos has full kernel module support for eBPF, See:
   - [Cilium System Requirements](https://docs.cilium.io/en/v1.14/operations/system_requirements/)
   - [Talos Kernel Config AMD64](https://github.com/siderolabs/pkgs/blob/main/kernel/build/config-amd64)

--- a/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
@@ -288,6 +288,12 @@ For more details: [GCP ILB support / support scope local routes to be configured
 
 ## Other things to know
 
+- After installing Cilium, `cilium connectivity test` might hang and/or fail with errors similar to
+
+    ```Error creating: pods "client-69748f45d8-9b9jg" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "client" must not include "NET_RAW" in securityContext.capabilities.add)```
+
+  This is expected, you can workaround it by adding the `pod-security.kubernetes.io/enforce=priviledged` [label on the namespace level]({{< relref "../configuration/pod-security">}}).
+
 - Talos has full kernel module support for eBPF, See:
   - [Cilium System Requirements](https://docs.cilium.io/en/v1.14/operations/system_requirements/)
   - [Talos Kernel Config AMD64](https://github.com/siderolabs/pkgs/blob/main/kernel/build/config-amd64)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Updated the Cilium docs to include explanations about the Pod Security Admission.

## Why? (reasoning)
For users unfamiliar with the changes introduced in K8s 1.25 and enforced by Talos that might bumb their heads against Pod Security Admission related issues after installing Cilium.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
