### PR TITLE
fix: do not extract xattrs in unsquashfs

### DIFF
--- a/internal/pkg/extensions/kernel_modules.go
+++ b/internal/pkg/extensions/kernel_modules.go
@@ -194,7 +194,7 @@ func extractRootfsFromInitramfs(r io.Reader, rootfsFilePath string) error {
 }
 
 func unsquash(squashfsPath, dest, path string) error {
-	cmd := exec.Command("unsquashfs", "-d", dest, "-f", "-n", squashfsPath, path)
+	cmd := exec.Command("unsquashfs", "-no-xattrs", "-d", dest, "-f", "-n", squashfsPath, path)
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()


### PR DESCRIPTION
Fix building on SELinux systems. Extracting xattrs led to return code 2 as a non-critical error. This should not influence extension build.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
