### PR TITLE
fix: kube-apiserver authorizers order

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -24,6 +24,7 @@ preface = """
 
 Talos is built with Go 1.23.4.
 """
+
     [notes.driver-rebind]
         title = "Driver Rebind"
         description = """\
@@ -43,6 +44,35 @@ The kernel argument `talos.unified_cgroup_hierarchy` is now ignored.
         description = """\
 Kernel parameter `talos.auditd.disabled=1` can be used to disable Talos built-in `auditd` service.
 """
+
+    [notes.kube-apiserver-authorization-config]
+        title = "kube-apiserver Authorization Config"
+        description = """\
+When using `.cluster.apiServer.authorizationConfig` the user provided order for the authorizers is honoured and `Node` and `RBAC` authorizers are always added to the end if not explicitly specified.
+
+Eg: If user provides only `Webhook` authorizer, the final order will be `Webhook`, `Node`, `RBAC`.
+
+To provide a specific order for `Node` or `RBAC` explicitly, user can provide the authorizer in the order they want.
+
+Eg:
+
+```yaml
+cluster:
+  apiServer:
+    authorizationConfig:
+      - type: Node
+        name: Node
+      - type: Webhook
+        name: Webhook
+        webhook:
+          connectionInfo:
+            type: InClusterConfig
+        ...
+      - type: RBAC
+        name: rbac
+```
+
+Usage of `authorization-mode` CLI argument will not support this form of customization.
 
 [make_deps]
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -131,11 +131,6 @@ func NewControlPlaneAuthorizationController() *ControlPlaneAuthorizationControll
 				var authorizers []k8s.AuthorizationAuthorizersSpec
 
 				for _, authorizer := range cfgProvider.Cluster().APIServer().AuthorizationConfig() {
-					// skip Node and RBAC authorizers as we add them by default later on.
-					if authorizer.Type() == "Node" || authorizer.Type() == "RBAC" {
-						continue
-					}
-
 					authorizers = slices.Concat(authorizers, []k8s.AuthorizationAuthorizersSpec{
 						{
 							Type:    authorizer.Type(),
@@ -145,7 +140,25 @@ func NewControlPlaneAuthorizationController() *ControlPlaneAuthorizationControll
 					})
 				}
 
-				res.TypedSpec().Config = slices.Concat(v1alpha1.APIServerDefaultAuthorizationConfigAuthorizers, authorizers)
+				if !slices.ContainsFunc(authorizers, func(a k8s.AuthorizationAuthorizersSpec) bool {
+					return a.Type == "Node"
+				}) {
+					authorizers = slices.Insert(authorizers, 0, k8s.AuthorizationAuthorizersSpec{
+						Type: "Node",
+						Name: "node",
+					})
+				}
+
+				if !slices.ContainsFunc(authorizers, func(a k8s.AuthorizationAuthorizersSpec) bool {
+					return a.Type == "RBAC"
+				}) {
+					authorizers = slices.Insert(authorizers, 1, k8s.AuthorizationAuthorizersSpec{
+						Type: "RBAC",
+						Name: "rbac",
+					})
+				}
+
+				res.TypedSpec().Config = authorizers
 
 				return nil
 			},


### PR DESCRIPTION
Fixes handling of `kube-apiserver` authorization config authorizers order.

Fixes: #10110