### PR TITLE
fix: remove extra logging on ethtool ioctl failures

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -210,9 +210,7 @@ func (ctrl *LinkStatusController) reconcile(
 
 			if ethState == nil {
 				state, err := ethtoolIoctlClient.LinkState(link.Attributes.Name)
-				if err != nil {
-					logger.Warn("error querying ethtool ioctl link state", zap.String("link", link.Attributes.Name), zap.Error(err))
-				} else {
+				if err == nil {
 					ethState = &ethtool.LinkState{
 						Interface: ethtool.Interface{
 							Index: int(link.Index),


### PR DESCRIPTION
We should ignore this, it's a totally an optional feature used in containers (Talos on its own kernel has ethtool-netlink).

Fixes #9296
