### PR TITLE
chore: support version with and without `v` prefix

### DIFF
--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // VersionContract describes Talos version to generate config for.
@@ -39,6 +40,8 @@ var versionRegexp = regexp.MustCompile(`^v(\d+)\.(\d+)($|\.)`)
 
 // ParseContractFromVersion parses Talos version into VersionContract.
 func ParseContractFromVersion(version string) (*VersionContract, error) {
+	version = "v" + strings.TrimPrefix(version, "v")
+
 	matches := versionRegexp.FindStringSubmatch(version)
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("error parsing version %q", version)

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -32,6 +32,7 @@ func TestContractParseVersion(t *testing.T) {
 		"v1.5.1":         config.TalosVersion1_5,
 		"v1.88":          {1, 88},
 		"v1.5.3-alpha.4": config.TalosVersion1_5,
+		"1.6":            config.TalosVersion1_6,
 	} {
 		t.Run(v, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Support passing in version with and without `v` prefix to Talos machine config version contract parser.