### PR TITLE
fix: invalid date field in iqn/nqn

### DIFF
--- a/internal/app/machined/pkg/controllers/files/iqn.go
+++ b/internal/app/machined/pkg/controllers/files/iqn.go
@@ -87,7 +87,7 @@ func (ctrl *IQNController) Run(ctx context.Context, r controller.Runtime, _ *zap
 				spec := r.TypedSpec()
 
 				// Fri Nov 3 16:19:12 2017 -0700 is the date of the first commit in the talos repository.
-				spec.Contents = []byte(fmt.Sprintf("InitiatorName=iqn.2017.11.dev.talos:%s\n", machineID))
+				spec.Contents = []byte(fmt.Sprintf("InitiatorName=iqn.2017-11.dev.talos:%s\n", machineID))
 				spec.Mode = 0o600
 				spec.SelinuxLabel = constants.EtcSelinuxLabel
 

--- a/internal/app/machined/pkg/controllers/files/nqn.go
+++ b/internal/app/machined/pkg/controllers/files/nqn.go
@@ -108,7 +108,7 @@ func (ctrl *NQNController) Run(ctx context.Context, r controller.Runtime, _ *zap
 				spec := r.TypedSpec()
 
 				// Fri Nov 3 16:19:12 2017 -0700 is the date of the first commit in the talos repository.
-				spec.Contents = []byte(fmt.Sprintf("nqn.2017.11.dev.talos:uuid:%s", hostID.String()))
+				spec.Contents = []byte(fmt.Sprintf("nqn.2017-11.dev.talos:uuid:%s", hostID.String()))
 				spec.Mode = 0o600
 				spec.SelinuxLabel = constants.EtcSelinuxLabel
 


### PR DESCRIPTION
This sets the date field to `yyyy-mm` in the generated IQN/NQN.

See: https://datatracker.ietf.org/doc/html/rfc7143#section-4.2.7.4
Signed-off-by: bzub <bzub@users.noreply.github.com>

Fixes: https://github.com/siderolabs/talos/issues/10206