### PR TITLE
chore: add test for gvisor extension with platform kvm

### DIFF
--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -362,10 +362,18 @@ func (suite *ExtensionsSuiteQEMU) TestExtensionsHelloWorldService() {
 }
 
 // TestExtensionsGvisor verifies gvisor runtime class is working.
-// TODO: frezbo: re-enable once https://github.com/siderolabs/extensions/issues/417 is addressed.
-// func (suite *ExtensionsSuiteQEMU) TestExtensionsGvisor() {
-// 	suite.testRuntimeClass("gvisor", "runsc")
-// }
+func (suite *ExtensionsSuiteQEMU) TestExtensionsGvisor() {
+	suite.T().Skip("skipping until https://github.com/siderolabs/extensions/issues/417 is addressed.")
+
+	suite.testRuntimeClass("gvisor", "runsc")
+}
+
+// TestExtensionsGvisorKVM verifies gvisor runtime class with kvm platform is working.
+func (suite *ExtensionsSuiteQEMU) TestExtensionsGvisorKVM() {
+	suite.T().Skip("skipping until https://github.com/siderolabs/extensions/issues/417 is addressed.")
+
+	suite.testRuntimeClass("gvisor-kvm", "runsc-kvm")
+}
 
 // TestExtensionsKataContainers verifies gvisor runtime class is working.
 func (suite *ExtensionsSuiteQEMU) TestExtensionsKataContainers() {


### PR DESCRIPTION
Add test for Gvisor extensions when kvm platform is used.

The test is marked as skipped until pod termination issue is resolved.