### PR TITLE
feat: introduce metal agent mode

### DIFF
--- a/internal/app/machined/pkg/runtime/mode.go
+++ b/internal/app/machined/pkg/runtime/mode.go
@@ -21,6 +21,8 @@ const (
 	ModeContainer
 	// ModeMetal is the metal runtime mode.
 	ModeMetal
+	// ModeMetalAgent is the metal agent runtime mode.
+	ModeMetalAgent
 )
 
 const (
@@ -37,14 +39,15 @@ const (
 )
 
 const (
-	cloud     = "cloud"
-	container = "container"
-	metal     = "metal"
+	cloud      = "cloud"
+	container  = "container"
+	metal      = "metal"
+	metalAgent = "metal-agent"
 )
 
 // String returns the string representation of a Mode.
 func (m Mode) String() string {
-	return [...]string{cloud, container, metal}[m]
+	return [...]string{cloud, container, metal, metalAgent}[m]
 }
 
 // RequiresInstall implements config.RuntimeMode.
@@ -62,6 +65,11 @@ func (m Mode) Supports(feature ModeCapability) bool {
 	return (m.capabilities() & uint64(feature)) != 0
 }
 
+// IsAgent returns true if the mode is an agent mode (i.e. metal agent mode).
+func (m Mode) IsAgent() bool {
+	return m == ModeMetalAgent
+}
+
 // ParseMode returns a `Mode` that matches the specified string.
 func ParseMode(s string) (mod Mode, err error) {
 	switch s {
@@ -71,6 +79,8 @@ func ParseMode(s string) (mod Mode, err error) {
 		mod = ModeContainer
 	case metal:
 		mod = ModeMetal
+	case metalAgent:
+		mod = ModeMetalAgent
 	default:
 		return mod, fmt.Errorf("unknown runtime mode: %q", s)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -43,7 +43,9 @@ const (
 )
 
 // Metal is a discoverer for non-cloud environments.
-type Metal struct{}
+type Metal struct {
+	IsAgent bool
+}
 
 // Name implements the platform.Platform interface.
 func (m *Metal) Name() string {
@@ -118,6 +120,10 @@ func (m *Metal) Configuration(ctx context.Context, r state.State) ([]byte, error
 
 // Mode implements the platform.Platform interface.
 func (m *Metal) Mode() runtime.Mode {
+	if m.IsAgent {
+		return runtime.ModeMetalAgent
+	}
+
 	return runtime.ModeMetal
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -113,7 +113,11 @@ func newPlatform(platform string) (p runtime.Platform, err error) {
 	case "hcloud":
 		p = &hcloud.Hcloud{}
 	case constants.PlatformMetal:
-		p = &metal.Metal{}
+		_, metalAgentCheckErr := os.Stat(constants.MetalAgentModeFlagPath)
+
+		p = &metal.Metal{
+			IsAgent: metalAgentCheckErr == nil,
+		}
 	case "opennebula":
 		p = &opennebula.OpenNebula{}
 	case "openstack":

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -120,6 +120,15 @@ func WaitForUSB(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	}, "waitForUSB"
 }
 
+// LogMode represents the LogMode task.
+func LogMode(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+		logger.Printf("running in mode: %s", r.State().Platform().Mode())
+
+		return nil
+	}, "logMode"
+}
+
 // EnforceKSPPRequirements represents the EnforceKSPPRequirements task.
 func EnforceKSPPRequirements(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -96,7 +96,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&block.LVMActivationController{},
 		&block.SystemDiskController{},
 		&block.UserDiskConfigController{},
-		&block.VolumeConfigController{},
+		&block.VolumeConfigController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&block.VolumeManagerController{},
 		&cluster.AffiliateMergeController{},
 		cluster.NewConfigController(),
@@ -314,7 +316,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			Drainer: drainer,
 		},
 		&runtimecontrollers.MaintenanceConfigController{},
-		&runtimecontrollers.MaintenanceServiceController{},
+		&runtimecontrollers.MaintenanceServiceController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&runtimecontrollers.MachineStatusController{
 			V1Alpha1Events: ctrl.v1alpha1Runtime.Events(),
 		},

--- a/pkg/machinery/cel/celenv/celenv.go
+++ b/pkg/machinery/cel/celenv/celenv.go
@@ -16,6 +16,16 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/resource/definitions/block"
 )
 
+// Empty is an empty CEL environment.
+var Empty = sync.OnceValue(func() *cel.Env {
+	env, err := cel.NewEnv()
+	if err != nil {
+		panic(err)
+	}
+
+	return env
+})
+
 // DiskLocator is a disk locator CEL environment.
 var DiskLocator = sync.OnceValue(func() *cel.Env {
 	var diskSpec block.DiskSpec

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1094,6 +1094,9 @@ const (
 	//
 	// Note: 116 = 't' and 108 = 'l' in ASCII.
 	HostDNSAddress = "169.254.116.108"
+
+	// MetalAgentModeFlagPath is the path to the file indicating if the node is running in Metal Agent mode.
+	MetalAgentModeFlagPath = "/usr/local/etc/is-metal-agent"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Introduce a new operating mode called the metal agent mode.

The mode is activated by the presence of a `/usr/local/etc/is-metal-agent` file under the root FS.

In this mode, Talos will:
- Only run the Initialize sequence, won't follow it up with the install/boot sequences
- Mark STATE partitions as `missing`, so Talos will always be in "not installed" state.
- Block applying configuration via API while in maintenance mode.

This mode can be used e.g., to collect hardware information from bare-metal servers.