### PR TITLE
docs: activate 1.9 docs as default

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -113,7 +113,7 @@ version_menu = "Releases"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/v1.8"
+url_latest_version = "/v1.9"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/siderolabs/talos"
@@ -142,11 +142,11 @@ prism_syntax_highlighting = false
 
 [[params.versions]]
 url = "/v1.9/"
-version = "v1.9 (pre-release)"
+version = "v1.9 (latest)"
 
 [[params.versions]]
 url = "/v1.8/"
-version = "v1.8 (latest)"
+version = "v1.8"
 
 [[params.versions]]
 url = "/v1.7/"

--- a/website/content/v1.8/_index.md
+++ b/website/content/v1.8/_index.md
@@ -10,7 +10,6 @@ kubernetesRelease: "1.31.1"
 prevKubernetesRelease: "1.30.0"
 nvidiaContainerToolkitRelease: "v1.16.1"
 nvidiaDriverRelease: "535.183.06"
-menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.9/_index.md
+++ b/website/content/v1.9/_index.md
@@ -5,12 +5,12 @@ linkTitle: "Documentation"
 images: ["images/talos-dev-banner.png"]
 cascade:
   type: docs
-lastRelease: v1.9.0-beta.1
+lastRelease: v1.9.0
 kubernetesRelease: "1.32.0"
 prevKubernetesRelease: "1.31.1"
 nvidiaContainerToolkitRelease: "v1.17.2"
 nvidiaDriverRelease: "535.216.03"
-preRelease: true
+menu: main
 ---
 
 ## Welcome


### PR DESCRIPTION
Make Talos 1.9 documentation the default one.
