### PR TITLE
feat(security): set TLS minimum version to 12

### DIFF
--- a/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
+++ b/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
@@ -171,6 +171,7 @@ func runHTTPServer(ctx context.Context, certPEM, keyPEM []byte) error {
 
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{certificate},
+                MinVersion: 12
 	}
 
 	subFs, err := fs.Sub(httpFs, "httproot")

--- a/cmd/talosctl/cmd/mgmt/siderolink_launch_linux.go
+++ b/cmd/talosctl/cmd/mgmt/siderolink_launch_linux.go
@@ -83,6 +83,7 @@ func run(ctx context.Context) error {
 
 		apiTLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{apiCert},
+                        MinVersion: 12
 		}
 	}
 

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -108,6 +108,7 @@ func (c *Args) WithClientMaintenance(enforceFingerprints []string, action func(c
 		context.Background(), func(ctx context.Context) error {
 			tlsConfig := &tls.Config{
 				InsecureSkipVerify: true,
+                                MinVersion: 12
 			}
 
 			if len(enforceFingerprints) > 0 {


### PR DESCRIPTION
Set minimum TLS version to 12 in all TLS configurations across multiple components:
- HTTP server in air-gapped debug environments
- SideroLink API for Linux
- Client maintenance mode

This change enhances security by enforcing a more recent TLS protocol version. 

https://github.com/golang/go/issues/45428
