### PR TITLE
fix: put cluster name to the worker machine config

### DIFF
--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -196,8 +196,6 @@ func (suite *GenSuite) testGenConfigPatch(patch []byte) {
 				switch {
 				case tt.shouldAffect[configName]:
 					suite.Assert().Equal("bar", cfg.Cluster().Name(), "checking %q", configName)
-				case configName == "worker.yaml":
-					suite.Assert().Equal("", cfg.Cluster().Name(), "checking %q", configName)
 				default:
 					suite.Assert().Equal("foo", cfg.Cluster().Name(), "checking %q", configName)
 				}

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -144,3 +144,8 @@ func (contract *VersionContract) HostDNSEnabled() bool {
 func (contract *VersionContract) UseRSAServiceAccountKey() bool {
 	return contract.Greater(TalosVersion1_6)
 }
+
+// ClusterNameForWorkers returns true if version of Talos should put cluster name to the worker machine config.
+func (contract *VersionContract) ClusterNameForWorkers() bool {
+	return contract.Greater(TalosVersion1_7)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -60,6 +60,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.KubePrismEnabled())
 	assert.True(t, contract.HostDNSEnabled())
 	assert.True(t, contract.UseRSAServiceAccountKey())
+	assert.True(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_8(t *testing.T) {
@@ -79,6 +80,7 @@ func TestContract1_8(t *testing.T) {
 	assert.True(t, contract.KubePrismEnabled())
 	assert.True(t, contract.HostDNSEnabled())
 	assert.True(t, contract.UseRSAServiceAccountKey())
+	assert.True(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_7(t *testing.T) {
@@ -98,6 +100,7 @@ func TestContract1_7(t *testing.T) {
 	assert.True(t, contract.KubePrismEnabled())
 	assert.True(t, contract.HostDNSEnabled())
 	assert.True(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_6(t *testing.T) {
@@ -117,6 +120,7 @@ func TestContract1_6(t *testing.T) {
 	assert.True(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_5(t *testing.T) {
@@ -136,6 +140,7 @@ func TestContract1_5(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_4(t *testing.T) {
@@ -155,6 +160,7 @@ func TestContract1_4(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -174,6 +180,7 @@ func TestContract1_3(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -193,6 +200,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -212,6 +220,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -231,4 +240,5 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.KubePrismEnabled())
 	assert.False(t, contract.HostDNSEnabled())
 	assert.False(t, contract.UseRSAServiceAccountKey())
+	assert.False(t, contract.ClusterNameForWorkers())
 }

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -147,6 +147,10 @@ func (in *Input) worker() ([]config.Document, error) {
 		}
 	}
 
+	if in.Options.VersionContract.ClusterNameForWorkers() {
+		cluster.ClusterName = in.ClusterName
+	}
+
 	v1alpha1Config.MachineConfig = machine
 	v1alpha1Config.ClusterConfig = cluster
 

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.8/base-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.8/base-worker.yaml
@@ -30,6 +30,7 @@ cluster:
     secret: pofHbABZq7VXuObsdLdy/bHmz6hlMHZ3p8+6WKrv1ic=
     controlPlane:
         endpoint: https://base:6443
+    clusterName: base
     network:
         dnsDomain: cluster.local
         podSubnets:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.8/overrides-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.8/overrides-worker.yaml
@@ -49,6 +49,7 @@ cluster:
     secret: pofHbABZq7VXuObsdLdy/bHmz6hlMHZ3p8+6WKrv1ic=
     controlPlane:
         endpoint: https://base:6443
+    clusterName: base
     network:
         cni:
             name: custom


### PR DESCRIPTION
This is 1.8+ only.

Fixes #8694
