### PR TITLE
fix: ignore forbidden error when waiting for pod eviction

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -275,6 +275,9 @@ func (h *Client) waitForPodDeleted(ctx context.Context, p *corev1.Pod) error {
 		switch {
 		case apierrors.IsNotFound(err):
 			return nil
+		case apierrors.IsForbidden(err):
+			// in Kubernetes 1.32+, NodeRestriction plugin won't let us list a pod which is not on our node, including deleted ones
+			return nil
 		case err != nil:
 			if IsRetryableError(err) {
 				return retry.ExpectedError(err)


### PR DESCRIPTION
K8s 1.32+ won't lest us get deleted pods as it doesn't belong to our node, so just assume the pod is gone (at least it's not on our node anymore).

Fixes #10154

