### PR TITLE
chore: account for resource sorting in dns upstream resource

### DIFF
--- a/internal/app/machined/pkg/controllers/network/resolver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge.go
@@ -94,9 +94,7 @@ func (ctrl *ResolverMergeController) Run(ctx context.Context, r controller.Runti
 		}
 
 		if final.DNSServers != nil {
-			if err = r.Modify(ctx, network.NewResolverSpec(network.NamespaceName, network.ResolverID), func(res resource.Resource) error {
-				spec := res.(*network.ResolverSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewResolverSpec(network.NamespaceName, network.ResolverID), func(spec *network.ResolverSpec) error {
 				*spec.TypedSpec() = final
 
 				return nil
@@ -150,9 +148,9 @@ func mergeDNSServers(dst *[]netip.Addr, src []netip.Addr) {
 	// and same vice versa for IPv6
 	switch {
 	case dstHasV4 && !srcHasV4:
-		*dst = append(slices.Clone(src), filterIPFamily(*dst, true)...)
+		*dst = slices.Concat(src, filterIPFamily(*dst, true))
 	case dstHasV6 && !srcHasV6:
-		*dst = append(slices.Clone(src), filterIPFamily(*dst, false)...)
+		*dst = slices.Concat(src, filterIPFamily(*dst, false))
 	default:
 		*dst = src
 	}

--- a/pkg/machinery/resources/network/dns_upstream.go
+++ b/pkg/machinery/resources/network/dns_upstream.go
@@ -29,6 +29,7 @@ type DNSUpstreamSpecSpec struct {
 	// We could use a generic struct here, but without generic aliases the usage would look ugly.
 	// Once generic aliases are here, redo the type above as `type DNSUpstream[P Proxy] = typed.Resource[...]`.
 	Prx Proxy
+	Idx int
 }
 
 // MarshalYAML implements yaml.Marshaler interface.
@@ -38,6 +39,7 @@ func (d *DNSUpstreamSpecSpec) MarshalYAML() (any, error) {
 	return map[string]string{
 		"healthy": strconv.FormatBool(d.Prx.Fails() == 0),
 		"addr":    d.Prx.Addr(),
+		"idx":     strconv.Itoa(d.Idx),
 	}, nil
 }
 
@@ -66,6 +68,10 @@ func (DNSUpstreamExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 			{
 				Name:     "Address",
 				JSONPath: "{.addr}",
+			},
+			{
+				Name:     "Idx",
+				JSONPath: "{.idx}",
 			},
 		},
 	}


### PR DESCRIPTION
`List` returns a sorted (by id) list of resources. This doesn't work when the order of dns upstreams is important. Because of that add an `Idx` field to the "DNSUpstreams.net.talos.dev" resource, so we can preserve order.

Fixes #9274