### PR TITLE
fix talos version in vmware.sh for 1.7.6

### DIFF
--- a/website/content/v1.7/_index.md
+++ b/website/content/v1.7/_index.md
@@ -5,8 +5,8 @@ linkTitle: "Documentation"
 images: ["images/talos-dev-banner.png"]
 cascade:
   type: docs
-lastRelease: v1.7.0
-kubernetesRelease: "1.30.0"
+lastRelease: v1.7.6
+kubernetesRelease: "1.30.3"
 prevKubernetesRelease: "1.29.3"
 nvidiaContainerToolkitRelease: "v1.14.5"
 nvidiaDriverRelease: "535.129.03"

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware.md
@@ -93,8 +93,10 @@ If you wish to carry out the manual approach, simply skip ahead to the "Manual A
 ### Scripted Install
 
 Download the `vmware.sh` script to your local machine.
-You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/vmware.sh"`.
+You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/vmware.sh" | sed s/latest/{{< release >}}/`.
 This script has default variables for things like Talos version and cluster name that may be interesting to tweak before deploying.
+
+The script downloads VMWare OVA with `talos-vmtoolsd` from [Image Factory](https://factory.talos.dev/?arch=amd64&cmdline-set=true&extensions=-&extensions=siderolabs%2Fvmtoolsd-guest-agent&platform=vmware&target=cloud&version={{< release >}}) extension pre-installed.
 
 #### Import OVA
 

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
@@ -6,7 +6,3 @@
       dhcp: true
       vip:
         ip: <VIP>
-- op: replace
-  path: /cluster/extraManifests
-  value:
-    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/vmware.sh
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/vmware/vmware.sh
@@ -13,7 +13,7 @@ set -e
 # export GOVC_NETWORK='PortGroup Name'
 
 CLUSTER_NAME=${CLUSTER_NAME:=vmware-test}
-TALOS_VERSION=v1.1.0
+TALOS_VERSION=${TALOS_VERSION:=latest}
 OVA_PATH=${OVA_PATH:="https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/vmware-amd64.ova"}
 
 CONTROL_PLANE_COUNT=${CONTROL_PLANE_COUNT:=3}

--- a/website/content/v1.8/_index.md
+++ b/website/content/v1.8/_index.md
@@ -5,7 +5,7 @@ linkTitle: "Documentation"
 images: ["images/talos-dev-banner.png"]
 cascade:
   type: docs
-lastRelease: v1.8.0-alpha.0
+lastRelease: v1.8.0-alpha.1
 kubernetesRelease: "1.31.0-rc.1"
 prevKubernetesRelease: "1.30.0"
 nvidiaContainerToolkitRelease: "v1.14.5"

--- a/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware.md
@@ -36,10 +36,6 @@ It's contents should look like the following:
       dhcp: true
       vip:
         ip: <VIP>
-- op: replace
-  path: /cluster/extraManifests
-  value:
-    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"
 ```
 
 With the patch in hand, generate machine configs with:
@@ -93,8 +89,10 @@ If you wish to carry out the manual approach, simply skip ahead to the "Manual A
 ### Scripted Install
 
 Download the `vmware.sh` script to your local machine.
-You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/vmware.sh"`.
+You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/vmware.sh" | sed s/latest/{{< release >}}/`.
 This script has default variables for things like Talos version and cluster name that may be interesting to tweak before deploying.
+
+The script downloads VMWare OVA with `talos-vmtoolsd` from [Image Factory](https://factory.talos.dev/?arch=amd64&cmdline-set=true&extensions=-&extensions=siderolabs%2Fvmtoolsd-guest-agent&platform=vmware&target=cloud&version={{< release >}}) extension pre-installed.
 
 #### Import OVA
 

--- a/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
+++ b/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml
@@ -6,7 +6,3 @@
       dhcp: true
       vip:
         ip: <VIP>
-- op: replace
-  path: /cluster/extraManifests
-  value:
-    - "https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml"

--- a/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware/vmware.sh
+++ b/website/content/v1.8/talos-guides/install/virtualized-platforms/vmware/vmware.sh
@@ -13,8 +13,8 @@ set -e
 # export GOVC_NETWORK='PortGroup Name'
 
 CLUSTER_NAME=${CLUSTER_NAME:=vmware-test}
-TALOS_VERSION=v1.1.0
-OVA_PATH=${OVA_PATH:="https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/vmware-amd64.ova"}
+TALOS_VERSION=${TALOS_VERSION:=latest}
+OVA_PATH=${OVA_PATH:="https://factory.talos.dev/image/903b2da78f99adef03cbbd4df6714563823f63218508800751560d3bc3557e40/${TALOS_VERSION}/vmware-amd64.ova"}
 
 CONTROL_PLANE_COUNT=${CONTROL_PLANE_COUNT:=3}
 CONTROL_PLANE_CPU=${CONTROL_PLANE_CPU:=2}


### PR DESCRIPTION


## What? (description)
fix talos version in vmware.sh for 1.7.6

## Why? (reasoning)

using the script from the v1.7 repo/website version, it uploads an OVA of talos 1.1, which won't work

