### PR TITLE
fix: correctly handle dns messages in our dns implementation

### DIFF
--- a/internal/integration/api/common.go
+++ b/internal/integration/api/common.go
@@ -166,6 +166,14 @@ func (suite *CommonSuite) TestDNSResolver() {
 
 	suite.Require().Equal("", stdout)
 	suite.Require().Contains(stderr, "'index.html' saved")
+
+	stdout, stderr, err = suite.ExecuteCommandInPod(suite.ctx, namespace, pod, "nslookup really-long-record.dev.siderolabs.io")
+	suite.Require().NoError(err)
+
+	suite.Require().Contains(stdout, "really-long-record.dev.siderolabs.io")
+	suite.Require().NotContains(stdout, "Can't find")
+	suite.Require().NotContains(stdout, "No answer")
+	suite.Require().Equal(stderr, "")
 }
 
 func init() {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -180,8 +181,5 @@ func init() {
 	flag.StringVar(&provision_test.DefaultSettings.CustomCNIURL, "talos.provision.custom-cni-url", provision_test.DefaultSettings.CustomCNIURL, "custom CNI URL for the cluster (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.CNIBundleURL, "talos.provision.cni-bundle-url", provision_test.DefaultSettings.CNIBundleURL, "URL to download CNI bundle from")
 
-	allSuites = append(allSuites, api.GetAllSuites()...)
-	allSuites = append(allSuites, cli.GetAllSuites()...)
-	allSuites = append(allSuites, k8s.GetAllSuites()...)
-	allSuites = append(allSuites, provision_test.GetAllSuites()...)
+	allSuites = slices.Concat(api.GetAllSuites(), cli.GetAllSuites(), k8s.GetAllSuites(), provision_test.GetAllSuites())
 }


### PR DESCRIPTION
- By default, github.com/miekg/dns uses `dns.MinMsgSize` for UDP messages, which is 512 bytes. This is too small for some DNS request/responses, and can cause truncation and errors. This change sets the buffer size to `dns.DefaultMsgSize`
4096 bytes, which is the maximum size of a dns packet payload per RFC 6891.
- We also retry the request if the response is truncated or previous connection was closed.
- And finally we properly handle the case where the response is larger than the client buffer size,
and we return a truncated correct response.

Closes #8763