### PR TITLE
fix: duplicate qemu drive ids

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -406,7 +406,7 @@ func launchVM(config *LaunchConfig) error {
 	if config.ExtraISOPath != "" {
 		args = append(args,
 			"-drive",
-			fmt.Sprintf("file=%s,media=cdrom", config.ExtraISOPath),
+			fmt.Sprintf("id=cdrom1,file=%s,media=cdrom", config.ExtraISOPath),
 		)
 	}
 
@@ -462,7 +462,7 @@ func launchVM(config *LaunchConfig) error {
 		case config.ISOPath != "":
 			args = append(args,
 				"-drive",
-				fmt.Sprintf("file=%s,media=cdrom", config.ISOPath),
+				fmt.Sprintf("id=cdrom0,file=%s,media=cdrom", config.ISOPath),
 			)
 		case config.USBPath != "":
 			args = append(args,


### PR DESCRIPTION
Fix an issue introduced in https://github.com/siderolabs/talos/issues/10097 where if rom drives are used with qemu, they get (automatically) assigned a duplicate id of `virtio0`, which is now used for the main drives.

Please let me know if a different naming convention should be used, or if the ids should be automatically indexed instead of the hardcoded values.

### Before the fix:
```sh
$ talosctl cluster create --provisioner qemu  --controlplanes 1 --iso-path _out/metal-arm64.iso

# talos-default-controlplane-1.log
starting /usr/bin/qemu-system-aarch64 with args:
-m 4096 -smp cpus=4 -cpu max -nographic -netdev tap,id=net0,ifname=tap0,script=no,downscript=no -device virtio-net-pci,netdev=net0,mac=ea:77:d9:dd:45:9a -device virtio-rng-pci -device virtio-balloon,deflate-on-oom=on -monitor unix:/root/.talos/clusters/talos-default/talos-default-controlplane-1.monitor,server,nowait -no-reboot -boot order=cd,reboot-timeout=5000 -smbios type=1,uuid=d54ea25a-2308-4f8f-961b-c530b7b38128 -smbios type=11,value=io.systemd.stub.kernel-cmdline-extra=console=ttyS0 -chardev socket,path=/root/.talos/clusters/talos-default/talos-default-controlplane-1.sock,server=on,wait=off,id=qga0 -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 -device i6300esb,id=watchdog0 -watchdog-action pause \
-drive id=virtio0,format=raw,if=none,file=/root/.talos/clusters/talos-default/talos-default-controlplane-1-0.disk,cache=none \
-device virtio-blk-pci,drive=virtio0,logical_block_size=512,physical_block_size=512 -machine virt,gic-version=max,accel=kvm -drive file=/root/.talos/clusters/talos-default/talos-default-controlplane-1-flash0.img,format=raw,if=pflash -drive file=/root/.talos/clusters/talos-default/talos-default-controlplane-1-flash1.img,format=raw,if=pflash \
-drive file=_out/metal-arm64.iso,media=cdrom

qemu-system-aarch64: -drive file=_out/metal-arm64.iso,media=cdrom: Device with id 'virtio0' already exists
process exited with error exit status 1
```

