### PR TITLE
fix: report internally service as unhealthy if not running

### DIFF
--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -282,6 +282,10 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 	go func() {
 		errCh <- runnr.Run(func(s events.ServiceState, msg string, args ...any) {
 			svcrunner.UpdateState(ctx, s, msg, args...)
+
+			if s != events.StateRunning {
+				svcrunner.healthState.Update(false, "service not running")
+			}
 		})
 	}()
 


### PR DESCRIPTION
Otherwise the internal code might assume that the service is still running and healthy, never issuing a health change event.

Fixes #9271
