### PR TITLE
chore(ci): save support zip always after tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-07T15:01:48Z by kres 1fc767a.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: default
 concurrency:
@@ -216,6 +216,8 @@ jobs:
           name: talos-logs-e2e-docker-short
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   e2e-iso:
@@ -285,6 +287,8 @@ jobs:
           name: talos-logs-e2e-iso
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   e2e-qemu-short:
@@ -355,6 +359,8 @@ jobs:
           name: talos-logs-e2e-qemu-short
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-aws:
@@ -1052,6 +1058,8 @@ jobs:
           name: talos-logs-integration-cilium
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-cloud-images:
@@ -1234,6 +1242,8 @@ jobs:
           name: talos-logs-integration-qemu
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-equinix-metal:
@@ -1474,6 +1484,8 @@ jobs:
           name: talos-logs-integration-extensions
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-gcp:
@@ -1782,6 +1794,8 @@ jobs:
           name: talos-logs-integration-image-factory
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-images:
@@ -1972,6 +1986,8 @@ jobs:
           name: talos-logs-integration-misc-0
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-misc-1:
@@ -2081,6 +2097,8 @@ jobs:
           name: talos-logs-integration-misc-1
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-misc-2:
@@ -2197,6 +2215,8 @@ jobs:
           name: talos-logs-integration-misc-2
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-misc-3:
@@ -2297,6 +2317,8 @@ jobs:
           name: talos-logs-integration-misc-3
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-misc-4:
@@ -2421,6 +2443,8 @@ jobs:
           name: talos-logs-integration-misc-4
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-provision-0:
@@ -2516,6 +2540,8 @@ jobs:
           name: talos-logs-integration-provision-0
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-provision-1:
@@ -2611,6 +2637,8 @@ jobs:
           name: talos-logs-integration-provision-1
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-provision-2:
@@ -2706,6 +2734,8 @@ jobs:
           name: talos-logs-integration-provision-2
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-qemu:
@@ -2802,6 +2832,8 @@ jobs:
           name: talos-logs-integration-qemu
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-qemu-csi-longhorn:
@@ -2923,6 +2955,8 @@ jobs:
           name: talos-logs-integration-qemu-csi-longhorn
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-qemu-csi-rook-ceph:
@@ -3022,6 +3056,8 @@ jobs:
           name: talos-logs-integration-qemu-csi-rook-ceph
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-qemu-encrypted-vip:
@@ -3120,6 +3156,8 @@ jobs:
           name: talos-logs-integration-qemu-encrypted-vip
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-qemu-race:
@@ -3225,6 +3263,8 @@ jobs:
           name: talos-logs-integration-qemu-race
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   integration-reproducibility-test:
@@ -3411,6 +3451,8 @@ jobs:
           name: talos-logs-integration-trusted-boot
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
   push:

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-cilium-cron
 concurrency:
@@ -121,5 +121,7 @@ jobs:
           name: talos-logs-integration-cilium
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-conformance-cron.yaml
+++ b/.github/workflows/integration-conformance-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-conformance-cron
 concurrency:
@@ -93,5 +93,7 @@ jobs:
           name: talos-logs-integration-qemu
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-extensions-cron.yaml
+++ b/.github/workflows/integration-extensions-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-20T17:49:19Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-extensions-cron
 concurrency:
@@ -123,5 +123,7 @@ jobs:
           name: talos-logs-integration-extensions
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-image-factory-cron
 concurrency:
@@ -180,5 +180,7 @@ jobs:
           name: talos-logs-integration-image-factory
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-misc-0-cron.yaml
+++ b/.github/workflows/integration-misc-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-misc-0-cron
 concurrency:
@@ -106,5 +106,7 @@ jobs:
           name: talos-logs-integration-misc-0
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-misc-1-cron.yaml
+++ b/.github/workflows/integration-misc-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-misc-1-cron
 concurrency:
@@ -108,5 +108,7 @@ jobs:
           name: talos-logs-integration-misc-1
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-misc-2-cron
 concurrency:
@@ -115,5 +115,7 @@ jobs:
           name: talos-logs-integration-misc-2
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-misc-3-cron.yaml
+++ b/.github/workflows/integration-misc-3-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-23T17:20:56Z by kres 6d3cad4.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-misc-3-cron
 concurrency:
@@ -99,5 +99,7 @@ jobs:
           name: talos-logs-integration-misc-3
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-misc-4-cron.yaml
+++ b/.github/workflows/integration-misc-4-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-07T15:01:48Z by kres 1fc767a.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-misc-4-cron
 concurrency:
@@ -123,5 +123,7 @@ jobs:
           name: talos-logs-integration-misc-4
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-provision-0-cron.yaml
+++ b/.github/workflows/integration-provision-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-18T16:27:22Z by kres 34e72ac.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-provision-0-cron
 concurrency:
@@ -94,5 +94,7 @@ jobs:
           name: talos-logs-integration-provision-0
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-provision-1-cron.yaml
+++ b/.github/workflows/integration-provision-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-18T16:27:22Z by kres 34e72ac.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-provision-1-cron
 concurrency:
@@ -94,5 +94,7 @@ jobs:
           name: talos-logs-integration-provision-1
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-provision-2-cron.yaml
+++ b/.github/workflows/integration-provision-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-18T16:27:22Z by kres 34e72ac.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-provision-2-cron
 concurrency:
@@ -94,5 +94,7 @@ jobs:
           name: talos-logs-integration-provision-2
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-16T13:22:04Z by kres 34e72ac.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-qemu-cron
 concurrency:
@@ -95,5 +95,7 @@ jobs:
           name: talos-logs-integration-qemu
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-qemu-csi-longhorn-cron
 concurrency:
@@ -120,5 +120,7 @@ jobs:
           name: talos-logs-integration-qemu-csi-longhorn
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-23T13:32:15Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-qemu-csi-rook-ceph-cron
 concurrency:
@@ -98,5 +98,7 @@ jobs:
           name: talos-logs-integration-qemu-csi-rook-ceph
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
+++ b/.github/workflows/integration-qemu-encrypted-vip-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-20T17:49:19Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-qemu-encrypted-vip-cron
 concurrency:
@@ -97,5 +97,7 @@ jobs:
           name: talos-logs-integration-qemu-encrypted-vip
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-qemu-race-cron.yaml
+++ b/.github/workflows/integration-qemu-race-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-21T05:02:59Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-qemu-race-cron
 concurrency:
@@ -104,5 +104,7 @@ jobs:
           name: talos-logs-integration-qemu-race
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-09T13:58:35Z by kres 8be5fa7.
+# Generated on 2024-11-08T11:46:41Z by kres 1fc767a.
 
 name: integration-trusted-boot-cron
 concurrency:
@@ -115,5 +115,7 @@ jobs:
           name: talos-logs-integration-trusted-boot
           path: |-
             ~/.talos/clusters/**/*.log
+            ~/.talos/clusters/**/support.zip
+            /tmp/support-*.zip
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -235,6 +235,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: e2e-qemu-short
       depends:
@@ -263,6 +265,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: e2e-docker-short
       depends:
@@ -291,6 +295,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu
       buildxOptions:
@@ -344,6 +350,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-conformance
       buildxOptions:
@@ -396,6 +404,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-trusted-boot
       buildxOptions:
@@ -467,6 +477,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-0
       buildxOptions:
@@ -518,6 +530,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-1
       buildxOptions:
@@ -569,6 +583,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-provision-2
       buildxOptions:
@@ -620,6 +636,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-0
       buildxOptions:
@@ -686,6 +704,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-1
       buildxOptions:
@@ -754,6 +774,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-2
       buildxOptions:
@@ -827,6 +849,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-3
       buildxOptions:
@@ -886,6 +910,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-misc-4
       buildxOptions:
@@ -969,6 +995,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-extensions
       buildxOptions:
@@ -1050,6 +1078,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-cilium
       buildxOptions:
@@ -1130,6 +1160,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-encrypted-vip
       buildxOptions:
@@ -1185,6 +1217,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-race
       buildxOptions:
@@ -1247,6 +1281,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-csi-rook-ceph
       buildxOptions:
@@ -1305,6 +1341,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-qemu-csi-longhorn
       buildxOptions:
@@ -1384,6 +1422,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-images
       buildxOptions:
@@ -1620,6 +1660,8 @@ spec:
             disableExecutableListGeneration: true
             artifactPath: ~/.talos/clusters/**/*.log
             additionalArtifacts:
+              - "~/.talos/clusters/**/support.zip"
+              - "/tmp/support-*.zip"
               - "!~/.talos/clusters/**/swtpm.log"
     - name: integration-aws
       buildxOptions:

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -1298,7 +1298,7 @@ func init() {
 	createCmd.Flags().BoolVar(&withInitNode, "with-init-node", false, "create the cluster with an init node")
 	createCmd.Flags().StringVar(&customCNIUrl, customCNIUrlFlag, "", "install custom CNI from the URL (Talos cluster)")
 	createCmd.Flags().StringVar(&dnsDomain, dnsDomainFlag, "cluster.local", "the dns domain to use for cluster")
-	createCmd.Flags().BoolVar(&crashdumpOnFailure, "crashdump", false, "print debug crashdump to stderr when cluster startup fails")
+	createCmd.Flags().BoolVar(&crashdumpOnFailure, "crashdump", false, "generate support zip when cluster startup fails")
 	createCmd.Flags().BoolVar(&skipKubeconfig, "skip-kubeconfig", false, "skip merging kubeconfig from the created cluster")
 	createCmd.Flags().BoolVar(&skipInjectingConfig, "skip-injecting-config", false, "skip injecting config from embedded metadata server, write config files to current directory")
 	createCmd.Flags().BoolVar(&encryptStatePartition, encryptStatePartitionFlag, false, "enable state partition encryption")

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -15,7 +15,8 @@ import (
 )
 
 var destroyCmdFlags struct {
-	forceDelete bool
+	forceDelete            bool
+	saveSupportArchivePath string
 }
 
 // destroyCmd represents the cluster destroy command.
@@ -42,11 +43,12 @@ func destroy(ctx context.Context) error {
 		return err
 	}
 
-	return provisioner.Destroy(ctx, cluster, provision.WithDeleteOnErr(destroyCmdFlags.forceDelete))
+	return provisioner.Destroy(ctx, cluster, provision.WithDeleteOnErr(destroyCmdFlags.forceDelete), provision.WithSaveSupportArchivePath(destroyCmdFlags.saveSupportArchivePath))
 }
 
 func init() {
 	destroyCmd.PersistentFlags().BoolVarP(&destroyCmdFlags.forceDelete, "force", "f", false, "force deletion of cluster directory if there were errors")
+	destroyCmd.PersistentFlags().StringVarP(&destroyCmdFlags.saveSupportArchivePath, "save-support-archive-path", "", "", "save support archive to the specified file on destroy")
 
 	Cmd.AddCommand(destroyCmd)
 }

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -27,8 +27,10 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}" --save-support-archive-path=/tmp/support-${CLUSTER_NAME}.zip
 }
+
+trap destroy_cluster SIGINT EXIT
 
 create_cluster
 get_kubeconfig

--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -66,8 +66,10 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}" --save-support-archive-path=/tmp/support-${CLUSTER_NAME}.zip
 }
+
+trap destroy_cluster SIGINT EXIT
 
 create_cluster
 
@@ -82,5 +84,3 @@ if [[ "${FACTORY_UPGRADE:-false}" == "true" ]]; then
     ${TALOSCTL} get extensions | grep "${FACTORY_UPGRADE_SCHEMATIC:-$FACTORY_SCHEMATIC}"
     assert_secureboot
 fi
-
-destroy_cluster

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -32,9 +32,10 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}" --save-support-archive-path=/tmp/support-${CLUSTER_NAME}.zip
 }
+
+trap destroy_cluster SIGINT EXIT
 
 create_cluster
 sleep 5
-destroy_cluster

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -224,6 +224,7 @@ function create_cluster {
     --install-image="${INSTALLER_IMAGE}" \
     --with-init-node=false \
     --cni-bundle-url="${ARTIFACTS}/talosctl-cni-bundle-\${ARCH}.tar.gz" \
+    --crashdump \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     "${QEMU_FLAGS[@]}"
 
@@ -231,8 +232,10 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}" --save-support-archive-path=/tmp/support-${CLUSTER_NAME}.zip
 }
+
+trap destroy_cluster SIGINT EXIT
 
 create_cluster
 
@@ -258,6 +261,3 @@ case "${TEST_MODE:-default}" in
     fi
     ;;
 esac
-
-
-destroy_cluster

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -37,7 +36,6 @@ var allSuites []suite.TestingSuite
 // Flag values.
 var (
 	failFast         bool
-	crashdumpEnabled bool
 	trustedBoot      bool
 	extensionsQEMU   bool
 	extensionsNvidia bool
@@ -95,7 +93,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	provision_test.DefaultSettings.CurrentVersion = expectedVersion
-	provision_test.DefaultSettings.CrashdumpEnabled = crashdumpEnabled
 
 	for _, s := range allSuites {
 		if configuredSuite, ok := s.(base.ConfiguredSuite); ok {
@@ -134,10 +131,6 @@ func TestIntegration(t *testing.T) {
 			break
 		}
 	}
-
-	if t.Failed() && crashdumpEnabled && cluster != nil && provisioner != nil {
-		provisioner.CrashDump(context.Background(), cluster, os.Stderr)
-	}
 }
 
 func init() {
@@ -149,7 +142,6 @@ func init() {
 	}
 
 	flag.BoolVar(&failFast, "talos.failfast", false, "fail the test run on the first failed test")
-	flag.BoolVar(&crashdumpEnabled, "talos.crashdump", false, "print crashdump on test failure (only if provisioner is enabled)")
 	flag.BoolVar(&trustedBoot, "talos.trustedboot", false, "enable tests for trusted boot mode")
 	flag.BoolVar(&extensionsQEMU, "talos.extensions.qemu", false, "enable tests for qemu extensions")
 	flag.BoolVar(&extensionsNvidia, "talos.extensions.nvidia", false, "enable tests for nvidia extensions")

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -79,8 +79,6 @@ type Settings struct {
 	CurrentVersion string
 	// Custom CNI URL to use.
 	CustomCNIURL string
-	// Enable crashdump on failure.
-	CrashdumpEnabled bool
 	// CNI bundle for QEMU provisioner.
 	CNIBundleURL string
 }
@@ -138,12 +136,6 @@ func (suite *BaseSuite) SetupSuite() {
 
 // TearDownSuite ...
 func (suite *BaseSuite) TearDownSuite() {
-	if suite.T().Failed() && DefaultSettings.CrashdumpEnabled && suite.Cluster != nil {
-		// for failed tests, produce crash dump for easier debugging,
-		// as cluster is going to be torn down below
-		suite.provisioner.CrashDump(suite.ctx, suite.Cluster, os.Stderr)
-	}
-
 	if suite.clusterAccess != nil {
 		suite.Assert().NoError(suite.clusterAccess.Close())
 	}

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -133,6 +133,15 @@ func WithDeleteOnErr(v bool) Option {
 	}
 }
 
+// WithSaveSupportArchivePath specifies path to save support archive on destroy.
+func WithSaveSupportArchivePath(path string) Option {
+	return func(o *Options) error {
+		o.SaveSupportArchivePath = path
+
+		return nil
+	}
+}
+
 // WithKMS inits KMS server in the provisioner.
 func WithKMS(endpoint string) Option {
 	return func(o *Options) error {
@@ -181,9 +190,10 @@ type Options struct {
 	ExtraUEFISearchPaths []string
 
 	// Expose ports to worker machines in docker provisioner
-	DockerPorts       []string
-	DockerPortsHostIP string
-	DeleteStateOnErr  bool
+	DockerPorts            []string
+	DockerPortsHostIP      string
+	SaveSupportArchivePath string
+	DeleteStateOnErr       bool
 
 	KMSEndpoint      string
 	JSONLogsEndpoint string

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	cl "github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
@@ -42,6 +43,12 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 	}
 
 	defer deleteStateDirectory(options.DeleteStateOnErr) //nolint:errcheck
+
+	if options.SaveSupportArchivePath != "" {
+		fmt.Fprintln(options.LogWriter, "saving support archive")
+
+		cl.Crashdump(ctx, cluster, options.LogWriter, options.SaveSupportArchivePath)
+	}
 
 	fmt.Fprintln(options.LogWriter, "stopping VMs")
 

--- a/pkg/provision/providers/vm/crashdump.go
+++ b/pkg/provision/providers/vm/crashdump.go
@@ -6,13 +6,24 @@ package vm
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"path/filepath"
 
 	cl "github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
 // CrashDump produces debug information to help with debugging failures.
-func (p *Provisioner) CrashDump(ctx context.Context, cluster provision.Cluster, out io.Writer) {
-	cl.Crashdump(ctx, cluster, out)
+func (p *Provisioner) CrashDump(ctx context.Context, cluster provision.Cluster, logWriter io.Writer) {
+	statePath, err := cluster.StatePath()
+	if err != nil {
+		fmt.Fprintf(logWriter, "error getting state path: %s\n", err)
+
+		return
+	}
+
+	supportZipPath := filepath.Join(statePath, "support.zip")
+
+	cl.Crashdump(ctx, cluster, logWriter, supportZipPath)
 }

--- a/website/content/v1.9/advanced/developing-talos.md
+++ b/website/content/v1.9/advanced/developing-talos.md
@@ -162,7 +162,6 @@ Running short tests against QEMU provisioned cluster:
 _out/integration-test-linux-amd64 \
     -talos.provisioner=qemu \
     -test.v \
-    -talos.crashdump=false \
     -test.short \
     -talos.talosctlpath=$PWD/_out/talosctl-linux-amd64
 ```

--- a/website/content/v1.9/reference/cli.md
+++ b/website/content/v1.9/reference/cli.md
@@ -155,7 +155,7 @@ talosctl cluster create [flags]
       --controlplanes int                        the number of controlplanes to create (default 1)
       --cpus string                              the share of CPUs as fraction (each control plane/VM) (default "2.0")
       --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
-      --crashdump                                print debug crashdump to stderr when cluster startup fails
+      --crashdump                                generate support zip when cluster startup fails
       --custom-cni-url string                    install custom CNI from the URL (Talos cluster)
       --disable-dhcp-hostname                    skip announcing hostname via DHCP (QEMU only)
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
@@ -254,8 +254,9 @@ talosctl cluster destroy [flags]
 ### Options
 
 ```
-  -f, --force   force deletion of cluster directory if there were errors
-  -h, --help    help for destroy
+  -f, --force                              force deletion of cluster directory if there were errors
+  -h, --help                               help for destroy
+      --save-support-archive-path string   save support archive to the specified file on destroy
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Save `support.zip` always, also use a different folder for saving logs, so we can save artifacts of multi cluster tests.