### PR TITLE
docs: fix incorrect path for openebs in documentation

### DIFF
--- a/website/content/v1.7/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva.md
+++ b/website/content/v1.7/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva.md
@@ -26,9 +26,9 @@ Create a machine config patch with the contents below and save as `patch.yaml`
 machine:
   kubelet:
     extraMounts:
-      - destination: /var/local/openebs
+      - destination: /var/openebs/local
         type: bind
-        source: /var/local/openebs
+        source: /var/openebs/local
         options:
           - bind
           - rshared


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Fixes an incorrect path in the current documentation that prevents OpenEBS from working.  The documentation for 1.8 has the correct path, but whoever fixed it for that didn't make the change in the current stable docs.

## Why? (reasoning)
So that the documentation results in a system that works.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
