### PR TITLE
chore: add arm64 target for integration-test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -964,7 +964,7 @@ RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type
 
 # The integration-test targets builds integration test binary.
 
-FROM base AS integration-test-linux-build
+FROM base AS integration-test-linux-amd64-build
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
 ARG GOAMD64
@@ -973,20 +973,21 @@ RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=amd64 GOAMD64=${GOAMD64}
     -tags integration,integration_api,integration_cli,integration_k8s \
     ./internal/integration
 
-FROM scratch AS integration-test-linux
-COPY --from=integration-test-linux-build /src/integration.test /integration-test-linux-amd64
+FROM scratch AS integration-test-linux-amd64
+COPY --from=integration-test-linux-amd64-build /src/integration.test /integration-test-linux-amd64
 
-FROM base AS integration-test-darwin-build
+FROM base AS integration-test-linux-arm64-build
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
-ARG GOAMD64
-RUN --mount=type=cache,target=/.cache GOOS=darwin GOARCH=amd64 GOAMD64=${GOAMD64} go test -v -c ${GO_BUILDFLAGS} \
+RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=arm64 go test -v -c ${GO_BUILDFLAGS} \
     -ldflags "${GO_LDFLAGS}" \
     -tags integration,integration_api,integration_cli,integration_k8s \
     ./internal/integration
 
-FROM scratch AS integration-test-darwin
-COPY --from=integration-test-darwin-build /src/integration.test /integration-test-darwin-amd64
+FROM scratch AS integration-test-linux-arm64
+COPY --from=integration-test-linux-arm64-build /src/integration.test /integration-test-linux-arm64
+
+FROM --platform=${BUILDPLATFORM} integration-test-${TARGETOS}-${TARGETARCH} AS integration-test-targetarch
 
 # The integration-test-provision target builds integration test binary with provisioning tests.
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
 TALOSCTL_EXECUTABLE := $(PWD)/$(ARTIFACTS)/$(TALOSCTL_DEFAULT_TARGET)-$(ARCH)
-INTEGRATION_TEST_DEFAULT_TARGET := integration-test-$(OPERATING_SYSTEM)
+INTEGRATION_TEST := integration-test
+INTEGRATION_TEST_DEFAULT_TARGET := $(INTEGRATION_TEST)-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_PROVISION_DEFAULT_TARGET := integration-test-provision-$(OPERATING_SYSTEM)
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.31.1
@@ -482,7 +483,13 @@ unit-tests-race: ## Performs unit tests with race detection enabled.
 	@$(MAKE) target-$@ TARGET_ARGS="--allow security.insecure" PLATFORM=linux/amd64
 
 $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64:
-	@$(MAKE) local-$(INTEGRATION_TEST_DEFAULT_TARGET) DEST=$(ARTIFACTS) PLATFORM=linux/amd64 WITH_RACE=true NAME=Client PUSH=false
+	@$(MAKE) local-$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 DEST=$(ARTIFACTS) PLATFORM=linux/amd64 WITH_RACE=true NAME=Client PUSH=false
+
+$(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-arm64:
+	@$(MAKE) local-$(INTEGRATION_TEST_DEFAULT_TARGET)-arm64 DEST=$(ARTIFACTS) PLATFORM=linux/arm64 WITH_RACE=true NAME=Client PUSH=false
+
+$(ARTIFACTS)/$(INTEGRATION_TEST):
+	@$(MAKE) local-$(INTEGRATION_TEST)-targetarch DEST=$(ARTIFACTS)
 
 $(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64:
 	@$(MAKE) local-$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET) DEST=$(ARTIFACTS) PLATFORM=linux/amd64 WITH_RACE=true NAME=Client


### PR DESCRIPTION
Add arm64 target for integration-test, make developing on arm64 machines easier.