### PR TITLE
fix: use imager incoming version for extension validation

### DIFF
--- a/cmd/installer/pkg/install/extensions.go
+++ b/cmd/installer/pkg/install/extensions.go
@@ -16,11 +16,12 @@ import (
 
 func (i *Installer) installExtensions() error {
 	builder := extensions.Builder{
-		InitramfsPath:     fmt.Sprintf(constants.InitramfsAssetPath, i.options.Arch),
-		Arch:              i.options.Arch,
-		ExtensionTreePath: constants.SystemExtensionsPath,
-		Printf:            log.Printf,
-		Quirks:            quirks.New(i.options.Version),
+		InitramfsPath:             fmt.Sprintf(constants.InitramfsAssetPath, i.options.Arch),
+		Arch:                      i.options.Arch,
+		ExtensionTreePath:         constants.SystemExtensionsPath,
+		ExtensionValidateContents: true,
+		Printf:                    log.Printf,
+		Quirks:                    quirks.New(i.options.Version),
 	}
 
 	return builder.Build()

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -29,6 +29,11 @@ func New(talosVersion string) Quirks {
 
 var minVersionResetOption = semver.MustParse("1.4.0")
 
+// Version returns the Talos version.
+func (q Quirks) Version() semver.Version {
+	return *q.v
+}
+
 // SupportsResetGRUBOption returns true if the Talos version supports the reset option in GRUB menu (image and ISO).
 func (q Quirks) SupportsResetGRUBOption() bool {
 	// if the version doesn't parse, we assume it's latest Talos


### PR DESCRIPTION
Use the version coming from imager to validate extension constraints.

Part of : #9694