### PR TITLE
docs: Added warning about NVMe bus path bug

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2245,9 +2245,9 @@
         "busPath": {
           "type": "string",
           "title": "busPath",
-          "description": "Disk bus path.\n",
-          "markdownDescription": "Disk bus path.",
-          "x-intellij-html-description": "\u003cp\u003eDisk bus path.\u003c/p\u003e\n"
+          "description": "Disk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.\n",
+          "markdownDescription": "Disk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.",
+          "x-intellij-html-description": "\u003cp\u003eDisk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see \u003ca href=\"https://github.com/siderolabs/go-blockdevice/issues/114\" target=\"_blank\"\u003ehttps://github.com/siderolabs/go-blockdevice/issues/114\u003c/a\u003e.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -972,7 +972,9 @@ type InstallDiskSelector struct {
 	//     - nvme
 	//     - sd
 	Type InstallDiskType `yaml:"type,omitempty"`
-	//   description: Disk bus path.
+	//   description: |
+	//      Disk bus path.
+	//      Warning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.
 	//   examples:
 	//     - value: '"/pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0"'
 	//     - value: '"/pci0000:00/*"'

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1150,7 +1150,7 @@ func (InstallDiskSelector) Doc() *encoder.Doc {
 				Name:        "busPath",
 				Type:        "string",
 				Note:        "",
-				Description: "Disk bus path.",
+				Description: "Disk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Disk bus path." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 		},

--- a/website/content/v1.9/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.9/reference/configuration/v1alpha1/config.md
@@ -1976,7 +1976,7 @@ size: <= 2TB
 |`uuid` |string |Disk UUID `/sys/block/<dev>/uuid`.  | |
 |`wwid` |string |Disk WWID `/sys/block/<dev>/wwid`.  | |
 |`type` |InstallDiskType |Disk Type.  |`ssd`<br />`hdd`<br />`nvme`<br />`sd`<br /> |
-|`busPath` |string |Disk bus path. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`busPath` |string |<details><summary>Disk bus path.</summary>Warning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0
 {{< /highlight >}}{{< highlight yaml >}}
 busPath: /pci0000:00/*

--- a/website/content/v1.9/schemas/config.schema.json
+++ b/website/content/v1.9/schemas/config.schema.json
@@ -2245,9 +2245,9 @@
         "busPath": {
           "type": "string",
           "title": "busPath",
-          "description": "Disk bus path.\n",
-          "markdownDescription": "Disk bus path.",
-          "x-intellij-html-description": "\u003cp\u003eDisk bus path.\u003c/p\u003e\n"
+          "description": "Disk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.\n",
+          "markdownDescription": "Disk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see https://github.com/siderolabs/go-blockdevice/issues/114.",
+          "x-intellij-html-description": "\u003cp\u003eDisk bus path.\nWarning: This requires special configuration for NVMe drives. For details, see \u003ca href=\"https://github.com/siderolabs/go-blockdevice/issues/114\" target=\"_blank\"\u003ehttps://github.com/siderolabs/go-blockdevice/issues/114\u003c/a\u003e.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

As discussed [here](https://github.com/siderolabs/go-blockdevice/issues/114), this adds a warning to the docs about a bug with bus path matching for NVMe drives.

Note that `website/content/v1.9/reference/configuration/v1alpha1/config.md` dropped some comments for some reason... not sure why.

## Why? (reasoning)

Maintainers have elected to not fix the bug. This helps other users be aware of the issue, the impact of it, and how to mitigate it.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
