### PR TITLE
feat: update Flannel to v0.25.6

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -33,7 +33,7 @@ Linux: 6.6.45
 containerd: 2.0.0-rc.3
 runc: 1.2.0-rc.2
 etcd: 3.5.15
-Flannel: 0.25.5
+Flannel: 0.25.6
 Flannel CNI plugin: 1.5.1
 CoreDNS: 1.1.13
 

--- a/pkg/flannel/template.go
+++ b/pkg/flannel/template.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.25.5/Documentation/kube-flannel.yml DO NOT EDIT
+// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.25.6/Documentation/kube-flannel.yml DO NOT EDIT
 
 package flannel
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -972,7 +972,7 @@ const (
 	DashboardTTY = 2
 
 	// FlannelVersion is the version of flannel to use.
-	FlannelVersion = "v0.25.5"
+	FlannelVersion = "v0.25.6"
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"


### PR DESCRIPTION
See https://github.com/flannel-io/flannel/releases/tag/v0.25.6
