### PR TITLE
fix: merge of VolumeConfig documents with sizes

### DIFF
--- a/pkg/machinery/config/types/block/byte_size.go
+++ b/pkg/machinery/config/types/block/byte_size.go
@@ -6,6 +6,7 @@ package block
 
 import (
 	"encoding"
+	"fmt"
 	"slices"
 	"strconv"
 
@@ -79,4 +80,17 @@ func (bs *ByteSize) UnmarshalText(text []byte) error {
 // IsZero implements yaml.IsZeroer.
 func (bs ByteSize) IsZero() bool {
 	return bs.value == nil && bs.raw == nil
+}
+
+// Merge implements merger interface.
+func (bs *ByteSize) Merge(other any) error {
+	otherBS, ok := other.(ByteSize)
+	if !ok {
+		return fmt.Errorf("cannot merge %T with %T", bs, other)
+	}
+
+	bs.raw = otherBS.raw
+	bs.value = otherBS.value
+
+	return nil
 }

--- a/pkg/machinery/config/types/block/volume_config_test.go
+++ b/pkg/machinery/config/types/block/volume_config_test.go
@@ -184,10 +184,12 @@ func TestVolumeConfigMerge(t *testing.T) {
 	c2.MetaName = constants.EphemeralPartitionLabel
 
 	require.NoError(t, c2.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 150`)))
+	require.NoError(t, c2.ProvisioningSpec.ProvisioningMaxSize.UnmarshalText([]byte("2.5TiB")))
 
 	require.NoError(t, merge.Merge(c1, c2))
 
 	assert.Equal(t, c1.ProvisioningSpec.DiskSelectorSpec.Match, c2.ProvisioningSpec.DiskSelectorSpec.Match)
+	assert.Equal(t, c1.ProvisioningSpec.ProvisioningMaxSize, c2.ProvisioningSpec.ProvisioningMaxSize)
 }
 
 type validationMode struct{}


### PR DESCRIPTION
Without the fix, the merge panics for `min`/`maxSize` due to missing `Merge` method.
