### PR TITLE
chore(ci): fix cluster name generation

### DIFF
--- a/hack/test/e2e-aws-prepare.sh
+++ b/hack/test/e2e-aws-prepare.sh
@@ -59,7 +59,7 @@ esac
 
 mkdir -p "${ARTIFACTS}/e2e-aws-generated"
 
-NAME_PREFIX="talos-e2e-${SHA}-aws"
+NAME_PREFIX="talos-e2e-${SHA}-aws-${E2E_AWS_TARGET}"
 
 jq --null-input \
   --arg WORKER_GROUP "${WORKER_GROUP}" \


### PR DESCRIPTION
Append the target name to the cluster name so that parallel tests do not create resources with same names.