### PR TITLE
chore: small usability fixes

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"log"
 	"os/signal"
-	"reflect"
 	"regexp"
+	"slices"
 	"syscall"
 	"time"
 
@@ -260,7 +260,7 @@ func verifyExtKeyUsage(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) 
 			continue
 		}
 
-		if !reflect.DeepEqual(cert.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}) {
+		if !slices.Equal(cert.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}) {
 			return fmt.Errorf("certificate %q is missing the client auth extended key usage", cert.Subject)
 		}
 	}

--- a/internal/app/machined/pkg/controllers/cluster/cluster_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/cluster_test.go
@@ -6,7 +6,6 @@ package cluster_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -17,8 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/siderolabs/talos/pkg/logging"
+	"go.uber.org/zap/zaptest"
 )
 
 type ClusterSuite struct {
@@ -40,9 +38,7 @@ func (suite *ClusterSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/cluster/discovery_service_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/discovery_service_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"io"
-	"log"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -22,11 +21,11 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	clusteradapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/cluster"
 	clusterctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/cluster"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/proto"
@@ -113,7 +112,7 @@ func (suite *DiscoveryServiceSuite) TestReconcile() {
 	defer cliCtxCancel()
 
 	go func() {
-		errCh <- cli.Run(cliCtx, logging.Wrap(log.Writer()), notifyCh)
+		errCh <- cli.Run(cliCtx, zaptest.NewLogger(suite.T()), notifyCh)
 	}()
 
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
@@ -328,7 +327,7 @@ func (suite *DiscoveryServiceSuite) TestDisable() {
 	defer cliCtxCancel()
 
 	go func() {
-		errCh <- cli.Run(cliCtx, logging.Wrap(log.Writer()), notifyCh)
+		errCh <- cli.Run(cliCtx, zaptest.NewLogger(suite.T()), notifyCh)
 	}()
 
 	// inject some affiliate via our client, controller should publish it as an affiliate

--- a/internal/app/machined/pkg/controllers/cluster/endpoint.go
+++ b/internal/app/machined/pkg/controllers/cluster/endpoint.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -82,7 +82,7 @@ func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, l
 			r,
 			k8s.NewEndpoint(k8s.ControlPlaneNamespaceName, k8s.ControlPlaneDiscoveredEndpointsID),
 			func(r *k8s.Endpoint) error {
-				if !reflect.DeepEqual(r.TypedSpec().Addresses, endpoints) {
+				if !slices.Equal(r.TypedSpec().Addresses, endpoints) {
 					logger.Debug("updated controlplane endpoints", zap.Any("endpoints", endpoints))
 				}
 

--- a/internal/app/machined/pkg/controllers/etcd/advertised_peer.go
+++ b/internal/app/machined/pkg/controllers/etcd/advertised_peer.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"reflect"
+	"slices"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -153,7 +153,7 @@ func (ctrl *AdvertisedPeerController) updateAdvertisedPeers(ctx context.Context,
 	})
 	currentPeerURLs := localMember.PeerURLs
 
-	if reflect.DeepEqual(newPeerURLs, currentPeerURLs) {
+	if slices.Equal(newPeerURLs, currentPeerURLs) {
 		return nil
 	}
 

--- a/internal/app/machined/pkg/controllers/files/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/files/etcfile_test.go
@@ -6,7 +6,6 @@ package files_test
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,9 +21,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	filesctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/files"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/files"
 )
 
@@ -50,7 +49,7 @@ func (suite *EtcFileSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.startRuntime()

--- a/internal/app/machined/pkg/controllers/hardware/hardware_test.go
+++ b/internal/app/machined/pkg/controllers/hardware/hardware_test.go
@@ -6,7 +6,6 @@ package hardware_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -17,8 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/siderolabs/talos/pkg/logging"
+	"go.uber.org/zap/zaptest"
 )
 
 type HardwareSuite struct {
@@ -40,9 +38,7 @@ func (suite *HardwareSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/k8s/address_filter_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/address_filter_test.go
@@ -8,7 +8,6 @@ package k8s_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"sync"
 	"testing"
@@ -21,9 +20,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -51,7 +50,7 @@ func (suite *K8sAddressFilterSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.AddressFilterController{}))

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -7,8 +7,7 @@ package k8s_test
 import (
 	"context"
 	"fmt"
-	"log"
-	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,13 +22,13 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	v1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 
 	k8sadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/k8s"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
@@ -54,7 +53,7 @@ func (suite *ControlPlaneStaticPodSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.ControlPlaneStaticPodController{}))
@@ -93,7 +92,7 @@ func (suite *ControlPlaneStaticPodSuite) assertControlPlaneStaticPods(manifests 
 
 	ids := xslices.Map(resources.Items, func(r resource.Resource) string { return r.Metadata().ID() })
 
-	if !reflect.DeepEqual(manifests, ids) {
+	if !slices.Equal(manifests, ids) {
 		return retry.ExpectedErrorf("expected %q, got %q", manifests, ids)
 	}
 

--- a/internal/app/machined/pkg/controllers/k8s/endpoint.go
+++ b/internal/app/machined/pkg/controllers/k8s/endpoint.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"reflect"
 	"slices"
 	"time"
 
@@ -213,7 +212,7 @@ func (ctrl *EndpointController) updateEndpointsResource(ctx context.Context, r c
 		r,
 		k8s.NewEndpoint(k8s.ControlPlaneNamespaceName, k8s.ControlPlaneAPIServerEndpointsID),
 		func(r *k8s.Endpoint) error {
-			if !reflect.DeepEqual(r.TypedSpec().Addresses, addrs) {
+			if !slices.Equal(r.TypedSpec().Addresses, addrs) {
 				logger.Debug("updated controlplane endpoints", zap.Any("endpoints", addrs))
 			}
 

--- a/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
@@ -7,8 +7,7 @@ package k8s_test
 
 import (
 	"context"
-	"log"
-	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -22,10 +21,10 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	k8sadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/k8s"
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -49,7 +48,7 @@ func (suite *ExtraManifestSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.ExtraManifestController{}))
@@ -79,7 +78,7 @@ func (suite *ExtraManifestSuite) assertExtraManifests(manifests []string) error 
 
 	ids := xslices.Map(resources.Items, func(r resource.Resource) string { return r.Metadata().ID() })
 
-	if !reflect.DeepEqual(manifests, ids) {
+	if !slices.Equal(manifests, ids) {
 		return retry.ExpectedErrorf("expected %q, got %q", manifests, ids)
 	}
 

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
@@ -7,7 +7,6 @@ package k8s_test
 
 import (
 	"context"
-	"log"
 	"net/url"
 	"sync"
 	"testing"
@@ -22,9 +21,9 @@ import (
 	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -51,7 +50,7 @@ func (suite *KubeletConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(k8sctrl.NewKubeletConfigController()))

--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
@@ -7,7 +7,6 @@ package k8s_test
 
 import (
 	"context"
-	"log"
 	"net/url"
 	"sync"
 	"testing"
@@ -20,9 +19,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -49,7 +48,7 @@ func (suite *NodeIPConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(k8sctrl.NewNodeIPConfigController()))

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_config_test.go
@@ -7,7 +7,6 @@ package k8s_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -19,10 +18,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -48,7 +47,7 @@ func (suite *StaticPodConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.StaticPodConfigController{}))

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_server_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_server_test.go
@@ -8,7 +8,6 @@ package k8s_test
 import (
 	"context"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -22,9 +21,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 )
 
@@ -47,7 +46,7 @@ func (suite *StaticPodListSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.StaticPodServerController{}))

--- a/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
+++ b/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 	"sort"
 	"sync"
@@ -542,7 +541,7 @@ func (t *CRDController) needsUpdate(secret *corev1.Secret, desiredRoles []string
 		return true
 	}
 
-	if !reflect.DeepEqual(t.talosCA.Crt, talosconfigCA) {
+	if !bytes.Equal(t.talosCA.Crt, talosconfigCA) {
 		t.logger.Debug("ca mismatch detected")
 
 		return true
@@ -608,7 +607,7 @@ func (t *CRDController) needsUpdate(secret *corev1.Secret, desiredRoles []string
 	sort.Strings(actualRoles)
 	sort.Strings(desiredRoles)
 
-	if !reflect.DeepEqual(actualRoles, desiredRoles) {
+	if !slices.Equal(actualRoles, desiredRoles) {
 		t.logger.Debug("roles in certificate do not match desired roles",
 			zap.Strings("actual", actualRoles), zap.Strings("desired", desiredRoles))
 

--- a/internal/app/machined/pkg/controllers/kubespan/kubespan_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/kubespan_test.go
@@ -6,8 +6,7 @@ package kubespan_test
 
 import (
 	"context"
-	"log"
-	"reflect"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -20,8 +19,7 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/siderolabs/talos/pkg/logging"
+	"go.uber.org/zap/zaptest"
 )
 
 type KubeSpanSuite struct {
@@ -43,9 +41,7 @@ func (suite *KubeSpanSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 
@@ -70,7 +66,7 @@ func (suite *KubeSpanSuite) assertResourceIDs(md resource.Metadata, expectedIDs 
 
 		sort.Strings(expectedIDs)
 
-		if !reflect.DeepEqual(actualIDs, expectedIDs) {
+		if !slices.Equal(actualIDs, expectedIDs) {
 			return retry.ExpectedErrorf("ids do no match expected %v != actual %v", expectedIDs, actualIDs)
 		}
 

--- a/internal/app/machined/pkg/controllers/network/address_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_config_test.go
@@ -7,7 +7,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"sort"
@@ -24,9 +23,9 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -53,7 +52,7 @@ func (suite *AddressConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))

--- a/internal/app/machined/pkg/controllers/network/address_event_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_event_test.go
@@ -7,7 +7,6 @@ package network_test
 import (
 	"context"
 	"errors"
-	"log"
 	"net/netip"
 	"sync"
 	"testing"
@@ -19,9 +18,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/proto"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -64,7 +63,7 @@ func (suite *AddressEventsSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(

--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"sync"
 	"testing"
@@ -23,10 +22,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -50,7 +49,7 @@ func (suite *AddressMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/address_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec_test.go
@@ -8,7 +8,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"net"
 	"net/netip"
@@ -25,10 +24,10 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sys/unix"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -52,7 +51,7 @@ func (suite *AddressSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressSpecController{}))

--- a/internal/app/machined/pkg/controllers/network/address_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_status_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -18,9 +17,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -43,7 +42,7 @@ func (suite *AddressStatusSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressStatusController{}))

--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -7,7 +7,6 @@ package network_test
 import (
 	"context"
 	"errors"
-	"log"
 	"net/netip"
 	"net/url"
 	"os"
@@ -25,10 +24,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -63,7 +62,7 @@ func (suite *EtcFileConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.startRuntime()

--- a/internal/app/machined/pkg/controllers/network/hardware_addr_test.go
+++ b/internal/app/machined/pkg/controllers/network/hardware_addr_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net"
 	"sync"
 	"testing"
@@ -21,9 +20,9 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -47,7 +46,7 @@ func (suite *HardwareAddrSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.HardwareAddrController{}))

--- a/internal/app/machined/pkg/controllers/network/hostname_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"net/url"
 	"strings"
@@ -25,10 +24,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
@@ -59,7 +58,7 @@ func (suite *HostnameConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/network/hostname_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -19,9 +18,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -44,7 +43,7 @@ func (suite *HostnameMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.HostnameMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/hostname_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_spec_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -18,10 +17,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -44,7 +43,7 @@ func (suite *HostnameSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"net/url"
 	"sync"
@@ -25,9 +24,9 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -54,7 +53,7 @@ func (suite *LinkConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))

--- a/internal/app/machined/pkg/controllers/network/link_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -20,10 +19,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -47,7 +46,7 @@ func (suite *LinkMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.LinkMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -8,7 +8,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"net/netip"
 	"os"
@@ -25,12 +24,12 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -59,7 +58,7 @@ func (suite *LinkSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	// create fake device ready status

--- a/internal/app/machined/pkg/controllers/network/link_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_status_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"net"
 	"os"
@@ -27,10 +26,10 @@ import (
 	"github.com/mdlayher/netlink"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sys/unix"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -55,7 +54,7 @@ func (suite *LinkStatusSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	// create fake device ready status

--- a/internal/app/machined/pkg/controllers/network/operator/vip/equinix_metal_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator/vip/equinix_metal_test.go
@@ -6,14 +6,13 @@ package vip_test
 
 import (
 	"context"
-	"log"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/operator/vip"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -43,7 +42,7 @@ func TestEquinixMetalHandler(t *testing.T) {
 		}
 	}
 
-	logger := logging.Wrap(log.Writer())
+	logger := zaptest.NewLogger(t)
 
 	handler1 := vip.NewEquinixMetalHandler(logger, settings["TALOS_EM_VIP"], network.VIPEquinixMetalSpec{
 		ProjectID: settings["TALOS_EM_PROJECT_ID"],

--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/url"
 	"sync"
 	"testing"
@@ -24,9 +23,9 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -53,7 +52,7 @@ func (suite *OperatorConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))

--- a/internal/app/machined/pkg/controllers/network/operator_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -19,10 +18,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -45,7 +44,7 @@ func (suite *OperatorMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.OperatorMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/operator_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec_test.go
@@ -7,7 +7,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/netip"
 	"sync"
 	"testing"
@@ -21,11 +20,11 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/operator"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -155,7 +154,7 @@ func (suite *OperatorSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	runningOperators = map[string]*mockOperator{}

--- a/internal/app/machined/pkg/controllers/network/operator_vip_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_vip_config_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"net/url"
 	"sync"
@@ -21,9 +20,9 @@ import (
 	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -49,7 +48,7 @@ func (suite *OperatorVIPConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -8,7 +8,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -24,10 +23,10 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -56,7 +55,7 @@ func (suite *PlatformConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.statePath = suite.T().TempDir()

--- a/internal/app/machined/pkg/controllers/network/resolver_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"net/url"
 	"sync"
@@ -23,10 +22,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -57,7 +56,7 @@ func (suite *ResolverConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/network/resolver_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"sync"
 	"testing"
@@ -20,9 +19,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -46,7 +45,7 @@ func (suite *ResolverMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.ResolverMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/resolver_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_spec_test.go
@@ -7,9 +7,8 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
-	"reflect"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -21,9 +20,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -47,7 +46,7 @@ func (suite *ResolverSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.ResolverSpecController{}))
@@ -80,7 +79,7 @@ func (suite *ResolverSpecSuite) assertStatus(id string, servers ...netip.Addr) e
 
 	status := r.(*network.ResolverStatus) //nolint:errcheck,forcetypeassert
 
-	if !reflect.DeepEqual(status.TypedSpec().DNSServers, servers) {
+	if !slices.Equal(status.TypedSpec().DNSServers, servers) {
 		return retry.ExpectedErrorf("server list mismatch: %q != %q", status.TypedSpec().DNSServers, servers)
 	}
 

--- a/internal/app/machined/pkg/controllers/network/route_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_config_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"net/url"
 	"sync"
@@ -22,9 +21,9 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -51,7 +50,7 @@ func (suite *RouteConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))

--- a/internal/app/machined/pkg/controllers/network/route_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/netip"
 	"sync"
 	"testing"
@@ -20,10 +19,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -47,7 +46,7 @@ func (suite *RouteMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.RouteMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -7,7 +7,6 @@ package network_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"net"
 	"net/netip"
@@ -24,11 +23,11 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -56,7 +55,7 @@ func (suite *RouteSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.RouteSpecController{}))

--- a/internal/app/machined/pkg/controllers/network/route_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_status_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -18,9 +17,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -44,7 +43,7 @@ func (suite *RouteStatusSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.RouteStatusController{}))

--- a/internal/app/machined/pkg/controllers/network/timeserver_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_config_test.go
@@ -6,7 +6,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"net/url"
 	"sync"
 	"testing"
@@ -22,10 +21,10 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -56,7 +55,7 @@ func (suite *TimeServerConfigSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/network/timeserver_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_merge_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -19,9 +18,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -45,7 +44,7 @@ func (suite *TimeServerMergeSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.TimeServerMergeController{}))

--- a/internal/app/machined/pkg/controllers/network/timeserver_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_spec_test.go
@@ -7,8 +7,7 @@ package network_test
 
 import (
 	"context"
-	"log"
-	"reflect"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -20,9 +19,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -46,7 +45,7 @@ func (suite *TimeServerSpecSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.TimeServerSpecController{}))
@@ -79,7 +78,7 @@ func (suite *TimeServerSpecSuite) assertStatus(id string, servers ...string) err
 
 	status := r.(*network.TimeServerStatus) //nolint:errcheck,forcetypeassert
 
-	if !reflect.DeepEqual(status.TypedSpec().NTPServers, servers) {
+	if !slices.Equal(status.TypedSpec().NTPServers, servers) {
 		return retry.ExpectedErrorf("server list mismatch: %q != %q", status.TypedSpec().NTPServers, servers)
 	}
 

--- a/internal/app/machined/pkg/controllers/perf/perf_test.go
+++ b/internal/app/machined/pkg/controllers/perf/perf_test.go
@@ -6,7 +6,6 @@ package perf_test
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -18,9 +17,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/perf"
-	"github.com/siderolabs/talos/pkg/logging"
 	perfresource "github.com/siderolabs/talos/pkg/machinery/resources/perf"
 )
 
@@ -44,9 +43,7 @@ func (suite *PerfSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/runtime/common_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/common_test.go
@@ -7,7 +7,6 @@ package runtime_test
 import (
 	"context"
 	"errors"
-	"log"
 	"sync"
 	"time"
 
@@ -18,8 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/siderolabs/talos/pkg/logging"
+	"go.uber.org/zap/zaptest"
 )
 
 const (
@@ -47,9 +45,7 @@ func (suite *RuntimeSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 

--- a/internal/app/machined/pkg/controllers/runtime/cri_image_gc_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/cri_image_gc_test.go
@@ -6,7 +6,6 @@ package runtime_test
 
 import (
 	"context"
-	"reflect"
 	"slices"
 	"sort"
 	"sync"
@@ -179,7 +178,7 @@ func (suite *CRIImageGCSuite) TestReconcile() {
 		imageList, _ := suite.mockImageService.List(suite.Ctx()) //nolint:errcheck
 		actualImages := xslices.Map(imageList, func(i images.Image) string { return i.Name })
 
-		if reflect.DeepEqual(expectedImages, actualImages) {
+		if slices.Equal(expectedImages, actualImages) {
 			return nil
 		}
 

--- a/internal/app/machined/pkg/controllers/runtime/extension_service_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/extension_service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"sync"
 	"testing"
@@ -147,7 +148,7 @@ func (suite *ExtensionServiceSuite) TestReconcile() {
 		func() error {
 			ids := svcMock.getIDs()
 
-			if !reflect.DeepEqual(ids, []string{"ext-frr", "ext-hello-world"}) {
+			if !slices.Equal(ids, []string{"ext-frr", "ext-hello-world"}) {
 				return retry.ExpectedErrorf("services registered: %q", ids)
 			}
 

--- a/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
+++ b/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -264,7 +264,7 @@ func (ctrl *MaintenanceServiceController) Run(ctx context.Context, r controller.
 		// print additional information for the user on important state changes
 		reachableAddresses := xslices.Map(cfg.TypedSpec().ReachableAddresses, netip.Addr.String)
 
-		if !reflect.DeepEqual(lastReachableAddresses, reachableAddresses) {
+		if !slices.Equal(lastReachableAddresses, reachableAddresses) {
 			logger.Info("this machine is reachable at:")
 
 			for _, addr := range reachableAddresses {

--- a/internal/app/machined/pkg/controllers/secrets/api_cert_sans_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_cert_sans_test.go
@@ -7,7 +7,7 @@ package secrets_test
 import (
 	"fmt"
 	"net/netip"
-	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -110,7 +110,7 @@ func (suite *APICertSANsSuite) TestReconcileControlPlane() {
 
 		expectedDNSNames := []string{"bar", "bar.some.org", "other.org"}
 
-		if !reflect.DeepEqual(expectedDNSNames, spec.DNSNames) {
+		if !slices.Equal(expectedDNSNames, spec.DNSNames) {
 			return retry.ExpectedErrorf("expected %v, got %v", expectedDNSNames, spec.DNSNames)
 		}
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_cert_sans_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
-	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -143,7 +143,7 @@ func (suite *KubernetesCertSANsSuite) TestReconcile() {
 			"some.other.url",
 		}
 
-		if !reflect.DeepEqual(spec.DNSNames, expectedDNSNames) {
+		if !slices.Equal(spec.DNSNames, expectedDNSNames) {
 			return retry.ExpectedErrorf("expected %v, got %v", expectedDNSNames, spec.DNSNames)
 		}
 

--- a/internal/app/machined/pkg/controllers/time/sync_test.go
+++ b/internal/app/machined/pkg/controllers/time/sync_test.go
@@ -6,8 +6,6 @@ package time_test
 
 import (
 	"context"
-	"log"
-	"reflect"
 	"slices"
 	"sync"
 	"testing"
@@ -22,11 +20,11 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	timectrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -62,9 +60,7 @@ func (suite *SyncSuite) SetupTest() {
 
 	var err error
 
-	logger := logging.Wrap(log.Writer())
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
 	suite.Require().NoError(err)
 }
 
@@ -339,7 +335,7 @@ func (suite *SyncSuite) TestReconcileSyncChangeConfig() {
 	suite.Assert().NoError(
 		retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			func() error {
-				if !reflect.DeepEqual(mockSyncer.getTimeServers(), []string{"127.0.0.1"}) {
+				if !slices.Equal(mockSyncer.getTimeServers(), []string{"127.0.0.1"}) {
 					return retry.ExpectedErrorf("time servers not updated yet")
 				}
 

--- a/internal/app/machined/pkg/runtime/mode_test.go
+++ b/internal/app/machined/pkg/runtime/mode_test.go
@@ -6,7 +6,6 @@
 package runtime_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -90,7 +89,7 @@ func TestParseMode(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(gotM, tt.wantM) {
+			if gotM != tt.wantM {
 				t.Errorf("ParseMode() = %v, want %v", gotM, tt.wantM)
 			}
 		})

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula_test.go
@@ -6,7 +6,6 @@ package opennebula_test
 
 import (
 	_ "embed"
-	"fmt"
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/state"
@@ -35,6 +34,6 @@ func TestParseMetadata(t *testing.T) {
 	marshaled, err := yaml.Marshal(networkConfig)
 	require.NoError(t, err)
 
-	fmt.Print(marshaled)
+	t.Log(string(marshaled))
 	assert.Equal(t, expectedNetworkConfig, string(marshaled))
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
@@ -7,6 +7,7 @@ package v1alpha1
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -57,9 +58,11 @@ func TestPhaseList_Append(t *testing.T) {
 		},
 	}
 
+	cmp := func(a, b runtime.Phase) bool { return a.Name == b.Name }
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.p = tt.p.Append(tt.args.name, tt.args.tasks...); !reflect.DeepEqual(tt.p, tt.want) {
+			if tt.p = tt.p.Append(tt.args.name, tt.args.tasks...); !slices.EqualFunc(tt.p, tt.want, cmp) {
 				t.Errorf("PhaseList.Append() = %v, want %v", tt.p, tt.want)
 			}
 		})
@@ -102,9 +105,11 @@ func TestPhaseList_AppendWhen(t *testing.T) {
 		},
 	}
 
+	cmp := func(a, b runtime.Phase) bool { return a.Name == b.Name }
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.p = tt.p.AppendWhen(tt.args.when, tt.args.name, tt.args.tasks...); !reflect.DeepEqual(tt.p, tt.want) {
+			if tt.p = tt.p.AppendWhen(tt.args.when, tt.args.name, tt.args.tasks...); !slices.EqualFunc(tt.p, tt.want, cmp) {
 				t.Errorf("PhaseList.AppendWhen() = %v, want %v", tt.p, tt.want)
 			}
 		})

--- a/internal/pkg/meta/internal/adv/syslinux/syslinux_test.go
+++ b/internal/pkg/meta/internal/adv/syslinux/syslinux_test.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -54,7 +54,7 @@ func TestNewADV(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(gotAdv, tt.wantAdv) {
+			if !bytes.Equal(gotAdv, tt.wantAdv) {
 				t.Errorf("NewADV() = %v, want %v", gotAdv, tt.wantAdv)
 			}
 		})
@@ -100,7 +100,7 @@ func TestADV_ReadTag(t *testing.T) {
 			}
 
 			tags := tt.a.ListTags()
-			if !reflect.DeepEqual(tags, []uint8{tt.args.t}) {
+			if !slices.Equal(tags, []uint8{tt.args.t}) {
 				t.Errorf("ADV.ListTags() got = %v, want %v", tags, []uint8{tt.args.t})
 			}
 		})

--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -12,7 +12,6 @@ import (
 	"math/bits"
 	"net"
 	"os"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -124,7 +123,7 @@ func (syncer *Syncer) SetTimeServers(timeServers []string) {
 	syncer.timeServersMu.Lock()
 	defer syncer.timeServersMu.Unlock()
 
-	if reflect.DeepEqual(timeServers, syncer.timeServers) {
+	if slices.Equal(timeServers, syncer.timeServers) {
 		return
 	}
 
@@ -213,6 +212,7 @@ func (syncer *Syncer) Run(ctx context.Context) {
 			zap.Duration("jitter", time.Duration(syncer.spikeDetector.Jitter()*float64(time.Second))),
 			zap.Duration("poll_interval", pollInterval),
 			zap.Bool("spike", spike),
+			zap.Bool("resp_exists", resp != nil),
 		)
 
 		if resp != nil && !spike {

--- a/internal/pkg/ntp/ntp_test.go
+++ b/internal/pkg/ntp/ntp_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -17,11 +16,11 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/pkg/ntp"
 	"github.com/siderolabs/talos/internal/pkg/timex"
-	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -167,7 +166,7 @@ func (suite *NTPSuite) fakeQuery(host string) (resp *beevikntp.Response, err err
 }
 
 func (suite *NTPSuite) TestSync() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{constants.DefaultNTPServer})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{constants.DefaultNTPServer})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -197,7 +196,7 @@ func (suite *NTPSuite) TestSync() {
 }
 
 func (suite *NTPSuite) TestSyncContinuous() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.3"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.3"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -244,7 +243,7 @@ func (suite *NTPSuite) TestSyncContinuous() {
 }
 
 func (suite *NTPSuite) TestSyncWithSpikes() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.7"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.7"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -296,7 +295,7 @@ func (suite *NTPSuite) TestSyncWithSpikes() {
 }
 
 func (suite *NTPSuite) TestSyncChangeTimeservers() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.1"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.1"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -334,7 +333,7 @@ func (suite *NTPSuite) TestSyncChangeTimeservers() {
 }
 
 func (suite *NTPSuite) TestSyncIterateTimeservers() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -386,7 +385,7 @@ func (suite *NTPSuite) TestSyncIterateTimeservers() {
 }
 
 func (suite *NTPSuite) TestSyncEpochChange() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.5"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.5"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock
@@ -425,7 +424,7 @@ func (suite *NTPSuite) TestSyncEpochChange() {
 }
 
 func (suite *NTPSuite) TestSyncSwitchTimeservers() {
-	syncer := ntp.NewSyncer(logging.Wrap(log.Writer()).With(zap.String("controller", "ntp")), []string{"127.0.0.6", "127.0.0.4"})
+	syncer := ntp.NewSyncer(zaptest.NewLogger(suite.T()).With(zap.String("controller", "ntp")), []string{"127.0.0.6", "127.0.0.4"})
 
 	syncer.AdjustTime = suite.adjustSystemClock
 	syncer.CurrentTime = suite.getSystemClock

--- a/pkg/machinery/config/configpatcher/configpatcher_test.go
+++ b/pkg/machinery/config/configpatcher/configpatcher_test.go
@@ -5,7 +5,7 @@
 package configpatcher_test
 
 import (
-	"reflect"
+	"bytes"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -61,7 +61,7 @@ func TestJSON6902(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
+			if !bytes.Equal(got, tt.want) {
 				t.Errorf("JSON6902 got: \n%v\n but wanted: \n%v", string(got), string(tt.want))
 			}
 		})


### PR DESCRIPTION
* Replace logging.Wrap(log.Writer()) with zaptest.NewLogger(suite.T()) where possible.
* Replace reflect.DeepEqual with =|slices.Equal|bytes.Equal where possible.