### PR TITLE
fix: make vmware platform common code build on all arches

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package vmware provides the VMware platform implementation.
+package vmware
+
+import (
+	"github.com/siderolabs/go-procfs/procfs"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// VMware is the concrete type that implements the platform.Platform interface.
+type VMware struct{}
+
+// Name implements the platform.Platform interface.
+func (v *VMware) Name() string {
+	return "vmware"
+}
+
+// Mode implements the platform.Platform interface.
+func (v *VMware) Mode() runtime.Mode {
+	return runtime.ModeCloud
+}
+
+// KernelArgs implements the runtime.Platform interface.
+func (v *VMware) KernelArgs(arch string) procfs.Parameters {
+	switch arch {
+	case "amd64":
+		return []*procfs.Parameter{
+			procfs.NewParameter(constants.KernelParamConfig).Append(constants.ConfigGuestInfo),
+			procfs.NewParameter("console").Append("tty0").Append("ttyS0"),
+			procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),
+			procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
+		}
+	default:
+		return nil // not supported on !amd64
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -4,7 +4,6 @@
 
 //go:build amd64
 
-// Package vmware provides the VMware platform implementation.
 package vmware
 
 import (
@@ -26,14 +25,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
-
-// VMware is the concrete type that implements the platform.Platform interface.
-type VMware struct{}
-
-// Name implements the platform.Platform interface.
-func (v *VMware) Name() string {
-	return "vmware"
-}
 
 // Read and de-base64 a property from `extraConfig`. This is commonly referred to as `guestinfo`.
 func readConfigFromExtraConfig(extraConfig *rpcvmx.Config, key string) ([]byte, error) {
@@ -212,21 +203,6 @@ func (v *VMware) Configuration(context.Context, state.State) ([]byte, error) {
 	}
 
 	return nil, nil
-}
-
-// Mode implements the platform.Platform interface.
-func (v *VMware) Mode() runtime.Mode {
-	return runtime.ModeCloud
-}
-
-// KernelArgs implements the runtime.Platform interface.
-func (v *VMware) KernelArgs(string) procfs.Parameters {
-	return []*procfs.Parameter{
-		procfs.NewParameter(constants.KernelParamConfig).Append(constants.ConfigGuestInfo),
-		procfs.NewParameter("console").Append("tty0").Append("ttyS0"),
-		procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),
-		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
-	}
 }
 
 // Read VMware GuestInfo metadata if available.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -11,32 +11,13 @@ import (
 	"errors"
 
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 )
 
-// VMware is the concrete type that implements the platform.Platform interface.
-type VMware struct{}
-
-// Name implements the platform.Platform interface.
-func (v *VMware) Name() string {
-	return "vmware"
-}
-
 // Configuration implements the platform.Platform interface.
 func (v *VMware) Configuration(context.Context, state.State) ([]byte, error) {
 	return nil, errors.New("arch not supported")
-}
-
-// Mode implements the platform.Platform interface.
-func (v *VMware) Mode() runtime.Mode {
-	return runtime.ModeCloud
-}
-
-// KernelArgs implements the runtime.Platform interface.
-func (v *VMware) KernelArgs(string) procfs.Parameters {
-	return []*procfs.Parameter{}
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.


### PR DESCRIPTION
Even though VMWare doesn't support non-amd64 case, for the imager (and Image Factory), the common stuff should work correctly for any arch the imager is running with (as arm64 imager can generate amd64 VMWare image).

See https://github.com/siderolabs/image-factory/issues/164
