### PR TITLE
refactor: use quirks in kernel args

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -123,10 +123,10 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		cmdline.Append(constants.KernelParamConfig, opts.ConfigSource)
 	}
 
-	cmdline.SetAll(p.KernelArgs(opts.Arch).Strings())
+	cmdline.SetAll(p.KernelArgs(opts.Arch, quirks.Quirks{}).Strings())
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
-	if err := cmdline.AppendAll(kernel.DefaultArgs); err != nil {
+	if err := cmdline.AppendAll(kernel.DefaultArgs(quirks.Quirks{})); err != nil {
 		return err
 	}
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -54,6 +54,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 	"github.com/siderolabs/talos/pkg/provision"
@@ -905,6 +906,7 @@ func create(ctx context.Context) error {
 		nodeReq := provision.NodeRequest{
 			Name:                  nodeName(clusterName, "controlplane", i+1, nodeUUID),
 			Type:                  machine.TypeControlPlane,
+			Quirks:                quirks.New(talosVersion),
 			IPs:                   nodeIPs,
 			Memory:                controlPlaneMemory,
 			NanoCPUs:              controlPlaneNanoCPUs,
@@ -983,6 +985,7 @@ func create(ctx context.Context) error {
 				Name:                  nodeName(clusterName, "worker", i, nodeUUID),
 				Type:                  machine.TypeWorker,
 				IPs:                   nodeIPs,
+				Quirks:                quirks.New(talosVersion),
 				Memory:                workerMemory,
 				NanoCPUs:              workerNanoCPUs,
 				Disks:                 disks,

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -28,6 +28,7 @@ import (
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -714,7 +715,7 @@ func (mock *platformMock) Mode() v1alpha1runtime.Mode {
 	return v1alpha1runtime.ModeCloud
 }
 
-func (mock *platformMock) KernelArgs(string) procfs.Parameters {
+func (mock *platformMock) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return nil
 }
 

--- a/internal/app/machined/pkg/runtime/platform.go
+++ b/internal/app/machined/pkg/runtime/platform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-procfs/procfs"
 
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -30,7 +31,7 @@ type Platform interface {
 	Configuration(context.Context, state.State) ([]byte, error)
 
 	// KernelArgs returns additional kernel arguments which should be injected for the kernel boot.
-	KernelArgs(arch string) procfs.Parameters
+	KernelArgs(arch string, quirks quirks.Quirks) procfs.Parameters
 
 	// NetworkConfiguration fetches network configuration from the platform metadata.
 	//

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai.go
@@ -19,6 +19,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -167,7 +168,7 @@ func (a *Akamai) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *Akamai) KernelArgs(string) procfs.Parameters {
+func (a *Akamai) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0").Append("tty0").Append("tty1"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -23,6 +23,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -142,7 +143,7 @@ func (a *AWS) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *AWS) KernelArgs(string) procfs.Parameters {
+func (a *AWS) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -216,7 +217,7 @@ func (a *Azure) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *Azure) KernelArgs(string) procfs.Parameters {
+func (a *Azure) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0,115200n8"),
 		procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/cloudstack/cloudstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/cloudstack/cloudstack.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -86,7 +87,7 @@ func (e *Cloudstack) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (e *Cloudstack) KernelArgs(string) procfs.Parameters {
+func (e *Cloudstack) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/container/internal/files"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
 
@@ -51,7 +52,7 @@ func (c *Container) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (c *Container) KernelArgs(string) procfs.Parameters {
+func (c *Container) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return nil
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -256,7 +257,7 @@ func (d *DigitalOcean) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (d *DigitalOcean) KernelArgs(string) procfs.Parameters {
+func (d *DigitalOcean) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0").Append("tty0").Append("tty1"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -112,7 +113,7 @@ func (p *EquinixMetal) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (p *EquinixMetal) KernelArgs(arch string) procfs.Parameters {
+func (p *EquinixMetal) KernelArgs(arch string, _ quirks.Quirks) procfs.Parameters {
 	switch arch {
 	case "amd64":
 		return []*procfs.Parameter{

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/exoscale/exoscale.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -86,7 +87,7 @@ func (e *Exoscale) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (e *Exoscale) KernelArgs(string) procfs.Parameters {
+func (e *Exoscale) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -199,7 +200,7 @@ func (g *GCP) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (g *GCP) KernelArgs(string) procfs.Parameters {
+func (g *GCP) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -186,7 +187,7 @@ func (h *Hcloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (h *Hcloud) KernelArgs(string) procfs.Parameters {
+func (h *Hcloud) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -108,7 +109,7 @@ func (n *Nocloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (n *Nocloud) KernelArgs(string) procfs.Parameters {
+func (n *Nocloud) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -225,7 +226,7 @@ func (o *OpenNebula) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *OpenNebula) KernelArgs(string) procfs.Parameters {
+func (o *OpenNebula) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -25,6 +25,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -378,7 +379,7 @@ func (o *OpenStack) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *OpenStack) KernelArgs(string) procfs.Parameters {
+func (o *OpenStack) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/oracle/oracle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -159,7 +160,7 @@ func (o *Oracle) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (o *Oracle) KernelArgs(string) procfs.Parameters {
+func (o *Oracle) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -199,7 +200,7 @@ func (s *Scaleway) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (s *Scaleway) KernelArgs(string) procfs.Parameters {
+func (s *Scaleway) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -19,6 +19,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -195,7 +196,7 @@ func (u *UpCloud) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (u *UpCloud) KernelArgs(string) procfs.Parameters {
+func (u *UpCloud) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 )
 
 // VMware is the concrete type that implements the platform.Platform interface.
@@ -26,7 +27,7 @@ func (v *VMware) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (v *VMware) KernelArgs(arch string) procfs.Parameters {
+func (v *VMware) KernelArgs(arch string, _ quirks.Quirks) procfs.Parameters {
 	switch arch {
 	case "amd64":
 		return []*procfs.Parameter{

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/vultr.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -176,7 +177,7 @@ func (v *Vultr) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (v *Vultr) KernelArgs(string) procfs.Parameters {
+func (v *Vultr) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 	}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -184,8 +184,6 @@ func RunInstallerContainer(
 		constants.KernelParamEquinixMetalEvents,
 		constants.KernelParamDashboardDisabled,
 		constants.KernelParamNetIfnames,
-		constants.KernelParamSELinux,
-		constants.KernelParamSELinuxEnforcing,
 	} {
 		if c := procfs.ProcCmdline().Get(preservedArg).First(); c != nil {
 			args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", preservedArg, *c))

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -331,31 +331,21 @@ func (i *Imager) buildCmdline() error {
 		return err
 	}
 
+	q := quirks.New(i.prof.Version)
+
 	cmdline := procfs.NewCmdline("")
 
 	// platform kernel args
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
 
-	cmdline.SetAll(p.KernelArgs(i.prof.Arch).Strings())
+	cmdline.SetAll(p.KernelArgs(i.prof.Arch, q).Strings())
 
-	if quirks.New(i.prof.Version).SupportsHaltIfInstalled() && i.prof.Output.Kind == profile.OutKindISO {
+	if q.SupportsHaltIfInstalled() && i.prof.Output.Kind == profile.OutKindISO {
 		cmdline.Append(constants.KernelParamHaltIfInstalled, "1")
 	}
 
-	if quirks.New(i.prof.Version).SupportsMetalPlatformConsoleTTYS0() && i.prof.Platform == constants.PlatformMetal && i.prof.Arch == "amd64" {
-		// Talos 1.8+ drops ttyS0 console for metal, restore previous args
-		cmdline.DeleteAll("console")
-		cmdline.Append("console", "ttyS0")
-		cmdline.Append("console", "tty0")
-	}
-
-	if quirks.New(i.prof.Version).SupportsSELinux() {
-		// Talos 1.10 introduces SELinux in permissive mode
-		cmdline.Append(constants.KernelParamSELinux, "1")
-	}
-
 	// board kernel args
-	if i.prof.Board != "" && !quirks.New(i.prof.Version).SupportsOverlay() {
+	if i.prof.Board != "" && !q.SupportsOverlay() {
 		var b talosruntime.Board
 
 		b, err = board.NewBoard(i.prof.Board)
@@ -378,12 +368,12 @@ func (i *Imager) buildCmdline() error {
 	}
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
-	if err = cmdline.AppendAll(kernel.DefaultArgs); err != nil {
+	if err = cmdline.AppendAll(kernel.DefaultArgs(q)); err != nil {
 		return err
 	}
 
 	if i.prof.SecureBootEnabled() {
-		if err = cmdline.AppendAll(kernel.SecureBootArgs); err != nil {
+		if err = cmdline.AppendAll(kernel.SecureBootArgs(q)); err != nil {
 			return err
 		}
 	}

--- a/pkg/imager/imager_test.go
+++ b/pkg/imager/imager_test.go
@@ -101,7 +101,7 @@ func TestImager(t *testing.T) {
 				Version: "1.10.0",
 			},
 
-			expected: "talos.platform=metal console=tty0 selinux=1 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+			expected: "talos.platform=metal console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 selinux=1", //nolint:lll
 		},
 		{
 			name: "cmdline-1.10-arm64",
@@ -116,7 +116,7 @@ func TestImager(t *testing.T) {
 				Version: "1.10.0",
 			},
 
-			expected: "talos.platform=metal console=ttyAMA0 console=tty0 selinux=1 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512", //nolint:lll
+			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 selinux=1", //nolint:lll
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -140,7 +140,7 @@ func (q Quirks) SkipDataPartitions() bool {
 // minVersionSELinux is the version that enabled SELinux and added respective parameters.
 var minVersionSELinux = semver.MustParse("1.10.0")
 
-// SupportsSELinux returns true if the Talos version supports already has console=ttyS0 kernel argument.
+// SupportsSELinux returns true if the Talos version enables selinux=1 by default.
 func (q Quirks) SupportsSELinux() bool {
 	// if the version doesn't parse, we assume it's latest Talos
 	if q.v == nil {

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -8,6 +8,9 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 )
 
 const (
@@ -18,24 +21,34 @@ const (
 )
 
 // DefaultArgs returns the Talos default kernel commandline options.
-var DefaultArgs = []string{
-	"init_on_alloc=1",
-	"slab_nomerge=",
-	"pti=on",
-	"consoleblank=0",
-	// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
-	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
-	"nvme_core.io_timeout=4294967295",
-	// Disable rate limited printk
-	"printk.devkmsg=on",
-	"ima_template=ima-ng",
-	"ima_appraise=fix",
-	"ima_hash=sha512",
+func DefaultArgs(quirks quirks.Quirks) []string {
+	result := []string{
+		"init_on_alloc=1",
+		"slab_nomerge=",
+		"pti=on",
+		"consoleblank=0",
+		// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
+		// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
+		"nvme_core.io_timeout=4294967295",
+		// Disable rate limited printk
+		"printk.devkmsg=on",
+		"ima_template=ima-ng",
+		"ima_appraise=fix",
+		"ima_hash=sha512",
+	}
+
+	if quirks.SupportsSELinux() {
+		result = append(result, constants.KernelParamSELinux+"=1")
+	}
+
+	return result
 }
 
 // SecureBootArgs returns the kernel commandline options required for secure boot.
-var SecureBootArgs = []string{
-	"lockdown=confidentiality",
+func SecureBootArgs(quirks.Quirks) []string {
+	return []string{
+		"lockdown=confidentiality",
+	}
 }
 
 // Param represents a kernel system property.

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -71,7 +71,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	cmdline := procfs.NewCmdline("")
 
-	cmdline.SetAll(kernel.DefaultArgs)
+	cmdline.SetAll(kernel.DefaultArgs(nodeReq.Quirks))
 
 	// required to get kernel console
 	cmdline.Append("console", arch.Console())

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 )
 
 // ClusterRequest is the root object describing cluster to be provisioned.
@@ -181,6 +182,8 @@ type NodeRequest struct {
 	Name string
 	IPs  []netip.Addr
 	Type machine.Type
+
+	Quirks quirks.Quirks
 
 	Config                config.Provider
 	ConfigInjectionMethod ConfigInjectionMethod


### PR DESCRIPTION
Make default args depend on quirks, and also pass quirks down to platform code.

Reduces amount of hacks, but it is functionally equivalent.
