### PR TITLE
fix: lock provisioning order of user disk partitions

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -1162,6 +1162,8 @@ func parseCPUShare(cpus string) (int64, error) {
 }
 
 func getDisks() ([]*provision.Disk, error) {
+	const GPTAlignment = 2 * 1024 * 1024 // 2 MB
+
 	// should have at least a single primary disk
 	disks := []*provision.Disk{
 		{
@@ -1211,8 +1213,8 @@ func getDisks() ([]*provision.Disk, error) {
 		}
 
 		disks = append(disks, &provision.Disk{
-			// add 1 MB to make extra room for GPT and alignment
-			Size:            diskSize + 2*1024*1024,
+			// add 2 MB per partition to make extra room for GPT and alignment
+			Size:            diskSize + GPTAlignment*uint64(len(diskPartitions)+1),
 			Partitions:      diskPartitions,
 			SkipPreallocate: !clusterDiskPreallocate,
 			Driver:          "ide",

--- a/internal/app/machined/pkg/controllers/block/user_disk_config.go
+++ b/internal/app/machined/pkg/controllers/block/user_disk_config.go
@@ -105,7 +105,11 @@ func (ctrl *UserDiskConfigController) Run(ctx context.Context, r controller.Runt
 							vc.TypedSpec().Type = block.VolumeTypePartition
 
 							vc.TypedSpec().Provisioning = block.ProvisioningSpec{
-								Wave: block.WaveUserDisks,
+								// it's crucial to keep the order of provisioning locked within each disk, otherwise
+								// provisioning might order them different way, and create partitions in wrong order
+								// the matcher on partition idx would then discover partitions in wrong order, and mount them
+								// in wrong order
+								Wave: block.WaveLegacyUserDisks + idx,
 								DiskSelector: block.DiskSelector{
 									Match: diskPathMatch(resolvedDevicePath),
 								},

--- a/internal/app/machined/pkg/controllers/block/user_disk_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/user_disk_config_test.go
@@ -132,6 +132,7 @@ func (suite *UserDiskConfigSuite) TestReconcileUserDisk() {
 		ctest.AssertResource(suite, id, func(r *block.VolumeConfig, asrt *assert.Assertions) {
 			asrt.NotEmpty(r.TypedSpec().Provisioning)
 			asrt.Contains(r.Metadata().Labels().Raw(), block.UserDiskLabel)
+			asrt.GreaterOrEqual(r.TypedSpec().Provisioning.Wave, block.WaveLegacyUserDisks)
 		})
 	}
 

--- a/pkg/machinery/resources/block/volume_config.go
+++ b/pkg/machinery/resources/block/volume_config.go
@@ -45,8 +45,9 @@ type VolumeConfigSpec struct {
 
 // Wave constants.
 const (
-	WaveSystemDisk = -1
-	WaveUserDisks  = 0
+	WaveSystemDisk      = -1
+	WaveUserDisks       = 0
+	WaveLegacyUserDisks = 1000000 // legacy user disks rely on specific order of provisioning
 )
 
 // ProvisioningSpec is the spec for volume provisioning.


### PR DESCRIPTION
Fixes #9877

As a side-effect, fix alignment of user disks for newer QEMU versions.
