### PR TITLE
fix: add endpoints for "virtual" `host-dns` service

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates/talos-host-dns-svc-template.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/templates/talos-host-dns-svc-template.yaml
@@ -15,3 +15,19 @@ spec:
     protocol: TCP
     targetPort: 53
   type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: host-dns
+  namespace: kube-system
+subsets:
+  - addresses:
+    - ip: {{ .ServiceHostDNSAddress }}
+    ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP


### PR DESCRIPTION
Without endpoints `kube-proxy` adds an automatic reject rule for the service if it has no endpoints which breaks host network namespace DNS resolving with `forwardKubeDNSToHost: true`.
