### PR TITLE
chore: enable TPM2 by default in CI

### DIFF
--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -24,7 +24,7 @@ case "${FACTORY_BOOT_METHOD:-iso}" in
     QEMU_FLAGS+=("--ipxe-boot-script=${FACTORY_SCHEME}://${PXE_FACTORY_HOSTNAME}/pxe/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64")
     ;;
   secureboot-iso)
-    QEMU_FLAGS+=("--iso-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64-secureboot.iso" "--with-tpm2" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
+    QEMU_FLAGS+=("--iso-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64-secureboot.iso" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
     INSTALLER_IMAGE_NAME=installer-secureboot
     ;;
 esac
@@ -59,6 +59,7 @@ function create_cluster {
     --with-apply-config \
     --talos-version="${FACTORY_VERSION}" \
     --install-image="${FACTORY_HOSTNAME}/${INSTALLER_IMAGE_NAME}/${FACTORY_SCHEMATIC}:${FACTORY_VERSION}" \
+    --with-tpm2 \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     "${QEMU_FLAGS[@]}"
 

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -26,6 +26,7 @@ function create_cluster {
     --with-apply-config \
     --install-image=${REGISTRY:-ghcr.io}/siderolabs/installer:${TAG} \
     --cni-bundle-url=${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+    --with-tpm2 \
     "${REGISTRY_MIRROR_FLAGS[@]}"
 
   "${TALOSCTL}" config node "${NODE}"

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -163,7 +163,7 @@ case "${WITH_TRUSTED_BOOT_ISO:-false}" in
     ;;
   *)
     INSTALLER_IMAGE=${INSTALLER_IMAGE}-amd64-secureboot
-    QEMU_FLAGS+=("--iso-path=_out/metal-amd64-secureboot.iso" "--with-tpm2" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
+    QEMU_FLAGS+=("--iso-path=_out/metal-amd64-secureboot.iso" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
     ;;
 esac
 
@@ -225,6 +225,7 @@ function create_cluster {
     --with-init-node=false \
     --cni-bundle-url="${ARTIFACTS}/talosctl-cni-bundle-\${ARCH}.tar.gz" \
     --crashdump \
+    --with-tpm2 \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     "${QEMU_FLAGS[@]}"
 

--- a/internal/integration/api/selinux.go
+++ b/internal/integration/api/selinux.go
@@ -104,6 +104,14 @@ func (suite *SELinuxSuite) TestFileMountLabels() {
 		// Mounts and runtime-generated files
 		constants.SystemEtcPath: constants.EtcSelinuxLabel,
 		"/etc":                  constants.EtcSelinuxLabel,
+		// Devices labeled by subsystems, labeled by udev
+		"/dev/rtc0":      "system_u:object_r:rtc_device_t:s0",
+		"/dev/tpm0":      "system_u:object_r:tpm_device_t:s0",
+		"/dev/tpmrm0":    "system_u:object_r:tpm_device_t:s0",
+		"/dev/watchdog":  "system_u:object_r:wdt_device_t:s0",
+		"/dev/watchdog0": "system_u:object_r:wdt_device_t:s0",
+		"/dev/null":      "system_u:object_r:null_device_t:s0",
+		"/dev/zero":      "system_u:object_r:null_device_t:s0",
 	}
 
 	// Only running on controlplane
@@ -119,25 +127,12 @@ func (suite *SELinuxSuite) TestFileMountLabels() {
 	}
 	maps.Copy(expectedLabelsControlPlane, expectedLabelsWorker)
 
-	// Devices labeled by subsystems, labeled by udev
-	expectedLabelsDevices := map[string]string{
-		"/dev/rtc0":      "system_u:object_r:rtc_device_t:s0",
-		"/dev/tpm0":      "system_u:object_r:tpm_device_t:s0",
-		"/dev/tpmrm0":    "system_u:object_r:tpm_device_t:s0",
-		"/dev/watchdog":  "system_u:object_r:wdt_device_t:s0",
-		"/dev/watchdog0": "system_u:object_r:wdt_device_t:s0",
-		"/dev/null":      "system_u:object_r:null_device_t:s0",
-		"/dev/zero":      "system_u:object_r:null_device_t:s0",
-	}
-
-	suite.checkFileLabels(workers, expectedLabelsWorker, false)
-	suite.checkFileLabels(controlplanes, expectedLabelsControlPlane, false)
-	suite.checkFileLabels(workers, expectedLabelsDevices, true)
-	suite.checkFileLabels(controlplanes, expectedLabelsDevices, true)
+	suite.checkFileLabels(workers, expectedLabelsWorker)
+	suite.checkFileLabels(controlplanes, expectedLabelsControlPlane)
 }
 
 //nolint:gocyclo
-func (suite *SELinuxSuite) checkFileLabels(nodes []string, expectedLabels map[string]string, allowMissing bool) {
+func (suite *SELinuxSuite) checkFileLabels(nodes []string, expectedLabels map[string]string) {
 	paths := make([]string, 0, len(expectedLabels))
 	for k := range expectedLabels {
 		paths = append(paths, k)
@@ -167,7 +162,7 @@ func (suite *SELinuxSuite) checkFileLabels(nodes []string, expectedLabels map[st
 
 				suite.Require().NoError(err)
 
-				err = helpers.ReadGRPCStream(stream, func(info *machineapi.FileInfo, node string, multipleNodes bool) error {
+				suite.Require().NoError(helpers.ReadGRPCStream(stream, func(info *machineapi.FileInfo, node string, multipleNodes bool) error {
 					// E.g. /var/lib should inherit /var label, while /var/run is a new mountpoint
 					if slices.Contains(paths, info.Name) && info.Name != path {
 						return nil
@@ -191,16 +186,7 @@ func (suite *SELinuxSuite) checkFileLabels(nodes []string, expectedLabels map[st
 					suite.Require().True(found)
 
 					return nil
-				})
-
-				if allowMissing {
-					if err != nil {
-						suite.Require().Contains(err.Error(), "lstat")
-						suite.Require().Contains(err.Error(), "no such file or directory")
-					}
-				} else {
-					suite.Require().NoError(err)
-				}
+				}))
 			}
 		}
 	}


### PR DESCRIPTION
With some tests requiring TPM and others benefitting from it (SELinux label test) it's better to always enable it as our CI has swtpm installed.

Do not automatically enable TPM2 in talosctl as it might be a breaking change to users who do not have swtpm available.

Partially reverts: a13f82c59456574238a75959ff395746c93f1cfa regarding tests

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
