### PR TITLE
chore: make qemu check flag consistent with code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -997,7 +997,7 @@ jobs:
           WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}]'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-cilium-strict
@@ -1009,7 +1009,7 @@ jobs:
           WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-cilium-strict-kubespan
@@ -1022,7 +1022,7 @@ jobs:
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_KUBESPAN: "true"
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -82,7 +82,7 @@ jobs:
           WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}]'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-cilium-strict
@@ -94,7 +94,7 @@ jobs:
           WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-cilium-strict-kubespan
@@ -107,7 +107,7 @@ jobs:
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_KUBESPAN: "true"
-          WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: "yes"
+          WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1016,7 +1016,7 @@ spec:
           withSudo: true
           environment:
             SHORT_INTEGRATION_TEST: yes
-            WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: yes
+            WITH_SKIP_K8S_NODE_READINESS_CHECK: yes
             WITH_CUSTOM_CNI: cilium
             WITH_FIREWALL: accept
             QEMU_WORKERS: 2
@@ -1027,7 +1027,7 @@ spec:
           withSudo: true
           environment:
             SHORT_INTEGRATION_TEST: yes
-            WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: yes
+            WITH_SKIP_K8S_NODE_READINESS_CHECK: yes
             WITH_CUSTOM_CNI: cilium
             WITH_FIREWALL: accept
             QEMU_WORKERS: 2
@@ -1039,7 +1039,7 @@ spec:
           withSudo: true
           environment:
             SHORT_INTEGRATION_TEST: yes
-            WITH_SKIP_BOOT_PHASE_FINISHED_CHECK: yes
+            WITH_SKIP_K8S_NODE_READINESS_CHECK: yes
             WITH_CUSTOM_CNI: cilium
             WITH_FIREWALL: accept
             WITH_KUBESPAN: true

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -128,11 +128,11 @@ case "${WITH_CONFIG_PATCH_WORKER:-false}" in
     ;;
 esac
 
-case "${WITH_SKIP_BOOT_PHASE_FINISHED_CHECK:-false}" in
+case "${WITH_SKIP_K8S_NODE_READINESS_CHECK:-false}" in
   false)
     ;;
   *)
-    QEMU_FLAGS+=("--skip-boot-phase-finished-check")
+    QEMU_FLAGS+=("--skip-k8s-node-readiness-check")
     ;;
 esac
 

--- a/website/content/v1.8/reference/cli.md
+++ b/website/content/v1.8/reference/cli.md
@@ -144,8 +144,8 @@ talosctl cluster create [flags]
       --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT (QEMU provisioner only)
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
-      --skip-boot-phase-finished-check           skip waiting for node to finish boot phase
       --skip-injecting-config                    skip injecting config from embedded metadata server, write config files to current directory
+      --skip-k8s-node-readiness-check            skip k8s node readiness checks
       --skip-kubeconfig                          skip merging kubeconfig from the created cluster
       --talos-version string                     the desired Talos version to generate config for (if not set, defaults to image version)
       --talosconfig string                       The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.


### PR DESCRIPTION
Restructure code as per changes from #9198.

This makes the flag name to be in sync with what it actually does.