### PR TITLE
chore: handle I/O error for xfs_repair

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -151,7 +151,7 @@ func mountRetry(f RetryFunc, p *Point, isUnmount bool) (err error) {
 			case unix.ENOENT, unix.ENODEV:
 				// if udevd triggers BLKRRPART ioctl, partition device entry might disappear temporarily
 				return retry.ExpectedError(err)
-			case unix.EUCLEAN:
+			case unix.EUCLEAN, unix.EIO:
 				if errRepair := p.Repair(); errRepair != nil {
 					return fmt.Errorf("error repairing: %w", errRepair)
 				}


### PR DESCRIPTION
Run `xfs_repair` on `unix.EIO` error.

```text
16T18:19:30.85674118Z]: XFS (sdb5): Mounting V5 Filesystem
109.200.197.196: kern:    info: [2024-04-16T18:19:30.92421418Z]: XFS (sdb5): Ending clean mount
109.200.197.196: kern:  notice: [2024-04-16T18:19:36.42651618Z]: XFS (sdb6): Mounting V5 Filesystem
109.200.197.196: kern:    info: [2024-04-16T18:19:36.49568918Z]: XFS (sdb6): Ending clean mount
109.200.197.196: kern:  notice: [2024-04-16T18:19:36.54484918Z]: XFS (sdb6): Quotacheck needed: Please wait.
109.200.197.196: kern:  notice: [2024-04-16T18:19:36.54586418Z]: XFS (sdb6): Quotacheck: Done.
109.200.197.196: kern:   alert: [2024-05-13T15:13:11.99476118Z]: XFS (sdb6): log I/O error -5
109.200.197.196: kern:   alert: [2024-05-13T15:13:11.99477118Z]: XFS (sdb6): Filesystem has been shut down due to log error (0x2).
109.200.197.196: kern:   alert: [2024-05-13T15:13:11.99477318Z]: XFS (sdb6): Please unmount the filesystem and rectify the problem(s).
```