### PR TITLE
fix: selinux handling and apparmor tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ZSTD_COMPRESSION_LEVEL ?= 18
 CI_RELEASE_TAG := $(shell git log --oneline --format=%B -n 1 HEAD^2 -- 2>/dev/null | head -n 1 | sed -r "/^release\(.*\)/ s/^release\((.*)\):.*$$/\\1/; t; Q")
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/siderolabs/tools:v1.9.0-alpha.0-5-g63ecd80
+TOOLS ?= ghcr.io/siderolabs/tools:v1.9.0-alpha.0-7-g3750064
 
 DEBUG_TOOLS_SOURCE := scratch
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -183,10 +183,12 @@ case "${WITH_APPARMOR_LSM_ENABLED:-false}" in
 machine:
   install:
     extraKernelArgs:
-      - security=apparmor
+      - lsm=lockdown,capability,yama,apparmor,bpf
+      - apparmor=1
 EOF
 
     QEMU_FLAGS+=("--config-patch=@${TMP}/kernel-security.patch")
+    QEMU_FLAGS+=("--extra-boot-kernel-args=-selinux")
     ;;
 esac
 

--- a/internal/integration/k8s/apparmor.go
+++ b/internal/integration/k8s/apparmor.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 )
 
 // ApparmorSuite verifies that a pod with apparmor security context with `RuntimeDefault` works.
@@ -42,7 +44,11 @@ func (suite *ApparmorSuite) TestApparmor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	suite.T().Cleanup(cancel)
 
-	reader, err := suite.Client.Read(ctx, "/sys/kernel/security/lsm")
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	nodeCtx := client.WithNodes(ctx, node)
+
+	reader, err := suite.Client.Read(nodeCtx, "/sys/kernel/security/lsm")
 	suite.Require().NoError(err)
 
 	// read from reader into a buffer

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/talos/internal/pkg/containers/image"
 	"github.com/siderolabs/talos/internal/pkg/environment"
 	"github.com/siderolabs/talos/internal/pkg/extensions"
+	"github.com/siderolabs/talos/internal/pkg/selinux"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	configcore "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -206,11 +207,14 @@ func RunInstallerContainer(disk, platform, ref string, cfg configcore.Config, cf
 		oci.WithReadonlyPaths(nil),
 		oci.WithWriteableSysfs,
 		oci.WithWriteableCgroupfs,
-		oci.WithSelinuxLabel(constants.SelinuxLabelInstaller),
 		oci.WithApparmorProfile(""),
 		oci.WithSeccompUnconfined,
 		oci.WithAllDevicesAllowed,
 		oci.WithEnv(environment.Get(cfg)),
+	}
+
+	if selinux.IsEnabled() {
+		specOpts = append(specOpts, oci.WithSelinuxLabel(constants.SelinuxLabelInstaller))
 	}
 
 	containerOpts := []containerd.NewContainerOpts{

--- a/internal/pkg/mount/v2/pseudo.go
+++ b/internal/pkg/mount/v2/pseudo.go
@@ -33,13 +33,19 @@ func PseudoSubMountPoints() Points {
 		NewPoint("bpf", "/sys/fs/bpf", "bpf"),
 		NewPoint("securityfs", "/sys/kernel/security", "securityfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME)),
 		NewPoint("tracefs", "/sys/kernel/tracing", "tracefs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV)),
-		NewPoint("selinuxfs", "/sys/fs/selinux", "selinuxfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_RELATIME)),
 	}
 
 	if _, err := os.Stat(constants.EFIVarsMountPoint); err == nil {
 		// mount EFI vars if they exist
 		points = append(points,
 			NewPoint("efivars", constants.EFIVarsMountPoint, "efivarfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME|unix.MS_RDONLY)),
+		)
+	}
+
+	if _, err := os.Stat("/sys/fs/selinux"); err == nil {
+		// mount selinuxfs if it exists
+		points = append(points,
+			NewPoint("selinuxfs", "/sys/fs/selinux", "selinuxfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_RELATIME)),
 		)
 	}
 

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -351,7 +351,7 @@ func (i *Imager) buildCmdline() error {
 
 	if quirks.New(i.prof.Version).SupportsSELinux() {
 		// Talos 1.9 introduces SELinux in permissive mode
-		cmdline.Append("selinux", "1")
+		cmdline.Append(constants.KernelParamSELinux, "1")
 	}
 
 	// board kernel args

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -85,11 +85,14 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	cmdline.Append("talos.platform", constants.PlatformMetal)
 
 	// SELinux
-	cmdline.Append("selinux", "1")
+	cmdline.Append(constants.KernelParamSELinux, "1")
 
 	// add overrides
 	if nodeReq.ExtraKernelArgs != nil {
-		if err = cmdline.AppendAll(nodeReq.ExtraKernelArgs.Strings()); err != nil {
+		if err = cmdline.AppendAll(
+			nodeReq.ExtraKernelArgs.Strings(),
+			procfs.WithDeleteNegatedArgs(),
+		); err != nil {
 			return provision.NodeInfo{}, err
 		}
 	}


### PR DESCRIPTION
Conditionally mount selinuxfs only if it's present.

Fix AppArmor tests, `apparmor` and other minor LSM's and set
`apparmor=1`.