### PR TITLE
fix: use correct default search domain

### DIFF
--- a/internal/app/machined/pkg/controllers/network/resolver_config.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config.go
@@ -188,7 +188,7 @@ func (ctrl *ResolverConfigController) getDefault(cfg talosconfig.Config, hostnam
 		return spec
 	}
 
-	spec.SearchDomains = []string{hostnameStatus.FQDN()}
+	spec.SearchDomains = []string{hostnameStatus.Domainname}
 
 	return spec
 }


### PR DESCRIPTION
Search domain should be domain name of the hostname, not the FQDN.

Bug introduced in #9844
