### PR TITLE
Update getting-started.md

### DIFF
--- a/website/content/v1.10/introduction/getting-started.md
+++ b/website/content/v1.10/introduction/getting-started.md
@@ -86,13 +86,17 @@ The endpoint should be formatted like:
 When Talos boots without a configuration, such as when booting off the Talos ISO, it
 enters maintenance mode and waits for a configuration to be provided.
 
-> A configuration can be passed in on boot via kernel parameters or metadata servers.
-> See [Production Notes]({{< relref "prodnotes#configure-talos" >}}).
+> NOTE: Talos initially loads the OS to RAM, and only installs to disk after the configuration is applied.
+> If you reboot the machine before applying machine config, make sure your boot media is still present.
 
 Unlike traditional Linux, Talos Linux is _not_ configured by SSHing to the server and issuing commands.
 Instead, the entire state of the machine is defined by a `machine config` file which is passed to the server.
 This allows machines to be managed in a declarative way, and lends itself to GitOps and modern operations paradigms.
+
 The state of a machine is completely defined by, and can be reproduced from, the machine configuration file.
+
+> A configuration can be passed in on boot via kernel parameters or metadata servers.
+> See [Production Notes]({{< relref "prodnotes#configure-talos" >}}).
 
 To generate the machine configurations for a cluster, run this command on the workstation where you installed `talosctl`:
 
@@ -158,7 +162,7 @@ You can verify which disks your nodes have by using the `talosctl get disks --in
 For example, the `talosctl get disks` command below shows that the system has a `vda` drive, not an `sda`:
 
 ```sh
-$ talosctl -n 192.168.0.2 disks --insecure
+$ talosctl -n 192.168.0.2 get disks --insecure
 DEV        MODEL   SERIAL   TYPE   UUID   WWID  MODALIAS                    NAME   SIZE    BUS_PATH
 /dev/vda   -       -        HDD    -      -      virtio:d00000002v00001AF4   -      69 GB   /pci0000:00/0000:00:06.0/virtio2/
 ```

--- a/website/content/v1.9/introduction/getting-started.md
+++ b/website/content/v1.9/introduction/getting-started.md
@@ -86,13 +86,17 @@ The endpoint should be formatted like:
 When Talos boots without a configuration, such as when booting off the Talos ISO, it
 enters maintenance mode and waits for a configuration to be provided.
 
-> A configuration can be passed in on boot via kernel parameters or metadata servers.
-> See [Production Notes]({{< relref "prodnotes#configure-talos" >}}).
+> NOTE: Talos initially loads the OS to RAM, and only installs to disk after the configuration is applied.
+> If you reboot the machine before applying machine config, make sure your boot media is still present.
 
 Unlike traditional Linux, Talos Linux is _not_ configured by SSHing to the server and issuing commands.
 Instead, the entire state of the machine is defined by a `machine config` file which is passed to the server.
 This allows machines to be managed in a declarative way, and lends itself to GitOps and modern operations paradigms.
+
 The state of a machine is completely defined by, and can be reproduced from, the machine configuration file.
+
+> A configuration can be passed in on boot via kernel parameters or metadata servers.
+> See [Production Notes]({{< relref "prodnotes#configure-talos" >}}).
 
 To generate the machine configurations for a cluster, run this command on the workstation where you installed `talosctl`:
 


### PR DESCRIPTION
## What? (description)

Clarifies even further that Talos is loaded to RAM until configuration is applied. Really trying to hammer it home. see #10349 

## Why? (reasoning)

Talos loading to RAM first is a unique aspect, outside the typical. Really hammering it home that if one restarts the machine, the OS is 'gone' and needs to be restarted. The reason https://github.com/siderolabs/talos/issues/10349 was because I went in with the assumption that the ISO wasn't needed any more before applying a configuration, which got me into the loop of UEFI shell.