### PR TITLE
chore: fix shutdown typo in shutdown sequence

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -388,7 +388,7 @@ func (*Sequencer) Shutdown(r runtime.Runtime, in *machineapi.ShutdownRequest) []
 	skipNodeRegistration := r.Config() != nil && r.Config().Machine() != nil && r.Config().Machine().Kubelet().SkipNodeRegistration()
 
 	phases := PhaseList{}.Append(
-		"storeShudown",
+		"storeShutdown",
 		StoreShutdownEmergency,
 	).AppendWhen(
 		!in.GetForce() && !skipNodeRegistration,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Simple fix of a typo in the word "shutdown".

## Why? (reasoning)
\-

## Acceptance

Please use the following checklist:

- [ ] ~~you linked an issue (if applicable)~~
- [ ] ~~you included tests (if applicable)~~
- [x] you ran conformance (`make conformance`)
I guess this is expected behavior for my signature?
```
commit         GPG Identity                 FAILED        openpgp: signature made by unknown entity
```
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
