### PR TITLE
Update proxmox.md

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/proxmox.md
@@ -220,6 +220,7 @@ talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/controlpl
 
 You should now see some action in the Proxmox console for this VM.
 Talos will be installed to disk, the VM will reboot, and then Talos will configure the Kubernetes control plane on this VM.
+The VM will remain in stage `Booting` until the bootstrap is completed in a later step.
 
 > Note: This process can be repeated multiple times to create an HA control plane.
 

--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/proxmox.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/proxmox.md
@@ -220,6 +220,7 @@ talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/controlpl
 
 You should now see some action in the Proxmox console for this VM.
 Talos will be installed to disk, the VM will reboot, and then Talos will configure the Kubernetes control plane on this VM.
+The VM will remain in stage `Booting` until the bootstrap is completed in a later step.
 
 > Note: This process can be repeated multiple times to create an HA control plane.
 


### PR DESCRIPTION
# Pull Request


## What?
Update Proxmox documentation to clarify that it is expected that the control plane VM will be stuck in stage booting until bootstrap is performed.

## Why?
As a newbie I found this part of the documentation confusing, and I was wasting time debugging why my control plane didn't get further than booting stage. I am not the only person who has encountered this misconception (https://github.com/siderolabs/talos/issues/9983).

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
