### PR TITLE
fix: remove host bind mount for `/tmp` for trustd

### DIFF
--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -138,7 +138,6 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 
 	// Set the mounts.
 	mounts := []specs.Mount{
-		{Type: "bind", Destination: "/tmp", Source: "/tmp", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: filepath.Dir(constants.TrustdRuntimeSocketPath), Source: filepath.Dir(constants.TrustdRuntimeSocketPath), Options: []string{"rbind", "ro"}},
 	}
 


### PR DESCRIPTION
Not sure why this mount was needed, but it was added long time ago, and I believe it's no longer needed.
