### PR TITLE
chore: deprecate cgroupsv1 in non-container mode

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -28,6 +28,12 @@ preface = """
 Talos is built with Go 1.23.3.
 """
 
+    [notes.cgroupsv1]
+        title = "cgroups version 1"
+        description = """\
+Support for cgroupsv1 is deprecated, and will be removed in Talos 1.10 (for non-container mode).
+"""
+
     [notes.machineConfigKubeAPIServer]
         title = "Kube APIServer Authorization Config"
         description = """\

--- a/internal/app/machined/pkg/startup/cgroups.go
+++ b/internal/app/machined/pkg/startup/cgroups.go
@@ -31,7 +31,7 @@ func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 	if !rt.State().Platform().Mode().InContainer() {
 		// assert that cgroupsv2 is being used when running not in container mode,
 		// as Talos sets up cgroupsv2 on its own
-		if cgroups.Mode() != cgroups.Unified && !mount.ForceGGroupsV1() {
+		if cgroups.Mode() != cgroups.Unified && !mount.ForceCGroupsV1() {
 			return errors.New("cgroupsv2 should be used")
 		}
 	}

--- a/internal/app/machined/pkg/startup/tasks.go
+++ b/internal/app/machined/pkg/startup/tasks.go
@@ -71,11 +71,13 @@ func InitVolumeLifecycle(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 }
 
 // MountCgroups represents mounts the cgroupfs (only in !container).
-//
-//nolint:dupl
 func MountCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtime, next NextTaskFunc) error {
 	if rt.State().Platform().Mode().InContainer() {
 		return next()(ctx, log, rt, next)
+	}
+
+	if mount.ForceCGroupsV1() {
+		log.Warn("cgroupsv1 is deprecated and will not be supported in the 1.10 release other than in the container mode")
 	}
 
 	unmounter, err := mount.CGroupMountPoints().Mount()
@@ -93,8 +95,6 @@ func MountCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtime, next
 }
 
 // MountPseudoLate mounts the late pseudo filesystems (only in !container).
-//
-//nolint:dupl
 func MountPseudoLate(ctx context.Context, log *zap.Logger, rt runtime.Runtime, next NextTaskFunc) error {
 	if rt.State().Platform().Mode().InContainer() {
 		return next()(ctx, log, rt, next)

--- a/internal/pkg/mount/v2/cgroups.go
+++ b/internal/pkg/mount/v2/cgroups.go
@@ -14,14 +14,14 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
-// ForceGGroupsV1 returns the cgroup version to be used (only for !container mode).
-func ForceGGroupsV1() bool {
+// ForceCGroupsV1 returns the cgroup version to be used (only for !container mode).
+func ForceCGroupsV1() bool {
 	return pointer.SafeDeref(procfs.ProcCmdline().Get(constants.KernelParamCGroups).First()) == "0"
 }
 
 // CGroupMountPoints returns the cgroup mount points.
 func CGroupMountPoints() Points {
-	if ForceGGroupsV1() {
+	if ForceCGroupsV1() {
 		return cgroupMountPointsV1()
 	}
 

--- a/website/content/v1.9/reference/kernel.md
+++ b/website/content/v1.9/reference/kernel.md
@@ -233,6 +233,8 @@ Valid options are:
 
 #### `talos.unified_cgroup_hierarchy`
 
+> Deprecated: From the 1.10 release it is planned that `cgroupsv1` will only be supported in the container mode.
+
 Talos defaults to always using the unified cgroup hierarchy (`cgroupsv2`), but `cgroupsv1`
 can be forced with `talos.unified_cgroup_hierarchy=0`.
 


### PR DESCRIPTION
Also fix a typo.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
