### PR TITLE
fix: correctly add console args for ttyS0

### DIFF
--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -336,15 +336,18 @@ func (i *Imager) buildCmdline() error {
 	// platform kernel args
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
 
+	cmdline.SetAll(p.KernelArgs(i.prof.Arch).Strings())
+
 	if quirks.New(i.prof.Version).SupportsHaltIfInstalled() && i.prof.Output.Kind == profile.OutKindISO {
 		cmdline.Append(constants.KernelParamHaltIfInstalled, "1")
 	}
 
-	if quirks.New(i.prof.Version).SupportsMetalPlatformConsoleTTYS0() && i.prof.Platform == constants.PlatformMetal {
+	if quirks.New(i.prof.Version).SupportsMetalPlatformConsoleTTYS0() && i.prof.Platform == constants.PlatformMetal && i.prof.Arch == "amd64" {
+		// Talos 1.8+ drops ttyS0 console for metal, restore previous args
+		cmdline.DeleteAll("console")
 		cmdline.Append("console", "ttyS0")
+		cmdline.Append("console", "tty0")
 	}
-
-	cmdline.SetAll(p.KernelArgs(i.prof.Arch).Strings())
 
 	// board kernel args
 	if i.prof.Board != "" && !quirks.New(i.prof.Version).SupportsOverlay() {

--- a/pkg/imager/imager_test.go
+++ b/pkg/imager/imager_test.go
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package imager_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/imager"
+	"github.com/siderolabs/talos/pkg/imager/profile"
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+func TestImager(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+
+		prof profile.Profile
+
+		expected string
+	}{
+		{
+			name: "cmdline-pre1.8-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.7.0",
+			},
+
+			expected: "talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+		},
+		{
+			name: "cmdline-pre1.8-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.7.0",
+			},
+
+			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+		},
+		{
+			name: "cmdline-1.8-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.8.0",
+			},
+
+			expected: "talos.platform=metal console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+		},
+		{
+			name: "cmdline-1.8-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.8.0",
+			},
+
+			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			t.Cleanup(cancel)
+
+			imgr, err := imager.New(test.prof)
+			require.NoError(t, err)
+
+			outPath := t.TempDir()
+
+			outputPath, err := imgr.Execute(ctx, outPath, reporter.New())
+			require.NoError(t, err)
+
+			out, err := os.ReadFile(outputPath)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, string(out))
+		})
+	}
+}


### PR DESCRIPTION
The previous code didn't work, as it was manipulating args before they were reset by the platform.

Also it was producing wrong order of console args.

Both fixed, plus a unit-test.
