### PR TITLE
chore: fix spurious generate failures

### DIFF
--- a/pkg/flannel/flannel.go
+++ b/pkg/flannel/flannel.go
@@ -5,4 +5,4 @@
 // Package flannel provides flannel default manifest.
 package flannel
 
-//go:generate go run ./gen.go
+//go:generate env CGO_ENABLED=0 go run ./gen.go

--- a/pkg/machinery/version/osrelease.go
+++ b/pkg/machinery/version/osrelease.go
@@ -4,7 +4,7 @@
 
 package version
 
-//go:generate go run ./gen.go
+//go:generate env CGO_ENABLED=0 go run ./gen.go
 
 import (
 	"bytes"


### PR DESCRIPTION
```
fork/exec /tmp/go-build720301329/b001/exe/gen: no such file or directory
pkg/flannel/flannel.go:8: running "go": exit status 1
```

I believe the root cause might be cache miss, that might cause `generate` target to be called from `WITH_RACE=true` target, enabling `CGO_ENABLED=1`, so it is random to reproduce (depends on buildkit cache behavior).

