### PR TITLE
feat: add recommended app.kubernetes.io labels to control-plane Pods

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -462,8 +462,13 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 					constants.AnnotationStaticPodConfigVersion:     configResource.Metadata().Version().String(),
 				},
 				Labels: map[string]string{
-					"tier":    "control-plane",
-					"k8s-app": k8s.APIServerID,
+					"tier":                         "control-plane",
+					"k8s-app":                      k8s.APIServerID,
+					"component":                    k8s.APIServerID,
+					"app.kubernetes.io/name":       k8s.APIServerID,
+					"app.kubernetes.io/version":    compatibility.VersionFromImageRef(cfg.Image).String(),
+					"app.kubernetes.io/component":  "control-plane",
+					"app.kubernetes.io/managed-by": "Talos",
 				},
 			},
 			Spec: v1.PodSpec{
@@ -635,8 +640,13 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 					constants.AnnotationStaticPodConfigVersion:  configResource.Metadata().Version().String(),
 				},
 				Labels: map[string]string{
-					"tier":    "control-plane",
-					"k8s-app": k8s.ControllerManagerID,
+					"tier":                         "control-plane",
+					"k8s-app":                      k8s.ControllerManagerID,
+					"component":                    k8s.ControllerManagerID,
+					"app.kubernetes.io/name":       k8s.ControllerManagerID,
+					"app.kubernetes.io/version":    compatibility.VersionFromImageRef(cfg.Image).String(),
+					"app.kubernetes.io/component":  "control-plane",
+					"app.kubernetes.io/managed-by": "Talos",
 				},
 			},
 			Spec: v1.PodSpec{
@@ -820,8 +830,13 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 					constants.AnnotationStaticPodConfigVersion:  configResource.Metadata().Version().String(),
 				},
 				Labels: map[string]string{
-					"tier":    "control-plane",
-					"k8s-app": k8s.SchedulerID,
+					"tier":                         "control-plane",
+					"k8s-app":                      k8s.SchedulerID,
+					"component":                    k8s.SchedulerID,
+					"app.kubernetes.io/name":       k8s.SchedulerID,
+					"app.kubernetes.io/version":    compatibility.VersionFromImageRef(cfg.Image).String(),
+					"app.kubernetes.io/component":  "control-plane",
+					"app.kubernetes.io/managed-by": "Talos",
 				},
 			},
 			Spec: v1.PodSpec{


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Closes #9450. This PR adds most of the [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/). These are just my own suggestions though, feel free to suggest different ones or fewer. In particular, not sure about /component vs /part-of so maybe better to leave them out? I also left out `/instance`, not quite sure what to set that to or how, probably something with the node name though.

## Why? (reasoning)

It's useful to have a set of uniform labels across Pods when looking at metrics and logs or even `kubectl` output, for example.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
  - not really applicable
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
  - seemed to have unrelated failures

> See `make help` for a description of the available targets.
