### PR TITLE
fix(ci): cron jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T15:02:03Z by kres b5844f8.
+# Generated on 2024-05-25T14:28:32Z by kres b5844f8.
 
 name: default
 concurrency:
@@ -407,7 +407,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-aws-prepare
@@ -511,6 +511,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: uki-certs
         if: github.event_name == 'schedule'
         env:
@@ -657,6 +661,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: uki-certs
         if: github.event_name == 'schedule'
         env:
@@ -1133,7 +1141,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64
+          PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
@@ -1235,6 +1243,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: build
         if: github.event_name == 'schedule'
         env:
@@ -2718,6 +2730,13 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
+      - name: images-essential
+        if: github.event_name == 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64
+        run: |
+          make images-essential
       - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-aws-cron.yaml
+++ b/.github/workflows/integration-aws-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T14:28:32Z by kres b5844f8.
 
 name: integration-aws-cron
 concurrency:
@@ -90,7 +90,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
+          PLATFORM: linux/amd64
         run: |
           make images-essential
       - name: e2e-aws-prepare

--- a/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
 
 name: integration-aws-nvidia-nonfree-cron
 concurrency:
@@ -68,6 +68,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: uki-certs
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-aws-nvidia-oss-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
 
 name: integration-aws-nvidia-oss-cron
 concurrency:
@@ -68,6 +68,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: uki-certs
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-equinix-metal-cron.yaml
+++ b/.github/workflows/integration-equinix-metal-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
 
 name: integration-equinix-metal-cron
 concurrency:
@@ -72,7 +72,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64
+          PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |
           make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64

--- a/.github/workflows/integration-extensions-cron.yaml
+++ b/.github/workflows/integration-extensions-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
 
 name: integration-extensions-cron
 concurrency:
@@ -62,6 +62,10 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: generate
+        if: github.event_name == 'schedule'
+        run: |
+          make generate
       - name: build
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-images-cron.yaml
+++ b/.github/workflows/integration-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-26T11:34:32Z by kres b5844f8.
 
 name: integration-images-cron
 concurrency:
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 3 * * *
+    - cron: 30 2 * * *
 jobs:
   default:
     runs-on:

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
 
 name: integration-trusted-boot-cron
 concurrency:
@@ -80,6 +80,13 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
+      - name: images-essential
+        if: github.event_name == 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64
+        run: |
+          make images-essential
       - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -338,6 +338,12 @@ spec:
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
+        - name: images-essential
+          conditions:
+            - only-on-schedule
+          environment:
+            PLATFORM: linux/amd64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: secureboot-iso
           conditions:
             - only-on-schedule
@@ -745,6 +751,9 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: generate
+          conditions:
+            - only-on-schedule
         - name: build
           conditions:
             - only-on-schedule
@@ -985,7 +994,7 @@ spec:
         - self-hosted
         - generic # this is pretty fast, so we can use generic
       crons:
-        - '30 3 * * *'
+        - '30 2 * * *'
       triggerLabels:
         - integration/images
       steps:
@@ -1223,7 +1232,7 @@ spec:
           conditions:
             - only-on-schedule
           environment:
-            PLATFORM: linux/amd64,linux/arm64
+            PLATFORM: linux/amd64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
@@ -1271,6 +1280,9 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: generate
+          conditions:
+            - only-on-schedule
         - name: uki-certs
           conditions:
             - only-on-schedule
@@ -1361,6 +1373,9 @@ spec:
           artifactStep:
             type: download
             artifactPath: _out
+        - name: generate
+          conditions:
+            - only-on-schedule
         - name: uki-certs
           conditions:
             - only-on-schedule
@@ -1531,7 +1546,7 @@ spec:
             - only-on-schedule
           command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
           environment:
-            PLATFORM: linux/amd64
+            PLATFORM: linux/amd64,linux/arm64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
         - name: talosctl-cni-bundle


### PR DESCRIPTION
Crons needing extensions need the `generate` step as a dependency for the `talos-metadata` file.

TrustedBoot needs the `secureboot-installer`.
Equinix needs arm64 since we boot an arm64 box as part of integration.