### PR TITLE
fix: update CoreDNS health check

### DIFF
--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -45,7 +45,7 @@ func DefaultClusterChecks() []ClusterCheck {
 			// wait for coredns to report ready
 			func(cluster ClusterInfo) conditions.Condition {
 				return conditions.PollingCondition("coredns to report ready", func(ctx context.Context) error {
-					present, replicas, err := ReplicaSetPresent(ctx, cluster, "kube-system", "k8s-app=kube-dns")
+					present, replicas, err := DeploymentPresent(ctx, cluster, "kube-system", "k8s-app=kube-dns")
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
The fix in #9233 wasn't correct, as it was looking for number of replicas in a "random" ReplicaSet. If the deployment has multiple replica sets, it leads to unexpected results.

Instead, read the Deployment resource directly.
