### PR TITLE
docs: clarify custom CA certificate compatibility with KMS STATE partition encryption

### DIFF
--- a/website/content/v1.10/reference/kernel.md
+++ b/website/content/v1.10/reference/kernel.md
@@ -158,6 +158,8 @@ One such example is to provide [a custom CA certificate]({{<  relref "../talos-g
 cat config.yaml | zstd --compress --ultra -22 | base64 -w 0
 ```
 
+Please note that configuration from this argument is only loaded if the configuration hasn't been yet saved to `STATE` partition.
+
 #### `talos.platform`
 
 The platform name on which Talos will run.

--- a/website/content/v1.10/talos-guides/configuration/certificate-authorities.md
+++ b/website/content/v1.10/talos-guides/configuration/certificate-authorities.md
@@ -23,3 +23,6 @@ certificates: |-
 Multiple documents can be appended, and multiple CA certificates might be present in each configuration document.
 
 This configuration can be also applied in maintenance mode.
+
+Please note that if the `STATE` partition is encrypted, the CA certificates will be only be loaded after the partition is unlocked.
+So the encryption method should allow unlocking the partition without the need for a CA certificate.

--- a/website/content/v1.10/talos-guides/configuration/disk-encryption.md
+++ b/website/content/v1.10/talos-guides/configuration/disk-encryption.md
@@ -38,6 +38,7 @@ Talos Linux supports four encryption methods, which can be combined together for
 > It uses the hardware characteristics of the machine in order to decrypt the data, so drives that have been removed, or recycled from a cloud environment or attached to a different virtual machine, will maintain their protection and encryption.
 >
 > Note: When using KMS encryption for `STATE` partition the network configuration can't be provided via the machine configuration, as KMS requires network connectivity before `STATE` partition is unlocked.
+> Also custom CA certificates cannot be used for the KMS server, as these are stored in the `STATE` partition as well.
 
 ## Configuration
 

--- a/website/content/v1.9/reference/kernel.md
+++ b/website/content/v1.9/reference/kernel.md
@@ -158,6 +158,8 @@ One such example is to provide [a custom CA certificate]({{<  relref "../talos-g
 cat config.yaml | zstd --compress --ultra -22 | base64 -w 0
 ```
 
+Please note that configuration from this argument is only loaded if the configuration hasn't been yet saved to `STATE` partition.
+
 #### `talos.platform`
 
 The platform name on which Talos will run.

--- a/website/content/v1.9/talos-guides/configuration/certificate-authorities.md
+++ b/website/content/v1.9/talos-guides/configuration/certificate-authorities.md
@@ -23,3 +23,6 @@ certificates: |-
 Multiple documents can be appended, and multiple CA certificates might be present in each configuration document.
 
 This configuration can be also applied in maintenance mode.
+
+Please note that if the `STATE` partition is encrypted, the CA certificates will be only be loaded after the partition is unlocked.
+So the encryption method should allow unlocking the partition without the need for a CA certificate.

--- a/website/content/v1.9/talos-guides/configuration/disk-encryption.md
+++ b/website/content/v1.9/talos-guides/configuration/disk-encryption.md
@@ -38,6 +38,7 @@ Talos Linux supports four encryption methods, which can be combined together for
 > It uses the hardware characteristics of the machine in order to decrypt the data, so drives that have been removed, or recycled from a cloud environment or attached to a different virtual machine, will maintain their protection and encryption.
 >
 > Note: When using KMS encryption for `STATE` partition the network configuration can't be provided via the machine configuration, as KMS requires network connectivity before `STATE` partition is unlocked.
+> Also custom CA certificates cannot be used for the KMS server, as these are stored in the `STATE` partition as well.
 
 ## Configuration
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Add information to docs about STATE partition encryption using a KMS with custom CA certificates

## Why? (reasoning)
I failed in getting this information from the docs in the places I had looked, and so had opened #10542.
Hopefully this will help future users.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
