### PR TITLE
fix: correct error message for invalid ip=

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -214,7 +214,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 
 					ntpIP, err = netip.ParseAddr(fields[i])
 					if err != nil {
-						return settings, fmt.Errorf("error parsing DNS IP: %w", err)
+						return settings, fmt.Errorf("error parsing NTP IP: %w", err)
 					}
 
 					settings.NTPAddresses = append(settings.NTPAddresses, ntpIP)


### PR DESCRIPTION
Fix copy pasta in parse NTP address error message.