### PR TITLE
refactor: mount /run, /system and /tmp via tasks, not in initramfs

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -91,6 +91,9 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 		)
 	default:
 		phases = phases.Append(
+			"mountTmpfs",
+			MountTmpFilesystems,
+		).Append(
 			"systemRequirements",
 			EnforceKSPPRequirements,
 			SetupSystemDirectory,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1949,6 +1949,22 @@ func haltIfInstalled(seq runtime.Sequence, _ any) (runtime.TaskExecutionFunc, st
 	}, "haltIfInstalled"
 }
 
+// MountTmpFilesystems represents the MountTmpFilesystems task.
+func MountTmpFilesystems(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+		tmpPoints := mountv2.Points{
+			mountv2.NewPoint("tmpfs", "/run", "tmpfs", mountv2.WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_RELATIME), mountv2.WithData("mode=0755")),
+			mountv2.NewPoint("tmpfs", "/system", "tmpfs", mountv2.WithData("mode=0755")),
+			mountv2.NewPoint("tmpfs", "/tmp", "tmpfs", mountv2.WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV), mountv2.WithData("size=64M"), mountv2.WithData("mode=0755")),
+		}
+
+		// TODO REVIEW: do we need to unmount these?
+		_, err := tmpPoints.Mount()
+
+		return err
+	}, "mountTmpfs"
+}
+
 // MountStatePartition mounts the system partition.
 func MountStatePartition(required bool) func(seq runtime.Sequence, _ any) (runtime.TaskExecutionFunc, string) {
 	return func(seq runtime.Sequence, _ any) (runtime.TaskExecutionFunc, string) {

--- a/internal/pkg/mount/v2/pseudo.go
+++ b/internal/pkg/mount/v2/pseudo.go
@@ -18,9 +18,6 @@ func Pseudo() Points {
 		NewPoint("devtmpfs", "/dev", "devtmpfs", WithFlags(unix.MS_NOSUID), WithData("mode=0755")),
 		NewPoint("proc", "/proc", "proc", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV)),
 		NewPoint("sysfs", "/sys", "sysfs"),
-		NewPoint("tmpfs", "/run", "tmpfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_RELATIME), WithData("mode=0755")),
-		NewPoint("tmpfs", "/system", "tmpfs", WithData("mode=0755")),
-		NewPoint("tmpfs", "/tmp", "tmpfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV), WithData("size=64M"), WithData("mode=0755")),
 	}
 }
 


### PR DESCRIPTION
These are not used in initramfs, and require extra actions to relabel /system and /run in case they are mounted before loading the SELinux policy. Move them farther thus

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>

Part of #9648
