### PR TITLE
fix: ensure proper closure of client.Client.conn with finalizer

### DIFF
--- a/pkg/machinery/client/connection.go
+++ b/pkg/machinery/client/connection.go
@@ -28,7 +28,7 @@ import (
 
 // Conn returns underlying client connection.
 func (c *Client) Conn() *grpc.ClientConn {
-	return c.conn.ClientConn
+	return c.conn.conn
 }
 
 // getConn creates new gRPC connection.

--- a/pkg/machinery/client/grpc_connection_wrapper.go
+++ b/pkg/machinery/client/grpc_connection_wrapper.go
@@ -6,33 +6,108 @@ package client
 
 import (
 	"context"
+	"runtime"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 )
 
 type grpcConnectionWrapper struct {
-	*grpc.ClientConn
+	conn *grpc.ClientConn
 
 	clusterName string
 }
 
 func newGRPCConnectionWrapper(clusterName string, conn *grpc.ClientConn) *grpcConnectionWrapper {
-	return &grpcConnectionWrapper{
-		ClientConn:  conn,
+	res := &grpcConnectionWrapper{
+		conn:        conn,
 		clusterName: clusterName,
 	}
+
+	runtime.SetFinalizer(res, func(c *grpcConnectionWrapper) { c.Close() }) //nolint:errcheck
+
+	return res
+}
+
+func (c *grpcConnectionWrapper) Close() error {
+	err := c.conn.Close()
+
+	runtime.SetFinalizer(c, nil)
+	runtime.KeepAlive(c)
+
+	return err
+}
+
+// NewStream begins a streaming RPC.
+func (c *grpcConnectionWrapper) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	res, err := c.conn.NewStream(c.appendMetadata(ctx), desc, method, opts...)
+
+	runtime.KeepAlive(c)
+
+	return res, err
 }
 
 // Invoke performs a unary RPC and returns after the response is received
 // into reply.
 func (c *grpcConnectionWrapper) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
-	return c.ClientConn.Invoke(c.appendMetadata(ctx), method, args, reply, opts...)
+	err := c.conn.Invoke(c.appendMetadata(ctx), method, args, reply, opts...)
+
+	runtime.KeepAlive(c)
+
+	return err
 }
 
-// NewStream begins a streaming RPC.
-func (c *grpcConnectionWrapper) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-	return c.ClientConn.NewStream(c.appendMetadata(ctx), desc, method, opts...)
+func (c *grpcConnectionWrapper) CanonicalTarget() string {
+	res := c.conn.Target()
+
+	runtime.KeepAlive(c)
+
+	return res
+}
+
+func (c *grpcConnectionWrapper) Connect() {
+	c.conn.Connect()
+
+	runtime.KeepAlive(c)
+}
+
+func (c *grpcConnectionWrapper) GetMethodConfig(method string) grpc.MethodConfig { //nolint:staticcheck
+	res := c.conn.GetMethodConfig(method)
+
+	runtime.KeepAlive(c)
+
+	return res
+}
+
+func (c *grpcConnectionWrapper) GetState() connectivity.State {
+	res := c.conn.GetState()
+
+	runtime.KeepAlive(c)
+
+	return res
+}
+
+func (c *grpcConnectionWrapper) ResetConnectBackoff() {
+	c.conn.ResetConnectBackoff()
+
+	runtime.KeepAlive(c)
+}
+
+func (c *grpcConnectionWrapper) Target() string {
+	res := c.conn.Target()
+
+	runtime.KeepAlive(c)
+
+	return res
+}
+
+func (c *grpcConnectionWrapper) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	res := c.conn.WaitForStateChange(ctx, sourceState)
+
+	runtime.KeepAlive(c)
+
+	return res
 }
 
 func (c *grpcConnectionWrapper) appendMetadata(ctx context.Context) context.Context {


### PR DESCRIPTION
As @smira noted in #10263, as soon as compiler can assume that variable is unneeded, it's free to drop it, and runtime if free to GC it. We want to prevent that, because sometimes variable can be dropped while one of its fields methods is called or in-flight (the last method in scope for example).

To do this we need to patch two things:
1. Ensure that we call [runtime.KeepAlive](https://pkg.go.dev/runtime#KeepAlive) in all methods after the main logic path.
2. Replace embedding with unexported fields and add methods (and KeepAlive's) manually. Otherwise, "promoted" methods do not "keep-alive" our object and GC is free to collect it.

Even tho `ClientConnInterface` interface defines only two methods, we don't know how many type assertions happen inside, so we export everything from `*grpc.ClientConn` to our type.