### PR TITLE
fix: ignore member not found error on leave cluster

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -171,6 +171,11 @@ func (c *Client) LeaveCluster(ctx context.Context, st state.State) error {
 			return retry.ExpectedError(err)
 		}
 
+		if errors.Is(err, rpctypes.ErrMemberNotFound) {
+			// already removed, nothing to do
+			return nil
+		}
+
 		return err
 	}); err != nil {
 		return err


### PR DESCRIPTION
Fixes #10040

Sometimes etcd after 'server stoppped' error actually removes a member, so the next attempt returns member not found, ignore it, as our goal was to remove a member.
