### PR TITLE
chore: drop runc memfd bind added in #9069

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -127,9 +127,6 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			ValidationMode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
 		&config.MachineTypeController{},
-		&cri.RuncMemFDBindController{
-			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
-		},
 		&cri.SeccompProfileController{},
 		&cri.SeccompProfileFileController{
 			V1Alpha1Mode:             ctrl.v1alpha1Runtime.State().Platform().Mode(),


### PR DESCRIPTION
As of runc 1.2.0, it internally uses an `ovverlay` mount instead of cloning `/proc/self/exe` and
https://github.com/opencontainers/runc/pull/4482/files drops and the `DMZ` code. This also reduces code that Talos has to maintain.

Fixes: #9543 
