### PR TITLE
feat: add Talos 1.9 compatiblity guarantees

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos17"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos18"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos19"
 )
 
 // KubernetesVersion embeds Kubernetes version.
@@ -41,6 +42,8 @@ func (v *KubernetesVersion) String() string {
 }
 
 // SupportedWith checks if the Kubernetes version is supported with specified version of Talos.
+//
+//nolint:gocyclo
 func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 	var minK8sVersion, maxK8sVersion semver.Version
 
@@ -59,6 +62,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 		minK8sVersion, maxK8sVersion = talos17.MinimumKubernetesVersion, talos17.MaximumKubernetesVersion
 	case talos18.MajorMinor: // upgrades to 1.8.x
 		minK8sVersion, maxK8sVersion = talos18.MinimumKubernetesVersion, talos18.MaximumKubernetesVersion
+	case talos19.MajorMinor: // upgrades to 1.9.x
+		minK8sVersion, maxK8sVersion = talos19.MinimumKubernetesVersion, talos19.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -253,12 +253,45 @@ func TestKubernetesCompatibility18(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility19(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.28.1",
+			target:            "1.9.0",
+		},
+		{
+			kubernetesVersion: "1.27.1",
+			target:            "1.9.0",
+		},
+		{
+			kubernetesVersion: "1.31.3",
+			target:            "1.9.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.32.0-rc.0",
+			target:            "1.9.7",
+		},
+		{
+			kubernetesVersion: "1.33.0-alpha.0",
+			target:            "1.9.0",
+			expectedError:     "version of Kubernetes 1.33.0-alpha.0 is too new to be used with Talos 1.9.0",
+		},
+		{
+			kubernetesVersion: "1.26.1",
+			target:            "1.9.0",
+			expectedError:     "version of Kubernetes 1.26.1 is too old to be used with Talos 1.9.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.9.0-alpha.0",
-			expectedError:     "compatibility with version 1.9.0-alpha.0 is not supported",
+			target:            "1.10.0-alpha.0",
+			expectedError:     "compatibility with version 1.10.0-alpha.0 is not supported",
 		},
 		{
 			kubernetesVersion: "1.25.0",

--- a/pkg/machinery/compatibility/talos19/talos19.go
+++ b/pkg/machinery/compatibility/talos19/talos19.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos19 provides compatibility constants for Talos 1.9.
+package talos19
+
+import (
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinor is the major.minor version of Talos 1.9.
+var MajorMinor = [2]uint64{1, 9}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.9.
+var MinimumHostUpgradeVersion = semver.MustParse("1.8.0")
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.9.
+var MaximumHostDowngradeVersion = semver.MustParse("1.11.0")
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.9.
+var DeniedHostUpgradeVersions []semver.Version
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.9.
+var MinimumKubernetesVersion = semver.MustParse("1.27.0")
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.9.
+var MaximumKubernetesVersion = semver.MustParse("1.32.99")

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos16"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos17"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos18"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos19"
 )
 
 // TalosVersion embeds Talos version.
@@ -94,6 +95,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	case talos18.MajorMinor: // upgrades to 1.8.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos18.MinimumHostUpgradeVersion, talos18.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos18.DeniedHostUpgradeVersions
+	case talos19.MajorMinor: // upgrades to 1.9.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos19.MinimumHostUpgradeVersion, talos19.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos19.DeniedHostUpgradeVersions
 	default:
 		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
 	}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -286,17 +286,58 @@ func TestTalosUpgradeCompatibility18(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility19(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.8.0",
+			target: "1.9.0",
+		},
+		{
+			host:   "1.8.0-alpha.0",
+			target: "1.9.0",
+		},
+		{
+			host:   "1.8.0",
+			target: "1.9.0-alpha.0",
+		},
+		{
+			host:   "1.8.3",
+			target: "1.9.1",
+		},
+		{
+			host:   "1.9.0-beta.0",
+			target: "1.9.0",
+		},
+		{
+			host:   "1.9.5",
+			target: "1.9.3",
+		},
+		{
+			host:          "1.7.0",
+			target:        "1.9.0",
+			expectedError: `host version 1.7.0 is too old to upgrade to Talos 1.9.0`,
+		},
+		{
+			host:          "1.11.0-alpha.0",
+			target:        "1.9.0",
+			expectedError: `host version 1.11.0-alpha.0 is too new to downgrade to Talos 1.9.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.9.0-alpha.0",
-			expectedError: `upgrades to version 1.9.0-alpha.0 are not supported`,
+			target:        "1.10.0-alpha.0",
+			expectedError: `upgrades to version 1.10.0-alpha.0 are not supported`,
 		},
 		{
 			host:          "1.4.0",
-			target:        "1.10.0-alpha.0",
-			expectedError: `upgrades to version 1.10.0-alpha.0 are not supported`,
+			target:        "1.11.0-alpha.0",
+			expectedError: `upgrades to version 1.11.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)


### PR DESCRIPTION
To be backported to Talos 1.8 machinery to provide upgrade compatibility.
