### PR TITLE
docs: remove typo on resetting a machine page

### DIFF
--- a/website/content/v1.10/talos-guides/resetting-a-machine.md
+++ b/website/content/v1.10/talos-guides/resetting-a-machine.md
@@ -22,7 +22,7 @@ There are a couple of flags as part of this command:
 Flags:
       --graceful                        if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
       --reboot                          if true, reboot the node after resetting instead of shutting down
-      --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact keep other partitions intact
+      --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact
 ```
 
 The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.

--- a/website/content/v1.9/talos-guides/resetting-a-machine.md
+++ b/website/content/v1.9/talos-guides/resetting-a-machine.md
@@ -22,7 +22,7 @@ There are a couple of flags as part of this command:
 Flags:
       --graceful                        if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
       --reboot                          if true, reboot the node after resetting instead of shutting down
-      --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact keep other partitions intact
+      --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact
 ```
 
 The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.


### PR DESCRIPTION
Remove minor typo on [Resetting a Machine](https://www.talos.dev/v1.9/talos-guides/resetting-a-machine/).

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Corrects a typo in the documentation.

## Why? (reasoning)

To improve the documentation

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
