### PR TITLE
fix: do not trim 0 from process SELinux label

### DIFF
--- a/internal/pkg/miniprocfs/processes.go
+++ b/internal/pkg/miniprocfs/processes.go
@@ -164,7 +164,7 @@ func (procs *Processes) readProc(pidString string) (*machine.ProcessInfo, error)
 	var label string
 
 	if err = procs.readFileIntoBuf(path + "attr/current"); err == nil {
-		label = string(bytes.Trim(procs.buf, "\x000\n"))
+		label = string(bytes.Trim(procs.buf, "\x00\n"))
 	}
 
 	return &machine.ProcessInfo{


### PR DESCRIPTION
Seems like a typo, zero is a valid character in SELinux labels

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
