### PR TITLE
fix: merge extension service config files by `mountPath`

### DIFF
--- a/pkg/machinery/config/configpatcher/testdata/multidoc/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/config.yaml
@@ -9,3 +9,12 @@ machine:
 apiVersion: v1alpha1
 kind: SideroLinkConfig
 apiUrl: https://siderolink.api/join?jointoken=secret&user=alice
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: foo
+configFiles:
+    - content: hello
+      mountPath: /etc/foo
+environment:
+    - FOO=BAR

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/expected.yaml
@@ -13,3 +13,15 @@ cluster: null
 apiVersion: v1alpha1
 kind: SideroLinkConfig
 apiUrl: https://siderolink.api/join?jointoken=secret&user=bob
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: foo
+configFiles:
+    - content: hello world
+      mountPath: /etc/foo
+    - content: another hello
+      mountPath: /etc/bar
+environment:
+    - FOO=BAR
+    - XXX=YYY

--- a/pkg/machinery/config/configpatcher/testdata/multidoc/strategic2.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/multidoc/strategic2.yaml
@@ -1,3 +1,14 @@
 apiVersion: v1alpha1
 kind: SideroLinkConfig
 apiUrl: https://siderolink.api/join?jointoken=secret&user=bob
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: foo
+configFiles:
+    - content: hello world
+      mountPath: /etc/foo
+    - content: another hello
+      mountPath: /etc/bar
+environment:
+    - XXX=YYY

--- a/website/content/v1.8/talos-guides/configuration/patching.md
+++ b/website/content/v1.8/talos-guides/configuration/patching.md
@@ -50,6 +50,7 @@ There are some special rules:
   - `network.interfaces` section is merged with the value in the machine config if there is a match on `interface:` or `deviceSelector:` keys
   - `network.interfaces.vlans` section is merged with the value in the machine config if there is a match on the `vlanId:` key
   - `cluster.apiServer.auditPolicy` value is replaced on merge
+  - `ExtensionServiceConfig.configFiles` section is merged matching on `mountPath` (replacing `content` if matches)
 
 When patching a [multi-document machine configuration]({{< relref "../../reference/configuration" >}}), following rules apply:
 


### PR DESCRIPTION
Allow overwriting config file content.
