### PR TITLE
chore: disable coredns cache for cluster domain

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates/core-dns-template.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/templates/core-dns-template.yaml
@@ -65,9 +65,17 @@ data:
         kubernetes {{ .ClusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+           max_concurrent 1000
+        }
         cache 30
+        {{- if .ClusterDomain }} {
+           disable success {{ .ClusterDomain }}
+           disable denial {{ .ClusterDomain }}
+        }
+        {{- end }}
         loop
         reload
         loadbalance


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/128359

Also bring in small changes from upstream CoreDNS config.