### PR TITLE
docs: add a note about syslog sending messages to services

### DIFF
--- a/website/content/v1.10/talos-guides/configuration/logging.md
+++ b/website/content/v1.10/talos-guides/configuration/logging.md
@@ -105,6 +105,9 @@ machine:
 
 The specified `extraTags` are added to every message sent to the destination verbatim.
 
+> `syslog` is considered a service in Talos, and so messages/logs sent to syslog (e.g., by system extensions) are considered
+> service logs and will be sent to any configured remote receivers without further configuration.
+
 ### Kernel logs
 
 Kernel log delivery can be enabled with the `talos.logging.kernel` kernel command line argument, which can be specified
@@ -332,7 +335,7 @@ helm repo add fluent https://fluent.github.io/helm-charts
 helm upgrade -i --namespace=kube-system -f fluentd-bit.yaml fluent-bit fluent/fluent-bit
 ```
 
-Now  we need to find the service IP.
+Now we need to find the service IP.
 
 ```shell
 $ kubectl -n kube-system get svc -l app.kubernetes.io/name=fluent-bit

--- a/website/content/v1.9/talos-guides/configuration/logging.md
+++ b/website/content/v1.9/talos-guides/configuration/logging.md
@@ -2,7 +2,7 @@
 title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
-  - ../../guiides/logging
+  - ../../guides/logging
 ---
 
 ## Viewing logs
@@ -104,6 +104,9 @@ machine:
 ```
 
 The specified `extraTags` are added to every message sent to the destination verbatim.
+
+> `syslog` is considered a service in Talos, and so messages/logs sent to syslog (e.g., by system extensions) are considered
+> service logs and will be sent to any configured remote receivers without further configuration.
 
 ### Kernel logs
 
@@ -332,7 +335,7 @@ helm repo add fluent https://fluent.github.io/helm-charts
 helm upgrade -i --namespace=kube-system -f fluentd-bit.yaml fluent-bit fluent/fluent-bit
 ```
 
-Now  we need to find the service IP.
+Now we need to find the service IP.
 
 ```shell
 $ kubectl -n kube-system get svc -l app.kubernetes.io/name=fluent-bit


### PR DESCRIPTION
Refs: #10356

Adds a note to the website docs about syslog being part of services, so any messages sent there will be output to any configured remote logging receivers.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Adds a note to the website docs about syslog being part of services, so any messages sent there will be output to any configured remote logging receivers. I added this to both 1.9 and 1.10 website branches to ensure it was in future versions.

## Why? (reasoning)
Details in referenced issue (#10356), but the other 2 logging facilities (kernel and services) have specific callouts with respect to configuring a remote receiver, but syslog does not. This clarifies that syslog is part of services, so messages sent there will be sent to the services receiver.

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`) <- see note below
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

Note: conformance test output was: 
```
POLICY         CHECK                        STATUS        MESSAGE
commit         Header Length                PASS          Header is 58 characters
commit         Imperative Mood              PASS          Commit begins with imperative verb
commit         Header Case                  PASS          Header case is valid
commit         Header Last Character        PASS          Header last character is valid
commit         DCO                          PASS          Developer Certificate of Origin was found
commit         GPG                          PASS          GPG signature found
commit         GPG Identity                 FAILED        openpgp: signature made by unknown entity
commit         Conventional Commit          PASS          Commit message is a valid conventional commit
commit         Spellcheck                   PASS          Commit contains 0 misspellings
commit         Number of Commits            PASS          HEAD is 1 commit(s) ahead of refs/heads/main
commit         Commit Body                  PASS          Commit body is valid
license        File Header                  PASS          All files have a valid license header
```

This is my first time signing something with gpg, and I believe I followed the steps to add my key to my GitHub profile so I'm not sure what to do about the failed identity test. Thanks!
