### PR TITLE
docs: remove mention of enabling KubePrism after v1.6

### DIFF
--- a/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
@@ -235,11 +235,6 @@ cluster:
       name: none
   proxy:
     disabled: true
-machine:
-  features:
-    kubePrism:
-      enabled: true
-      port: 7445
 ```
 
 ```bash

--- a/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
@@ -235,11 +235,6 @@ cluster:
       name: none
   proxy:
     disabled: true
-machine:
-  features:
-    kubePrism:
-      enabled: true
-      port: 7445
 ```
 
 ```bash

--- a/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
@@ -235,11 +235,6 @@ cluster:
       name: none
   proxy:
     disabled: true
-machine:
-  features:
-    kubePrism:
-      enabled: true
-      port: 7445
 ```
 
 ```bash


### PR DESCRIPTION
# Pull Request

## What? (description)

I noticed in the docs [here](https://github.com/siderolabs/talos/blob/8df5b85ec7e8ca53fd73c9c095ee5c453d5c4e51/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md?plain=1#L241) it mentions enabling the KubePrism feature.
However, [here](https://github.com/siderolabs/talos/blob/8df5b85ec7e8ca53fd73c9c095ee5c453d5c4e51/website/content/v1.8/kubernetes-guides/configuration/kubeprism.md?plain=1#L25) the docs mention it's enabled by default since 1.6.

## Why? (reasoning)

So I was wondering if *not* removing the mention of enabling KubePrism in v1.6+ was a mistake? Note it was mentioned several times in the docs v1.5.

Disclaimer: I have no idea

```
❯ rg "kubePrism:" --glob "*deploying-cilium.md" -A1
website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
240:    kubePrism:
241-      enabled: true

website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
240:    kubePrism:
241-      enabled: true

website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
240:    kubePrism:
241-      enabled: true

website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
32:    kubePrism:
33-      enabled: true
--
56:    kubePrism:
57-      enabled: true
--
212:    kubePrism:
213-      enabled: true
--
240:    kubePrism:
241-      enabled: true
--
264:    kubePrism:
265-      enabled: true
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
  gpg-identity fails, I'm guessing known team member has to sign the commit?
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)
