### PR TITLE
Fix QEMU Provisioner on ArchLinux

### DIFF
--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -129,11 +129,13 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			"/usr/share/ovmf",
 			"/usr/share/OVMF",
 			"/usr/share/qemu",
+			"/usr/share/ovmf/x64", // Arch Linux
 		}
 
 		// Secure boot enabled firmware files
 		uefiSourceFiles := []string{
 			"OVMF_CODE_4M.secboot.fd",
+			"OVMF_CODE.secboot.4m.fd", // Arch Linux
 			"OVMF_CODE.secboot.fd",
 			"OVMF.secboot.fd",
 			"edk2-x86_64-secure-code.fd", // Alpine Linux
@@ -143,6 +145,7 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 		// Non-secure boot firmware files
 		uefiSourceFilesInsecure := []string{
 			"OVMF_CODE_4M.fd",
+			"OVMF_CODE.4m.fd", // Arch Linux
 			"OVMF_CODE.fd",
 			"OVMF.fd",
 			"ovmf-x86_64-4m-code.bin",
@@ -151,6 +154,7 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 		// Empty vars files
 		uefiVarsFiles := []string{
 			"OVMF_VARS_4M.fd",
+			"OVMF_VARS.4m.fd", // Arch Linux
 			"OVMF_VARS.fd",
 			"ovmf-x86_64-4m-vars.bin",
 		}


### PR DESCRIPTION
# Pull Request

## What? (description)

This patch adds a file search name and a file path for the QEMU provisioner for Arch Linux systems.

## Why? (reasoning)

*tl;dr* ArchLinux renamed the 4M BIOS file over a year ago and in the last week removed the fallback it was using instead.

ArchLinux [recently stopped shipping 2M BIOS images](https://gitlab.archlinux.org/archlinux/packaging/packages/edk2/-/commit/75700baee1f5073d558029efc0e03612bedfc048) which the ability to use the QEMU provisioner on the distro. The existence of the 2M images have been masking the inability to find the 4M versions.

Several [years ago](https://gitlab.archlinux.org/archlinux/packaging/packages/edk2/-/commit/a4adfc922a23333b6705d498b05288a27ef88d88) the package maintainer for Arch's evdk2 BIOS images renamed the files with a non-standard name. Since then tools using the search paths were accidentally falling back on the 2M images. This tool is one of the ones affected and this patch addresses the file name path and adds the standard search path for ArchLinux.

You can [verify the destination](https://gitlab.archlinux.org/archlinux/packaging/packages/edk2/-/blob/main/PKGBUILD?ref_type=heads#L395-402) of the various install paths.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

I ran the conformance check, the only failure there is:

```
commit         GPG Identity                 FAILED        openpgp: signature made by unknown entity
```

That unknown entity is my personal signature which I suppose is expected. Let me know if there is something more you'd like me to do for this.

I wasn't able to get the unit-tests working as I'm using podman/buildah on my local system not docker which doesn't support a few of the more exotic container patterns used in the unit-tests (I gave up when I got to the layer linking). I was able to generate a fresh talosctl binary from my branch which I'm using locally for now.