### PR TITLE
fix: fix diff printing

### DIFF
--- a/pkg/machinery/config/configdiff/configdiff.go
+++ b/pkg/machinery/config/configdiff/configdiff.go
@@ -109,7 +109,7 @@ func outputDiff(w io.Writer, u gotextdiff.Unified, noColor bool) {
 			cyan.Fprintf(w, " +%d", hunk.ToLine) //nolint:errcheck
 		}
 
-		cyan.Printf(" @@\n") //nolint:errcheck
+		cyan.Fprintf(w, " @@\n") //nolint:errcheck
 
 		for _, l := range hunk.Lines {
 			switch l.Kind { //nolint:exhaustive

--- a/pkg/machinery/config/configdiff/configdiff_test.go
+++ b/pkg/machinery/config/configdiff/configdiff_test.go
@@ -60,13 +60,13 @@ func TestDiffString(t *testing.T) {
 			name:   "new doc",
 			oldCfg: []config.Document{v1alpha1Cfg},
 			newCfg: []config.Document{v1alpha1Cfg, siderolinkConfig},
-			want:   "--- a\n+++ b\n@@ -4,3 +4,7     token: foo\n     certSANs: []\n cluster: null\n+---\n+apiVersion: v1alpha1\n+kind: SideroLinkConfig\n+apiUrl: https://example.com\n",
+			want:   "--- a\n+++ b\n@@ -4,3 +4,7 @@\n     token: foo\n     certSANs: []\n cluster: null\n+---\n+apiVersion: v1alpha1\n+kind: SideroLinkConfig\n+apiUrl: https://example.com\n",
 		},
 		{
 			name:   "updated field",
 			oldCfg: []config.Document{v1alpha1Cfg, siderolinkConfig},
 			newCfg: []config.Document{v1alpha1CfgOther, siderolinkConfig},
-			want:   "--- a\n+++ b\n@@ -1,6 +1,6 version: v1alpha1\n machine:\n-    type: controlplane\n+    type: worker\n     token: foo\n     certSANs: []\n cluster: null\n",
+			want:   "--- a\n+++ b\n@@ -1,6 +1,6 @@\n version: v1alpha1\n machine:\n-    type: controlplane\n+    type: worker\n     token: foo\n     certSANs: []\n cluster: null\n",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The second `@@` was not written to the same writer

This was breaking ability to pipe the diff output to tools that understand [`unidiff`](https://en.wikipedia.org/wiki/Diff#Unified_format)