### PR TITLE
fix: enforce secureboot enroll option only for supported releases

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -519,9 +519,9 @@ func create(ctx context.Context) error {
 			}
 		}
 
-		if talosVersion != "latest" {
-			var versionContract *config.VersionContract
+		var versionContract *config.VersionContract
 
+		if talosVersion != "latest" {
 			versionContract, err = config.ParseContractFromVersion(talosVersion)
 			if err != nil {
 				return fmt.Errorf("error parsing Talos version %q: %w", talosVersion, err)
@@ -562,10 +562,14 @@ func create(ctx context.Context) error {
 
 					provisionOptions = append(provisionOptions, provision.WithKMS(nethelpers.JoinHostPort("0.0.0.0", port)))
 				case "tpm":
+					keyTPM := &v1alpha1.EncryptionKeyTPM{}
+
+					if versionContract.SecureBootEnrollEnforcementSupported() {
+						keyTPM.TPMCheckSecurebootStatusOnEnroll = pointer.To(true)
+					}
+
 					keys = append(keys, &v1alpha1.EncryptionKey{
-						KeyTPM: &v1alpha1.EncryptionKeyTPM{
-							TPMCheckSecurebootStatusOnEnroll: pointer.To(true),
-						},
+						KeyTPM:  keyTPM,
 						KeySlot: i,
 					})
 				default:

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -163,3 +163,8 @@ func (contract *VersionContract) HostDNSForwardKubeDNSToHost() bool {
 func (contract *VersionContract) AddExcludeFromExternalLoadBalancer() bool {
 	return contract.Greater(TalosVersion1_7)
 }
+
+// SecureBootEnrollEnforcementSupported returns true if version of Talos supports SecureBoot enforcement on enroll.
+func (contract *VersionContract) SecureBootEnrollEnforcementSupported() bool {
+	return contract.Greater(TalosVersion1_7)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -64,6 +64,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.ClusterNameForWorkers())
 	assert.True(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.True(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.True(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_8(t *testing.T) {
@@ -86,6 +87,7 @@ func TestContract1_8(t *testing.T) {
 	assert.True(t, contract.ClusterNameForWorkers())
 	assert.True(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.True(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.True(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_7(t *testing.T) {
@@ -108,6 +110,7 @@ func TestContract1_7(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_6(t *testing.T) {
@@ -130,6 +133,7 @@ func TestContract1_6(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_5(t *testing.T) {
@@ -152,6 +156,7 @@ func TestContract1_5(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_4(t *testing.T) {
@@ -174,6 +179,7 @@ func TestContract1_4(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -196,6 +202,7 @@ func TestContract1_3(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -218,6 +225,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -240,6 +248,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -262,4 +271,5 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.ClusterNameForWorkers())
 	assert.False(t, contract.HostDNSForwardKubeDNSToHost())
 	assert.False(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.False(t, contract.SecureBootEnrollEnforcementSupported())
 }


### PR DESCRIPTION
Follow up for #9005
