### PR TITLE
docs: replace removed Cilium/kubeProxyReplacement value

### DIFF
--- a/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.8/kubernetes-guides/network/deploying-cilium.md
@@ -64,7 +64,7 @@ Install the [Cilium CLI](https://docs.cilium.io/en/v1.13/gettingstarted/k8s-inst
 ```bash
 cilium install \
     --set ipam.mode=kubernetes \
-    --set kubeProxyReplacement=disabled \
+    --set kubeProxyReplacement=false \
     --set securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set cgroup.autoMount.enabled=false \
@@ -111,7 +111,7 @@ helm install \
     --version 1.15.6 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set kubeProxyReplacement=disabled \
+    --set kubeProxyReplacement=false \
     --set securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set cgroup.autoMount.enabled=false \
@@ -149,7 +149,7 @@ helm template \
     --version 1.15.6 \
     --namespace kube-system \
     --set ipam.mode=kubernetes \
-    --set kubeProxyReplacement=disabled \
+    --set kubeProxyReplacement=false \
     --set securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
     --set securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}" \
     --set cgroup.autoMount.enabled=false \


### PR DESCRIPTION
`disabled` was removed in https://github.com/cilium/cilium/pull/31286

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

`kubeProxyReplacement` `disabled` has to be changed to `false`.

## Why? (reasoning)

`disabled` is no longer valid upstream

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
