### PR TITLE
fix: power on the machine on reboot request in qemu power api

### DIFF
--- a/pkg/provision/providers/qemu/controller.go
+++ b/pkg/provision/providers/qemu/controller.go
@@ -87,7 +87,11 @@ func (c *Controller) Reboot() error {
 	c.mu.Lock()
 
 	if c.state == PoweredOff {
+		c.state = PoweredOn
+
 		c.mu.Unlock()
+
+		c.commandsCh <- VMCommandStart
 
 		return nil
 	}


### PR DESCRIPTION
IPMI powers on a machine when a PowerCycle command is sent, making a prior power on call unnecessary. We probably want to do the same thing in our API-based power implementation.