### PR TITLE
Proxmox install update to add QEMU guest agent guidance

### DIFF
--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
@@ -36,7 +36,7 @@ You can download `metal-amd64.iso` via
 
 ```bash
 mkdir -p _out/
-curl https://github.com/siderolabs/talos/releases/download/<version>/metal-<arch>.iso -L -o _out/metal-<arch>.iso
+curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-<arch>.iso -L -o _out/metal-<arch>.iso
 ```
 
 For example version `{{< release >}}` for `linux` platform:
@@ -45,6 +45,32 @@ For example version `{{< release >}}` for `linux` platform:
 mkdir -p _out/
 curl https://github.com/siderolabs/talos/releases/download/{{< release >}}/metal-amd64.iso -L -o _out/metal-amd64.iso
 ```
+
+### QEMU guest agent support (iso)
+
+- If you need the QEMU guest agent so you can do guest VM shutdowns of your Talos VMs, then you will need a custom ISO
+- To get this, navigate to https://factory.talos.dev/
+- Scroll down and select your Talos version (`{{< release >}}` for example)
+- Then tick the box for `siderolabs/qemu-guest-agent` and submit
+- This will provide you with a link to the bare metal ISO
+- The lines we're interested in are as follows
+
+```text
+Metal ISO
+
+amd64 ISO
+    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/{{< release >}}/metal-amd64.iso
+arm64 ISO
+    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/{{< release >}}/metal-arm64.iso
+
+Installer Image
+
+For the initial Talos install or upgrade use the following installer image:
+factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
+```
+
+- Download the above ISO (this will most likely be `amd64` for you)
+- Take note of the `factory.talos.dev/installer` URL as you'll need it later
 
 ## Upload ISO
 
@@ -171,6 +197,17 @@ This will create several files in the `_out` directory: `controlplane.yaml`, `wo
 > ```
 >
 > Update `controlplane.yaml` and `worker.yaml` config files to point to the correct disk location.
+
+### QEMU guest agent support
+
+For QEMU guest agent support, you can generate the config with the custom install image:
+
+```bash
+talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --installer-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
+```
+
+- In Proxmox, go to your VM --> Options and ensure that `QEMU Guest Agent` is `Enabled`
+- The QEMU agent is now configured
 
 ## Create Control Plane Node
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
- Update to Proxmox docs to give guidance on installing with the QEMU guest agent

## Why? (reasoning)
- Without the QEMU guest agent, you cannot `shutdown` the Talos VMs in Proxmox
- The `shutdown` command just hangs until Proxmox eventually terminates the VM

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
