### PR TITLE
docs: add missing `--talosconfig` parameter to end of Hetzner guide

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/hetzner.md
@@ -290,7 +290,7 @@ cluster:
 Then run the following command:
 
 ```bash
-talosctl patch machineconfig --patch-file patch.yaml --nodes <comma separated list of all your nodes' IP addresses>
+talosctl --talosconfig talosconfig patch machineconfig --patch-file patch.yaml --nodes <comma separated list of all your nodes' IP addresses>
 ```
 
 With that in place, we can now follow the [official instructions](https://github.com/hetznercloud/hcloud-cloud-controller-manager), ignoring the `kubeadm` related steps.

--- a/website/content/v1.9/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.9/talos-guides/install/cloud-platforms/hetzner.md
@@ -290,7 +290,7 @@ cluster:
 Then run the following command:
 
 ```bash
-talosctl patch machineconfig --patch-file patch.yaml --nodes <comma separated list of all your nodes' IP addresses>
+talosctl --talosconfig talosconfig patch machineconfig --patch-file patch.yaml --nodes <comma separated list of all your nodes' IP addresses>
 ```
 
 With that in place, we can now follow the [official instructions](https://github.com/hetznercloud/hcloud-cloud-controller-manager), ignoring the `kubeadm` related steps.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
The last command of the Hetzner platform guide was missing the `--talosconfig` flag which would make the CLI connect to a local cluster, which is incorrect in this context.

## Why? (reasoning)
The current command doesn't work :)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
