### PR TITLE
fix: don't enable hostDNS for versions of Talos which do not have it

### DIFF
--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -93,7 +93,7 @@ func (in *Input) init() ([]config.Document, error) {
 		machine.MachineKubelet.KubeletDisableManifestsDirectory = pointer.To(true)
 	}
 
-	if in.Options.VersionContract.HostDNSEnabled() || in.Options.HostDNSForwardKubeDNSToHost.ValueOrZero() {
+	if in.Options.VersionContract.HostDNSEnabled() {
 		machine.MachineFeatures.HostDNSSupport = &v1alpha1.HostDNSConfig{
 			HostDNSEnabled:              pointer.To(true),
 			HostDNSForwardKubeDNSToHost: in.Options.HostDNSForwardKubeDNSToHost.Ptr(),

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -94,7 +94,7 @@ func (in *Input) worker() ([]config.Document, error) {
 		machine.MachineKubelet.KubeletDisableManifestsDirectory = pointer.To(true)
 	}
 
-	if in.Options.VersionContract.HostDNSEnabled() || in.Options.HostDNSForwardKubeDNSToHost.ValueOrZero() {
+	if in.Options.VersionContract.HostDNSEnabled() {
 		machine.MachineFeatures.HostDNSSupport = &v1alpha1.HostDNSConfig{
 			HostDNSEnabled:              pointer.To(true),
 			HostDNSForwardKubeDNSToHost: in.Options.HostDNSForwardKubeDNSToHost.Ptr(),


### PR DESCRIPTION
The problem is that `talosctl cluster create` tries to enable forwardKubeDNSToHost (for 1.7+), but due to the wrong condition this tries to enable `hostDNS` for any version of Talos, while it's only supported since 1.7+.
