### PR TITLE
Remove arch-specific etcd image tag

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
@@ -6,7 +6,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	goruntime "runtime"
 
 	"github.com/siderolabs/crypto/x509"
 
@@ -16,14 +15,9 @@ import (
 // Image implements the config.Etcd interface.
 func (e *EtcdConfig) Image() string {
 	image := e.ContainerImage
-	suffix := ""
-
-	if goruntime.GOARCH == "arm64" {
-		suffix = "-arm64"
-	}
 
 	if image == "" {
-		image = fmt.Sprintf("%s:%s%s", constants.EtcdImage, constants.DefaultEtcdVersion, suffix)
+		image = fmt.Sprintf("%s:%s", constants.EtcdImage, constants.DefaultEtcdVersion)
 	}
 
 	return image


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Remove the architecture-specific tag usage for the etcd image.

## Why? (reasoning)

The main etcd image is now multi-arch. The linux/arm64 variant of v3.5.13 and v3.5.13-arm64 resolve to the same image, so this shouldn't have any actual affect on etcd in arm64 environments. Cleaning up the special case resolves some weirdness with e.g. `talosctl images default` to producing output that depends on your local arch as opposed to the arch of your target servers.

## Acceptance

Please use the following checklist:

N/A
