### PR TITLE
fix: make immage cache config apply immediately

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -135,7 +135,8 @@ func (r *Runtime) CanApplyImmediate(cfg config.Provider) error {
 	// * .machine.nodeTaints
 	// * .machine.features.kubernetesTalosAPIAccess
 	// * .machine.features.kubePrism
-	// * .machine.features.localDNS
+	// * .machine.features.hostDNS
+	// * .machine.features.imageCache
 	newConfig.ConfigDebug = currentConfig.ConfigDebug
 	newConfig.ClusterConfig = currentConfig.ClusterConfig
 
@@ -163,6 +164,7 @@ func (r *Runtime) CanApplyImmediate(cfg config.Provider) error {
 			newConfig.MachineConfig.MachineFeatures.KubernetesTalosAPIAccessConfig = currentConfig.MachineConfig.MachineFeatures.KubernetesTalosAPIAccessConfig
 			newConfig.MachineConfig.MachineFeatures.KubePrismSupport = currentConfig.MachineConfig.MachineFeatures.KubePrismSupport
 			newConfig.MachineConfig.MachineFeatures.HostDNSSupport = currentConfig.MachineConfig.MachineFeatures.HostDNSSupport
+			newConfig.MachineConfig.MachineFeatures.ImageCache = currentConfig.MachineConfig.MachineFeatures.ImageCache
 		}
 	}
 

--- a/website/content/v1.8/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.8/talos-guides/configuration/editing-machine-configuration.md
@@ -51,6 +51,8 @@ The list of config changes allowed to be applied immediately in Talos {{< releas
 * `.machine.kernel`
 * `.machine.registries` (CRI containerd plugin will not pick up the registry authentication settings without a reboot)
 * `.machine.features.kubernetesTalosAPIAccess`
+* `.machine.features.hostDNS`
+* `.machine.features.kubePrism`
 
 ### `talosctl apply-config`
 

--- a/website/content/v1.9/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.9/talos-guides/configuration/editing-machine-configuration.md
@@ -51,6 +51,9 @@ The list of config changes allowed to be applied immediately in Talos {{< releas
 * `.machine.kernel`
 * `.machine.registries` (CRI containerd plugin will not pick up the registry authentication settings without a reboot)
 * `.machine.features.kubernetesTalosAPIAccess`
+* `.machine.features.hostDNS`
+* `.machine.features.imageCache`
+* `.machine.features.kubePrism`
 
 ### `talosctl apply-config`
 


### PR DESCRIPTION
Allow to change image cache config without a reboot.
