### PR TITLE
fix: make route normalization keep family

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -257,7 +257,7 @@ func (ctrl *RouteConfigController) processDevicesConfiguration(logger *zap.Logge
 			}
 		}
 
-		route.Normalize()
+		normalizedFamily := route.Normalize()
 
 		route.Priority = in.Metric()
 		if route.Priority == 0 {
@@ -271,6 +271,8 @@ func (ctrl *RouteConfigController) processDevicesConfiguration(logger *zap.Logge
 			route.Family = nethelpers.FamilyInet6
 		case !value.IsZero(route.Destination) && route.Destination.Addr().Is6():
 			route.Family = nethelpers.FamilyInet6
+		case normalizedFamily != 0:
+			route.Family = normalizedFamily
 		default:
 			route.Family = nethelpers.FamilyInet4
 		}

--- a/pkg/machinery/resources/network/route_spec_test.go
+++ b/pkg/machinery/resources/network/route_spec_test.go
@@ -73,9 +73,31 @@ func TestRoutSpecNormalize(t *testing.T) {
 		MTU:         1400,
 	}
 
-	spec.Normalize()
+	normalizedFamily := spec.Normalize()
 
 	assert.Equal(t, netip.Prefix{}, spec.Destination)
 	assert.Equal(t, netip.Addr{}, spec.Source)
 	assert.Equal(t, netip.Addr{}, spec.Gateway)
+	assert.Equal(t, nethelpers.FamilyInet4, normalizedFamily)
+	assert.Equal(t, nethelpers.ScopeGlobal, spec.Scope)
+}
+
+func TestRoutSpecNormalizeV6(t *testing.T) {
+	spec := network.RouteSpecSpec{
+		Family:      nethelpers.FamilyInet4,
+		Destination: netip.MustParsePrefix("::/0"),
+		OutLinkName: "eth0",
+		Table:       nethelpers.TableLocal,
+		Priority:    1024,
+		ConfigLayer: network.ConfigPlatform,
+		MTU:         1400,
+	}
+
+	normalizedFamily := spec.Normalize()
+
+	assert.Equal(t, netip.Prefix{}, spec.Destination)
+	assert.Equal(t, netip.Addr{}, spec.Source)
+	assert.Equal(t, netip.Addr{}, spec.Gateway)
+	assert.Equal(t, nethelpers.FamilyInet6, normalizedFamily)
+	assert.Equal(t, nethelpers.ScopeGlobal, spec.Scope)
 }


### PR DESCRIPTION
When we normalize the route with e.g. IPv6 all addresses (`::/0`), we were wiping the family information. Keep the information, and also fix the scope for such routes.

Fixes #9624
