### PR TITLE
fix: get next rule number for IPv6 in the appropriate chain

### DIFF
--- a/internal/app/machined/pkg/controllers/kubespan/routing_rules.go
+++ b/internal/app/machined/pkg/controllers/kubespan/routing_rules.go
@@ -69,7 +69,7 @@ func (m *rulesManager) Install() error {
 		Attributes: &rtnetlink.RuleAttributes{
 			FwMark:   pointer.To(m.InternalMark),
 			FwMask:   pointer.To(m.MarkMask),
-			Priority: pointer.To(nextRuleNumber(nc, unix.AF_INET)),
+			Priority: pointer.To(nextRuleNumber(nc, unix.AF_INET6)),
 		},
 	}); err != nil {
 		if !errors.Is(err, os.ErrExist) {


### PR DESCRIPTION
Does not fix anything, but looks more correct

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
