### PR TITLE
Documentation fix typo "an MacOS" to "on MacOS"

### DIFF
--- a/website/content/v1.10/introduction/getting-started.md
+++ b/website/content/v1.10/introduction/getting-started.md
@@ -25,7 +25,7 @@ Regardless of where you run Talos, the steps to create a Kubernetes cluster are:
 `talosctl` is a CLI tool which interfaces with the Talos API.
 Talos Linux has no SSH access: `talosctl` is the tool you use to interact with the operating system on the machines.
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.10/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.10/talos-guides/install/local-platforms/qemu.md
@@ -41,7 +41,7 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.10/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.10/talos-guides/install/local-platforms/virtualbox.md
@@ -26,7 +26,7 @@ apt install virtualbox
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/proxmox.md
@@ -22,7 +22,7 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.7/introduction/getting-started.md
+++ b/website/content/v1.7/introduction/getting-started.md
@@ -25,7 +25,7 @@ Regardless of where you run Talos, the steps to create a Kubernetes cluster are:
 `talosctl` is a CLI tool which interfaces with the Talos API.
 Talos Linux has no SSH access: `talosctl` is the tool you use to interact with the operating system on the machines.
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.7/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.7/talos-guides/install/local-platforms/qemu.md
@@ -41,7 +41,7 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.7/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.7/talos-guides/install/local-platforms/virtualbox.md
@@ -26,7 +26,7 @@ apt install virtualbox
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.7/talos-guides/install/virtualized-platforms/proxmox.md
@@ -22,7 +22,7 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.8/introduction/getting-started.md
+++ b/website/content/v1.8/introduction/getting-started.md
@@ -25,7 +25,7 @@ Regardless of where you run Talos, the steps to create a Kubernetes cluster are:
 `talosctl` is a CLI tool which interfaces with the Talos API.
 Talos Linux has no SSH access: `talosctl` is the tool you use to interact with the operating system on the machines.
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.8/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.8/talos-guides/install/local-platforms/qemu.md
@@ -41,7 +41,7 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.8/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.8/talos-guides/install/local-platforms/virtualbox.md
@@ -26,7 +26,7 @@ apt install virtualbox
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.8/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.8/talos-guides/install/virtualized-platforms/proxmox.md
@@ -22,7 +22,7 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.9/introduction/getting-started.md
+++ b/website/content/v1.9/introduction/getting-started.md
@@ -25,7 +25,7 @@ Regardless of where you run Talos, the steps to create a Kubernetes cluster are:
 `talosctl` is a CLI tool which interfaces with the Talos API.
 Talos Linux has no SSH access: `talosctl` is the tool you use to interact with the operating system on the machines.
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.9/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.9/talos-guides/install/local-platforms/qemu.md
@@ -41,7 +41,7 @@ apt install qemu-system-x86 qemu-kvm
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.9/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.9/talos-guides/install/local-platforms/virtualbox.md
@@ -26,7 +26,7 @@ apt install virtualbox
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl

--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/proxmox.md
@@ -22,7 +22,7 @@ Visit the [Proxmox](https://www.proxmox.com/en/downloads) downloads page if nece
 
 ### Install talosctl
 
-You can download `talosctl` an MacOS and Linux via:
+You can download `talosctl` on MacOS and Linux via:
 
 ```bash
 brew install siderolabs/tap/talosctl


### PR DESCRIPTION
# Pull Request

I am discovering this amazing project ! Thank you very much for it.
During reading the documentation I found this typo. I open this PR to fix it.

## What? (description)

Documentation typo.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`) . make docs fail on the following error : 

```
7.750 2025/01/20 19:48:49 generating docs for type: "KernelModuleConfig"
------
Dockerfile:355
--------------------
 353 |     RUN gofumpt -w ./pkg/
 354 |     WORKDIR /src/pkg/machinery
 355 | >>> RUN --mount=type=cache,target=/.cache go generate ./...
 356 |     RUN gotagsrewrite .
 357 |     RUN goimports -w -local github.com/siderolabs/talos ./
--------------------
ERROR: failed to solve: process "/toolchain/bin/bash -c go generate ./..." did not complete successfully: exit code: 1
```

- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
