### PR TITLE
fix: wipe system partitions correctly via kernel args

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -569,6 +569,11 @@ func (opt *ResetOptions) GetSystemDiskTargets() []runtime.PartitionTarget {
 	return xslices.Map(opt.systemDiskTargets, func(t *partition.VolumeWipeTarget) runtime.PartitionTarget { return t })
 }
 
+// String implements runtime.ResetOptions interface.
+func (opt *ResetOptions) String() string {
+	return strings.Join(xslices.Map(opt.systemDiskTargets, func(t *partition.VolumeWipeTarget) string { return t.String() }), ", ")
+}
+
 // Reset resets the node.
 //
 //nolint:gocyclo
@@ -635,9 +640,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 				return nil, fmt.Errorf("failed to reset: volume %q is not ready", spec.Label)
 			}
 
-			target := &partition.VolumeWipeTarget{
-				VolumeStatus: volumeStatus,
-			}
+			target := partition.VolumeWipeTargetFromVolumeStatus(volumeStatus)
 
 			if spec.Wipe {
 				opts.systemDiskTargets = append(opts.systemDiskTargets, target)

--- a/internal/pkg/partition/wipe.go
+++ b/internal/pkg/partition/wipe.go
@@ -16,43 +16,74 @@ import (
 
 // VolumeWipeTarget is a target for wiping a volume.
 type VolumeWipeTarget struct {
-	VolumeStatus *blockres.VolumeStatus
+	label string
+
+	parentDevName, devName string
+}
+
+// VolumeWipeTargetFromVolumeStatus creates a new VolumeWipeTarget from a VolumeStatus.
+func VolumeWipeTargetFromVolumeStatus(vs *blockres.VolumeStatus) *VolumeWipeTarget {
+	parentDevName := vs.TypedSpec().ParentLocation
+
+	if parentDevName == "" {
+		parentDevName = vs.TypedSpec().Location
+	}
+
+	return &VolumeWipeTarget{
+		label:         vs.Metadata().ID(),
+		parentDevName: parentDevName,
+		devName:       vs.TypedSpec().Location,
+	}
+}
+
+// VolumeWipeTargetFromDiscoveredVolume creates a new VolumeWipeTarget from a DiscoveredVolume.
+func VolumeWipeTargetFromDiscoveredVolume(dv *blockres.DiscoveredVolume) *VolumeWipeTarget {
+	parentDevName := dv.TypedSpec().ParentDevPath
+
+	if parentDevName == "" {
+		parentDevName = dv.TypedSpec().DevPath
+	}
+
+	return &VolumeWipeTarget{
+		label:         dv.TypedSpec().PartitionLabel,
+		parentDevName: parentDevName,
+		devName:       dv.TypedSpec().DevPath,
+	}
 }
 
 // GetLabel implements runtime.PartitionTarget.
 func (v *VolumeWipeTarget) GetLabel() string {
-	return v.VolumeStatus.Metadata().ID()
+	return v.label
+}
+
+// String implements runtime.PartitionTarget.
+func (v *VolumeWipeTarget) String() string {
+	return fmt.Sprintf("%s:%s", v.label, v.devName)
 }
 
 // Wipe implements runtime.PartitionTarget.
 func (v *VolumeWipeTarget) Wipe(ctx context.Context, log func(string, ...any)) error {
-	parentDevName := v.VolumeStatus.TypedSpec().ParentLocation
-
-	if parentDevName == "" {
-		parentDevName = v.VolumeStatus.TypedSpec().Location
-	}
-
-	parentBd, err := block.NewFromPath(parentDevName)
+	parentBd, err := block.NewFromPath(v.parentDevName)
 	if err != nil {
-		return fmt.Errorf("error opening block device %q: %w", parentDevName, err)
+		return fmt.Errorf("error opening block device %q: %w", v.parentDevName, err)
 	}
 
 	defer parentBd.Close() //nolint:errcheck
 
 	if err = parentBd.RetryLockWithTimeout(ctx, true, time.Minute); err != nil {
-		return fmt.Errorf("error locking block device %q: %w", parentDevName, err)
+		return fmt.Errorf("error locking block device %q: %w", v.parentDevName, err)
 	}
 
 	defer parentBd.Unlock() //nolint:errcheck
 
-	bd, err := block.NewFromPath(v.VolumeStatus.TypedSpec().Location, block.OpenForWrite())
+	bd, err := block.NewFromPath(v.devName, block.OpenForWrite())
 	if err != nil {
-		return fmt.Errorf("error opening block device %q: %w", v.VolumeStatus.TypedSpec().Location, err)
+		return fmt.Errorf("error opening block device %q: %w", v.devName, err)
 	}
 
 	defer bd.Close() //nolint:errcheck
 
-	log("wiping the volume %q (%s)", v.GetLabel(), v.VolumeStatus.TypedSpec().Location)
+	log("wiping the volume %q (%s)", v.GetLabel(), v.devName)
 
 	return bd.FastWipe()
 }


### PR DESCRIPTION
Use `DiscoveredVolumes` instead of `VolumeStatus`, force reboot to avoid confusion in the volume controller.

Fixes #9448
