### PR TITLE
fix: add upgrade errata for arm64/zboot kernels

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -228,7 +228,7 @@ func NewInstaller(ctx context.Context, cmdline *procfs.Cmdline, mode Mode, opts 
 //
 //nolint:gocyclo,cyclop
 func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
-	errataBTF()
+	errataArm64ZBoot()
 
 	if mode == ModeUpgrade {
 		if err = i.errataNetIfnames(); err != nil {


### PR DESCRIPTION
Fixes #8854

Talos 1.8.0 instroduces EFI ZBoot compression, and kexec from 1.7.0 to compressed kernel doesn't work.
