### PR TITLE
fix: nocloud network link matching on MAC addresses

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
@@ -320,7 +320,15 @@ func (n *Nocloud) applyNetworkConfigV1(config *NetworkConfig, st state.State, ne
 				macAddressMatched := false
 
 				for hostInterface := range hostInterfaces.All() {
+					if !hostInterface.TypedSpec().Physical() {
+						continue
+					}
+
 					macAddress := hostInterface.TypedSpec().PermanentAddr.String()
+					if macAddress == "" {
+						macAddress = hostInterface.TypedSpec().HardwareAddr.String()
+					}
+
 					if macAddress == ntwrk.Mac {
 						name = hostInterface.Metadata().ID()
 						macAddressMatched = true
@@ -626,7 +634,15 @@ func (n *Nocloud) applyNetworkConfigV2(config *NetworkConfig, st state.State, ne
 			macAddressMatched := false
 
 			for hostInterface := range hostInterfaces.All() {
+				if !hostInterface.TypedSpec().Physical() {
+					continue
+				}
+
 				macAddress := hostInterface.TypedSpec().PermanentAddr.String()
+				if macAddress == "" {
+					macAddress = hostInterface.TypedSpec().HardwareAddr.String()
+				}
+
 				if macAddress == eth.Match.HWAddr {
 					name = hostInterface.Metadata().ID()
 					macAddressMatched = true

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -63,6 +63,12 @@ func TestParseMetadata(t *testing.T) {
 
 			st := state.WrapCore(namespaced.NewState(inmem.Build))
 
+			bond0 := network.NewLinkStatus(network.NamespaceName, "bond0")
+			bond0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf7} // this link is not a physical one, so it should be ignored
+			bond0.TypedSpec().Type = nethelpers.LinkEther
+			bond0.TypedSpec().Kind = "bond"
+			require.NoError(t, st.Create(context.TODO(), bond0))
+
 			eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
 			eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf7}
 			eth0.TypedSpec().Type = nethelpers.LinkEther
@@ -70,13 +76,14 @@ func TestParseMetadata(t *testing.T) {
 			require.NoError(t, st.Create(context.TODO(), eth0))
 
 			eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
+			eth1.TypedSpec().HardwareAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf9} // this link has a permanent address, so hardware addr should be ignored
 			eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf8}
 			eth1.TypedSpec().Type = nethelpers.LinkEther
 			eth1.TypedSpec().Kind = ""
 			require.NoError(t, st.Create(context.TODO(), eth1))
 
 			eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
-			eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf9}
+			eth2.TypedSpec().HardwareAddr = nethelpers.HardwareAddr{0x68, 0x05, 0xca, 0xb8, 0xf1, 0xf9} // this link doesn't have a permanent address, but only a hardware address
 			eth2.TypedSpec().Type = nethelpers.LinkEther
 			eth2.TypedSpec().Kind = ""
 			require.NoError(t, st.Create(context.TODO(), eth2))


### PR DESCRIPTION
Fixes #9811

Fall back to non-permanent hardware addresses, ignore non-physical links (e.g. bonds).
