### PR TITLE
Docs update resetting-a-machine.md to include example of reset cmd

### DIFF
--- a/website/content/v1.9/talos-guides/resetting-a-machine.md
+++ b/website/content/v1.9/talos-guides/resetting-a-machine.md
@@ -10,12 +10,15 @@ Bear in mind that this is a destructive action for the given machine.
 Doing this means removing the machine from Kubernetes, `etcd` (if applicable), and clears any data on the machine that would normally persist a reboot.
 
 ## CLI
+The API command for doing this is `talosctl reset`.  
+```sh
+talosctl reset -n <node_ip> -e <endpoint_ip_to_be_reset> --talosconfig=./talosconfig
+```
 
 > WARNING: Running a `talosctl reset` on cloud VM's might result in the VM being unable to boot as this wipes the entire disk.
 It might be more useful to just wipe the [STATE]({{< relref "../learn-more/architecture/#file-system-partitions" >}}) and [EPHEMERAL]({{< relref "../learn-more/architecture/#file-system-partitions" >}}) partitions on a cloud VM if not booting via `iPXE`.
 `talosctl reset --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL`
 
-The API command for doing this is `talosctl reset`.
 There are a couple of flags as part of this command:
 
 ```bash


### PR DESCRIPTION
## What 
Slight formatting change and provided example of `talosctl reset`.

## Why
Consistency of showing example and made `reset` the focus of the section.
