### PR TITLE
chore: remove matrix links from docs

### DIFF
--- a/website/content/v0.10/_index.md
+++ b/website/content/v0.10/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.11/_index.md
+++ b/website/content/v0.11/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.12/_index.md
+++ b/website/content/v0.12/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.13/_index.md
+++ b/website/content/v0.13/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.14/_index.md
+++ b/website/content/v0.14/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.6/_index.md
+++ b/website/content/v0.6/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.7/_index.md
+++ b/website/content/v0.7/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.8/_index.md
+++ b/website/content/v0.8/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v0.9/_index.md
+++ b/website/content/v0.9/_index.md
@@ -21,9 +21,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.0/_index.md
+++ b/website/content/v1.0/_index.md
@@ -26,9 +26,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.1/_index.md
+++ b/website/content/v1.1/_index.md
@@ -27,9 +27,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.2/_index.md
+++ b/website/content/v1.2/_index.md
@@ -28,9 +28,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.3/_index.md
+++ b/website/content/v1.3/_index.md
@@ -28,9 +28,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.4/_index.md
+++ b/website/content/v1.4/_index.md
@@ -28,9 +28,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.5/_index.md
+++ b/website/content/v1.5/_index.md
@@ -27,9 +27,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)

--- a/website/content/v1.6/_index.md
+++ b/website/content/v1.6/_index.md
@@ -27,9 +27,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Community Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Community Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)

--- a/website/content/v1.7/_index.md
+++ b/website/content/v1.7/_index.md
@@ -29,9 +29,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Community Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Community Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)

--- a/website/content/v1.8/_index.md
+++ b/website/content/v1.8/_index.md
@@ -29,9 +29,6 @@ If you are just getting familiar with Talos, we recommend starting here:
 - GitHub: [repo](https://github.com/siderolabs/talos)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
 - Community Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
-- Matrix: Join our Matrix channels:
-  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
-  - Community Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Forum: [community](https://groups.google.com/a/siderolabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/talossystems)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)


### PR DESCRIPTION
This PR removes the matrix links since those rooms are no longer in use.