### PR TITLE
Update deprecated command in README.md

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
@@ -160,7 +160,7 @@ Our control plane nodes have the IPs: `192.168.121.203`, `192.168.121.119`, `192
 Now you should be able to interact with Talos nodes that are in maintenance mode:
 
 ```bash
-talosctl -n 192.168.121.203 disks --insecure
+talosctl -n 192.168.121.203 get disks --insecure
 ```
 
 Sample output:

--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
@@ -160,7 +160,7 @@ Our control plane nodes have the IPs: `192.168.121.203`, `192.168.121.119`, `192
 Now you should be able to interact with Talos nodes that are in maintenance mode:
 
 ```bash
-talosctl -n 192.168.121.203 disks --insecure
+talosctl -n 192.168.121.203 get disks --insecure
 ```
 
 Sample output:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Updating `talocs disks (...)` in the documentation to `talosctl get disks (...)` to reflect the new command.

## Why? (reasoning)
Running `talosctl disks` will throw:
```
`talosctl disks` is deprecated, please use `talosctl get disks`, `talosctl get systemdisk`, `talosctl get discoveredvolumes` instead
```

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
