### PR TITLE
fix: parse SideroLink API endpoint correctly

### DIFF
--- a/internal/app/machined/pkg/controllers/siderolink/config_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/config_test.go
@@ -44,7 +44,7 @@ func (suite *ConfigSuite) TestConfig() {
 
 	siderolinkConfig := &siderolinkcfg.ConfigV1Alpha1{
 		APIUrlConfig: meta.URL{
-			URL: must.Value(url.Parse("https://api.sidero.dev"))(suite.T()),
+			URL: must.Value(url.Parse("https://api.sidero.dev:334"))(suite.T()),
 		},
 	}
 
@@ -55,7 +55,8 @@ func (suite *ConfigSuite) TestConfig() {
 
 	rtestutils.AssertResources(suite.Ctx(), suite.T(), suite.State(), []resource.ID{siderolink.ConfigID},
 		func(c *siderolink.Config, assert *assert.Assertions) {
-			assert.Equal("https://api.sidero.dev", c.TypedSpec().APIEndpoint)
+			assert.Equal("https://api.sidero.dev:334", c.TypedSpec().APIEndpoint)
+			assert.Equal("api.sidero.dev:334", c.TypedSpec().Host)
 		})
 }
 

--- a/internal/app/machined/pkg/controllers/siderolink/status.go
+++ b/internal/app/machined/pkg/controllers/siderolink/status.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"time"
 
@@ -125,15 +124,9 @@ func (ctrl *StatusController) reconcileStatus(ctx context.Context, r controller.
 		return nil
 	}
 
-	var parsed *url.URL
-
-	if parsed, err = url.Parse(cfg.TypedSpec().APIEndpoint); err != nil {
-		return fmt.Errorf("failed to parse siderolink API endpoint: %w", err)
-	}
-
-	host, _, err := net.SplitHostPort(parsed.Host)
+	host, _, err := net.SplitHostPort(cfg.TypedSpec().Host)
 	if err != nil {
-		host = parsed.Host
+		host = cfg.TypedSpec().Host
 	}
 
 	down, err := peerDown(wgClient)

--- a/internal/app/machined/pkg/controllers/siderolink/status_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/status_test.go
@@ -57,6 +57,7 @@ func (suite *StatusSuite) TestStatus() {
 	siderolinkConfig := siderolink.NewConfig(config.NamespaceName, siderolink.ConfigID)
 
 	siderolinkConfig.TypedSpec().APIEndpoint = "https://siderolink.example.org:1234?jointoken=supersecret&foo=bar#some=fragment"
+	siderolinkConfig.TypedSpec().Host = "siderolink.example.org:1234"
 
 	suite.Require().NoError(suite.State().Create(suite.Ctx(), siderolinkConfig))
 
@@ -86,6 +87,7 @@ func (suite *StatusSuite) TestStatus() {
 	// update API endpoint
 
 	siderolinkConfig.TypedSpec().APIEndpoint = "https://new.example.org?jointoken=supersecret"
+	siderolinkConfig.TypedSpec().Host = "new.example.org"
 
 	suite.Require().NoError(suite.State().Update(suite.Ctx(), siderolinkConfig))
 	suite.assertStatus("new.example.org", true)


### PR DESCRIPTION
In the status controller, there was a wrong method to parse the endpoint which doesn't account for all supported formats.

Use already parsed version in the config resource instead.
