### PR TITLE
Fixed typo in parameter for installing QEMU guest agent support

### DIFF
--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
@@ -205,7 +205,7 @@ This will create several files in the `_out` directory: `controlplane.yaml`, `wo
 For QEMU guest agent support, you can generate the config with the custom install image:
 
 ```bash
-talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --installer-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
+talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
 ```
 
 - In Proxmox, go to your VM --> Options and ensure that `QEMU Guest Agent` is `Enabled`

--- a/website/content/v1.8/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.8/talos-guides/install/virtualized-platforms/proxmox.md
@@ -205,7 +205,7 @@ This will create several files in the `_out` directory: `controlplane.yaml`, `wo
 For QEMU guest agent support, you can generate the config with the custom install image:
 
 ```bash
-talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --installer-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
+talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:{{< release >}}
 ```
 
 - In Proxmox, go to your VM --> Options and ensure that `QEMU Guest Agent` is `Enabled`


### PR DESCRIPTION
This PR fixes an issue I encountered installing Talos on Proxmox. The docs indicate that the command to install QEMU guest agent support is: 

`talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --installer-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v1.7.0`

(using my generated image instead of the example) which caused an error when I ran that command. According to the help with the command (`talosctl gen config --help`), the parameters is `--install-image`, not `--installer-image`. This PR changes `--installer-image` to `--install-image` for both the v1.7 and v1.8 pages.
