### PR TITLE
feat: use container DNS when in container mode

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -169,7 +170,7 @@ func (suite *LocalAffiliateSuite) TestCPGeneration() {
 		asrt.Equal("Talos ("+version.Tag+")", spec.OperatingSystem)
 		asrt.Equal(cluster.KubeSpanAffiliateSpec{}, spec.KubeSpan)
 		asrt.NotNil(spec.ControlPlane)
-		asrt.Equal(6445, spec.ControlPlane.APIServerPort)
+		asrt.Equal(6445, pointer.SafeDeref(spec.ControlPlane).APIServerPort)
 	})
 
 	discoveryConfig.TypedSpec().DiscoveryEnabled = false

--- a/internal/app/machined/pkg/controllers/config/acquire.go
+++ b/internal/app/machined/pkg/controllers/config/acquire.go
@@ -214,6 +214,12 @@ func (validationModeDiskConfig) RequiresInstall() bool {
 	return false
 }
 
+// InContainer implements validation.RuntimeMode interface.
+func (validationModeDiskConfig) InContainer() bool {
+	// containers don't persist config to disk
+	return false
+}
+
 // String implements validation.RuntimeMode interface.
 func (validationModeDiskConfig) String() string {
 	return "diskConfig"

--- a/internal/app/machined/pkg/controllers/config/acquire_test.go
+++ b/internal/app/machined/pkg/controllers/config/acquire_test.go
@@ -128,6 +128,10 @@ func (v validationModeMock) RequiresInstall() bool {
 	return false
 }
 
+func (v validationModeMock) InContainer() bool {
+	return false
+}
+
 func TestAcquireSuite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
@@ -127,10 +127,6 @@ func (ctrl *DNSResolveCacheController) Run(ctx context.Context, r controller.Run
 						return fmt.Errorf("error creating dns runner: %w", rErr)
 					}
 
-					if runner == nil {
-						continue
-					}
-
 					ctrl.runners[runnerCfg] = pair.MakePair(runner.Start(ctrl.handleDone(ctx, logger)))
 				}
 
@@ -264,14 +260,7 @@ func newDNSRunner(cfg runnerConfig, cache *dns.Cache, logger *zap.Logger) (*dns.
 	case "udp", "udp6":
 		packetConn, err := dns.NewUDPPacketConn(cfg.net, cfg.addr.String())
 		if err != nil {
-			if cfg.net == "udp6" {
-				logger.Warn("error creating UDPv6 listener", zap.Error(err))
-
-				// If we can't bind to ipv6, we can continue with ipv4
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("error creating udp packet conn: %w", err)
+			return nil, fmt.Errorf("error creating %q packet conn: %w", cfg.net, err)
 		}
 
 		serverOpts = dns.ServerOptions{
@@ -283,14 +272,7 @@ func newDNSRunner(cfg runnerConfig, cache *dns.Cache, logger *zap.Logger) (*dns.
 	case "tcp", "tcp6":
 		listener, err := dns.NewTCPListener(cfg.net, cfg.addr.String())
 		if err != nil {
-			if cfg.net == "tcp6" {
-				logger.Warn("error creating TCPv6 listener", zap.Error(err))
-
-				// If we can't bind to ipv6, we can continue with ipv4
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("error creating tcp listener: %w", err)
+			return nil, fmt.Errorf("error creating %q listener: %w", cfg.net, err)
 		}
 
 		serverOpts = dns.ServerOptions{

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
@@ -176,6 +176,5 @@ func getDynamicPort() (string, error) {
 func makeAddrs(port string) []netip.AddrPort {
 	return []netip.AddrPort{
 		netip.MustParseAddrPort("127.0.0.53:" + port),
-		netip.MustParseAddrPort("[::1]:" + port),
 	}
 }

--- a/internal/app/machined/pkg/controllers/network/hostdns_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config.go
@@ -87,7 +87,6 @@ func (ctrl *HostDNSConfigController) Run(ctx context.Context, r controller.Runti
 		if err := safe.WriterModify(ctx, r, network.NewHostDNSConfig(network.HostDNSConfigID), func(res *network.HostDNSConfig) error {
 			res.TypedSpec().ListenAddresses = []netip.AddrPort{
 				netip.MustParseAddrPort("127.0.0.53:53"),
-				netip.MustParseAddrPort("[::1]:53"),
 			}
 
 			res.TypedSpec().ServiceHostDNSAddress = netip.Addr{}

--- a/internal/app/machined/pkg/controllers/network/status_test.go
+++ b/internal/app/machined/pkg/controllers/network/status_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/resources/files"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -101,7 +102,11 @@ func TestStatusSuite(t *testing.T) {
 		DefaultSuite: ctest.DefaultSuite{
 			Timeout: 3 * time.Second,
 			AfterSetup: func(suite *ctest.DefaultSuite) {
-				suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.StatusController{}))
+				suite.Require().NoError(suite.Runtime().RegisterController(
+					&netctrl.StatusController{
+						V1Alpha1Mode: runtime.ModeMetal,
+					},
+				))
 			},
 		},
 	})

--- a/internal/app/machined/pkg/runtime/mode.go
+++ b/internal/app/machined/pkg/runtime/mode.go
@@ -52,6 +52,11 @@ func (m Mode) RequiresInstall() bool {
 	return m == ModeMetal
 }
 
+// InContainer implements config.RuntimeMode.
+func (m Mode) InContainer() bool {
+	return m == ModeContainer
+}
+
 // Supports returns mode capability.
 func (m Mode) Supports(feature ModeCapability) bool {
 	return (m.capabilities() & uint64(feature)) != 0

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/hostname.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/hostname.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package files provides internal methods to container platform to read files.
+package files
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+// ReadHostname reads and parses /etc/hostname file.
+func ReadHostname(path string) (network.HostnameSpecSpec, error) {
+	hostname, err := os.ReadFile(path)
+	if err != nil {
+		return network.HostnameSpecSpec{}, err
+	}
+
+	hostname = bytes.TrimSpace(hostname)
+
+	hostnameSpec := network.HostnameSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+	}
+
+	if err = hostnameSpec.ParseFQDN(string(hostname)); err != nil {
+		return network.HostnameSpecSpec{}, err
+	}
+
+	return hostnameSpec, nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/hostname_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/hostname_test.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package files_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files"
+)
+
+func TestReadHostname(t *testing.T) {
+	t.Parallel()
+
+	spec, err := files.ReadHostname("testdata/hostname")
+	require.NoError(t, err)
+
+	require.Equal(t, "foo", spec.Hostname)
+	require.Equal(t, "example.com", spec.Domainname)
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/resolv.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/resolv.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package files
+
+import (
+	"bytes"
+	"net/netip"
+	"os"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+// ReadResolvConf reads and parses /etc/resolv.conf file.
+func ReadResolvConf(path string) (network.ResolverSpecSpec, error) {
+	resolverSpec := network.ResolverSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+	}
+
+	resolvers, err := os.ReadFile(path)
+	if err != nil {
+		return resolverSpec, err
+	}
+
+	for _, line := range bytes.Split(resolvers, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		line, _, _ = bytes.Cut(line, []byte("#"))
+
+		if !bytes.HasPrefix(line, []byte("nameserver")) {
+			continue
+		}
+
+		line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("nameserver")))
+
+		if addr, err := netip.ParseAddr(string(line)); err == nil {
+			resolverSpec.DNSServers = append(resolverSpec.DNSServers, addr)
+		}
+	}
+
+	return resolverSpec, nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/resolv_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/resolv_test.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package files_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files"
+)
+
+func TestReadResolvConf(t *testing.T) {
+	t.Parallel()
+
+	spec, err := files.ReadResolvConf("testdata/resolv.conf")
+	require.NoError(t, err)
+
+	require.Equal(t, []netip.Addr{
+		netip.MustParseAddr("127.0.0.53"),
+		netip.MustParseAddr("::1"),
+	}, spec.DNSServers)
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/testdata/hostname
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/testdata/hostname
@@ -1,0 +1,1 @@
+foo.example.com

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/testdata/resolv.conf
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files/testdata/resolv.conf
@@ -1,0 +1,8 @@
+# This is /run/systemd/resolve/stub-resolv.conf managed by man:systemd-resolved(8).
+# Do not edit.
+
+nameserver 127.0.0.53 # v4 one
+options edns0 trust-ad
+search .
+
+  nameserver ::1   # this is V6

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -199,6 +199,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&network.DNSUpstreamController{},
 		&network.EtcFileController{
 			PodResolvConfPath: constants.PodResolvConfPath,
+			V1Alpha1Mode:      ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
 		&network.HardwareAddrController{},
 		&network.HostDNSConfigController{},
@@ -245,7 +246,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&network.RouteMergeController{},
 		&network.RouteSpecController{},
 		&network.RouteStatusController{},
-		&network.StatusController{},
+		&network.StatusController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&network.TimeServerConfigController{
 			Cmdline: procfs.ProcCmdline(),
 		},

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -52,7 +52,7 @@ func (suite *ValidateSuite) TestValidate() {
 	)
 
 	for _, configFile := range []string{"controlplane.yaml", "worker.yaml"} {
-		for _, mode := range []string{"cloud", "container"} {
+		for _, mode := range []string{"cloud", "metal"} {
 			suite.Run(fmt.Sprintf("%s-%s", configFile, mode), func() {
 				suite.RunCLI([]string{"validate", "-m", mode, "-c", configFile, "--strict"})
 			})

--- a/internal/integration/k8s/tink.go
+++ b/internal/integration/k8s/tink.go
@@ -143,6 +143,7 @@ func (suite *TinkSuite) TestDeploy() {
 		fmt.Sprintf("https://%s", net.JoinHostPort(lbNode, strconv.Itoa(k8sPort))),
 		constants.DefaultKubernetesVersion,
 		generate.WithAdditionalSubjectAltNames([]string{lbNode}),
+		generate.WithHostDNSForwardKubeDNSToHost(true),
 	)
 	suite.Require().NoError(err)
 

--- a/pkg/machinery/config/container/container_test.go
+++ b/pkg/machinery/config/container/container_test.go
@@ -208,3 +208,7 @@ func (validationMode) String() string {
 func (validationMode) RequiresInstall() bool {
 	return false
 }
+
+func (validationMode) InContainer() bool {
+	return false
+}

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -181,8 +181,8 @@ func (contract *VersionContract) KubePrismEnabled() bool {
 	return contract.Greater(TalosVersion1_5)
 }
 
-// LocalDNSEnabled returns true if local dns router should be enabled by default.
-func (contract *VersionContract) LocalDNSEnabled() bool {
+// HostDNSEnabled returns true if host dns router should be enabled by default.
+func (contract *VersionContract) HostDNSEnabled() bool {
 	return contract.Greater(TalosVersion1_6)
 }
 

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -66,7 +66,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.True(t, contract.DiskQuotaSupportEnabled())
 	assert.True(t, contract.KubePrismEnabled())
-	assert.True(t, contract.LocalDNSEnabled())
+	assert.True(t, contract.HostDNSEnabled())
 	assert.True(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -93,7 +93,7 @@ func TestContract1_7(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.True(t, contract.DiskQuotaSupportEnabled())
 	assert.True(t, contract.KubePrismEnabled())
-	assert.True(t, contract.LocalDNSEnabled())
+	assert.True(t, contract.HostDNSEnabled())
 	assert.True(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -120,7 +120,7 @@ func TestContract1_6(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.True(t, contract.DiskQuotaSupportEnabled())
 	assert.True(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -147,7 +147,7 @@ func TestContract1_5(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.True(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -174,7 +174,7 @@ func TestContract1_4(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -201,7 +201,7 @@ func TestContract1_3(t *testing.T) {
 	assert.True(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -228,7 +228,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -255,7 +255,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -282,7 +282,7 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -309,7 +309,7 @@ func TestContract0_14(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -336,7 +336,7 @@ func TestContract0_13(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -363,7 +363,7 @@ func TestContract0_12(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -390,7 +390,7 @@ func TestContract0_11(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -417,7 +417,7 @@ func TestContract0_10(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -444,7 +444,7 @@ func TestContract0_9(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }
 
@@ -471,6 +471,6 @@ func TestContract0_8(t *testing.T) {
 	assert.False(t, contract.SecretboxEncryptionSupported())
 	assert.False(t, contract.DiskQuotaSupportEnabled())
 	assert.False(t, contract.KubePrismEnabled())
-	assert.False(t, contract.LocalDNSEnabled())
+	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
 }

--- a/pkg/machinery/config/generate/generate_test.go
+++ b/pkg/machinery/config/generate/generate_test.go
@@ -177,3 +177,7 @@ func (m runtimeMode) String() string {
 func (m runtimeMode) RequiresInstall() bool {
 	return m.requiresInstall
 }
+
+func (runtimeMode) InContainer() bool {
+	return false
+}

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -95,9 +95,10 @@ func (in *Input) init() ([]config.Document, error) {
 		machine.MachineKubelet.KubeletDisableManifestsDirectory = pointer.To(true)
 	}
 
-	if in.Options.VersionContract.LocalDNSEnabled() {
+	if in.Options.VersionContract.HostDNSEnabled() || in.Options.HostDNSForwardKubeDNSToHost.ValueOrZero() {
 		machine.MachineFeatures.HostDNSSupport = &v1alpha1.HostDNSConfig{
-			HostDNSEnabled: pointer.To(true),
+			HostDNSEnabled:              pointer.To(true),
+			HostDNSForwardKubeDNSToHost: in.Options.HostDNSForwardKubeDNSToHost.Ptr(),
 		}
 	}
 

--- a/pkg/machinery/config/generate/options.go
+++ b/pkg/machinery/config/generate/options.go
@@ -261,6 +261,15 @@ func WithSecretsBundle(bundle *secrets.Bundle) Option {
 	}
 }
 
+// WithHostDNSForwardKubeDNSToHost specifies whether to forward kube-dns to host.
+func WithHostDNSForwardKubeDNSToHost(forward bool) Option {
+	return func(o *Options) error {
+		o.HostDNSForwardKubeDNSToHost = optional.Some(forward)
+
+		return nil
+	}
+}
+
 // Options describes generate parameters.
 type Options struct {
 	VersionContract *config.VersionContract
@@ -300,6 +309,8 @@ type Options struct {
 	DiscoveryEnabled               *bool
 
 	KubePrismPort optional.Optional[int]
+
+	HostDNSForwardKubeDNSToHost optional.Optional[bool]
 
 	// Client options.
 	Roles        role.Set

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -96,9 +96,10 @@ func (in *Input) worker() ([]config.Document, error) {
 		machine.MachineKubelet.KubeletDisableManifestsDirectory = pointer.To(true)
 	}
 
-	if in.Options.VersionContract.LocalDNSEnabled() {
+	if in.Options.VersionContract.HostDNSEnabled() || in.Options.HostDNSForwardKubeDNSToHost.ValueOrZero() {
 		machine.MachineFeatures.HostDNSSupport = &v1alpha1.HostDNSConfig{
-			HostDNSEnabled: pointer.To(true),
+			HostDNSEnabled:              pointer.To(true),
+			HostDNSForwardKubeDNSToHost: in.Options.HostDNSForwardKubeDNSToHost.Ptr(),
 		}
 	}
 

--- a/pkg/machinery/config/types/network/rule_config_test.go
+++ b/pkg/machinery/config/types/network/rule_config_test.go
@@ -195,3 +195,7 @@ func (validationMode) String() string {
 func (validationMode) RequiresInstall() bool {
 	return false
 }
+
+func (validationMode) InContainer() bool {
+	return false
+}

--- a/pkg/machinery/config/types/runtime/event_sink_test.go
+++ b/pkg/machinery/config/types/runtime/event_sink_test.go
@@ -92,3 +92,7 @@ func (validationMode) String() string {
 func (validationMode) RequiresInstall() bool {
 	return false
 }
+
+func (validationMode) InContainer() bool {
+	return false
+}

--- a/pkg/machinery/config/types/siderolink/siderolink_test.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_test.go
@@ -118,3 +118,7 @@ func (validationMode) String() string {
 func (validationMode) RequiresInstall() bool {
 	return false
 }
+
+func (validationMode) InContainer() bool {
+	return false
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -116,6 +116,17 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 		}
 	}
 
+	if mode.InContainer() {
+		// require that HostDNS features are enabled to passthrough container DNS to kube-dns
+		if !c.Machine().Features().HostDNS().Enabled() {
+			result = multierror.Append(result, errors.New("feature HostDNS should be enabled in container mode (.machine.features.hostDNS.enabled)"))
+		}
+
+		if !c.Machine().Features().HostDNS().ForwardKubeDNSToHost() {
+			result = multierror.Append(result, errors.New("feature HostDNS should forward kube-dns to host in container mode (.machine.features.hostDNS.forwardKubeDNSToHost)"))
+		}
+	}
+
 	if t := c.Machine().Type(); t != machine.TypeUnknown && t.String() != c.MachineConfig.MachineType {
 		warnings = append(warnings, fmt.Sprintf("use %q instead of %q for machine type", t.String(), c.MachineConfig.MachineType))
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -32,6 +32,10 @@ func (m runtimeMode) RequiresInstall() bool {
 	return m.requiresInstall
 }
 
+func (runtimeMode) InContainer() bool {
+	return false
+}
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/machinery/config/validation/mode.go
+++ b/pkg/machinery/config/validation/mode.go
@@ -10,4 +10,5 @@ import "fmt"
 type RuntimeMode interface {
 	fmt.Stringer
 	RequiresInstall() bool
+	InContainer() bool
 }

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -86,33 +86,11 @@ func (p *provisioner) Close() error {
 
 // GenOptions provides a list of additional config generate options.
 func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.Option {
-	nameservers := make([]string, 0, len(networkReq.Nameservers))
-
-	hasV4 := false
-	hasV6 := false
-
-	for _, subnet := range networkReq.CIDRs {
-		if subnet.Addr().Is6() {
-			hasV6 = true
-		} else {
-			hasV4 = true
-		}
-	}
-
-	// filter nameservers by IPv4/IPv6
-	for i := range networkReq.Nameservers {
-		if networkReq.Nameservers[i].Is6() && hasV6 {
-			nameservers = append(nameservers, networkReq.Nameservers[i].String())
-		} else if networkReq.Nameservers[i].Is4() && hasV4 {
-			nameservers = append(nameservers, networkReq.Nameservers[i].String())
-		}
-	}
-
 	return []generate.Option{
 		generate.WithNetworkOptions(
 			v1alpha1.WithNetworkInterfaceIgnore(v1alpha1.IfaceByName("eth0")),
-			v1alpha1.WithNetworkNameservers(nameservers...),
 		),
+		generate.WithHostDNSForwardKubeDNSToHost(true),
 	}
 }
 


### PR DESCRIPTION
More specifically, pick up `/etc/resolv.conf` contents by default when in container mode, and use that as a base resolver for the host DNS.

Fixes #8303
