### PR TITLE
feat: add on-link option for no cloud routes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
@@ -87,8 +87,9 @@ type Ethernet struct {
 	Routes []struct {
 		To     string `yaml:"to,omitempty"`
 		Via    string `yaml:"via,omitempty"`
-		Metric string `yaml:"metric,omitempty"`
+		Metric uint32 `yaml:"metric,omitempty"`
 		Table  uint32 `yaml:"table,omitempty"`
+		OnLink bool   `yaml:"on-link,omitempty"`
 	} `yaml:"routes,omitempty"`
 	RoutingPolicy []struct { // TODO
 		From  string `yaml:"froom,omitempty"`
@@ -542,26 +543,52 @@ func applyNetworkConfigV2Ethernet(name string, eth Ethernet, networkConfig *runt
 			return fmt.Errorf("failed to parse route destination: %w", err)
 		}
 
-		route := network.RouteSpecSpec{
+		routeSpec := network.RouteSpecSpec{
 			ConfigLayer: network.ConfigPlatform,
 			Destination: dest,
 			Gateway:     gw,
 			OutLinkName: name,
-			Table:       nethelpers.RoutingTable(route.Table),
+			Table:       withDefault(nethelpers.RoutingTable(route.Table), nethelpers.TableMain),
 			Protocol:    nethelpers.ProtocolStatic,
 			Type:        nethelpers.TypeUnicast,
 			Family:      nethelpers.FamilyInet4,
-			Priority:    network.DefaultRouteMetric,
+			Priority:    withDefault(route.Metric, network.DefaultRouteMetric),
 		}
 
 		if gw.Is6() {
-			route.Family = nethelpers.FamilyInet6
-			route.Priority = 2 * network.DefaultRouteMetric
+			routeSpec.Family = nethelpers.FamilyInet6
+
+			if routeSpec.Priority == network.DefaultRouteMetric {
+				routeSpec.Priority = 2 * network.DefaultRouteMetric
+			}
 		}
 
-		route.Normalize()
+		routeSpec.Normalize()
 
-		networkConfig.Routes = append(networkConfig.Routes, route)
+		networkConfig.Routes = append(networkConfig.Routes, routeSpec)
+
+		if route.OnLink && gw.Is4() {
+			// This assumes an interface with multiple routes will never have multiple statically set ips.
+			ipPrefix, err := netip.ParsePrefix(eth.Address[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse route source: %w", err)
+			}
+
+			routeSpec := network.RouteSpecSpec{
+				ConfigLayer: network.ConfigPlatform,
+				Destination: netip.PrefixFrom(gw, gw.BitLen()),
+				Source:      ipPrefix.Addr(),
+				OutLinkName: name,
+				Scope:       nethelpers.ScopeLink,
+				Table:       withDefault(nethelpers.RoutingTable(route.Table), nethelpers.TableMain),
+				Protocol:    nethelpers.ProtocolStatic,
+				Type:        nethelpers.TypeUnicast,
+				Family:      nethelpers.FamilyInet4,
+				Priority:    withDefault(route.Metric, network.DefaultRouteMetric),
+			}
+
+			networkConfig.Routes = append(networkConfig.Routes, routeSpec)
+		}
 	}
 
 	return nil
@@ -680,4 +707,14 @@ func (n *Nocloud) applyNetworkConfigV2(config *NetworkConfig, st state.State, ne
 	}
 
 	return nil
+}
+
+func withDefault[T comparable](v T, defaultValue T) T {
+	var zeroT T
+
+	if v == zeroT {
+		return defaultValue
+	}
+
+	return v
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
@@ -11,6 +11,12 @@ addresses:
       scope: global
       flags: permanent
       layer: platform
+    - address: 10.22.14.2/32
+      linkName: eth1
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
     - address: 10.10.4.140/29
       linkName: bond0
       family: inet4
@@ -19,6 +25,13 @@ addresses:
       layer: platform
 links:
     - name: eth0
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      layer: platform
+    - name: eth1
       logical: false
       up: true
       mtu: 0
@@ -93,11 +106,35 @@ routes:
       protocol: static
       layer: platform
     - family: inet4
+      dst: ""
+      src: ""
+      gateway: 192.168.14.1
+      outLinkName: eth1
+      table: main
+      priority: 100
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: 192.168.14.1/32
+      src: 10.22.14.2
+      gateway: ""
+      outLinkName: eth1
+      table: main
+      priority: 100
+      scope: link
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
       dst: 10.0.0.0/8
       src: ""
       gateway: 10.10.4.147
       outLinkName: bond0
-      table: unspec
+      table: main
       priority: 1024
       scope: global
       type: unicast
@@ -109,7 +146,7 @@ routes:
       src: ""
       gateway: 10.10.4.147
       outLinkName: bond0
-      table: unspec
+      table: main
       priority: 1024
       scope: global
       type: unicast
@@ -121,7 +158,7 @@ routes:
       src: ""
       gateway: 10.10.4.147
       outLinkName: bond0
-      table: unspec
+      table: main
       priority: 1024
       scope: global
       type: unicast

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v2-cloud-init.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v2-cloud-init.yaml
@@ -13,6 +13,18 @@ network:
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]
+    eth1:
+      match:
+        macaddress: '00:20:6e:1f:f9:a9'
+      addresses:
+        - 10.22.14.2/32
+      nameservers:
+        search: [ foo.local, bar.local ]
+      routes:
+        - to: "0.0.0.0/0"
+          via: "192.168.14.1"
+          metric: 100
+          on-link: true
 
     ext1:
       match:

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v2-nocloud.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/metadata-v2-nocloud.yaml
@@ -12,6 +12,18 @@ ethernets:
     nameservers:
       search: [foo.local, bar.local]
       addresses: [8.8.8.8]
+  eth1:
+    match:
+      macaddress: '00:20:6e:1f:f9:a9'
+    addresses:
+      - 10.22.14.2/32
+    nameservers:
+      search: [ foo.local, bar.local ]
+    routes:
+      - to: "0.0.0.0/0"
+        via: "192.168.14.1"
+        metric: 100
+        on-link: true
 
   ext1:
     match:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
added support to the nocloud network metadata to accept the on-link directive. The on-link directive allows a route to be directly connected to the interface and allows a gateway outside of the nic subnet.

## Why? (reasoning)
This is supported via kernel args but we need to use metadata passed in via an ISO and nocloud.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
