### PR TITLE
Add iscsi-tools extension to Prerequisites

### DIFF
--- a/website/content/v1.10/kubernetes-guides/configuration/synology-csi.md
+++ b/website/content/v1.10/kubernetes-guides/configuration/synology-csi.md
@@ -16,7 +16,7 @@ This guide assumes a very basic familiarity with iSCSI terminology (LUN, iSCSI t
 ## Prerequisites
 
 * Synology NAS running DSM 7.0 or above
-* Provisioned Talos cluster running Kubernetes v1.20 or above
+* Provisioned Talos cluster running Kubernetes v1.20 or above with `siderolabs/iscsi-tools` extension installed
 * (Optional) Both [Volume Snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/client/config/crd) and the [common snapshot controller](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/deploy/kubernetes/snapshot-controller) must be installed in your Kubernetes cluster if you want to use the **Snapshot** feature
 
 ## Setting up the Synology user account

--- a/website/content/v1.9/kubernetes-guides/configuration/synology-csi.md
+++ b/website/content/v1.9/kubernetes-guides/configuration/synology-csi.md
@@ -16,7 +16,7 @@ This guide assumes a very basic familiarity with iSCSI terminology (LUN, iSCSI t
 ## Prerequisites
 
 * Synology NAS running DSM 7.0 or above
-* Provisioned Talos cluster running Kubernetes v1.20 or above
+* Provisioned Talos cluster running Kubernetes v1.20 or above with `siderolabs/iscsi-tools` extension installed
 * (Optional) Both [Volume Snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/client/config/crd) and the [common snapshot controller](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/deploy/kubernetes/snapshot-controller) must be installed in your Kubernetes cluster if you want to use the **Snapshot** feature
 
 ## Setting up the Synology user account


### PR DESCRIPTION
This process will not work without the iscsi-tools extension installed on the talos cluster.

# Pull Request

## What? 
Documentation change to reflect reality of process of installing Synology-csi driver on a talos cluster

## Why? 
The document does not explicitly state that having siderolabs/iscsi-tools installed is a prerequisite, however attempting to mount a Persistent Volume claim without these tools being available on the cluster will lead to errors due to the iscsid not running on the nodes.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)


