### PR TITLE
chore: update enumer to a version that fixes Go 1.24 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,7 +222,7 @@ ARG STRINGER_VERSION
 RUN --mount=type=cache,target=/.cache go install golang.org/x/tools/cmd/stringer@${STRINGER_VERSION} \
     && mv /root/go/bin/stringer /usr/bin/stringer
 ARG ENUMER_VERSION
-RUN --mount=type=cache,target=/.cache go install github.com/dsseng/enumer@${ENUMER_VERSION} \
+RUN --mount=type=cache,target=/.cache go install github.com/dmarkham/enumer@${ENUMER_VERSION} \
     && mv /root/go/bin/enumer /usr/bin/enumer
 ARG DEEPCOPY_GEN_VERSION
 RUN --mount=type=cache,target=/.cache go install k8s.io/code-generator/cmd/deepcopy-gen@${DEEPCOPY_GEN_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,7 @@ GOLANGCILINT_VERSION ?= v1.62.2
 # renovate: datasource=go depName=golang.org/x/tools
 STRINGER_VERSION ?= v0.28.0
 # renovate: datasource=go depName=github.com/dmarkham/enumer
-# FIXME: https://github.com/dmarkham/enumer/issues/105
-ENUMER_VERSION ?= v1.5.11-0.20250217145611-d1015c2bde3f
+ENUMER_VERSION ?= v1.5.11
 # renovate: datasource=go depName=k8s.io/code-generator
 DEEPCOPY_GEN_VERSION ?= v0.32.0
 # renovate: datasource=go depName=github.com/planetscale/vtprotobuf


### PR DESCRIPTION
Go back to upstream releases after https://github.com/dmarkham/enumer/issues/105 has been fixed

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
