### PR TITLE
fix: strategic merge patch delete for map keys

### DIFF
--- a/pkg/machinery/config/configloader/internal/decoder/selector.go
+++ b/pkg/machinery/config/configloader/internal/decoder/selector.go
@@ -187,7 +187,7 @@ func deleteForPath(val reflect.Value, path []string, key, value string) error {
 
 			if idx := val.MapIndex(searchForVal); idx.IsValid() {
 				if len(path) == 0 {
-					val.SetMapIndex(searchForVal, reflect.Zero(valType.Elem()))
+					val.SetMapIndex(searchForVal, reflect.Value{})
 
 					return nil
 				}

--- a/pkg/machinery/config/configpatcher/testdata/patchdelete/controlplane_expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchdelete/controlplane_expected.yaml
@@ -26,8 +26,6 @@ machine:
         hostDNS:
             enabled: true
             forwardKubeDNSToHost: true
-    nodeLabels:
-        node.kubernetes.io/exclude-from-external-load-balancers: ""
 cluster:
     id: 0raF93qnkMvF-FZNuvyGozXNdLiT2FOWSlyBaW4PR-w=
     secret: pofHbABZq7VXuObsdLdy/bHmz6hlMHZ3p8+6WKrv1ic=

--- a/pkg/machinery/config/configpatcher/testdata/patchdelete/strategic2.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchdelete/strategic2.yaml
@@ -4,3 +4,7 @@ cluster:
     admissionControl:
     - name: PodSecurity
       $patch: delete
+machine:
+  nodeLabels:
+    node.kubernetes.io/exclude-from-external-load-balancers:
+      $patch: delete


### PR DESCRIPTION
When a map key is deleted, it should be deleted as a whole. Before the fix it was zeroing out map value by key.

Fixes #9325
