### PR TITLE
chore: pause sequencer when talos installed and iso booted

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -208,6 +208,16 @@ Starting with Talos 1.8, `console=ttyS0` kernel argument is removed from the met
 This should fix slow boot or no console output issues on most bare metal hardware.
 """
 
+    [notes.kernel-args]
+        title = "`talos.halt_if_installed` kernel argument"
+        description = """\
+Starting with Talos 1.8, ISO's generated from Boot Assets would have a new kernel argument `talos.halt_if_installed` which would pause the boot sequence until boot timeout if Talos is already installed on the disk.
+ISO generated for pre 1.8 versions would not have this kernel argument.
+
+This can be also explicitly enabled by setting `talos.halt_if_installed=1` in kernel argument.
+"""
+
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -133,6 +133,15 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			ResetSystemDiskPartitions,
 		).AppendWithDeferredCheck(
 			func() bool {
+				haltIfInstalledStr := procfs.ProcCmdline().Get(constants.KernelParamHaltIfInstalled).First()
+				haltIfInstalled, _ := strconv.ParseBool(pointer.SafeDeref(haltIfInstalledStr)) //nolint:errcheck
+
+				return r.State().Machine().Installed() && haltIfInstalled
+			},
+			"haltIfInstalled",
+			haltIfInstalled,
+		).AppendWithDeferredCheck(
+			func() bool {
 				return r.State().Machine().Installed()
 			},
 			"mountSystem",

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -336,6 +336,10 @@ func (i *Imager) buildCmdline() error {
 	// platform kernel args
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
 
+	if quirks.New(i.prof.Version).SupportsHaltIfInstalled() && i.prof.Output.Kind == profile.OutKindISO {
+		cmdline.Append(constants.KernelParamHaltIfInstalled, "1")
+	}
+
 	if quirks.New(i.prof.Version).SupportsMetalPlatformConsoleTTYS0() && i.prof.Platform == constants.PlatformMetal {
 		cmdline.Append("console", "ttyS0")
 	}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -84,6 +84,9 @@ const (
 	// KernelParamNetIfnames is the kernel parameter name to control predictable network interface names.
 	KernelParamNetIfnames = "net.ifnames"
 
+	// KernelParamHaltIfInstalled is the kernel parameter name to control if Talos should pause if booting from boot media while Talos is already installed.
+	KernelParamHaltIfInstalled = "talos.halt_if_installed"
+
 	// BoardNone indicates that the install is not for a specific board.
 	BoardNone = "none"
 

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -111,3 +111,16 @@ func (q Quirks) SupportsMetalPlatformConsoleTTYS0() bool {
 
 	return q.v.LT(maxVersionMetalPlatformConsoleTTYS0Dropped)
 }
+
+// minVersionSupportsHalfIfInstalled is the version that supports half if installed.
+var minVersionSupportsHalfIfInstalled = semver.MustParse("1.8.0")
+
+// SupportsHaltIfInstalled returns true if the Talos version supports half if installed.
+func (q Quirks) SupportsHaltIfInstalled() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minVersionSupportsHalfIfInstalled)
+}

--- a/website/content/v1.8/reference/kernel.md
+++ b/website/content/v1.8/reference/kernel.md
@@ -259,3 +259,8 @@ Example:
 ```text
 talos.device.settle_time=3m
 ```
+
+#### `talos.halt_if_installed`
+
+If set to `1`, Talos will pause the boot sequence and keeps printing a message until the boot timeout is reached if it detects that it is already installed.
+This is useful if booting from ISO/PXE and you want to prevent the machine accidentally booting from the ISO/PXE after installation to the disk.


### PR DESCRIPTION
Pause sequencer till the boot timeout when talos is booted from ISO, but an existing talos is installed to disk and
`talos.halt_if_installed` kernel argument is set.

Fixes https://github.com/siderolabs/talos/issues/9232