### PR TITLE
fix: disable kexec on GCP/Azure

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -223,6 +223,9 @@ func (a *Azure) KernelArgs(string) procfs.Parameters {
 		procfs.NewParameter("rootdelay").Append("300"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 		procfs.NewParameter(constants.KernelParamDashboardDisabled).Append("1"),
+		// disable 'kexec' as Azure VMs sometimes are stuck on kexec, and normal soft reboot
+		// doesn't take much longer on VMs
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -204,6 +204,9 @@ func (g *GCP) KernelArgs(string) procfs.Parameters {
 		procfs.NewParameter("console").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 		procfs.NewParameter(constants.KernelParamDashboardDisabled).Append("1"),
+		// disable 'kexec' as GCP VMs sometimes are stuck on kexec, and normal soft reboot
+		// doesn't take much longer on VMs
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 


### PR DESCRIPTION
It looks like VMs might be stuck on kexec, while there's little value in kexec with VMs.
