### PR TITLE
chore: ignore more plugins for system containerd

### DIFF
--- a/hack/containerd.toml
+++ b/hack/containerd.toml
@@ -1,12 +1,20 @@
 version = 3
 
 disabled_plugins = [
-    "io.containerd.grpc.v1.cri",
     "io.containerd.cri.v1.images",
     "io.containerd.cri.v1.runtime",
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.grpc.v1.sandbox-controllers",
+    "io.containerd.grpc.v1.sandboxes",
     "io.containerd.internal.v1.opt",
     "io.containerd.internal.v1.tracing",
+    "io.containerd.monitor.container.v1.restart",
     "io.containerd.nri.v1.nri",
+    "io.containerd.sandbox.controller.v1.podsandbox",
+    "io.containerd.sandbox.controller.v1.shim",
+    "io.containerd.sandbox.controller.v1",
+    "io.containerd.sandbox.store.v1.local",
+    "io.containerd.sandbox.store.v1",
     "io.containerd.snapshotter.v1.blockfile",
     "io.containerd.tracing.processor.v1.otlp",
 ]


### PR DESCRIPTION
This is to suppress warnings on failure to load plugins, which were harmless, but confusing.

Fixes #9393
