### PR TITLE
test: fix UKI preserving talos.config and image cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,7 +519,7 @@ uki-certs: talosctl ## Generate test certificates for SecureBoot/PCR Signing
 .PHONY: cache-create
 cache-create: installer imager ## Generate image cache.
 	@docker run --entrypoint /usr/local/bin/e2e.test registry.k8s.io/conformance:$(KUBECTL_VERSION) --list-images | \
-		$(TALOSCTL_EXECUTABLE) images integration --installer-tag=$(IMAGE_TAG)-amd64-secureboot --registry-and-user=$(REGISTRY_AND_USERNAME) | \
+		$(TALOSCTL_EXECUTABLE) images integration --installer-tag=$(IMAGE_TAG) --registry-and-user=$(REGISTRY_AND_USERNAME) | \
 		$(TALOSCTL_EXECUTABLE) images cache-create --image-cache-path=/tmp/cache.tar --images=- --force
 	@crane push /tmp/cache.tar $(REGISTRY_AND_USERNAME)/image-cache:$(IMAGE_TAG)
 	@$(MAKE) image-iso IMAGER_ARGS="--image-cache=$(REGISTRY_AND_USERNAME)/image-cache:$(IMAGE_TAG) --extra-kernel-arg='console=ttyS0'"

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -48,7 +48,7 @@ func (suite *ImageSuite) TestList() {
 	)
 }
 
-var imageCacheQuery = []string{"get", "imagecacheconfig", "--output", "jsonpath='{.spec.copyStatus}'"}
+var imageCacheQuery = []string{"get", "imagecacheconfig", "--output", "jsonpath='{.spec.status}'"}
 
 // TestPull verifies pulling images to the CRI.
 func (suite *ImageSuite) TestPull() {

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -51,7 +51,7 @@ func (suite *ListSuite) TestDepth() {
 
 	if stdout, _ := suite.RunCLI(imageCacheQuery); strings.Contains(stdout, "ready") {
 		// Image cache paths parts are longer
-		maxSeps = 9
+		maxSeps = 8
 	}
 
 	// checks that enough separators are encountered in the output


### PR DESCRIPTION
Fix image cache installer ref, and preserve talos.config with UKIs for `talosctl cluster create`.
