### PR TITLE
Fix 'containter' typo

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -48,7 +48,7 @@ func (flags imageCmdFlagsType) apiNamespace() (common.ContainerdNamespace, error
 var imageCmd = &cobra.Command{
 	Use:     "image",
 	Aliases: []string{"images"},
-	Short:   "Manage CRI containter images",
+	Short:   "Manage CRI container images",
 	Long:    ``,
 	Args:    cobra.NoArgs,
 }

--- a/website/content/v1.9/reference/cli.md
+++ b/website/content/v1.9/reference/cli.md
@@ -1824,7 +1824,7 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
 
 ### SEE ALSO
 
-* [talosctl image](#talosctl-image)	 - Manage CRI containter images
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
 
 ## talosctl image default
 
@@ -1853,7 +1853,7 @@ talosctl image default [flags]
 
 ### SEE ALSO
 
-* [talosctl image](#talosctl-image)	 - Manage CRI containter images
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
 
 ## talosctl image list
 
@@ -1882,7 +1882,7 @@ talosctl image list [flags]
 
 ### SEE ALSO
 
-* [talosctl image](#talosctl-image)	 - Manage CRI containter images
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
 
 ## talosctl image pull
 
@@ -1911,11 +1911,11 @@ talosctl image pull <image> [flags]
 
 ### SEE ALSO
 
-* [talosctl image](#talosctl-image)	 - Manage CRI containter images
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
 
 ## talosctl image
 
-Manage CRI containter images
+Manage CRI container images
 
 ### Options
 
@@ -3230,7 +3230,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl gen](#talosctl-gen)	 - Generate CAs, certificates, and private keys
 * [talosctl get](#talosctl-get)	 - Get a specific resource or list of resources (use 'talosctl get rd' to see all available resource types).
 * [talosctl health](#talosctl-health)	 - Check cluster health
-* [talosctl image](#talosctl-image)	 - Manage CRI containter images
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
 * [talosctl inject](#talosctl-inject)	 - Inject Talos API resources into Kubernetes manifests
 * [talosctl inspect](#talosctl-inspect)	 - Inspect internals of Talos
 * [talosctl kubeconfig](#talosctl-kubeconfig)	 - Download the admin kubeconfig from the node


### PR DESCRIPTION
# Pull Request

## What? (description)

Container has been spelled 'containter' at multiple places.

Changed `image.go` code is only for a command description, shouldn't have any impact. Other files are the website / documentation.