### PR TITLE
chore: drop console `ttyS0` argument.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1523,12 +1523,14 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
         run: |
           make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make images-essential
@@ -3110,6 +3112,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make images-essential
@@ -3117,6 +3120,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make secureboot-iso

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
+# Generated on 2024-08-25T07:59:04Z by kres 8e4bbb4.
 
 name: integration-image-factory-cron
 concurrency:
@@ -84,12 +84,14 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
         run: |
           make iso secureboot-iso
       - name: images-essential
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make images-essential

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-27T16:20:10Z by kres bcb280a.
+# Generated on 2024-08-25T05:01:25Z by kres 8e4bbb4.
 
 name: integration-trusted-boot-cron
 concurrency:
@@ -84,6 +84,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make images-essential
@@ -91,6 +92,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
           PLATFORM: linux/amd64
         run: |
           make secureboot-iso

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -425,12 +425,14 @@ spec:
             - only-on-schedule
           environment:
             PLATFORM: linux/amd64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: secureboot-iso
           conditions:
             - only-on-schedule
           environment:
             PLATFORM: linux/amd64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: integration-trusted-boot
           command: e2e-qemu
@@ -1425,12 +1427,14 @@ spec:
             - only-on-schedule
           command: iso secureboot-iso
           environment:
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:
             - only-on-schedule
           environment:
             PLATFORM: linux/amd64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: factory-1.6-iso
           command: e2e-image-factory

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -200,6 +200,14 @@ Talos Linux now supports a kernel command line argument `talos.device.settle_tim
 Talos Linux now supports Apache CloudStack platform.
 """
 
+    [notes.metal-image]
+        title = "Metal images"
+        description = """\
+Starting with Talos 1.8, `console=ttyS0` kernel argument is removed from the metal images and installer. If running virtualized in QEMU (For eg: Proxmox), this can be added as an extra kernel argument if needed via Image Factory or using Imager.
+
+This should fix slow boot or no console output issues on most bare metal hardware.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -162,7 +162,7 @@ func (m *Metal) KernelArgs(arch string) procfs.Parameters {
 	switch arch {
 	case "amd64":
 		return []*procfs.Parameter{
-			procfs.NewParameter("console").Append("ttyS0").Append("tty0"),
+			procfs.NewParameter("console").Append("tty0"),
 		}
 	case "arm64":
 		return []*procfs.Parameter{

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -335,6 +335,11 @@ func (i *Imager) buildCmdline() error {
 
 	// platform kernel args
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
+
+	if quirks.New(i.prof.Version).SupportsMetalPlatformConsoleTTYS0() && i.prof.Platform == constants.PlatformMetal {
+		cmdline.Append("console", "ttyS0")
+	}
+
 	cmdline.SetAll(p.KernelArgs(i.prof.Arch).Strings())
 
 	// board kernel args

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -98,3 +98,16 @@ func (q Quirks) SupportsMultidoc() bool {
 
 	return q.v.GTE(minVersionMultidoc)
 }
+
+// maxVersionMetalPlatformConsoleTTYS0Dropped is the version that dropped console=ttyS0 for metal image.
+var maxVersionMetalPlatformConsoleTTYS0Dropped = semver.MustParse("1.8.0")
+
+// SupportsMetalPlatformConsoleTTYS0 returns true if the Talos version supports already has console=ttyS0 kernel argument.
+func (q Quirks) SupportsMetalPlatformConsoleTTYS0() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return false
+	}
+
+	return q.v.LT(maxVersionMetalPlatformConsoleTTYS0Dropped)
+}

--- a/website/content/v1.8/talos-guides/configuration/logging.md
+++ b/website/content/v1.8/talos-guides/configuration/logging.md
@@ -12,7 +12,7 @@ Kernel messages can be retrieved with `talosctl dmesg` command:
 ```sh
 $ talosctl -n 172.20.1.2 dmesg
 
-172.20.1.2: kern:    info: [2021-11-10T10:09:37.662764956Z]: Command line: init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 console=ttyS0 reboot=k panic=1 talos.shutdown=halt talos.platform=metal talos.config=http://172.20.1.1:40101/config.yaml
+172.20.1.2: kern:    info: [2021-11-10T10:09:37.662764956Z]: Command line: init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 reboot=k panic=1 talos.shutdown=halt talos.platform=metal talos.config=http://172.20.1.1:40101/config.yaml
 [...]
 ```
 

--- a/website/content/v1.8/talos-guides/install/bare-metal-platforms/matchbox.md
+++ b/website/content/v1.8/talos-guides/install/bare-metal-platforms/matchbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
-aliases: 
+aliases:
   - ../../../bare-metal-platforms/matchbox
 ---
 
@@ -67,7 +67,6 @@ Download these files from the [release](https://github.com/siderolabs/talos/rele
       "slab_nomerge",
       "pti=on",
       "console=tty0",
-      "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
       "talos.config=http://matchbox.talos.dev/assets/controlplane.yaml"
@@ -93,7 +92,6 @@ Download these files from the [release](https://github.com/siderolabs/talos/rele
       "slab_nomerge",
       "pti=on",
       "console=tty0",
-      "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
       "talos.config=http://matchbox.talos.dev/assets/worker.yaml"

--- a/website/content/v1.8/talos-guides/install/bare-metal-platforms/secureboot.md
+++ b/website/content/v1.8/talos-guides/install/bare-metal-platforms/secureboot.md
@@ -198,7 +198,7 @@ output:
   kind: iso
   outFormat: raw
 skipped initramfs rebuild (no system extensions)
-kernel command line: talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality
+kernel command line: talos.platform=metal console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality
 UKI ready
 ISO ready
 output asset path: /out/metal-amd64-secureboot.iso
@@ -236,7 +236,7 @@ output:
   kind: installer
   outFormat: raw
 skipped initramfs rebuild (no system extensions)
-kernel command line: talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality
+kernel command line: talos.platform=metal console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality
 UKI ready
 installer container image ready
 output asset path: /out/installer-amd64-secureboot.tar


### PR DESCRIPTION
Drop `console=ttyS0` argument for metal images/installer.

`console=ttyS0` causes lot of issues with bare metal hardware when trying to use a physical serial port.

Ref:

* https://bugzilla.redhat.com/show_bug.cgi?id=1839923
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=763601;msg=17
* https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html
* https://github.com/coreos/fedora-coreos-tracker/issues/567

Fixes: #8695
Fixes: #8657
Fixes: #8127