### PR TITLE
chore: remove docs prior to 1.0 from website navigation

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -176,26 +176,6 @@ version = "v1.1"
 url = "/v1.0/"
 version = "v1.0"
 
-[[params.versions]]
-url = "/v0.14/"
-version = "v0.14"
-
-[[params.versions]]
-url = "/v0.13/"
-version = "v0.13"
-
-[[params.versions]]
-url = "/v0.12/"
-version = "v0.12"
-
-[[params.versions]]
-url = "/v0.11/"
-version = "v0.11"
-
-[[params.versions]]
-url = "/v0.10/"
-version = "v0.10"
-
 # User interface configuration
 [params.ui]
 #  Set to true to disable breadcrumb navigation.


### PR DESCRIPTION
These docs are still present in the repo, but won't be an option in the talos docs site.