### PR TITLE
feat: update Kubernetes to 1.32.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ INTEGRATION_TEST := integration-test
 INTEGRATION_TEST_DEFAULT_TARGET := $(INTEGRATION_TEST)-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_PROVISION_DEFAULT_TARGET := integration-test-provision-$(OPERATING_SYSTEM)
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
-KUBECTL_VERSION ?= v1.32.1
+KUBECTL_VERSION ?= v1.32.2
 # renovate: datasource=github-releases depName=kastenhq/kubestr
 KUBESTR_VERSION ?= v0.4.47
 # renovate: datasource=github-releases depName=helm/helm

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -24,6 +24,7 @@ preface = """
 * containerd: 2.0.2
 * etcd: 3.5.18
 * Flannel: 0.26.4
+* Kubernetes: 1.32.2
 
 Talos is built with Go 1.23.6.
 """

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -33,7 +33,7 @@ export TALOS_VERSION
 # Kubernetes
 
 export KUBECONFIG="${TMP}/kubeconfig"
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.32.1}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.32.2}
 
 export NAME_PREFIX="talos-e2e-${SHA}-${PLATFORM}"
 export TIMEOUT=1200

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -389,7 +389,7 @@ const (
 
 	// DefaultKubernetesVersion is the default target version of the control plane.
 	// renovate: datasource=github-releases depName=kubernetes/kubernetes
-	DefaultKubernetesVersion = "1.32.1"
+	DefaultKubernetesVersion = "1.32.2"
 
 	// SupportedKubernetesVersions is the number of Kubernetes versions supported by Talos starting from DefaultKubernesVersion going backwards.
 	SupportedKubernetesVersions = 6

--- a/website/content/v1.10/reference/cli.md
+++ b/website/content/v1.10/reference/cli.md
@@ -185,7 +185,7 @@ talosctl cluster create [flags]
       --ipxe-boot-script string                  iPXE boot script (URL) to use
       --iso-path string                          the ISO path to use for the initial boot (VM only)
       --kubeprism-port int                       KubePrism port (set to 0 to disable) (default 7445)
-      --kubernetes-version string                desired kubernetes version to run (default "1.32.1")
+      --kubernetes-version string                desired kubernetes version to run (default "1.32.2")
       --memory int                               the limit on memory usage in MB (each control plane/VM) (default 2048)
       --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
       --mount mount                              attach a mount to the container (Docker only)
@@ -1362,7 +1362,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
       --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")
-      --kubernetes-version string                desired kubernetes version to run (default "1.32.1")
+      --kubernetes-version string                desired kubernetes version to run (default "1.32.2")
   -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
   -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
   -p, --persist                                  the desired persist value for configs (default true)
@@ -1795,7 +1795,7 @@ talosctl image cache-create [flags]
 ### Examples
 
 ```
-talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:1.32.1 --image-cache-path=/tmp/talos-image-cache
+talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:1.32.2 --image-cache-path=/tmp/talos-image-cache
 
 Alternatively, stdin can be piped to the command:
 talosctl images default | talosctl images cache-create --image-cache-path=/tmp/talos-image-cache --images=-
@@ -3025,7 +3025,7 @@ talosctl upgrade-k8s [flags]
       --pre-pull-images                   pre-pull images before upgrade (default true)
       --proxy-image string                kube-proxy image to use (default "registry.k8s.io/kube-proxy")
       --scheduler-image string            kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
-      --to string                         the Kubernetes control plane version to upgrade to (default "1.32.1")
+      --to string                         the Kubernetes control plane version to upgrade to (default "1.32.2")
       --upgrade-kubelet                   upgrade kubelet service (default true)
       --with-docs                         patch all machine configs adding the documentation for each field (default true)
       --with-examples                     patch all machine configs with the commented examples (default true)

--- a/website/content/v1.10/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.10/reference/configuration/v1alpha1/config.md
@@ -90,7 +90,7 @@ controlPlane:
 {{< /highlight >}}</details> | |
 |`kubelet` |<a href="#Config.machine.kubelet">KubeletConfig</a> |Used to provide additional options to the kubelet. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.32.1 # The `image` field is an optional reference to an alternative kubelet image.
+    image: ghcr.io/siderolabs/kubelet:v1.32.2 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -519,7 +519,7 @@ KubeletConfig represents the kubelet config values.
 {{< highlight yaml >}}
 machine:
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.32.1 # The `image` field is an optional reference to an alternative kubelet image.
+        image: ghcr.io/siderolabs/kubelet:v1.32.2 # The `image` field is an optional reference to an alternative kubelet image.
         # The `extraArgs` field is used to provide additional flags to the kubelet.
         extraArgs:
             feature-gates: ServerSideApply=true
@@ -572,7 +572,7 @@ machine:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The `image` field is an optional reference to an alternative kubelet image. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: ghcr.io/siderolabs/kubelet:v1.32.1
+image: ghcr.io/siderolabs/kubelet:v1.32.2
 {{< /highlight >}}</details> | |
 |`clusterDNS` |[]string |The `ClusterDNS` field is an optional reference to an alternative kubelet clusterDNS ip list. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 clusterDNS:
@@ -2998,7 +2998,7 @@ serviceAccount:
 {{< /highlight >}}</details> | |
 |`apiServer` |<a href="#Config.cluster.apiServer">APIServerConfig</a> |API server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.32.1 # The container image used in the API server manifest.
+    image: registry.k8s.io/kube-apiserver:v1.32.2 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -3063,14 +3063,14 @@ apiServer:
 {{< /highlight >}}</details> | |
 |`controllerManager` |<a href="#Config.cluster.controllerManager">ControllerManagerConfig</a> |Controller manager server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.32.1 # The container image used in the controller manager manifest.
+    image: registry.k8s.io/kube-controller-manager:v1.32.2 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
         feature-gates: ServerSideApply=true
 {{< /highlight >}}</details> | |
 |`proxy` |<a href="#Config.cluster.proxy">ProxyConfig</a> |Kube-proxy server-specific configuration options <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 proxy:
-    image: registry.k8s.io/kube-proxy:v1.32.1 # The container image used in the kube-proxy manifest.
+    image: registry.k8s.io/kube-proxy:v1.32.2 # The container image used in the kube-proxy manifest.
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
@@ -3081,7 +3081,7 @@ proxy:
 {{< /highlight >}}</details> | |
 |`scheduler` |<a href="#Config.cluster.scheduler">SchedulerConfig</a> |Scheduler server specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.32.1 # The container image used in the scheduler manifest.
+    image: registry.k8s.io/kube-scheduler:v1.32.2 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
         feature-gates: AllBeta=true
@@ -3325,7 +3325,7 @@ APIServerConfig represents the kube apiserver configuration options.
 {{< highlight yaml >}}
 cluster:
     apiServer:
-        image: registry.k8s.io/kube-apiserver:v1.32.1 # The container image used in the API server manifest.
+        image: registry.k8s.io/kube-apiserver:v1.32.2 # The container image used in the API server manifest.
         # Extra arguments to supply to the API server.
         extraArgs:
             feature-gates: ServerSideApply=true
@@ -3393,7 +3393,7 @@ cluster:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the API server manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-apiserver:v1.32.1
+image: registry.k8s.io/kube-apiserver:v1.32.2
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the API server.  | |
 |`extraVolumes` |<a href="#Config.cluster.apiServer.extraVolumes.">[]VolumeMountConfig</a> |Extra volumes to mount to the API server static pod.  | |
@@ -3605,7 +3605,7 @@ ControllerManagerConfig represents the kube controller manager configuration opt
 {{< highlight yaml >}}
 cluster:
     controllerManager:
-        image: registry.k8s.io/kube-controller-manager:v1.32.1 # The container image used in the controller manager manifest.
+        image: registry.k8s.io/kube-controller-manager:v1.32.2 # The container image used in the controller manager manifest.
         # Extra arguments to supply to the controller manager.
         extraArgs:
             feature-gates: ServerSideApply=true
@@ -3615,7 +3615,7 @@ cluster:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the controller manager manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-controller-manager:v1.32.1
+image: registry.k8s.io/kube-controller-manager:v1.32.2
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the controller manager.  | |
 |`extraVolumes` |<a href="#Config.cluster.controllerManager.extraVolumes.">[]VolumeMountConfig</a> |Extra volumes to mount to the controller manager static pod.  | |
@@ -3685,7 +3685,7 @@ ProxyConfig represents the kube proxy configuration options.
 {{< highlight yaml >}}
 cluster:
     proxy:
-        image: registry.k8s.io/kube-proxy:v1.32.1 # The container image used in the kube-proxy manifest.
+        image: registry.k8s.io/kube-proxy:v1.32.2 # The container image used in the kube-proxy manifest.
         mode: ipvs # proxy mode of kube-proxy.
         # Extra arguments to supply to kube-proxy.
         extraArgs:
@@ -3702,7 +3702,7 @@ cluster:
 disabled: false
 {{< /highlight >}}</details> | |
 |`image` |string |The container image used in the kube-proxy manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-proxy:v1.32.1
+image: registry.k8s.io/kube-proxy:v1.32.2
 {{< /highlight >}}</details> | |
 |`mode` |string |<details><summary>proxy mode of kube-proxy.</summary>The default is 'iptables'.</details>  | |
 |`extraArgs` |map[string]string |Extra arguments to supply to kube-proxy.  | |
@@ -3721,7 +3721,7 @@ SchedulerConfig represents the kube scheduler configuration options.
 {{< highlight yaml >}}
 cluster:
     scheduler:
-        image: registry.k8s.io/kube-scheduler:v1.32.1 # The container image used in the scheduler manifest.
+        image: registry.k8s.io/kube-scheduler:v1.32.2 # The container image used in the scheduler manifest.
         # Extra arguments to supply to the scheduler.
         extraArgs:
             feature-gates: AllBeta=true
@@ -3731,7 +3731,7 @@ cluster:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`image` |string |The container image used in the scheduler manifest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: registry.k8s.io/kube-scheduler:v1.32.1
+image: registry.k8s.io/kube-scheduler:v1.32.2
 {{< /highlight >}}</details> | |
 |`extraArgs` |map[string]string |Extra arguments to supply to the scheduler.  | |
 |`extraVolumes` |<a href="#Config.cluster.scheduler.extraVolumes.">[]VolumeMountConfig</a> |Extra volumes to mount to the scheduler static pod.  | |


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/releases/tag/v1.32.2

The Go modules haven't been tagged yet, but it should not be important.
