### PR TITLE
fix: do not use pflag csv comma reader for config-patch

### DIFF
--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -162,7 +162,7 @@ func init() {
 	applyConfigCmd.Flags().BoolVarP(&applyConfigCmdFlags.insecure, "insecure", "i", false, "apply the config using the insecure (encrypted with no auth) maintenance service")
 	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.dryRun, "dry-run", false, "check how the config change will be applied in dry-run mode")
 	applyConfigCmd.Flags().StringSliceVar(&applyConfigCmdFlags.certFingerprints, "cert-fingerprint", nil, "list of server certificate fingeprints to accept (defaults to no check)")
-	applyConfigCmd.Flags().StringSliceVarP(&applyConfigCmdFlags.patches, "config-patch", "p", nil, "the list of config patches to apply to the local config file before sending it to the node")
+	applyConfigCmd.Flags().StringArrayVarP(&applyConfigCmdFlags.patches, "config-patch", "p", nil, "the list of config patches to apply to the local config file before sending it to the node")
 	applyConfigCmd.Flags().DurationVar(&applyConfigCmdFlags.configTryTimeout, "timeout", constants.ConfigTryTimeout, "the config will be rolled back after specified timeout (if try mode is selected)")
 	helpers.AddModeFlags(&applyConfigCmdFlags.Mode, applyConfigCmd)
 	addCommand(applyConfigCmd)

--- a/website/content/v1.9/reference/cli.md
+++ b/website/content/v1.9/reference/cli.md
@@ -17,7 +17,7 @@ talosctl apply-config [flags]
 
 ```
       --cert-fingerprint strings                                 list of server certificate fingeprints to accept (defaults to no check)
-  -p, --config-patch strings                                     the list of config patches to apply to the local config file before sending it to the node
+  -p, --config-patch stringArray                                 the list of config patches to apply to the local config file before sending it to the node
       --dry-run                                                  check how the config change will be applied in dry-run mode
   -f, --file string                                              the filename of the updated configuration
   -h, --help                                                     help for apply-config


### PR DESCRIPTION
Modules pflag and cobra use csv.Reader for `StringSliceVar` method. This doesn't work well with JSON, and we do not need this at all. Drop it.

Fixes #9493