### PR TITLE
feat: add parsing of vlanNNNN:ethX style VLAN cmdline args

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -337,10 +337,17 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 
 		_, vlanNumberString, ok := strings.Cut(vlanName, ".")
 		if !ok {
-			return settings, fmt.Errorf("malformed vlan commandline argument: %s", *vlanSettings)
+			vlanNumberString, ok = strings.CutPrefix(vlanName, "vlan")
+			if !ok {
+				return settings, fmt.Errorf("malformed vlan commandline argument: %s", *vlanSettings)
+			}
 		}
 
 		vlanID, err := strconv.Atoi(vlanNumberString)
+
+		if vlanID < 1 || 4095 < vlanID {
+			return settings, fmt.Errorf("invalid vlanID=%d, must be in the range 1..4095: %s", vlanID, *vlanSettings)
+		}
 
 		if err != nil || vlanNumberString == "" {
 			return settings, errors.New("unable to parse vlan")

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -5,6 +5,7 @@
 package network_test
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
 	"sort"
@@ -431,6 +432,58 @@ func (suite *CmdlineSuite) TestParse() {
 					},
 				},
 			},
+		},
+		{
+			name:    "vlan configuration with alternative link name vlan0008",
+			cmdline: "vlan=vlan0008:eth1",
+			expectedSettings: network.CmdlineNetworking{
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth1.8",
+						Logical:     true,
+						Up:          true,
+						Kind:        netconfig.LinkKindVLAN,
+						Type:        nethelpers.LinkEther,
+						ParentName:  "eth1",
+						ConfigLayer: netconfig.ConfigCmdline,
+						VLAN: netconfig.VLANSpec{
+							VID:      8,
+							Protocol: nethelpers.VLANProtocol8021Q,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "vlan configuration with alternative link name vlan1",
+			cmdline: "vlan=vlan4095:eth1",
+			expectedSettings: network.CmdlineNetworking{
+				NetworkLinkSpecs: []netconfig.LinkSpecSpec{
+					{
+						Name:        "eth1.4095",
+						Logical:     true,
+						Up:          true,
+						Kind:        netconfig.LinkKindVLAN,
+						Type:        nethelpers.LinkEther,
+						ParentName:  "eth1",
+						ConfigLayer: netconfig.ConfigCmdline,
+						VLAN: netconfig.VLANSpec{
+							VID:      4095,
+							Protocol: nethelpers.VLANProtocol8021Q,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "vlan configuration with invalid vlan ID 4096",
+			cmdline:       "vlan=eth1.4096:eth1",
+			expectedError: fmt.Sprintf("invalid vlanID=%d, must be in the range 1..4095: %s", 4096, "eth1.4096:eth1"),
+		},
+		{
+			name:          "vlan configuration with invalid vlan ID 0",
+			cmdline:       "vlan=eth1.0:eth1",
+			expectedError: fmt.Sprintf("invalid vlanID=%d, must be in the range 1..4095: %s", 0, "eth1.0:eth1"),
 		},
 		{
 			name:    "multiple ip configurations",


### PR DESCRIPTION
## What? (description)

Fixes #9552 

Recognize the alternative form `vlan=vlan1:eth1` for specifying VLANs on the kernel command line. Additionally adds a check for the vlan ID range.
The created links will still use the format ethX.NNNN for the interface names, but at least this patch allows parsing both forms on the command line.

## Why? (reasoning)

The Talos docs at https://www.talos.dev/v1.8/reference/kernel/#vlan refers to the dracut command line docs which describe two alternative formats for `vlan=`.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
