### PR TITLE
feat: support kexec from uki

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
@@ -8,6 +8,7 @@ package bootloader
 import (
 	"os"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot"
@@ -27,6 +28,9 @@ type Bootloader interface {
 	Revert(disk string) error
 	// RequiredPartitions returns the required partitions for the bootloader.
 	RequiredPartitions() []partition.Options
+
+	// KexecLoad does a kexec_file_load using the current entry of the bootloader.
+	KexecLoad(r runtime.Runtime, disk string) error
 }
 
 // Probe checks if any supported bootloaders are installed.

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -8,8 +8,14 @@ package grub
 import (
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/kexec"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
 	"github.com/siderolabs/talos/internal/pkg/partition"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/version"
@@ -42,6 +48,46 @@ func NewConfig() *Config {
 		Entries:        map[BootLabel]MenuEntry{},
 		AddResetOption: true,
 	}
+}
+
+// KexecLoad does a kexec using the bootloader config.
+func (c *Config) KexecLoad(r runtime.Runtime, disk string) error {
+	_, err := ProbeWithCallback(disk, options.ProbeOptions{}, func(grubConf *Config) error {
+		defaultEntry, ok := grubConf.Entries[grubConf.Default]
+
+		if !ok {
+			return nil
+		}
+
+		kernelPath := filepath.Join(constants.BootMountPoint, defaultEntry.Linux)
+		initrdPath := filepath.Join(constants.BootMountPoint, defaultEntry.Initrd)
+
+		kernel, err := os.Open(kernelPath)
+		if err != nil {
+			return err
+		}
+
+		defer kernel.Close() //nolint:errcheck
+
+		initrd, err := os.Open(initrdPath)
+		if err != nil {
+			return err
+		}
+
+		defer initrd.Close() //nolint:errcheck
+
+		cmdline := strings.TrimSpace(defaultEntry.Cmdline)
+
+		if err = kexec.Load(r, kernel, int(initrd.Fd()), cmdline); err != nil {
+			return err
+		}
+
+		log.Printf("prepared kexec environment kernel=%q initrd=%q cmdline=%q", kernelPath, initrdPath, cmdline)
+
+		return nil
+	})
+
+	return err
 }
 
 // RequiredPartitions returns the list of partitions required by the bootloader.

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/kexec/kexec.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/kexec/kexec.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package kexec call unix.KexecFileLoad with error handling.
+package kexec
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	goruntime "runtime"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/pkg/zboot"
+)
+
+// Load handles zboot for arm64 and calls unix.KexecFileLoad with error handling and sets the machine state to kexec prepared.
+func Load(r runtime.Runtime, kernel *os.File, initrdFD int, cmdline string) error {
+	kernelFD := int(kernel.Fd())
+
+	// on arm64 we need to extract the kernel from the zboot image if it's compressed
+	if goruntime.GOARCH == "arm64" {
+		var (
+			fileCloser io.Closer
+			extractErr error
+		)
+
+		kernelFD, fileCloser, extractErr = zboot.Extract(kernel)
+		if extractErr != nil {
+			return fmt.Errorf("failed to extract kernel from zboot: %w", extractErr)
+		}
+
+		defer func() {
+			if fileCloser != nil {
+				fileCloser.Close() //nolint:errcheck
+			}
+		}()
+	}
+
+	if err := unix.KexecFileLoad(kernelFD, initrdFD, cmdline, 0); err != nil {
+		switch {
+		case errors.Is(err, unix.ENOSYS):
+			log.Printf("kexec support is disabled in the kernel")
+
+			return nil
+		case errors.Is(err, unix.EPERM):
+			log.Printf("kexec support is disabled via sysctl")
+
+			return nil
+		case errors.Is(err, unix.EBUSY):
+			log.Printf("kexec is busy")
+
+			return nil
+		default:
+			return fmt.Errorf("error loading kernel for kexec: %w", err)
+		}
+	}
+
+	r.State().Machine().KexecPrepared(true)
+
+	return nil
+}

--- a/internal/pkg/uki/internal/pe/extract.go
+++ b/internal/pkg/uki/internal/pe/extract.go
@@ -17,9 +17,9 @@ type fileCloser interface {
 
 // AssetInfo contains the kernel, initrd, and cmdline from a PE file.
 type AssetInfo struct {
-	Kernel  io.ReadSeeker
-	Initrd  io.ReadSeeker
-	Cmdline io.ReadSeeker
+	Kernel  io.Reader
+	Initrd  io.Reader
+	Cmdline io.Reader
 	fileCloser
 }
 


### PR DESCRIPTION
Support kexec from UKI for non-secureboot by extracting kernel, initramfs and cmdline from UKI

Fixes: #10189