### PR TITLE
chore: replace math/rand with math/rand/v2

### DIFF
--- a/internal/app/machined/pkg/controllers/config/acquire_test.go
+++ b/internal/app/machined/pkg/controllers/config/acquire_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -153,7 +153,7 @@ func TestAcquireSuite(t *testing.T) {
 		}
 		s.eventPublisher = &eventPublisherMock{}
 
-		s.clusterName = fmt.Sprintf("cluster-%d", rand.Int31())
+		s.clusterName = fmt.Sprintf("cluster-%d", rand.Int32())
 		input, err := generate.NewInput(s.clusterName, "https://localhost:6443", "")
 		s.Require().NoError(err)
 

--- a/internal/app/machined/pkg/controllers/network/address_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"os"
@@ -61,7 +61,7 @@ func (suite *AddressSpecSuite) SetupTest() {
 }
 
 func (suite *AddressSpecSuite) uniqueDummyInterface() string {
-	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int31()&0xff, rand.Int31()&0xff, rand.Int31()&0xff)
+	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int32()&0xff, rand.Int32()&0xff, rand.Int32()&0xff)
 }
 
 func (suite *AddressSpecSuite) startRuntime() {

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net/netip"
 	"os"
 	"sync"
@@ -139,7 +139,7 @@ func (suite *LinkSpecSuite) assertNoInterface(id string) error {
 }
 
 func (suite *LinkSpecSuite) uniqueDummyInterface() string {
-	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int31()&0xff, rand.Int31()&0xff, rand.Int31()&0xff)
+	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int32()&0xff, rand.Int32()&0xff, rand.Int32()&0xff)
 }
 
 func (suite *LinkSpecSuite) TestLoopback() {
@@ -945,7 +945,8 @@ func TestSortBonds(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rnd := rand.New(rand.NewSource(seed))
+
+	rnd := rand.New(rand.NewPCG(uint64(time.Now().Unix()), uint64(time.Now().Unix())))
 
 	for i := range 100 {
 		res := toResources(expectedSlice)

--- a/internal/app/machined/pkg/controllers/network/link_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_status_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"strings"
@@ -79,7 +79,7 @@ func (suite *LinkStatusSuite) startRuntime() {
 }
 
 func (suite *LinkStatusSuite) uniqueDummyInterface() string {
-	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int31()&0xff, rand.Int31()&0xff, rand.Int31()&0xff)
+	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int32()&0xff, rand.Int32()&0xff, rand.Int32()&0xff)
 }
 
 func (suite *LinkStatusSuite) assertInterfaces(requiredIDs []string, check func(*network.LinkStatus) error) error {

--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"os"
@@ -67,7 +67,7 @@ func (suite *RouteSpecSuite) SetupTest() {
 }
 
 func (suite *RouteSpecSuite) uniqueDummyInterface() string {
-	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int31()&0xff, rand.Int31()&0xff, rand.Int31()&0xff)
+	return fmt.Sprintf("dummy%02x%02x%02x", rand.Int32()&0xff, rand.Int32()&0xff, rand.Int32()&0xff)
 }
 
 func (suite *RouteSpecSuite) startRuntime() {

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -13,7 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"path/filepath"
 	"strings"
 	"time"
@@ -143,7 +143,7 @@ func (apiSuite *APISuite) RandomDiscoveredNodeInternalIP(types ...machine.Type) 
 
 	apiSuite.Require().NotEmpty(nodes)
 
-	return nodes[rand.Intn(len(nodes))].InternalIP.String()
+	return nodes[rand.IntN(len(nodes))].InternalIP.String()
 }
 
 // Capabilities describes current cluster allowed actions.

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -9,7 +9,7 @@ package base
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -73,7 +73,7 @@ func (cliSuite *CLISuite) RandomDiscoveredNodeInternalIP(types ...machine.Type) 
 
 	cliSuite.Require().NotEmpty(nodes)
 
-	return nodes[rand.Intn(len(nodes))].InternalIP.String()
+	return nodes[rand.IntN(len(nodes))].InternalIP.String()
 }
 
 func (cliSuite *CLISuite) discoverKubectl() cluster.Info {

--- a/internal/pkg/dns/dns.go
+++ b/internal/pkg/dns/dns.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"slices"
 	"strings"

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"time"
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -11,7 +11,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -217,7 +217,7 @@ func download(req *http.Request, options *downloadOptions) (data []byte, err err
 	transport.RegisterProtocol("tftp", NewTFTPTransport())
 
 	if options.LowSrcPort {
-		port := 100 + rand.Intn(512)
+		port := 100 + rand.IntN(512)
 
 		localTCPAddr, tcperr := net.ResolveTCPAddr("tcp", ":"+strconv.Itoa(port))
 		if tcperr != nil {

--- a/pkg/machinery/client/resolver/roundrobin.go
+++ b/pkg/machinery/client/resolver/roundrobin.go
@@ -5,7 +5,7 @@
 package resolver
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"strings"


### PR DESCRIPTION
New package arrived in Go 1.22 which provides better rand primitives and functions. Use it instead of the old one.