### PR TITLE
fix: return proper value from Bridge.STP instead of plain nil

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1047,7 +1047,7 @@ func (b *Bridge) Interfaces() []string {
 // STP implements the config.Bridge interface.
 func (b *Bridge) STP() config.STP {
 	if b.BridgeSTP == nil {
-		return nil
+		return (*STP)(nil)
 	}
 
 	return b.BridgeSTP


### PR DESCRIPTION
Since we are returning interfaces in config, we have to return something typed for method chaining to work. Otherwise, it simply doesn't know what method to call because there is no type information. We also don't want to change the default config behavior, so we don't try to check for `nil` after calling `.STP()`.

Closes #8626