### PR TITLE
feat: talosctl kubeconfig write to stdout option

### DIFF
--- a/website/content/v1.10/reference/cli.md
+++ b/website/content/v1.10/reference/cli.md
@@ -2081,8 +2081,10 @@ Download the admin kubeconfig from the node
 ### Synopsis
 
 Download the admin kubeconfig from the node.
-If merge flag is defined, config will be merged with ~/.kube/config or [local-path] if specified.
-Otherwise kubeconfig will be written to PWD or [local-path] if specified.
+If merge flag is true, config will be merged with ~/.kube/config or [local-path] if specified.
+Otherwise, kubeconfig will be written to PWD or [local-path] if specified.
+
+If merge flag is false and [local-path] is "-", config will be written to stdout.
 
 ```
 talosctl kubeconfig [local-path] [flags]


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Add the option for "talosctl kubeconfig" to write to stdout, using "-" as the output filename where merge is false. "talosctl gen config" already supports this convention.

## Why? (reasoning)

This is useful to capture kubeconfig within keychains/vaults without writing it to disk first, for security purposes and for simplicity within scripts/automation.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
