### PR TITLE
chore: support debug shell for advanced development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ CI_RELEASE_TAG := $(shell git log --oneline --format=%B -n 1 HEAD^2 -- 2>/dev/nu
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/siderolabs/tools:v1.9.0-alpha.0-4-g2058296
 
+DEBUG_TOOLS_SOURCE := scratch
+
 PKGS_PREFIX ?= ghcr.io/siderolabs
 PKGS ?= v1.9.0-alpha.0-24-gbe92da0
 EXTRAS ?= v1.9.0-alpha.0-1-geab6e58
@@ -147,6 +149,11 @@ else
 GO_LDFLAGS += -s -w
 endif
 
+ifneq (, $(filter $(WITH_DEBUG_SHELL), t true TRUE y yes 1))
+# bash-minimal is a Dockerfile target that copies over the bash from siderolabs tools
+DEBUG_TOOLS_SOURCE := bash-minimal
+endif
+
 GO_BUILDFLAGS_TALOSCTL := $(GO_BUILDFLAGS) -tags "$(GO_BUILDTAGS_TALOSCTL)"
 GO_BUILDFLAGS += -tags "$(GO_BUILDTAGS)"
 
@@ -161,6 +168,7 @@ COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
+COMMON_ARGS += --build-arg=DEBUG_TOOLS_SOURCE=$(DEBUG_TOOLS_SOURCE)
 COMMON_ARGS += --build-arg=PKGS=$(PKGS)
 COMMON_ARGS += --build-arg=EXTRAS=$(EXTRAS)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)

--- a/internal/pkg/mount/switchroot/switchroot.go
+++ b/internal/pkg/mount/switchroot/switchroot.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/siderolabs/go-debug"
+	"github.com/siderolabs/go-procfs/procfs"
 	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/pkg/mount"
@@ -28,6 +29,8 @@ var preservedPaths = map[string]struct{}{
 
 // Switch moves the rootfs to a specified directory. See
 // https://github.com/karelzak/util-linux/blob/master/sys-utils/switch_root.c.
+//
+//nolint:gocyclo
 func Switch(prefix string, mountpoints *mount.Points) (err error) {
 	log.Println("moving mounts to the new rootfs")
 
@@ -86,6 +89,14 @@ func Switch(prefix string, mountpoints *mount.Points) (err error) {
 		envv = append(envv, "GORACE=halt_on_error=1")
 
 		log.Printf("race detection enabled with halt_on_error=1")
+	}
+
+	if val := procfs.ProcCmdline().Get("talos.debugshell"); val != nil {
+		if err = unix.Exec("/bin/bash", []string{"/bin/bash"}, envv); err != nil {
+			return fmt.Errorf("error executing /bin/bash: %w", err)
+		}
+
+		return nil
 	}
 
 	if err = unix.Exec("/sbin/init", []string{"/sbin/init"}, envv); err != nil {

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -79,6 +79,15 @@ func WithTPM2(enabled bool) Option {
 	}
 }
 
+// WithDebugShell drops into debug shell in initramfs.
+func WithDebugShell(enabled bool) Option {
+	return func(o *Options) error {
+		o.WithDebugShell = enabled
+
+		return nil
+	}
+}
+
 // WithExtraUEFISearchPaths configures additional search paths to look for UEFI firmware.
 func WithExtraUEFISearchPaths(extraUEFISearchPaths []string) Option {
 	return func(o *Options) error {
@@ -166,6 +175,8 @@ type Options struct {
 	UEFIEnabled bool
 	// Enable TPM2 emulation using swtpm.
 	TPM2Enabled bool
+	// Enable debug shell in the bootloader.
+	WithDebugShell bool
 	// Configure additional search paths to look for UEFI firmware.
 	ExtraUEFISearchPaths []string
 

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -56,6 +56,7 @@ type LaunchConfig struct {
 	NodeUUID          uuid.UUID
 	BadRTC            bool
 	ArchitectureData  Arch
+	WithDebugShell    bool
 
 	// Talos config
 	Config string
@@ -318,6 +319,14 @@ func launchVM(config *LaunchConfig) error {
 		"-device", "i6300esb,id=watchdog0",
 		"-watchdog-action",
 		"pause",
+	}
+
+	if config.WithDebugShell {
+		args = append(
+			args,
+			"-serial",
+			fmt.Sprintf("unix:%s/%s.serial,server,nowait", config.StatePath, config.Hostname),
+		)
 	}
 
 	var (

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -89,6 +89,10 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		}
 	}
 
+	if opts.WithDebugShell {
+		cmdline.Append("talos.debugshell", "")
+	}
+
 	var nodeConfig string
 
 	if !nodeReq.SkipInjectingConfig {
@@ -157,6 +161,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		TFTPServer:        nodeReq.TFTPServer,
 		IPXEBootFileName:  nodeReq.IPXEBootFilename,
 		APIPort:           apiPort,
+		WithDebugShell:    opts.WithDebugShell,
 	}
 
 	if clusterReq.IPXEBootScript != "" {

--- a/website/content/v1.9/advanced/developing-talos.md
+++ b/website/content/v1.9/advanced/developing-talos.md
@@ -177,6 +177,10 @@ Specfic tests can be run with `-test.run=TestIntegration/api.ResetSuite`.
 
 `make <something> WITH_DEBUG=1` enables Go profiling and other debug features, useful for local development.
 
+`make initramfs WITH_DEBUG_SHELL=true` adds bash and minimal utilities for debugging purposes.
+Combine with `--with-debug-shell` flag when creating cluster to obtain shell access.
+This is uncommonly used as in this case the bash shell will run in place of machined.
+
 ## Destroying Cluster
 
 ```bash


### PR DESCRIPTION
Support dropping into a very minimal debug shell.

```bash
sudo -E --preserve-env=HOME _out/talosctl-linux-amd64 cluster create --provisioner=qemu $REGISTRY_MIRROR_FLAGS --controlplanes=1 --workers=0 --with-bootloader=false --with-debug-shell
```