### PR TITLE
fix: increase host dns packet ttl for pods

### DIFF
--- a/internal/pkg/dns/dns_test.go
+++ b/internal/pkg/dns/dns_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/proxy"
 	dnssrv "github.com/miekg/dns"
+	"github.com/siderolabs/gen/ensure"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/gen/xtesting/check"
 	"github.com/stretchr/testify/require"
@@ -120,7 +121,7 @@ func newServer(t *testing.T, nameservers ...string) func() {
 
 	handler.SetProxy(pxs)
 
-	pc, err := dns.NewUDPPacketConn("udp", "127.0.0.53:10700")
+	pc, err := dns.NewUDPPacketConn("udp", "127.0.0.53:10700", ensure.Value(dns.MakeControl("udp", false)))
 	require.NoError(t, err)
 
 	nodeHandler := dns.NewNodeHandler(handler, &testResolver{}, l)


### PR DESCRIPTION
This PR fixes incorrect packet TTL if `forwardKubeDNSToHost` is enabled.

Credits go to Julian Wiedmann.

Closes #8698.