### PR TITLE
fix: installer with SecureBoot should contain UKIs

### DIFF
--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -436,7 +436,7 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 		ukiPath += ".signed" // support for older secureboot installers
 	}
 
-	if quirks.UseSDBootForUEFI() {
+	if quirks.UseSDBootForUEFI() || i.prof.SecureBootEnabled() {
 		artifacts = append(artifacts,
 			filemap.File{
 				ImagePath:  strings.TrimLeft(fmt.Sprintf(constants.SDBootAssetPath, i.prof.Arch), "/"),


### PR DESCRIPTION
A change to use UKIs by default broke generation of SecureBoot installers for older Talos versions.

Note: it's not affecting users, as the Image Factory hasn't been updated yet to the broken version.
