### PR TITLE
chore(ci): fix integration extensions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T14:28:32Z by kres b5844f8.
+# Generated on 2024-05-27T09:21:08Z by kres b5844f8.
 
 name: default
 concurrency:
@@ -1265,6 +1265,9 @@ jobs:
           path: _out/extensions
           ref: main
           repository: siderolabs/extensions
+      - name: unshallow-extensions
+        run: |
+          git -C _out/extensions fetch --prune --unshallow
       - name: set variables
         run: |
           cat _out/talos-metadata >> "$GITHUB_ENV"

--- a/.github/workflows/integration-extensions-cron.yaml
+++ b/.github/workflows/integration-extensions-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
+# Generated on 2024-05-27T09:21:08Z by kres b5844f8.
 
 name: integration-extensions-cron
 concurrency:
@@ -84,6 +84,9 @@ jobs:
           path: _out/extensions
           ref: main
           repository: siderolabs/extensions
+      - name: unshallow-extensions
+        run: |
+          git -C _out/extensions fetch --prune --unshallow
       - name: set variables
         run: |
           cat _out/talos-metadata >> "$GITHUB_ENV"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -770,6 +770,9 @@ spec:
             repository: siderolabs/extensions
             ref: main
             path: _out/extensions
+        - name: unshallow-extensions
+          nonMakeStep: true
+          command: git -C _out/extensions fetch --prune --unshallow
         - name: set variables
           nonMakeStep: true
           command: cat _out/talos-metadata >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ provision-tests-track-%:
 
 installer-with-extensions: $(ARTIFACTS)/extensions/_out/extensions-metadata
 	$(MAKE) image-installer \
-		IMAGER_ARGS="--base-installer-image=$(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG) $(shell cat $(ARTIFACTS)/extensions/_out/extensions-metadata | grep -vE 'tailscale|xen-guest-agent|nvidia' | xargs -n 1 echo --system-extension-image)"
+		IMAGER_ARGS="--base-installer-image=$(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG) $(shell cat $(ARTIFACTS)/extensions/_out/extensions-metadata | grep -vE 'tailscale|xen-guest-agent|nvidia|vmtoolsd-guest-agent' | xargs -n 1 echo --system-extension-image)"
 	crane push $(ARTIFACTS)/installer-amd64.tar $(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG)-amd64-extensions
 	echo -n "$(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG)-amd64-extensions" | jq -Rs -f hack/test/extensions/extension-patch-filter.jq | yq eval ".[] | split_doc" -P > $(ARTIFACTS)/extensions-patch.yaml
 


### PR DESCRIPTION
Now that extensions run the `extensions-validator` we need to fetch proper tags.