### PR TITLE
feat: update Flannel to 0.26.4

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,6 +23,7 @@ preface = """
 * runc: 1.2.4
 * containerd: 2.0.2
 * etcd: 3.5.18
+* Flannel: 0.26.4
 
 Talos is built with Go 1.23.5.
 """

--- a/pkg/flannel/template.go
+++ b/pkg/flannel/template.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.26.1/Documentation/kube-flannel.yml DO NOT EDIT
+// Code generated from the manifest https://raw.githubusercontent.com/flannel-io/flannel/v0.26.4/Documentation/kube-flannel.yml DO NOT EDIT
 
 package flannel
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1166,7 +1166,7 @@ const (
 	DashboardTTY = 2
 
 	// FlannelVersion is the version of flannel to use.
-	FlannelVersion = "v0.26.1"
+	FlannelVersion = "v0.26.4"
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"


### PR DESCRIPTION
See https://github.com/flannel-io/flannel/releases/tag/v0.26.4
