### PR TITLE
chore: move enabling SELinux by default to 1.10

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -42,21 +42,6 @@ Talos Linux now supports running Kubernetes pods with user namespaces enabled.
 Refer to the [documentation](https://www.talos.dev/v1.9/kubernetes-guides/configuration/usernamespace/) for more information.
 """
 
-    [notes.apparmor]
-        title = "AppArmor"
-        description = """\
-Talos Linux starting with v1.9 will ship with SELinux LSM enabled by default.
-If you need to use AppArmor LSM add the following to the machine configuration:
-
-```yaml
-machine:
-  install:
-     extraKernelArgs:
-      - -selinux
-      - lsm=lockdown,capability,yama,apparmor,bpf
-      - apparmor=1
-```
-"""
 
     [notes.auditd]
         title = "Auditd"

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -350,7 +350,7 @@ func (i *Imager) buildCmdline() error {
 	}
 
 	if quirks.New(i.prof.Version).SupportsSELinux() {
-		// Talos 1.9 introduces SELinux in permissive mode
+		// Talos 1.10 introduces SELinux in permissive mode
 		cmdline.Append(constants.KernelParamSELinux, "1")
 	}
 

--- a/pkg/imager/imager_test.go
+++ b/pkg/imager/imager_test.go
@@ -89,7 +89,7 @@ func TestImager(t *testing.T) {
 			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
 		},
 		{
-			name: "cmdline-1.9-amd64",
+			name: "cmdline-1.10-amd64",
 
 			prof: profile.Profile{
 				BaseProfileName: "metal",
@@ -98,13 +98,13 @@ func TestImager(t *testing.T) {
 					Kind:      profile.OutKindCmdline,
 					OutFormat: profile.OutFormatRaw,
 				},
-				Version: "1.9.0",
+				Version: "1.10.0",
 			},
 
 			expected: "talos.platform=metal console=tty0 selinux=1 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
 		},
 		{
-			name: "cmdline-1.9-arm64",
+			name: "cmdline-1.10-arm64",
 
 			prof: profile.Profile{
 				BaseProfileName: "metal",
@@ -113,7 +113,7 @@ func TestImager(t *testing.T) {
 					Kind:      profile.OutKindCmdline,
 					OutFormat: profile.OutFormatRaw,
 				},
-				Version: "1.9.0",
+				Version: "1.10.0",
 			},
 
 			expected: "talos.platform=metal console=ttyAMA0 console=tty0 selinux=1 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -138,7 +138,7 @@ func (q Quirks) SkipDataPartitions() bool {
 }
 
 // minVersionSELinux is the version that enabled SELinux and added respective parameters.
-var minVersionSELinux = semver.MustParse("1.9.0")
+var minVersionSELinux = semver.MustParse("1.10.0")
 
 // SupportsSELinux returns true if the Talos version supports already has console=ttyS0 kernel argument.
 func (q Quirks) SupportsSELinux() bool {

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -84,9 +84,6 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	// Talos config
 	cmdline.Append("talos.platform", constants.PlatformMetal)
 
-	// SELinux
-	cmdline.Append(constants.KernelParamSELinux, "1")
-
 	// add overrides
 	if nodeReq.ExtraKernelArgs != nil {
 		if err = cmdline.AppendAll(


### PR DESCRIPTION
For 1.9, we keep it disabled until it gets more production ready in 1.10.

It still can be enabled with `selinux=1`.
