### PR TITLE
chore: cleanup code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/siderolabs/crypto v0.5.0
 	github.com/siderolabs/discovery-api v0.1.4
 	github.com/siderolabs/discovery-client v0.1.10
-	github.com/siderolabs/gen v0.6.1
+	github.com/siderolabs/gen v0.7.0
 	github.com/siderolabs/go-api-signature v0.3.6
 	github.com/siderolabs/go-blockdevice v0.4.8
 	github.com/siderolabs/go-blockdevice/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/siderolabs/discovery-api v0.1.4 h1:2fMEFSMiWaD1zDiBDY5md8VxItvL1rDQRS
 github.com/siderolabs/discovery-api v0.1.4/go.mod h1:kaBy+G42v2xd/uAF/NIe383sjNTBE2AhxPTyi9SZI0s=
 github.com/siderolabs/discovery-client v0.1.10 h1:bTAvFLiISSzVXyYL1cIgAz8cPYd9ZfvhxwdebgtxARA=
 github.com/siderolabs/discovery-client v0.1.10/go.mod h1:Ew1z07eyJwqNwum84IKYH4S649KEKK5WUmRW49HlXS8=
-github.com/siderolabs/gen v0.6.1 h1:Mex6Q41Tlw3e+4cGvlju2x4UwULD5WMo/D82n7IxV0Y=
-github.com/siderolabs/gen v0.6.1/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
+github.com/siderolabs/gen v0.7.0 h1:uHAt3WD0dof28NHFuguWBbDokaXQraR/HyVxCLw2QCU=
+github.com/siderolabs/gen v0.7.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
 github.com/siderolabs/go-api-signature v0.3.6 h1:wDIsXbpl7Oa/FXvxB6uz4VL9INA9fmr3EbmjEZYFJrU=
 github.com/siderolabs/go-api-signature v0.3.6/go.mod h1:hoH13AfunHflxbXfh+NoploqV13ZTDfQ1mQJWNVSW9U=
 github.com/siderolabs/go-blockdevice v0.4.8 h1:KfdWvIx0Jft5YVuCsFIJFwjWEF1oqtzkgX9PeU9cX4c=

--- a/hack/cloud-image-uploader/go.mod
+++ b/hack/cloud-image-uploader/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.11
-	github.com/siderolabs/gen v0.6.1
+	github.com/siderolabs/gen v0.7.0
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.8.0

--- a/hack/cloud-image-uploader/go.sum
+++ b/hack/cloud-image-uploader/go.sum
@@ -179,8 +179,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
 github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
-github.com/siderolabs/gen v0.6.1 h1:Mex6Q41Tlw3e+4cGvlju2x4UwULD5WMo/D82n7IxV0Y=
-github.com/siderolabs/gen v0.6.1/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
+github.com/siderolabs/gen v0.7.0 h1:uHAt3WD0dof28NHFuguWBbDokaXQraR/HyVxCLw2QCU=
+github.com/siderolabs/gen v0.7.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
 github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9oCEg=
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/hack/docgen/go.mod
+++ b/hack/docgen/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	github.com/siderolabs/gen v0.6.1
+	github.com/siderolabs/gen v0.7.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/gofumpt v0.7.0

--- a/hack/docgen/go.sum
+++ b/hack/docgen/go.sum
@@ -31,8 +31,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/siderolabs/gen v0.6.1 h1:Mex6Q41Tlw3e+4cGvlju2x4UwULD5WMo/D82n7IxV0Y=
-github.com/siderolabs/gen v0.6.1/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
+github.com/siderolabs/gen v0.7.0 h1:uHAt3WD0dof28NHFuguWBbDokaXQraR/HyVxCLw2QCU=
+github.com/siderolabs/gen v0.7.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/unix4ever/yaml v0.0.0-20220527175918-f17b0f05cf2c h1:Vn6nVVu9MdOYvXPkJP83iX5jVIfvxFC9v9xIKb+DlaQ=

--- a/internal/app/machined/pkg/controllers/block/lvm.go
+++ b/internal/app/machined/pkg/controllers/block/lvm.go
@@ -59,11 +59,11 @@ func (ctrl *LVMActivationController) Outputs() []controller.Output {
 //nolint:gocyclo
 func (ctrl *LVMActivationController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	if ctrl.seenVolumes == nil {
-		ctrl.seenVolumes = make(map[string]struct{})
+		ctrl.seenVolumes = map[string]struct{}{}
 	}
 
 	if ctrl.activatedVGs == nil {
-		ctrl.activatedVGs = make(map[string]struct{})
+		ctrl.activatedVGs = map[string]struct{}{}
 	}
 
 	for {

--- a/internal/app/machined/pkg/controllers/block/system_disk.go
+++ b/internal/app/machined/pkg/controllers/block/system_disk.go
@@ -49,7 +49,7 @@ func (ctrl *SystemDiskController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *SystemDiskController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *SystemDiskController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-r.EventCh():

--- a/internal/app/machined/pkg/controllers/block/user_disk_config.go
+++ b/internal/app/machined/pkg/controllers/block/user_disk_config.go
@@ -67,7 +67,7 @@ func partitionIdxMatch(devicePath string, partitionIdx int) cel.Expression {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *UserDiskConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *UserDiskConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-r.EventCh():

--- a/internal/app/machined/pkg/controllers/block/volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config.go
@@ -132,7 +132,7 @@ func (ctrl *VolumeConfigController) convertEncryption(in cfg.Encryption, out *bl
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-r.EventCh():

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
@@ -60,7 +60,7 @@ func (ctrl *KubernetesPushController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	defer func() {
 		if ctrl.kubernetesClient != nil {
 			ctrl.kubernetesClient.Close() //nolint:errcheck

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -113,7 +113,7 @@ func (ctrl *LocalAffiliateController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/cluster/node_identity.go
+++ b/internal/app/machined/pkg/controllers/cluster/node_identity.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
@@ -99,8 +100,8 @@ func (ctrl *NodeIdentityController) Run(ctx context.Context, r controller.Runtim
 			return fmt.Errorf("error caching node identity: %w", err)
 		}
 
-		if err := r.Modify(ctx, cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity), func(r resource.Resource) error {
-			*r.(*cluster.Identity).TypedSpec() = localIdentity
+		if err := safe.WriterModify(ctx, r, cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity), func(r *cluster.Identity) error {
+			*r.TypedSpec() = localIdentity
 
 			return nil
 		}); err != nil {
@@ -108,12 +109,12 @@ func (ctrl *NodeIdentityController) Run(ctx context.Context, r controller.Runtim
 		}
 
 		// generate `/etc/machine-id` from node identity
-		if err := r.Modify(ctx, files.NewEtcFileSpec(files.NamespaceName, "machine-id"),
-			func(r resource.Resource) error {
+		if err := safe.WriterModify(ctx, r, files.NewEtcFileSpec(files.NamespaceName, "machine-id"),
+			func(r *files.EtcFileSpec) error {
 				var err error
 
-				r.(*files.EtcFileSpec).TypedSpec().Contents, err = clusteradapter.IdentitySpec(&localIdentity).ConvertMachineID()
-				r.(*files.EtcFileSpec).TypedSpec().Mode = 0o444
+				r.TypedSpec().Contents, err = clusteradapter.IdentitySpec(&localIdentity).ConvertMachineID()
+				r.TypedSpec().Mode = 0o444
 
 				return err
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/config/machine_type.go
+++ b/internal/app/machined/pkg/controllers/config/machine_type.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
@@ -50,7 +49,7 @@ func (ctrl *MachineTypeController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *MachineTypeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MachineTypeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -69,8 +68,8 @@ func (ctrl *MachineTypeController) Run(ctx context.Context, r controller.Runtime
 			machineType = cfg.Config().Machine().Type()
 		}
 
-		if err = r.Modify(ctx, config.NewMachineType(), func(r resource.Resource) error {
-			r.(*config.MachineType).SetMachineType(machineType)
+		if err = safe.WriterModify(ctx, r, config.NewMachineType(), func(r *config.MachineType) error {
+			r.SetMachineType(machineType)
 
 			return nil
 		}); err != nil {

--- a/internal/app/machined/pkg/controllers/cri/seccomp_profile.go
+++ b/internal/app/machined/pkg/controllers/cri/seccomp_profile.go
@@ -49,7 +49,7 @@ func (ctrl *SeccompProfileController) Outputs() []controller.Output {
 }
 
 // Run implements controller.StatsController interface.
-func (ctrl *SeccompProfileController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *SeccompProfileController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/cri/seccomp_profile_file.go
+++ b/internal/app/machined/pkg/controllers/cri/seccomp_profile_file.go
@@ -51,7 +51,7 @@ func (ctrl *SeccompProfileFileController) Outputs() []controller.Output {
 // Run implements controller.StatsController interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *SeccompProfileFileController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *SeccompProfileFileController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	// initially, wait for /var to be mounted
 	if err := r.UpdateInputs([]controller.Input{
 		{

--- a/internal/app/machined/pkg/controllers/etcd/member.go
+++ b/internal/app/machined/pkg/controllers/etcd/member.go
@@ -57,7 +57,7 @@ func (ctrl *MemberController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *MemberController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MemberController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/etcd/member_test.go
+++ b/internal/app/machined/pkg/controllers/etcd/member_test.go
@@ -42,7 +42,7 @@ type MemberSuite struct {
 
 func (suite *MemberSuite) assertEtcdMember(member *etcd.Member) func() error {
 	return func() error {
-		r, err := suite.State().Get(suite.Ctx(), member.Metadata())
+		r, err := ctest.Get[*etcd.Member](suite, member.Metadata())
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				return retry.ExpectedError(err)
@@ -51,7 +51,7 @@ func (suite *MemberSuite) assertEtcdMember(member *etcd.Member) func() error {
 			return err
 		}
 
-		spec := r.(*etcd.Member).TypedSpec()
+		spec := r.TypedSpec()
 		expectedSpec := member.TypedSpec()
 
 		suite.Require().Equal(expectedSpec.MemberID, spec.MemberID)

--- a/internal/app/machined/pkg/controllers/etcd/pki.go
+++ b/internal/app/machined/pkg/controllers/etcd/pki.go
@@ -62,7 +62,7 @@ func (ctrl *PKIController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *PKIController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *PKIController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/etcd/spec.go
+++ b/internal/app/machined/pkg/controllers/etcd/spec.go
@@ -67,7 +67,7 @@ func (ctrl *SpecController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *SpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *SpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/files/cri_config_parts.go
+++ b/internal/app/machined/pkg/controllers/files/cri_config_parts.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/internal/pkg/toml"
@@ -52,7 +52,7 @@ func (ctrl *CRIConfigPartsController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *CRIConfigPartsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *CRIConfigPartsController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	if ctrl.CRIConfdPath == "" {
 		ctrl.CRIConfdPath = constants.CRIConfdPath
 	}
@@ -77,9 +77,9 @@ func (ctrl *CRIConfigPartsController) Run(ctx context.Context, r controller.Runt
 			return err
 		}
 
-		if err := r.Modify(ctx, files.NewEtcFileSpec(files.NamespaceName, constants.CRIConfig),
-			func(r resource.Resource) error {
-				spec := r.(*files.EtcFileSpec).TypedSpec()
+		if err := safe.WriterModify(ctx, r, files.NewEtcFileSpec(files.NamespaceName, constants.CRIConfig),
+			func(r *files.EtcFileSpec) error {
+				spec := r.TypedSpec()
 
 				spec.Contents = out
 				spec.Mode = 0o600

--- a/internal/app/machined/pkg/controllers/files/cri_registry_config.go
+++ b/internal/app/machined/pkg/controllers/files/cri_registry_config.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
@@ -62,7 +61,7 @@ func (ctrl *CRIRegistryConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *CRIRegistryConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *CRIRegistryConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	basePath := filepath.Join(constants.CRIConfdPath, "hosts")
 	shadowPath := filepath.Join(constants.SystemPath, basePath)
 
@@ -113,9 +112,9 @@ func (ctrl *CRIRegistryConfigController) Run(ctx context.Context, r controller.R
 			criHosts = &containerd.HostsConfig{}
 		}
 
-		if err := r.Modify(ctx, files.NewEtcFileSpec(files.NamespaceName, constants.CRIRegistryConfigPart),
-			func(r resource.Resource) error {
-				spec := r.(*files.EtcFileSpec).TypedSpec()
+		if err := safe.WriterModify(ctx, r, files.NewEtcFileSpec(files.NamespaceName, constants.CRIRegistryConfigPart),
+			func(r *files.EtcFileSpec) error {
+				spec := r.TypedSpec()
 
 				spec.Contents = criRegistryContents
 				spec.Mode = 0o600

--- a/internal/app/machined/pkg/controllers/k8s/address_filter.go
+++ b/internal/app/machined/pkg/controllers/k8s/address_filter.go
@@ -54,7 +54,7 @@ func (ctrl *AddressFilterController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *AddressFilterController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *AddressFilterController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
@@ -87,7 +87,7 @@ func (ctrl *KubeletSpecController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *KubeletSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KubeletSpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod.go
@@ -74,7 +74,7 @@ func (ctrl *KubeletStaticPodController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KubeletStaticPodController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KubeletStaticPodController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	var kubeletClient *kubelet.Client
 
 	refreshTicker := time.NewTicker(15 * time.Second) // refresh kubelet pods status every 15 seconds

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -64,7 +64,7 @@ func (ctrl *ManifestController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *ManifestController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *ManifestController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/node_annotation_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_annotation_spec.go
@@ -58,7 +58,7 @@ func (ctrl *NodeAnnotationSpecController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *NodeAnnotationSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *NodeAnnotationSpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/node_cordoned_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_cordoned_spec.go
@@ -51,7 +51,7 @@ func (ctrl *NodeCordonedSpecController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *NodeCordonedSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *NodeCordonedSpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/node_label_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_label_spec.go
@@ -59,7 +59,7 @@ func (ctrl *NodeLabelSpecController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *NodeLabelSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *NodeLabelSpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/nodename.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodename.go
@@ -59,7 +59,7 @@ func (ctrl *NodenameController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *NodenameController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *NodenameController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
@@ -68,7 +68,7 @@ func (ctrl *RenderConfigsStaticPodController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -83,7 +83,7 @@ func (ctrl *RenderSecretsStaticPodController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/static_endpoint.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_endpoint.go
@@ -54,7 +54,7 @@ func (ctrl *StaticEndpointController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *StaticEndpointController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *StaticEndpointController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/k8s/static_pod_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/static_pod_config.go
@@ -54,7 +54,7 @@ func (ctrl *StaticPodConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *StaticPodConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *StaticPodConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/kubespan/endpoint.go
+++ b/internal/app/machined/pkg/controllers/kubespan/endpoint.go
@@ -63,7 +63,7 @@ func (ctrl *EndpointController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/value"
 	"github.com/siderolabs/go-procfs/procfs"
@@ -162,11 +163,12 @@ func (ctrl *AddressConfigController) apply(ctx context.Context, r controller.Run
 	for _, address := range addresses {
 		id := network.LayeredID(address.ConfigLayer, network.AddressID(address.LinkName, address.Address))
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewAddressSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.AddressSpec).TypedSpec() = address
+			func(r *network.AddressSpec) error {
+				*r.TypedSpec() = address
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/address_merge.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -56,7 +57,7 @@ func (ctrl *AddressMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -89,9 +90,7 @@ func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtim
 		conflictsDetected := 0
 
 		for id, address := range addresses {
-			if err = r.Modify(ctx, network.NewAddressSpec(network.NamespaceName, id), func(res resource.Resource) error {
-				addr := res.(*network.AddressSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewAddressSpec(network.NamespaceName, id), func(addr *network.AddressSpec) error {
 				*addr.TypedSpec() = *address.TypedSpec()
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
@@ -163,11 +163,12 @@ func (ctrl *DNSResolveCacheController) Run(ctx context.Context, r controller.Run
 		}
 
 		prxs := xiter.Map(
-			upstreams.All(),
 			// We are using iterator here to preserve finalizer on
 			func(upstream *network.DNSUpstream) *proxy.Proxy {
 				return upstream.TypedSpec().Value.Conn.Proxy().(*proxy.Proxy)
-			})
+			},
+			upstreams.All(),
+		)
 
 		if ctrl.handler.SetProxy(prxs) {
 			ctrl.Logger.Info("updated dns server nameservers", zap.Array("addrs", addrsArr(upstreams)))

--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -127,9 +127,9 @@ func (suite *EtcFileConfigSuite) SetupTest() {
 	suite.hostDNSConfig.TypedSpec().Enabled = true
 	suite.hostDNSConfig.TypedSpec().ListenAddresses = []netip.AddrPort{
 		netip.MustParseAddrPort("127.0.0.53:53"),
-		netip.MustParseAddrPort("10.96.0.9:53"),
+		netip.MustParseAddrPort("169.254.116.108:53"),
 	}
-	suite.hostDNSConfig.TypedSpec().ServiceHostDNSAddress = netip.MustParseAddr("10.96.0.9")
+	suite.hostDNSConfig.TypedSpec().ServiceHostDNSAddress = netip.MustParseAddr("169.254.116.108")
 }
 
 func (suite *EtcFileConfigSuite) startRuntime() {
@@ -228,7 +228,7 @@ func (suite *EtcFileConfigSuite) TestComplete() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n10.0.0.1    a b\n10.0.0.2    c d\n", //nolint:lll
 			resolvConf:       "nameserver 127.0.0.53\n\nsearch example.com\n",
-			resolvGlobalConf: "nameserver 10.96.0.9\n\nsearch example.com\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\n\nsearch example.com\n",
 		},
 	)
 }
@@ -239,7 +239,7 @@ func (suite *EtcFileConfigSuite) TestNoExtraHosts() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n\nsearch example.com\n",
-			resolvGlobalConf: "nameserver 10.96.0.9\n\nsearch example.com\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\n\nsearch example.com\n",
 		},
 	)
 }
@@ -262,7 +262,7 @@ func (suite *EtcFileConfigSuite) TestNoSearchDomain() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 10.96.0.9\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\n",
 		},
 	)
 }
@@ -275,7 +275,7 @@ func (suite *EtcFileConfigSuite) TestNoDomainname() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 10.96.0.9\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\n",
 		},
 	)
 }
@@ -286,7 +286,7 @@ func (suite *EtcFileConfigSuite) TestOnlyResolvers() {
 		etcFileContents{
 			hosts:            "",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 10.96.0.9\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\n",
 		},
 	)
 }

--- a/internal/app/machined/pkg/controllers/network/hardware_addr.go
+++ b/internal/app/machined/pkg/controllers/network/hardware_addr.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -47,7 +48,7 @@ func (ctrl *HardwareAddrController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *HardwareAddrController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *HardwareAddrController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -80,8 +81,8 @@ func (ctrl *HardwareAddrController) Run(ctx context.Context, r controller.Runtim
 				continue
 			}
 
-			if err = r.Modify(ctx, network.NewHardwareAddr(network.NamespaceName, network.FirstHardwareAddr), func(r resource.Resource) error {
-				spec := r.(*network.HardwareAddr).TypedSpec()
+			if err = safe.WriterModify(ctx, r, network.NewHardwareAddr(network.NamespaceName, network.FirstHardwareAddr), func(r *network.HardwareAddr) error {
+				spec := r.TypedSpec()
 
 				spec.HardwareAddr = link.TypedSpec().HardwareAddr
 				spec.Name = link.Metadata().ID()

--- a/internal/app/machined/pkg/controllers/network/hostname_merge.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_merge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -54,7 +55,7 @@ func (ctrl *HostnameMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *HostnameMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *HostnameMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,9 +84,7 @@ func (ctrl *HostnameMergeController) Run(ctx context.Context, r controller.Runti
 		}
 
 		if final.Hostname != "" {
-			if err = r.Modify(ctx, network.NewHostnameSpec(network.NamespaceName, network.HostnameID), func(res resource.Resource) error {
-				spec := res.(*network.HostnameSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewHostnameSpec(network.NamespaceName, network.HostnameID), func(spec *network.HostnameSpec) error {
 				*spec.TypedSpec() = final
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/hostname_spec.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_spec.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -91,9 +92,7 @@ func (ctrl *HostnameSpecController) Run(ctx context.Context, r controller.Runtim
 					return fmt.Errorf("error removing finalizer: %w", err)
 				}
 			case resource.PhaseRunning:
-				if err = r.Modify(ctx, network.NewHostnameStatus(network.NamespaceName, spec.Metadata().ID()), func(r resource.Resource) error {
-					status := r.(*network.HostnameStatus) //nolint:forcetypeassert,errcheck
-
+				if err = safe.WriterModify(ctx, r, network.NewHostnameStatus(network.NamespaceName, spec.Metadata().ID()), func(status *network.HostnameStatus) error {
 					status.TypedSpec().Hostname = spec.TypedSpec().Hostname
 					status.TypedSpec().Domainname = spec.TypedSpec().Domainname
 

--- a/internal/app/machined/pkg/controllers/network/link_config.go
+++ b/internal/app/machined/pkg/controllers/network/link_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/gen/pair/ordered"
@@ -236,11 +237,12 @@ func (ctrl *LinkConfigController) apply(ctx context.Context, r controller.Runtim
 	for _, link := range links {
 		id := network.LayeredID(link.ConfigLayer, network.LinkID(link.Name))
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewLinkSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.LinkSpec).TypedSpec() = link
+			func(r *network.LinkSpec) error {
+				*r.TypedSpec() = link
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/link_merge.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -103,9 +104,7 @@ func (ctrl *LinkMergeController) Run(ctx context.Context, r controller.Runtime, 
 		conflictsDetected := 0
 
 		for id, link := range links {
-			if err = r.Modify(ctx, network.NewLinkSpec(network.NamespaceName, id), func(res resource.Resource) error {
-				l := res.(*network.LinkSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewLinkSpec(network.NamespaceName, id), func(l *network.LinkSpec) error {
 				*l.TypedSpec() = *link
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/ethtool"
 	ethtoolioctl "github.com/safchain/ethtool"
@@ -221,8 +222,8 @@ func (ctrl *LinkStatusController) reconcile(
 			}
 		}
 
-		if err = r.Modify(ctx, network.NewLinkStatus(network.NamespaceName, link.Attributes.Name), func(r resource.Resource) error {
-			status := r.(*network.LinkStatus).TypedSpec()
+		if err = safe.WriterModify(ctx, r, network.NewLinkStatus(network.NamespaceName, link.Attributes.Name), func(r *network.LinkStatus) error {
+			status := r.TypedSpec()
 
 			status.Index = link.Index
 			status.HardwareAddr = nethelpers.HardwareAddr(link.Attributes.Address)

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
@@ -61,7 +61,7 @@ func (ctrl *NfTablesChainConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *NfTablesChainConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) (err error) {
+func (ctrl *NfTablesChainConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) (err error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -162,7 +162,10 @@ func (ctrl *NfTablesChainConfigController) Run(ctx context.Context, r controller
 										network.NfTablesRule{
 											MatchSourceAddress: &network.NfTablesAddressMatch{
 												IncludeSubnets: xslices.Map(
-													append(slices.Clone(cfg.Config().Cluster().Network().PodCIDRs()), cfg.Config().Cluster().Network().ServiceCIDRs()...),
+													slices.Concat(
+														cfg.Config().Cluster().Network().PodCIDRs(),
+														cfg.Config().Cluster().Network().ServiceCIDRs(),
+													),
 													netip.MustParsePrefix,
 												),
 											},

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/xslices"
@@ -303,11 +304,12 @@ func (ctrl *OperatorConfigController) apply(ctx context.Context, r controller.Ru
 	for _, spec := range specs {
 		id := network.LayeredID(spec.ConfigLayer, network.OperatorID(spec.Operator, spec.LinkName))
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewOperatorSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.OperatorSpec).TypedSpec() = spec
+			func(r *network.OperatorSpec) error {
+				*r.TypedSpec() = spec
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/operator_merge.go
+++ b/internal/app/machined/pkg/controllers/network/operator_merge.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -56,7 +57,7 @@ func (ctrl *OperatorMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *OperatorMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *OperatorMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -89,9 +90,7 @@ func (ctrl *OperatorMergeController) Run(ctx context.Context, r controller.Runti
 		conflictsDetected := 0
 
 		for id, operator := range operators {
-			if err = r.Modify(ctx, network.NewOperatorSpec(network.NamespaceName, id), func(res resource.Resource) error {
-				op := res.(*network.OperatorSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewOperatorSpec(network.NamespaceName, id), func(op *network.OperatorSpec) error {
 				*op.TypedSpec() = *operator.TypedSpec()
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/operator_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec_test.go
@@ -141,7 +141,7 @@ func (mock *mockOperator) TimeServerSpecs() []network.TimeServerSpecSpec {
 	return mock.timeservers
 }
 
-func (suite *OperatorSpecSuite) newOperator(logger *zap.Logger, spec *network.OperatorSpecSpec) operator.Operator {
+func (suite *OperatorSpecSuite) newOperator(_ *zap.Logger, spec *network.OperatorSpecSpec) operator.Operator {
 	return &mockOperator{
 		spec: *spec,
 	}
@@ -311,7 +311,8 @@ func (suite *OperatorSpecSuite) TestScheduling() {
 		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			func() error {
 				return suite.assertRunning(
-					[]string{"dhcp4/eth0", "vip/eth0"}, func(op *mockOperator) error {
+					[]string{"dhcp4/eth0", "vip/eth0"},
+					func(op *mockOperator) error {
 						switch op.spec.Operator { //nolint:exhaustive
 						case network.OperatorDHCP4:
 							suite.Assert().EqualValues(1024, op.spec.DHCP4.RouteMetric)
@@ -339,7 +340,8 @@ func (suite *OperatorSpecSuite) TestScheduling() {
 		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			func() error {
 				return suite.assertRunning(
-					[]string{"dhcp4/eth0", "vip/eth0"}, func(op *mockOperator) error {
+					[]string{"dhcp4/eth0", "vip/eth0"},
+					func(op *mockOperator) error {
 						switch op.spec.Operator { //nolint:exhaustive
 						case network.OperatorDHCP4:
 							suite.Assert().EqualValues(1024, op.spec.DHCP4.RouteMetric)

--- a/internal/app/machined/pkg/controllers/network/operator_vip_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_vip_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/xslices"
@@ -176,11 +177,12 @@ func (ctrl *OperatorVIPConfigController) apply(ctx context.Context, r controller
 	for _, spec := range specs {
 		id := network.LayeredID(spec.ConfigLayer, network.OperatorID(spec.Operator, spec.LinkName))
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewOperatorSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.OperatorSpec).TypedSpec() = spec
+			func(r *network.OperatorSpec) error {
+				*r.TypedSpec() = spec
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/resolver_config.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config.go
@@ -140,11 +140,12 @@ func (ctrl *ResolverConfigController) apply(ctx context.Context, r controller.Ru
 	for _, spec := range specs {
 		id := network.LayeredID(spec.ConfigLayer, network.ResolverID)
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewResolverSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.ResolverSpec).TypedSpec() = spec
+			func(r *network.ResolverSpec) error {
+				*r.TypedSpec() = spec
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/resolver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge.go
@@ -58,7 +58,7 @@ func (ctrl *ResolverMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *ResolverMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *ResolverMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/value"
 	"github.com/siderolabs/go-procfs/procfs"
@@ -156,11 +157,12 @@ func (ctrl *RouteConfigController) apply(ctx context.Context, r controller.Runti
 	for _, route := range routes {
 		id := network.LayeredID(route.ConfigLayer, network.RouteID(route.Table, route.Family, route.Destination, route.Gateway, route.Priority, route.OutLinkName))
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewRouteSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.RouteSpec).TypedSpec() = route
+			func(r *network.RouteSpec) error {
+				*r.TypedSpec() = route
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/route_merge.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -54,7 +55,7 @@ func (ctrl *RouteMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -87,9 +88,7 @@ func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime,
 		conflictsDetected := 0
 
 		for id, route := range routes {
-			if err = r.Modify(ctx, network.NewRouteSpec(network.NamespaceName, id), func(res resource.Resource) error {
-				rt := res.(*network.RouteSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewRouteSpec(network.NamespaceName, id), func(rt *network.RouteSpec) error {
 				*rt.TypedSpec() = *route.TypedSpec()
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/status.go
+++ b/internal/app/machined/pkg/controllers/network/status.go
@@ -76,7 +76,7 @@ func (ctrl *StatusController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *StatusController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *StatusController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/network/timeserver_config.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_config.go
@@ -140,11 +140,12 @@ func (ctrl *TimeServerConfigController) apply(ctx context.Context, r controller.
 	for _, spec := range specs {
 		id := network.LayeredID(spec.ConfigLayer, network.TimeServerID)
 
-		if err := r.Modify(
+		if err := safe.WriterModify(
 			ctx,
+			r,
 			network.NewTimeServerSpec(network.ConfigNamespaceName, id),
-			func(r resource.Resource) error {
-				*r.(*network.TimeServerSpec).TypedSpec() = spec
+			func(r *network.TimeServerSpec) error {
+				*r.TypedSpec() = spec
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/timeserver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_merge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -54,7 +55,7 @@ func (ctrl *TimeServerMergeController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *TimeServerMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *TimeServerMergeController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -89,9 +90,7 @@ func (ctrl *TimeServerMergeController) Run(ctx context.Context, r controller.Run
 		}
 
 		if final.NTPServers != nil {
-			if err = r.Modify(ctx, network.NewTimeServerSpec(network.NamespaceName, network.TimeServerID), func(res resource.Resource) error {
-				spec := res.(*network.TimeServerSpec) //nolint:errcheck,forcetypeassert
-
+			if err = safe.WriterModify(ctx, r, network.NewTimeServerSpec(network.NamespaceName, network.TimeServerID), func(spec *network.TimeServerSpec) error {
 				*spec.TypedSpec() = final
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/timeserver_spec.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_spec.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -97,9 +98,7 @@ func (ctrl *TimeServerSpecController) Run(ctx context.Context, r controller.Runt
 
 				logger.Info("setting time servers", zap.Strings("addresses", ntps))
 
-				if err = r.Modify(ctx, network.NewTimeServerStatus(network.NamespaceName, spec.Metadata().ID()), func(r resource.Resource) error {
-					status := r.(*network.TimeServerStatus) //nolint:forcetypeassert,errcheck
-
+				if err = safe.WriterModify(ctx, r, network.NewTimeServerStatus(network.NamespaceName, spec.Metadata().ID()), func(status *network.TimeServerStatus) error {
 					status.TypedSpec().NTPServers = spec.TypedSpec().NTPServers
 
 					return nil

--- a/internal/app/machined/pkg/controllers/runtime/devices_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/devices_status.go
@@ -42,7 +42,7 @@ func (ctrl *DevicesStatusController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *DevicesStatusController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *DevicesStatusController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	// in container mode, devices are always ready
 	if ctrl.V1Alpha1Mode != machineruntime.ModeContainer {
 		if err := v1alpha1.WaitForServiceHealthy(ctx, r, "udevd", nil); err != nil {

--- a/internal/app/machined/pkg/controllers/runtime/events_sink_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/events_sink_config.go
@@ -57,7 +57,7 @@ func (ctrl *EventsSinkConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *EventsSinkConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) (err error) {
+func (ctrl *EventsSinkConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) (err error) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/extension_service_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/extension_service_config.go
@@ -53,7 +53,7 @@ func (ctrl *ExtensionServiceConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *ExtensionServiceConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *ExtensionServiceConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/extension_service_config_files.go
+++ b/internal/app/machined/pkg/controllers/runtime/extension_service_config_files.go
@@ -55,7 +55,7 @@ func (ctrl *ExtensionServiceConfigFilesController) Outputs() []controller.Output
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *ExtensionServiceConfigFilesController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *ExtensionServiceConfigFilesController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
 		return nil
 	}

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_config.go
@@ -50,7 +50,7 @@ func (ctrl *KernelModuleConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KernelModuleConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KernelModuleConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
@@ -46,7 +46,7 @@ func (ctrl *KernelModuleSpecController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *KernelModuleSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KernelModuleSpecController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
 		// not supported in container mode
 		return nil

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_config.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
@@ -52,7 +51,7 @@ func (ctrl *KernelParamConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KernelParamConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KernelParamConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -72,8 +71,8 @@ func (ctrl *KernelParamConfigController) Run(ctx context.Context, r controller.R
 		setKernelParam := func(kind, key, value string) error {
 			item := runtime.NewKernelParamSpec(runtime.NamespaceName, kind+"."+key)
 
-			return r.Modify(ctx, item, func(res resource.Resource) error {
-				res.(*runtime.KernelParamSpec).TypedSpec().Value = value
+			return safe.WriterModify(ctx, r, item, func(res *runtime.KernelParamSpec) error {
+				res.TypedSpec().Value = value
 
 				return nil
 			})

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"go.uber.org/zap"
 
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -45,7 +45,7 @@ func (ctrl *KernelParamDefaultsController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *KernelParamDefaultsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KernelParamDefaultsController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	select {
 	case <-ctx.Done():
 		return nil
@@ -59,8 +59,8 @@ func (ctrl *KernelParamDefaultsController) Run(ctx context.Context, r controller
 			value := prop.Value
 			item := runtime.NewKernelParamDefaultSpec(runtime.NamespaceName, prop.Key)
 
-			if err := r.Modify(ctx, item, func(res resource.Resource) error {
-				res.(*runtime.KernelParamDefaultSpec).TypedSpec().Value = value
+			if err := safe.WriterModify(ctx, r, item, func(res *runtime.KernelParamDefaultSpec) error {
+				res.TypedSpec().Value = value
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_config.go
@@ -58,7 +58,7 @@ func (ctrl *KmsgLogConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KmsgLogConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) (err error) {
+func (ctrl *KmsgLogConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) (err error) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/machine_status_publisher.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status_publisher.go
@@ -48,7 +48,7 @@ func (ctrl *MachineStatusPublisherController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *MachineStatusPublisherController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MachineStatusPublisherController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/maintenance_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/maintenance_config.go
@@ -61,7 +61,7 @@ func (ctrl *MaintenanceConfigController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *MaintenanceConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MaintenanceConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/security_state.go
+++ b/internal/app/machined/pkg/controllers/runtime/security_state.go
@@ -62,7 +62,7 @@ func (ctrl *SecurityStateController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *SecurityStateController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *SecurityStateController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/runtime/watchdog_timer_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/watchdog_timer_config.go
@@ -49,7 +49,7 @@ func (ctrl *WatchdogTimerConfigController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *WatchdogTimerConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) (err error) {
+func (ctrl *WatchdogTimerConfigController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) (err error) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/secrets/etcd.go
+++ b/internal/app/machined/pkg/controllers/secrets/etcd.go
@@ -80,7 +80,7 @@ func (ctrl *EtcdController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -120,7 +120,7 @@ func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logge
 		}
 
 		// wait for time sync as certs depend on current time
-		timeSyncResource, err := r.Get(ctx, resource.NewMetadata(v1alpha1.NamespaceName, time.StatusType, time.StatusID, resource.VersionUndefined))
+		timeSyncResource, err := safe.ReaderGet[*time.Status](ctx, r, resource.NewMetadata(v1alpha1.NamespaceName, time.StatusType, time.StatusID, resource.VersionUndefined))
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				continue
@@ -129,7 +129,7 @@ func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logge
 			return err
 		}
 
-		if !timeSyncResource.(*time.Status).TypedSpec().Synced {
+		if !timeSyncResource.TypedSpec().Synced {
 			continue
 		}
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -71,7 +71,7 @@ func (ctrl *KubernetesController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KubernetesController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KubernetesController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	refreshTicker := time.NewTicker(KubernetesCertificateValidityDuration / 2)
 	defer refreshTicker.Stop()
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_dynamic_certs.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_dynamic_certs.go
@@ -51,7 +51,7 @@ func (ctrl *KubernetesDynamicCertsController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
-func (ctrl *KubernetesDynamicCertsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *KubernetesDynamicCertsController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	// wait for the network to be ready first, then switch to regular inputs
 	if err := r.UpdateInputs([]controller.Input{
 		{

--- a/internal/app/machined/pkg/controllers/secrets/maintenance_cert_sans.go
+++ b/internal/app/machined/pkg/controllers/secrets/maintenance_cert_sans.go
@@ -10,7 +10,6 @@ import (
 	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
@@ -58,7 +57,7 @@ func (ctrl *MaintenanceCertSANsController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *MaintenanceCertSANsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MaintenanceCertSANsController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -80,8 +79,8 @@ func (ctrl *MaintenanceCertSANsController) Run(ctx context.Context, r controller
 			return err
 		}
 
-		if err = r.Modify(ctx, secrets.NewCertSAN(secrets.NamespaceName, secrets.CertSANMaintenanceID), func(r resource.Resource) error {
-			spec := r.(*secrets.CertSAN).TypedSpec()
+		if err = safe.WriterModify(ctx, r, secrets.NewCertSAN(secrets.NamespaceName, secrets.CertSANMaintenanceID), func(r *secrets.CertSAN) error {
+			spec := r.TypedSpec()
 
 			spec.Reset()
 

--- a/internal/app/machined/pkg/controllers/secrets/maintenance_root.go
+++ b/internal/app/machined/pkg/controllers/secrets/maintenance_root.go
@@ -40,7 +40,7 @@ func (ctrl *MaintenanceRootController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *MaintenanceRootController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *MaintenanceRootController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	// run this controller only once, as the CA never changes
 	select {
 	case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/secrets/trusted_roots.go
+++ b/internal/app/machined/pkg/controllers/secrets/trusted_roots.go
@@ -56,7 +56,7 @@ func (ctrl *TrustedRootsController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *TrustedRootsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *TrustedRootsController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/app/machined/pkg/controllers/time/adjtime_status.go
+++ b/internal/app/machined/pkg/controllers/time/adjtime_status.go
@@ -45,7 +45,7 @@ func (ctrl *AdjtimeStatusController) Outputs() []controller.Output {
 }
 
 // Run implements controller.Controller interface.
-func (ctrl *AdjtimeStatusController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+func (ctrl *AdjtimeStatusController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
 	if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
 		// in container mode, clock is managed by the host
 		return nil

--- a/internal/app/machined/pkg/controllers/v1alpha1/service.go
+++ b/internal/app/machined/pkg/controllers/v1alpha1/service.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -74,9 +74,7 @@ func (ctrl *ServiceController) Run(ctx context.Context, r controller.Runtime, lo
 
 				switch msg.Action { //nolint:exhaustive
 				case machine.ServiceStateEvent_RUNNING:
-					if err := r.Modify(ctx, service, func(r resource.Resource) error {
-						svc := r.(*v1alpha1.Service) //nolint:errcheck,forcetypeassert
-
+					if err := safe.WriterModify(ctx, r, service, func(svc *v1alpha1.Service) error {
 						*svc.TypedSpec() = v1alpha1.ServiceSpec{
 							Running: true,
 							Healthy: msg.GetHealth().GetHealthy(),

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -195,12 +195,16 @@ func (r *Runtime) Logging() runtime.LoggingManager {
 
 // NodeName implements the Runtime interface.
 func (r *Runtime) NodeName() (string, error) {
-	nodenameResource, err := r.s.V1Alpha2().Resources().Get(context.Background(), resource.NewMetadata(k8s.NamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined))
+	nodenameResource, err := safe.ReaderGet[*k8s.Nodename](
+		context.Background(),
+		r.s.V1Alpha2().Resources(),
+		resource.NewMetadata(k8s.NamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined),
+	)
 	if err != nil {
 		return "", fmt.Errorf("error getting nodename resource: %w", err)
 	}
 
-	return nodenameResource.(*k8s.Nodename).TypedSpec().Nodename, nil
+	return nodenameResource.TypedSpec().Nodename, nil
 }
 
 // IsBootstrapAllowed checks for CRI to be up, checked in the bootstrap method.

--- a/internal/pkg/dashboard/components/networkinfo.go
+++ b/internal/pkg/dashboard/components/networkinfo.go
@@ -245,9 +245,7 @@ func (widget *NetworkInfo) gateway(statuses []*network.RouteStatus) string {
 }
 
 func (widget *NetworkInfo) resolvers(status *network.ResolverStatus) string {
-	strs := xslices.Map(status.TypedSpec().DNSServers, func(t netip.Addr) string {
-		return t.String()
-	})
+	strs := xslices.Map(status.TypedSpec().DNSServers, netip.Addr.String)
 
 	if len(strs) == 0 {
 		return none

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/siderolabs/crypto v0.5.0
-	github.com/siderolabs/gen v0.6.1
+	github.com/siderolabs/gen v0.7.0
 	github.com/siderolabs/go-api-signature v0.3.6
 	github.com/siderolabs/go-blockdevice v0.4.8
 	github.com/siderolabs/go-blockdevice/v2 v2.0.2

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -103,8 +103,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/siderolabs/crypto v0.5.0 h1:+Sox0aYLCcD0PAH2cbEcx557zUrONLtuj1Ws+2MFXGc=
 github.com/siderolabs/crypto v0.5.0/go.mod h1:hsR3tJ3aaeuhCChsLF4dBd9vlJVPvmhg4vvx2ez4aD4=
-github.com/siderolabs/gen v0.6.1 h1:Mex6Q41Tlw3e+4cGvlju2x4UwULD5WMo/D82n7IxV0Y=
-github.com/siderolabs/gen v0.6.1/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
+github.com/siderolabs/gen v0.7.0 h1:uHAt3WD0dof28NHFuguWBbDokaXQraR/HyVxCLw2QCU=
+github.com/siderolabs/gen v0.7.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
 github.com/siderolabs/go-api-signature v0.3.6 h1:wDIsXbpl7Oa/FXvxB6uz4VL9INA9fmr3EbmjEZYFJrU=
 github.com/siderolabs/go-api-signature v0.3.6/go.mod h1:hoH13AfunHflxbXfh+NoploqV13ZTDfQ1mQJWNVSW9U=
 github.com/siderolabs/go-blockdevice v0.4.8 h1:KfdWvIx0Jft5YVuCsFIJFwjWEF1oqtzkgX9PeU9cX4c=


### PR DESCRIPTION
- Replace unsafe resource interface calls with type-safe versions.
- Remove unused parameter names.
- Minor changes.