### PR TITLE
chore: use virtio driver for disks in arm64

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -878,6 +878,11 @@ func create(ctx context.Context) error {
 	for i := range extraDisks {
 		driver := "ide"
 
+		// ide driver is not supported on arm64
+		if targetArch == "arm64" {
+			driver = "virtio"
+		}
+
 		if i < len(extraDisksDrivers) {
 			driver = extraDisksDrivers[i]
 		}


### PR DESCRIPTION
ARM64 doesn't support `ide` as a disk driver for disks, use `virtio` instead.