### PR TITLE
docs: use single tags option for the controlplane nodes

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/gcp.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/gcp.md
@@ -139,10 +139,9 @@ for i in $( seq 0 2 ); do
   gcloud compute instances create talos-controlplane-$i \
     --image talos \
     --zone $REGION-b \
-    --tags talos-controlplane \
+    --tags talos-controlplane,talos-controlplane-$i \
     --boot-disk-size 20GB \
-    --metadata-from-file=user-data=./controlplane.yaml \
-    --tags talos-controlplane-$i
+    --metadata-from-file=user-data=./controlplane.yaml
 done
 
 # Add control plane nodes to instance group

--- a/website/content/v1.9/talos-guides/install/cloud-platforms/gcp.md
+++ b/website/content/v1.9/talos-guides/install/cloud-platforms/gcp.md
@@ -139,10 +139,9 @@ for i in $( seq 0 2 ); do
   gcloud compute instances create talos-controlplane-$i \
     --image talos \
     --zone $REGION-b \
-    --tags talos-controlplane \
+    --tags talos-controlplane,talos-controlplane-$i \
     --boot-disk-size 20GB \
-    --metadata-from-file=user-data=./controlplane.yaml \
-    --tags talos-controlplane-$i
+    --metadata-from-file=user-data=./controlplane.yaml
 done
 
 # Add control plane nodes to instance group


### PR DESCRIPTION
# Pull Request

## What? (description)
Seeing the following error:
```
talosctl --talosconfig talosconfig bootstrap

error executing bootstrap: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 34.111.111.111:50000: i/o timeout"
```

The reason is that `gcloud compute instances create` command only takes tags as a comma-separated list.
Otherwise, only the last one is applied

From the command help:
```
--tags=TAG,[TAG,...]
        Specifies a list of tags to apply to the instance. These tags allow
        network firewall rules and routes to be applied to specified VM
        instances. See gcloud compute firewall-rules create(1) for more
        details.
```
## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
