### PR TITLE
fix: return proper number from the `timeStampWriter`

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -99,6 +99,11 @@ func (c *Controller) setupLogging() error {
 		return fmt.Errorf("failed to setup logging: %w", err)
 	}
 
+	// Ensure that the logger is initialized and writer returns properly.
+	if err = log.Output(1, "machined logger initialized"); err != nil {
+		return fmt.Errorf("failed on log initialization: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
All `io.Writers` implementations expect that you return exactly `len(p)` bytes on successful exit. So do just that, and ensure in runtime that we do the proper thing.