### PR TITLE
Fix default openEBS StorageClass base path in docs to match the default in openEBS docs

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
@@ -28,9 +28,9 @@ machine:
     openebs.io/engine: mayastor
   kubelet:
     extraMounts:
-      - destination: /var/local/openebs
+      - destination: /var/openebs/local
         type: bind
-        source: /var/local/openebs
+        source: /var/openebs/local
         options:
           - rbind
           - rshared


### PR DESCRIPTION
# Pull Request
## What? (description)
Updates the default path used in the Talos docs to point to the [default base path in the openEBS docs.](https://openebs.io/docs/user-guides/local-storage-user-guide/local-pv-hostpath/hostpath-configuration#create-storageclass)

## Why? (reasoning)
Defaults should be used whenever possible, also addresses requested change here https://github.com/siderolabs/talos/pull/9079#pullrequestreview-2220183221

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
