### PR TITLE
fix: kexec when using sd-boot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-13T14:46:47Z by kres ec5ec04.
+# Generated on 2025-03-14T10:24:50Z by kres ec5ec04.
 
 name: default
 concurrency:
@@ -102,6 +102,7 @@ jobs:
       - name: iso
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
         run: |
           make iso secureboot-iso
       - name: images-essential
@@ -2214,6 +2215,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
         run: |
           make iso
       - name: images-essential
@@ -3808,8 +3810,8 @@ jobs:
       - name: Generate Checksums
         run: |
           cd _out
-          sha256sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64.raw.zst metal-arm64.raw.zst talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
-          sha512sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64.raw.zst metal-arm64.raw.zst talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
+          sha256sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
+          sha512sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
       - name: release
         uses: crazy-max/ghaction-github-release@v2
         with:
@@ -3821,6 +3823,8 @@ jobs:
             _out/initramfs-arm64.xz
             _out/metal-amd64.iso
             _out/metal-arm64.iso
+            _out/metal-amd64-uki.efi
+            _out/metal-arm64-uki.efi
             _out/metal-amd64.raw.zst
             _out/metal-arm64.raw.zst
             _out/talosctl-cni-bundle-amd64.tar.gz

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-10T14:45:43Z by kres ef4356e.
+# Generated on 2025-03-14T10:24:50Z by kres ec5ec04.
 
 name: integration-misc-2-cron
 concurrency:
@@ -88,6 +88,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
         run: |
           make iso
       - name: images-essential

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -112,6 +112,7 @@ spec:
         - name: iso
           command: iso secureboot-iso
           environment:
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           environment:
@@ -194,6 +195,8 @@ spec:
               - initramfs-arm64.xz
               - metal-amd64.iso
               - metal-arm64.iso
+              - metal-amd64-uki.efi
+              - metal-arm64-uki.efi
               - metal-amd64.raw.zst
               - metal-arm64.raw.zst
               - talosctl-cni-bundle-amd64.tar.gz
@@ -838,6 +841,7 @@ spec:
             - only-on-schedule
           command: iso
           environment:
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: images-essential
           conditions:

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1925,6 +1925,8 @@ func KexecPrepare(_ runtime.Sequence, data any) (runtime.TaskExecutionFunc, stri
 		}
 
 		if systemDisk == nil {
+			log.Print("kexec skipped as system disk is not found")
+
 			return nil // no system disk, no kexec
 		}
 


### PR DESCRIPTION
https://github.com/siderolabs/talos/pull/10443 broke kexec and `callback` was never being called.