### PR TITLE
fix: properly output multi-doc machine config in `get mc`

### DIFF
--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -58,8 +58,7 @@ func editFn(c *client.Client) func(context.Context, string, resource.Resource, e
 			return errors.New("only the machineconfig resource can be edited")
 		}
 
-		metadata := mc.Metadata()
-		id := metadata.ID()
+		id := mc.Metadata().ID()
 
 		body, err := yaml.Marshal(mc.Spec())
 		if err != nil {

--- a/cmd/talosctl/cmd/talos/output/json.go
+++ b/cmd/talosctl/cmd/talos/output/json.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/state"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 // JSON outputs resources in JSON format.
@@ -37,6 +39,10 @@ func (j *JSON) WriteHeader(definition *meta.ResourceDefinition, withEvents bool)
 
 // prepareEncodableData prepares the data of a resource to be encoded as JSON and populates it with some extra information.
 func (j *JSON) prepareEncodableData(node string, r resource.Resource, event state.EventType) (map[string]interface{}, error) {
+	if r.Metadata().Type() == config.MachineConfigType {
+		r = &mcYamlRepr{r}
+	}
+
 	out, err := resource.MarshalYAML(r)
 	if err != nil {
 		return nil, err

--- a/cmd/talosctl/cmd/talos/output/table.go
+++ b/cmd/talosctl/cmd/talos/output/table.go
@@ -96,7 +96,7 @@ func (table *Table) WriteResource(node string, r resource.Resource, event state.
 			return nil
 		}
 
-		values = append([]string{label}, values...)
+		values = slices.Insert(values, 0, label)
 	}
 
 	yml, err := yaml.Marshal(r.Spec())
@@ -121,7 +121,7 @@ func (table *Table) WriteResource(node string, r resource.Resource, event state.
 		values = append(values, value)
 	}
 
-	values = append([]string{node}, values...)
+	values = slices.Insert(values, 0, node)
 
 	_, err = fmt.Fprintln(&table.w, strings.Join(values, "\t"))
 


### PR DESCRIPTION
For `get mc -o json|yaml` we pretend that `spec` field is string and not an actual yaml map. That way you can see the full spec in unformatted view using `talosctl -n <node> get mc -o yaml` or formatted using `talosctl -n <node> get mc -o yaml | yq .spec`.

`edit mc` command is unaffected.

Fixes #8687