### PR TITLE
chore: make the Go binaries more reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,10 @@ INSTALLER_ARCH ?= all
 IMAGER_ARGS ?=
 
 CGO_ENABLED ?= 0
-GO_BUILDFLAGS ?=
+GO_BUILDFLAGS ?= -trimpath
 GO_BUILDTAGS ?= tcell_minimal,grpcnotrace
 GO_BUILDTAGS_TALOSCTL ?= grpcnotrace
-GO_LDFLAGS ?=
+GO_LDFLAGS ?= -buildid=${SHA}
 GOAMD64 ?= v2
 
 WITH_RACE ?= false


### PR DESCRIPTION
# Pull Request

## What? (description)
This makes the built Go binaries smaller. This sets a deterministic buildid based on the commit has. The other change is the removal of the prefix of the build directory. This isn't relevant for the built binary.

These changes make it possible to reduce the sizes of the binaries slightly and to produce the same binaries with the same version of the Go compiler.

The sizes of the talosctl binaries have been reduced slightly with these changes.

binary                           old size new size difference
talosctl-darwin-amd64            85209712 85156448 53264
talosctl-darwin-arm64            83390690 83324642 66048
talosctl-freebsd-amd64           83095714 83042466 53248
talosctl-freebsd-arm64           80674978 80609442 65536
talosctl-linux-amd64             86331544 86274200 57344
talosctl-linux-arm64             83820696 83755160 65536
talosctl-linux-armv7             80871576 80871576     0
talosctl-windows-amd64.exe       85077504 85026304 51200
talosctl-windows-arm64.exe       81485312 81434624 50688

## Why? (reasoning)
Having more reproducible binaries and smaller binaries is a good idea.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
