### PR TITLE
chore: track opened grpc connections

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
@@ -74,6 +74,7 @@ func (suite *TimedSuite) TestTime() {
 		grpc.WithContextDialer(dialer.DialUnix()),
 	)
 	suite.Require().NoError(err)
+	suite.T().Cleanup(func() { conn.Close() }) //nolint:errcheck
 
 	nClient := timeapi.NewTimeServiceClient(conn)
 	reply, err := nClient.Time(context.Background(), &emptypb.Empty{})
@@ -108,6 +109,7 @@ func (suite *TimedSuite) TestTimeCheck() {
 		grpc.WithContextDialer(dialer.DialUnix()),
 	)
 	suite.Require().NoError(err)
+	suite.T().Cleanup(func() { conn.Close() }) //nolint:errcheck
 
 	nClient := timeapi.NewTimeServiceClient(conn)
 	reply, err := nClient.TimeCheck(context.Background(), &timeapi.TimeRequest{Server: testServer})

--- a/internal/pkg/encryption/keys/kms.go
+++ b/internal/pkg/encryption/keys/kms.go
@@ -57,6 +57,8 @@ func (h *KMSKeyHandler) NewKey(ctx context.Context) (*encryption.Key, token.Toke
 		return nil, nil, fmt.Errorf("error dialing KMS endpoint %q: %w", h.kmsEndpoint, err)
 	}
 
+	defer conn.Close() //nolint:errcheck
+
 	client := kms.NewKMSServiceClient(conn)
 
 	key := make([]byte, 32)
@@ -101,6 +103,8 @@ func (h *KMSKeyHandler) GetKey(ctx context.Context, t token.Token) (*encryption.
 	if err != nil {
 		return nil, fmt.Errorf("error dialing KMS endpoint %q: %w", h.kmsEndpoint, err)
 	}
+
+	defer conn.Close() //nolint:errcheck
 
 	client := kms.NewKMSServiceClient(conn)
 

--- a/pkg/machinery/client/client_test.go
+++ b/pkg/machinery/client/client_test.go
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/siderolabs/gen/ensure"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+)
+
+func ExampleNew() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	connPprof := pprof.Lookup("machinery/client/grpc.grpcConn")
+	if connPprof == nil {
+		panic(errors.New("profile machinery/client/grpc.grpcConn not found"))
+	}
+
+	fmt.Println("before:", connPprof.Count())
+
+	c := ensure.Value(
+		client.New(
+			ctx,
+			client.WithUnixSocket("/path/to/socket"),
+			client.WithGRPCDialOptions(
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			),
+		),
+	)
+
+	fmt.Println("after client.New:", connPprof.Count())
+
+	if err := c.Close(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("after client.Close:", connPprof.Count())
+
+	c2 := ensure.Value(
+		client.New(
+			ctx,
+			client.WithUnixSocket("/path/to/socket"),
+			client.WithGRPCDialOptions(
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			),
+		),
+	)
+
+	fmt.Println("after client.New 2:", connPprof.Count())
+
+	_ = c2
+
+	runtime.GC()
+
+	fmt.Println("after gc:", connPprof.Count())
+
+	// Output:
+	// before: 0
+	// after client.New: 1
+	// after client.Close: 0
+	// after client.New 2: 1
+	// after gc: 1
+}


### PR DESCRIPTION
This is an alternative to #10283 which doesn't close the connections and instead allows us to easily track the lost grpc connections using pprof.

Fix various grpc leaks while we are at it.