### PR TITLE
Fix a typo

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/vultr.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/vultr.md
@@ -137,7 +137,7 @@ Once all the cluster nodes are correctly configured, the cluster can be bootstra
 It is important that the `talosctl bootstrap` command be executed only once and against only a single control plane node.
 
 ```bash
-talosctl --talosconfig talosconfig boostrap --endpoints $CONTROL_PLANE_1_ADDRESS --nodes $CONTROL_PLANE_1_ADDRESS
+talosctl --talosconfig talosconfig bootstrap --endpoints $CONTROL_PLANE_1_ADDRESS --nodes $CONTROL_PLANE_1_ADDRESS
 ```
 
 ### Configure Endpoints and Nodes

--- a/website/content/v1.9/talos-guides/install/cloud-platforms/vultr.md
+++ b/website/content/v1.9/talos-guides/install/cloud-platforms/vultr.md
@@ -137,7 +137,7 @@ Once all the cluster nodes are correctly configured, the cluster can be bootstra
 It is important that the `talosctl bootstrap` command be executed only once and against only a single control plane node.
 
 ```bash
-talosctl --talosconfig talosconfig boostrap --endpoints $CONTROL_PLANE_1_ADDRESS --nodes $CONTROL_PLANE_1_ADDRESS
+talosctl --talosconfig talosconfig bootstrap --endpoints $CONTROL_PLANE_1_ADDRESS --nodes $CONTROL_PLANE_1_ADDRESS
 ```
 
 ### Configure Endpoints and Nodes


### PR DESCRIPTION
The documentation for running talos on vultr misspells "bootstrap" as "boostrap".  Just want to fix that so the next person to do it can copy-paste, and not have to fix it themself.