### PR TITLE
fix: use more correct condition to skip generating hosts files

### DIFF
--- a/internal/pkg/containers/cri/containerd/hosts.go
+++ b/internal/pkg/containers/cri/containerd/hosts.go
@@ -172,7 +172,7 @@ func GenerateHosts(cfg config.Registries, basePath string) (*HostsConfig, error)
 	}
 
 	// process TLS config for non-mirrored endpoints (even if they were already processed)
-	for hostname, tlsConfig := range cfg.Config() {
+	for hostname, registryConfig := range cfg.Config() {
 		directoryName := hostDirectory(hostname)
 
 		if _, ok := config.Directories[directoryName]; ok {
@@ -180,11 +180,9 @@ func GenerateHosts(cfg config.Registries, basePath string) (*HostsConfig, error)
 			continue
 		}
 
-		if tlsConfig.TLS() != nil {
-			if tlsConfig.TLS().CA() == nil && tlsConfig.TLS().ClientIdentity() == nil && !tlsConfig.TLS().InsecureSkipVerify() {
-				// skip, no specific config
-				continue
-			}
+		if registryConfig.TLS() == nil || (registryConfig.TLS().CA() == nil && registryConfig.TLS().ClientIdentity() == nil && !registryConfig.TLS().InsecureSkipVerify()) {
+			// skip, no specific config
+			continue
 		}
 
 		if hostname == "*" {

--- a/internal/pkg/containers/cri/containerd/hosts_test.go
+++ b/internal/pkg/containers/cri/containerd/hosts_test.go
@@ -136,15 +136,6 @@ func TestGenerateHostsWithoutTLS(t *testing.T) {
 					},
 				},
 			},
-			"some.host_123_": {
-				Files: []*containerd.HostsFile{
-					{
-						Name:     "hosts.toml",
-						Mode:     0o600,
-						Contents: []byte("[host]\n  [host.'https://some.host:123']\n"),
-					},
-				},
-			},
 			"_default": {
 				Files: []*containerd.HostsFile{
 					{


### PR DESCRIPTION
After a fix a while ago, the condition was hard to understand - but we should skip this block as long as there's no TLS config, which might mean either being nil or having default values.

I found this while debugging #9594, but it doesn't change anything.
