### PR TITLE
docs: fix image factory links

### DIFF
--- a/website/content/v1.7/talos-guides/install/single-board-computers/bananapi_m64.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/bananapi_m64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Banana Pi M64 is `8e11dcb3c2803fbe893ab201fcadf1ef295568410e7ced95c6c8b122a5070ce4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/jetson_nano.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/jetson_nano.md
@@ -83,7 +83,7 @@ Once the flashing is done you can disconnect the USB cable and power off the Jet
 ## Download the Image
 
 The default schematic id for "vanilla" Jetson Nano is `c7d6f36c6bdfb45fd63178b202a67cff0dd270262269c64886b43f76880ecf1e`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Libretech H3 CC H5 is `5689d7795f91ac5bf6ccc85093fad8f8b27f6ea9d96a9ac5a059997bffd8ad5c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/nanopi_r4s.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/nanopi_r4s.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" NanoPi R4S is `5f74a09891d5830f0b36158d3d9ea3b1c9cc019848ace08ff63ba255e38c8da4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Orange Pi R1 Plus LTS is `da388062cd9318efdc7391982a77ebb2a97ed4fbda68f221354c17839a750509`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/pine64.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/pine64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 is `185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/rock4cplus.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/rock4cplus.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Rock 4c Plus is `ed7091ab924ef1406dadc4623c90f245868f03d262764ddc2c22c8a19eb37c1c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/rock64.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/rock64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 Rock64 is `0e162298269125049a51ec0a03c2ef85405a55e1d2ac36a7ef7292358cf3ce5a`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/rockpi_4.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/rockpi_4.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4 is `25d2690bb48685de5939edd6dee83a0e09591311e64ad03c550de00f8a521f51`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/rockpi_4c.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/rockpi_4c.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4c is `08e72e242b71f42c9db5bed80e8255b2e0d442a372bc09055b79537d9e3ce191`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.7/talos-guides/install/single-board-computers/rpi_generic.md
+++ b/website/content/v1.7/talos-guides/install/single-board-computers/rpi_generic.md
@@ -44,7 +44,7 @@ Power off the Raspberry Pi and remove the SD card from it.
 
 ## Download the Image
 
-The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/bananapi_m64.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/bananapi_m64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Banana Pi M64 is `8e11dcb3c2803fbe893ab201fcadf1ef295568410e7ced95c6c8b122a5070ce4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/jetson_nano.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/jetson_nano.md
@@ -83,7 +83,7 @@ Once the flashing is done you can disconnect the USB cable and power off the Jet
 ## Download the Image
 
 The default schematic id for "vanilla" Jetson Nano is `c7d6f36c6bdfb45fd63178b202a67cff0dd270262269c64886b43f76880ecf1e`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Libretech H3 CC H5 is `5689d7795f91ac5bf6ccc85093fad8f8b27f6ea9d96a9ac5a059997bffd8ad5c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/nanopi_r4s.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/nanopi_r4s.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" NanoPi R4S is `5f74a09891d5830f0b36158d3d9ea3b1c9cc019848ace08ff63ba255e38c8da4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Orange Pi R1 Plus LTS is `da388062cd9318efdc7391982a77ebb2a97ed4fbda68f221354c17839a750509`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/pine64.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/pine64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 is `185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/rock4cplus.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/rock4cplus.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Rock 4c Plus is `ed7091ab924ef1406dadc4623c90f245868f03d262764ddc2c22c8a19eb37c1c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/rock64.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/rock64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 Rock64 is `0e162298269125049a51ec0a03c2ef85405a55e1d2ac36a7ef7292358cf3ce5a`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/rockpi_4.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/rockpi_4.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4 is `25d2690bb48685de5939edd6dee83a0e09591311e64ad03c550de00f8a521f51`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/rockpi_4c.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/rockpi_4c.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4c is `08e72e242b71f42c9db5bed80e8255b2e0d442a372bc09055b79537d9e3ce191`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.8/talos-guides/install/single-board-computers/rpi_generic.md
+++ b/website/content/v1.8/talos-guides/install/single-board-computers/rpi_generic.md
@@ -44,7 +44,7 @@ Power off the Raspberry Pi and remove the SD card from it.
 
 ## Download the Image
 
-The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/bananapi_m64.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/bananapi_m64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Banana Pi M64 is `8e11dcb3c2803fbe893ab201fcadf1ef295568410e7ced95c6c8b122a5070ce4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/jetson_nano.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/jetson_nano.md
@@ -83,7 +83,7 @@ Once the flashing is done you can disconnect the USB cable and power off the Jet
 ## Download the Image
 
 The default schematic id for "vanilla" Jetson Nano is `c7d6f36c6bdfb45fd63178b202a67cff0dd270262269c64886b43f76880ecf1e`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Libretech H3 CC H5 is `5689d7795f91ac5bf6ccc85093fad8f8b27f6ea9d96a9ac5a059997bffd8ad5c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/nanopi_r4s.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/nanopi_r4s.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" NanoPi R4S is `5f74a09891d5830f0b36158d3d9ea3b1c9cc019848ace08ff63ba255e38c8da4`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/orangepi_r1_plus_lts.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image using Image Factory
 
 The default schematic id for "vanilla" Orange Pi R1 Plus LTS is `da388062cd9318efdc7391982a77ebb2a97ed4fbda68f221354c17839a750509`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/pine64.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/pine64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 is `185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/rock4cplus.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/rock4cplus.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Rock 4c Plus is `ed7091ab924ef1406dadc4623c90f245868f03d262764ddc2c22c8a19eb37c1c`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/rock64.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/rock64.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" Pine64 Rock64 is `0e162298269125049a51ec0a03c2ef85405a55e1d2ac36a7ef7292358cf3ce5a`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/rockpi_4.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/rockpi_4.md
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4 is `25d2690bb48685de5939edd6dee83a0e09591311e64ad03c550de00f8a521f51`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/rockpi_4c.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/rockpi_4c.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/talosctl
 ## Download the Image
 
 The default schematic id for "vanilla" RockPi 4c is `08e72e242b71f42c9db5bed80e8255b2e0d442a372bc09055b79537d9e3ce191`.
-Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 

--- a/website/content/v1.9/talos-guides/install/single-board-computers/rpi_generic.md
+++ b/website/content/v1.9/talos-guides/install/single-board-computers/rpi_generic.md
@@ -44,7 +44,7 @@ Power off the Raspberry Pi and remove the SD card from it.
 
 ## Download the Image
 
-The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory](/../../../learn-more/image-factory) documentation for more information.
+The default schematic id for "vanilla" Raspberry Pi generic image is `ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9`.Refer to the [Image Factory]({{< relref "../../../learn-more/image-factory" >}}) documentation for more information.
 
 Download the image and decompress it:
 


### PR DESCRIPTION
`relref` is verified by Hugo vs. the raw link.

Fixes #9499
