### PR TITLE
docs: fix typo cluser -> cluster

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1403,7 +1403,7 @@ type ClusterNetworkConfig struct {
 	//     The domain used by Kubernetes DNS.
 	//     The default is `cluster.local`
 	//   examples:
-	//     - value: '"cluser.local"'
+	//     - value: '"cluster.local"'
 	DNSDomain string `yaml:"dnsDomain"`
 	//   description: |
 	//     The pod subnet CIDR.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1804,7 +1804,7 @@ func (ClusterNetworkConfig) Doc() *encoder.Doc {
 	doc.AddExample("Configuring with flannel CNI and setting up subnets.", clusterNetworkExample())
 
 	doc.Fields[0].AddExample("", clusterCustomCNIExample())
-	doc.Fields[1].AddExample("", "cluser.local")
+	doc.Fields[1].AddExample("", "cluster.local")
 	doc.Fields[2].AddExample("", []string{"10.244.0.0/16"})
 	doc.Fields[3].AddExample("", []string{"10.96.0.0/12"})
 

--- a/website/content/v1.10/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.10/reference/configuration/v1alpha1/config.md
@@ -3214,7 +3214,7 @@ cni:
         - https://docs.projectcalico.org/archive/v3.20/manifests/canal.yaml
 {{< /highlight >}}</details> | |
 |`dnsDomain` |string |<details><summary>The domain used by Kubernetes DNS.</summary>The default is `cluster.local`</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-dnsDomain: cluser.local
+dnsDomain: cluster.local
 {{< /highlight >}}</details> | |
 |`podSubnets` |[]string |The pod subnet CIDR. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 podSubnets:

--- a/website/content/v1.9/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.9/reference/configuration/v1alpha1/config.md
@@ -3253,7 +3253,7 @@ cni:
         - https://docs.projectcalico.org/archive/v3.20/manifests/canal.yaml
 {{< /highlight >}}</details> | |
 |`dnsDomain` |string |<details><summary>The domain used by Kubernetes DNS.</summary>The default is `cluster.local`</details> <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-dnsDomain: cluser.local
+dnsDomain: cluster.local
 {{< /highlight >}}</details> | |
 |`podSubnets` |[]string |The pod subnet CIDR. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 podSubnets:


### PR DESCRIPTION
# Pull Request

## What? (description)

I'm not sure if it's intentional to show it as "cluser" jn the example but just in case this is a typo i opened this PR :)

## Acceptance

If its meant as an example maybe it should be changed to example.local? or corrected to cluster.local