### PR TITLE
fix: don't reset health status if service doesn't support health checks

### DIFF
--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -283,7 +283,7 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 		errCh <- runnr.Run(func(s events.ServiceState, msg string, args ...any) {
 			svcrunner.UpdateState(ctx, s, msg, args...)
 
-			if s != events.StateRunning {
+			if _, healthSupported := svcrunner.service.(HealthcheckedService); healthSupported && s != events.StateRunning {
 				svcrunner.healthState.Update(false, "service not running")
 			}
 		})


### PR DESCRIPTION
Fixes #9839

Bug was introduced in #9273
