### PR TITLE
Update nvidia-gpu-proprietary.md

### DIFF
--- a/website/content/v1.9/talos-guides/configuration/nvidia-gpu-proprietary.md
+++ b/website/content/v1.9/talos-guides/configuration/nvidia-gpu-proprietary.md
@@ -152,7 +152,7 @@ kubectl run \
   nvidia-test \
   --restart=Never \
   -ti --rm \
-  --image nvcr.io/nvidia/cuda:12.5.0-base-ubuntu22.04 \
+  --image nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04 \
   --overrides '{"spec": {"runtimeClassName": "nvidia"}}' \
   nvidia-smi
 ```


### PR DESCRIPTION
simple documentation update for the cuda pod sample in nvidia gpu instructions.

Nvidia drivers 550.x only support cuda upto 12.4.1
Compatibility matrix:
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Documentation update
## Why? (reasoning)
avoid cuda errors as per the cuda pod sample
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
