### PR TITLE
Typo: "As a safety messure Talos... -> As a safety measure, Talos..."

### DIFF
--- a/website/content/v1.0/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.0/kubernetes-guides/network/deploying-cilium.md
@@ -177,7 +177,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.1/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.1/kubernetes-guides/network/deploying-cilium.md
@@ -177,7 +177,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.2/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.2/kubernetes-guides/network/deploying-cilium.md
@@ -177,7 +177,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.3/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.3/kubernetes-guides/network/deploying-cilium.md
@@ -177,7 +177,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.4/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.4/kubernetes-guides/network/deploying-cilium.md
@@ -280,7 +280,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.5/kubernetes-guides/network/deploying-cilium.md
@@ -302,7 +302,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.6/kubernetes-guides/network/deploying-cilium.md
@@ -273,7 +273,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ## Known issues

--- a/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.7/kubernetes-guides/network/deploying-cilium.md
@@ -273,7 +273,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ### Method 5: Using a job

--- a/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
@@ -273,7 +273,7 @@ As the inline manifest is processed from top to bottom make sure to manually put
 - Only add the Cilium inline manifest to the control plane nodes machine configuration.
 - Make sure all control plane nodes have an identical configuration.
 - If you delete any of the generated resources they will be restored whenever a control plane node reboots.
-- As a safety messure Talos only creates missing resources from inline manifests, it never deletes or updates anything.
+- As a safety measure, Talos only creates missing resources from inline manifests, it never deletes or updates anything.
 - If you need to update a manifest make sure to first edit all control plane machine configurations and then run `talosctl upgrade-k8s` as it will take care of updating inline manifests.
 
 ### Method 5: Using a job


### PR DESCRIPTION
# Pull Request

## What? (description)

Fixes a typo/misspelling and missing interpunctuation:
"As a safety messure Talos..." → "As a safety measure, Talos...".

## Why? (reasoning)
Because I was reading through it and it was an easy fix.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
