### PR TITLE
feat: support generating unsigned UKIs

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -122,6 +122,7 @@ var (
 	nodeInitramfsPath         string
 	nodeISOPath               string
 	nodeUSBPath               string
+	nodeUKIPath               string
 	nodeDiskImagePath         string
 	nodeIPXEBootScript        string
 	applyConfigEnabled        bool
@@ -230,6 +231,9 @@ func downloadBootAssets(ctx context.Context) error {
 		},
 		{
 			path: &nodeUSBPath,
+		},
+		{
+			path: &nodeUKIPath,
 		},
 		{
 			path: &nodeDiskImagePath,
@@ -471,6 +475,7 @@ func create(ctx context.Context) error {
 		InitramfsPath:  nodeInitramfsPath,
 		ISOPath:        nodeISOPath,
 		USBPath:        nodeUSBPath,
+		UKIPath:        nodeUKIPath,
 		IPXEBootScript: nodeIPXEBootScript,
 		DiskImagePath:  nodeDiskImagePath,
 
@@ -1255,6 +1260,7 @@ func init() {
 	createCmd.Flags().StringVar(&nodeVmlinuzPath, "vmlinuz-path", helpers.ArtifactPath(constants.KernelAssetWithArch), "the compressed kernel image to use")
 	createCmd.Flags().StringVar(&nodeISOPath, "iso-path", "", "the ISO path to use for the initial boot (VM only)")
 	createCmd.Flags().StringVar(&nodeUSBPath, "usb-path", "", "the USB stick image path to use for the initial boot (VM only)")
+	createCmd.Flags().StringVar(&nodeUKIPath, "uki-path", "", "the UKI image path to use for the initial boot (VM only)")
 	createCmd.Flags().StringVar(&nodeInitramfsPath, "initrd-path", helpers.ArtifactPath(constants.InitramfsAssetWithArch), "initramfs image to use")
 	createCmd.Flags().StringVar(&nodeDiskImagePath, "disk-image-path", "", "disk image to use")
 	createCmd.Flags().StringVar(&nodeIPXEBootScript, "ipxe-boot-script", "", "iPXE boot script (URL) to use")

--- a/internal/pkg/secureboot/uki/generate.go
+++ b/internal/pkg/secureboot/uki/generate.go
@@ -185,10 +185,14 @@ func (builder *Builder) generatePCRPublicKey() error {
 }
 
 func (builder *Builder) generateKernel() error {
-	path := filepath.Join(builder.scratchDir, "kernel")
+	path := builder.KernelPath
 
-	if err := builder.peSigner.Sign(builder.KernelPath, path); err != nil {
-		return err
+	if builder.peSigner != nil {
+		path := filepath.Join(builder.scratchDir, "kernel")
+
+		if err := builder.peSigner.Sign(builder.KernelPath, path); err != nil {
+			return err
+		}
 	}
 
 	builder.sections = append(builder.sections,

--- a/pkg/imager/profile/default.go
+++ b/pkg/imager/profile/default.go
@@ -55,6 +55,22 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	"metal-uki": {
+		Platform:   constants.PlatformMetal,
+		SecureBoot: pointer.To(false),
+		Output: Output{
+			Kind:      OutKindUKI,
+			OutFormat: OutFormatRaw,
+		},
+	},
+	"secureboot-metal-uki": {
+		Platform:   constants.PlatformMetal,
+		SecureBoot: pointer.To(true),
+		Output: Output{
+			Kind:      OutKindUKI,
+			OutFormat: OutFormatRaw,
+		},
+	},
 	"secureboot-metal": {
 		Platform:   constants.PlatformMetal,
 		SecureBoot: pointer.To(true),

--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -209,15 +209,15 @@ func (i *Input) FillDefaults(arch, version string, secureboot bool) {
 		i.BaseInstaller.ImageRef = fmt.Sprintf("%s:%s", images.DefaultInstallerImageRepository, version)
 	}
 
+	if i.SDStub == zeroFileAsset {
+		i.SDStub.Path = fmt.Sprintf(constants.SDStubAssetPath, arch)
+	}
+
+	if i.SDBoot == zeroFileAsset {
+		i.SDBoot.Path = fmt.Sprintf(constants.SDBootAssetPath, arch)
+	}
+
 	if secureboot {
-		if i.SDStub == zeroFileAsset {
-			i.SDStub.Path = fmt.Sprintf(constants.SDStubAssetPath, arch)
-		}
-
-		if i.SDBoot == zeroFileAsset {
-			i.SDBoot.Path = fmt.Sprintf(constants.SDBootAssetPath, arch)
-		}
-
 		if i.SecureBoot == nil {
 			i.SecureBoot = &SecureBootAssets{}
 		}

--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -124,9 +124,6 @@ func (p *Profile) Validate() error {
 			return fmt.Errorf("customization of meta partition is not supported for %s output", p.Output.Kind)
 		}
 	case OutKindUKI:
-		if !p.SecureBootEnabled() {
-			return fmt.Errorf("!secureboot is not supported for %s output", p.Output.Kind)
-		}
 	}
 
 	return nil

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -49,6 +49,7 @@ type LaunchConfig struct {
 	InitrdPath        string
 	ISOPath           string
 	USBPath           string
+	UKIPath           string
 	ExtraISOPath      string
 	PFlashImages      []string
 	KernelArgs        string
@@ -467,6 +468,11 @@ func launchVM(config *LaunchConfig) error {
 				"-drive", fmt.Sprintf("if=none,id=stick,format=raw,read-only=on,file=%s", config.USBPath),
 				"-device", "nec-usb-xhci,id=xhci",
 				"-device", "usb-storage,bus=xhci.0,drive=stick,removable=on",
+			)
+		case config.UKIPath != "":
+			args = append(args,
+				"-kernel", config.UKIPath,
+				"-append", config.KernelArgs,
 			)
 		case config.KernelImagePath != "":
 			args = append(args,

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -230,6 +230,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		launchConfig.InitrdPath = strings.ReplaceAll(clusterReq.InitramfsPath, constants.ArchVariable, opts.TargetArch)
 		launchConfig.ISOPath = strings.ReplaceAll(clusterReq.ISOPath, constants.ArchVariable, opts.TargetArch)
 		launchConfig.USBPath = strings.ReplaceAll(clusterReq.USBPath, constants.ArchVariable, opts.TargetArch)
+		launchConfig.UKIPath = strings.ReplaceAll(clusterReq.UKIPath, constants.ArchVariable, opts.TargetArch)
 	}
 
 	launchConfig.StatePath, err = state.StatePath()

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -35,6 +35,7 @@ type ClusterRequest struct {
 	InitramfsPath  string
 	ISOPath        string
 	USBPath        string
+	UKIPath        string
 	DiskImagePath  string
 	IPXEBootScript string
 

--- a/website/content/v1.10/reference/cli.md
+++ b/website/content/v1.10/reference/cli.md
@@ -199,6 +199,7 @@ talosctl cluster create [flags]
       --skip-kubeconfig                          skip merging kubeconfig from the created cluster
       --talos-version string                     the desired Talos version to generate config for (if not set, defaults to image version)
       --talosconfig string                       The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --uki-path string                          the UKI image path to use for the initial boot (VM only)
       --usb-path string                          the USB stick image path to use for the initial boot (VM only)
       --use-vip                                  use a virtual IP for the controlplane endpoint instead of the loadbalancer
       --user-disk strings                        list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>


### PR DESCRIPTION
Support generating unsigned UKI's.

Also plumb in support to `talosctl cluster create` to boot off UKI's. This doesn't work yet as installer needs more work.

Part of #9633 