### PR TITLE
chore: update minimum hardware requirement for vmware ova

### DIFF
--- a/pkg/imager/ova/ova.go
+++ b/pkg/imager/ova/ova.go
@@ -65,7 +65,7 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>talos</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-15</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>


### PR DESCRIPTION
his PR bumps the minimum hardware family to vmx-15. This corresponds to "ESXi 6.7 U2" and matches the minimum required for anyone deploying the vsphere CSI as shown in [this](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-0AB6E692-AA47-4B6A-8CEA-38B754E16567.html) doc. This allows us to bypass an extra step anytime talos is deployed into a vsphere environment.
