### PR TITLE
fix: make image cache volume management less strict

### DIFF
--- a/internal/app/machined/pkg/controllers/block/volume_manager.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager.go
@@ -285,11 +285,6 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 
 		fullyProvisionedWave := math.MaxInt
 		allClosed := true
-		minWave := math.MinInt
-
-		if len(volumeConfigs) > 0 {
-			minWave = volumeConfigs[0].TypedSpec().Provisioning.Wave
-		}
 
 		for _, vc := range volumeConfigs {
 			// abort on context cancel, as each volume processing might take a while
@@ -346,8 +341,7 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 				volumeStatus.PreFailPhase = block.VolumePhase(0)
 			}
 
-			// if the wave we're working on is a minimum wave, let's not push the limit further, as minWave can be processed (partially)
-			if volumeStatus.Phase != block.VolumePhaseReady && vc.TypedSpec().Provisioning.Wave != minWave {
+			if volumeStatus.Phase != block.VolumePhaseReady {
 				fullyProvisionedWave = vc.TypedSpec().Provisioning.Wave - 1
 			}
 

--- a/internal/app/machined/pkg/controllers/cri/image_cache_config.go
+++ b/internal/app/machined/pkg/controllers/cri/image_cache_config.go
@@ -399,7 +399,7 @@ func (ctrl *ImageCacheConfigController) analyzeImageCacheVolumes(ctx context.Con
 	case ctrl.cacheCopyDone:
 		// if the copy has already been done, we don't need to do it again
 		copyStatus = cri.ImageCacheCopyStatusReady
-	case isoReady && diskReady:
+	case isoReady && diskReady && copySource != "" && copyTarget != "":
 		// ready to copy
 		if err := ctrl.copyImageCache(ctx, logger, copySource, copyTarget); err != nil {
 			return nil, fmt.Errorf("error copying image cache: %w", err)
@@ -420,7 +420,7 @@ func (ctrl *ImageCacheConfigController) analyzeImageCacheVolumes(ctx context.Con
 
 func (ctrl *ImageCacheConfigController) getImageCacheRoot(ctx context.Context, r controller.Reader, volumeStatus *block.VolumeStatus, mountReadyOnly bool) (optional.Optional[string], bool, error) {
 	switch volumeStatus.TypedSpec().Phase { //nolint:exhaustive
-	case block.VolumePhaseMissing:
+	case block.VolumePhaseMissing, block.VolumePhaseFailed, block.VolumePhaseWaiting:
 		// image cache is missing
 		return optional.None[string](), true, nil
 	case block.VolumePhaseReady:


### PR DESCRIPTION
When booting with an image cache enabled, without an ISO, but with disk image cache configured, Talos would block on install waiting for the image cache to be ready.

Current readiness checks expect that IMAGECACHE disk volume is ready before proceeding, but the volume itself might be blocked on provisioning before install (e.g. it might be allocated on a system disk which is not defined, or simply due to the volume provsioning order).

This change looses the checks so that image cache blocks fully only on ISO being present or missing, but disk image cache is okay to be missing.

This reverts a change from #10281 which introduced a regression that `EPHEMERAL` might be provisioned before `STATE`.
