### PR TITLE
fix: qemu: archive cluster logs only after stopping VMs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-07T13:42:22Z by kres d88db2f.
+# Generated on 2025-03-10T14:45:43Z by kres ef4356e.
 
 name: default
 concurrency:
@@ -2235,6 +2235,7 @@ jobs:
           USE_DISK_IMAGE: "true"
           VIA_MAINTENANCE_MODE: "true"
           WITH_DISK_ENCRYPTION: "true"
+          WITH_JSON_LOGS: "false"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-disk-image-bios
@@ -2874,7 +2875,6 @@ jobs:
           QEMU_EXTRA_DISKS_SIZE: "10240"
           USER_DISKS_MOUNTS: /var/lib/extra,/var/lib/p1,/var/lib/p2
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
-          WITH_JSON_LOGS: "true"
           WITH_USER_DISK: "true"
         run: |
           sudo -E make e2e-qemu

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-26T15:23:43Z by kres 1281806.
+# Generated on 2025-03-10T14:45:43Z by kres ef4356e.
 
 name: integration-misc-2-cron
 concurrency:
@@ -123,6 +123,7 @@ jobs:
           USE_DISK_IMAGE: "true"
           VIA_MAINTENANCE_MODE: "true"
           WITH_DISK_ENCRYPTION: "true"
+          WITH_JSON_LOGS: "false"
         run: |
           sudo -E make e2e-qemu
       - name: e2e-disk-image-bios

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -86,7 +86,6 @@ jobs:
           QEMU_EXTRA_DISKS_SIZE: "10240"
           USER_DISKS_MOUNTS: /var/lib/extra,/var/lib/p1,/var/lib/p2
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
-          WITH_JSON_LOGS: "true"
           WITH_USER_DISK: "true"
         run: |
           sudo -E make e2e-qemu

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,8 @@ linters:
     - protogetter # too annoying
     - perfsprint
     - recvcheck # too annoying
+    - nolintlint # cache issues https://github.com/golangci/golangci-lint/issues/3476
+    - tenv # deprecated
   disable-all: false
   fast: false
 

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -337,7 +337,6 @@ spec:
             QEMU_EXTRA_DISKS_SIZE: "10240"
             QEMU_EXTRA_DISKS_DRIVERS: "ide,nvme"
             WITH_CONFIG_PATCH_WORKER: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml"
-            WITH_JSON_LOGS: "true"
             WITH_USER_DISK: "true"
             USER_DISKS_MOUNTS: "/var/lib/extra,/var/lib/p1,/var/lib/p2"
         - name: save-talos-logs
@@ -873,6 +872,7 @@ spec:
             VIA_MAINTENANCE_MODE: true
             WITH_DISK_ENCRYPTION: true
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+            WITH_JSON_LOGS: "false" # test this path as well
         - name: e2e-disk-image-bios
           command: e2e-qemu
           withSudo: true

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -41,8 +41,10 @@ case "${WITH_VIRTUAL_IP:-false}" in
     ;;
 esac
 
-case "${WITH_JSON_LOGS:-false}" in
-  true)
+case "${WITH_JSON_LOGS:-true}" in
+  false)
+    ;;
+  *)
     QEMU_FLAGS+=("--with-json-logs")
     ;;
 esac

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -44,12 +44,6 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 
 	defer deleteStateDirectory(stateDirectoryPath, options.DeleteStateOnErr) //nolint:errcheck
 
-	if options.SaveClusterLogsArchivePath != "" {
-		fmt.Fprintf(options.LogWriter, "saving cluster logs archive to %s\n", options.SaveClusterLogsArchivePath)
-
-		cl.SaveClusterLogsArchive(stateDirectoryPath, options.SaveClusterLogsArchivePath)
-	}
-
 	if options.SaveSupportArchivePath != "" {
 		fmt.Fprintf(options.LogWriter, "saving support archive to %s\n", options.SaveSupportArchivePath)
 
@@ -89,12 +83,6 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
-	fmt.Fprintln(options.LogWriter, "removing json logs")
-
-	if err := p.DestroyJSONLogs(state); err != nil {
-		return err
-	}
-
 	fmt.Fprintln(options.LogWriter, "removing network")
 
 	if err := p.DestroyNetwork(state); err != nil {
@@ -108,6 +96,18 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 	}
 
 	fmt.Fprintln(options.LogWriter, "removing state directory")
+
+	if options.SaveClusterLogsArchivePath != "" {
+		fmt.Fprintf(options.LogWriter, "saving cluster logs archive to %s\n", options.SaveClusterLogsArchivePath)
+
+		cl.SaveClusterLogsArchive(stateDirectoryPath, options.SaveClusterLogsArchivePath)
+	}
+
+	fmt.Fprintln(options.LogWriter, "removing json logs")
+
+	if err := p.DestroyJSONLogs(state); err != nil {
+		return err
+	}
 
 	return deleteStateDirectory(stateDirectoryPath, true)
 }


### PR DESCRIPTION
Otherwise the archive is corrupted due to QEMU still writing to the logs while they are being archived

ci: enable --with-json-logs for any e2e-qemu runs

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
