### PR TITLE
fix: bump priority of OpenStack routes if IPv6 and default gateway

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -328,6 +328,11 @@ func (o *Openstack) ParseMetadata(
 
 			route.Normalize()
 
+			// double the priority of the route if it is actually the default gateway and IPv6
+			if route.Destination == (netip.Prefix{}) && family == nethelpers.FamilyInet6 {
+				route.Priority *= 2
+			}
+
 			networkConfig.Routes = append(networkConfig.Routes, route)
 		}
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -147,7 +147,7 @@ routes:
       gateway: fd00::1
       outLinkName: eth1
       table: main
-      priority: 1024
+      priority: 2048
       scope: global
       type: unicast
       flags: ""


### PR DESCRIPTION
IT looks like gateway is sometimes reported as a 'route' skipping a 'gateway' field.

Fixes #8619 