### PR TITLE
chore: fix release notes

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -4,6 +4,7 @@ commit = "HEAD"
 project_name = "Talos"
 github_repo = "siderolabs/talos"
 match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
+ignore_deps = ["github.com/coredns/coredns"]
 
 # previous release
 previous = "v1.7.0"


### PR DESCRIPTION
The github.com/coredns/coredns dropped the tag v1.11.2 for the previous version we were using, so `release-tool` can't generate the release notes.
