### PR TITLE
Add raw to file names

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/gcp.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/gcp.md
@@ -30,14 +30,14 @@ export REGION="us-central1"
 ### Create the Image
 
 First, download the Google Cloud image from a Talos [release](https://github.com/siderolabs/talos/releases).
-These images are called `gcp-$ARCH.tar.gz`.
+These images are called `gcp-$ARCH.raw.tar.gz`.
 
 #### Upload the Image
 
 Once you have downloaded the image, you can upload it to your storage bucket with:
 
 ```bash
-gsutil cp /path/to/gcp-amd64.tar.gz gs://$STORAGE_BUCKET
+gsutil cp /path/to/gcp-amd64.raw.tar.gz gs://$STORAGE_BUCKET
 ```
 
 #### Register the image
@@ -46,7 +46,7 @@ Now that the image is present in our bucket, we'll register it.
 
 ```bash
 gcloud compute images create talos \
- --source-uri=gs://$STORAGE_BUCKET/gcp-amd64.tar.gz \
+ --source-uri=gs://$STORAGE_BUCKET/gcp-amd64.raw.tar.gz \
  --guest-os-features=VIRTIO_SCSI_MULTIQUEUE
 ```
 


### PR DESCRIPTION
The gcp images contain the word raw in the file names. This caused a error when following the online guide.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Online docs reference gcp-amd64.tar.gz but the actual final name is gcp-amd64.raw.tar.gz 
## Why? (reasoning)
When I followed the instructions they failed because of this file name issue.
## Acceptance

Please use the following checklist:

- [ NA] you linked an issue (if applicable)
- [ NA] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
