### PR TITLE
docs: update SideroLinkConfig example

### DIFF
--- a/pkg/machinery/config/types/siderolink/siderolink.go
+++ b/pkg/machinery/config/types/siderolink/siderolink.go
@@ -57,7 +57,7 @@ type ConfigV1Alpha1 struct {
 	//     SideroLink API URL to connect to.
 	//   examples:
 	//     - value: >
-	//        "https://siderolink.api/join?token=secret"
+	//        "https://siderolink.api/?jointoken=secret"
 	//   schema:
 	//     type: string
 	//     pattern: "^(https|grpc)://"
@@ -76,7 +76,7 @@ func NewConfigV1Alpha1() *ConfigV1Alpha1 {
 
 func exampleConfigV1Alpha1() *ConfigV1Alpha1 {
 	cfg := NewConfigV1Alpha1()
-	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/join?token=secret"))
+	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/jointoken?token=secret"))
 
 	return cfg
 }

--- a/pkg/machinery/config/types/siderolink/siderolink_doc.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_doc.go
@@ -28,7 +28,7 @@ func (ConfigV1Alpha1) Doc() *encoder.Doc {
 
 	doc.AddExample("", exampleConfigV1Alpha1())
 
-	doc.Fields[1].AddExample("", "https://siderolink.api/join?token=secret")
+	doc.Fields[1].AddExample("", "https://siderolink.api/?jointoken=secret")
 
 	return doc
 }

--- a/pkg/machinery/config/types/siderolink/siderolink_test.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_test.go
@@ -21,13 +21,13 @@ func TestRedact(t *testing.T) {
 	t.Parallel()
 
 	cfg := siderolink.NewConfigV1Alpha1()
-	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/join?jointoken=secret&user=alice"))
+	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/?jointoken=secret&user=alice"))
 
-	assert.Equal(t, "https://siderolink.api/join?jointoken=secret&user=alice", cfg.SideroLink().APIUrl().String())
+	assert.Equal(t, "https://siderolink.api/?jointoken=secret&user=alice", cfg.SideroLink().APIUrl().String())
 
 	cfg.Redact("REDACTED")
 
-	assert.Equal(t, "https://siderolink.api/join?jointoken=REDACTED&user=alice", cfg.APIUrlConfig.String())
+	assert.Equal(t, "https://siderolink.api/?jointoken=REDACTED&user=alice", cfg.APIUrlConfig.String())
 }
 
 //go:embed testdata/document.yaml
@@ -37,7 +37,7 @@ func TestMarshalStability(t *testing.T) {
 	t.Parallel()
 
 	cfg := siderolink.NewConfigV1Alpha1()
-	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/join?jointoken=secret&user=alice"))
+	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/?jointoken=secret&user=alice"))
 
 	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
 	require.NoError(t, err)

--- a/pkg/machinery/config/types/siderolink/testdata/document.yaml
+++ b/pkg/machinery/config/types/siderolink/testdata/document.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1alpha1
 kind: SideroLinkConfig
-apiUrl: https://siderolink.api/join?jointoken=secret&user=alice
+apiUrl: https://siderolink.api/?jointoken=secret&user=alice

--- a/website/content/v1.10/reference/configuration/siderolink/siderolinkconfig.md
+++ b/website/content/v1.10/reference/configuration/siderolink/siderolinkconfig.md
@@ -16,14 +16,14 @@ title: SideroLinkConfig
 {{< highlight yaml >}}
 apiVersion: v1alpha1
 kind: SideroLinkConfig
-apiUrl: https://siderolink.api/join?token=secret # SideroLink API URL to connect to.
+apiUrl: https://siderolink.api/jointoken?token=secret # SideroLink API URL to connect to.
 {{< /highlight >}}
 
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`apiUrl` |URL |SideroLink API URL to connect to. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-apiUrl: https://siderolink.api/join?token=secret
+apiUrl: https://siderolink.api/?jointoken=secret
 {{< /highlight >}}</details> | |
 
 


### PR DESCRIPTION
The provided example wasn't valid, it should not have a path component.
