### PR TITLE
feat: add `--non-masquerade-cidrs` flag to `talosctl cluster create`

### DIFF
--- a/hack/start-registry-proxies.sh
+++ b/hack/start-registry-proxies.sh
@@ -23,3 +23,8 @@ docker run -d -p 5004:5000 \
     -e REGISTRY_PROXY_REMOTEURL=https://ghcr.io \
     --restart always \
     --name registry-ghcr.io registry:2
+
+docker run -d -p 5006:5000 \
+    -e REGISTRY_PROXY_REMOTEURL=https://factory.talos.dev \
+    --restart always \
+    --name registry-factory.talos.dev registry:2

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -122,10 +122,11 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 	state.ClusterInfo = provision.ClusterInfo{
 		ClusterName: request.Name,
 		Network: provision.NetworkInfo{
-			Name:         request.Network.Name,
-			CIDRs:        request.Network.CIDRs,
-			GatewayAddrs: request.Network.GatewayAddrs,
-			MTU:          request.Network.MTU,
+			Name:              request.Network.Name,
+			CIDRs:             request.Network.CIDRs,
+			NoMasqueradeCIDRs: request.Network.NoMasqueradeCIDRs,
+			GatewayAddrs:      request.Network.GatewayAddrs,
+			MTU:               request.Network.MTU,
 		},
 		Nodes:              nodeInfo,
 		ExtraNodes:         pxeNodeInfo,

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -133,6 +133,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		NetworkConfig:     state.VMCNIConfig,
 		CNI:               clusterReq.Network.CNI,
 		CIDRs:             clusterReq.Network.CIDRs,
+		NoMasqueradeCIDRs: clusterReq.Network.NoMasqueradeCIDRs,
 		IPs:               nodeReq.IPs,
 		GatewayAddrs:      clusterReq.Network.GatewayAddrs,
 		MTU:               clusterReq.Network.MTU,

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -58,11 +58,12 @@ type CNIConfig struct {
 
 // NetworkRequest describes cluster network.
 type NetworkRequest struct {
-	Name         string
-	CIDRs        []netip.Prefix
-	GatewayAddrs []netip.Addr
-	MTU          int
-	Nameservers  []netip.Addr
+	Name              string
+	CIDRs             []netip.Prefix
+	NoMasqueradeCIDRs []netip.Prefix
+	GatewayAddrs      []netip.Addr
+	MTU               int
+	Nameservers       []netip.Addr
 
 	LoadBalancerPorts []int
 

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -38,10 +38,11 @@ type ClusterInfo struct {
 
 // NetworkInfo describes cluster network.
 type NetworkInfo struct {
-	Name         string
-	CIDRs        []netip.Prefix
-	GatewayAddrs []netip.Addr
-	MTU          int
+	Name              string
+	CIDRs             []netip.Prefix
+	GatewayAddrs      []netip.Addr
+	MTU               int
+	NoMasqueradeCIDRs []netip.Prefix
 }
 
 // NodeInfo describes a node.

--- a/website/content/v1.8/reference/cli.md
+++ b/website/content/v1.8/reference/cli.md
@@ -140,6 +140,7 @@ talosctl cluster create [flags]
       --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
       --mtu int                                  MTU of the cluster network (default 1500)
       --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
+      --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT (QEMU provisioner only)
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
       --skip-boot-phase-finished-check           skip waiting for node to finish boot phase


### PR DESCRIPTION
Allow skipping NAT for the given destinations from a cluster network. This option makes it possible to form an etcd cluster from clusters in different networks created by running `talosctl cluster create` command multiple times using different CIDRs: they simply should have the CIDR of the other clusters passed with `--non-masquerade-cidrs`.
