### PR TITLE
fix(ci): fix crons by setting up buildx always

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: default
 concurrency:
@@ -362,6 +362,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -378,11 +385,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -390,12 +403,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
@@ -504,11 +511,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -516,17 +529,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: checkout extensions
@@ -650,11 +657,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -662,17 +675,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: checkout extensions
@@ -773,6 +780,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -789,11 +803,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -801,17 +821,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-azure-prepare
@@ -899,6 +913,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -913,7 +934,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -921,19 +942,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-cilium
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -1014,6 +1022,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -1034,27 +1049,10 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -1108,6 +1106,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -1128,7 +1133,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1136,19 +1141,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-equinix-metal-prepare
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -1247,7 +1239,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1255,19 +1247,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: checkout extensions
         uses: actions/checkout@v4
         with:
@@ -1343,6 +1322,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -1353,6 +1339,12 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
@@ -1375,7 +1367,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: factory-1.6-iso
@@ -1493,6 +1485,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -1507,7 +1506,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1515,19 +1514,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -1578,6 +1564,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -1588,11 +1581,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1600,17 +1599,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-firewall
@@ -1762,7 +1755,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1770,19 +1763,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare
@@ -1856,7 +1836,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1864,19 +1844,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare
@@ -1950,7 +1917,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1958,19 +1925,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare
@@ -2023,6 +1977,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -2037,7 +1998,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -2045,19 +2006,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2107,6 +2055,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -2121,7 +2076,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -2129,19 +2084,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu-csi
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2198,6 +2140,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -2212,7 +2161,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -2220,19 +2169,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2306,7 +2242,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -2314,19 +2250,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: build-race
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2403,31 +2326,6 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: reproducibility-test
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2477,6 +2375,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -2487,11 +2392,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -2499,19 +2410,13 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
+      - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64
         run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
+          make secureboot-iso
       - name: integration-trusted-boot
         env:
           EXTRA_TEST_ARGS: -talos.trustedboot

--- a/.github/workflows/integration-aws-cron.yaml
+++ b/.github/workflows/integration-aws-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-aws-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -61,11 +68,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -73,12 +86,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-aws-nvidia-nonfree-cron
 concurrency:
@@ -68,11 +68,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -80,17 +86,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: checkout extensions

--- a/.github/workflows/integration-aws-nvidia-oss-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-aws-nvidia-oss-cron
 concurrency:
@@ -68,11 +68,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -80,17 +86,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: checkout extensions

--- a/.github/workflows/integration-azure-cron.yaml
+++ b/.github/workflows/integration-azure-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-azure-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -61,11 +68,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -73,17 +86,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-azure-prepare

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-cilium-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -59,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-cilium
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-cloud-images-cron.yaml
+++ b/.github/workflows/integration-cloud-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-cloud-images-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -65,27 +72,10 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-equinix-metal-cron.yaml
+++ b/.github/workflows/integration-equinix-metal-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-equinix-metal-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Mask secrets
         run: |
           echo -e "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
@@ -65,7 +72,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -73,19 +80,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-equinix-metal-prepare
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-extensions-cron.yaml
+++ b/.github/workflows/integration-extensions-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-extensions-cron
 concurrency:
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -74,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: checkout extensions
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-image-factory-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -55,6 +62,12 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
@@ -77,7 +90,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: factory-1.6-iso

--- a/.github/workflows/integration-images-cron.yaml
+++ b/.github/workflows/integration-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-images-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -59,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-misc-cron.yaml
+++ b/.github/workflows/integration-misc-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-misc-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -55,11 +62,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,17 +80,11 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-firewall

--- a/.github/workflows/integration-provision-0-cron.yaml
+++ b/.github/workflows/integration-provision-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-provision-0-cron
 concurrency:
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -74,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare

--- a/.github/workflows/integration-provision-1-cron.yaml
+++ b/.github/workflows/integration-provision-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-provision-1-cron
 concurrency:
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -74,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare

--- a/.github/workflows/integration-provision-2-cron.yaml
+++ b/.github/workflows/integration-provision-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-provision-2-cron
 concurrency:
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -74,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-qemu-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -59,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-qemu-csi-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-qemu-csi-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -59,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu-csi
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
+++ b/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-qemu-encrypted-vip-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -59,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-qemu-race-cron.yaml
+++ b/.github/workflows/integration-qemu-race-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-qemu-race-cron
 concurrency:
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -74,19 +74,6 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: build-race
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-reproducibility-test-cron.yaml
+++ b/.github/workflows/integration-reproducibility-test-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-reproducibility-test-cron
 concurrency:
@@ -62,31 +62,6 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: reproducibility-test
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T10:20:45Z by kres 2688b70.
+# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
 
 name: integration-trusted-boot-cron
 concurrency:
@@ -45,6 +45,13 @@ jobs:
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
@@ -55,11 +62,17 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: uki-certs
+        if: github.event_name == 'schedule'
+        env:
+          PLATFORM: linux/amd64
+        run: |
+          make uki-certs
       - name: build
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -67,19 +80,13 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: iso
+      - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64
         run: |
-          make iso secureboot-iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
+          make secureboot-iso
       - name: integration-trusted-boot
         env:
           EXTRA_TEST_ARGS: -talos.trustedboot

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -266,6 +266,8 @@ spec:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             SHORT_INTEGRATION_TEST: yes
     - name: integration-qemu
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -287,29 +289,19 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-qemu
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-trusted-boot
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -326,28 +318,27 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
+        - name: secureboot-iso
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: integration-trusted-boot
           command: e2e-qemu
@@ -382,24 +373,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: provision-tests-prepare
         - name: provision-tests-track-0
           withSudo: true
@@ -430,24 +409,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: provision-tests-prepare
         - name: provision-tests-track-1
           withSudo: true
@@ -478,30 +445,20 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: provision-tests-prepare
         - name: provision-tests-track-2
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-misc
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -518,28 +475,27 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-firewall
           command: e2e-qemu
@@ -649,24 +605,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -699,6 +643,8 @@ spec:
             EXTRA_TEST_ARGS: -talos.extensions.qemu
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-cilium
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -720,24 +666,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-cilium
           command: e2e-qemu
           withSudo: true
@@ -775,6 +709,8 @@ spec:
             WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-qemu-encrypted-vip
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -796,24 +732,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-qemu
           withSudo: true
           environment:
@@ -845,24 +769,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: build-race
           command: initramfs installer
           environment:
@@ -878,6 +790,8 @@ spec:
             TAG_SUFFIX: -race
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-qemu-csi
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -899,24 +813,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-qemu-csi
           command: e2e-qemu
           withSudo: true
@@ -930,6 +832,8 @@ spec:
             WITH_TEST: run_csi_tests
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-images
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -951,24 +855,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -992,33 +884,12 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: reproducibility-test
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
     - name: integration-cloud-images
+      buildxOptions:
+        enabled: true
       sops: true
       depends:
         - default
@@ -1041,30 +912,17 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images
           environment:
             PLATFORM: linux/amd64,linux/arm64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: cloud-images
     - name: integration-image-factory
+      buildxOptions:
+        enabled: true
       depends:
         - default
       runners:
@@ -1081,6 +939,11 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
@@ -1102,7 +965,7 @@ spec:
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: factory-1.6-iso
           command: e2e-image-factory
@@ -1176,6 +1039,8 @@ spec:
             FACTORY_SCHEMATIC: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
             KUBERNETES_VERSION: 1.26.5
     - name: integration-aws
+      buildxOptions:
+        enabled: true
       sops: true
       depends:
         - default
@@ -1193,23 +1058,22 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
@@ -1262,28 +1126,27 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
@@ -1353,28 +1216,27 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
@@ -1425,6 +1287,8 @@ spec:
             TF_E2E_TEST_TYPE: aws
             TF_E2E_ACTION: destroy
     - name: integration-azure
+      buildxOptions:
+        enabled: true
       sops: true
       depends:
         - default
@@ -1442,28 +1306,27 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: uki-certs
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
         - name: build
           conditions:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-azure-prepare
           environment:
@@ -1499,6 +1362,8 @@ spec:
             ARM_CLIENT_SECRET: ${{ env.AZURE_CLIENT_SECRET }}
             ARM_TENANT_ID: ${{ env.AZURE_TENANT_ID }}
     - name: integration-equinix-metal
+      buildxOptions:
+        enabled: true
       sops: true
       depends:
         - default
@@ -1521,24 +1386,12 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: iso
-          conditions:
-            - only-on-schedule
-          command: iso secureboot-iso
-          environment:
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-equinix-metal-prepare
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io


### PR DESCRIPTION
Fix crons by setting up buildx always, also make sure `images-essential` has `uki-certs` as dependency.

Also use platform as `linux/amd64` in CI integration tests and cron jobs, since we don't run tests with arm64 binaries.