### PR TITLE
chore: add version compatibility for Talos 1.10

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/pair/ordered"
 
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos110"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
@@ -64,6 +65,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 		minK8sVersion, maxK8sVersion = talos18.MinimumKubernetesVersion, talos18.MaximumKubernetesVersion
 	case talos19.MajorMinor: // upgrades to 1.9.x
 		minK8sVersion, maxK8sVersion = talos19.MinimumKubernetesVersion, talos19.MaximumKubernetesVersion
+	case talos110.MajorMinor: // upgrades to 1.10.x
+		minK8sVersion, maxK8sVersion = talos110.MinimumKubernetesVersion, talos110.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -286,12 +286,45 @@ func TestKubernetesCompatibility19(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility110(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.29.1",
+			target:            "1.10.0",
+		},
+		{
+			kubernetesVersion: "1.28.1",
+			target:            "1.10.0",
+		},
+		{
+			kubernetesVersion: "1.32.3",
+			target:            "1.10.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.33.0-rc.0",
+			target:            "1.10.7",
+		},
+		{
+			kubernetesVersion: "1.34.0-alpha.0",
+			target:            "1.10.0",
+			expectedError:     "version of Kubernetes 1.34.0-alpha.0 is too new to be used with Talos 1.10.0",
+		},
+		{
+			kubernetesVersion: "1.27.1",
+			target:            "1.10.0",
+			expectedError:     "version of Kubernetes 1.27.1 is too old to be used with Talos 1.10.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.10.0-alpha.0",
-			expectedError:     "compatibility with version 1.10.0-alpha.0 is not supported",
+			target:            "1.11.0-alpha.0",
+			expectedError:     "compatibility with version 1.11.0-alpha.0 is not supported",
 		},
 		{
 			kubernetesVersion: "1.25.0",

--- a/pkg/machinery/compatibility/talos110/talos110.go
+++ b/pkg/machinery/compatibility/talos110/talos110.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos110 provides compatibility constants for Talos 1.10.
+package talos110
+
+import (
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinor is the major.minor version of Talos 1.10.
+var MajorMinor = [2]uint64{1, 10}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.10.
+var MinimumHostUpgradeVersion = semver.MustParse("1.8.0")
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.10.
+var MaximumHostDowngradeVersion = semver.MustParse("1.12.0")
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.10.
+var DeniedHostUpgradeVersions []semver.Version
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.10.
+var MinimumKubernetesVersion = semver.MustParse("1.28.0")
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.10.
+var MaximumKubernetesVersion = semver.MustParse("1.33.99")

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/siderolabs/gen/pair/ordered"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos110"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
@@ -98,6 +99,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	case talos19.MajorMinor: // upgrades to 1.9.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos19.MinimumHostUpgradeVersion, talos19.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos19.DeniedHostUpgradeVersions
+	case talos110.MajorMinor: // upgrades to 1.10.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos110.MinimumHostUpgradeVersion, talos110.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos110.DeniedHostUpgradeVersions
 	default:
 		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
 	}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -327,17 +327,58 @@ func TestTalosUpgradeCompatibility19(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility110(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.8.0",
+			target: "1.10.0",
+		},
+		{
+			host:   "1.9.0-alpha.0",
+			target: "1.10.0",
+		},
+		{
+			host:   "1.8.0",
+			target: "1.10.0-alpha.0",
+		},
+		{
+			host:   "1.9.3",
+			target: "1.10.1",
+		},
+		{
+			host:   "1.10.0-beta.0",
+			target: "1.10.0",
+		},
+		{
+			host:   "1.10.5",
+			target: "1.10.3",
+		},
+		{
+			host:          "1.7.0",
+			target:        "1.10.0",
+			expectedError: `host version 1.7.0 is too old to upgrade to Talos 1.10.0`,
+		},
+		{
+			host:          "1.12.0-alpha.0",
+			target:        "1.10.0",
+			expectedError: `host version 1.12.0-alpha.0 is too new to downgrade to Talos 1.10.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.10.0-alpha.0",
-			expectedError: `upgrades to version 1.10.0-alpha.0 are not supported`,
+			target:        "1.11.0-alpha.0",
+			expectedError: `upgrades to version 1.11.0-alpha.0 are not supported`,
 		},
 		{
 			host:          "1.4.0",
-			target:        "1.11.0-alpha.0",
-			expectedError: `upgrades to version 1.11.0-alpha.0 are not supported`,
+			target:        "1.12.0-alpha.0",
+			expectedError: `upgrades to version 1.12.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -25,6 +25,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion1_10    = &VersionContract{1, 10}
 	TalosVersion1_9     = &VersionContract{1, 9}
 	TalosVersion1_8     = &VersionContract{1, 8}
 	TalosVersion1_7     = &VersionContract{1, 7}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -67,6 +67,29 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.SecureBootEnrollEnforcementSupported())
 }
 
+func TestContract1_10(t *testing.T) {
+	contract := config.TalosVersion1_9
+
+	assert.True(t, contract.PodSecurityAdmissionEnabled())
+	assert.True(t, contract.StableHostnameEnabled())
+	assert.True(t, contract.KubeletDefaultRuntimeSeccompProfileEnabled())
+	assert.False(t, contract.KubernetesAlternateImageRegistries())
+	assert.True(t, contract.KubernetesAllowSchedulingOnControlPlanes())
+	assert.True(t, contract.KubernetesDiscoveryBackendDisabled())
+	assert.True(t, contract.ApidExtKeyUsageCheckEnabled())
+	assert.True(t, contract.APIServerAuditPolicySupported())
+	assert.True(t, contract.KubeletManifestsDirectoryDisabled())
+	assert.True(t, contract.SecretboxEncryptionSupported())
+	assert.True(t, contract.DiskQuotaSupportEnabled())
+	assert.True(t, contract.KubePrismEnabled())
+	assert.True(t, contract.HostDNSEnabled())
+	assert.True(t, contract.UseRSAServiceAccountKey())
+	assert.True(t, contract.ClusterNameForWorkers())
+	assert.True(t, contract.HostDNSForwardKubeDNSToHost())
+	assert.True(t, contract.AddExcludeFromExternalLoadBalancer())
+	assert.True(t, contract.SecureBootEnrollEnforcementSupported())
+}
+
 func TestContract1_9(t *testing.T) {
 	contract := config.TalosVersion1_9
 


### PR DESCRIPTION
To be backported to 1.9 machinery to provide some forward compatibility.
