### PR TITLE
fix: use reboot delay only in case of error

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -118,12 +118,12 @@ func handle(ctx context.Context, err error) {
 				rebootCmd = 0
 			}
 		}
-	}
 
-	if rebootCmd == unix.LINUX_REBOOT_CMD_RESTART {
-		for i := 10; i >= 0; i-- {
-			log.Printf("rebooting in %d seconds\n", i)
-			time.Sleep(1 * time.Second)
+		if rebootCmd == unix.LINUX_REBOOT_CMD_RESTART {
+			for i := 10; i >= 0; i-- {
+				log.Printf("rebooting in %d seconds\n", i)
+				time.Sleep(1 * time.Second)
+			}
 		}
 	}
 


### PR DESCRIPTION
Delay the reboot for 10 seconds only if Talos hits an error, but otherwise just proceed with the requested action.

This removes 10 seconds on "regular" reboot without kexec.
