### PR TITLE
fix: path for ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -755,8 +755,8 @@ COPY --chmod=0644 hack/lvm.conf /rootfs/etc/lvm/lvm.conf
 COPY --chmod=0644 --from=base /src/pkg/machinery/version/os-release /rootfs/etc/os-release
 RUN <<END
     ln -s /usr/share/zoneinfo/Etc/UTC /rootfs/etc/localtime
-    touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part,cri/conf.d/base-spec.json,ssl/certs/ca-certificates,selinux/targeted/contexts/files/file_contexts,iscsi/initiatorname.iscsi,nvme/{hostid,hostnqn}}
-    ln -s ca-certificates /rootfs/etc/ssl/certs/ca-certificates.crt
+    touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part,cri/conf.d/base-spec.json,ssl/certs/ca-certificates.crt,selinux/targeted/contexts/files/file_contexts,iscsi/initiatorname.iscsi,nvme/{hostid,hostnqn}}
+    ln -s ca-certificates.crt /rootfs/etc/ssl/certs/ca-certificates
     ln -s /etc/ssl /rootfs/etc/pki
     ln -s /etc/ssl /rootfs/usr/share/ca-certificates
     ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
@@ -841,9 +841,9 @@ COPY --chmod=0644 hack/lvm.conf /rootfs/etc/lvm/lvm.conf
 COPY --chmod=0644 --from=base /src/pkg/machinery/version/os-release /rootfs/etc/os-release
 RUN <<END
     ln -s /usr/share/zoneinfo/Etc/UTC /rootfs/etc/localtime
-    touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part,cri/conf.d/base-spec.json,ssl/certs/ca-certificates,selinux/targeted/contexts/files/file_contexts,iscsi/initiatorname.iscsi,nvme/{hostid,hostnqn}}
+    touch /rootfs/etc/{extensions.yaml,resolv.conf,hosts,machine-id,cri/conf.d/cri.toml,cri/conf.d/01-registries.part,cri/conf.d/20-customization.part,cri/conf.d/base-spec.json,ssl/certs/ca-certificates.crt,selinux/targeted/contexts/files/file_contexts,iscsi/initiatorname.iscsi,nvme/{hostid,hostnqn}}
+    ln -s ca-certificates.crt /rootfs/etc/ssl/certs/ca-certificates
     ln -s /etc/ssl /rootfs/etc/pki
-    ln -s ca-certificates /rootfs/etc/ssl/certs/ca-certificates.crt
     ln -s /etc/ssl /rootfs/usr/share/ca-certificates
     ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
     ln -s /etc/ssl /rootfs/etc/ca-certificates


### PR DESCRIPTION
Before:

```
ls -l /etc/ssl/certs/
NODE         MODE         UID   GID   SIZE(B)   LASTMOD           LABEL                         NAME
172.20.0.2   drwxr-xr-x   0     0     65        Feb 12 14:20:52   system_u:object_r:etc_t:s0   .
172.20.0.2   -rw-r--r--   0     0     0         Feb 12 14:20:52   system_u:object_r:etc_t:s0   ca-certificates
172.20.0.2   -rw-r--r--   0     0     231212    Feb 12 16:47:29   system_u:object_r:etc_t:s0   ca-certificates.crt
```

After:

```
172.20.0.5   Lrwxrwxrwx   0     0     19        Feb 12 14:20:52   system_u:object_r:etc_t:s0   ca-certificates -> ca-certificates.crt
172.20.0.5   -rw-r--r--   0     0     231212    Feb 12 17:20:12   system_u:object_r:etc_t:s0   ca-certificates.crt
```

