### PR TITLE
feat: add permanent hardware addr to device selectors

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -83,6 +83,13 @@ In Talos 1.9 this was fixed, so that by default an upstream registry is used as 
 configuration option `.skipFallback` can be used to disable this behavior both for Talos and CRI plugin.
 """
 
+    [notes.device-selectors]
+        title = "Device Selectors"
+        description = """\
+Talos now supports matching on permanent hardware (MAC) address of the network interfaces.
+This is specifically useful to match bond members, as they change their hardware addresses when they become part of the bond.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/network/device_config.go
+++ b/internal/app/machined/pkg/controllers/network/device_config.go
@@ -214,6 +214,7 @@ func (ctrl *DeviceConfigController) selectDevices(selector talosconfig.NetworkDe
 
 		for _, pair := range [][]string{
 			{selector.HardwareAddress(), linkStatusSpec.HardwareAddr.String()},
+			{selector.PermanentAddress(), linkStatusSpec.PermanentAddr.String()},
 			{selector.PCIID(), linkStatusSpec.PCIID},
 			{selector.KernelDriver(), linkStatusSpec.Driver},
 			{selector.Bus(), linkStatusSpec.BusPath},

--- a/internal/app/machined/pkg/controllers/network/device_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/device_config_test.go
@@ -174,10 +174,10 @@ func (suite *DeviceConfigSpecSuite) TestBondSelectors() {
 							BondMode: "balance-rr",
 							BondDeviceSelectors: []v1alpha1.NetworkDeviceSelector{
 								{
-									NetworkDeviceHardwareAddress: "00:*",
+									NetworkDevicePermanentAddress: "00:*",
 								},
 								{
-									NetworkDeviceHardwareAddress: "01:*",
+									NetworkDevicePermanentAddress: "01:*",
 								},
 							},
 						},
@@ -226,7 +226,7 @@ func (suite *DeviceConfigSpecSuite) TestBondSelectors() {
 		suite.Require().NoError(err)
 
 		status := network.NewLinkStatus(network.NamespaceName, link.name)
-		status.TypedSpec().HardwareAddr = nethelpers.HardwareAddr(hwaddr)
+		status.TypedSpec().PermanentAddr = nethelpers.HardwareAddr(hwaddr)
 		suite.Require().NoError(suite.State().Create(suite.Ctx(), status))
 	}
 

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -318,6 +318,7 @@ type KubeSpanFilters interface {
 type NetworkDeviceSelector interface {
 	Bus() string
 	HardwareAddress() string
+	PermanentAddress() string
 	PCIID() string
 	KernelDriver() string
 	Physical() *bool

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -3008,9 +3008,16 @@
         "hardwareAddr": {
           "type": "string",
           "title": "hardwareAddr",
-          "description": "Device hardware address, supports matching by wildcard.\n",
-          "markdownDescription": "Device hardware address, supports matching by wildcard.",
-          "x-intellij-html-description": "\u003cp\u003eDevice hardware address, supports matching by wildcard.\u003c/p\u003e\n"
+          "description": "Device hardware (MAC) address, supports matching by wildcard.\n",
+          "markdownDescription": "Device hardware (MAC) address, supports matching by wildcard.",
+          "x-intellij-html-description": "\u003cp\u003eDevice hardware (MAC) address, supports matching by wildcard.\u003c/p\u003e\n"
+        },
+        "permanentAddr": {
+          "type": "string",
+          "title": "permanentAddr",
+          "description": "Device permanent hardware address, supports matching by wildcard.\nThe permanent address doesn’t change when the link is enslaved to a bond,\nso it’s recommended to use this field for bond members.\n",
+          "markdownDescription": "Device permanent hardware address, supports matching by wildcard.\nThe permanent address doesn't change when the link is enslaved to a bond,\nso it's recommended to use this field for bond members.",
+          "x-intellij-html-description": "\u003cp\u003eDevice permanent hardware address, supports matching by wildcard.\nThe permanent address doesn\u0026rsquo;t change when the link is enslaved to a bond,\nso it\u0026rsquo;s recommended to use this field for bond members.\u003c/p\u003e\n"
         },
         "pciID": {
           "type": "string",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -851,6 +851,11 @@ func (s *NetworkDeviceSelector) HardwareAddress() string {
 	return s.NetworkDeviceHardwareAddress
 }
 
+// PermanentAddress implements config.NetworkDeviceSelector interface.
+func (s *NetworkDeviceSelector) PermanentAddress() string {
+	return s.NetworkDevicePermanentAddress
+}
+
 // PCIID implements config.NetworkDeviceSelector interface.
 func (s *NetworkDeviceSelector) PCIID() string {
 	return s.NetworkDevicePCIID

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2324,8 +2324,13 @@ type KubeSpanFilters struct {
 type NetworkDeviceSelector struct {
 	// description: PCI, USB bus prefix, supports matching by wildcard.
 	NetworkDeviceBus string `yaml:"busPath,omitempty"`
-	// description: Device hardware address, supports matching by wildcard.
+	// description: Device hardware (MAC) address, supports matching by wildcard.
 	NetworkDeviceHardwareAddress string `yaml:"hardwareAddr,omitempty"`
+	// description: |
+	//    Device permanent hardware address, supports matching by wildcard.
+	//    The permanent address doesn't change when the link is enslaved to a bond,
+	//    so it's recommended to use this field for bond members.
+	NetworkDevicePermanentAddress string `yaml:"permanentAddr,omitempty"`
 	// description: PCI ID (vendor ID, product ID), supports matching by wildcard.
 	NetworkDevicePCIID string `yaml:"pciID,omitempty"`
 	// description: Kernel driver, supports matching by wildcard.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -3791,8 +3791,15 @@ func (NetworkDeviceSelector) Doc() *encoder.Doc {
 				Name:        "hardwareAddr",
 				Type:        "string",
 				Note:        "",
-				Description: "Device hardware address, supports matching by wildcard.",
-				Comments:    [3]string{"" /* encoder.HeadComment */, "Device hardware address, supports matching by wildcard." /* encoder.LineComment */, "" /* encoder.FootComment */},
+				Description: "Device hardware (MAC) address, supports matching by wildcard.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Device hardware (MAC) address, supports matching by wildcard." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "permanentAddr",
+				Type:        "string",
+				Note:        "",
+				Description: "Device permanent hardware address, supports matching by wildcard.\nThe permanent address doesn't change when the link is enslaved to a bond,\nso it's recommended to use this field for bond members.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Device permanent hardware address, supports matching by wildcard." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
 				Name:        "pciID",

--- a/website/content/v1.9/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.9/reference/configuration/v1alpha1/config.md
@@ -172,12 +172,12 @@ network:
           #     busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
           # # select a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
           # deviceSelector:
-          #     hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+          #     hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
           #     driver: virtio # Kernel driver, supports matching by wildcard.
           # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
           # deviceSelector:
           #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-          #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+          #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
           #       driver: virtio # Kernel driver, supports matching by wildcard.
 
           # # Bond specific options.
@@ -189,7 +189,7 @@ network:
           #     # Picks a network device using the selector.
           #     deviceSelectors:
           #         - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-          #         - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+          #         - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
           #           driver: virtio # Kernel driver, supports matching by wildcard.
           #     mode: 802.3ad # A bond option.
           #     lacpRate: fast # A bond option.
@@ -747,12 +747,12 @@ machine:
               #     busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
               # # select a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
               # deviceSelector:
-              #     hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #     hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #     driver: virtio # Kernel driver, supports matching by wildcard.
               # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
               # deviceSelector:
               #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-              #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #       driver: virtio # Kernel driver, supports matching by wildcard.
 
               # # Bond specific options.
@@ -764,7 +764,7 @@ machine:
               #     # Picks a network device using the selector.
               #     deviceSelectors:
               #         - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-              #         - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #         - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #           driver: virtio # Kernel driver, supports matching by wildcard.
               #     mode: 802.3ad # A bond option.
               #     lacpRate: fast # A bond option.
@@ -862,12 +862,12 @@ interfaces:
       #     busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
       # # select a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
       # deviceSelector:
-      #     hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+      #     hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
       #     driver: virtio # Kernel driver, supports matching by wildcard.
       # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
       # deviceSelector:
       #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-      #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+      #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
       #       driver: virtio # Kernel driver, supports matching by wildcard.
 
       # # Bond specific options.
@@ -879,7 +879,7 @@ interfaces:
       #     # Picks a network device using the selector.
       #     deviceSelectors:
       #         - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-      #         - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+      #         - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
       #           driver: virtio # Kernel driver, supports matching by wildcard.
       #     mode: 802.3ad # A bond option.
       #     lacpRate: fast # A bond option.
@@ -986,12 +986,12 @@ machine:
               #     busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
               # # select a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
               # deviceSelector:
-              #     hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #     hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #     driver: virtio # Kernel driver, supports matching by wildcard.
               # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
               # deviceSelector:
               #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-              #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #       driver: virtio # Kernel driver, supports matching by wildcard.
 
               # # Bond specific options.
@@ -1003,7 +1003,7 @@ machine:
               #     # Picks a network device using the selector.
               #     deviceSelectors:
               #         - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-              #         - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+              #         - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
               #           driver: virtio # Kernel driver, supports matching by wildcard.
               #     mode: 802.3ad # A bond option.
               #     lacpRate: fast # A bond option.
@@ -1072,7 +1072,7 @@ deviceSelector:
     busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
 {{< /highlight >}}{{< highlight yaml >}}
 deviceSelector:
-    hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+    hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
     driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}</details> | |
 |`addresses` |[]string |<details><summary>Assigns static IP addresses to the interface.</summary>An address can be specified either in proper CIDR notation or as a standalone address (netmask of all ones is assumed).</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
@@ -1101,7 +1101,7 @@ bond:
     # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
     # deviceSelectors:
     #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-    #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+    #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
     #       driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}</details> | |
 |`bridge` |<a href="#Config.machine.network.interfaces..bridge">Bridge</a> |Bridge specific options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
@@ -1179,7 +1179,7 @@ machine:
     network:
         interfaces:
             - deviceSelector:
-                hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+                hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
                 driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}
 
@@ -1189,7 +1189,7 @@ machine:
         interfaces:
             - deviceSelector:
                 - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-                - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+                - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
                   driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}
 
@@ -1197,7 +1197,8 @@ machine:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`busPath` |string |PCI, USB bus prefix, supports matching by wildcard.  | |
-|`hardwareAddr` |string |Device hardware address, supports matching by wildcard.  | |
+|`hardwareAddr` |string |Device hardware (MAC) address, supports matching by wildcard.  | |
+|`permanentAddr` |string |<details><summary>Device permanent hardware address, supports matching by wildcard.</summary>The permanent address doesn't change when the link is enslaved to a bond,<br />so it's recommended to use this field for bond members.</details>  | |
 |`pciID` |string |PCI ID (vendor ID, product ID), supports matching by wildcard.  | |
 |`driver` |string |Kernel driver, supports matching by wildcard.  | |
 |`physical` |bool |Select only physical devices.  | |
@@ -1261,7 +1262,7 @@ machine:
                 # # select a device with bus prefix 00:*, a device with mac address matching `*:f0:ab` and `virtio` kernel driver.
                 # deviceSelectors:
                 #     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-                #     - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+                #     - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
                 #       driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}
 
@@ -1272,7 +1273,7 @@ machine:
 |`deviceSelectors` |<a href="#Config.machine.network.interfaces..bond.deviceSelectors.">[]NetworkDeviceSelector</a> |<details><summary>Picks a network device using the selector.</summary>Mutually exclusive with `interfaces`.<br />Supports partial match using wildcard syntax.</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 deviceSelectors:
     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-    - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+    - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
       driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}</details> | |
 |`arpIPTarget` |[]string |<details><summary>A bond option.</summary>Please see the official kernel documentation.<br />Not supported at the moment.</details>  | |
@@ -1326,7 +1327,7 @@ machine:
         interfaces:
             - bond:
                 deviceSelectors:
-                    hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+                    hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
                     driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}
 
@@ -1337,7 +1338,7 @@ machine:
             - bond:
                 deviceSelectors:
                     - busPath: 00:* # PCI, USB bus prefix, supports matching by wildcard.
-                    - hardwareAddr: '*:f0:ab' # Device hardware address, supports matching by wildcard.
+                    - hardwareAddr: '*:f0:ab' # Device hardware (MAC) address, supports matching by wildcard.
                       driver: virtio # Kernel driver, supports matching by wildcard.
 {{< /highlight >}}
 
@@ -1345,7 +1346,8 @@ machine:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`busPath` |string |PCI, USB bus prefix, supports matching by wildcard.  | |
-|`hardwareAddr` |string |Device hardware address, supports matching by wildcard.  | |
+|`hardwareAddr` |string |Device hardware (MAC) address, supports matching by wildcard.  | |
+|`permanentAddr` |string |<details><summary>Device permanent hardware address, supports matching by wildcard.</summary>The permanent address doesn't change when the link is enslaved to a bond,<br />so it's recommended to use this field for bond members.</details>  | |
 |`pciID` |string |PCI ID (vendor ID, product ID), supports matching by wildcard.  | |
 |`driver` |string |Kernel driver, supports matching by wildcard.  | |
 |`physical` |bool |Select only physical devices.  | |

--- a/website/content/v1.9/schemas/config.schema.json
+++ b/website/content/v1.9/schemas/config.schema.json
@@ -3008,9 +3008,16 @@
         "hardwareAddr": {
           "type": "string",
           "title": "hardwareAddr",
-          "description": "Device hardware address, supports matching by wildcard.\n",
-          "markdownDescription": "Device hardware address, supports matching by wildcard.",
-          "x-intellij-html-description": "\u003cp\u003eDevice hardware address, supports matching by wildcard.\u003c/p\u003e\n"
+          "description": "Device hardware (MAC) address, supports matching by wildcard.\n",
+          "markdownDescription": "Device hardware (MAC) address, supports matching by wildcard.",
+          "x-intellij-html-description": "\u003cp\u003eDevice hardware (MAC) address, supports matching by wildcard.\u003c/p\u003e\n"
+        },
+        "permanentAddr": {
+          "type": "string",
+          "title": "permanentAddr",
+          "description": "Device permanent hardware address, supports matching by wildcard.\nThe permanent address doesn’t change when the link is enslaved to a bond,\nso it’s recommended to use this field for bond members.\n",
+          "markdownDescription": "Device permanent hardware address, supports matching by wildcard.\nThe permanent address doesn't change when the link is enslaved to a bond,\nso it's recommended to use this field for bond members.",
+          "x-intellij-html-description": "\u003cp\u003eDevice permanent hardware address, supports matching by wildcard.\nThe permanent address doesn\u0026rsquo;t change when the link is enslaved to a bond,\nso it\u0026rsquo;s recommended to use this field for bond members.\u003c/p\u003e\n"
         },
         "pciID": {
           "type": "string",

--- a/website/content/v1.9/talos-guides/network/device-selector.md
+++ b/website/content/v1.9/talos-guides/network/device-selector.md
@@ -34,6 +34,7 @@ The available hardware information used in the selector can be observed in the `
 spec:
   ...
   hardwareAddr: 4e:95:8e:8f:e4:47
+  permanentAddr: 4e:95:8e:8f:e4:47
   busPath: 0000:06:00.0
   driver: alx
   pciID: 1969:E0B1
@@ -43,6 +44,7 @@ The following qualifiers are available:
 
 - `driver` - matches a device by its driver name
 - `hardwareAddr` - matches a device by its hardware address
+- `permanentAddr` - matches a device by its permanent hardware address
 - `busPath` - matches a device by its PCI bus path
 - `pciID` - matches a device by its PCI vendor and device ID
 - `physical` - matches only physical devices (vs. virtual devices, e.g. bonds and VLANs)
@@ -62,8 +64,10 @@ machine:
         bond:
           mode: balance-rr
           deviceSelectors:
-            - hardwareAddr: '00:50:56:8e:8f:e4'
-            - hardwareAddr: '00:50:57:9c:2c:2d'
+            - permanentAddr: '00:50:56:8e:8f:e4'
+            - permanentAddr: '00:50:57:9c:2c:2d'
 ```
 
 In this example, the `bond0` interface will be created and bonded using two devices with the specified hardware addresses.
+For bonding, use `permanentAddr` instead of `hardwareAddr` to match the permanent hardware address of the device, as `hardwareAddr` might change
+as the link becomes part of the bond.


### PR DESCRIPTION
This should fix the problem of including bond members by MAC address when MAC address changes as the link becomes part of the bond.
