### PR TITLE
feat: implement specifying filesystem for user disks

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -952,8 +952,13 @@ func mountDisks(logger *log.Logger, r runtime.Runtime) (err error) {
 				}
 			}
 
+			filesystemType := disk.FileSystemType()
+			if filesystemType == "" {
+				filesystemType = "xfs"
+			}
+
 			mountpoints.Set(partname,
-				mount.NewMountPoint(partname, part.MountPoint(), "xfs", unix.MS_NOATIME, "",
+				mount.NewMountPoint(partname, part.MountPoint(), filesystemType, unix.MS_NOATIME, "",
 					mount.WithProjectQuota(r.Config().Machine().Features().DiskQuotaSupportEnabled()),
 				),
 			)

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -62,6 +62,7 @@ type NodeTaints map[string]string
 // mounting extra disks.
 type Disk interface {
 	Device() string
+	FileSystemType() string
 	Partitions() []Partition
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1487,8 +1487,15 @@ type AdminKubeconfigConfig struct {
 type MachineDisk struct {
 	//   description: The name of the disk to use.
 	DeviceName string `yaml:"device,omitempty"`
+	//   description: The partition format, eg ext4
+	DeviceFileSystemField string `yaml:"deviceFileSystem,omitempty"`
 	//   description: A list of partitions to create on the disk.
 	DiskPartitions []*DiskPartition `yaml:"partitions,omitempty"`
+}
+
+// FileSystemType represents the filesystem that already exists on the disk.
+func (d *MachineDisk) FileSystemType() string {
+	return d.DeviceFileSystemField
 }
 
 // DiskSize partition size in bytes.

--- a/pkg/makefs/btrfs.go
+++ b/pkg/makefs/btrfs.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package makefs
+
+import (
+	"github.com/siderolabs/go-cmd/pkg/cmd"
+)
+
+// Btrfs creates a btrfs filesystem on the specified partition.
+func Btrfs(partname string, setters ...Option) error {
+	opts := NewDefaultOptions(setters...)
+
+	var args []string
+
+	if opts.Label != "" {
+		args = append(args, "--label", opts.Label)
+	}
+
+	args = append(args, partname)
+
+	_, err := cmd.Run("mkfs.btrfs", args...)
+
+	return err
+}
+
+// BtrfsGrow expands a btrfs filesystem to the maximum possible.
+func BtrfsGrow(partname string) error {
+	_, err := cmd.Run("btrfs", "filesystem", "resize", "max", partname)
+	return err
+}
+
+// BtrfsRepair repairs a Btrfs filesystem on the specified partition.
+func BtrfsRepair(partname string, setters ...Option) error {
+	opts := NewDefaultOptions(setters...)
+
+	var args []string
+
+	if opts.Reproducible {
+		args = append(args, "--init-csum-tree", "--init-extent-tree")
+	}
+
+	args = append(args, "--repair", partname)
+
+	_, err := cmd.Run("btrfs", append([]string{"check"}, args...)...)
+
+	return err
+}

--- a/pkg/makefs/ext.go
+++ b/pkg/makefs/ext.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package makefs
+
+import (
+	"github.com/siderolabs/go-cmd/pkg/cmd"
+)
+
+// ExtGrow expands an ext4 filesystem to the maximum possible.
+func ExtGrow(partname string) error {
+	_, err := cmd.Run("resize2fs", partname)
+
+	return err
+}
+
+// ExtRepair repairs an ext2/3/4 filesystem on the specified partition.
+func ExtRepair(partname string, setters ...Option) error {
+	opts := NewDefaultOptions(setters...)
+
+	var args []string
+
+	if opts.Reproducible {
+		args = append(args, "-f")
+	}
+
+	args = append(args, partname)
+
+	_, err := cmd.Run("e2fsck", args...)
+
+	return err
+}

--- a/website/content/v1.8/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.8/reference/configuration/v1alpha1/config.md
@@ -1802,6 +1802,7 @@ machine:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`device` |string |The name of the disk to use.  | |
+|`deviceFileSystem` |string |The partition format, eg ext4  | |
 |`partitions` |<a href="#Config.machine.disks..partitions.">[]DiskPartition</a> |A list of partitions to create on the disk.  | |
 
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Implement specifying filesystem for user disks and fallback to xfs as before if omitted.

## Why? (reasoning)

Not all disks will always be formatted as xfs, and thus it couldn't mount other partitions even if kernel has the required support like ext4.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
