### PR TITLE
chore(ci): fio benchmark results as separate artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-20T16:57:17Z by kres 3b3f992.
+# Generated on 2025-01-21T10:29:14Z by kres 3075de9.
 
 name: default
 concurrency:
@@ -2956,6 +2956,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-longhorn
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -2963,7 +2970,6 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"
   integration-qemu-csi-openebs:
     permissions:
@@ -3058,6 +3064,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-openebs
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -3065,7 +3078,6 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"
   integration-qemu-csi-rook-ceph:
     permissions:
@@ -3159,6 +3171,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-rook-ceph
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -3166,7 +3185,6 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"
   integration-qemu-encrypted-vip:
     permissions:

--- a/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-20T16:57:17Z by kres 3b3f992.
+# Generated on 2025-01-21T10:29:14Z by kres 3075de9.
 
 name: integration-qemu-csi-longhorn-cron
 concurrency:
@@ -119,6 +119,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-longhorn
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -126,5 +133,4 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"

--- a/.github/workflows/integration-qemu-csi-openebs-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-openebs-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-16T11:00:37Z by kres 3b3f992.
+# Generated on 2025-01-21T10:29:14Z by kres 3075de9.
 
 name: integration-qemu-csi-openebs-cron
 concurrency:
@@ -94,6 +94,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-openebs
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -101,5 +108,4 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"

--- a/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-16T11:00:37Z by kres 3b3f992.
+# Generated on 2025-01-21T10:29:14Z by kres 3075de9.
 
 name: integration-qemu-csi-rook-ceph-cron
 concurrency:
@@ -93,6 +93,13 @@ jobs:
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fio-integration-qemu-csi-rook-ceph
+          path: |
+            /tmp/fio-*.json
+          retention-days: "180"
+      - name: save artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -100,5 +107,4 @@ jobs:
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip
-            /tmp/fio-*.json
           retention-days: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1346,6 +1346,13 @@ spec:
             WITH_CONFIG_PATCH: "@hack/test/patches/rook-ceph.yaml"
             EXTRA_TEST_ARGS: -talos.csi=rook-ceph
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-fio-benchmark
+          artifactStep:
+            type: upload
+            artifactName: fio-integration-qemu-csi-rook-ceph
+            disableExecutableListGeneration: true
+            artifactPath: /tmp/fio-*.json
+            retentionDays: "180"
         - name: save-talos-logs
           conditions:
             - always
@@ -1356,7 +1363,6 @@ spec:
             artifactPath: /tmp/logs-*.tar.gz
             additionalArtifacts:
               - "/tmp/support-*.zip"
-              - "/tmp/fio-*.json"
     - name: integration-qemu-csi-longhorn
       buildxOptions:
         enabled: true
@@ -1430,6 +1436,13 @@ spec:
             WITH_CONFIG_PATCH: "@_out/installer-extensions-patch.yaml:@_out/kubelet-fat-patch.yaml:@hack/test/patches/longhorn.yaml"
             EXTRA_TEST_ARGS: -talos.csi=longhorn
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-fio-benchmark
+          artifactStep:
+            type: upload
+            artifactName: fio-integration-qemu-csi-longhorn
+            disableExecutableListGeneration: true
+            artifactPath: /tmp/fio-*.json
+            retentionDays: "180"
         - name: save-talos-logs
           conditions:
             - always
@@ -1440,7 +1453,6 @@ spec:
             artifactPath: /tmp/logs-*.tar.gz
             additionalArtifacts:
               - "/tmp/support-*.zip"
-              - "/tmp/fio-*.json"
     - name: integration-qemu-csi-openebs
       buildxOptions:
         enabled: true
@@ -1491,6 +1503,13 @@ spec:
             WITH_CONFIG_PATCH_WORKER: "@hack/test/patches/openebs.yaml"
             EXTRA_TEST_ARGS: -talos.csi=openebs
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-fio-benchmark
+          artifactStep:
+            type: upload
+            artifactName: fio-integration-qemu-csi-openebs
+            disableExecutableListGeneration: true
+            artifactPath: /tmp/fio-*.json
+            retentionDays: "180"
         - name: save-talos-logs
           conditions:
             - always
@@ -1501,7 +1520,6 @@ spec:
             artifactPath: /tmp/logs-*.tar.gz
             additionalArtifacts:
               - "/tmp/support-*.zip"
-              - "/tmp/fio-*.json"
     - name: integration-images
       buildxOptions:
         enabled: true


### PR DESCRIPTION
Save `fio` benchmark results as separate artifacts for upto 6 months so we could compare results b/w talos releases.