### PR TITLE
docs: fix a typo in Wireguard docs

### DIFF
--- a/website/content/v1.10/talos-guides/network/wireguard-network.md
+++ b/website/content/v1.10/talos-guides/network/wireguard-network.md
@@ -94,7 +94,7 @@ network:
         peers:
           allowedIPs:
             - 192.168.88.0/24
-          endpoint: 209.202.254.14.8172
+          endpoint: 209.202.254.14:8172
           publicKey: ABCDEF...
 ...
 ```

--- a/website/content/v1.9/talos-guides/network/wireguard-network.md
+++ b/website/content/v1.9/talos-guides/network/wireguard-network.md
@@ -94,7 +94,7 @@ network:
         peers:
           allowedIPs:
             - 192.168.88.0/24
-          endpoint: 209.202.254.14.8172
+          endpoint: 209.202.254.14:8172
           publicKey: ABCDEF...
 ...
 ```


### PR DESCRIPTION
There is an error in the docu

