### PR TITLE
fix: Use mtu network option for podman

### DIFF
--- a/pkg/provision/providers/docker/reflect.go
+++ b/pkg/provision/providers/docker/reflect.go
@@ -51,7 +51,10 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory s
 			res.clusterInfo.Network.GatewayAddrs = append(res.clusterInfo.Network.GatewayAddrs, addr)
 		}
 
-		mtuStr := network.Options["com.docker.network.driver.mtu"]
+		mtuStr, ok := network.Options["com.docker.network.driver.mtu"]
+		if !ok {
+			mtuStr = network.Options["mtu"] // Use the podman version of the option
+		}
 
 		res.clusterInfo.Network.MTU, err = strconv.Atoi(mtuStr)
 		if err != nil {


### PR DESCRIPTION
For podman the network options is not 'com.docker.network.driver.mtu but only mtu.
This patches allow to use podman for local clusters

Fixes: #7881
