### PR TITLE
Allow /sbin/ldconfig (support for glibc extension for nvidia gpu-operator)

### DIFF
--- a/pkg/machinery/extensions/extensions.go
+++ b/pkg/machinery/extensions/extensions.go
@@ -12,7 +12,10 @@ var AllowedPaths = []string{
 	"/etc/cri/conf.d",
 	"/lib/firmware",
 	"/lib/modules",
+	// The glibc loader is required by glibc dynamic binaries.
 	"/lib64/ld-linux-x86-64.so.2",
+	// /sbin/ldconfig is required by the nvidia container toolkit.
+	"/sbin/ldconfig",
 	"/usr/etc/udev/rules.d",
 	"/usr/local",
 	// glvnd, egl and vulkan are needed for OpenGL/Vulkan.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This PR allows `/sbin/ldconfig` in extensions.

## Why? (reasoning)

Allowing `/sbin/ldconfig` in extensions is a simple change that should have basically no bad side effects. It allows the NVIDIA container toolkit to work on Talos without modification.

## Original "Why?" that allowed containers with SYS_MODULE

The NVIDIA gpu-operator includes machinery to manage the driver on nodes via driver containers. These containers, usually provided by NVIDIA, include basically a giant shell script that will fetch, build, and load the kernel modules for the node's kernel. It will also unload these modules when the container terminates, and provide the userspace components by copying them to `/run/nvidia/driver` on the node.

More recently, driver containers have gained the ability to provide [precompiled kernel modules](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/precompiled-drivers.html) on supported Linux distributions (Ubuntu today).

The intention here is for SideroLabs to build their own driver containers and let the gpu-operator manage them. Is it not a clear-cut better approach than the existing extensions, but it better aligns with NVIDIA's general direction for supporting GPUs in Kubernetes and provides more flexibility for cluster operators by decoupling NVIDIA driver releases from Talos releases (even with the recent addition of LTS and production extension flavors).

Of course, producing driver containers will either need to be coupled with kernel builds to use the ephemeral module signing key, or SideroLabs may change its approach and e.g. retain the signing key for each Talos release to decouple NVIDIA driver builds from kernel builds. Another approach would be to use `SYSTEM_EXTRA_CERTIFICATE` (see https://github.com/torvalds/linux/commit/c4c36105958576fee87d2c75f4b69b6e5bbde772) to allow Image Factory to insert a signing certificate provided by the user, which could then build their own driver containers.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
