### PR TITLE
fix: ignore errors to stop pods

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1230,13 +1230,17 @@ func stopAndRemoveAllPods(stopAction cri.StopAction) runtime.TaskExecutionFunc {
 		// CNI, preventing the CRI from cleaning up the pod's networking.
 
 		if err = client.StopAndRemovePodSandboxes(ctx, stopAction, runtimeapi.NamespaceMode_POD, runtimeapi.NamespaceMode_CONTAINER); err != nil {
-			return err
+			logger.Printf("failed to stop and remove pods with POD network mode: %s", err)
 		}
 
 		// With the POD network mode pods out of the way, we kill the remaining
 		// pods.
 
-		return client.StopAndRemovePodSandboxes(ctx, stopAction)
+		if err = client.StopAndRemovePodSandboxes(ctx, stopAction); err != nil {
+			logger.Printf("failed to stop and remove pods: %s", err)
+		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
If Talos fails to stop the pods, it doesn't affect any future operations.

Prevously it was critical for the install/upgrade to succeed, as it tried to remove whole partition table, but now even dangling mounts won't affect upgrades.

Sometimes pods can't be stopped because of network file systems.

Fixes #10174

