### PR TITLE
fix: check for `nil` machine config during installation

### DIFF
--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -69,7 +69,7 @@ func runInstallCmd(ctx context.Context) (err error) {
 			}
 		}
 
-		if config.Machine().Install().LegacyBIOSSupport() {
+		if config.Machine() != nil && config.Machine().Install().LegacyBIOSSupport() {
 			options.LegacyBIOSSupport = true
 		}
 	}


### PR DESCRIPTION
Otherwise we get `nil reference` exception during maintenance mode upgrade with partial machine configs.