### PR TITLE
chore: stop using containerd package for cri namespace

### DIFF
--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
@@ -39,7 +38,7 @@ var containersCmd = &cobra.Command{
 			)
 
 			if kubernetesFlag {
-				namespace = criconstants.K8sContainerdNamespace
+				namespace = constants.K8sContainerdNamespace
 				driver = common.ContainerDriver_CRI
 			} else {
 				namespace = constants.SystemContainerdNamespace

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"sync"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -55,7 +54,7 @@ var logsCmd = &cobra.Command{
 			)
 
 			if kubernetesFlag {
-				namespace = criconstants.K8sContainerdNamespace
+				namespace = constants.K8sContainerdNamespace
 				driver = common.ContainerDriver_CRI
 			} else {
 				namespace = constants.SystemContainerdNamespace

--- a/cmd/talosctl/cmd/talos/netstat.go
+++ b/cmd/talosctl/cmd/talos/netstat.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var netstatCmdFlags struct {
@@ -207,7 +207,7 @@ func netstatFlagsToRequest() *machine.NetstatRequest {
 }
 
 func (n *netstat) getPodNetNsFromNode(ctx context.Context) (err error) {
-	resp, err := n.client.Containers(ctx, criconstants.K8sContainerdNamespace, common.ContainerDriver_CRI)
+	resp, err := n.client.Containers(ctx, constants.K8sContainerdNamespace, common.ContainerDriver_CRI)
 	if err != nil {
 		cli.Warning("error getting containers: %v", err)
 

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -37,7 +36,7 @@ var restartCmd = &cobra.Command{
 			)
 
 			if kubernetesFlag {
-				namespace = criconstants.K8sContainerdNamespace
+				namespace = constants.K8sContainerdNamespace
 				driver = common.ContainerDriver_CRI
 			} else {
 				namespace = constants.SystemContainerdNamespace

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/siderolabs/gen/maps"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -188,7 +187,7 @@ func getContainersFromNode(kubernetes bool) []string {
 			)
 
 			if kubernetes {
-				namespace = criconstants.K8sContainerdNamespace
+				namespace = constants.K8sContainerdNamespace
 				driver = common.ContainerDriver_CRI
 			} else {
 				namespace = constants.SystemContainerdNamespace

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
@@ -38,7 +37,7 @@ var statsCmd = &cobra.Command{
 			)
 
 			if kubernetesFlag {
-				namespace = criconstants.K8sContainerdNamespace
+				namespace = constants.K8sContainerdNamespace
 				driver = common.ContainerDriver_CRI
 			} else {
 				namespace = constants.SystemContainerdNamespace

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
@@ -10,7 +10,6 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/containerd/containerd/platforms"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,7 +26,7 @@ func containerdNamespaceHelper(ctx context.Context, ns common.ContainerdNamespac
 
 	switch ns {
 	case common.ContainerdNamespace_NS_CRI:
-		namespaceName = criconstants.K8sContainerdNamespace
+		namespaceName = constants.K8sContainerdNamespace
 	case common.ContainerdNamespace_NS_SYSTEM:
 		namespaceName = constants.SystemContainerdNamespace
 	case common.ContainerdNamespace_NS_UNKNOWN:

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -23,7 +23,6 @@ import (
 	"syscall"
 	"time"
 
-	criconstants "github.com/containerd/containerd/pkg/cri/constants"
 	cosiv1alpha1 "github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -1257,7 +1256,7 @@ func k8slogs(ctx context.Context, req *machine.LogsRequest) (chunker.Chunker, io
 func getContainerInspector(ctx context.Context, namespace string, driver common.ContainerDriver) (containers.Inspector, error) {
 	switch driver {
 	case common.ContainerDriver_CRI:
-		if namespace != criconstants.K8sContainerdNamespace {
+		if namespace != constants.K8sContainerdNamespace {
 			return nil, errors.New("CRI inspector is supported only for K8s namespace")
 		}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -485,6 +485,9 @@ const (
 	// SystemContainerdAddress is the path to the system containerd socket.
 	SystemContainerdAddress = SystemRunPath + "/containerd/containerd.sock"
 
+	// K8sContainerdNamespace is the Containerd namespace for CRI pods.
+	K8sContainerdNamespace = "k8s.io"
+
 	// CRIContainerdAddress is the path to the CRI containerd socket address.
 	CRIContainerdAddress = "/run/containerd/containerd.sock"
 


### PR DESCRIPTION
In containerd 2.0 source tree, this constant is under `internal`, so we can't import it directly.

So instead re-declare it as a Talos constant.

Doing this multi-staged, as `go-talos-support` is using it as well, and to update it to stop importing old containerd library I need first to declare the constant in Talos source tree.
