### PR TITLE
fix: Add missing TOOLS_PREFIX for WITH_DEBUG_SHELL builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,8 +202,8 @@ FROM ${PKG_XZ} AS pkg-xz
 FROM ${PKG_ZLIB} AS pkg-zlib
 FROM ${PKG_ZSTD} AS pkg-zstd
 
-FROM --platform=amd64 ${TOOLS} AS tools-amd64
-FROM --platform=arm64 ${TOOLS} AS tools-arm64
+FROM --platform=amd64 ${TOOLS_PREFIX}:${TOOLS} AS tools-amd64
+FROM --platform=arm64 ${TOOLS_PREFIX}:${TOOLS} AS tools-arm64
 
 FROM scratch AS pkg-debug-tools-scratch-amd64
 FROM scratch AS pkg-debug-tools-scratch-arm64


### PR DESCRIPTION
This was broken after `${TOOLS_PREFIX}` was introduced in fd8131cb86.