### PR TITLE
chore(ci): drop crashdump, save logs as artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T09:21:08Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: default
 concurrency:
@@ -125,7 +125,7 @@ jobs:
       - name: save artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: |-
             _out
             !_out/coverage.txt
@@ -192,7 +192,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         run: |
@@ -203,6 +203,15 @@ jobs:
           SHORT_INTEGRATION_TEST: "yes"
         run: |
           make e2e-docker
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-e2e-docker-short
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   e2e-iso:
     permissions:
       actions: read
@@ -250,7 +259,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         run: |
@@ -260,6 +269,15 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make e2e-iso
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-e2e-iso
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   e2e-qemu-short:
     permissions:
       actions: read
@@ -307,7 +325,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         run: |
@@ -318,6 +336,15 @@ jobs:
           SHORT_INTEGRATION_TEST: "yes"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-e2e-qemu-short
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-aws:
     permissions:
       actions: read
@@ -379,7 +406,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -505,7 +532,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -655,7 +682,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -805,7 +832,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -932,7 +959,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -986,6 +1013,15 @@ jobs:
           WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-cilium
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-cloud-images:
     permissions:
       actions: read
@@ -1047,7 +1083,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1131,7 +1167,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1237,7 +1273,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1293,6 +1329,15 @@ jobs:
           WITH_CONFIG_PATCH_WORKER: '@_out/extensions-patch.yaml'
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-extensions
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-image-factory:
     permissions:
       actions: read
@@ -1348,7 +1393,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1456,6 +1501,15 @@ jobs:
           KUBERNETES_VERSION: 1.26.5
         run: |
           sudo -E make e2e-image-factory
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-image-factory
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-images:
     permissions:
       actions: read
@@ -1511,7 +1565,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1590,7 +1644,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1629,6 +1683,15 @@ jobs:
           WITH_CONTROL_PLANE_PORT: "443"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-0
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-misc-1:
     permissions:
       actions: read
@@ -1684,7 +1747,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1741,6 +1804,15 @@ jobs:
           WITH_SIDEROLINK_AGENT: tunnel
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-1
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-misc-2:
     permissions:
       actions: read
@@ -1796,7 +1868,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1844,6 +1916,15 @@ jobs:
           WITH_DISK_ENCRYPTION: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-2
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-misc-3:
     permissions:
       actions: read
@@ -1899,7 +1980,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -1924,6 +2005,15 @@ jobs:
           WITH_NETWORK_CHAOS: "yes"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-3
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-misc-4:
     permissions:
       actions: read
@@ -1979,7 +2069,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2013,6 +2103,15 @@ jobs:
           WITH_SIDEROLINK_AGENT: tunnel
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-4
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-provision-0:
     permissions:
       actions: read
@@ -2068,7 +2167,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2094,6 +2193,15 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-0
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-0
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-provision-1:
     permissions:
       actions: read
@@ -2149,7 +2257,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2175,6 +2283,15 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-1
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-1
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-provision-2:
     permissions:
       actions: read
@@ -2230,7 +2347,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2256,6 +2373,15 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-2
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-2
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-qemu:
     permissions:
       actions: read
@@ -2311,7 +2437,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2334,6 +2460,15 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-qemu-csi:
     permissions:
       actions: read
@@ -2389,7 +2524,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2419,6 +2554,15 @@ jobs:
           WITH_TEST: run_csi_tests
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-csi
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-qemu-encrypted-vip:
     permissions:
       actions: read
@@ -2474,7 +2618,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2500,6 +2644,15 @@ jobs:
           WITH_VIRTUAL_IP: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-encrypted-vip
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-qemu-race:
     permissions:
       actions: read
@@ -2555,7 +2708,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2588,6 +2741,15 @@ jobs:
           TAG_SUFFIX: -race
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-race
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   integration-reproducibility-test:
     permissions:
       actions: read
@@ -2643,7 +2805,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2709,7 +2871,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -2755,6 +2917,15 @@ jobs:
           WITH_TRUSTED_BOOT_ISO: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-trusted-boot
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
   push:
     permissions:
       actions: read

--- a/.github/workflows/integration-aws-cron.yaml
+++ b/.github/workflows/integration-aws-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T14:28:32Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-aws-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-aws-nvidia-nonfree-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-aws-nvidia-oss-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-aws-nvidia-oss-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-azure-cron.yaml
+++ b/.github/workflows/integration-azure-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-azure-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-cilium-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -110,3 +110,12 @@ jobs:
           WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-cilium
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-cloud-images-cron.yaml
+++ b/.github/workflows/integration-cloud-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-cloud-images-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-equinix-metal-cron.yaml
+++ b/.github/workflows/integration-equinix-metal-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-equinix-metal-cron
 concurrency:
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-extensions-cron.yaml
+++ b/.github/workflows/integration-extensions-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T09:21:08Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-extensions-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -112,3 +112,12 @@ jobs:
           WITH_CONFIG_PATCH_WORKER: '@_out/extensions-patch.yaml'
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-extensions
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-image-factory-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -164,3 +164,12 @@ jobs:
           KUBERNETES_VERSION: 1.26.5
         run: |
           sudo -E make e2e-image-factory
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-image-factory
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-images-cron.yaml
+++ b/.github/workflows/integration-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-26T11:34:32Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-images-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-misc-0-cron.yaml
+++ b/.github/workflows/integration-misc-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T15:02:03Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-misc-0-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -95,3 +95,12 @@ jobs:
           WITH_CONTROL_PLANE_PORT: "443"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-0
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-misc-1-cron.yaml
+++ b/.github/workflows/integration-misc-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T13:05:32Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-misc-1-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -113,3 +113,12 @@ jobs:
           WITH_SIDEROLINK_AGENT: tunnel
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-1
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T13:05:32Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-misc-2-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -104,3 +104,12 @@ jobs:
           WITH_DISK_ENCRYPTION: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-2
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-misc-3-cron.yaml
+++ b/.github/workflows/integration-misc-3-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T15:02:03Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-misc-3-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -81,3 +81,12 @@ jobs:
           WITH_NETWORK_CHAOS: "yes"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-3
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-misc-4-cron.yaml
+++ b/.github/workflows/integration-misc-4-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T15:02:03Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-misc-4-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -90,3 +90,12 @@ jobs:
           WITH_SIDEROLINK_AGENT: tunnel
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-misc-4
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-provision-0-cron.yaml
+++ b/.github/workflows/integration-provision-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-provision-0-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -82,3 +82,12 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-0
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-0
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-provision-1-cron.yaml
+++ b/.github/workflows/integration-provision-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-provision-1-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -82,3 +82,12 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-1
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-1
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-provision-2-cron.yaml
+++ b/.github/workflows/integration-provision-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-provision-2-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -82,3 +82,12 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make provision-tests-track-2
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-provision-2
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-qemu-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -79,3 +79,12 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-qemu-csi-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-qemu-csi-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -86,3 +86,12 @@ jobs:
           WITH_TEST: run_csi_tests
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-csi
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
+++ b/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-qemu-encrypted-vip-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -82,3 +82,12 @@ jobs:
           WITH_VIRTUAL_IP: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-encrypted-vip
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-qemu-race-cron.yaml
+++ b/.github/workflows/integration-qemu-race-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-qemu-race-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -89,3 +89,12 @@ jobs:
           TAG_SUFFIX: -race
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-race
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.github/workflows/integration-reproducibility-test-cron.yaml
+++ b/.github/workflows/integration-reproducibility-test-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-24T09:48:06Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-reproducibility-test-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-25T11:30:52Z by kres b5844f8.
+# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
 
 name: integration-trusted-boot-cron
 concurrency:
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: talos-artifacts
           path: _out
       - name: Fix artifact permissions
         if: github.event_name != 'schedule'
@@ -102,3 +102,12 @@ jobs:
           WITH_TRUSTED_BOOT_ISO: "true"
         run: |
           sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-trusted-boot
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -122,6 +122,7 @@ spec:
         - name: save-artifacts
           artifactStep:
             type: upload
+            artifactName: talos-artifacts
             artifactPath: _out
             additionalArtifacts:
               - "!_out/coverage.txt"
@@ -232,11 +233,22 @@ spec:
         - name: download-artifacts
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: e2e-iso
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-e2e-iso
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: e2e-qemu-short
       depends:
         - default
@@ -247,12 +259,23 @@ spec:
         - name: download-artifacts
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: e2e-qemu
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             SHORT_INTEGRATION_TEST: yes
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-e2e-qemu-short
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: e2e-docker-short
       depends:
         - default
@@ -263,12 +286,23 @@ spec:
         - name: download-artifacts
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: e2e-docker
           withSudo: false
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             SHORT_INTEGRATION_TEST: yes
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-e2e-docker-short
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu
       buildxOptions:
         enabled: true
@@ -287,6 +321,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -303,6 +338,16 @@ spec:
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-qemu
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-trusted-boot
       buildxOptions:
         enabled: true
@@ -321,6 +366,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: uki-certs
           conditions:
@@ -358,6 +404,16 @@ spec:
             WITH_TRUSTED_BOOT_ISO: true
             EXTRA_TEST_ARGS: -talos.trustedboot
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-trusted-boot
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-0
       buildxOptions:
         enabled: true
@@ -377,6 +433,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -394,6 +451,16 @@ spec:
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-provision-0
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-1
       buildxOptions:
         enabled: true
@@ -413,6 +480,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -430,6 +498,16 @@ spec:
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-provision-1
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-2
       buildxOptions:
         enabled: true
@@ -449,6 +527,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -466,6 +545,16 @@ spec:
           withSudo: true
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-provision-2
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-0
       buildxOptions:
         enabled: true
@@ -485,6 +574,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -518,6 +608,16 @@ spec:
             SHORT_INTEGRATION_TEST: yes
             WITH_CONTROL_PLANE_PORT: 443
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-misc-0
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-1
       buildxOptions:
         enabled: true
@@ -537,6 +637,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -588,6 +689,16 @@ spec:
             WITH_SIDEROLINK_AGENT: tunnel
             VIA_MAINTENANCE_MODE: true
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-misc-1
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-2
       buildxOptions:
         enabled: true
@@ -607,6 +718,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: uki-certs
           conditions:
@@ -647,6 +759,16 @@ spec:
             VIA_MAINTENANCE_MODE: true
             WITH_DISK_ENCRYPTION: true
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-misc-2
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-3
       buildxOptions:
         enabled: true
@@ -666,6 +788,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -685,6 +808,16 @@ spec:
             SHORT_INTEGRATION_TEST: yes
             WITH_NETWORK_CHAOS: yes
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-misc-3
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-4
       buildxOptions:
         enabled: true
@@ -704,6 +837,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -732,6 +866,16 @@ spec:
             WITH_SIDEROLINK_AGENT: tunnel
             VIA_MAINTENANCE_MODE: true
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-misc-4
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-extensions
       buildxOptions:
         enabled: true
@@ -750,6 +894,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: generate
           conditions:
@@ -799,6 +944,16 @@ spec:
             SHORT_INTEGRATION_TEST: yes
             EXTRA_TEST_ARGS: -talos.extensions.qemu
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-extensions
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-cilium
       buildxOptions:
         enabled: true
@@ -817,6 +972,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -865,6 +1021,16 @@ spec:
             CILIUM_INSTALL_TYPE: strict
             WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-cilium
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-encrypted-vip
       buildxOptions:
         enabled: true
@@ -883,6 +1049,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -902,6 +1069,16 @@ spec:
             WITH_VIRTUAL_IP: true
             WITH_KUBESPAN: true
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-qemu-encrypted-vip
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-race
       buildxOptions:
         enabled: true
@@ -920,6 +1097,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -946,6 +1124,16 @@ spec:
           environment:
             TAG_SUFFIX: -race
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-qemu-race
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-csi
       buildxOptions:
         enabled: true
@@ -964,6 +1152,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -988,6 +1177,16 @@ spec:
             QEMU_EXTRA_DISKS_SIZE: 12288
             WITH_TEST: run_csi_tests
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-qemu-csi
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-images
       buildxOptions:
         enabled: true
@@ -1006,6 +1205,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -1040,6 +1240,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: reproducibility-test
           environment:
@@ -1063,6 +1264,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:
@@ -1095,6 +1297,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: uki-certs
           conditions:
@@ -1195,6 +1398,16 @@ spec:
             FACTORY_VERSION: v1.3.7
             FACTORY_SCHEMATIC: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
             KUBERNETES_VERSION: 1.26.5
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-image-factory
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-aws
       buildxOptions:
         enabled: true
@@ -1214,6 +1427,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: uki-certs
           conditions:
@@ -1282,6 +1496,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: generate
           conditions:
@@ -1375,6 +1590,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: generate
           conditions:
@@ -1468,6 +1684,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: uki-certs
           conditions:
@@ -1543,6 +1760,7 @@ spec:
             - not-on-schedule
           artifactStep:
             type: download
+            artifactName: talos-artifacts
             artifactPath: _out
         - name: build
           conditions:

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -21,8 +21,7 @@ function create_cluster {
     --memory=2048 \
     --cpus=2.0 \
     --with-init-node=false \
-    "${REGISTRY_MIRROR_FLAGS[@]}" \
-    --crashdump
+    "${REGISTRY_MIRROR_FLAGS[@]}"
 
   "${TALOSCTL}" config node 10.5.0.2
 }

--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -59,7 +59,6 @@ function create_cluster {
     --with-apply-config \
     --talos-version="${FACTORY_VERSION}" \
     --install-image="${FACTORY_HOSTNAME}/${INSTALLER_IMAGE_NAME}/${FACTORY_SCHEMATIC}:${FACTORY_VERSION}" \
-    --crashdump \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     "${QEMU_FLAGS[@]}"
 

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -26,7 +26,6 @@ function create_cluster {
     --with-apply-config \
     --install-image=${REGISTRY:-ghcr.io}/siderolabs/installer:${TAG} \
     --cni-bundle-url=${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
-    --crashdump \
     "${REGISTRY_MIRROR_FLAGS[@]}"
 
   "${TALOSCTL}" config node "${NODE}"

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -184,7 +184,6 @@ function create_cluster {
     --install-image="${INSTALLER_IMAGE}" \
     --with-init-node=false \
     --cni-bundle-url="${ARTIFACTS}/talosctl-cni-bundle-\${ARCH}.tar.gz" \
-    --crashdump \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     "${QEMU_FLAGS[@]}"
 


### PR DESCRIPTION
Drop `--crashdump` and save talos cluster logs as artifacts.