### PR TITLE
fix(ci): skip test if `UserNamespacesSupport` feature gate is not set

### DIFF
--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -519,7 +519,7 @@ func (suite *ExtensionsSuiteQEMU) mdADMArrayExists() bool {
 // TestExtensionsZFS verifies zfs is working, udev rules work and the pool is mounted on reboot.
 func (suite *ExtensionsSuiteQEMU) TestExtensionsZFS() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
-	suite.AssertServicesRunning(suite.ctx, node, map[string]string{"ext-zpool-importer": "Finished"})
+	suite.AssertServicesRunning(suite.ctx, node, map[string]string{"ext-zfs-service": "Running"})
 
 	userDisks, err := suite.UserDisks(suite.ctx, node)
 	suite.Require().NoError(err)


### PR DESCRIPTION
We should not just rely on the sysctl, also confirm that `UserNamespacesSupport=true` feature gate is set for apiserver, so that the tests gets skipped if only sysctl is set.