### PR TITLE
fix: support `extra-disks` when using iso

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -419,7 +419,8 @@ func launchVM(config *LaunchConfig) error {
 	if !diskBootable || !config.BootloaderEnabled {
 		if config.ISOPath != "" {
 			args = append(args,
-				"-cdrom", config.ISOPath,
+				"-drive",
+				fmt.Sprintf("file=%s,media=cdrom", config.ISOPath),
 			)
 		} else if config.KernelImagePath != "" {
 			args = append(args,


### PR DESCRIPTION
When using `iso` and `extra-disks` we're getting errors like below for any nodes than the first node.

```text
qemu-system-aarch64: -cdrom _out/metal-arm64-secureboot.iso: drive with bus=0, unit=2 (index=2) exists
```

Fix by explicitly specifying the the media is cdrom, so qemu doesn't index.