### PR TITLE
chore: drop semicolon for supporting vfat filesystems

### DIFF
--- a/internal/app/machined/pkg/system/services/registry/registry.go
+++ b/internal/app/machined/pkg/system/services/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -191,7 +192,9 @@ func (svc *Service) resolveCanonicalRef(p params) (reference.Canonical, error) {
 		return nil, xerrors.NewTaggedf[internalErrorTag]("failed to hash manifest: %w", err)
 	}
 
-	sha256file := filepath.Join("manifests", namedTagged.Name(), "digest", digest.NewDigestFromBytes(digest.SHA256, ntSum).String())
+	digestString := strings.ReplaceAll(digest.NewDigestFromBytes(digest.SHA256, ntSum).String(), "sha256:", "sha256-")
+
+	sha256file := filepath.Join("manifests", namedTagged.Name(), "digest", digestString)
 
 	sSum, err := hashFile(sha256file, svc.root)
 	if err != nil {

--- a/internal/app/machined/pkg/system/services/registry/store.go
+++ b/internal/app/machined/pkg/system/services/registry/store.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -101,7 +102,7 @@ func (s *singleFileStore) blobPath(dgst digest.Digest) (string, error) {
 		return "", fmt.Errorf("cannot calculate blob path from invalid digest: %v: %w", err, errdefs.ErrInvalidArgument)
 	}
 
-	return filepath.Join(s.path, dgst.String()), nil
+	return filepath.Join(s.path, strings.ReplaceAll(dgst.String(), "sha256:", "sha256-")), nil
 }
 
 var errUnimplemented = errors.New("unimplemented")

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
@@ -87,13 +88,15 @@ func (suite *ImageSuite) TestCacheCreate() {
 		return "--images=" + image
 	})
 
-	cacheFile := suite.T().TempDir() + "/cache.tar"
+	cacheDir := suite.T().TempDir()
 
-	args := []string{"image", "cache-create", "--image-cache-path", cacheFile}
+	args := []string{"image", "cache-create", "--image-cache-path", cacheDir}
 
 	args = append(args, imagesArgs...)
 
 	suite.RunCLI(args, base.StdoutEmpty(), base.StderrNotEmpty())
+
+	assert.FileExistsf(suite.T(), cacheDir+"/index.json", "index.json should exist in the image cache directory")
 }
 
 func init() {

--- a/pkg/imager/cache/cache.go
+++ b/pkg/imager/cache/cache.go
@@ -149,7 +149,7 @@ func Generate(images []string, platform string, insecure bool, imageLayerCachePa
 			}
 		}
 
-		if err := os.WriteFile(filepath.Join(digestDir, rmt.Digest.String()), manifest, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(digestDir, strings.ReplaceAll(rmt.Digest.String(), "sha256:", "sha256-")), manifest, 0o644); err != nil {
 			return err
 		}
 
@@ -182,7 +182,7 @@ func Generate(images []string, platform string, insecure bool, imageLayerCachePa
 			return fmt.Errorf("platform manifest hash: %w", err)
 		}
 
-		if err := os.WriteFile(filepath.Join(digestDir, fmt.Sprintf("sha256:%x", h.Sum(nil))), platformManifest, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(digestDir, fmt.Sprintf("sha256-%x", h.Sum(nil))), platformManifest, 0o644); err != nil {
 			return err
 		}
 
@@ -191,7 +191,7 @@ func Generate(images []string, platform string, insecure bool, imageLayerCachePa
 			return fmt.Errorf("getting image config hash: %w", err)
 		}
 
-		if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, configHash.String()), config, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, strings.ReplaceAll(configHash.String(), "sha256:", "sha256-")), config, 0o644); err != nil {
 			return err
 		}
 
@@ -244,7 +244,7 @@ func processLayer(layer v1.Layer, dstDir string) error {
 		return fmt.Errorf("getting layer digest: %w", err)
 	}
 
-	blobPath := filepath.Join(dstDir, blobsDir, digest.String())
+	blobPath := filepath.Join(dstDir, blobsDir, strings.ReplaceAll(digest.String(), "sha256:", "sha256-"))
 
 	if _, err := os.Stat(blobPath); err == nil {
 		// we already have this blob, skip it


### PR DESCRIPTION
Drop semicolon in generated cache to support copying image cache to vfat filesystems.

Fixes: #9935