### PR TITLE
feat: support noclooud instance-id from dmi

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
@@ -248,8 +248,8 @@ func (n *Nocloud) acquireConfig(ctx context.Context, r state.State) (metadataNet
 	}
 
 	var (
-		metaBaseURL, hostname string
-		networkSource         bool
+		metaBaseURL, hostname, instanceID string
+		networkSource                     bool
 	)
 
 	options := strings.Split(s.SystemInformation.SerialNumber, ";")
@@ -274,6 +274,9 @@ func (n *Nocloud) acquireConfig(ctx context.Context, r state.State) (metadataNet
 				}
 			case "h":
 				hostname = parts[1]
+
+			case "i":
+				instanceID = parts[1]
 			}
 		}
 	}
@@ -294,6 +297,10 @@ func (n *Nocloud) acquireConfig(ctx context.Context, r state.State) (metadataNet
 
 	if hostname != "" {
 		metadata.Hostname = hostname
+	}
+
+	if instanceID != "" {
+		metadata.InstanceID = instanceID
 	}
 
 	// Some providers may provide the hostname via user-data instead of meta-data (e.g. Proxmox VE)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

The official documentation has a "i" value that is used as the instance-id meta parameter.
https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html

## Why? (reasoning)

```shell
-smbios type=1,serial=ds=nocloud;h=my-host-name;i=id-1234
```

I know that the cloud (Proxmox) sets a randomly generated instance-id in the metadata file. This value cannot be reliably used in the future by code, as there is no mapping to a real ID, UUID, or other identifiers.

This PR aims to override the randomly generated Proxmox value.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
