### PR TITLE
chore: bump deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/siderolabs/go-smbios v0.3.2
 	github.com/siderolabs/go-tail v0.1.1
 	github.com/siderolabs/go-talos-support v0.1.1-0.20240521144823-69891cf04662
-	github.com/siderolabs/grpc-proxy v0.4.0
+	github.com/siderolabs/grpc-proxy v0.4.1
 	github.com/siderolabs/kms-client v0.1.0
 	github.com/siderolabs/net v0.4.0
 	github.com/siderolabs/siderolink v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/siderolabs/go-tail v0.1.1 h1:3XeJgd97OHyFAIE7nQEMcRhOfnv7DvXbu0BRKbtT
 github.com/siderolabs/go-tail v0.1.1/go.mod h1:IihAL39acadXHfb5fEAOKK2DaDFIrG2+VD3b2H/ziZ0=
 github.com/siderolabs/go-talos-support v0.1.1-0.20240521144823-69891cf04662 h1:TnpJ279GAgW8LLJGwjyB/ups0iJSAOGJtKXd3Kl9yP8=
 github.com/siderolabs/go-talos-support v0.1.1-0.20240521144823-69891cf04662/go.mod h1:YRs6CWqvFmRnxTE3cuOPM23ZasuzaNGNEeyFajsI+tw=
-github.com/siderolabs/grpc-proxy v0.4.0 h1:zYrhqLYs8JlYoLHYeel7/XwXDZ4OJ5XyP9wX7JlbPew=
-github.com/siderolabs/grpc-proxy v0.4.0/go.mod h1:QDurYOwQD4H8BKyvCuUxMiuG/etYnb/++xaQB644NdU=
+github.com/siderolabs/grpc-proxy v0.4.1 h1:UTYviMqb65oKjnH7dy5D+U4zMJ6iCTjAN6x6K/Ss120=
+github.com/siderolabs/grpc-proxy v0.4.1/go.mod h1:QwQuLUpJrlN08kpP0m63oO/SEeoz0dEhU9ndlBafc0Y=
 github.com/siderolabs/kms-client v0.1.0 h1:rCDWzcDDsNlp6zdyLngOuuhchVILn+vwUQy3tk6rQps=
 github.com/siderolabs/kms-client v0.1.0/go.mod h1:4UQkRhuEh3kaK7VhJxez4YyJLv6lPEff7g3Pa6Y9okg=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -178,7 +178,7 @@ func apidMain() error {
 				grpc.Creds(
 					credentials.NewTLS(serverTLSConfig),
 				),
-				grpc.CustomCodec(proxy.Codec()), //nolint:staticcheck
+				grpc.ForceServerCodec(proxy.Codec()),
 				grpc.UnknownServiceHandler(
 					proxy.TransparentHandler(
 						router.Director,
@@ -205,7 +205,7 @@ func apidMain() error {
 			router,
 			factory.WithDefaultLog(),
 			factory.ServerOptions(
-				grpc.CustomCodec(proxy.Codec()), //nolint:staticcheck
+				grpc.ForceServerCodec(proxy.Codec()),
 				grpc.UnknownServiceHandler(
 					proxy.TransparentHandler(
 						router.Director,

--- a/internal/app/apid/pkg/backend/apid.go
+++ b/internal/app/apid/pkg/backend/apid.go
@@ -117,8 +117,8 @@ func (a *APID) GetConnection(ctx context.Context, fullMethodName string) (contex
 		}),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
+			grpc.ForceCodec(proxy.Codec()),
 		),
-		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
 		grpc.WithSharedWriteBuffer(true),
 	)
 

--- a/pkg/grpc/proxy/backend/local.go
+++ b/pkg/grpc/proxy/backend/local.go
@@ -62,8 +62,8 @@ func (l *Local) GetConnection(ctx context.Context, fullMethodName string) (conte
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
+			grpc.ForceCodec(proxy.Codec()),
 		),
-		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
 		grpc.WithSharedWriteBuffer(true),
 	)
 

--- a/pkg/machinery/client/connection.go
+++ b/pkg/machinery/client/connection.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/siderolabs/gen/xslices"
@@ -40,16 +41,18 @@ func (c *Client) getConn(opts ...grpc.DialOption) (*grpcConnectionWrapper, error
 			constants.ApidPort),
 	)
 
-	dialOpts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions( // enable compression by default
-			// TODO: enable compression for Talos 1.7+
-			// grpc.UseCompressor(gzip.Name),
-			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
-		),
-		grpc.WithSharedWriteBuffer(true),
-	}
-	dialOpts = append(dialOpts, c.options.grpcDialOptions...)
-	dialOpts = append(dialOpts, opts...)
+	dialOpts := slices.Concat(
+		[]grpc.DialOption{
+			grpc.WithDefaultCallOptions( // enable compression by default
+				// TODO: enable compression for Talos 1.7+
+				// grpc.UseCompressor(gzip.Name),
+				grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
+			),
+			grpc.WithSharedWriteBuffer(true),
+		},
+		c.options.grpcDialOptions,
+		opts,
+	)
 
 	if c.options.unixSocketPath != "" {
 		conn, err := grpc.NewClient(target, dialOpts...)


### PR DESCRIPTION
Bump github.com/siderolabs/grpc-proxy to v0.4.1 and replace deprecated calls to `grpc.CustomCodec`.