### PR TITLE
docs: fix docker getting started typo

### DIFF
--- a/website/content/v1.7/talos-guides/install/local-platforms/docker.md
+++ b/website/content/v1.7/talos-guides/install/local-platforms/docker.md
@@ -17,11 +17,17 @@ The follow are requirements for running Talos in Docker:
 - Docker 18.03 or greater
 - a recent version of [`talosctl`](https://github.com/siderolabs/talos/releases)
 
+{{% alert title="Note" color="info" %}}
+If you are using Docker Desktop on a macOS computer, and you encounter the error: *Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?* you may need to manually create the link for the Docker socket:
+```sudo ln -s "$HOME/.docker/run/docker.sock" /var/run/docker.sock```
+
+{{% /alert %}}
+
 ## Caveats
 
 Due to the fact that Talos will be running in a container, certain APIs are not available.
 For example `upgrade`, `reset`, and similar APIs don't apply in container mode.
-Further, when running on a Mac in docker,  due to networking limitations, VIPs are not supported.
+Further, when running on a Mac in docker, due to networking limitations, VIPs are not supported.
 
 ## Create the Cluster
 
@@ -44,7 +50,7 @@ Talos and Kubernetes API are mapped to a random port on the host machine, the re
 Talos API endpoint can be found using `talosctl config info`:
 
 ```bash
-$ talosctcl config info
+$ talosctl config info
 ...
 Endpoints:           127.0.0.1:38423
 ```

--- a/website/content/v1.8/talos-guides/install/local-platforms/docker.md
+++ b/website/content/v1.8/talos-guides/install/local-platforms/docker.md
@@ -6,12 +6,13 @@ aliases:
 ---
 
 In this guide we will create a Kubernetes cluster in Docker, using a containerized version of Talos.
+
 Running Talos in Docker is intended to be used in CI pipelines, and local testing when you need a quick and easy cluster.
-It also provides an excellent way for developers to develop against the same version of Talos as is used in production.
+Furthermore, if you are running Talos in production, it provides an excellent way for developers to develop against the same version of Talos.
 
 ## Requirements
 
-The follow are the requirements for running Talos in Docker:
+The follow are requirements for running Talos in Docker:
 
 - Docker 18.03 or greater
 - a recent version of [`talosctl`](https://github.com/siderolabs/talos/releases)
@@ -26,7 +27,7 @@ If you are using Docker Desktop on a macOS computer, and you encounter the error
 
 Due to the fact that Talos will be running in a container, certain APIs are not available.
 For example `upgrade`, `reset`, and similar APIs don't apply in container mode.
-Further, when running on a Mac in docker,  due to networking limitations, VIPs are not supported.
+Further, when running on a Mac in docker, due to networking limitations, VIPs are not supported.
 
 ## Create the Cluster
 
@@ -36,7 +37,7 @@ Creating a local cluster is as simple as:
 talosctl cluster create
 ```
 
-Once the above finishes, your `talosconfig` (`~/.talos/config`)  and `kubeconfig` (`~/.kube/config`) will be configured to point to the new cluster.
+Once the above finishes successfully, your `talosconfig` (`~/.talos/config`)  and `kubeconfig` (`~/.kube/config`) will be configured to point to the new cluster.
 
 > Note: Startup times can take up to a minute or more before the cluster is available.
 


### PR DESCRIPTION
s/talosctcl/talosctl/g