### PR TITLE
fix: drop /opt mount for containers/tink

### DIFF
--- a/internal/integration/k8s/tink.go
+++ b/internal/integration/k8s/tink.go
@@ -420,7 +420,7 @@ func (suite *TinkSuite) getTinkManifests(namespace, serviceName, ssName, talosIm
 			},
 		},
 		xslices.Map(
-			constants.Overlays,
+			xslices.Filter(constants.Overlays, func(overlay string) bool { return overlay != "/opt" }), // /opt/cni/bin contains CNI binaries
 			func(mountPath string) overlayMountSpec {
 				return overlayMountSpec{
 					MountPoint: mountPath,

--- a/website/content/v1.8/talos-guides/install/cloud-platforms/kubernetes.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/kubernetes.md
@@ -100,6 +100,4 @@ volumeMounts:
     name: etc-kubernetes
   - mountPath: /usr/libexec/kubernetes
     name: usr-libexec-kubernetes
-  - mountPath: /opt
-    name: opt
 ```


### PR DESCRIPTION
The `/opt/cni/bin` in the rootfs contains CNI binaries, which get overwritten by the volume mount.
