### PR TITLE
docs: fix kubespan name inconsistency

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -240,7 +240,7 @@
         },
         "kind": {
           "enum": [
-            "KubespanEndpoints"
+            "KubeSpanEndpoints"
           ],
           "title": "kind",
           "description": "kind is the kind of the resource.\n",

--- a/pkg/machinery/config/types/network/kubespan_endpoints.go
+++ b/pkg/machinery/config/types/network/kubespan_endpoints.go
@@ -16,7 +16,7 @@ import (
 )
 
 // KubespanEndpointsKind is a KubeSpan endpoints document kind.
-const KubespanEndpointsKind = "KubespanEndpointsConfig"
+const KubespanEndpointsKind = "KubeSpanEndpointsConfig"
 
 func init() {
 	registry.Register(KubespanEndpointsKind, func(version string) config.Document {
@@ -38,9 +38,9 @@ var (
 //
 //	examples:
 //	  - value: exampleKubespanEndpointsV1Alpha1()
-//	alias: KubespanEndpoints
+//	alias: KubeSpanEndpointsConfig
 //	schemaRoot: true
-//	schemaMeta: v1alpha1/KubespanEndpoints
+//	schemaMeta: v1alpha1/KubeSpanEndpoints
 type KubespanEndpointsConfigV1Alpha1 struct {
 	meta.Meta `yaml:",inline"`
 	//   description: |

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -39,9 +39,9 @@ func (DefaultActionConfigV1Alpha1) Doc() *encoder.Doc {
 
 func (KubespanEndpointsConfigV1Alpha1) Doc() *encoder.Doc {
 	doc := &encoder.Doc{
-		Type:        "KubespanEndpoints",
-		Comments:    [3]string{"" /* encoder.HeadComment */, "KubespanEndpoints is a config document to configure KubeSpan endpoints." /* encoder.LineComment */, "" /* encoder.FootComment */},
-		Description: "KubespanEndpoints is a config document to configure KubeSpan endpoints.",
+		Type:        "KubeSpanEndpointsConfig",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.",
 		Fields: []encoder.Doc{
 			{}, {
 				Name:        "extraAnnouncedEndpoints",

--- a/pkg/machinery/config/types/network/testdata/kubespanendpointsconfig.yaml
+++ b/pkg/machinery/config/types/network/testdata/kubespanendpointsconfig.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1alpha1
-kind: KubespanEndpointsConfig
+kind: KubeSpanEndpointsConfig
 extraAnnouncedEndpoints:
     - 3.4.5.6:123
     - 10.11.12.13:456

--- a/website/content/v1.8/reference/configuration/network/kubespanendpointsconfig.md
+++ b/website/content/v1.8/reference/configuration/network/kubespanendpointsconfig.md
@@ -1,6 +1,6 @@
 ---
-description: KubespanEndpoints is a config document to configure KubeSpan endpoints.
-title: KubespanEndpoints
+description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
+title: KubeSpanEndpointsConfig
 ---
 
 <!-- markdownlint-disable -->
@@ -15,7 +15,7 @@ title: KubespanEndpoints
 
 {{< highlight yaml >}}
 apiVersion: v1alpha1
-kind: KubespanEndpointsConfig
+kind: KubeSpanEndpointsConfig
 # A list of extra Wireguard endpoints to announce from this machine.
 extraAnnouncedEndpoints:
     - 192.168.13.46:52000

--- a/website/content/v1.8/schemas/config.schema.json
+++ b/website/content/v1.8/schemas/config.schema.json
@@ -240,7 +240,7 @@
         },
         "kind": {
           "enum": [
-            "KubespanEndpoints"
+            "KubeSpanEndpoints"
           ],
           "title": "kind",
           "description": "kind is the kind of the resource.\n",

--- a/website/content/v1.8/talos-guides/network/kubespan.md
+++ b/website/content/v1.8/talos-guides/network/kubespan.md
@@ -134,7 +134,7 @@ The `filters` setting allows hiding some endpoints from being advertised over Ku
 This is useful when some endpoints are known to be unreachable between the nodes, so that KubeSpan doesn't try to establish a connection to them.
 Another use-case is hiding some endpoints if nodes can connect on multiple networks, and some of the networks are more preferable than others.
 
-To include additional announced endpoints, such as inbound NAT mappings, you can add the [machine config document]({{< relref "../../reference/configuration/network/kubespanendpoints" >}}).
+To include additional announced endpoints, such as inbound NAT mappings, you can add the [machine config document]({{< relref "../../reference/configuration/network/kubespanendpointsconfig" >}}).
 
 ```yaml
 apiVersion: v1alpha1

--- a/website/content/v1.8/talos-guides/upgrading-talos.md
+++ b/website/content/v1.8/talos-guides/upgrading-talos.md
@@ -96,7 +96,7 @@ future.
 
 ## Machine Configuration Changes
 
-* new machine configuration documents: [VolumeConfig]({{< relref "../reference/configuration/block/volumeconfig" >}}), [KubespanEndpointsConfig]({{< relref "../reference/configuration/network/kubespanendpoints" >}}),
+* new machine configuration documents: [VolumeConfig]({{< relref "../reference/configuration/block/volumeconfig" >}}), [KubespanEndpointsConfig]({{< relref "../reference/configuration/network/kubespanendpointsconfig" >}}),
   [TrustedRootsConfig]({{< relref "../reference/configuration/security/trustedrootsconfig" >}})
 * new fields in the [v1alpha1]({{< relref "../reference/configuration/v1alpha1/config" >}}) document:
   * [`.machine.nodeAnnotations`]({{< relref "../reference/configuration/v1alpha1/config#Config.machine" >}})


### PR DESCRIPTION
Fix the inconsistent use of KubeSpan in docs and Config suffix for the config kind.