### PR TITLE
test: add Equnix Metal sample metadata with two bonds

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
@@ -1,0 +1,156 @@
+addresses:
+    - address: 147.28.162.183/31
+      linkName: bond0
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+    - address: 2604:1380:45f2:6f00::1/127
+      linkName: bond0
+      family: inet6
+      scope: global
+      flags: permanent
+      layer: platform
+    - address: 10.68.217.1/31
+      linkName: bond0
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+links:
+    - name: eth0
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond0
+      layer: platform
+    - name: eth1
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond1
+      layer: platform
+    - name: eth2
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond0
+      slaveIndex: 1
+      layer: platform
+    - name: eth3
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      masterName: bond1
+      slaveIndex: 1
+      layer: platform
+    - name: bond0
+      logical: true
+      up: true
+      mtu: 0
+      kind: bond
+      type: ether
+      bondMaster:
+        mode: 802.3ad
+        xmitHashPolicy: layer3+4
+        lacpRate: slow
+        arpValidate: none
+        arpAllTargets: any
+        primaryReselect: always
+        failOverMac: 0
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+        resendIgmp: 1
+        lpInterval: 1
+        packetsPerSlave: 1
+        numPeerNotif: 1
+        tlbLogicalLb: 1
+        adActorSysPrio: 65535
+      layer: platform
+    - name: bond1
+      logical: true
+      up: true
+      mtu: 0
+      kind: bond
+      type: ether
+      bondMaster:
+        mode: 802.3ad
+        xmitHashPolicy: layer3+4
+        lacpRate: slow
+        arpValidate: none
+        arpAllTargets: any
+        primaryReselect: always
+        failOverMac: 0
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+        resendIgmp: 1
+        lpInterval: 1
+        packetsPerSlave: 1
+        numPeerNotif: 1
+        tlbLogicalLb: 1
+        adActorSysPrio: 65535
+      layer: platform
+routes:
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 147.28.162.182
+      outLinkName: bond0
+      table: main
+      priority: 1024
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: '2604:1380:45f2:6f00::'
+      outLinkName: bond0
+      table: main
+      priority: 2048
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: 10.0.0.0/8
+      src: ""
+      gateway: 10.68.217.0
+      outLinkName: bond0
+      table: main
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+hostnames:
+    - hostname: devcluster-38uvi6
+      domainname: ""
+      layer: platform
+resolvers: []
+timeServers: []
+operators: []
+externalIPs:
+    - 147.28.162.183
+    - 2604:1380:45f2:6f00::1
+metadata:
+    platform: equinixMetal
+    hostname: devcluster-38uvi6
+    region: dc
+    zone: dc13
+    instanceType: n2.xlarge.x86
+    instanceId: b45359b0-5a13-454b-82eb-d4959924f9f0
+    providerId: equinixmetal://b45359b0-5a13-454b-82eb-d4959924f9f0

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/metadata-2bonds.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/metadata-2bonds.json
@@ -1,0 +1,146 @@
+{
+    "id": "b45359b0-5a13-454b-82eb-d4959924f9f0",
+    "hostname": "devcluster-38uvi6",
+    "iqn": "iqn.2024-05.net.packet:device.b45359b0",
+    "operating_system": {
+      "slug": "custom_ipxe",
+      "version": "1",
+      "distro": "custom_ipxe",
+      "license_activation": { "state": "unlicensed" },
+      "image_tag": null
+    },
+    "plan": "n2.xlarge.x86",
+    "reserved": false,
+    "class": "n2.xlarge.x86",
+    "facility": "dc13",
+    "metro": "dc",
+    "private_subnets": ["10.0.0.0/8"],
+    "tags": [],
+    "ssh_keys": [
+    ],
+    "customdata": {},
+    "specs": {
+      "cpus": [
+        { "count": 2, "type": "Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz" }
+      ],
+      "memory": { "total": "384GB" },
+      "drives": [
+        { "count": 2, "size": "120GB", "type": "SSD", "category": "boot" },
+        { "count": 1, "size": "3.8TB", "type": "NVME", "category": "storage" }
+      ],
+      "nics": [{ "count": 4, "type": "10Gbps" }],
+      "features": { "uefi": false }
+    },
+    "switch_short_id": "5b2b2148",
+    "state": "active",
+    "storage_source": "default",
+    "storage": {
+      "disks": [
+        {
+          "device": "/dev/sda",
+          "wipeTable": true,
+          "partitions": [
+            { "label": "BIOS", "number": 1, "size": 4096 },
+            { "label": "SWAP", "number": 2, "size": "3993600" },
+            { "label": "ROOT", "number": 3, "size": 0 }
+          ]
+        }
+      ],
+      "filesystems": [
+        {
+          "mount": {
+            "device": "/dev/sda3",
+            "format": "ext4",
+            "point": "/",
+            "create": { "options": ["-L", "ROOT"] }
+          }
+        },
+        {
+          "mount": {
+            "device": "/dev/sda2",
+            "format": "swap",
+            "point": "none",
+            "create": { "options": ["-L", "SWAP"] }
+          }
+        }
+      ]
+    },
+    "volumes": [],
+    "boot_drive_hint": "DELLBOSS VD",
+    "network": {
+      "bonding": {
+        "mode": 4,
+        "link_aggregation": "mlag_ha",
+        "mac": "e4:43:4b:d0:7b:50"
+      },
+      "interfaces": [
+        { "name": "eth0", "mac": "e4:43:4b:d0:7b:50", "bond": "bond0" },
+        { "name": "eth1", "mac": "e4:43:4b:d0:7b:51", "bond": "bond1" },
+        { "name": "eth2", "mac": "e4:43:4b:d0:7b:52", "bond": "bond0" },
+        { "name": "eth3", "mac": "e4:43:4b:d0:7b:53", "bond": "bond1" }
+      ],
+      "addresses": [
+        {
+          "id": "e5e5c1db-ef6d-4461-958e-50b88a96833e",
+          "address_family": 4,
+          "netmask": "255.255.255.254",
+          "created_at": "2024-05-22T17:59:09Z",
+          "public": true,
+          "cidr": 31,
+          "management": true,
+          "enabled": true,
+          "network": "147.28.162.182",
+          "address": "147.28.162.183",
+          "gateway": "147.28.162.182",
+          "parent_block": {
+            "network": "147.28.162.182",
+            "netmask": "255.255.255.254",
+            "cidr": 31,
+            "href": "/ips/909dbc49-1640-4b0a-b9c4-20e4cef044e8"
+          }
+        },
+        {
+          "id": "1cc68fbc-c0d3-42e2-a186-a73923e65bec",
+          "address_family": 6,
+          "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe",
+          "created_at": "2024-05-22T17:59:09Z",
+          "public": true,
+          "cidr": 127,
+          "management": true,
+          "enabled": true,
+          "network": "2604:1380:45f2:6f00::",
+          "address": "2604:1380:45f2:6f00::1",
+          "gateway": "2604:1380:45f2:6f00::",
+          "parent_block": {
+            "network": "2604:1380:45f2:6f00:0000:0000:0000:0000",
+            "netmask": "ffff:ffff:ffff:ff00:0000:0000:0000:0000",
+            "cidr": 56,
+            "href": "/ips/77b6f5dd-11e9-47bd-9c5c-6db6ec29fe42"
+          }
+        },
+        {
+          "id": "8d4d7e88-730c-409e-97b6-99b2f69aeede",
+          "address_family": 4,
+          "netmask": "255.255.255.254",
+          "created_at": "2024-05-22T17:59:09Z",
+          "public": false,
+          "cidr": 31,
+          "management": true,
+          "enabled": true,
+          "network": "10.68.217.0",
+          "address": "10.68.217.1",
+          "gateway": "10.68.217.0",
+          "parent_block": {
+            "network": "10.68.217.0",
+            "netmask": "255.255.255.128",
+            "cidr": 25,
+            "href": "/ips/6258119f-c7c4-4158-a54a-fb317263a3ce"
+          }
+        }
+      ],
+      "metal_gateways": []
+    },
+    "api_url": "https://metadata.packet.net",
+    "phone_home_url": "http://tinkerbell.dc13.packet.net/phone-home",
+    "user_state_url": "http://tinkerbell.dc13.packet.net/events"
+  }


### PR DESCRIPTION
Talos doesn't support MLAG aggregation yet, but having the initial testcase is a good step forward.
