### PR TITLE
feat: allow extensions to log to console

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -27,9 +27,9 @@ import (
 
 // containerdRunner is a runner.Runner that runs container in containerd.
 type containerdRunner struct {
-	args  *runner.Args
-	opts  *runner.Options
-	debug bool
+	args         *runner.Args
+	opts         *runner.Options
+	logToConsole bool
 
 	stop    chan struct{}
 	stopped chan struct{}
@@ -41,13 +41,13 @@ type containerdRunner struct {
 }
 
 // NewRunner creates runner.Runner that runs a container in containerd.
-func NewRunner(debug bool, args *runner.Args, setters ...runner.Option) runner.Runner {
+func NewRunner(logToConsole bool, args *runner.Args, setters ...runner.Option) runner.Runner {
 	r := &containerdRunner{
-		args:    args,
-		opts:    runner.DefaultOptions(),
-		debug:   debug,
-		stop:    make(chan struct{}),
-		stopped: make(chan struct{}),
+		args:         args,
+		opts:         runner.DefaultOptions(),
+		logToConsole: logToConsole,
+		stop:         make(chan struct{}),
+		stopped:      make(chan struct{}),
 	}
 
 	for _, setter := range setters {
@@ -170,7 +170,7 @@ func (c *containerdRunner) Run(eventSink events.Recorder) error {
 
 	var w io.Writer = logW
 
-	if c.debug {
+	if c.logToConsole {
 		w = io.MultiWriter(w, os.Stdout)
 	}
 

--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -201,14 +201,18 @@ func (svc *Extension) Runner(r runtime.Runtime) (runner.Runner, error) {
 
 	ociSpecOpts := svc.getOCIOptions(envVars, mounts)
 
-	debug := false
+	logToConsole := false
 
 	if r.Config() != nil {
-		debug = r.Config().Debug()
+		logToConsole = r.Config().Debug()
+	}
+
+	if svc.Spec.LogToConsole {
+		logToConsole = true
 	}
 
 	return restart.New(containerd.NewRunner(
-		debug,
+		logToConsole,
 		&args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithNamespace(constants.SystemContainerdNamespace),

--- a/pkg/machinery/extensions/services/services.go
+++ b/pkg/machinery/extensions/services/services.go
@@ -31,6 +31,8 @@ type Spec struct {
 	Depends []Dependency `yaml:"depends"`
 	// Restart configuration.
 	Restart RestartKind `yaml:"restart"`
+	// LogToConsole enables sending service logs to the console.
+	LogToConsole bool `yaml:"logToConsole"`
 }
 
 // Container specifies service container to run.

--- a/website/content/v1.8/advanced/extension-services.md
+++ b/website/content/v1.8/advanced/extension-services.md
@@ -44,6 +44,7 @@ depends:
        - etcfiles
    - time: true
 restart: never|always|untilSuccess
+logToConsole: true|false
 ```
 
 ### `name`
@@ -138,6 +139,12 @@ Field `restart` defines the service restart policy, it allows to either configur
 * `always`: restart service always
 * `never`: start service only once and never restart
 * `untilSuccess`: restart failing service, stop restarting on successful run
+
+### `logToConsole`
+
+Field `logToConsole` defines whether the service logs should also be written to the console, i.e., to kernel log buffer (or to the container logs in container mode).
+
+This feature is particularly useful for debugging extensions that operate in maintenance mode or early in the boot process when service logs cannot be accessed yet.
 
 ## Example
 

--- a/website/content/v1.9/advanced/extension-services.md
+++ b/website/content/v1.9/advanced/extension-services.md
@@ -44,6 +44,7 @@ depends:
        - etcfiles
    - time: true
 restart: never|always|untilSuccess
+logToConsole: true|false
 ```
 
 ### `name`
@@ -138,6 +139,12 @@ Field `restart` defines the service restart policy, it allows to either configur
 * `always`: restart service always
 * `never`: start service only once and never restart
 * `untilSuccess`: restart failing service, stop restarting on successful run
+
+### `logToConsole`
+
+Field `logToConsole` defines whether the service logs should also be written to the console, i.e., to kernel log buffer (or to the container logs in container mode).
+
+This feature is particularly useful for debugging extensions that operate in maintenance mode or early in the boot process when service logs cannot be accessed yet.
 
 ## Example
 


### PR DESCRIPTION
Allow extensions to opt-in for their logs to be printed in the console, i.e., Talos kernel log buffer as well as their default logging target.