### PR TITLE
feat: update Flannel to v0.26.0

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -20,7 +20,7 @@ preface = """
         description = """\
 Linux: 6.6.57
 containerd: 2.0.0-rc.5
-Flannel: 0.25.7
+Flannel: 0.26.0
 Kubernetes: 1.32.0-alpha.2
 runc: 1.2.0
 

--- a/pkg/flannel/template.go
+++ b/pkg/flannel/template.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.25.7/Documentation/kube-flannel.yml DO NOT EDIT
+// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.26.0/Documentation/kube-flannel.yml DO NOT EDIT
 
 package flannel
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1037,7 +1037,7 @@ const (
 	DashboardTTY = 2
 
 	// FlannelVersion is the version of flannel to use.
-	FlannelVersion = "v0.25.7"
+	FlannelVersion = "v0.26.0"
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"


### PR DESCRIPTION
See https://github.com/flannel-io/flannel/releases/tag/v0.26.0

(Not backporting this, as it is built against CNI 1.6.0 which is only in `main`).