### PR TITLE
Update replicated-local-storage-with-openebs.md

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
@@ -28,9 +28,9 @@ machine:
     openebs.io/engine: mayastor
   kubelet:
     extraMounts:
-      - destination: /var/local/openebs
+      - destination: /var/openebs/local
         type: bind
-        source: /var/local/openebs
+        source: /var/openebs/local
         options:
           - rbind
           - rshared

--- a/website/content/v1.9/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
+++ b/website/content/v1.9/kubernetes-guides/configuration/replicated-local-storage-with-openebs.md
@@ -28,9 +28,9 @@ machine:
     openebs.io/engine: mayastor
   kubelet:
     extraMounts:
-      - destination: /var/local/openebs
+      - destination: /var/openebs/local
         type: bind
-        source: /var/local/openebs
+        source: /var/openebs/local
         options:
           - rbind
           - rshared


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

I fixed a small typo in the documentation to configure OpenEBS on Talos.

## Why? (reasoning)

The documentation to configure OpenEBS on Talos is using an incorrect path when applying the machine configuration via the patch file. The destination path where OpenEBS mounts is `/var/openebs/local`, whereas the patch file uses `/var/local/openebs`.

The correct path is also defined in [the OpenEBS documentation](https://openebs.netlify.app/docs/user-guides/local-storage-user-guide/local-pv-hostpath/hostpath-installation).

With the incorrect path, the test deployment fails with an error where it complains about the unavailability of the path `/var/local/openebs`.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
