### PR TITLE
feat: provide an option to enforce SecureBoot for TPM enrollment

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -563,7 +563,9 @@ func create(ctx context.Context) error {
 					provisionOptions = append(provisionOptions, provision.WithKMS(nethelpers.JoinHostPort("0.0.0.0", port)))
 				case "tpm":
 					keys = append(keys, &v1alpha1.EncryptionKey{
-						KeyTPM:  &v1alpha1.EncryptionKeyTPM{},
+						KeyTPM: &v1alpha1.EncryptionKeyTPM{
+							TPMCheckSecurebootStatusOnEnroll: pointer.To(true),
+						},
 						KeySlot: i,
 					})
 				default:

--- a/internal/pkg/encryption/keys/keys.go
+++ b/internal/pkg/encryption/keys/keys.go
@@ -48,7 +48,7 @@ func NewHandler(cfg config.EncryptionKey, options ...KeyOption) (Handler, error)
 
 		return NewKMSKeyHandler(key, cfg.KMS().Endpoint(), opts.GetSystemInformation)
 	case cfg.TPM() != nil:
-		return NewTPMKeyHandler(key)
+		return NewTPMKeyHandler(key, cfg.TPM().CheckSecurebootOnEnroll())
 	}
 
 	return nil, errors.New("malformed config: no key handler can be created")

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -396,6 +396,7 @@ type EncryptionKeyNodeID interface {
 
 // EncryptionKeyTPM encryption key sealed by TPM.
 type EncryptionKeyTPM interface {
+	CheckSecurebootOnEnroll() bool
 	String() string
 }
 

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -1649,7 +1649,15 @@
       "type": "object"
     },
     "v1alpha1.EncryptionKeyTPM": {
-      "properties": {},
+      "properties": {
+        "checkSecurebootStatusOnEnroll": {
+          "type": "boolean",
+          "title": "checkSecurebootStatusOnEnroll",
+          "description": "Check that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.\n",
+          "markdownDescription": "Check that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.",
+          "x-intellij-html-description": "\u003cp\u003eCheck that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.\u003c/p\u003e\n"
+        }
+      },
       "additionalProperties": false,
       "type": "object"
     },

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1456,6 +1456,15 @@ func (e *EncryptionKeyTPM) String() string {
 	return "tpm"
 }
 
+// CheckSecurebootOnEnroll implements the config.Provider interface.
+func (e *EncryptionKeyTPM) CheckSecurebootOnEnroll() bool {
+	if e == nil {
+		return false
+	}
+
+	return pointer.SafeDeref(e.TPMCheckSecurebootStatusOnEnroll)
+}
+
 // Slot implements the config.Provider interface.
 func (e *EncryptionKey) Slot() int {
 	return e.KeySlot

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1621,7 +1621,16 @@ type EncryptionKeyKMS struct {
 }
 
 // EncryptionKeyTPM represents a key that is generated and then sealed/unsealed by the TPM.
-type EncryptionKeyTPM struct{}
+type EncryptionKeyTPM struct {
+	//   description: >
+	//     Check that Secureboot is enabled in the EFI firmware.
+	//
+	//     If Secureboot is not enabled, the enrollment of the key will fail.
+	//     As the TPM key is anyways bound to the value of PCR 7,
+	//     changing Secureboot status or configuration
+	//     after the initial enrollment will make the key unusable.
+	TPMCheckSecurebootStatusOnEnroll *bool `yaml:"checkSecurebootStatusOnEnroll,omitempty"`
+}
 
 // EncryptionKeyNodeID represents deterministically generated key from the node UUID and PartitionLabel.
 type EncryptionKeyNodeID struct{}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -2183,7 +2183,15 @@ func (EncryptionKeyTPM) Doc() *encoder.Doc {
 				FieldName: "tpm",
 			},
 		},
-		Fields: []encoder.Doc{},
+		Fields: []encoder.Doc{
+			{
+				Name:        "checkSecurebootStatusOnEnroll",
+				Type:        "bool",
+				Note:        "",
+				Description: "Check that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Check that Secureboot is enabled in the EFI firmware." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+		},
 	}
 
 	return doc

--- a/website/content/v1.8/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.8/reference/configuration/v1alpha1/config.md
@@ -2397,6 +2397,10 @@ EncryptionKeyTPM represents a key that is generated and then sealed/unsealed by 
 
 
 
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`checkSecurebootStatusOnEnroll` |bool |<details><summary>Check that Secureboot is enabled in the EFI firmware.</summary>If Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.</details>  | |
+
 
 
 
@@ -2515,6 +2519,10 @@ EncryptionKeyTPM represents a key that is generated and then sealed/unsealed by 
 
 
 
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`checkSecurebootStatusOnEnroll` |bool |<details><summary>Check that Secureboot is enabled in the EFI firmware.</summary>If Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.</details>  | |
 
 
 

--- a/website/content/v1.8/schemas/config.schema.json
+++ b/website/content/v1.8/schemas/config.schema.json
@@ -1649,7 +1649,15 @@
       "type": "object"
     },
     "v1alpha1.EncryptionKeyTPM": {
-      "properties": {},
+      "properties": {
+        "checkSecurebootStatusOnEnroll": {
+          "type": "boolean",
+          "title": "checkSecurebootStatusOnEnroll",
+          "description": "Check that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.\n",
+          "markdownDescription": "Check that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.",
+          "x-intellij-html-description": "\u003cp\u003eCheck that Secureboot is enabled in the EFI firmware.\nIf Secureboot is not enabled, the enrollment of the key will fail. As the TPM key is anyways bound to the value of PCR 7, changing Secureboot status or configuration after the initial enrollment will make the key unusable.\u003c/p\u003e\n"
+        }
+      },
       "additionalProperties": false,
       "type": "object"
     },


### PR DESCRIPTION
Fixes #8995

There is no security impact, as the actual SecureBoot state/configuration is measured into the PCR 7 and the disk encryption key unsealing is tied to this value.

This is more to provide a way to avoid accidentally encrypting to the TPM while SecureBoot is not enabled.
