### PR TITLE
Update vmware.md - old snippet: flannel was missing between cni and extraargs

### DIFF
--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/vmware.md
@@ -75,8 +75,9 @@ If you apply the patch you can save this to a separate file (e.g. cni-patch.yaml
 cluster:
   network:
     cni:
-      extraArgs:
-        - --flannel-backend=host-gw
+      flannel:
+         extraArgs:
+           - --flannel-backend=host-gw
 ```
 
 ## Set Environment Variables


### PR DESCRIPTION


# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
This Pull Request updates the documentation by adding the missing flannel between the cni and extraargs sections. The snippet now reflects the actual configuration.

## Why? (reasoning)
The previous documentation was outdated and contained an error that could lead to confusion. By including flannel, the configuration is now correctly represented, which especially helps new users apply the correct settings.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
