### PR TITLE
fix: increase udp buffer limit for dns server

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates/core-dns-template.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/templates/core-dns-template.yaml
@@ -71,6 +71,7 @@ data:
         loop
         reload
         loadbalance
+        bufsize 4096
     }
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
By default, github.com/miekg/dns uses `dns.MinMsgSize` for UDP messages, which is 512 bytes. This is too small for some DNS request/responses, and can cause truncation and errors. This change sets the buffer size to `dns.DefaultMsgSize` 4096 bytes, which is the maximum size of a dns packet payload per RFC 6891.

Also increase CoreDNS dns request payload limit to 4096 from the default 1232 bytes.

For #8763