### PR TITLE
fix: talosctl support and race tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-24T15:00:58Z by kres fcff05e.
+# Generated on 2024-12-25T15:13:54Z by kres fcff05e.
 
 name: default
 concurrency:
@@ -3367,6 +3367,8 @@ jobs:
           QEMU_EXTRA_DISKS: "3"
           QEMU_EXTRA_DISKS_DRIVERS: ide,nvme
           QEMU_EXTRA_DISKS_SIZE: "10240"
+          QEMU_MEMORY_CONTROLPLANES: "4096"
+          QEMU_MEMORY_WORKERS: "4096"
           TAG_SUFFIX: -race
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
         run: |

--- a/.github/workflows/integration-qemu-race-cron.yaml
+++ b/.github/workflows/integration-qemu-race-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-28T13:53:18Z by kres 232fe63.
+# Generated on 2024-12-25T15:13:54Z by kres fcff05e.
 
 name: integration-qemu-race-cron
 concurrency:
@@ -94,6 +94,8 @@ jobs:
           QEMU_EXTRA_DISKS: "3"
           QEMU_EXTRA_DISKS_DRIVERS: ide,nvme
           QEMU_EXTRA_DISKS_SIZE: "10240"
+          QEMU_MEMORY_CONTROLPLANES: "4096"
+          QEMU_MEMORY_WORKERS: "4096"
           TAG_SUFFIX: -race
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
         run: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1283,6 +1283,8 @@ spec:
             QEMU_EXTRA_DISKS_SIZE: "10240"
             QEMU_EXTRA_DISKS_DRIVERS: "ide,nvme"
             WITH_CONFIG_PATCH_WORKER: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml"
+            QEMU_MEMORY_CONTROLPLANES: 4096 # race-enabled Talos consumes lots of RAM
+            QEMU_MEMORY_WORKERS: 4096
             TAG_SUFFIX: -race
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: save-talos-logs

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-smbios v0.3.3
 	github.com/siderolabs/go-tail v0.1.1
-	github.com/siderolabs/go-talos-support v0.1.1
+	github.com/siderolabs/go-talos-support v0.1.2
 	github.com/siderolabs/grpc-proxy v0.5.1
 	github.com/siderolabs/kms-client v0.1.0
 	github.com/siderolabs/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -675,8 +675,8 @@ github.com/siderolabs/go-smbios v0.3.3 h1:rM3UKHQ8in1mqNRkpV75Ls3Wnk6rAhQJVYKUsK
 github.com/siderolabs/go-smbios v0.3.3/go.mod h1:kScnr0XSyzLfkRo/ChjITgI0rPRQnIi6PdgbxVCwA9U=
 github.com/siderolabs/go-tail v0.1.1 h1:3XeJgd97OHyFAIE7nQEMcRhOfnv7DvXbu0BRKbtT6u8=
 github.com/siderolabs/go-tail v0.1.1/go.mod h1:IihAL39acadXHfb5fEAOKK2DaDFIrG2+VD3b2H/ziZ0=
-github.com/siderolabs/go-talos-support v0.1.1 h1:g51J0WQssQAycU/0cDliC2l4uX2H02yUs2+fa5pCvHg=
-github.com/siderolabs/go-talos-support v0.1.1/go.mod h1:o4woiYS+2J3djCQgyHZRVZQm8XpazQr+XPcTXAZvamo=
+github.com/siderolabs/go-talos-support v0.1.2 h1:xKFwT8emzxpmamIe3W35QlmadC54OaPNO9/Y+fL7WwM=
+github.com/siderolabs/go-talos-support v0.1.2/go.mod h1:o9zRfWJQhW5j3PQxs7v0jmG4igD4peDatqbAGQFe4oo=
 github.com/siderolabs/grpc-proxy v0.5.1 h1:WTZYLMPTZPt43BzEJ02LT9kYA9qAfquWwCezc6NPPYE=
 github.com/siderolabs/grpc-proxy v0.5.1/go.mod h1:EQwE87LiWxhiIUPBeWmpjJb9DIWxWID8R6ARtdTC+8A=
 github.com/siderolabs/kms-client v0.1.0 h1:rCDWzcDDsNlp6zdyLngOuuhchVILn+vwUQy3tk6rQps=

--- a/internal/app/machined/pkg/startup/cgroups.go
+++ b/internal/app/machined/pkg/startup/cgroups.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/cgroups/v3/cgroup1"
 	"github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/siderolabs/go-debug"
 	"github.com/siderolabs/go-pointer"
 	"go.uber.org/zap"
 
@@ -21,6 +22,16 @@ import (
 	"github.com/siderolabs/talos/internal/pkg/cgroup"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
+
+func zeroIfRace[T any](v T) T {
+	if debug.RaceEnabled {
+		var zeroT T
+
+		return zeroT
+	}
+
+	return v
+}
 
 // CreateSystemCgroups creates system cgroups.
 //
@@ -130,7 +141,7 @@ func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 			name: constants.CgroupDashboard,
 			resources: &cgroup2.Resources{
 				Memory: &cgroup2.Memory{
-					Max: pointer.To[int64](constants.CgroupDashboardMaxMemory),
+					Max: zeroIfRace(pointer.To[int64](constants.CgroupDashboardMaxMemory)),
 				},
 				CPU: &cgroup2.CPU{
 					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupDashboardMillicores))),
@@ -143,7 +154,7 @@ func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 				Memory: &cgroup2.Memory{
 					Min: pointer.To[int64](constants.CgroupApidReservedMemory),
 					Low: pointer.To[int64](constants.CgroupApidReservedMemory * 2),
-					Max: pointer.To[int64](constants.CgroupApidMaxMemory),
+					Max: zeroIfRace(pointer.To[int64](constants.CgroupApidMaxMemory)),
 				},
 				CPU: &cgroup2.CPU{
 					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupApidMillicores))),
@@ -156,7 +167,7 @@ func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 				Memory: &cgroup2.Memory{
 					Min: pointer.To[int64](constants.CgroupTrustdReservedMemory),
 					Low: pointer.To[int64](constants.CgroupTrustdReservedMemory * 2),
-					Max: pointer.To[int64](constants.CgroupTrustdMaxMemory),
+					Max: zeroIfRace(pointer.To[int64](constants.CgroupTrustdMaxMemory)),
 				},
 				CPU: &cgroup2.CPU{
 					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupTrustdMillicores))),


### PR DESCRIPTION
1. Don't set max cgroups limit if race mode is enabled (only in test mode). When e.g. apid/trustd are built with race detector on, they consume 10x the memory.
2. Fix a data race in `talosctl support` when showing UI progress.
3. Fix an issue pulling `kubeconfig` in `talosctl support` - pull from endpoints (controlplanes) without setting any nodes.
4. Fix a deadlock in support on context cancel.

Fixes #10036
