### PR TITLE
fix: overlay installer operations

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -124,6 +124,8 @@ var rootCmd = &cobra.Command{
 						},
 						ExtraOptions: extraOverlayOptions,
 					}
+
+					prof.Input.OverlayInstaller.ImageRef = cmdFlags.OverlayImage
 				}
 
 				prof.Input.SystemExtensions = xslices.Map(

--- a/cmd/installer/cmd/installer/root.go
+++ b/cmd/installer/cmd/installer/root.go
@@ -48,16 +48,21 @@ func Execute() {
 	}
 }
 
-var options = &install.Options{}
+var options = &install.Options{
+	Board: constants.BoardNone,
+}
 
-var bootloader bool
+var (
+	bootloader bool
+	dummy      string
+)
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
 	rootCmd.PersistentFlags().StringVar(&options.Disk, "disk", "", "The path to the disk to install to")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringVar(&options.Arch, "arch", runtime.GOARCH, "The target architecture")
-	rootCmd.PersistentFlags().StringVar(&options.Board, "board", constants.BoardNone, "Deprecated: no op")
+	rootCmd.PersistentFlags().StringVar(&dummy, "board", constants.BoardNone, "Deprecated: no op")
 	rootCmd.PersistentFlags().StringArrayVar(&options.ExtraKernelArgs, "extra-kernel-arg", []string{}, "Extra argument to pass to the kernel")
 	rootCmd.PersistentFlags().BoolVar(&bootloader, "bootloader", true, "Deprecated: no op")
 	rootCmd.PersistentFlags().BoolVar(&options.Upgrade, "upgrade", false, "Indicates that the install is being performed by an upgrade")

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -411,6 +411,21 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 	}
 
 	if i.overlayInstaller != nil {
+		tempOverlayPath := filepath.Join(i.tempDir, "overlay-installer", constants.ImagerOverlayBasePath)
+
+		if err := os.MkdirAll(tempOverlayPath, 0o755); err != nil {
+			return fmt.Errorf("failed to create overlay directory: %w", err)
+		}
+
+		if err := i.prof.Input.OverlayInstaller.Extract(
+			ctx,
+			tempOverlayPath,
+			i.prof.Arch,
+			progressPrintf(report, reporter.Update{Message: "pulling overlay for installer...", Status: reporter.StatusRunning}),
+		); err != nil {
+			return err
+		}
+
 		extraOpts, internalErr := yaml.Marshal(i.prof.Overlay.ExtraOptions)
 		if internalErr != nil {
 			return fmt.Errorf("failed to marshal extra options: %w", internalErr)
@@ -430,11 +445,11 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 			mode       os.FileMode
 		}{
 			{
-				sourcePath: filepath.Join(i.tempDir, constants.ImagerOverlayArtifactsPath),
+				sourcePath: filepath.Join(i.tempDir, "overlay-installer", constants.ImagerOverlayArtifactsPath),
 				imagePath:  strings.TrimLeft(constants.ImagerOverlayArtifactsPath, "/"),
 			},
 			{
-				sourcePath: filepath.Join(i.tempDir, constants.ImagerOverlayInstallersPath, i.prof.Overlay.Name),
+				sourcePath: filepath.Join(i.tempDir, "overlay-installer", constants.ImagerOverlayInstallersPath, i.prof.Overlay.Name),
 				imagePath:  strings.TrimLeft(constants.ImagerOverlayInstallerDefaultPath, "/"),
 				mode:       0o755,
 			},

--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -54,6 +54,10 @@ type Input struct {
 	RPiFirmware FileAsset `yaml:"rpiFirmware,omitempty"`
 	// Base installer image to mutate.
 	BaseInstaller ContainerAsset `yaml:"baseInstaller,omitempty"`
+	// OverlayInstaller is an overlay image to inject into the installer.
+	//
+	// OverlayInstaller architecture should match the output installer architecture.
+	OverlayInstaller ContainerAsset `yaml:"overlayInstaller,omitempty"`
 	// SecureBoot is a section with secureboot keys, only for SecureBoot enabled builds.
 	SecureBoot *SecureBootAssets `yaml:"secureboot,omitempty"`
 	// SystemExtensions is a list of system extensions to install.


### PR DESCRIPTION
1. Use overlay installer to build the `cmdline` when running in install/upgrade mode.

2. Pull down the overlay installer with the arch specific to the installer being generated, vs. the arch of the `imager`.

3. Print a message when running an overlay installer.
