### PR TITLE
fix: do not ignore IPv6 errors in DNSResolveCacheController

### DIFF
--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
@@ -127,10 +127,6 @@ func (ctrl *DNSResolveCacheController) Run(ctx context.Context, r controller.Run
 						return fmt.Errorf("error creating dns runner: %w", rErr)
 					}
 
-					if runner == nil {
-						continue
-					}
-
 					ctrl.runners[runnerCfg] = pair.MakePair(runner.Start(ctrl.handleDone(ctx, logger)))
 				}
 
@@ -264,14 +260,7 @@ func newDNSRunner(cfg runnerConfig, cache *dns.Cache, logger *zap.Logger) (*dns.
 	case "udp", "udp6":
 		packetConn, err := dns.NewUDPPacketConn(cfg.net, cfg.addr.String())
 		if err != nil {
-			if cfg.net == "udp6" {
-				logger.Warn("error creating UDPv6 listener", zap.Error(err))
-
-				// If we can't bind to ipv6, we can continue with ipv4
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("error creating udp packet conn: %w", err)
+			return nil, fmt.Errorf("error creating %q packet conn: %w", cfg.net, err)
 		}
 
 		serverOpts = dns.ServerOptions{
@@ -283,14 +272,7 @@ func newDNSRunner(cfg runnerConfig, cache *dns.Cache, logger *zap.Logger) (*dns.
 	case "tcp", "tcp6":
 		listener, err := dns.NewTCPListener(cfg.net, cfg.addr.String())
 		if err != nil {
-			if cfg.net == "tcp6" {
-				logger.Warn("error creating TCPv6 listener", zap.Error(err))
-
-				// If we can't bind to ipv6, we can continue with ipv4
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("error creating tcp listener: %w", err)
+			return nil, fmt.Errorf("error creating %q listener: %w", cfg.net, err)
 		}
 
 		serverOpts = dns.ServerOptions{

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
@@ -176,6 +176,5 @@ func getDynamicPort() (string, error) {
 func makeAddrs(port string) []netip.AddrPort {
 	return []netip.AddrPort{
 		netip.MustParseAddrPort("127.0.0.53:" + port),
-		netip.MustParseAddrPort("[::1]:" + port),
 	}
 }


### PR DESCRIPTION
Currently, if we try to raise dns listener on IPv6 address and listening fails for any reason, we just silently ignore this for and move on. The reason for this is that raising listener "by default" on IPv6 `::1` sometimes simply doesn't work. However, if the user decides to use IPv6 service subnet CIDR and `forwardKubeDNSToHost` AND starting dns listening on this IPv6 network fails for any reason, we will just silently ignore the error, which is not what we want.

After Andrey's [PR](https://github.com/siderolabs/talos/pull/8583) that will remove `::1` from default `resolv.conf` we no longer have the first problematic part, so it makes sense to no longer ignore IPv6 dns errors. This commit does this.

Depends on #8583