### PR TITLE
docs(hetzner): fix invalid input in field user_data

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/hetzner.md
@@ -180,11 +180,14 @@ hcloud load-balancer add-target controlplane \
 Using the IP/DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines by issuing:
 
 ```bash
-$ talosctl gen config talos-k8s-hcloud-tutorial https://<load balancer IP or DNS>:6443
+$ talosctl gen config talos-k8s-hcloud-tutorial https://<load balancer IP or DNS>:6443 \
+    --with-examples=false --with-docs=false
 created controlplane.yaml
 created worker.yaml
 created talosconfig
 ```
+
+Generating the config without examples and docs is necessary because otherwise you can easily exceed the 32 kb limit on uploadable userdata (see [issue 8805](https://github.com/siderolabs/talos/issues/8805)).
 
 At this point, you can modify the generated configs to your liking.
 Optionally, you can specify `--config-patch` with RFC6902 jsonpatches which will be applied during the config generation.


### PR DESCRIPTION
Talos config files greater than 32kb will create an error when trying to create Hetzner servers. This also applies for the default configuration.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
