### PR TITLE
chore: move csi tests as go test

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,15 @@
         },
         {
             "fileMatch": [
+                "internal/integration/k8s/constants.go"
+            ],
+            "matchStrings": [
+                "\\/\\/\\s+renovate: datasource=(?<datasource>.*?)(?:\\s+extractVersion=(?<extractVersion>.+?))?(?:\\s+versioning=(?<versioning>.+?))?\\s+depName=(?<depName>.+?)?(?:\\s+registryUrl=(?<registryUrl>.+?))?\\s.*Version\\s+=\\s+\\\"(?<currentValue>.+?)\\\""
+            ],
+            "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+        },
+        {
+            "fileMatch": [
                 "Dockerfile"
             ],
             "matchStrings": [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-14T14:49:10Z by kres 7be2a05.
+# Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
 name: default
 concurrency:
@@ -994,7 +994,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-no-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
@@ -1006,7 +1006,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
@@ -1018,7 +1018,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_KUBESPAN: "true"
@@ -1428,7 +1428,7 @@ jobs:
           QEMU_EXTRA_DISKS: "3"
           QEMU_MEMORY_WORKERS: "4096"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH_WORKER: '@_out/extensions-patch.yaml'
+          WITH_CONFIG_PATCH_WORKER: '@_out/installer-extensions-patch.yaml:@hack/test/patches/extensions.yaml'
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
@@ -1989,7 +1989,7 @@ jobs:
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/machine/install/extraKernelArgs/-", "value": "talos.unified_cgroup_hierarchy=0"}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cgroupsv1.yaml'
           WITH_UEFI: "false"
         run: |
           sudo -E make e2e-qemu
@@ -2562,7 +2562,7 @@ jobs:
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
-  integration-qemu-csi:
+  integration-qemu-csi-longhorn:
     permissions:
       actions: read
       contents: write
@@ -2572,7 +2572,7 @@ jobs:
     runs-on:
       - self-hosted
       - talos
-    if: contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-csi')
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-csi') || contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-csi-longhorn')
     needs:
       - default
     steps:
@@ -2635,8 +2635,122 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: e2e-qemu-csi
+      - name: checkout extensions
+        uses: actions/checkout@v4
+        with:
+          path: _out/extensions
+          ref: main
+          repository: siderolabs/extensions
+      - name: set variables
+        run: |
+          cat _out/talos-metadata >> "$GITHUB_ENV"
+      - name: build extensions
         env:
+          PLATFORM: linux/amd64
+          PUSH: "true"
+          REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make iscsi-tools util-linux-tools extensions-metadata -C _out/extensions
+      - name: installer extensions
+        env:
+          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools'
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make installer-with-extensions
+      - name: e2e-qemu-csi-longhorn
+        env:
+          EXTRA_TEST_ARGS: -talos.csi=longhorn
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          QEMU_WORKERS: "3"
+          SHORT_INTEGRATION_TEST: "yes"
+          WITH_CONFIG_PATCH: '@_out/installer-extensions-patch.yaml:@hack/test/patches/longhorn.yaml'
+        run: |
+          sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-integration-qemu-csi-longhorn
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
+  integration-qemu-csi-rook-ceph:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      - self-hosted
+      - talos
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-csi') || contains(fromJSON(needs.default.outputs.labels), 'integration/qemu-csi-rook-ceph')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.3.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Download artifacts
+        if: github.event_name != 'schedule'
+        uses: actions/download-artifact@v4
+        with:
+          name: talos-artifacts
+          path: _out
+      - name: Fix artifact permissions
+        if: github.event_name != 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: build
+        if: github.event_name == 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64
+          PUSH: "true"
+        run: |
+          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
+      - name: talosctl-cni-bundle
+        if: github.event_name == 'schedule'
+        run: |
+          make talosctl-cni-bundle
+      - name: e2e-qemu-csi-rook-ceph
+        env:
+          EXTRA_TEST_ARGS: -talos.csi=rook-ceph
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_CPUS_WORKERS: "4"
           QEMU_EXTRA_DISKS: "1"
@@ -2644,14 +2758,14 @@ jobs:
           QEMU_MEMORY_WORKERS: "5120"
           QEMU_WORKERS: "3"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_TEST: run_csi_tests
+          WITH_CONFIG_PATCH: '@hack/test/patches/rook-ceph.yaml'
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: talos-logs-integration-qemu-csi
+          name: talos-logs-integration-qemu-csi-rook-ceph
           path: |-
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
+# Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
 name: integration-cilium-cron
 concurrency:
@@ -79,7 +79,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-no-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
@@ -91,7 +91,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_SKIP_K8S_NODE_READINESS_CHECK: "yes"
@@ -103,7 +103,7 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "2"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cilium-kubeproxy.yaml'
           WITH_CUSTOM_CNI: cilium
           WITH_FIREWALL: accept
           WITH_KUBESPAN: "true"

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
+# Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
 name: integration-misc-2-cron
 concurrency:
@@ -91,7 +91,7 @@ jobs:
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH: '[{"op": "add", "path": "/machine/install/extraKernelArgs/-", "value": "talos.unified_cgroup_hierarchy=0"}]'
+          WITH_CONFIG_PATCH: '@hack/test/patches/cgroupsv1.yaml'
           WITH_UEFI: "false"
         run: |
           sudo -E make e2e-qemu

--- a/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
@@ -1,8 +1,8 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
+# Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
-name: integration-qemu-csi-cron
+name: integration-qemu-csi-longhorn-cron
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -74,23 +74,42 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: e2e-qemu-csi
+      - name: checkout extensions
+        uses: actions/checkout@v4
+        with:
+          path: _out/extensions
+          ref: main
+          repository: siderolabs/extensions
+      - name: set variables
+        run: |
+          cat _out/talos-metadata >> "$GITHUB_ENV"
+      - name: build extensions
         env:
+          PLATFORM: linux/amd64
+          PUSH: "true"
+          REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make iscsi-tools util-linux-tools extensions-metadata -C _out/extensions
+      - name: installer extensions
+        env:
+          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools'
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          QEMU_CPUS_WORKERS: "4"
-          QEMU_EXTRA_DISKS: "1"
-          QEMU_EXTRA_DISKS_SIZE: "12288"
-          QEMU_MEMORY_WORKERS: "5120"
+        run: |
+          make installer-with-extensions
+      - name: e2e-qemu-csi-longhorn
+        env:
+          EXTRA_TEST_ARGS: -talos.csi=longhorn
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_WORKERS: "3"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_TEST: run_csi_tests
+          WITH_CONFIG_PATCH: '@_out/installer-extensions-patch.yaml:@hack/test/patches/longhorn.yaml'
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: talos-logs-integration-qemu-csi
+          name: talos-logs-integration-qemu-csi-longhorn
           path: |-
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log

--- a/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
@@ -2,13 +2,13 @@
 #
 # Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
-name: integration-extensions-cron
+name: integration-qemu-csi-rook-ceph-cron
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 6 * * *
+    - cron: 30 3 * * *
 jobs:
   default:
     runs-on:
@@ -62,10 +62,6 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
       - name: build
         if: github.event_name == 'schedule'
         env:
@@ -78,45 +74,24 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
-      - name: checkout extensions
-        uses: actions/checkout@v4
-        with:
-          path: _out/extensions
-          ref: main
-          repository: siderolabs/extensions
-      - name: unshallow-extensions
-        run: |
-          git -C _out/extensions fetch --prune --unshallow
-      - name: set variables
-        run: |
-          cat _out/talos-metadata >> "$GITHUB_ENV"
-      - name: build extensions
+      - name: e2e-qemu-csi-rook-ceph
         env:
-          PLATFORM: linux/amd64
-          PUSH: "true"
-          REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make all extensions-metadata -C _out/extensions
-      - name: installer extensions
-        env:
+          EXTRA_TEST_ARGS: -talos.csi=rook-ceph
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make installer-with-extensions
-      - name: e2e-extensions
-        env:
-          EXTRA_TEST_ARGS: -talos.extensions.qemu
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          QEMU_EXTRA_DISKS: "3"
-          QEMU_MEMORY_WORKERS: "4096"
+          QEMU_CPUS_WORKERS: "4"
+          QEMU_EXTRA_DISKS: "1"
+          QEMU_EXTRA_DISKS_SIZE: "12288"
+          QEMU_MEMORY_WORKERS: "5120"
+          QEMU_WORKERS: "3"
           SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH_WORKER: '@_out/installer-extensions-patch.yaml:@hack/test/patches/extensions.yaml'
+          WITH_CONFIG_PATCH: '@hack/test/patches/rook-ceph.yaml'
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: talos-logs-integration-extensions
+          name: talos-logs-integration-qemu-csi-rook-ceph
           path: |-
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-11T15:17:44Z by kres 7360563.
+# Generated on 2024-08-24T17:38:15Z by kres 8e4bbb4.
 
 name: slack-notify
 "on":
@@ -22,7 +22,8 @@ name: slack-notify
       - integration-cilium-cron
       - integration-qemu-encrypted-vip-cron
       - integration-qemu-race-cron
-      - integration-qemu-csi-cron
+      - integration-qemu-csi-rook-ceph-cron
+      - integration-qemu-csi-longhorn-cron
       - integration-images-cron
       - integration-reproducibility-test-cron
       - integration-cloud-images-cron

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -67,7 +67,8 @@ spec:
     - integration-conformance
     - integration-qemu-encrypted-vip
     - integration-qemu-race
-    - integration-qemu-csi
+    - integration-qemu-csi-rook-ceph
+    - integration-qemu-csi-longhorn
     - integration-images
     - integration-reproducibility-test
     - integration-cloud-images
@@ -767,7 +768,7 @@ spec:
           environment:
             SHORT_INTEGRATION_TEST: yes
             WITH_UEFI: false
-            WITH_CONFIG_PATCH: '[{"op": "add", "path": "/machine/install/extraKernelArgs/-", "value": "talos.unified_cgroup_hierarchy=0"}]' #use cgroupsv1
+            WITH_CONFIG_PATCH: "@hack/test/patches/cgroupsv1.yaml" #use cgroupsv1
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-disk-image
           command: e2e-qemu
@@ -965,7 +966,7 @@ spec:
           withSudo: true
           environment:
             QEMU_MEMORY_WORKERS: 4096
-            WITH_CONFIG_PATCH_WORKER: "@_out/extensions-patch.yaml"
+            WITH_CONFIG_PATCH_WORKER: "@_out/installer-extensions-patch.yaml:@hack/test/patches/extensions.yaml"
             QEMU_EXTRA_DISKS: 3
             SHORT_INTEGRATION_TEST: yes
             EXTRA_TEST_ARGS: -talos.extensions.qemu
@@ -1020,7 +1021,7 @@ spec:
             WITH_CUSTOM_CNI: cilium
             WITH_FIREWALL: accept
             QEMU_WORKERS: 2
-            WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}]'
+            WITH_CONFIG_PATCH: "@hack/test/patches/cilium-no-kubeproxy.yaml"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-cilium-strict
           command: e2e-qemu
@@ -1032,7 +1033,7 @@ spec:
             WITH_FIREWALL: accept
             QEMU_WORKERS: 2
             CILIUM_INSTALL_TYPE: strict
-            WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+            WITH_CONFIG_PATCH: "@hack/test/patches/cilium-kubeproxy.yaml"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-cilium-strict-kubespan
           command: e2e-qemu
@@ -1045,7 +1046,7 @@ spec:
             WITH_KUBESPAN: true
             QEMU_WORKERS: 2
             CILIUM_INSTALL_TYPE: strict
-            WITH_CONFIG_PATCH: '[{"op": "add", "path": "/cluster/network", "value": {"cni": {"name": "none"}}}, {"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]'
+            WITH_CONFIG_PATCH: "@hack/test/patches/cilium-kubeproxy.yaml"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: save-talos-logs
           conditions:
@@ -1160,7 +1161,7 @@ spec:
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
               - "!~/.talos/clusters/**/swtpm.log"
-    - name: integration-qemu-csi
+    - name: integration-qemu-csi-rook-ceph
       buildxOptions:
         enabled: true
       depends:
@@ -1172,6 +1173,7 @@ spec:
         - '30 3 * * *'
       triggerLabels:
         - integration/qemu-csi
+        - integration/qemu-csi-rook-ceph
       steps:
         - name: download-artifacts
           conditions:
@@ -1191,7 +1193,7 @@ spec:
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
-        - name: e2e-qemu-csi
+        - name: e2e-qemu-csi-rook-ceph
           command: e2e-qemu
           withSudo: true
           environment:
@@ -1201,14 +1203,88 @@ spec:
             QEMU_MEMORY_WORKERS: 5120
             QEMU_EXTRA_DISKS: 1
             QEMU_EXTRA_DISKS_SIZE: 12288
-            WITH_TEST: run_csi_tests
+            WITH_CONFIG_PATCH: "@hack/test/patches/rook-ceph.yaml"
+            EXTRA_TEST_ARGS: -talos.csi=rook-ceph
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: save-talos-logs
           conditions:
             - always
           artifactStep:
             type: upload
-            artifactName: talos-logs-integration-qemu-csi
+            artifactName: talos-logs-integration-qemu-csi-rook-ceph
+            disableExecutableListGeneration: true
+            artifactPath: ~/.talos/clusters/**/*.log
+            additionalArtifacts:
+              - "!~/.talos/clusters/**/swtpm.log"
+    - name: integration-qemu-csi-longhorn
+      buildxOptions:
+        enabled: true
+      depends:
+        - default
+      runners:
+        - self-hosted
+        - talos
+      crons:
+        - '30 3 * * *'
+      triggerLabels:
+        - integration/qemu-csi
+        - integration/qemu-csi-longhorn
+      steps:
+        - name: download-artifacts
+          conditions:
+            - not-on-schedule
+          artifactStep:
+            type: download
+            artifactName: talos-artifacts
+            artifactPath: _out
+        - name: build
+          conditions:
+            - only-on-schedule
+          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer imager talos _out/integration-test-linux-amd64
+          environment:
+            PLATFORM: linux/amd64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+            PUSH: true
+        - name: talosctl-cni-bundle
+          conditions:
+            - only-on-schedule
+        - name: checkout extensions
+          checkoutStep:
+            repository: siderolabs/extensions
+            ref: main
+            path: _out/extensions
+        - name: set variables
+          nonMakeStep: true
+          command: cat _out/talos-metadata >> "$GITHUB_ENV"
+        - name: build extensions
+          command: iscsi-tools util-linux-tools extensions-metadata
+          arguments:
+            - -C
+            - _out/extensions
+          environment:
+            PLATFORM: linux/amd64
+            PUSH: true
+            REGISTRY: registry.dev.siderolabs.io
+        - name: installer extensions
+          command: installer-with-extensions
+          environment:
+            EXTENSIONS_FILTER_COMMAND: "grep -E 'iscsi-tools|util-linux-tools'"
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: e2e-qemu-csi-longhorn
+          command: e2e-qemu
+          withSudo: true
+          environment:
+            SHORT_INTEGRATION_TEST: yes
+            QEMU_WORKERS: 3
+            WITH_CONFIG_PATCH: "@_out/installer-extensions-patch.yaml:@hack/test/patches/longhorn.yaml"
+            EXTRA_TEST_ARGS: -talos.csi=longhorn
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-talos-logs
+          conditions:
+            - always
+          artifactStep:
+            type: upload
+            artifactName: talos-logs-integration-qemu-csi-longhorn
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -116,7 +116,11 @@ case "${WITH_CONFIG_PATCH:-false}" in
   false)
     ;;
   *)
-    QEMU_FLAGS+=("--config-patch=${WITH_CONFIG_PATCH}")
+    [[ ! ${WITH_CONFIG_PATCH} =~ ^@ ]] && echo "WITH_CONFIG_PATCH variable should start with @" && exit 1
+
+    for i in ${WITH_CONFIG_PATCH//:/ }; do
+      QEMU_FLAGS+=("--config-patch=${i}")
+    done
     ;;
 esac
 
@@ -124,7 +128,11 @@ case "${WITH_CONFIG_PATCH_WORKER:-false}" in
   false)
     ;;
   *)
-    QEMU_FLAGS+=("--config-patch-worker=${WITH_CONFIG_PATCH_WORKER}")
+    [[ ! ${WITH_CONFIG_PATCH_WORKER} =~ ^@ ]] && echo "WITH_CONFIG_PATCH_WORKER variable should start with @" && exit 1
+
+    for i in ${WITH_CONFIG_PATCH_WORKER//:/ }; do
+      QEMU_FLAGS+=("--config-patch-worker=${i}")
+    done
     ;;
 esac
 

--- a/hack/test/patches/cgroupsv1.yaml
+++ b/hack/test/patches/cgroupsv1.yaml
@@ -1,0 +1,4 @@
+machine:
+  install:
+    extraKernelArgs:
+      - talos.unified_cgroup_hierarchy=0

--- a/hack/test/patches/cilium-kubeproxy.yaml
+++ b/hack/test/patches/cilium-kubeproxy.yaml
@@ -1,0 +1,6 @@
+cluster:
+  network:
+    cni:
+      name: none
+  proxy:
+    disabled: true

--- a/hack/test/patches/cilium-no-kubeproxy.yaml
+++ b/hack/test/patches/cilium-no-kubeproxy.yaml
@@ -1,0 +1,4 @@
+cluster:
+  network:
+    cni:
+      name: none

--- a/hack/test/patches/extensions.yaml
+++ b/hack/test/patches/extensions.yaml
@@ -1,0 +1,47 @@
+machine:
+  sysctls:
+    user.max_user_namespaces: "11255"
+  kernel:
+    modules:
+      - name: asix
+      - name: ax88179_178a
+      - name: ax88796b
+      - name: binfmt_misc
+      - name: btrfs
+      - name: cdc_ether
+      - name: cdc_mbim
+      - name: cdc_ncm
+      - name: cdc_subset
+      - name: cdc_wdm
+      - name: cxgb
+      - name: cxgb3
+      - name: cxgb4
+      - name: cxgb4vf
+      - name: drbd
+      - name: gasket
+      - name: net1080
+      - name: option
+      - name: qmi_wwan
+      - name: r8153_ecm
+      - name: thunderbolt
+      - name: thunderbolt_net
+      - name: usb_wwan
+      - name: usbnet
+      - name: usbserial
+      - name: zaurus
+      - name: zfs
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: tailscale
+environment:
+  - TS_AUTHKEY=tskey-0000000000000000
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: nut-client
+configFiles:
+  - content: |-
+      MONITOR ${upsmonHost} 1 remote ${upsmonPasswd} slave
+      SHUTDOWNCMD "/sbin/poweroff"
+    mountPath: /usr/local/etc/nut/upsmon.conf

--- a/hack/test/patches/longhorn.yaml
+++ b/hack/test/patches/longhorn.yaml
@@ -1,0 +1,18 @@
+machine:
+  kubelet:
+    extraMounts:
+      - destination: /var/lib/longhorn
+        type: bind
+        source: /var/lib/longhorn
+        options:
+          - bind
+          - rshared
+          - rw
+cluster:
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          exemptions:
+            namespaces:
+              - longhorn-system

--- a/hack/test/patches/rook-ceph.yaml
+++ b/hack/test/patches/rook-ceph.yaml
@@ -1,0 +1,8 @@
+cluster:
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          exemptions:
+            namespaces:
+              - rook-ceph

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -33,6 +33,10 @@ type TalosSuite struct {
 	TalosctlPath string
 	// KubectlPath is a path to kubectl binary
 	KubectlPath string
+	// HelmPath is a path to helm binary
+	HelmPath string
+	// KubeStrPath is a path to kubestr binary
+	KubeStrPath string
 	// ExtensionsQEMU runs tests with qemu and extensions enabled
 	ExtensionsQEMU bool
 	// ExtensionsNvidia runs tests with nvidia extensions enabled
@@ -41,6 +45,10 @@ type TalosSuite struct {
 	TrustedBoot bool
 	// TalosImage is the image name for 'talos' container.
 	TalosImage string
+	// CSITestName is the name of the CSI test to run
+	CSITestName string
+	// CSITestTimeout is the timeout for the CSI test
+	CSITestTimeout string
 
 	discoveredNodes cluster.Info
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -36,11 +36,12 @@ var allSuites []suite.TestingSuite
 
 // Flag values.
 var (
-	failFast          bool
-	crashdumpEnabled  bool
-	trustedBoot       bool
-	extensionsQEMU    bool
-	extensionsNvidia  bool
+	failFast         bool
+	crashdumpEnabled bool
+	trustedBoot      bool
+	extensionsQEMU   bool
+	extensionsNvidia bool
+
 	talosConfig       string
 	endpoint          string
 	k8sEndpoint       string
@@ -48,10 +49,14 @@ var (
 	expectedGoVersion string
 	talosctlPath      string
 	kubectlPath       string
+	helmPath          string
+	kubeStrPath       string
 	provisionerName   string
 	clusterName       string
 	stateDir          string
 	talosImage        string
+	csiTestName       string
+	csiTestTimeout    string
 )
 
 // TestIntegration ...
@@ -103,10 +108,14 @@ func TestIntegration(t *testing.T) {
 				GoVersion:        expectedGoVersion,
 				TalosctlPath:     talosctlPath,
 				KubectlPath:      kubectlPath,
+				HelmPath:         helmPath,
+				KubeStrPath:      kubeStrPath,
 				ExtensionsQEMU:   extensionsQEMU,
 				ExtensionsNvidia: extensionsNvidia,
 				TrustedBoot:      trustedBoot,
 				TalosImage:       talosImage,
+				CSITestName:      csiTestName,
+				CSITestTimeout:   csiTestTimeout,
 			})
 		}
 
@@ -166,7 +175,11 @@ func init() {
 	flag.StringVar(&expectedGoVersion, "talos.go.version", constants.GoVersion, "expected Talos version")
 	flag.StringVar(&talosctlPath, "talos.talosctlpath", "talosctl", "The path to 'talosctl' binary")
 	flag.StringVar(&kubectlPath, "talos.kubectlpath", "kubectl", "The path to 'kubectl' binary")
+	flag.StringVar(&helmPath, "talos.helmpath", "helm", "The path to 'helm' binary")
+	flag.StringVar(&kubeStrPath, "talos.kubestrpath", "kubestr", "The path to 'kubestr' binary")
 	flag.StringVar(&talosImage, "talos.image", images.DefaultTalosImageRepository, "The default 'talos' container image")
+	flag.StringVar(&csiTestName, "talos.csi", "", "CSI test to run")
+	flag.StringVar(&csiTestTimeout, "talos.csi.timeout", "15m", "CSI test timeout")
 
 	flag.StringVar(&provision_test.DefaultSettings.CIDR, "talos.provision.cidr", provision_test.DefaultSettings.CIDR, "CIDR to use to provision clusters (provision tests only)")
 	flag.Var(&provision_test.DefaultSettings.RegistryMirrors, "talos.provision.registry-mirror", "registry mirrors to use (provision tests only)")

--- a/internal/integration/k8s/constants.go
+++ b/internal/integration/k8s/constants.go
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+// Package k8s provides Kubernetes integration tests.
+package k8s
+
+const (
+	// RookCephHelmChartVersion is the version of the Rook Ceph Helm chart to use.
+	// renovate: datasource=helm versioning=helm depName=rook-ceph registryUrl=https://charts.rook.io/release
+	RookCephHelmChartVersion = "v1.15.0"
+	// LongHornHelmChartVersion is the version of the Longhorn Helm chart to use.
+	// renovate: datasource=helm versioning=helm depName=longhorn registryUrl=https://charts.longhorn.io
+	LongHornHelmChartVersion = "v1.7.0"
+)

--- a/internal/integration/k8s/longhorn.go
+++ b/internal/integration/k8s/longhorn.go
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_k8s
+
+package k8s
+
+import (
+	"context"
+	"time"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+)
+
+// LongHornSuite tests deploying Longhorn.
+type LongHornSuite struct {
+	base.K8sSuite
+}
+
+// SuiteName returns the name of the suite.
+func (suite *LongHornSuite) SuiteName() string {
+	return "k8s.LongHornSuite"
+}
+
+// TestDeploy tests deploying Longhorn and running a simple test.
+func (suite *LongHornSuite) TestDeploy() {
+	if suite.Cluster == nil {
+		suite.T().Skip("without full cluster state reaching out to the node IP is not reliable")
+	}
+
+	if suite.CSITestName != "longhorn" {
+		suite.T().Skip("skipping longhorn test as it is not enabled")
+	}
+
+	timeout, err := time.ParseDuration(suite.CSITestTimeout)
+	if err != nil {
+		suite.T().Fatalf("failed to parse timeout: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	suite.T().Cleanup(cancel)
+
+	if err := suite.HelmInstall(
+		ctx,
+		"longhorn-system",
+		"https://charts.longhorn.io",
+		LongHornHelmChartVersion,
+		"longhorn",
+		"longhorn",
+		nil,
+	); err != nil {
+		suite.T().Fatalf("failed to install Longhorn chart: %v", err)
+	}
+
+	suite.Require().NoError(suite.RunFIOTest(ctx, "longhorn", "10G"))
+}
+
+func init() {
+	allSuites = append(allSuites, new(LongHornSuite))
+}

--- a/internal/integration/k8s/rook.go
+++ b/internal/integration/k8s/rook.go
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_k8s
+
+package k8s
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+)
+
+//go:embed testdata/rook-ceph-cluster-values.yaml
+var rookCephClusterValues []byte
+
+// RookSuite tests deploying Rook.
+type RookSuite struct {
+	base.K8sSuite
+}
+
+// SuiteName returns the name of the suite.
+func (suite *RookSuite) SuiteName() string {
+	return "k8s.RookSuite"
+}
+
+// TestDeploy tests deploying Rook and running a simple test.
+func (suite *RookSuite) TestDeploy() {
+	if suite.Cluster == nil {
+		suite.T().Skip("without full cluster state reaching out to the node IP is not reliable")
+	}
+
+	if suite.CSITestName != "rook-ceph" {
+		suite.T().Skip("skipping rook-ceph test as it is not enabled")
+	}
+
+	timeout, err := time.ParseDuration(suite.CSITestTimeout)
+	if err != nil {
+		suite.T().Fatalf("failed to parse timeout: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	suite.T().Cleanup(cancel)
+
+	if err := suite.HelmInstall(
+		ctx,
+		"rook-ceph",
+		"https://charts.rook.io/release",
+		RookCephHelmChartVersion,
+		"rook-ceph",
+		"rook-ceph",
+		nil,
+	); err != nil {
+		suite.T().Fatalf("failed to install Rook chart: %v", err)
+	}
+
+	if err := suite.HelmInstall(
+		ctx,
+		"rook-ceph",
+		"https://charts.rook.io/release",
+		RookCephHelmChartVersion,
+		"rook-ceph-cluster",
+		"rook-ceph-cluster",
+		rookCephClusterValues,
+	); err != nil {
+		suite.T().Fatalf("failed to install Rook chart: %v", err)
+	}
+
+	if err := suite.WaitForResource(ctx, "rook-ceph", "ceph.rook.io", "CephCluster", "v1", "rook-ceph", "{.status.phase}", "Ready"); err != nil {
+		suite.T().Fatalf("failed to wait for CephCluster to be Ready: %v", err)
+	}
+
+	if err := suite.WaitForResource(ctx, "rook-ceph", "ceph.rook.io", "CephCluster", "v1", "rook-ceph", "{.status.state}", "Created"); err != nil {
+		suite.T().Fatalf("failed to wait for CephCluster to be Created: %v", err)
+	}
+
+	if err := suite.WaitForResource(ctx, "rook-ceph", "ceph.rook.io", "CephCluster", "v1", "rook-ceph", "{.status.ceph.health}", "HEALTH_OK"); err != nil {
+		suite.T().Fatalf("failed to wait for CephCluster to be HEALTH_OK: %v", err)
+	}
+
+	suite.Require().NoError(suite.RunFIOTest(ctx, "ceph-block", "10G"))
+}
+
+func init() {
+	allSuites = append(allSuites, new(RookSuite))
+}

--- a/internal/integration/k8s/testdata/rook-ceph-cluster-values.yaml
+++ b/internal/integration/k8s/testdata/rook-ceph-cluster-values.yaml
@@ -1,0 +1,17 @@
+operatorNamespace: rook-ceph
+cephFileSystems: []
+cephObjectStores: []
+cephClusterSpec:
+  crashCollector:
+    disable: true
+  logCollector:
+    enabled: false
+  dashboard:
+    enabled: false
+  resources:
+    osd:
+      limits:
+        memory: "2Gi"
+      requests:
+        cpu: "500m"
+        memory: "1Gi"


### PR DESCRIPTION
Move rook-ceph CSI tests as go tests.
This allows us to add more CSI tests in the future.

Fixes: #9135