### PR TITLE
fix: disable NRI plugin in a different way

### DIFF
--- a/hack/cri-containerd.toml
+++ b/hack/cri-containerd.toml
@@ -1,7 +1,6 @@
 version = 3
 
 disabled_plugins = [
-    "io.containerd.nri.v1.nri",
     "io.containerd.internal.v1.tracing",
     "io.containerd.snapshotter.v1.blockfile",
     "io.containerd.tracing.processor.v1.otlp",

--- a/hack/cri-plugin.part
+++ b/hack/cri-plugin.part
@@ -5,3 +5,6 @@ version = 3
 
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
   base_runtime_spec = "/etc/cri/conf.d/base-spec.json"
+
+[plugins."io.containerd.nri.v1.nri"]
+  disable = true

--- a/website/content/v1.10/talos-guides/configuration/containerd.md
+++ b/website/content/v1.10/talos-guides/configuration/containerd.md
@@ -63,3 +63,21 @@ NODE         NAMESPACE   ID                                                     
 172.20.0.5   k8s.io      kube-system/kube-proxy-xp7jq                                    registry.k8s.io/pause:3.8                                  1780   SANDBOX_READY
 172.20.0.5   k8s.io      └─ kube-system/kube-proxy-xp7jq:kube-proxy:84fc77c59e17         registry.k8s.io/kube-proxy:v1.26.0-alpha.3                 1843   CONTAINER_RUNNING
 ```
+
+### Enabling NRI Plugins
+
+By default, Talos disables [NRI](https://github.com/containerd/containerd/blob/main/docs/NRI.md) plugins in `containerd`, as they might have security implications.
+However, if you need to enable them, you can do so by adding the following configuration:
+
+```yaml
+machine:
+  files:
+    - content: |
+        [plugins]
+          [plugins."io.containerd.nri.v1.nri"]
+             disable = false
+      path: /etc/cri/conf.d/20-customization.part
+      op: create
+```
+
+After applying the configuration, the NRI plugins can be deployed, for example plugins from [this repository](https://containers.github.io/nri-plugins/stable/docs/index.html).


### PR DESCRIPTION
This way it's easy to re-enable NRI plugins with a simple change.

See https://github.com/siderolabs/talos/discussions/10068

I tested that it works e2e with NRI plugins repository.
