### PR TITLE
feat: validate docker image references in upgrade options

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/distribution/reference"
 	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/gen/xiter"
 	"github.com/siderolabs/go-kubernetes/kubernetes/manifests"
@@ -42,10 +43,43 @@ type UpgradeProvider interface {
 	cluster.K8sProvider
 }
 
+// ValidateImageReference validates if the provided string is a valid Docker image reference.
+func ValidateImageReference(ref string) error {
+	_, err := reference.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("invalid image reference: %w", err)
+	}
+
+	return nil
+}
+
+// Validate checks all image references in the upgrade options.
+func (options *UpgradeOptions) Validate() error {
+	images := map[string]string{
+		"kubelet":            options.KubeletImage,
+		"apiserver":          options.APIServerImage,
+		"controller-manager": options.ControllerManagerImage,
+		"scheduler":          options.SchedulerImage,
+		"proxy":              options.ProxyImage,
+	}
+
+	for name, image := range images {
+		if err := ValidateImageReference(image); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
 // Upgrade the Kubernetes control plane components, manifests, kubelets.
 //
 //nolint:gocyclo
 func Upgrade(ctx context.Context, cluster UpgradeProvider, options UpgradeOptions) error {
+	if err := options.Validate(); err != nil {
+		return fmt.Errorf("invalid upgrade options: %w", err)
+	}
+
 	if !options.Path.IsSupported() {
 		return fmt.Errorf("unsupported upgrade path %s (from %q to %q)", options.Path, options.Path.FromVersion(), options.Path.ToVersion())
 	}

--- a/pkg/cluster/kubernetes/upgrade_test.go
+++ b/pkg/cluster/kubernetes/upgrade_test.go
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/cluster/kubernetes"
+)
+
+func TestValidateImageReference(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid simple image",
+			ref:     "k8s.gcr.io/kube-apiserver:v1.23.0",
+			wantErr: false,
+		},
+		{
+			name:    "valid image with digest",
+			ref:     "k8s.gcr.io/kube-apiserver@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantErr: false,
+		},
+		{
+			name:    "valid image with port",
+			ref:     "localhost:5000/kube-apiserver:latest",
+			wantErr: false,
+		},
+		{
+			name:    "invalid image reference",
+			ref:     "invalid/image@sha256:invalid",
+			wantErr: true,
+			errMsg:  "invalid image reference",
+		},
+		{
+			name:    "invalid image reference v2",
+			ref:     ":v1.32.1",
+			wantErr: true,
+			errMsg:  "invalid image reference",
+		},
+		{
+			name:    "empty image reference",
+			ref:     "",
+			wantErr: true,
+			errMsg:  "invalid image reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := kubernetes.ValidateImageReference(tt.ref)
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpgradeOptions_validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options kubernetes.UpgradeOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid images",
+			options: kubernetes.UpgradeOptions{
+				KubeletImage:           "k8s.gcr.io/kubelet:v1.23.0",
+				APIServerImage:         "k8s.gcr.io/kube-apiserver:v1.23.0",
+				ControllerManagerImage: "k8s.gcr.io/kube-controller-manager:v1.23.0",
+				SchedulerImage:         "k8s.gcr.io/kube-scheduler:v1.23.0",
+				ProxyImage:             "k8s.gcr.io/kube-proxy:v1.23.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid kubelet image",
+			options: kubernetes.UpgradeOptions{
+				KubeletImage:           "invalid/image@sha256:invalid",
+				APIServerImage:         "k8s.gcr.io/kube-apiserver:v1.23.0",
+				ControllerManagerImage: "k8s.gcr.io/kube-controller-manager:v1.23.0",
+				SchedulerImage:         "k8s.gcr.io/kube-scheduler:v1.23.0",
+				ProxyImage:             "k8s.gcr.io/kube-proxy:v1.23.0",
+			},
+			wantErr: true,
+			errMsg:  "kubelet: invalid image reference",
+		},
+		{
+			name: "invalid apiserver image",
+			options: kubernetes.UpgradeOptions{
+				KubeletImage:           "k8s.gcr.io/kubelet:v1.23.0",
+				APIServerImage:         ":v1.23.0",
+				ControllerManagerImage: "k8s.gcr.io/kube-controller-manager:v1.23.0",
+				SchedulerImage:         "k8s.gcr.io/kube-scheduler:v1.23.0",
+				ProxyImage:             "k8s.gcr.io/kube-proxy:v1.23.0",
+			},
+			wantErr: true,
+			errMsg:  "apiserver: invalid image reference",
+		},
+		{
+			name: "image with digest",
+			options: kubernetes.UpgradeOptions{
+				KubeletImage:           "k8s.gcr.io/kubelet@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				APIServerImage:         "k8s.gcr.io/kube-apiserver:v1.23.0",
+				ControllerManagerImage: "k8s.gcr.io/kube-controller-manager:v1.23.0",
+				SchedulerImage:         "k8s.gcr.io/kube-scheduler:v1.23.0",
+				ProxyImage:             "k8s.gcr.io/kube-proxy:v1.23.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "image with port number",
+			options: kubernetes.UpgradeOptions{
+				KubeletImage:           "localhost:5000/kubelet:latest",
+				APIServerImage:         "k8s.gcr.io/kube-apiserver:v1.23.0",
+				ControllerManagerImage: "k8s.gcr.io/kube-controller-manager:v1.23.0",
+				SchedulerImage:         "k8s.gcr.io/kube-scheduler:v1.23.0",
+				ProxyImage:             "k8s.gcr.io/kube-proxy:v1.23.0",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.options.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What? (description)

This commit adds validation for Docker image references in the UpgradeOptions struct. The validation ensures that all image fields (kubelet, apiserver, controller-manager, scheduler, proxy) are valid Docker image references before proceeding with the upgrade process.

The implementation:
- Uses the distribution/reference package for robust Docker image validation
- Validates all image fields in UpgradeOptions struct
- Performs validation before starting the upgrade process
- Provides clear error messages indicating which image field is invalid
- Includes comprehensive tests covering various image reference formats
- Supports backward compatibility

This change helps prevent potential issues during the upgrade process by catching invalid image references early with clear error messages.

## Why? (reasoning)

When working with the library, I broke my Kubernetes cluster. 

```bash
Upgrading Kubernetes to version v1.32.1
discovered controlplane nodes ["10.10.10.10"]
updating "kube-apiserver" to version "1.32.1"
 > "10.10.10.10": starting update
 > update kube-apiserver: v1.32.0 -> 1.32.1
 > "10.10.10.10": machine configuration patched
 > "10.10.10.10": waiting for kube-apiserver pod update
 > "10.10.10.10": kube-apiserver: waiting, config version mismatch: got "12", expected "13"
^Csignal: interrupt

talosctl --talosconfig=./talosconfig  --nodes=10.10.10.10 logs kubelet  | grep kube-apiserver | tail -1
10.10.10.10: {"ts":1739781513171.0198,"caller":"kubelet/pod_workers.go:1301","msg":"Error syncing pod, skipping","pod":{"name":"kube-apiserver-azalio-talos-cp1","namespace":"kube-system"},"podUID":"c0185797c1b64406a14ccd9c6585cd36","err":"failed to \"StartContainer\" for \"kube-apiserver\" with InvalidImageName: \"Failed to apply default image tag \\\":v1.32.1\\\": couldn't parse image name \\\":v1.32.1\\\": invalid reference format\"","errCauses":[{"error":"failed to \"StartContainer\" for \"kube-apiserver\" with InvalidImageName: \"Failed to apply default image tag \\\":v1.32.1\\\": couldn't parse image name \\\":v1.32.1\\\": invalid reference format\""}]}
```

I started to investigate the issue and realized that the [Upgrade](https://github.com/siderolabs/talos/blob/main/pkg/cluster/kubernetes/talos_managed.go#L48) function was not checking if all the necessary parameters had been submitted. 
For instance, it turned out that the image being downloaded was `:v1.31.1`, which is clearly the wrong version to download. 

This caused the Kubernetes cluster to become unstable. I have created a patch to validate these options and ensure that they are correct.

I have written a simple example to demonstrate this behavior.
https://gist.github.com/azalio/4017548d95cc9b75ae2e8c9725fccca6

## Acceptance

Please use the following checklist:

- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)

```bash
commit         GPG Identity                 FAILED        openpgp: signature made by unknown entity
```

- [x] you formatted your code (`make fmt`)

I have launched, but these are not my own changes.

```bash
	modified:   api/resource/definitions/block/block.proto
	modified:   api/resource/definitions/cluster/cluster.proto
	modified:   api/resource/definitions/cri/cri.proto
	modified:   api/resource/definitions/enums/enums.proto
	modified:   api/resource/definitions/etcd/etcd.proto
	modified:   api/resource/definitions/extensions/extensions.proto
	modified:   api/resource/definitions/files/files.proto
	modified:   api/resource/definitions/hardware/hardware.proto
	modified:   api/resource/definitions/k8s/k8s.proto
	modified:   api/resource/definitions/kubeaccess/kubeaccess.proto
	modified:   api/resource/definitions/kubespan/kubespan.proto
	modified:   api/resource/definitions/network/network.proto
	modified:   api/resource/definitions/perf/perf.proto
	modified:   api/resource/definitions/proto/proto.proto
	modified:   api/resource/definitions/runtime/runtime.proto
	modified:   api/resource/definitions/secrets/secrets.proto
	modified:   api/resource/definitions/siderolink/siderolink.proto
	modified:   api/resource/definitions/time/time.proto
	modified:   api/resource/definitions/v1alpha1/v1alpha1.proto
```

- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
