### PR TITLE
fix: improve container detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -760,6 +760,7 @@ RUN <<END
 END
 
 FROM rootfs-base-${TARGETARCH} AS rootfs-base
+RUN echo "true" > /rootfs/usr/etc/in-container
 RUN find /rootfs -print0 \
     | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -67,6 +67,10 @@ const (
 
 // CurrentPlatform is a helper func for discovering the current platform.
 func CurrentPlatform() (p runtime.Platform, err error) {
+	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
+		return newPlatform("container")
+	}
+
 	var platform string
 
 	if p := procfs.ProcCmdline().Get(constants.KernelParamPlatform).First(); p != nil {


### PR DESCRIPTION
Instead of relying on cmdline (which will not work in case it's TinK on Talos, for example), add a file to container rootfs to signal the platform to machined.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
