### PR TITLE
fix: registry mirror fallback handling

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -71,6 +71,18 @@ This command allows you to view the cgroup resource consumption and limits for a
 Talos previously used `eudev` to provide `udevd`, now it uses `systemd-udevd` instead.
 """
 
+    [notes.registry-mirrors]
+        title = "Registry Mirrors"
+        description = """\
+In versions before Talos 1.9, there was a discrepancy between the way Talos itself and CRI plugin resolves registry mirrors:
+Talos will never fall back to the default registry if endpoints are configured, while CRI plugin will.
+
+> Note: Talos Linux pulls images for the `installer`, `kubelet`, `etcd`, while all workload images are pulled by the CRI plugin.
+
+In Talos 1.9 this was fixed, so that by default an upstream registry is used as a fallback in all cases, while new registry mirror
+configuration option `.skipFallback` can be used to disable this behavior both for Talos and CRI plugin.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/pkg/containers/cri/containerd/hosts_test.go
+++ b/internal/pkg/containers/cri/containerd/hosts_test.go
@@ -83,7 +83,7 @@ func TestGenerateHostsWithTLS(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("[host]\n  [host.'https://some.host:123']\n    ca = '/etc/cri/conf.d/hosts/some.host_123_/some.host:123-ca.crt'\n    client = [['/etc/cri/conf.d/hosts/some.host_123_/some.host:123-client.crt', '/etc/cri/conf.d/hosts/some.host_123_/some.host:123-client.key']]\n    skip_verify = true\n"), //nolint:lll
+						Contents: []byte("server = 'https://some.host:123'\nca = '/etc/cri/conf.d/hosts/some.host_123_/some.host:123-ca.crt'\nclient = [['/etc/cri/conf.d/hosts/some.host_123_/some.host:123-client.crt', '/etc/cri/conf.d/hosts/some.host_123_/some.host:123-client.key']]\nskip_verify = true\n"), //nolint:lll
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestGenerateHostsWithTLS(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("[host]\n  [host.'https://registry-2.docker.io']\n    skip_verify = true\n"),
+						Contents: []byte("server = 'https://registry-2.docker.io'\nskip_verify = true\n"),
 					},
 				},
 			},
@@ -210,7 +210,7 @@ func TestGenerateHostsTLSWildcard(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("[host]\n  [host.'https://my-registry1']\n    ca = '/etc/cri/conf.d/hosts/my-registry1/my-registry1-ca.crt'\n"),
+						Contents: []byte("server = 'https://my-registry1'\nca = '/etc/cri/conf.d/hosts/my-registry1/my-registry1-ca.crt'\n"),
 					},
 				},
 			},
@@ -278,7 +278,58 @@ func TestGenerateHostsWithHarbor(t *testing.T) {
 					{
 						Name:     "hosts.toml",
 						Mode:     0o600,
-						Contents: []byte("[host]\n  [host.'https://harbor']\n    skip_verify = true\n"),
+						Contents: []byte("server = 'https://harbor'\nskip_verify = true\n"),
+					},
+				},
+			},
+		},
+	}, result)
+}
+
+func TestGenerateHostsSkipFallback(t *testing.T) {
+	cfg := &mockConfig{
+		mirrors: map[string]*v1alpha1.RegistryMirrorConfig{
+			"docker.io": {
+				MirrorEndpoints:    []string{"https://harbor/v2/mirrors/proxy.docker.io", "http://127.0.0.1:5001/v2/"},
+				MirrorOverridePath: pointer.To(true),
+				MirrorSkipFallback: pointer.To(true),
+			},
+			"ghcr.io": {
+				MirrorEndpoints:    []string{"http://127.0.0.1:5002"},
+				MirrorSkipFallback: pointer.To(true),
+			},
+		},
+	}
+
+	result, err := containerd.GenerateHosts(cfg, "/etc/cri/conf.d/hosts")
+	require.NoError(t, err)
+
+	t.Logf(
+		"config docker.io %q",
+		string(result.Directories["docker.io"].Files[0].Contents),
+	)
+	t.Logf(
+		"config ghcr.io %q",
+		string(result.Directories["ghcr.io"].Files[0].Contents),
+	)
+
+	assert.Equal(t, &containerd.HostsConfig{
+		Directories: map[string]*containerd.HostsDirectory{
+			"docker.io": {
+				Files: []*containerd.HostsFile{
+					{
+						Name:     "hosts.toml",
+						Mode:     0o600,
+						Contents: []byte("server = 'http://127.0.0.1:5001/v2/'\ncapabilities = ['pull', 'resolve']\noverride_path = true\n[host]\n  [host.'https://harbor/v2/mirrors/proxy.docker.io']\n    capabilities = ['pull', 'resolve']\n    override_path = true\n"), //nolint:lll
+					},
+				},
+			},
+			"ghcr.io": {
+				Files: []*containerd.HostsFile{
+					{
+						Name:     "hosts.toml",
+						Mode:     0o600,
+						Contents: []byte("server = 'http://127.0.0.1:5002'\ncapabilities = ['pull', 'resolve']\n"),
 					},
 				},
 			},

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -366,6 +366,7 @@ type Registries interface {
 type RegistryMirrorConfig interface {
 	Endpoints() []string
 	OverridePath() bool
+	SkipFallback() bool
 }
 
 // RegistryConfig specifies auth & TLS config per registry.

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -3239,6 +3239,13 @@
           "description": "Use the exact path specified for the endpoint (don’t append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.\n",
           "markdownDescription": "Use the exact path specified for the endpoint (don't append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.",
           "x-intellij-html-description": "\u003cp\u003eUse the exact path specified for the endpoint (don\u0026rsquo;t append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.\u003c/p\u003e\n"
+        },
+        "skipFallback": {
+          "type": "boolean",
+          "title": "skipFallback",
+          "description": "Skip fallback to the upstream endpoint, for example the mirror configuration\nfor docker.io will not fallback to registry-1.docker.io.\n",
+          "markdownDescription": "Skip fallback to the upstream endpoint, for example the mirror configuration\nfor `docker.io` will not fallback to `registry-1.docker.io`.",
+          "x-intellij-html-description": "\u003cp\u003eSkip fallback to the upstream endpoint, for example the mirror configuration\nfor \u003ccode\u003edocker.io\u003c/code\u003e will not fallback to \u003ccode\u003eregistry-1.docker.io\u003c/code\u003e.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1464,6 +1464,11 @@ func (r *RegistryMirrorConfig) OverridePath() bool {
 	return pointer.SafeDeref(r.MirrorOverridePath)
 }
 
+// SkipFallback implements the Registries interface.
+func (r *RegistryMirrorConfig) SkipFallback() bool {
+	return pointer.SafeDeref(r.MirrorSkipFallback)
+}
+
 // Content implements the config.Provider interface.
 func (f *MachineFile) Content() string {
 	return f.FileContent

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2057,6 +2057,10 @@ type RegistryMirrorConfig struct {
 	//     This setting is often required for setting up multiple mirrors
 	//     on a single instance of a registry.
 	MirrorOverridePath *bool `yaml:"overridePath,omitempty"`
+	//   description: |
+	//     Skip fallback to the upstream endpoint, for example the mirror configuration
+	//     for `docker.io` will not fallback to `registry-1.docker.io`.
+	MirrorSkipFallback *bool `yaml:"skipFallback,omitempty"`
 }
 
 // RegistryConfig specifies auth & TLS config per registry.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -3224,6 +3224,13 @@ func (RegistryMirrorConfig) Doc() *encoder.Doc {
 				Description: "Use the exact path specified for the endpoint (don't append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Use the exact path specified for the endpoint (don't append /v2/)." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "skipFallback",
+				Type:        "bool",
+				Note:        "",
+				Description: "Skip fallback to the upstream endpoint, for example the mirror configuration\nfor `docker.io` will not fallback to `registry-1.docker.io`.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Skip fallback to the upstream endpoint, for example the mirror configuration" /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/website/content/v1.9/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.9/reference/configuration/v1alpha1/config.md
@@ -2152,6 +2152,7 @@ machine:
 |-------|------|-------------|----------|
 |`endpoints` |[]string |<details><summary>List of endpoints (URLs) for registry mirrors to use.</summary>Endpoint configures HTTP/HTTPS access mode, host name,<br />port and path (if path is not set, it defaults to `/v2`).</details>  | |
 |`overridePath` |bool |<details><summary>Use the exact path specified for the endpoint (don't append /v2/).</summary>This setting is often required for setting up multiple mirrors<br />on a single instance of a registry.</details>  | |
+|`skipFallback` |bool |<details><summary>Skip fallback to the upstream endpoint, for example the mirror configuration</summary>for `docker.io` will not fallback to `registry-1.docker.io`.</details>  | |
 
 
 

--- a/website/content/v1.9/schemas/config.schema.json
+++ b/website/content/v1.9/schemas/config.schema.json
@@ -3239,6 +3239,13 @@
           "description": "Use the exact path specified for the endpoint (don’t append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.\n",
           "markdownDescription": "Use the exact path specified for the endpoint (don't append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.",
           "x-intellij-html-description": "\u003cp\u003eUse the exact path specified for the endpoint (don\u0026rsquo;t append /v2/).\nThis setting is often required for setting up multiple mirrors\non a single instance of a registry.\u003c/p\u003e\n"
+        },
+        "skipFallback": {
+          "type": "boolean",
+          "title": "skipFallback",
+          "description": "Skip fallback to the upstream endpoint, for example the mirror configuration\nfor docker.io will not fallback to registry-1.docker.io.\n",
+          "markdownDescription": "Skip fallback to the upstream endpoint, for example the mirror configuration\nfor `docker.io` will not fallback to `registry-1.docker.io`.",
+          "x-intellij-html-description": "\u003cp\u003eSkip fallback to the upstream endpoint, for example the mirror configuration\nfor \u003ccode\u003edocker.io\u003c/code\u003e will not fallback to \u003ccode\u003eregistry-1.docker.io\u003c/code\u003e.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Fixes #9613

This has two changes:

* adjust Talos registry resolver to match containerd (CRI) resolver: use by default upstream as a fallback
* add a machine config option to skip upstream as a fallback, and adjust CRI configuration accordingly

See https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples for details on CRI's `hosts.toml`.
