### PR TITLE
fix: wait for devices to be discovered before probing filesystems

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -76,7 +76,7 @@ func (m *Metal) Configuration(ctx context.Context, r state.State) ([]byte, error
 
 	switch *option {
 	case constants.MetalConfigISOLabel:
-		return readConfigFromISO()
+		return readConfigFromISO(ctx, r)
 	default:
 		if err := netutils.Wait(ctx, r); err != nil {
 			return nil, err
@@ -119,7 +119,11 @@ func (m *Metal) Mode() runtime.Mode {
 	return runtime.ModeMetal
 }
 
-func readConfigFromISO() ([]byte, error) {
+func readConfigFromISO(ctx context.Context, r state.State) ([]byte, error) {
+	if err := netutils.WaitForDevicesReady(ctx, r); err != nil {
+		return nil, fmt.Errorf("failed to wait for devices: %w", err)
+	}
+
 	dev, err := probe.GetDevWithFileSystemLabel(constants.MetalConfigISOLabel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find %s iso: %w", constants.MetalConfigISOLabel, err)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -58,14 +58,20 @@ func TestParseMetadata(t *testing.T) {
 
 			eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
 			eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf7}
+			eth0.TypedSpec().Type = nethelpers.LinkEther
+			eth0.TypedSpec().Kind = ""
 			require.NoError(t, st.Create(context.TODO(), eth0))
 
 			eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
 			eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf8}
+			eth1.TypedSpec().Type = nethelpers.LinkEther
+			eth1.TypedSpec().Kind = ""
 			require.NoError(t, st.Create(context.TODO(), eth1))
 
 			eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
 			eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf9}
+			eth2.TypedSpec().Type = nethelpers.LinkEther
+			eth2.TypedSpec().Kind = ""
 			require.NoError(t, st.Create(context.TODO(), eth2))
 
 			var m nocloud.NetworkConfig

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/metadata.go
@@ -6,17 +6,20 @@
 package opennebula
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-blockdevice/blockdevice/filesystem"
 	"github.com/siderolabs/go-blockdevice/blockdevice/probe"
 	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 )
 
 const (
@@ -25,7 +28,11 @@ const (
 	mnt            = "/mnt"
 )
 
-func (o *OpenNebula) contextFromCD() (oneContext []byte, err error) {
+func (o *OpenNebula) contextFromCD(ctx context.Context, r state.State) (oneContext []byte, err error) {
+	if err := netutils.WaitForDevicesReady(ctx, r); err != nil {
+		return nil, fmt.Errorf("failed to wait for devices: %w", err)
+	}
+
 	var dev *probe.ProbedBlockDevice
 
 	dev, err = probe.GetDevWithFileSystemLabel(strings.ToLower(configISOLabel))

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
@@ -196,7 +196,7 @@ func (o *OpenNebula) ParseMetadata(st state.State, oneContextPlain []byte) (*run
 
 // Configuration implements the runtime.Platform interface.
 func (o *OpenNebula) Configuration(ctx context.Context, r state.State) (machineConfig []byte, err error) {
-	oneContextPlain, err := o.contextFromCD()
+	oneContextPlain, err := o.contextFromCD(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (o *OpenNebula) KernelArgs(string) procfs.Parameters {
 
 // NetworkConfiguration implements the runtime.Platform interface.
 func (o *OpenNebula) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
-	oneContext, err := o.contextFromCD()
+	oneContext, err := o.contextFromCD(ctx, st)
 	if stderrors.Is(err, errors.ErrNoConfigSource) {
 		err = nil
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula_test.go
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-// go test -v  ./internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula
+
 package opennebula_test
 
 import (

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -351,7 +351,7 @@ func (o *Openstack) ParseMetadata(
 
 // Configuration implements the runtime.Platform interface.
 func (o *Openstack) Configuration(ctx context.Context, r state.State) (machineConfig []byte, err error) {
-	_, _, machineConfig, err = o.configFromCD()
+	_, _, machineConfig, err = o.configFromCD(ctx, r)
 	if err != nil {
 		if err = netutils.Wait(ctx, r); err != nil {
 			return nil, err
@@ -389,7 +389,7 @@ func (o *Openstack) KernelArgs(string) procfs.Parameters {
 func (o *Openstack) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
 	networkSource := false
 
-	metadataConfigDl, metadataNetworkConfigDl, _, err := o.configFromCD()
+	metadataConfigDl, metadataNetworkConfigDl, _, err := o.configFromCD(ctx, st)
 	if err != nil {
 		metadataConfigDl, metadataNetworkConfigDl, _, err = o.configFromNetwork(ctx)
 		if stderrors.Is(err, errors.ErrNoConfigSource) {


### PR DESCRIPTION
With Talos 1.7+, more storage drivers are split as modules, so the devices might not be discovered by the time platform config is going to be loaded. Explicitly wait for udevd to settle down before trying to probe a CD.

Fixes #8625
