### PR TITLE
fix: extracting cmdline multi profile UKIs

### DIFF
--- a/internal/pkg/uki/internal/pe/extract_test.go
+++ b/internal/pkg/uki/internal/pe/extract_test.go
@@ -23,7 +23,7 @@ func TestUKIExtract(t *testing.T) {
 
 	destFile := filepath.Join(destDir, "vmlinuz.efi")
 
-	for _, section := range []string{"linux", "initrd", "cmdline"} {
+	for _, section := range []string{"linux", "initrd", "cmdline", "profile-default", "profile-reset", "cmdline-reset"} {
 		assert.NoError(t, os.WriteFile(filepath.Join(destDir, section), []byte(section), 0o644))
 	}
 
@@ -43,6 +43,24 @@ func TestUKIExtract(t *testing.T) {
 		{
 			Name:    ".cmdline",
 			Path:    filepath.Join(destDir, "cmdline"),
+			Measure: false,
+			Append:  true,
+		},
+		{
+			Name:    ".profile",
+			Path:    filepath.Join(destDir, "profile-default"),
+			Measure: false,
+			Append:  true,
+		},
+		{
+			Name:    ".profile",
+			Path:    filepath.Join(destDir, "profile-reset"),
+			Measure: false,
+			Append:  true,
+		},
+		{
+			Name:    ".cmdline",
+			Path:    filepath.Join(destDir, "cmdline-reset"),
 			Measure: false,
 			Append:  true,
 		},

--- a/internal/pkg/uki/internal/pe/pe_test.go
+++ b/internal/pkg/uki/internal/pe/pe_test.go
@@ -145,10 +145,10 @@ func TestMultipleSections(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	unamePath := filepath.Join(tmpDir, "uname")
-	require.NoError(t, os.WriteFile(unamePath, []byte("Talos-helloworld"), 0o644))
+	require.NoError(t, os.WriteFile(unamePath, []byte("Talos"), 0o644))
 
 	unameNewPath := filepath.Join(tmpDir, "uname-new")
-	require.NoError(t, os.WriteFile(unameNewPath, []byte("Talos-foobar"), 0o644))
+	require.NoError(t, os.WriteFile(unameNewPath, []byte("Talos-new"), 0o644))
 
 	outNative := filepath.Join(tmpDir, "uki-native.bin")
 
@@ -174,6 +174,6 @@ func TestMultipleSections(t *testing.T) {
 
 	sectionContents := extractSection(t, outNative, ".uname")
 
-	assert.Contains(t, sectionContents, "Talos-helloworld")
-	assert.Contains(t, sectionContents, "Talos-foobar")
+	assert.Contains(t, sectionContents, "Talos")
+	assert.Contains(t, sectionContents, "Talos-new")
 }


### PR DESCRIPTION
When extracting `.cmdline` from multi profile UKI's we only need the first cmdline, rest are profile specific and not the default cmdline.