### PR TITLE
fix: mount pseudo sub-mountpoints in init

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -44,6 +44,10 @@ func run() error {
 		return err
 	}
 
+	if _, err := mount.PseudoSubMountPoints().Mount(); err != nil {
+		return err
+	}
+
 	// Setup logging to /dev/kmsg.
 	if err := kmsg.SetupLogger(nil, "[talos] [initramfs]", nil); err != nil {
 		return err

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -95,7 +95,6 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			EnforceKSPPRequirements,
 			SetupSystemDirectory,
 			MountCgroups,
-			MountPseudoFilesystems,
 			SetRLimit,
 			InitVolumeLifecycle,
 		).Append(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -351,15 +351,6 @@ func MountCgroups(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	}, "mountCgroups"
 }
 
-// MountPseudoFilesystems represents the MountPseudoFilesystems task.
-func MountPseudoFilesystems(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
-	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		_, err := mountv2.PseudoSubMountPoints().Mount()
-
-		return err
-	}, "mountPseudoFilesystems"
-}
-
 // SetRLimit represents the SetRLimit task.
 func SetRLimit(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {


### PR DESCRIPTION
Mount them early, they will be moved to the new root in switch root process as they're under.
