### PR TITLE
Add more information to the wireguard interface definition

### DIFF
--- a/website/content/v1.7/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.7/reference/configuration/v1alpha1/config.md
@@ -1558,32 +1558,38 @@ DeviceWireguardConfig contains settings for configuring Wireguard network interf
 machine:
     network:
         interfaces:
-            - wireguard:
-                privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
-                listenPort: 51111 # Specifies a device's listening port.
-                # Specifies a list of peer configurations to apply to a device.
-                peers:
-                    - publicKey: ABCDEF... # Specifies the public key of this peer.
-                      endpoint: 192.168.1.3 # Specifies the endpoint of this peer entry.
-                      # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
-                      allowedIPs:
-                        - 192.168.1.0/24
+          - interface: wg0 # Name of the wireguard interface
+            addresses:
+              - 192.168.2.1/24 # Address to assign to the interface
+            wireguard:
+              privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+              listenPort: 51111 # Specifies a device's listening port.
+              # Specifies a list of peer configurations to apply to a device.
+              peers:
+              - publicKey: ABCDEF... # Specifies the public key of this peer.
+                endpoint: 192.168.1.3 # Specifies the endpoint of this peer entry.
+                # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+                allowedIPs:
+                  - 192.168.1.0/24
 {{< /highlight >}}
 
 {{< highlight yaml >}}
 machine:
     network:
         interfaces:
-            - wireguard:
-                privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
-                # Specifies a list of peer configurations to apply to a device.
-                peers:
-                    - publicKey: ABCDEF... # Specifies the public key of this peer.
-                      endpoint: 192.168.1.2:51822 # Specifies the endpoint of this peer entry.
-                      persistentKeepaliveInterval: 10s # Specifies the persistent keepalive interval for this peer.
-                      # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
-                      allowedIPs:
-                        - 192.168.1.0/24
+        - interface: wg0 # Name of the wireguard interface
+          addresses:
+            - 192.168.2.1/24 # Address to assign to the interface
+          wireguard:
+            privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+            # Specifies a list of peer configurations to apply to a device.
+            peers:
+              - publicKey: ABCDEF... # Specifies the public key of this peer.
+                endpoint: 192.168.1.2:51822 # Specifies the endpoint of this peer entry.
+                persistentKeepaliveInterval: 10s # Specifies the persistent keepalive interval for this peer.
+                # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+                allowedIPs:
+                  - 192.168.1.0/24
 {{< /highlight >}}
 
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Modified the reference to the wireguard configuration options to include the interface description.

## Why? (reasoning)
The configuration implied to me that you didn't need to create an interface, but you do. In order to fix that I had to look at the other wireguard documentation to see that. In my eyes this will help be more clear on the creation of wireguard interfaces.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
