### PR TITLE
fix: close pcap file

### DIFF
--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -108,6 +108,11 @@ e.g. by excluding packets with the port 50000.
 				if err != nil {
 					return err
 				}
+				defer func() {
+					if cerr := out.Close(); cerr != nil && err == nil {
+						err = cerr
+					}
+				}()
 			}
 
 			_, err = io.Copy(out, r)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
close pcap  output file
## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
