### PR TITLE
fix: mount selinuxfs only when SELinux is enabled

### DIFF
--- a/internal/pkg/mount/v2/pseudo.go
+++ b/internal/pkg/mount/v2/pseudo.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/siderolabs/talos/internal/pkg/selinux"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -49,8 +50,8 @@ func PseudoSubMountPoints() Points {
 		)
 	}
 
-	if _, err := os.Stat("/sys/fs/selinux"); err == nil {
-		// mount selinuxfs if it exists
+	if selinux.IsEnabled() {
+		// mount selinuxfs if it is enabled, which implies SELinux is the major LSM
 		points = append(points,
 			NewPoint("selinuxfs", "/sys/fs/selinux", "selinuxfs", WithFlags(unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_RELATIME)),
 		)


### PR DESCRIPTION
Having selinuxfs mounted might confuse some software, as conventional Linux systems do not have selinuxfs mounted when SELinux is disabled and no policy is loaded.

Fixes #10083

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
