### PR TITLE
fix: make ingress firewall filter traffic to nodeports

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -119,6 +119,12 @@ This also changes Talos root filesystem structure for unified /usr, with other d
 System extensions must move their directories accordingly for 1.10.
 """
 
+    [notes.ingress-firewall]
+        title = "Ingress Firewall"
+        description = """\
+Talos Ingress Firewall now filters access to Kubernetes NodePort services correctly.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
@@ -83,7 +83,7 @@ func (ctrl *NfTablesChainConfigController) Run(ctx context.Context, r controller
 
 					spec.Type = nethelpers.ChainTypeFilter
 					spec.Hook = nethelpers.ChainHookInput
-					spec.Priority = nethelpers.ChainPriorityFilter
+					spec.Priority = nethelpers.ChainPriorityMangle + 10
 					spec.Policy = nethelpers.VerdictAccept
 
 					// preamble

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_config_test.go
@@ -87,7 +87,7 @@ func (suite *NfTablesChainConfigTestSuite) TestDefaultAccept() {
 		spec := chain.TypedSpec()
 
 		asrt.Equal(nethelpers.ChainTypeFilter, spec.Type)
-		asrt.Equal(nethelpers.ChainPriorityFilter, spec.Priority)
+		asrt.Equal(nethelpers.ChainPriorityMangle+10, spec.Priority)
 		asrt.Equal(nethelpers.ChainHookInput, spec.Hook)
 		asrt.Equal(nethelpers.VerdictAccept, spec.Policy)
 
@@ -165,7 +165,7 @@ func (suite *NfTablesChainConfigTestSuite) TestDefaultBlock() {
 		spec := chain.TypedSpec()
 
 		asrt.Equal(nethelpers.ChainTypeFilter, spec.Type)
-		asrt.Equal(nethelpers.ChainPriorityFilter, spec.Priority)
+		asrt.Equal(nethelpers.ChainPriorityMangle+10, spec.Priority)
 		asrt.Equal(nethelpers.ChainHookInput, spec.Hook)
 		asrt.Equal(nethelpers.VerdictDrop, spec.Policy)
 


### PR DESCRIPTION
This fixes #10347

The core issue was that Talos nftables chain had priority 0 (`filter`), while kube-proxy does DNAT for node ports at priority -110 (before Talos can see source traffic), so Talos rule doesn't match.

Move Talos priority to -140, so it runs before kube-proxy.

