### PR TITLE
test: add json logs test environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-23T13:32:15Z by kres 8be5fa7.
+# Generated on 2024-10-16T13:22:04Z by kres 34e72ac.
 
 name: default
 concurrency:
@@ -2775,6 +2775,7 @@ jobs:
           QEMU_EXTRA_DISKS_DRIVERS: ide,nvme
           QEMU_EXTRA_DISKS_SIZE: "10240"
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
+          WITH_JSON_LOGS: "true"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-20T16:31:33Z by kres 8be5fa7.
+# Generated on 2024-10-16T13:22:04Z by kres 34e72ac.
 
 name: integration-qemu-cron
 concurrency:
@@ -85,6 +85,7 @@ jobs:
           QEMU_EXTRA_DISKS_DRIVERS: ide,nvme
           QEMU_EXTRA_DISKS_SIZE: "10240"
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
+          WITH_JSON_LOGS: "true"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -333,6 +333,7 @@ spec:
             QEMU_EXTRA_DISKS_SIZE: "10240"
             QEMU_EXTRA_DISKS_DRIVERS: "ide,nvme"
             WITH_CONFIG_PATCH_WORKER: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml"
+            WITH_JSON_LOGS: "true"
         - name: save-talos-logs
           conditions:
             - always

--- a/cmd/talosctl/cmd/mgmt/json_logs_launch.go
+++ b/cmd/talosctl/cmd/mgmt/json_logs_launch.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mgmt
+
+import (
+	"bufio"
+	"log"
+	"net"
+	"net/netip"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+var jsonLogsLaunchCmdFlags struct {
+	addr string
+}
+
+// jsonLogsLaunchCmd represents the kms-launch command.
+var jsonLogsLaunchCmd = &cobra.Command{
+	Use:    "json-logs-launch",
+	Short:  "Internal command used by QEMU provisioner",
+	Long:   ``,
+	Args:   cobra.NoArgs,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		lis, err := net.Listen("tcp", jsonLogsLaunchCmdFlags.addr)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("starting JSON logs server on %s", jsonLogsLaunchCmdFlags.addr)
+
+		eg, ctx := errgroup.WithContext(cmd.Context())
+
+		eg.Go(func() error {
+			for {
+				conn, err := lis.Accept()
+				if err != nil {
+					return err
+				}
+
+				go func() {
+					defer conn.Close() //nolint:errcheck
+
+					remoteAddr := conn.RemoteAddr().String()
+
+					if addr, err := netip.ParseAddrPort(remoteAddr); err == nil {
+						remoteAddr = addr.Addr().String()
+					}
+
+					scanner := bufio.NewScanner(conn)
+
+					for scanner.Scan() {
+						log.Printf("%s: %s", remoteAddr, scanner.Text())
+					}
+				}()
+			}
+		})
+
+		eg.Go(func() error {
+			<-ctx.Done()
+
+			return lis.Close()
+		})
+
+		return eg.Wait()
+	},
+}
+
+func init() {
+	jsonLogsLaunchCmd.Flags().StringVar(&jsonLogsLaunchCmdFlags.addr, "addr", "localhost:3000", "JSON logs listen address")
+	addCommand(jsonLogsLaunchCmd)
+}

--- a/cmd/talosctl/cmd/mgmt/kms_launch.go
+++ b/cmd/talosctl/cmd/mgmt/kms_launch.go
@@ -74,7 +74,7 @@ var kmsLaunchCmd = &cobra.Command{
 			return nil
 		})
 
-		return s.Serve(lis)
+		return eg.Wait()
 	},
 }
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -42,6 +42,12 @@ case "${WITH_VIRTUAL_IP:-false}" in
     ;;
 esac
 
+case "${WITH_JSON_LOGS:-false}" in
+  true)
+    QEMU_FLAGS+=("--with-json-logs")
+    ;;
+esac
+
 case "${WITH_CLUSTER_DISCOVERY:-true}" in
   false)
     QEMU_FLAGS+=("--with-cluster-discovery=false" "--kubeprism-port=0") # disable both KubePrism and cluster discovery

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -133,6 +133,15 @@ func WithKMS(endpoint string) Option {
 	}
 }
 
+// WithJSONLogs specifies endpoint to send logs in JSON format.
+func WithJSONLogs(endpoint string) Option {
+	return func(o *Options) error {
+		o.JSONLogsEndpoint = endpoint
+
+		return nil
+	}
+}
+
 // WithSiderolinkAgent enables or disables siderolink agent.
 func WithSiderolinkAgent(v bool) Option {
 	return func(o *Options) error {
@@ -165,7 +174,8 @@ type Options struct {
 	DockerPortsHostIP string
 	DeleteStateOnErr  bool
 
-	KMSEndpoint string
+	KMSEndpoint      string
+	JSONLogsEndpoint string
 
 	SiderolinkEnabled bool
 }

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -16,7 +16,7 @@ import (
 
 // Create Talos cluster as a set of qemu VMs.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (p *provisioner) Create(ctx context.Context, request provision.ClusterRequest, opts ...provision.Option) (provision.Cluster, error) {
 	options := provision.DefaultOptions()
 
@@ -75,6 +75,14 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 		if err = p.CreateKMS(state, request, options); err != nil {
 			return nil, fmt.Errorf("error creating KMS server: %w", err)
+		}
+	}
+
+	if options.JSONLogsEndpoint != "" {
+		fmt.Fprintln(options.LogWriter, "creating JSON logs server")
+
+		if err = p.CreateJSONLogs(state, request, options); err != nil {
+			return nil, fmt.Errorf("error creating JSON logs server: %w", err)
 		}
 	}
 

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -76,6 +76,12 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
+	fmt.Fprintln(options.LogWriter, "removing json logs")
+
+	if err := p.DestroyJSONLogs(state); err != nil {
+		return err
+	}
+
 	fmt.Fprintln(options.LogWriter, "removing network")
 
 	if err := p.DestroyNetwork(state); err != nil {

--- a/pkg/provision/providers/vm/json-logs.go
+++ b/pkg/provision/providers/vm/json-logs.go
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+const (
+	jsonLogsPid = "json-logs.pid"
+	jsonLogsLog = "json-logs.log"
+)
+
+// CreateJSONLogs creates JSON logs server.
+func (p *Provisioner) CreateJSONLogs(state *State, clusterReq provision.ClusterRequest, options provision.Options) error {
+	pidPath := state.GetRelativePath(jsonLogsPid)
+
+	logFile, err := os.OpenFile(state.GetRelativePath(jsonLogsLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return err
+	}
+
+	defer logFile.Close() //nolint:errcheck
+
+	key := make([]byte, 32)
+	if _, err = io.ReadFull(rand.Reader, key); err != nil {
+		return err
+	}
+
+	args := []string{
+		"json-logs-launch",
+		"--addr", options.JSONLogsEndpoint,
+	}
+
+	cmd := exec.Command(clusterReq.SelfExecutable, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // daemonize
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing LB PID file: %w", err)
+	}
+
+	return nil
+}
+
+// DestroyJSONLogs destroys JSON logs server.
+func (p *Provisioner) DestroyJSONLogs(state *State) error {
+	pidPath := state.GetRelativePath(jsonLogsPid)
+
+	return StopProcessByPidfile(pidPath)
+}

--- a/website/content/v1.9/reference/cli.md
+++ b/website/content/v1.9/reference/cli.md
@@ -209,6 +209,7 @@ talosctl cluster create [flags]
       --with-debug                               enable debug in Talos config to send service logs to the console
       --with-firewall string                     inject firewall rules into the cluster, value is default policy - accept/block (QEMU only)
       --with-init-node                           create the cluster with an init node
+      --with-json-logs                           enable JSON logs receiver and configure Talos to send logs there
       --with-kubespan                            enable KubeSpan system
       --with-network-bandwidth int               specify bandwidth restriction (in kbps) on the bridge interface when creating a qemu cluster
       --with-network-chaos                       enable to use network chaos parameters when creating a qemu cluster


### PR DESCRIPTION
Add an option to `talosctl cluster create` to start a JSON log receiver, and enabled it optionally.

Enable in `integration-qemu`.

See #9510
