### PR TITLE
fix: correct indentation for 'name: ci' in controlplane and worker test data

### DIFF
--- a/pkg/machinery/config/configloader/testdata/controlplane.test
+++ b/pkg/machinery/config/configloader/testdata/controlplane.test
@@ -314,7 +314,7 @@ cluster:
     #       apiVersion: v1
     #       kind: Namespace
     #       metadata:
-    #       	name: ci
+    #         name: ci
 
 
     # # Core DNS specific configuration options.

--- a/pkg/machinery/config/configloader/testdata/worker.test
+++ b/pkg/machinery/config/configloader/testdata/worker.test
@@ -357,7 +357,7 @@ cluster:
     #         apiVersion: v1
     #         kind: Namespace
     #         metadata:
-    #         	name: ci
+    #           name: ci
 
     # # Settings for admin kubeconfig generation.
     # adminKubeconfig:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
correct indentation for 'name: ci' in controlplane and worker test data
## Why? (reasoning)
more user-friendly to expand
## Acceptance

Please use the following checklist:

- [x ] you linted your code (`make lint`)


> See `make help` for a description of the available targets.
