### PR TITLE
Fix typo in documentation

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/device-plugins.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/device-plugins.md
@@ -103,7 +103,7 @@ Now that the device plugin is deployed, you can deploy a pod that requests the d
 The request for the device is specified as a [resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) in the pod spec.
 
 ```yaml
-requests:
+resources:
   limits:
     squat.ai/tun: "1"
 ```


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
There is an error in line 106 of changed documentation, the yaml key is supposed to be resources not requests

## Why? (reasoning)
kubectl errors due to the key not found
```
strict decoding error: unknown field "spec.template.spec.containers[0].requests"
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
