### PR TITLE
docs: fix grpc_tunnel value to true

### DIFF
--- a/website/content/v1.7/talos-guides/network/siderolink.md
+++ b/website/content/v1.7/talos-guides/network/siderolink.md
@@ -12,10 +12,10 @@ SideroLink is a foundation building block of [Sidero Omni](https://www.siderolab
 
 SideroLink is configured by providing the SideroLink API server address, either via kernel command line argument `siderolink.api` or as a [config document]({{< relref "../../reference/configuration/siderolink/siderolinkconfig" >}}).
 
-SideroLink API URL: `https://siderolink.api/?jointoken=token&grpc_tunnel=yes`.
+SideroLink API URL: `https://siderolink.api/?jointoken=token&grpc_tunnel=true`.
 If URL scheme is `grpc://`, the connection will be established without TLS, otherwise, the connection will be established with TLS.
 If specified, join token `token` will be sent to the SideroLink server.
-If `grpc_tunnel` is set to `yes`, the Wireguard traffic will be tunneled over the same SideroLink API gRPC connection instead of using plain UDP.
+If `grpc_tunnel` is set to `true`, the Wireguard traffic will be tunneled over the same SideroLink API gRPC connection instead of using plain UDP.
 
 ## Connection Flow
 

--- a/website/content/v1.8/talos-guides/network/siderolink.md
+++ b/website/content/v1.8/talos-guides/network/siderolink.md
@@ -12,10 +12,10 @@ SideroLink is a foundation building block of [Sidero Omni](https://www.siderolab
 
 SideroLink is configured by providing the SideroLink API server address, either via kernel command line argument `siderolink.api` or as a [config document]({{< relref "../../reference/configuration/siderolink/siderolinkconfig" >}}).
 
-SideroLink API URL: `https://siderolink.api/?jointoken=token&grpc_tunnel=yes`.
+SideroLink API URL: `https://siderolink.api/?jointoken=token&grpc_tunnel=true`.
 If URL scheme is `grpc://`, the connection will be established without TLS, otherwise, the connection will be established with TLS.
 If specified, join token `token` will be sent to the SideroLink server.
-If `grpc_tunnel` is set to `yes`, the Wireguard traffic will be tunneled over the same SideroLink API gRPC connection instead of using plain UDP.
+If `grpc_tunnel` is set to `true`, the Wireguard traffic will be tunneled over the same SideroLink API gRPC connection instead of using plain UDP.
 
 ## Connection Flow
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Changing documentation about siderolink so that the value to enable grpc_tunnel is `true`, so it will be `https://siderolink.api/?jointoken=token&grpc_tunnel=true`, which is what the code is actually looking for.

## Why? (reasoning)

grpc_tunnel is described as being enabled by using the value yes in the docs, but it should be true.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
