### PR TITLE
fix: correctly map link names/aliases when using VIP operator

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -205,7 +205,7 @@ func (ctrl *AddressConfigController) parseCmdline(logger *zap.Logger) (addresses
 		return
 	}
 
-	settings, err := ParseCmdlineNetwork(ctrl.Cmdline)
+	settings, err := ParseCmdlineNetwork(ctrl.Cmdline, network.NewEmptyLinkResolver())
 	if err != nil {
 		logger.Info("ignoring cmdline parse failure", zap.Error(err))
 

--- a/internal/app/machined/pkg/controllers/network/hostname_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config.go
@@ -230,7 +230,7 @@ func (ctrl *HostnameConfigController) parseCmdline(logger *zap.Logger) (spec net
 		return
 	}
 
-	settings, err := ParseCmdlineNetwork(ctrl.Cmdline)
+	settings, err := ParseCmdlineNetwork(ctrl.Cmdline, network.NewEmptyLinkResolver())
 	if err != nil {
 		logger.Warn("ignoring error", zap.Error(err))
 

--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -6,25 +6,18 @@
 package network_test
 
 import (
-	"context"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
-	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/go-procfs/procfs"
-	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap/zaptest"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -34,86 +27,34 @@ import (
 )
 
 type OperatorConfigSuite struct {
-	suite.Suite
-
-	state state.State
-
-	runtime *runtime.Runtime
-	wg      sync.WaitGroup
-
-	ctx       context.Context //nolint:containedctx
-	ctxCancel context.CancelFunc
-}
-
-func (suite *OperatorConfigSuite) SetupTest() {
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
-
-	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var err error
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
-	suite.Require().NoError(err)
-
-	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.DeviceConfigController{}))
-}
-
-func (suite *OperatorConfigSuite) startRuntime() {
-	suite.wg.Add(1)
-
-	go func() {
-		defer suite.wg.Done()
-
-		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
-	}()
+	ctest.DefaultSuite
 }
 
 func (suite *OperatorConfigSuite) assertOperators(requiredIDs []string, check func(*network.OperatorSpec, *assert.Assertions)) {
-	assertResources(suite.ctx, suite.T(), suite.state, requiredIDs, check, rtestutils.WithNamespace(network.ConfigNamespaceName))
+	ctest.AssertResources(suite, requiredIDs, check, rtestutils.WithNamespace(network.ConfigNamespaceName))
 }
 
-func (suite *OperatorConfigSuite) assertNoOperators(unexpectedIDs []string) error {
-	unexpIDs := make(map[string]struct{}, len(unexpectedIDs))
-
+func (suite *OperatorConfigSuite) assertNoOperators(unexpectedIDs []string) {
 	for _, id := range unexpectedIDs {
-		unexpIDs[id] = struct{}{}
+		ctest.AssertNoResource[*network.OperatorSpec](suite, id, rtestutils.WithNamespace(network.ConfigNamespaceName))
 	}
-
-	resources, err := suite.state.List(
-		suite.ctx,
-		resource.NewMetadata(network.ConfigNamespaceName, network.OperatorSpecType, "", resource.VersionUndefined),
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, res := range resources.Items {
-		_, unexpected := unexpIDs[res.Metadata().ID()]
-		if unexpected {
-			return retry.ExpectedErrorf("unexpected ID %q", res.Metadata().ID())
-		}
-	}
-
-	return nil
 }
 
 func (suite *OperatorConfigSuite) TestDefaultDHCP() {
 	suite.Require().NoError(
-		suite.runtime.RegisterController(
+		suite.Runtime().RegisterController(
 			&netctrl.OperatorConfigController{
 				Cmdline: procfs.NewCmdline("talos.network.interface.ignore=eth2"),
 			},
 		),
 	)
 
-	suite.startRuntime()
-
 	for _, link := range []string{"eth0", "eth1", "eth2"} {
 		linkStatus := network.NewLinkStatus(network.NamespaceName, link)
 		linkStatus.TypedSpec().Type = nethelpers.LinkEther
 		linkStatus.TypedSpec().LinkState = true
 
-		suite.Require().NoError(suite.state.Create(suite.ctx, linkStatus))
+		suite.Create(linkStatus)
 	}
 
 	suite.assertOperators(
@@ -137,21 +78,19 @@ func (suite *OperatorConfigSuite) TestDefaultDHCP() {
 
 func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 	suite.Require().NoError(
-		suite.runtime.RegisterController(
+		suite.Runtime().RegisterController(
 			&netctrl.OperatorConfigController{
 				Cmdline: procfs.NewCmdline("ip=172.20.0.2::172.20.0.1:255.255.255.0::eth1::::: ip=eth3:dhcp"),
 			},
 		),
 	)
 
-	suite.startRuntime()
-
 	for _, link := range []string{"eth0", "eth1", "eth2"} {
 		linkStatus := network.NewLinkStatus(network.NamespaceName, link)
 		linkStatus.TypedSpec().Type = nethelpers.LinkEther
 		linkStatus.TypedSpec().LinkState = true
 
-		suite.Require().NoError(suite.state.Create(suite.ctx, linkStatus))
+		suite.Create(linkStatus)
 	}
 
 	suite.assertOperators(
@@ -177,28 +116,22 @@ func (suite *OperatorConfigSuite) TestDefaultDHCPCmdline() {
 
 	// remove link
 	suite.Require().NoError(
-		suite.state.Destroy(
-			suite.ctx,
+		suite.State().Destroy(
+			suite.Ctx(),
 			resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "eth2", resource.VersionUndefined),
 		),
 	)
 
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertNoOperators(
-					[]string{
-						"default/dhcp4/eth2",
-					},
-				)
-			},
-		),
+	suite.assertNoOperators(
+		[]string{
+			"default/dhcp4/eth2",
+		},
 	)
 }
 
 func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 	suite.Require().NoError(
-		suite.runtime.RegisterController(
+		suite.Runtime().RegisterController(
 			&netctrl.OperatorConfigController{
 				Cmdline: procfs.NewCmdline("talos.network.interface.ignore=eth5"),
 			},
@@ -206,21 +139,19 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 	)
 	// add LinkConfig controller to produce link specs based on machine configuration
 	suite.Require().NoError(
-		suite.runtime.RegisterController(
+		suite.Runtime().RegisterController(
 			&netctrl.LinkConfigController{
 				Cmdline: procfs.NewCmdline("talos.network.interface.ignore=eth5"),
 			},
 		),
 	)
 
-	suite.startRuntime()
-
 	for _, link := range []string{"eth0", "eth1", "eth2"} {
 		linkStatus := network.NewLinkStatus(network.NamespaceName, link)
 		linkStatus.TypedSpec().Type = nethelpers.LinkEther
 		linkStatus.TypedSpec().LinkState = true
 
-		suite.Require().NoError(suite.state.Create(suite.ctx, linkStatus))
+		suite.Create(linkStatus)
 	}
 
 	u, err := url.Parse("https://foo:6443")
@@ -289,7 +220,7 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 		),
 	)
 
-	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+	suite.Create(cfg)
 
 	suite.assertOperators(
 		[]string{
@@ -320,27 +251,19 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP4() {
 		},
 	)
 
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertNoOperators(
-					[]string{
-						"configuration/dhcp4/eth0",
-						"default/dhcp4/eth0",
-						"configuration/dhcp4/eth2",
-						"default/dhcp4/eth2",
-						"configuration/dhcp4/eth4.26",
-					},
-				)
-			},
-		),
+	suite.assertNoOperators(
+		[]string{
+			"configuration/dhcp4/eth0",
+			"default/dhcp4/eth0",
+			"configuration/dhcp4/eth2",
+			"default/dhcp4/eth2",
+			"configuration/dhcp4/eth4.26",
+		},
 	)
 }
 
 func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP6() {
-	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.OperatorConfigController{}))
-
-	suite.startRuntime()
+	suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.OperatorConfigController{}))
 
 	u, err := url.Parse("https://foo:6443")
 	suite.Require().NoError(err)
@@ -388,7 +311,7 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP6() {
 		),
 	)
 
-	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+	suite.Create(cfg)
 
 	suite.assertOperators(
 		[]string{
@@ -409,27 +332,170 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP6() {
 		},
 	)
 
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertNoOperators(
-					[]string{
-						"configuration/dhcp6/eth1",
-					},
-				)
-			},
-		),
+	suite.assertNoOperators(
+		[]string{
+			"configuration/dhcp6/eth1",
+		},
 	)
 }
 
-func (suite *OperatorConfigSuite) TearDownTest() {
-	suite.T().Log("tear down")
+func (suite *OperatorConfigSuite) TestMachineConfigurationWithAliases() {
+	suite.Require().NoError(
+		suite.Runtime().RegisterController(
+			&netctrl.OperatorConfigController{},
+		),
+	)
+	// add LinkConfig controller to produce link specs based on machine configuration
+	suite.Require().NoError(
+		suite.Runtime().RegisterController(
+			&netctrl.LinkConfigController{},
+		),
+	)
 
-	suite.ctxCancel()
+	for _, link := range []struct {
+		name    string
+		aliases []string
+	}{
+		{
+			name:    "eth0",
+			aliases: []string{"enx0123"},
+		},
+		{
+			name:    "eth1",
+			aliases: []string{"enx0456"},
+		},
+		{
+			name:    "eth2",
+			aliases: []string{"enxa"},
+		},
+		{
+			name:    "eth3",
+			aliases: []string{"enxb"},
+		},
+		{
+			name:    "eth4",
+			aliases: []string{"enxc"},
+		},
+	} {
+		status := network.NewLinkStatus(network.NamespaceName, link.name)
+		status.TypedSpec().AltNames = link.aliases
+		status.TypedSpec().Type = nethelpers.LinkEther
+		status.TypedSpec().LinkState = true
 
-	suite.wg.Wait()
+		suite.Create(status)
+	}
+
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(
+		container.NewV1Alpha1(
+			&v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineNetwork: &v1alpha1.NetworkConfig{
+						NetworkInterfaces: []*v1alpha1.Device{
+							{
+								DeviceInterface: "enx0123",
+							},
+							{
+								DeviceInterface: "enx0456",
+								DeviceDHCP:      pointer.To(true),
+							},
+							{
+								DeviceIgnore:    pointer.To(true),
+								DeviceInterface: "enxa",
+								DeviceDHCP:      pointer.To(true),
+							},
+							{
+								DeviceInterface: "enxb",
+								DeviceDHCP:      pointer.To(true),
+								DeviceDHCPOptions: &v1alpha1.DHCPOptions{
+									DHCPIPv4:        pointer.To(true),
+									DHCPRouteMetric: 256,
+								},
+							},
+							{
+								DeviceInterface: "enxc",
+								DeviceVlans: []*v1alpha1.Vlan{
+									{
+										VlanID:   25,
+										VlanDHCP: pointer.To(true),
+									},
+									{
+										VlanID: 26,
+									},
+									{
+										VlanID: 27,
+										VlanDHCPOptions: &v1alpha1.DHCPOptions{
+											DHCPRouteMetric: 256,
+										},
+									},
+								},
+							},
+							{
+								DeviceInterface: "enxd",
+								DeviceDHCP:      pointer.To(true),
+							},
+						},
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							URL: u,
+						},
+					},
+				},
+			},
+		),
+	)
+
+	suite.Create(cfg)
+
+	suite.assertOperators(
+		[]string{
+			"configuration/dhcp4/eth1",
+			"configuration/dhcp4/eth3",
+			"configuration/dhcp4/enxc.25",
+		}, func(r *network.OperatorSpec, asrt *assert.Assertions) {
+			asrt.Equal(network.OperatorDHCP4, r.TypedSpec().Operator)
+			asrt.True(r.TypedSpec().RequireUp)
+
+			switch r.Metadata().ID() {
+			case "configuration/dhcp4/eth1":
+				asrt.Equal("eth1", r.TypedSpec().LinkName)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+			case "configuration/dhcp4/eth3":
+				asrt.Equal("eth3", r.TypedSpec().LinkName)
+				asrt.EqualValues(256, r.TypedSpec().DHCP4.RouteMetric)
+			case "configuration/dhcp4/enxc.25":
+				asrt.Equal("enxc.25", r.TypedSpec().LinkName)
+				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
+			}
+		},
+	)
+
+	suite.assertNoOperators(
+		[]string{
+			"configuration/dhcp4/eth0",
+			"default/dhcp4/eth0",
+			"configuration/dhcp4/eth2",
+			"default/dhcp4/eth2",
+			"configuration/dhcp4/eth4.26",
+		},
+	)
 }
 
 func TestOperatorConfigSuite(t *testing.T) {
-	suite.Run(t, new(OperatorConfigSuite))
+	t.Parallel()
+
+	suite.Run(t, &OperatorConfigSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 5 * time.Second,
+			AfterSetup: func(s *ctest.DefaultSuite) {
+				s.Require().NoError(s.Runtime().RegisterController(&netctrl.DeviceConfigController{}))
+			},
+		},
+	})
 }

--- a/internal/app/machined/pkg/controllers/network/resolver_config.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config.go
@@ -198,7 +198,7 @@ func (ctrl *ResolverConfigController) parseCmdline(logger *zap.Logger) (spec net
 		return
 	}
 
-	settings, err := ParseCmdlineNetwork(ctrl.Cmdline)
+	settings, err := ParseCmdlineNetwork(ctrl.Cmdline, network.NewEmptyLinkResolver())
 	if err != nil {
 		logger.Warn("ignoring error", zap.Error(err))
 

--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -181,7 +181,7 @@ func (ctrl *RouteConfigController) parseCmdline(logger *zap.Logger) (routes []ne
 		return
 	}
 
-	settings, err := ParseCmdlineNetwork(ctrl.Cmdline)
+	settings, err := ParseCmdlineNetwork(ctrl.Cmdline, network.NewEmptyLinkResolver())
 	if err != nil {
 		logger.Info("ignoring error", zap.Error(err))
 

--- a/internal/app/machined/pkg/controllers/network/timeserver_config.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_config.go
@@ -171,7 +171,7 @@ func (ctrl *TimeServerConfigController) parseCmdline(logger *zap.Logger) (spec n
 		return
 	}
 
-	settings, err := ParseCmdlineNetwork(ctrl.Cmdline)
+	settings, err := ParseCmdlineNetwork(ctrl.Cmdline, network.NewEmptyLinkResolver())
 	if err != nil {
 		logger.Warn("ignoring error", zap.Error(err))
 

--- a/pkg/machinery/resources/network/link_name_resolver.go
+++ b/pkg/machinery/resources/network/link_name_resolver.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import "iter"
+
+// LinkResolver resolves link names and aliases to actual link names.
+type LinkResolver struct {
+	lookup map[string]string // map of link names/aliases to link names
+}
+
+// Resolve resolves the link name or alias to the actual link name.
+//
+// If the link name or alias is not found in the lookup table, it is returned as is.
+func (r *LinkResolver) Resolve(name string) string {
+	if resolved, ok := r.lookup[name]; ok {
+		return resolved
+	}
+
+	return name
+}
+
+// NewLinkResolver creates a new link name resolver.
+func NewLinkResolver(f func() iter.Seq[*LinkStatus]) *LinkResolver {
+	lookup := make(map[string]string)
+
+	for link := range f() {
+		for alias := range AllLinkAliases(link) {
+			lookup[alias] = link.Metadata().ID()
+		}
+	}
+
+	for link := range f() {
+		lookup[link.Metadata().ID()] = link.Metadata().ID()
+	}
+
+	return &LinkResolver{lookup: lookup}
+}
+
+// NewEmptyLinkResolver creates a new link name resolver with an empty lookup table.
+func NewEmptyLinkResolver() *LinkResolver {
+	return &LinkResolver{}
+}

--- a/pkg/machinery/resources/network/link_name_resolver_test.go
+++ b/pkg/machinery/resources/network/link_name_resolver_test.go
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network_test
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+func TestLinkNameResolver(t *testing.T) {
+	t.Parallel()
+
+	link1 := network.NewLinkStatus(network.NamespaceName, "eth0")
+	link1.TypedSpec().Alias = "net0"
+	link1.TypedSpec().AltNames = []string{"ext0"}
+
+	link2 := network.NewLinkStatus(network.NamespaceName, "eth1")
+
+	link3 := network.NewLinkStatus(network.NamespaceName, "eth2")
+	link3.TypedSpec().AltNames = []string{"ext2"}
+
+	links := []*network.LinkStatus{
+		link1,
+		link2,
+		link3,
+	}
+
+	resolver := network.NewLinkResolver(func() iter.Seq[*network.LinkStatus] { return slices.Values(links) })
+
+	assert.Equal(t, "eth0", resolver.Resolve("eth0"))
+	assert.Equal(t, "eth0", resolver.Resolve("net0"))
+	assert.Equal(t, "eth0", resolver.Resolve("ext0"))
+	assert.Equal(t, "eth1", resolver.Resolve("eth1"))
+	assert.Equal(t, "eth2", resolver.Resolve("eth2"))
+	assert.Equal(t, "eth2", resolver.Resolve("ext2"))
+	assert.Equal(t, "eth3", resolver.Resolve("eth3"))
+}


### PR DESCRIPTION
Also fix/clean up tests, and add more tests specific to link aliases.

Fixes #10402
