### PR TITLE
fix: ignore invalid NTP responses

### DIFF
--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -392,18 +392,15 @@ func (syncer *Syncer) queryNTP(server string) (*Measurement, error) {
 	)
 
 	validationError := resp.Validate()
+	if validationError != nil {
+		return nil, validationError
+	}
 
-	measurement := &Measurement{
+	return &Measurement{
 		ClockOffset: resp.ClockOffset,
 		Leap:        resp.Leap,
-		Spike:       false,
-	}
-
-	if validationError == nil {
-		measurement.Spike = syncer.isSpike(resp)
-	}
-
-	return measurement, validationError
+		Spike:       syncer.isSpike(resp),
+	}, nil
 }
 
 // log2i returns 0 for v == 0 and v == 1.


### PR DESCRIPTION
Due to the bug introduced when refactoring for PTP devices, invalid NTP responses (including for example NTP kiss of death), were incorrectly handled when only a single NTP server was used.

The error was logged, but the response was used to adjust the time which leads to unexpected time jumps.

Properly ignore any invalid NTP response.

Without this fix, the adjustment from the invalid response is applied.