### PR TITLE
chore: update protoc-gen-doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,8 +182,12 @@ RUN --mount=type=cache,target=/.cache go install github.com/siderolabs/importvet
     && mv /go/bin/importvet /toolchain/go/bin/importvet
 RUN --mount=type=cache,target=/.cache go install golang.org/x/vuln/cmd/govulncheck@latest \
     && mv /go/bin/govulncheck /toolchain/go/bin/govulncheck
-RUN --mount=type=cache,target=/.cache go install github.com/uber/prototool/cmd/prototool@v1.10.0 \
+ARG PROTOTOOL_VERSION
+RUN --mount=type=cache,target=/.cache go install github.com/uber/prototool/cmd/prototool@${PROTOTOOL_VERSION} \
     && mv /go/bin/prototool /toolchain/go/bin/prototool
+ARG PROTOC_GEN_DOC_VERSION
+RUN --mount=type=cache,target=/.cache go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@${PROTOC_GEN_DOC_VERSION} \
+    && mv /go/bin/protoc-gen-doc /toolchain/go/bin/protoc-gen-doc
 COPY ./hack/docgen /go/src/github.com/siderolabs/talos-hack-docgen
 RUN --mount=type=cache,target=/.cache cd /go/src/github.com/siderolabs/talos-hack-docgen \
     && go build -o docgen . \
@@ -1054,7 +1058,7 @@ RUN env HOME=/home/user TAG=latest /bin/talosctl docs --config /tmp/configuratio
     && env HOME=/home/user TAG=latest /bin/talosctl docs --cli /tmp
 COPY ./pkg/machinery/config/schemas/*.schema.json /tmp/schemas/
 
-FROM pseudomuto/protoc-gen-doc AS proto-docs-build
+FROM tools AS proto-docs-build
 COPY --from=generate-build /api /protos
 COPY ./hack/protoc-gen-doc/markdown.tmpl /tmp/markdown.tmpl
 RUN protoc \

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ VTPROTOBUF_VERSION ?= v0.6.0
 DEEPCOPY_VERSION ?= v0.5.6
 # renovate: datasource=go depName=github.com/siderolabs/importvet
 IMPORTVET_VERSION ?= v0.2.0
+# not setting renovate config since the repo is archived
+PROTOTOOL_VERSION ?= v1.10.0
+# renovate: datasource=go depName=github.com/pseudomuto/protoc-gen-doc
+PROTOC_GEN_DOC_VERSION ?= v1.5.1
 # renovate: datasource=npm depName=markdownlint-cli
 MARKDOWNLINTCLI_VERSION ?= 0.40.0
 # renovate: datasource=npm depName=textlint
@@ -161,6 +165,8 @@ COMMON_ARGS += --build-arg=ENUMER_VERSION=$(ENUMER_VERSION)
 COMMON_ARGS += --build-arg=DEEPCOPY_GEN_VERSION=$(DEEPCOPY_GEN_VERSION)
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION=$(VTPROTOBUF_VERSION)
 COMMON_ARGS += --build-arg=IMPORTVET_VERSION=$(IMPORTVET_VERSION)
+COMMON_ARGS += --build-arg=PROTOTOOL_VERSION=$(PROTOTOOL_VERSION)
+COMMON_ARGS += --build-arg=PROTOC_GEN_DOC_VERSION=$(PROTOC_GEN_DOC_VERSION)
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION=$(GOLANGCILINT_VERSION)
 COMMON_ARGS += --build-arg=DEEPCOPY_VERSION=$(DEEPCOPY_VERSION)
 COMMON_ARGS += --build-arg=MARKDOWNLINTCLI_VERSION=$(MARKDOWNLINTCLI_VERSION)


### PR DESCRIPTION
`protoc-gen-doc` was using `pseudomuto/protoc-gen-doc` image which was running go 1.17. Update to use `go install` from source like other tools.