### PR TITLE
chore: add constant for Board Turing RK1

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -128,6 +128,9 @@ const (
 	// BoardNanoPiR4S is the name of the Friendlyelec Nano Pi R4S.
 	BoardNanoPiR4S = "nanopi_r4s"
 
+	// BoardTuringRK1 is the name of the Turing RK1 SoM.
+	BoardTuringRK1 = "turingrk1"
+
 	// KernelParamHostname is the kernel parameter name for specifying the
 	// hostname.
 	KernelParamHostname = "talos.hostname"


### PR DESCRIPTION
This is silly, but the constant is needed for Omni to cleanly add Turing RK1 to:
https://github.com/siderolabs/omni/blob/main/internal/backend/runtime/omni/controllers/omni/installation_media.go#L273

and
https://github.com/siderolabs/omni/blob/main/internal/backend/runtime/omni/controllers/omni/internal/boards/boards.go#L17