### PR TITLE
Add --talosconfig option with generated talosconfig file when using talosctl

### DIFF
--- a/website/content/v1.8/talos-guides/install/cloud-platforms/aws.md
+++ b/website/content/v1.8/talos-guides/install/cloud-platforms/aws.md
@@ -378,13 +378,17 @@ for INSTANCE in ${CP_INSTANCES[@]}; do
 done
 ```
 
-### Bootstrap `etcd`
+### Export the `talosconfig` file
 
 Export the `talosconfig` file so commands sent to Talos will be authenticated.
 
 ```bash
 export TALOSCONFIG=$(pwd)/talosconfig
+```
 
+### Bootstrap `etcd`
+
+```bash
 WORKER_INSTANCES=( $(aws autoscaling \
     describe-auto-scaling-instances \
     --query 'AutoScalingInstances[?AutoScalingGroupName==`talos-aws-tutorial-worker`].InstanceId' \

--- a/website/content/v1.9/talos-guides/install/cloud-platforms/aws.md
+++ b/website/content/v1.9/talos-guides/install/cloud-platforms/aws.md
@@ -378,13 +378,17 @@ for INSTANCE in ${CP_INSTANCES[@]}; do
 done
 ```
 
-### Bootstrap `etcd`
+### Export the `talosconfig` file
 
 Export the `talosconfig` file so commands sent to Talos will be authenticated.
 
 ```bash
 export TALOSCONFIG=$(pwd)/talosconfig
+```
 
+### Bootstrap `etcd`
+
+```bash
 WORKER_INSTANCES=( $(aws autoscaling \
     describe-auto-scaling-instances \
     --query 'AutoScalingInstances[?AutoScalingGroupName==`talos-aws-tutorial-worker`].InstanceId' \


### PR DESCRIPTION
# Pull Request

## What? (description)
Cannot boostrap (and other talosctl command) to the cluster build on AWS

## Why? (reasoning)
To boostrap the cluster then gather dashboard or other talosctl command (health...), I need to specify the --talosconfig parameter with the generated file
.
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
