### PR TITLE
fix: do not stop udevd before unmounting volumes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -839,7 +839,7 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 func StopServicesEphemeral(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		// stopping 'cri' service stops everything which depends on it (kubelet, etcd, ...)
-		return system.Services(nil).StopWithRevDepenencies(ctx, "cri", "udevd", "trustd")
+		return system.Services(nil).StopWithRevDepenencies(ctx, "cri", "trustd")
 	}, "stopServicesForUpgrade"
 }
 


### PR DESCRIPTION
As udevd is required by cryptsetup which will timeout if udevd is not working, do not stop it in StopServicesEphemeral, but let StopAllServices handle udev shutdown after cryptsetup close is called

Ref: https://bbs.archlinux.org/viewtopic.php?id=162415

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
