### PR TITLE
docs: add not about mayastor nvme_tcp init container check

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/storage.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/storage.md
@@ -120,6 +120,10 @@ talosctl -n <node ip> service kubelet restart
 
 Continue setting up [Mayastor](https://mayastor.gitbook.io/introduction/quickstart/deploy-mayastor) using the official documentation.
 
+> Note: The Mayastor helm chart uses an init container that checks for the `nvme_tcp` module.
+> It does not mount `/sys` and will not be able to find it.
+> Easiest solution is to disable the init container.
+
 ### Piraeus / LINSTOR
 
 * [Piraeus-Operator](https://piraeus.io/)


### PR DESCRIPTION
The Mayastor helm chart ships with an init container that won't mount /sys and runs lsmod. Add a note in the guide as this is not obvious.

There are few hits on google. Had to search the slack channel for information. Adding pull request to make this information more accessible.