### PR TITLE
test: bump timeout on rotate CA test

### DIFF
--- a/internal/integration/api/rotate.go
+++ b/internal/integration/api/rotate.go
@@ -43,7 +43,7 @@ func (suite *RotateCASuite) SuiteName() string {
 // SetupTest ...
 func (suite *RotateCASuite) SetupTest() {
 	// make sure API calls have timeout
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 5*time.Minute)
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 10*time.Minute)
 }
 
 // TearDownTest ...


### PR DESCRIPTION
When using VIP, recovery of Kubernetes controlplane takes more time (plus given the fact that the test rotates PKI twice).

