### PR TITLE
Ignore digest part of images when checking version in pre-flight

### DIFF
--- a/cmd/installer/pkg/install/preflight_test.go
+++ b/cmd/installer/pkg/install/preflight_test.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/installer/pkg/install"
+)
+
+func TestKubernetesVersionFromImageRef(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		imageRef string
+
+		expectedVersion string
+	}{
+		{
+			imageRef:        "ghcr.io/siderolabs/kubelet:v1.32.2",
+			expectedVersion: "1.32.2",
+		},
+		{
+			imageRef:        "ghcr.io/siderolabs/kubelet:v1.32.2@sha256:123456",
+			expectedVersion: "1.32.2",
+		},
+	} {
+		t.Run(test.imageRef, func(t *testing.T) {
+			t.Parallel()
+
+			version, err := install.KubernetesVersionFromImageRef(test.imageRef)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedVersion, version.String())
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Ignore the digest part of container images in machineconfig when checking semantic version validity through github.com/blang/semver/v4.

Closes #10373.

## Why? (reasoning)

We want to pin image digests, but pre-flight tries to validate tag _and_ digest for semantic versioning.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
