### PR TITLE
doc: Fix version typo in kube-proxy manual upgrade

### DIFF
--- a/website/content/v1.1/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.1/kubernetes-guides/upgrading-kubernetes.md
@@ -278,7 +278,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: k8s.gcr.io/kube-proxy:v{{< k8s_release >}}
+          image: k8s.gcr.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.10/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.10/kubernetes-guides/upgrading-kubernetes.md
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.2/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.2/kubernetes-guides/upgrading-kubernetes.md
@@ -278,7 +278,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: k8s.gcr.io/kube-proxy:v{{< k8s_release >}}
+          image: k8s.gcr.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.3/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.3/kubernetes-guides/upgrading-kubernetes.md
@@ -278,7 +278,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.4/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.4/kubernetes-guides/upgrading-kubernetes.md
@@ -281,7 +281,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.5/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.5/kubernetes-guides/upgrading-kubernetes.md
@@ -281,7 +281,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.6/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.6/kubernetes-guides/upgrading-kubernetes.md
@@ -283,7 +283,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.7/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.7/kubernetes-guides/upgrading-kubernetes.md
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.8/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.8/kubernetes-guides/upgrading-kubernetes.md
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```

--- a/website/content/v1.9/kubernetes-guides/upgrading-kubernetes.md
+++ b/website/content/v1.9/kubernetes-guides/upgrading-kubernetes.md
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
         - name: kube-proxy
-          image: registry.k8s.io/kube-proxy:v{{< k8s_release >}}
+          image: registry.k8s.io/kube-proxy:v{{< k8s_prev_release >}}
       tolerations:
         - ...
 ```


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

In the manual kubernetes upgrade website doc there is a typo where kube-proxy version is the same (in the change from X to Y example), this can confuse ppl following the doc

## Why? (reasoning)

Can confuse someone, mostly an OCD from my side

