### PR TITLE
fix: make `system_disk` condition work properly before install

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -96,7 +96,7 @@ var imageListCmd = &cobra.Command{
 
 // imagePullCmd represents the image pull command.
 var imagePullCmd = &cobra.Command{
-	Use:     "pull",
+	Use:     "pull <image>",
 	Aliases: []string{"p"},
 	Short:   "Pull an image into CRI",
 	Long:    ``,

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
@@ -92,10 +92,7 @@ func LocateAndProvision(ctx context.Context, logger *zap.Logger, volumeContext M
 			continue
 		}
 
-		matches, err := volumeContext.Cfg.TypedSpec().Provisioning.DiskSelector.Match.EvalBool(celenv.DiskLocator(), map[string]any{
-			"disk":        diskCtx.Disk,
-			"system_disk": diskCtx.SystemDisk,
-		})
+		matches, err := volumeContext.Cfg.TypedSpec().Provisioning.DiskSelector.Match.EvalBool(celenv.DiskLocator(), diskCtx.ToCELContext())
 		if err != nil {
 			return fmt.Errorf("error evaluating disk locator: %w", err)
 		}

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
@@ -8,6 +8,8 @@ package volumes
 import (
 	"cmp"
 
+	"github.com/siderolabs/gen/optional"
+
 	blockpb "github.com/siderolabs/talos/pkg/machinery/api/resource/definitions/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
@@ -40,7 +42,20 @@ type Retryable struct{}
 // DiskContext captures the context of a disk.
 type DiskContext struct {
 	Disk       *blockpb.DiskSpec
-	SystemDisk bool
+	SystemDisk optional.Optional[bool]
+}
+
+// ToCELContext converts the disk context to CEL contexts.
+func (d *DiskContext) ToCELContext() map[string]any {
+	result := map[string]any{
+		"disk": d.Disk,
+	}
+
+	if val, ok := d.SystemDisk.Get(); ok {
+		result["system_disk"] = val
+	}
+
+	return result
 }
 
 // ManagerContext captures the context of the volume manager.

--- a/internal/app/machined/pkg/controllers/block/volume_manager.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager.go
@@ -209,9 +209,15 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 				return volumes.DiskContext{}, err
 			}
 
+			var optionalSystemDisk optional.Optional[bool]
+
+			if systemDisk != nil {
+				optionalSystemDisk = optional.Some(d.Metadata().ID() == systemDisk.TypedSpec().DiskID)
+			}
+
 			return volumes.DiskContext{
 				Disk:       spec,
-				SystemDisk: systemDisk != nil && d.Metadata().ID() == systemDisk.TypedSpec().DiskID,
+				SystemDisk: optionalSystemDisk,
 			}, nil
 		})
 		if err != nil {

--- a/website/content/v1.9/reference/cli.md
+++ b/website/content/v1.9/reference/cli.md
@@ -1888,7 +1888,7 @@ talosctl image list [flags]
 Pull an image into CRI
 
 ```
-talosctl image pull [flags]
+talosctl image pull <image> [flags]
 ```
 
 ### Options


### PR DESCRIPTION
The problem was with specific disk selector `!system_disk` - in previous implementation, as `system_disk` defaulted to false even if the system disk is not known yet, this might result in picking up a disk which is going to be system disk before system disk is picked.

In new implementation, as `system_disk` is not set before it is detected, the condition containing `system_disk` (in either way) would fail to execute and volume provision will be delayed until system disk is detected.

Also:

Fixes #9809
