### PR TITLE
docs: fix talosctl spelling

### DIFF
--- a/website/content/v1.7/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.7/talos-guides/configuration/editing-machine-configuration.md
@@ -84,7 +84,7 @@ talosctl -n IP apply machineconfig --mode=interactive
 
 > Note: when a Talos node is running in the maintenance mode it's necessary to provide `--insecure (-i)` flag to connect to the API and apply the config.
 
-### `taloctl edit machineconfig`
+### `talosctl edit machineconfig`
 
 Command `talosctl edit` loads current machine configuration from the node and launches configured editor to modify the config.
 If config hasn't been changed in the editor (or if updated config is empty), update is not applied.

--- a/website/content/v1.8/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.8/talos-guides/configuration/editing-machine-configuration.md
@@ -84,7 +84,7 @@ talosctl -n IP apply machineconfig --mode=interactive
 
 > Note: when a Talos node is running in the maintenance mode it's necessary to provide `--insecure (-i)` flag to connect to the API and apply the config.
 
-### `taloctl edit machineconfig`
+### `talosctl edit machineconfig`
 
 Command `talosctl edit` loads current machine configuration from the node and launches configured editor to modify the config.
 If config hasn't been changed in the editor (or if updated config is empty), update is not applied.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Fixing a typo in the v1.7 and v1.8 docs. Ran `make docs` but didn't see any extra changes to commit.

## Why? (reasoning)

Just to fix a misspelling I noticed after copy/pasting the command.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
