### PR TITLE
fix: make Talos META partition match more precise

### DIFF
--- a/internal/app/machined/pkg/controllers/block/discovery.go
+++ b/internal/app/machined/pkg/controllers/block/discovery.go
@@ -238,11 +238,7 @@ func (ctrl *DiscoveryController) rescan(ctx context.Context, r controller.Runtim
 				dv.TypedSpec().Parent = id
 				dv.TypedSpec().ParentDevPath = filepath.Join("/dev", id)
 
-				if nested.ProbedSize != 0 {
-					dv.TypedSpec().SetSize(nested.ProbedSize)
-				} else {
-					dv.TypedSpec().SetSize(nested.PartitionSize)
-				}
+				dv.TypedSpec().SetSize(nested.PartitionSize)
 
 				dv.TypedSpec().SectorSize = info.SectorSize
 				dv.TypedSpec().IOSize = info.IOSize

--- a/internal/app/machined/pkg/controllers/block/volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config.go
@@ -78,7 +78,7 @@ func labelVolumeMatchAndNonEmpty(label string) cel.Expression {
 }
 
 func metaMatch() cel.Expression {
-	return cel.MustExpression(cel.ParseBooleanExpression(fmt.Sprintf("volume.partition_label == '%s' && volume.name in ['', 'talosmeta']", constants.MetaPartitionLabel), celenv.VolumeLocator()))
+	return cel.MustExpression(cel.ParseBooleanExpression(fmt.Sprintf("volume.partition_label == '%s' && volume.name in ['', 'talosmeta'] && volume.size == 1048576u", constants.MetaPartitionLabel), celenv.VolumeLocator())) //nolint:lll
 }
 
 func systemDiskMatch() cel.Expression {

--- a/internal/app/machined/pkg/controllers/block/volume_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config_test.go
@@ -92,7 +92,7 @@ func (suite *VolumeConfigSuite) TestReconcileDefaults() {
 		locator, err := r.TypedSpec().Locator.Match.MarshalText()
 		asrt.NoError(err)
 
-		asrt.Equal(`volume.partition_label == "META" && volume.name in ["", "talosmeta"]`, string(locator))
+		asrt.Equal(`volume.partition_label == "META" && volume.name in ["", "talosmeta"] && volume.size == 1048576u`, string(locator))
 	})
 	ctest.AssertResource(suite, constants.StatePartitionLabel, func(r *block.VolumeConfig, asrt *assert.Assertions) {
 		asrt.NotEmpty(r.TypedSpec().Provisioning)


### PR DESCRIPTION
Fixes #9786

Match on exact expected size otherwise as `META` name is common, Talos might find `META` where it shouldn't be.
