### PR TITLE
fix: properly halt installation if Talos already installed

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1603,7 +1603,7 @@ func SaveStateEncryptionConfig(runtime.Sequence, any) (runtime.TaskExecutionFunc
 }
 
 // haltIfInstalled halts the boot process if Talos is installed to disk but booted from ISO.
-func haltIfInstalled(seq runtime.Sequence, _ any) (runtime.TaskExecutionFunc, string) {
+func haltIfInstalled(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
 		ctx, cancel := context.WithTimeout(ctx, constants.BootTimeout)
 		defer cancel()
@@ -1611,13 +1611,15 @@ func haltIfInstalled(seq runtime.Sequence, _ any) (runtime.TaskExecutionFunc, st
 		timer := time.NewTicker(30 * time.Second)
 		defer timer.Stop()
 
-		select {
-		case <-timer.C:
+		for {
 			logger.Printf("Talos is already installed to disk but booted from another media and %s kernel parameter is set. Please reboot from the disk.", constants.KernelParamHaltIfInstalled)
-		case <-ctx.Done():
-		}
 
-		return nil
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 	}, "haltIfInstalled"
 }
 


### PR DESCRIPTION
Do not return from the function unless ctx is canceled.