### PR TITLE
fix: multiple fixes for dashboard/no data

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -15,5 +15,5 @@ assignees: ""
 ### Environment
 
 - Talos version: [`talosctl version --nodes <problematic nodes>`]
-- Kubernetes version: [`kubectl version --short`]
+- Kubernetes version: [`kubectl version`]
 - Platform:

--- a/internal/pkg/dashboard/apidata/node.go
+++ b/internal/pkg/dashboard/apidata/node.go
@@ -13,7 +13,6 @@ import (
 // Node represents data gathered from a single node.
 type Node struct {
 	// These fields are directly API responses.
-	Hostname      *machine.Hostname
 	LoadAvg       *machine.LoadAvg
 	Version       *machine.Version
 	Memory        *machine.Memory


### PR DESCRIPTION
There were multiple issues:

* `hostname` in the header is coming from resources, and the one in API data was unused
* we should update to `n/a` if the value is not available
* if the node is unavailable, the response contains a message with placeholders with a proxy error, and that should be honored to ignore the response; if instead we use it as it is, it puts zero value, which results in funny output.

Fixes #10383
