### PR TITLE
fix: filter out non-printable characters in process line

### DIFF
--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -178,6 +178,7 @@ var cpu = func(p1, p2 *machineapi.ProcessInfo) bool {
 	return p1.CpuTime > p2.CpuTime
 }
 
+//nolint:gocyclo
 func processesOutput(ctx context.Context, c *client.Client) (output string, err error) {
 	var remotePeer peer.Peer
 
@@ -213,6 +214,15 @@ func processesOutput(ctx context.Context, c *client.Client) (output string, err 
 			default:
 				args = p.Args
 			}
+
+			// filter out non-printable characters
+			args = strings.Map(func(r rune) rune {
+				if r < 32 || r > 126 {
+					return ' '
+				}
+
+				return r
+			}, args)
 
 			node := defaultNode
 

--- a/internal/pkg/dashboard/components/tables.go
+++ b/internal/pkg/dashboard/components/tables.go
@@ -50,6 +50,8 @@ func NewProcessTable() *ProcessTable {
 }
 
 // OnAPIDataChange implements the APIDataListener interface.
+//
+//nolint:gocyclo
 func (widget *ProcessTable) OnAPIDataChange(node string, data *apidata.Data) {
 	nodeData := data.Nodes[node]
 
@@ -96,6 +98,15 @@ func (widget *ProcessTable) OnAPIDataChange(node string, data *apidata.Data) {
 			default:
 				args = proc.Args
 			}
+
+			// filter out non-printable characters
+			args = strings.Map(func(r rune) rune {
+				if r < 32 || r > 126 {
+					return ' '
+				}
+
+				return r
+			}, args)
 
 			line := fmt.Sprintf("%7d  %s  %6.1f  %6.1f  %8s  %8s  %10s  %4d  %s",
 				proc.GetPid(),


### PR DESCRIPTION
Otherwise the output might be distorted by characters like `\n`.
