### PR TITLE
fix: update containerd configuration and settings

### DIFF
--- a/hack/containerd.toml
+++ b/hack/containerd.toml
@@ -1,7 +1,9 @@
-version = 2
+version = 3
 
 disabled_plugins = [
     "io.containerd.grpc.v1.cri",
+    "io.containerd.cri.v1.images",
+    "io.containerd.cri.v1.runtime",
     "io.containerd.internal.v1.opt",
     "io.containerd.internal.v1.tracing",
     "io.containerd.nri.v1.nri",

--- a/hack/cri-containerd.toml
+++ b/hack/cri-containerd.toml
@@ -1,4 +1,4 @@
-version = 2
+version = 3
 
 disabled_plugins = [
     "io.containerd.nri.v1.nri",

--- a/hack/cri-plugin.part
+++ b/hack/cri-plugin.part
@@ -1,5 +1,4 @@
-version = 2
+version = 3
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-    runtime_type = "io.containerd.runc.v2"
-    discard_unpacked_layers = true
+[plugins."io.containerd.cri.v1.images"]
+  discard_unpacked_layers = true

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -104,7 +104,12 @@ func (c *Containerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		debug,
 		args,
 		runner.WithLoggingManager(r.Logging()),
-		runner.WithEnv(environment.Get(r.Config())),
+		runner.WithEnv(append(
+			environment.Get(r.Config()),
+			// append a default value for XDG_RUNTIME_DIR for the services running on the host
+			// see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+			"XDG_RUNTIME_DIR=/run",
+		)),
 		runner.WithOOMScoreAdj(-999),
 		runner.WithCgroupPath(constants.CgroupSystemRuntime),
 		runner.WithDroppedCapabilities(constants.DefaultDroppedCapabilities),

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -98,7 +98,12 @@ func (c *CRI) Runner(r runtime.Runtime) (runner.Runner, error) {
 		r.Config().Debug(),
 		args,
 		runner.WithLoggingManager(r.Logging()),
-		runner.WithEnv(environment.Get(r.Config())),
+		runner.WithEnv(append(
+			environment.Get(r.Config()),
+			// append a default value for XDG_RUNTIME_DIR for the services running on the host
+			// see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+			"XDG_RUNTIME_DIR=/run",
+		)),
 		runner.WithOOMScoreAdj(-500),
 		runner.WithCgroupPath(constants.CgroupPodRuntime),
 		runner.WithDroppedCapabilities(constants.DefaultDroppedCapabilities),

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -85,6 +85,11 @@ func (c *Udevd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithCgroupPath(constants.CgroupUdevd),
 		runner.WithDroppedCapabilities(constants.UdevdDroppedCapabilities),
+		runner.WithEnv([]string{
+			// append a default value for XDG_RUNTIME_DIR for the services running on the host
+			// see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+			"XDG_RUNTIME_DIR=/run",
+		}),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/pkg/containers/cri/containerd/config.go
+++ b/internal/pkg/containers/cri/containerd/config.go
@@ -30,7 +30,7 @@ type CRIConfig struct {
 
 // PluginsConfig represents the CRI plugins config.
 type PluginsConfig struct {
-	CRI CRIConfig `toml:"io.containerd.grpc.v1.cri"`
+	CRI CRIConfig `toml:"io.containerd.cri.v1.images"`
 }
 
 // Config represnts the containerd config.

--- a/internal/pkg/containers/cri/containerd/testdata/cri.toml
+++ b/internal/pkg/containers/cri/containerd/testdata/cri.toml
@@ -1,11 +1,11 @@
 [plugins]
-  [plugins.'io.containerd.grpc.v1.cri']
-    [plugins.'io.containerd.grpc.v1.cri'.registry]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry]
       config_path = '/etc/cri/conf.d/hosts'
 
-      [plugins.'io.containerd.grpc.v1.cri'.registry.configs]
-        [plugins.'io.containerd.grpc.v1.cri'.registry.configs.'some.host:123']
-          [plugins.'io.containerd.grpc.v1.cri'.registry.configs.'some.host:123'.auth]
+      [plugins.'io.containerd.cri.v1.images'.registry.configs]
+        [plugins.'io.containerd.cri.v1.images'.registry.configs.'some.host:123']
+          [plugins.'io.containerd.cri.v1.images'.registry.configs.'some.host:123'.auth]
             username = 'root'
             password = 'secret'
             auth = 'auth'

--- a/website/content/v1.8/talos-guides/configuration/containerd.md
+++ b/website/content/v1.8/talos-guides/configuration/containerd.md
@@ -45,8 +45,8 @@ machine:
   files:
     - content: |
         [plugins]
-          [plugins."io.containerd.grpc.v1.cri"]
-            sandbox_image = "registry.k8s.io/pause:3.8"
+          [plugins."io.containerd.cri.v1.images".pinned_images]
+            sandbox = "registry.k8s.io/pause:3.8"
       path: /etc/cri/conf.d/20-customization.part
       op: create
 ```

--- a/website/content/v1.8/talos-guides/configuration/nvidia-gpu-proprietary.md
+++ b/website/content/v1.8/talos-guides/configuration/nvidia-gpu-proprietary.md
@@ -117,8 +117,8 @@ Create a patch yaml `nvidia-default-runtimeclass.yaml` to update the machine con
   value:
     - content: |
         [plugins]
-          [plugins."io.containerd.grpc.v1.cri"]
-            [plugins."io.containerd.grpc.v1.cri".containerd]
+          [plugins."io.containerd.cri.v1.runtime"]
+            [plugins."io.containerd.cri.v1.runtime".containerd]
               default_runtime_name = "nvidia"
       path: /etc/cri/conf.d/20-customization.part
       op: create

--- a/website/content/v1.8/talos-guides/configuration/nvidia-gpu.md
+++ b/website/content/v1.8/talos-guides/configuration/nvidia-gpu.md
@@ -116,8 +116,8 @@ Create a patch yaml `nvidia-default-runtimeclass.yaml` to update the machine con
   value:
     - content: |
         [plugins]
-          [plugins."io.containerd.grpc.v1.cri"]
-            [plugins."io.containerd.grpc.v1.cri".containerd]
+          [plugins."plugins."io.containerd.cri.v1.runtime"]
+            [plugins."io.containerd.cri.v1.runtime".containerd]
               default_runtime_name = "nvidia"
       path: /etc/cri/conf.d/20-customization.part
       op: create


### PR DESCRIPTION
Provide `XDG_RUNTIME_DIR` environment variable, this specifically fixes the `kubectl exec` action when `/tmp` is filled up.

Update containerd configuration to version 3 and fix it up.
