### PR TITLE
feat: provide a simple way to delete keys in config merge

### DIFF
--- a/pkg/machinery/config/configpatcher/testdata/delete/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/delete/config.yaml
@@ -1,0 +1,5 @@
+version: v1alpha1
+machine:
+  nodeLabels:
+    foo: bar
+    bogus: something

--- a/pkg/machinery/config/configpatcher/testdata/delete/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/delete/expected.yaml
@@ -1,0 +1,8 @@
+version: v1alpha1
+machine:
+    type: ""
+    token: ""
+    certSANs: []
+    nodeLabels:
+        foo: bar
+cluster: null

--- a/pkg/machinery/config/configpatcher/testdata/delete/patch.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/delete/patch.yaml
@@ -1,0 +1,3 @@
+machine:
+  nodeLabels:
+    bogus: $delete

--- a/pkg/machinery/config/merge/merge_test.go
+++ b/pkg/machinery/config/merge/merge_test.go
@@ -308,6 +308,25 @@ func TestMerge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unstructed with delete marker",
+			left: Unstructured{
+				"a": "v",
+				"b": []any{
+					"c",
+					"d",
+				},
+				"c": "x",
+			},
+			right: Unstructured{
+				"a": "$delete",
+				"b": "$delete",
+				"d": "$delete",
+			},
+			expected: Unstructured{
+				"c": "x",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := merge.Merge(tt.left, tt.right)


### PR DESCRIPTION
With strategic merge patches, we had no way to delete values by patching.

It might be tricky to implement it fully, but one simple case is easy - deleting keys from the map (e.g. `nodeLabels`) on merge.
