### PR TITLE
feat: generate iso's with both UKI and grub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-01-22T17:37:55Z by kres 3075de9.
+# Generated on 2025-01-24T14:30:35Z by kres 3075de9.
 
 name: default
 concurrency:
@@ -2196,6 +2196,16 @@ jobs:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-bios
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
+          WITH_UEFI: "false"
+        run: |
+          sudo -E make e2e-qemu
+      - name: e2e-bios-iso
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-bios-iso
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          VIA_MAINTENANCE_MODE: "true"
+          WITH_ISO: "true"
           WITH_UEFI: "false"
         run: |
           sudo -E make e2e-qemu

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T13:55:17Z by kres b9507d6.
+# Generated on 2025-01-24T14:30:35Z by kres 3075de9.
 
 name: integration-misc-2-cron
 concurrency:
@@ -96,6 +96,16 @@ jobs:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-bios
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
+          WITH_UEFI: "false"
+        run: |
+          sudo -E make e2e-qemu
+      - name: e2e-bios-iso
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-bios-iso
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          VIA_MAINTENANCE_MODE: "true"
+          WITH_ISO: "true"
           WITH_UEFI: "false"
         run: |
           sudo -E make e2e-qemu

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -838,6 +838,16 @@ spec:
             SHORT_INTEGRATION_TEST: yes
             WITH_UEFI: false
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: e2e-bios-iso
+          command: e2e-qemu
+          withSudo: true
+          environment:
+            GITHUB_STEP_NAME: ${{ github.job}}-e2e-bios-iso
+            SHORT_INTEGRATION_TEST: yes
+            WITH_UEFI: false
+            VIA_MAINTENANCE_MODE: true
+            WITH_ISO: true
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-disk-image
           command: e2e-qemu
           withSudo: true

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ secureboot-iso: image-secureboot-iso ## Builds UEFI only ISO which uses UKI and 
 
 .PHONY: secureboot-installer
 secureboot-installer: ## Builds UEFI only installer which uses UKI and push it to the registry.
-	@$(MAKE) image-secureboot-installer IMAGER_ARGS="--base-installer-image $(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG) $(IMAGER_ARGS)"
+	@$(MAKE) image-secureboot-installer IMAGER_ARGS="--base-installer-image $(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG) --extra-kernel-arg=console=ttyS0 $(IMAGER_ARGS)"
 	@for platform in $(subst $(,),$(space),$(PLATFORM)); do \
 		arch=$$(basename "$${platform}") && \
 		crane push $(ARTIFACTS)/installer-$${arch}-secureboot.tar $(REGISTRY_AND_USERNAME)/installer:$(IMAGE_TAG)-$${arch}-secureboot ; \

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -94,6 +94,12 @@ Talos now generates `/etc/nvme/hostnqn` and `/etc/nvme/hostid` files based on th
 The NQN can be read by `talosctl read /etc/nvme/hostnqn`
 """
 
+    [notes.iso]
+        title = "ISO"
+        description = """\
+Talos starting with 1.10 will have ISO's that will use GRUB only for legacy BIOS and systemd-boot for modern UEFI systems.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -9,6 +9,8 @@ CLUSTER_NAME=e2e-iso
 
 NODE="172.20.2.2"
 
+INSTALLER_IMAGE=${INSTALLER_IMAGE}-amd64-secureboot # we don't use secureboot part here, but this installer contains UKIs
+
 function create_cluster {
   build_registry_mirrors
 
@@ -24,7 +26,7 @@ function create_cluster {
     --cpus=2.0 \
     --cidr=172.20.2.0/24 \
     --with-apply-config \
-    --install-image=${REGISTRY:-ghcr.io}/siderolabs/installer:${TAG} \
+    --install-image="${INSTALLER_IMAGE}" \
     --cni-bundle-url=${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
     "${REGISTRY_MIRROR_FLAGS[@]}"
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -135,6 +135,7 @@ case "${WITH_ISO:-false}" in
   false)
     ;;
   *)
+    INSTALLER_IMAGE=${INSTALLER_IMAGE}-amd64-secureboot # we don't use secureboot part here, but this installer contains UKIs
     QEMU_FLAGS+=("--iso-path=${ARTIFACTS}/metal-amd64.iso")
     ;;
 esac

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -111,9 +111,9 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 		if !needBuildUKI {
 			return "", fmt.Errorf("UKI output is not supported in this Talos version")
 		}
-	case profile.OutKindISO, profile.OutKindImage:
+	case profile.OutKindImage:
 		needBuildUKI = needBuildUKI && i.prof.SecureBootEnabled()
-	case profile.OutKindInstaller:
+	case profile.OutKindISO, profile.OutKindInstaller:
 		needBuildUKI = needBuildUKI || quirks.New(i.prof.Version).UseSDBootForUEFI()
 	case profile.OutKindCmdline, profile.OutKindKernel, profile.OutKindInitramfs:
 		needBuildUKI = false

--- a/pkg/imager/iso/hybrid.go
+++ b/pkg/imager/iso/hybrid.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package iso
+
+import "path/filepath"
+
+// CreateHybrid creates an ISO image that supports both BIOS and UEFI booting.
+func (options Options) CreateHybrid(printf func(string, ...any)) (Generator, error) {
+	if _, err := options.CreateGRUB(printf); err != nil {
+		return nil, err
+	}
+
+	if _, err := options.CreateUEFI(printf); err != nil {
+		return nil, err
+	}
+
+	efiBootImg := filepath.Join(options.ScratchDir, "efiboot.img")
+
+	return &ExecutorOptions{
+		Command: "grub-mkrescue",
+		Version: options.Version,
+		Arguments: []string{
+			"--compress=xz",
+			"--output=" + options.OutPath,
+			"--verbose",
+			"--directory=/usr/lib/grub/i386-pc", // only for BIOS boot
+			"-m", "efiboot.img",                 // exclude the EFI boot image from the ISO
+			options.ScratchDir,
+			"-eltorito-alt-boot",
+			"-e", "--interval:appended_partition_2:all::", // use appended partition 2 for EFI
+			"-append_partition", "2", "0xef", efiBootImg,
+			"-appended_part_as_gpt",
+			"-partition_cyl_align", // pad partition to cylinder boundary
+			"all",
+			"-partition_offset", "16", // support booting from USB
+			"-iso_mbr_part_type", "0x83", // just to have more clear info when doing a fdisk -l
+			"-no-emul-boot",
+			"--",
+		},
+	}, nil
+}

--- a/pkg/imager/iso/iso.go
+++ b/pkg/imager/iso/iso.go
@@ -5,7 +5,17 @@
 // Package iso contains functions for creating ISO images.
 package iso
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/siderolabs/go-cmd/pkg/cmd"
+
+	"github.com/siderolabs/talos/pkg/imager/utils"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
+)
 
 // VolumeID returns a valid volume ID for the given label.
 func VolumeID(label string) string {
@@ -40,4 +50,76 @@ func Label(version string, secureboot bool) string {
 	}
 
 	return label + version
+}
+
+// ExecutorOptions defines the iso generation options.
+type ExecutorOptions struct {
+	Command   string
+	Version   string
+	Arguments []string
+}
+
+// Generator is an interface for executing the iso generation.
+type Generator interface {
+	Generate() error
+}
+
+// Options describe the input generating different types of ISOs.
+type Options struct {
+	KernelPath    string
+	InitramfsPath string
+	Cmdline       string
+
+	UKIPath    string
+	SDBootPath string
+
+	Arch    string
+	Version string
+
+	// A value in loader.conf secure-boot-enroll: off, manual, if-safe, force.
+	SDBootSecureBootEnrollKeys string
+
+	// UKISigningCertDer is the DER encoded UKI signing certificate.
+	UKISigningCertDerPath string
+
+	// optional, for auto-enrolling secureboot keys
+	PlatformKeyPath    string
+	KeyExchangeKeyPath string
+	SignatureKeyPath   string
+
+	ScratchDir string
+	OutPath    string
+}
+
+// Generate creates an ISO image.
+func (e *ExecutorOptions) Generate() error {
+	if epoch, ok, err := utils.SourceDateEpoch(); err != nil {
+		return err
+	} else if ok {
+		// set EFI FAT image serial number
+		if err := os.Setenv("GRUB_FAT_SERIAL_NUMBER", fmt.Sprintf("%x", uint32(epoch))); err != nil {
+			return err
+		}
+
+		e.Arguments = append(e.Arguments,
+			"-volume_date", "all_file_dates", fmt.Sprintf("=%d", epoch),
+			"-volume_date", "uuid", time.Unix(epoch, 0).Format("2006010215040500"),
+		)
+	}
+
+	if quirks.New(e.Version).SupportsISOLabel() {
+		label := Label(e.Version, false)
+
+		e.Arguments = append(e.Arguments,
+			"-volid", VolumeID(label),
+			"-volset-id", label,
+		)
+	}
+
+	_, err := cmd.Run(e.Command, e.Arguments...)
+	if err != nil {
+		return fmt.Errorf("failed to create ISO: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -319,6 +319,7 @@ func launchVM(config *LaunchConfig) error {
 		"-no-reboot",
 		"-boot", fmt.Sprintf("order=%s,reboot-timeout=5000", bootOrder),
 		"-smbios", fmt.Sprintf("type=1,uuid=%s", config.NodeUUID),
+		"-smbios", "type=11,value=io.systemd.stub.kernel-cmdline-extra=console=ttyS0",
 		"-chardev", fmt.Sprintf("socket,path=%s/%s.sock,server=on,wait=off,id=qga0", config.StatePath, config.Hostname),
 		"-device", "virtio-serial",
 		"-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0",

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -132,7 +132,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		return provision.NodeInfo{}, fmt.Errorf("error finding listen address for the API: %w", err)
 	}
 
-	defaultBootOrder := "cn"
+	defaultBootOrder := "cd"
 	if nodeReq.DefaultBootOrder != "" {
 		defaultBootOrder = nodeReq.DefaultBootOrder
 	}


### PR DESCRIPTION
Starting with Talos 1.10, the default generated ISO's will use GRUB for BIOS boot and sd-boot for EFI boot.

Fixes: #10192