### PR TITLE
fix: require accepted CAs on worker nodes

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -337,7 +337,7 @@ func (ctrl *APIController) generateControlPlane(ctx context.Context, r controlle
 func (ctrl *APIController) generateWorker(ctx context.Context, r controller.Runtime, logger *zap.Logger,
 	rootSpec *secrets.OSRootSpec, endpointsStr []string, certSANs *secrets.CertSANSpec,
 ) error {
-	remoteGen, err := gen.NewRemoteGenerator(rootSpec.Token, endpointsStr, rootSpec.IssuingCA)
+	remoteGen, err := gen.NewRemoteGenerator(rootSpec.Token, endpointsStr, rootSpec.AcceptedCAs)
 	if err != nil {
 		return fmt.Errorf("failed creating trustd client: %w", err)
 	}

--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"context"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -397,7 +398,14 @@ func (suite *ApplyConfigSuite) TestApplyDryRun() {
 
 	cfgDataOut := suite.PatchV1Alpha1Config(provider, func(cfg *v1alpha1.Config) {
 		// this won't be possible without a reboot
-		cfg.MachineConfig.MachineType = "controlplane"
+		cfg.MachineConfig.MachineFiles = append(cfg.MachineConfig.MachineFiles,
+			&v1alpha1.MachineFile{
+				FileContent:     "test",
+				FilePermissions: v1alpha1.FileMode(os.ModePerm),
+				FilePath:        "/var/lib/test",
+				FileOp:          "create",
+			},
+		)
 	})
 
 	reply, err := suite.Client.ApplyConfiguration(

--- a/pkg/grpc/gen/remote.go
+++ b/pkg/grpc/gen/remote.go
@@ -28,7 +28,7 @@ type RemoteGenerator struct {
 }
 
 // NewRemoteGenerator initializes a RemoteGenerator with a preconfigured grpc.ClientConn.
-func NewRemoteGenerator(token string, endpoints []string, ca *x509.PEMEncodedCertificateAndKey) (g *RemoteGenerator, err error) {
+func NewRemoteGenerator(token string, endpoints []string, acceptedCAs []*x509.PEMEncodedCertificate) (g *RemoteGenerator, err error) {
 	if len(endpoints) == 0 {
 		return nil, errors.New("at least one root of trust endpoint is required")
 	}
@@ -37,7 +37,7 @@ func NewRemoteGenerator(token string, endpoints []string, ca *x509.PEMEncodedCer
 
 	g = &RemoteGenerator{}
 
-	conn, err := basic.NewConnection(fmt.Sprintf("%s:///%s", resolver.RoundRobinResolverScheme, strings.Join(endpoints, ",")), basic.NewTokenCredentials(token), ca)
+	conn, err := basic.NewConnection(fmt.Sprintf("%s:///%s", resolver.RoundRobinResolverScheme, strings.Join(endpoints, ",")), basic.NewTokenCredentials(token), acceptedCAs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machinery/config/container/container_test.go
+++ b/pkg/machinery/config/container/container_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/xtesting/must"
 	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
@@ -137,6 +138,9 @@ func TestValidate(t *testing.T) {
 		},
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineType: "worker",
+			MachineCA: &x509.PEMEncodedCertificateAndKey{
+				Crt: []byte("cert"),
+			},
 		},
 	}
 


### PR DESCRIPTION
Note: this issue never happens with default Talos worker configuration (generated by Omni, `talosctl gen config` or CABPT).

Before change https://github.com/siderolabs/talos/pull/4294 3 years ago, worker nodes connected to trustd in "insecure" mode (without validating the trustd server certificate). The change kept backwards compatibility, so it still allowed insecure mode on upgrades.

Now it's time to break this compatibility promise, and require accepted CAs to be always present. Adds validation for machine configuration, so if upgrade is attempeted, it would not validate the machine config without accepted CAs.

Now lack of accepted CAs would lead to failure to connect to trustd.
