### PR TITLE
chore: fix go.work resolution

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,7 +100,7 @@ linters-settings:
       - golang.zx2c4.com/wireguard
       - golang.zx2c4.com/wireguard/wgctrl
     retract-allow-no-explanation: false
-    exclude-forbidden: true
+    exclude-forbidden: false
 
 linters:
   enable-all: true

--- a/go.mod
+++ b/go.mod
@@ -367,3 +367,5 @@ require (
 	tags.cncf.io/container-device-interface v0.7.2 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.7.0 // indirect
 )
+
+exclude github.com/containerd/containerd v1.7.0


### PR DESCRIPTION
See https://github.com/golang/go/issues/60126

The issue is that `containerd/containerd` is an indirect dependency via a circular import from `containerd/containerd/v2` via `microsoft/hccsim`, but in fact it's not used/built into Talos.

So explicitly exclude it, so that `go.work` flows work once again.

@DmitriyMV found the issue and a workaround