### PR TITLE
fix: do not try to bootstrap cluster if `wait` flag is false

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -922,14 +922,14 @@ func nodeName(clusterName, role string, index int, uuid uuid.UUID) string {
 }
 
 func postCreate(ctx context.Context, clusterAccess *access.Adapter) error {
+	if !clusterWait {
+		return nil
+	}
+
 	if !withInitNode {
 		if err := clusterAccess.Bootstrap(ctx, os.Stdout); err != nil {
 			return fmt.Errorf("bootstrap error: %w", err)
 		}
-	}
-
-	if !clusterWait {
-		return nil
 	}
 
 	// Run cluster readiness checks


### PR DESCRIPTION
Otherwise to make `--wait=false` work you have to also pass `--with-init-node` flag, which looks weird.

I guess it should be a nice change, unless it breaks some backward compability.