### PR TITLE
chore: de-hardcode list of extra images for image-cache test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-20T16:57:17Z by kres 3b3f992.
+# Generated on 2025-01-20T18:03:22Z by kres 3b3f992.
 
 name: default
 concurrency:
@@ -1564,7 +1564,6 @@ jobs:
       - name: image-cache
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          MORE_IMAGES: alpine;registry.k8s.io/conformance:v1.32.1;registry.k8s.io/e2e-test-images/busybox:1.36.1-1;registry.k8s.io/e2e-test-images/agnhost:2.53;registry.k8s.io/e2e-test-images/httpd:2.4.38-4;registry.k8s.io/e2e-test-images/nonewprivs:1.3;registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7;registry.k8s.io/e2e-test-images/nautilus:1.7;registry.k8s.io/e2e-test-images/sample-apiserver:1.29.2;registry.k8s.io/e2e-test-images/nginx:1.14-4;registry.k8s.io/etcd:3.5.16-0;registry.k8s.io/e2e-test-images/httpd:2.4.39-4
           PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1633,7 +1633,6 @@ spec:
             PLATFORM: linux/amd64,linux/arm64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
-            MORE_IMAGES: "alpine;registry.k8s.io/conformance:v1.32.1;registry.k8s.io/e2e-test-images/busybox:1.36.1-1;registry.k8s.io/e2e-test-images/agnhost:2.53;registry.k8s.io/e2e-test-images/httpd:2.4.38-4;registry.k8s.io/e2e-test-images/nonewprivs:1.3;registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7;registry.k8s.io/e2e-test-images/nautilus:1.7;registry.k8s.io/e2e-test-images/sample-apiserver:1.29.2;registry.k8s.io/e2e-test-images/nginx:1.14-4;registry.k8s.io/etcd:3.5.16-0;registry.k8s.io/e2e-test-images/httpd:2.4.39-4"
         - name: e2e-image-cache
           command: e2e-qemu
           withSudo: true

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,6 @@ IMAGER_EXTRA_PKGS ?= \
 INSTALLER_PKGS ?= $(INSTALLER_ONLY_PKGS) $(IMAGER_EXTRA_PKGS)
 IMAGER_ARGS ?=
 
-MORE_IMAGES ?=
-
 CGO_ENABLED ?= 0
 GO_BUILDFLAGS ?=
 GO_BUILDTAGS ?= tcell_minimal,grpcnotrace
@@ -491,7 +489,9 @@ uki-certs: talosctl ## Generate test certificates for SecureBoot/PCR Signing
 
 .PHONY: cache-create
 cache-create: installer imager ## Generate image cache.
-	@( $(TALOSCTL_EXECUTABLE) images default | grep -v 'siderolabs/installer'; echo "$(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG)"; echo "$(MORE_IMAGES)" | tr ';' '\n' ) | $(TALOSCTL_EXECUTABLE) images cache-create --image-cache-path=/tmp/cache.tar --images=- --force
+	@docker run --entrypoint /usr/local/bin/e2e.test registry.k8s.io/conformance:$(KUBECTL_VERSION) --list-images | \
+		$(TALOSCTL_EXECUTABLE) images integration --installer-tag=$(IMAGE_TAG) --registry-and-user=$(REGISTRY_AND_USERNAME) | \
+		$(TALOSCTL_EXECUTABLE) images cache-create --image-cache-path=/tmp/cache.tar --images=- --force
 	@crane push /tmp/cache.tar $(REGISTRY_AND_USERNAME)/image-cache:$(IMAGE_TAG)
 	@$(MAKE) image-iso IMAGER_ARGS="--image-cache=$(REGISTRY_AND_USERNAME)/image-cache:$(IMAGE_TAG) --extra-kernel-arg='console=ttyS0'"
 


### PR DESCRIPTION
Get the image list using `registry.k8s.io/conformance` image instead of hardcoding it. Add new command `talosctl image integration` to create a proper list of k8s integration images for `talosctl images cache-create` command.