### PR TITLE
fix: correct structprotogen example

### DIFF
--- a/hack/structprotogen/main.go
+++ b/hack/structprotogen/main.go
@@ -25,7 +25,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "structprotogen path dest",
 	Short:   "This CLI is used to generate proto files from Go structs into one proto file",
-	Example: "gotagsrewrite github.com/siderolabs/talos/pkg/machinery/resources/... ./api/resource/definitions",
+	Example: "structprotogen github.com/siderolabs/talos/pkg/machinery/resources/... ./api/resource/definitions",
 	Args:    cobra.ExactArgs(2),
 	Version: "v1.0.0",
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Pull Request

## What? (description)

Fix example of structprotogen to reference the right name.

## Why? (reasoning)

Found the wrong binary name reference within the example during fiddling around and getting around the source code.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
