### PR TITLE
fix: handling of empty registry config

### DIFF
--- a/internal/app/machined/pkg/controllers/cri/registries_config_test.go
+++ b/internal/app/machined/pkg/controllers/cri/registries_config_test.go
@@ -242,11 +242,7 @@ func (suite *ConfigSuite) TestRegistryTLS() {
 	})
 }
 
-func (suite *ConfigSuite) TestRegistryNoMachineConfig() {
-	cfg := config.NewMachineConfig(container.NewV1Alpha1(nil))
-
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), cfg))
-
+func (suite *ConfigSuite) TestRegistryImageCacheNoConfig() {
 	ic := crires.NewImageCacheConfig()
 	ic.TypedSpec().Roots = []string{"/imagecache"}
 	ic.TypedSpec().Status = crires.ImageCacheStatusReady
@@ -267,6 +263,16 @@ func (suite *ConfigSuite) TestRegistryNoMachineConfig() {
 	})
 }
 
+func (suite *ConfigSuite) TestRegistryNoConfig() {
+	ctest.AssertResource(suite, crires.RegistriesConfigID, func(r *crires.RegistriesConfig, a *assert.Assertions) {
+		spec := r.TypedSpec()
+
+		a.Empty(
+			spec.RegistryMirrors,
+		)
+	})
+}
+
 func TestConfigSuite(t *testing.T) {
 	t.Parallel()
 
@@ -274,7 +280,7 @@ func TestConfigSuite(t *testing.T) {
 		DefaultSuite: ctest.DefaultSuite{
 			Timeout: 5 * time.Second,
 			AfterSetup: func(s *ctest.DefaultSuite) {
-				s.Require().NoError(s.Runtime().RegisterController(cri.NewRegistriesConfigController()))
+				s.Require().NoError(s.Runtime().RegisterController(&cri.RegistriesConfigController{}))
 			},
 		},
 	})

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -137,6 +137,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&cri.ImageCacheConfigController{
 			V1Alpha1ServiceManager: system.Services(ctrl.v1alpha1Runtime),
 		},
+		&cri.RegistriesConfigController{},
 		&cri.SeccompProfileController{},
 		&cri.SeccompProfileFileController{
 			V1Alpha1Mode:             ctrl.v1alpha1Runtime.State().Platform().Mode(),
@@ -296,7 +297,6 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		network.NewTimeServerMergeController(),
 		&network.TimeServerSpecController{},
 		&perf.StatsController{},
-		cri.NewRegistriesConfigController(),
 		&runtimecontrollers.CRIImageGCController{},
 		&runtimecontrollers.DevicesStatusController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),


### PR DESCRIPTION
If there is no machine config at all, empty registry config should be still created.

Drop TransformController here and use regular controller, as we need to act on no resource.

See https://github.com/siderolabs/omni/issues/877
