### PR TITLE
chore: drop deprecated allowSchedulingOnMasters

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,6 +23,13 @@ preface = """
 
 Talos is built with Go 1.23.4.
 """
+    [notes.machineconfig]
+        title = "cluster.allowSchedulingOnMasters"
+        description = """\
+The machine config field item `.cluster.allowSchedulingOnMasters` which has been deprecated since Talos 1.2 has now been removed.
+Use the `.cluster.allowSchedulingOnControlPlanes` field instead.
+"""
+
     [notes.driver-rebind]
         title = "Driver Rebind"
         description = """\

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -190,13 +190,8 @@ func (in *Input) init() ([]config.Document, error) {
 		ClusterInlineManifests: v1alpha1.ClusterInlineManifests{},
 	}
 
-	if in.Options.AllowSchedulingOnControlPlanes {
-		if in.Options.VersionContract.KubernetesAllowSchedulingOnControlPlanes() {
-			cluster.AllowSchedulingOnControlPlanes = pointer.To(in.Options.AllowSchedulingOnControlPlanes)
-		} else {
-			// backwards compatibility for Talos versions older than 1.2
-			cluster.AllowSchedulingOnMasters = pointer.To(in.Options.AllowSchedulingOnControlPlanes) //nolint:staticcheck
-		}
+	if in.Options.AllowSchedulingOnControlPlanes && in.Options.VersionContract.KubernetesAllowSchedulingOnControlPlanes() {
+		cluster.AllowSchedulingOnControlPlanes = pointer.To(in.Options.AllowSchedulingOnControlPlanes)
 	}
 
 	if in.Options.DiscoveryEnabled != nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -179,11 +179,7 @@ func (c *ClusterConfig) AdminKubeconfig() config.AdminKubeconfig {
 
 // ScheduleOnControlPlanes implements the config.ClusterConfig interface.
 func (c *ClusterConfig) ScheduleOnControlPlanes() bool {
-	if c.AllowSchedulingOnControlPlanes != nil {
-		return pointer.SafeDeref(c.AllowSchedulingOnControlPlanes)
-	}
-
-	return pointer.SafeDeref(c.AllowSchedulingOnMasters)
+	return pointer.SafeDeref(c.AllowSchedulingOnControlPlanes)
 }
 
 // ID returns the unique identifier for the cluster.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -520,10 +520,6 @@ type ClusterConfig struct {
 	//   examples:
 	//     - value: clusterAdminKubeconfigExample()
 	AdminKubeconfigConfig *AdminKubeconfigConfig `yaml:"adminKubeconfig,omitempty"`
-	// docgen:nodoc
-	//
-	// Deprecated: Use `AllowSchedulingOnControlPlanes` instead.
-	AllowSchedulingOnMasters *bool `yaml:"allowSchedulingOnMasters,omitempty"`
 	//   description: |
 	//     Allows running workload on control-plane nodes.
 	//   values:

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -527,7 +527,6 @@ func (ClusterConfig) Doc() *encoder.Doc {
 				Description: "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Settings for admin kubeconfig generation." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
-			{},
 			{
 				Name:        "allowSchedulingOnControlPlanes",
 				Type:        "bool",
@@ -572,7 +571,7 @@ func (ClusterConfig) Doc() *encoder.Doc {
 	})
 	doc.Fields[22].AddExample("", clusterInlineManifestsExample())
 	doc.Fields[23].AddExample("", clusterAdminKubeconfigExample())
-	doc.Fields[25].AddExample("", true)
+	doc.Fields[24].AddExample("", true)
 
 	return doc
 }

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -341,11 +341,7 @@ func (in *ClusterConfig) DeepCopyInto(out *ClusterConfig) {
 		*out = new(AdminKubeconfigConfig)
 		**out = **in
 	}
-	if in.AllowSchedulingOnMasters != nil {
-		in, out := &in.AllowSchedulingOnMasters, &out.AllowSchedulingOnMasters
-		*out = new(bool)
-		**out = **in
-	}
+
 	if in.AllowSchedulingOnControlPlanes != nil {
 		in, out := &in.AllowSchedulingOnControlPlanes, &out.AllowSchedulingOnControlPlanes
 		*out = new(bool)


### PR DESCRIPTION
Drop deprecated `.cluster.allowSchedulingOnMasters` machine config field.