### PR TITLE
386 build

### DIFF
--- a/internal/pkg/ntp/timeval_32.go
+++ b/internal/pkg/ntp/timeval_32.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build 386
+
+package ntp
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func Timeval(offset time.Duration) unix.Timeval {
+	t := unix.Timeval{
+		Sec:  int32(offset / time.Second),
+		Usec: int32(offset / time.Nanosecond % time.Second),
+	}
+
+	// kernel wants tv_usec to be positive
+	if t.Usec < 0 {
+		t.Sec--
+		t.Usec += int32(time.Second / time.Nanosecond)
+	}
+
+	return t
+}
+
+func SetOffset(t *unix.Timex, offset time.Duration) {
+	t.Offset = int32(offset / time.Nanosecond)
+}
+
+func SetConstant(t *unix.Timex, constant int) { t.Constant = int32(constant) }

--- a/internal/pkg/ntp/timeval_32.go
+++ b/internal/pkg/ntp/timeval_32.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Timeval(offset time.Duration) unix.Timeval {
+func toTimeval(offset time.Duration) unix.Timeval {
 	t := unix.Timeval{
 		Sec:  int32(offset / time.Second),
 		Usec: int32(offset / time.Nanosecond % time.Second),
@@ -27,8 +27,12 @@ func Timeval(offset time.Duration) unix.Timeval {
 	return t
 }
 
-func SetOffset(t *unix.Timex, offset time.Duration) {
+func toUnix(ts unix.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func setOffset(t *unix.Timex, offset time.Duration) {
 	t.Offset = int32(offset / time.Nanosecond)
 }
 
-func SetConstant(t *unix.Timex, constant int) { t.Constant = int32(constant) }
+func setConstant(t *unix.Timex, constant int) { t.Constant = int32(constant) }

--- a/internal/pkg/ntp/timeval_64.go
+++ b/internal/pkg/ntp/timeval_64.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !386
+
+package ntp
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func Timeval(offset time.Duration) unix.Timeval {
+	t := unix.Timeval{
+		Sec:  int64(offset / time.Second),
+		Usec: int64(offset / time.Nanosecond % time.Second),
+	}
+
+	// kernel wants tv_usec to be positive
+	if t.Usec < 0 {
+		t.Sec--
+		t.Usec += int64(time.Second / time.Nanosecond)
+	}
+
+	return t
+}
+
+func SetOffset(t *unix.Timex, offset time.Duration) {
+	t.Offset = int64(offset / time.Nanosecond)
+}
+
+func SetConstant(t *unix.Timex, constant int) { t.Constant = int64(constant) }

--- a/internal/pkg/ntp/timeval_64.go
+++ b/internal/pkg/ntp/timeval_64.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Timeval(offset time.Duration) unix.Timeval {
+func toTimeval(offset time.Duration) unix.Timeval {
 	t := unix.Timeval{
 		Sec:  int64(offset / time.Second),
 		Usec: int64(offset / time.Nanosecond % time.Second),
@@ -27,8 +27,8 @@ func Timeval(offset time.Duration) unix.Timeval {
 	return t
 }
 
-func SetOffset(t *unix.Timex, offset time.Duration) {
+func setOffset(t *unix.Timex, offset time.Duration) {
 	t.Offset = int64(offset / time.Nanosecond)
 }
 
-func SetConstant(t *unix.Timex, constant int) { t.Constant = int64(constant) }
+func setConstant(t *unix.Timex, constant int) { t.Constant = int64(constant) }


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Adds files with conditional compilation for handling unix.Time* values on GOARCH=386 systems.

## Why? (reasoning)

To support building `machined` for i686. (I realise that Talos doesn't support i386, but I have an experimental Nix flake that attempts to generate a container image for running worker nodes on i686 hardware, and decided to upstream some changes for building `machined` for 32-bit targets.)

Feel free to reject if this is not something you plan on supporting.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

`make fmt` modifies lots of unrelated proto files. `make conformance` complains about commit-case, but the first line should already conform, as far as I can tell.