### PR TITLE
fix: add NVMe target kernel modules

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -130,6 +130,11 @@ kernel/drivers/net/usb/r8152.ko
 kernel/drivers/net/vmxnet3/vmxnet3.ko
 kernel/drivers/net/vrf.ko
 kernel/drivers/nvme/host/nvme.ko
+kernel/drivers/nvme/target/nvme-loop.ko
+kernel/drivers/nvme/target/nvmet-fc.ko
+kernel/drivers/nvme/target/nvmet.ko
+kernel/drivers/nvme/target/nvmet-rdma.ko
+kernel/drivers/nvme/target/nvmet-tcp.ko
 kernel/drivers/scsi/aacraid/aacraid.ko
 kernel/drivers/scsi/hpsa.ko
 kernel/drivers/scsi/isci/isci.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -32,6 +32,11 @@ kernel/drivers/net/ethernet/mellanox/mlxsw/mlxsw_spectrum.ko
 kernel/drivers/net/ethernet/sfc/sfc.ko
 kernel/drivers/net/ethernet/sfc/siena/sfc-siena.ko
 kernel/drivers/net/vrf.ko
+kernel/drivers/nvme/target/nvme-loop.ko
+kernel/drivers/nvme/target/nvmet-fc.ko
+kernel/drivers/nvme/target/nvmet.ko
+kernel/drivers/nvme/target/nvmet-rdma.ko
+kernel/drivers/nvme/target/nvmet-tcp.ko
 kernel/drivers/scsi/mpi3mr/mpi3mr.ko
 kernel/drivers/vfio/pci/vfio-pci-core.ko
 kernel/drivers/vfio/pci/vfio-pci.ko


### PR DESCRIPTION
Fixes #9214

This finishes the work which started in
https://github.com/siderolabs/pkgs/pull/906, but it never got finished.
