### PR TITLE
chore: require enabled bootloader for docker provisioner

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/cluster.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/cluster.go
@@ -6,6 +6,7 @@
 package cluster
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,13 @@ var Cmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "A collection of commands for managing local docker-based or QEMU-based clusters",
 	Long:  ``,
+	PersistentPreRunE: func(*cobra.Command, []string) error {
+		if provisionerName == docker && !bootloaderEnabled {
+			return errors.New("docker provisioner requires bootloader to be enabled")
+		}
+
+		return nil
+	},
 }
 
 var (
@@ -36,7 +44,7 @@ func init() {
 		defaultCNIDir = filepath.Join(talosDir, "cni")
 	}
 
-	Cmd.PersistentFlags().StringVar(&provisionerName, "provisioner", "docker", "Talos cluster provisioner to use")
+	Cmd.PersistentFlags().StringVar(&provisionerName, "provisioner", docker, "Talos cluster provisioner to use")
 	Cmd.PersistentFlags().StringVar(&stateDir, "state", defaultStateDir, "directory path to store cluster state")
 	Cmd.PersistentFlags().StringVar(&clusterName, "name", "talos-default", "the name of the cluster")
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -54,6 +54,8 @@ import (
 )
 
 const (
+	docker = "docker"
+
 	// gatewayOffset is the offset from the network address of the IP address of the network gateway.
 	gatewayOffset = 1
 
@@ -446,7 +448,7 @@ func create(ctx context.Context) error {
 	var configBundleOpts []bundle.Option
 
 	if ports != "" {
-		if provisionerName != "docker" {
+		if provisionerName != docker {
 			return errors.New("exposed-ports flag only supported with docker provisioner")
 		}
 
@@ -505,7 +507,7 @@ func create(ctx context.Context) error {
 		}
 
 		if talosVersion == "" {
-			if provisionerName == "docker" {
+			if provisionerName == docker {
 				parts := strings.Split(nodeImage, ":")
 
 				talosVersion = parts[len(parts)-1]


### PR DESCRIPTION
Otherwise, it doesn't make sense.