### PR TITLE
feat: use ethtool ioctl to get link status when netlink api not avail…

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -207,6 +207,20 @@ func (ctrl *LinkStatusController) reconcile(
 			if err == nil && permAddr != "" {
 				permanentAddr, _ = net.ParseMAC(permAddr) //nolint:errcheck
 			}
+
+			if ethState == nil {
+				state, err := ethtoolIoctlClient.LinkState(link.Attributes.Name)
+				if err != nil {
+					logger.Warn("error querying ethtool ioctl link state", zap.String("link", link.Attributes.Name), zap.Error(err))
+				} else {
+					ethState = &ethtool.LinkState{
+						Interface: ethtool.Interface{
+							Index: int(link.Index),
+						},
+						Link: state > 0,
+					}
+				}
+			}
 		}
 
 		if err = r.Modify(ctx, network.NewLinkStatus(network.NamespaceName, link.Attributes.Name), func(r resource.Resource) error {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
when kernel not support ethtool-netlink(kernel < 5.6), will try to use ethtool ioctl to get link status.

## Why? (reasoning)
it will benefit some scenario for run in docker or k8s with some special nic (for example sriov vf)
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)  it complains with "openpgp: signature made by unknown entity",i try,but failed
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
