### PR TITLE
chore: lock microsoft secureboot certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -310,14 +310,15 @@ COPY --from=pkg-ipxe-amd64 /usr/libexec/snp.efi /amd64/snp.efi
 COPY --from=pkg-ipxe-arm64 /usr/libexec/snp.efi /arm64/snp.efi
 
 FROM scratch AS microsoft-secureboot-database
-ADD https://github.com/microsoft/secureboot_objects.git /
+ARG MICROSOFT_SECUREBOOT_RELEASE
+ADD https://github.com/microsoft/secureboot_objects.git#${MICROSOFT_SECUREBOOT_RELEASE}:PreSignedObjects /
 
 FROM scratch AS microsoft-key-keys
-COPY --from=microsoft-secureboot-database /PreSignedObjects/KEK/Certificates/*.der /kek/
+COPY --from=microsoft-secureboot-database /KEK/Certificates/*.der /kek/
 
 FROM scratch AS microsoft-db-keys
-COPY --from=microsoft-secureboot-database /PreSignedObjects/DB/Certificates/MicCor*.der /db/
-COPY --from=microsoft-secureboot-database /PreSignedObjects/DB/Certificates/microsoft*.der /db/
+COPY --from=microsoft-secureboot-database /DB/Certificates/MicCor*.der /db/
+COPY --from=microsoft-secureboot-database /DB/Certificates/microsoft*.der /db/
 
 FROM --platform=${BUILDPLATFORM} scratch AS generate
 COPY --from=proto-format-build /src/api /api/

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ HELM_VERSION ?= v3.15.2
 CLUSTERCTL_VERSION ?= 1.7.3
 # renovate: datasource=github-releases depName=cilium/cilium-cli
 CILIUM_CLI_VERSION ?= v0.16.11
+# renovate: datasource=github-releases depName=microsoft/secureboot_objects
+MICROSOFT_SECUREBOOT_RELEASE ?= v1.1.3
+
 KUBECTL_URL ?= https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OPERATING_SYSTEM)/amd64/kubectl
 KUBESTR_URL ?= https://github.com/kastenhq/kubestr/releases/download/$(KUBESTR_VERSION)/kubestr_$(subst v,,$(KUBESTR_VERSION))_Linux_amd64.tar.gz
 HELM_URL ?= https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz
@@ -209,6 +212,7 @@ COMMON_ARGS += --build-arg=PKG_KERNEL=$(PKG_KERNEL)
 COMMON_ARGS += --build-arg=PKG_TALOSCTL_CNI_BUNDLE_INSTALL=$(PKG_TALOSCTL_CNI_BUNDLE_INSTALL)
 COMMON_ARGS += --build-arg=ABBREV_TAG=$(ABBREV_TAG)
 COMMON_ARGS += --build-arg=ZSTD_COMPRESSION_LEVEL=$(ZSTD_COMPRESSION_LEVEL)
+COMMON_ARGS += --build-arg=MICROSOFT_SECUREBOOT_RELEASE=$(MICROSOFT_SECUREBOOT_RELEASE)
 
 CI_ARGS ?=
 


### PR DESCRIPTION
Point to the last release to avoid updates on `make generate`.
