### PR TITLE
chore: remove i915/amdgpu drivers

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -26,14 +26,11 @@ kernel/drivers/edac/igen6_edac.ko
 kernel/drivers/edac/sb_edac.ko
 kernel/drivers/edac/skx_edac.ko
 kernel/drivers/edac/x38_edac.ko
-kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko
-kernel/drivers/gpu/drm/amd/amdxcp/amdxcp.ko
 kernel/drivers/gpu/drm/display/drm_display_helper.ko
 kernel/drivers/gpu/drm/drm_buddy.ko
 kernel/drivers/gpu/drm/drm_exec.ko
 kernel/drivers/gpu/drm/drm_suballoc_helper.ko
 kernel/drivers/gpu/drm/drm_ttm_helper.ko
-kernel/drivers/gpu/drm/i915/i915.ko
 kernel/drivers/gpu/drm/scheduler/gpu-sched.ko
 kernel/drivers/gpu/drm/ttm/ttm.ko
 kernel/drivers/hid/hid-a4tech.ko

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -27,6 +27,14 @@ preface = """
 Talos is built with Go 1.23.3.
 """
 
+    [notes.drm]
+        title = "Direct Rendering Manager (DRM)"
+        description = """\
+Starting with Talos 1.9, the `i915` and `amdgpu` DRM drivers will be dropped from the Talos squashfs.
+There will be new system extensions named `i915` and `amdgpu` that would contain both the drivers and firmware packaged together.
+Upgrades via Image Factory will automatically include the new extensions if previously `i915-ucode` or `amdgpu-firmware` were used.
+"""
+
     [notes.usernamespaces]
         title = "User Namespaces"
         description = """\


### PR DESCRIPTION
Drop i915 and amdgpu drivers from Talos rootfs, these will be packaged as extensions containing both firmware and drivers.

Some modules like `ttm`, `i2c-algo-bit` etc have been left off since they are used by both amdgpu and i915, so makes sense to keep in plain talos.

Part of: #9728