### PR TITLE
feat: provide device extra settle timeout

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -174,6 +174,12 @@ Talos Linux now bundles by default the following standard CNI plugins:
 The Talos bundled Flannel manifest was simplified to remove the `install-cni` step.
 """
 
+    [notes.udevd]
+        title = "Device Extra Settle Timeout"
+        description = """\
+Talos Linux now supports a kernel command line argument `talos.device.settle_time=3m` to set the device extra settle timeout to workaround issues with broken drivers.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -67,6 +67,10 @@ const (
 	// disk to wipe on the next boot and reboot.
 	KernelParamWipe = "talos.experimental.wipe"
 
+	// KernelParamDeviceSettleTime is the kernel parameter name for specifying the
+	// extra device settle timeout.
+	KernelParamDeviceSettleTime = "talos.device.settle_time"
+
 	// KernelParamCGroups is the kernel parameter name for specifying the
 	// cgroups version to use (default is cgroupsv2, setting this kernel arg to '0' forces cgroupsv1).
 	KernelParamCGroups = "talos.unified_cgroup_hierarchy"

--- a/website/content/v1.8/reference/kernel.md
+++ b/website/content/v1.8/reference/kernel.md
@@ -245,3 +245,17 @@ Example:
 ```text
 talos.environment=http_proxy=http://proxy.example.com:8080 talos.environment=https_proxy=http://proxy.example.com:8080
 ```
+
+#### `talos.device.settle_time`
+
+The time in Go duration format to wait for devices to settle before starting the boot process.
+By default, Talos waits for `udevd` to scan and settle, but with some RAID controllers `udevd` might
+report settled devices before they are actually ready.
+Adding this kernel argument provides extra settle time on top of `udevd` settle time.
+The maximum value is `10m` (10 minutes).
+
+Example:
+
+```text
+talos.device.settle_time=3m
+```


### PR DESCRIPTION
Fixes #9092

This is a workaround for broken hardware drivers (e.g. RAID controllers), which report settled event too early.
