### PR TITLE
Docs: Update Equinix Guide

### DIFF
--- a/website/content/v1.8/talos-guides/install/bare-metal-platforms/equinix-metal.md
+++ b/website/content/v1.8/talos-guides/install/bare-metal-platforms/equinix-metal.md
@@ -93,11 +93,11 @@ This guide assumes the user has a working API token,and the [Equinix Metal CLI](
 ```bash
 metal device create \
   --project-id $PROJECT_ID \
-  --facility $FACILITY \
+  --metro $METRO \
   --operating-system "custom_ipxe" \
   --ipxe-script-url "https://pxe.factory.talos.dev/pxe/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/{{< release >}}/equinixMetal-amd64" \
-  --plan $PLAN\
-  --hostname $HOSTNAME\
+  --plan $PLAN \
+  --hostname $HOSTNAME \
   --userdata-file controlplane.yaml
 ```
 


### PR DESCRIPTION
# Pull Request

Following the most recent livestream (https://www.youtube.com/live/J0DAWK21stA), I'm adding in a few small fixes, specifically to the device create command in the Equinix Metal guide, specifically this PR:

* Adds `--always-pxe` which was required to successfully boot, and
* Uses `metros` instead of `facilities` as the latter is deprecated (https://deploy.equinix.com/developers/docs/metal/locations/facilities/)
