### PR TITLE
docs: add instructions for differing network interface name

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
@@ -186,7 +186,8 @@ Edit `controlplane.yaml` to add the virtual IP you picked to a network interface
 machine:
   network:
     interfaces:
-      - interface: eth0
+      - deviceSelector:
+          physical: true # should select any hardware network device, if you have just one, it will be selected
         dhcp: true
         vip:
           ip: 192.168.121.100

--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
@@ -186,7 +186,8 @@ Edit `controlplane.yaml` to add the virtual IP you picked to a network interface
 machine:
   network:
     interfaces:
-      - interface: eth0
+      - deviceSelector:
+          physical: true # should select any hardware network device, if you have just one, it will be selected
         dhcp: true
         vip:
           ip: 192.168.121.100


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Adding instruction how to get the VMs network interface. If the network interface name differs from eth0, e.g. enp1s0, the virtual IP address definition would be ignored.

## Why? (reasoning)
The network interface name came up for me differently than eth0, causing the setting to be ignored and subsequently the IP address not being assigned. That ultimately caused the initialization halted on sending a HTTP request to the virtual IP address.

To lower the obstacles for newcomers I feel it to be appropriate to provide the `talosctl` command to request the actual interface name.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
