### PR TITLE
docs: Fix typo in extraMounts directory definition for openebs/mayastor documentation

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
@@ -28,9 +28,9 @@ machine:
     openebs.io/engine: mayastor
   kubelet:
     extraMounts:
-      - destination: /var/openebs/local
+      - destination: /var/local/openebs
         type: bind
-        source: /var/openebs/local
+        source: /var/local/openebs
         options:
           - rbind
           - rshared

--- a/website/content/v1.9/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
+++ b/website/content/v1.9/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
@@ -28,9 +28,9 @@ machine:
     openebs.io/engine: mayastor
   kubelet:
     extraMounts:
-      - destination: /var/openebs/local
+      - destination: /var/local/openebs
         type: bind
-        source: /var/openebs/local
+        source: /var/local/openebs
         options:
           - rbind
           - rshared


### PR DESCRIPTION
# Pull Request

## What? (description)

This pr fixes a typo in directory definition for patching talos with openebs/mayastor documentation:
`/var/openebs/local` -> `/var/local/openebs`

## Why? (reasoning)

openebs fails to install with the specified patch applied to talos nodes. Upon investigation the directory hierarchy was swapped in the example. openebs expects the `/var/local/openebs` mount not `/var/openebs/local`

## Acceptance

openebs installation was failing until this change was applied. patching the nodes caused the appropriate extra mount to be applied and openebs progressed successfully

