### PR TITLE
fix: build of talosctl on non-Linux platforms

### DIFF
--- a/internal/pkg/tpm/tpm_linux.go
+++ b/internal/pkg/tpm/tpm_linux.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+// Package tpm provides TPM 2.0 support.
+package tpm
+
+import (
+	"errors"
+	"os"
+
+	"github.com/google/go-tpm/tpm2/transport"
+	"github.com/google/go-tpm/tpm2/transport/linuxtpm"
+)
+
+// Open a TPM device.
+//
+// Tries first /dev/tpmrm0 and then /dev/tpm0.
+func Open() (transport.TPMCloser, error) {
+	tpm, err := linuxtpm.Open("/dev/tpmrm0")
+
+	if errors.Is(err, os.ErrNotExist) {
+		tpm, err = linuxtpm.Open("/dev/tpm0")
+	}
+
+	return tpm, err
+}

--- a/internal/pkg/tpm/tpm_other.go
+++ b/internal/pkg/tpm/tpm_other.go
@@ -2,26 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build !linux
+
 // Package tpm provides TPM 2.0 support.
 package tpm
 
 import (
 	"errors"
-	"os"
 
 	"github.com/google/go-tpm/tpm2/transport"
-	"github.com/google/go-tpm/tpm2/transport/linuxtpm"
 )
 
 // Open a TPM device.
-//
-// Tries first /dev/tpmrm0 and then /dev/tpm0.
 func Open() (transport.TPMCloser, error) {
-	tpm, err := linuxtpm.Open("/dev/tpmrm0")
-
-	if errors.Is(err, os.ErrNotExist) {
-		tpm, err = linuxtpm.Open("/dev/tpm0")
-	}
-
-	return tpm, err
+	return nil, errors.New("TPM device is not available")
 }


### PR DESCRIPTION
The code from `talosctl` imports transitively tpm package, so make it build on non-Linux.
