### PR TITLE
chore: drop k8s timeout in the default kubeconfig

### DIFF
--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -8,7 +8,6 @@ package base
 
 import (
 	"context"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +35,6 @@ func discoverNodesK8s(ctx context.Context, client *client.Client, suite *TalosSu
 	}
 
 	// patch timeout
-	config.Timeout = time.Minute
 	if suite.K8sEndpoint != "" {
 		config.Host = suite.K8sEndpoint
 	}

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -67,8 +67,6 @@ func (k8sSuite *K8sSuite) SetupSuite() {
 	})
 	k8sSuite.Require().NoError(err)
 
-	// patch timeout
-	config.Timeout = time.Minute
 	if k8sSuite.K8sEndpoint != "" {
 		config.Host = k8sSuite.K8sEndpoint
 	}

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -65,9 +64,6 @@ func (k *KubernetesClient) K8sRestConfig(ctx context.Context) (*rest.Config, err
 	if err != nil {
 		return nil, err
 	}
-
-	// patch timeout
-	config.Timeout = time.Minute
 
 	if k.ForceEndpoint != "" {
 		forceEndpoint, _ := strings.CutPrefix(k.ForceEndpoint, "https://")

--- a/pkg/cluster/sonobuoy/sonobuoy.go
+++ b/pkg/cluster/sonobuoy/sonobuoy.go
@@ -137,9 +137,6 @@ func Run(ctx context.Context, cluster cluster.K8sProvider, options *Options) err
 		return fmt.Errorf("error getting kubernetes config: %w", err)
 	}
 
-	// reset timeout to prevent log streaming from timing out
-	cfg.Timeout = 0
-
 	skc, err := sonodynamic.NewAPIHelperFromRESTConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("couldn't get sonobuoy api helper: %w", err)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -51,10 +51,6 @@ func NewClientFromKubeletKubeconfig() (*Client, error) {
 		return nil, err
 	}
 
-	if config.Timeout == 0 {
-		config.Timeout = 30 * time.Second
-	}
-
 	return NewForConfig(config)
 }
 


### PR DESCRIPTION
(This is not user-facing, but rather internal use of the kubeconfig in the tests/inside the machine).

This was added 4 years ago as a workaround, but instead of a global timeout we should rather use contexts with timeouts/deadlines (and we do!).

Setting a global timeout breaks streaming Kubernetes pod logs.
