### PR TITLE
docs: Fix Kernel Self Protection Project (KSPP) references

### DIFF
--- a/website/content/v1.8/learn-more/components.md
+++ b/website/content/v1.8/learn-more/components.md
@@ -19,7 +19,7 @@ In the following, the focus is on the Talos Linux specific components.
 | apid       | When interacting with Talos, the gRPC API endpoint you interact with directly is provided by `apid`. `apid` acts as the gateway for all component interactions and forwards the requests to `machined`.                                                                                                        |
 | containerd | An industry-standard container runtime with an emphasis on simplicity, robustness, and portability. To learn more, see the [containerd website](https://containerd.io).                                                                                                                                        |
 | machined   | Talos replacement for the traditional Linux init-process. Specially designed to run Kubernetes and does not allow starting arbitrary user services.                                                                                                                                                            |
-| kernel     | The Linux kernel included with Talos is configured according to the recommendations outlined in the [Kernel Self Protection Project](http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project).                                                                                                        |
+| kernel     | The Linux kernel included with Talos is configured according to the recommendations outlined in the [Kernel Self Protection Project](https://kspp.github.io/).                                                                                                        |
 | trustd     | To run and operate a Kubernetes cluster, a certain level of trust is required. Based on the concept of a 'Root of Trust', `trustd` is a simple daemon responsible for establishing trust within the system.                                                                                                    |
 | udevd      | Implementation of `eudev` into `machined`. `eudev` is Gentoo's fork of udev, systemd's device file manager for the Linux kernel. It manages device nodes in /dev and handles all user space actions when adding or removing devices. To learn more, see the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Eudev). |
 
@@ -100,7 +100,7 @@ The `machined` process handles all machine configuration, API handling, resource
 
 ### kernel
 
-The Linux kernel included with Talos is configured according to the recommendations outlined in the Kernel Self Protection Project ([KSSP](http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project)).
+The Linux kernel included with Talos is configured according to the recommendations outlined in the Kernel Self Protection Project ([KSPP](https://kspp.github.io/)).
 
 ### trustd
 

--- a/website/content/v1.8/reference/kernel.md
+++ b/website/content/v1.8/reference/kernel.md
@@ -8,7 +8,7 @@ description: "Linux kernel reference."
 Talos supports a number of kernel commandline parameters.  Some are required for
 it to operate.  Others are optional and useful in certain circumstances.
 
-Several of these are enforced by the Kernel Self Protection Project [KSPP](https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings).
+Several of these are enforced by the Kernel Self Protection Project [KSPP](https://kspp.github.io/Recommended_Settings).
 
 **Required** parameters:
 


### PR DESCRIPTION
Update KSPP related URLs and fix acronym typo from "KSSP" to "KSPP".
