### PR TITLE
fix: change the UEFI firmware search path order

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -1285,6 +1285,10 @@ func getContainerInspector(ctx context.Context, namespace string, driver common.
 func (s *Server) Read(in *machine.ReadRequest, srv machine.MachineService_ReadServer) (err error) {
 	stat, err := os.Stat(in.Path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return status.Error(codes.NotFound, err.Error())
+		}
+
 		return err
 	}
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -448,7 +448,9 @@ func (apiSuite *APISuite) HashKubeletCert(ctx context.Context, node string) (str
 
 	_, err = io.Copy(hash, reader)
 	if err != nil {
-		return "", err
+		if client.StatusCode(err) != codes.NotFound { // not found, swallow it
+			return "", err
+		}
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), reader.Close()

--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -124,8 +124,6 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			"ovmf-x86_64-4m-vars.bin",
 		}
 
-		uefiSourceFiles = append(uefiSourceFiles, uefiSourceFilesInsecure...)
-
 		// Append extra search paths
 		uefiSourcePathPrefixes = append(uefiSourcePathPrefixes, extraUEFISearchPaths...)
 
@@ -140,6 +138,12 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 
 			for _, f := range uefiVarsFiles {
 				uefiVarsPaths = append(uefiVarsPaths, filepath.Join(p, f))
+			}
+		}
+
+		for _, p := range uefiSourcePathPrefixes {
+			for _, f := range uefiSourceFilesInsecure {
+				uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, f))
 			}
 		}
 


### PR DESCRIPTION
Ensure that SecureBoot enabled images come before regular ones.

With Ubuntu 24.04 `ovmf` package, due to the ordering of the search paths `talosctl` might pick up a wrong image and disable SecureBoot.
