### PR TITLE
fix: image cache generation on Windows

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -245,7 +245,7 @@ var imageCacheCreateCmd = &cobra.Command{
 	Short: "Create a cache of images in OCI format into a directory",
 	Long:  `Create a cache of images in OCI format into a directory`,
 	Example: fmt.Sprintf(
-		`talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:%s --image-cache-path=/tmp/talos-image-cache
+		`talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:v%s --image-cache-path=/tmp/talos-image-cache
 
 Alternatively, stdin can be piped to the command:
 talosctl images default | talosctl images cache-create --image-cache-path=/tmp/talos-image-cache --images=-

--- a/pkg/imager/cache/cache.go
+++ b/pkg/imager/cache/cache.go
@@ -115,8 +115,8 @@ func Generate(images []string, platform string, insecure bool, imageLayerCachePa
 			return fmt.Errorf("parsing reference %q: %w", src, err)
 		}
 
-		referenceDir := filepath.Join(tmpDir, manifestsDir, rewriteRegistry(ref.Context().RegistryStr(), src), ref.Context().RepositoryStr(), "reference")
-		digestDir := filepath.Join(tmpDir, manifestsDir, rewriteRegistry(ref.Context().RegistryStr(), src), ref.Context().RepositoryStr(), "digest")
+		referenceDir := filepath.Join(tmpDir, manifestsDir, rewriteRegistry(ref.Context().RegistryStr(), src), filepath.FromSlash(ref.Context().RepositoryStr()), "reference")
+		digestDir := filepath.Join(tmpDir, manifestsDir, rewriteRegistry(ref.Context().RegistryStr(), src), filepath.FromSlash(ref.Context().RepositoryStr()), "digest")
 
 		// if the reference was parsed as a tag, use it
 		tag, ok := ref.(name.Tag)

--- a/pkg/imager/filemap/filemap.go
+++ b/pkg/imager/filemap/filemap.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	stdpath "path"
 	"path/filepath"
 	"slices"
 
@@ -49,7 +50,7 @@ func Walk(sourceBasePath, imageBasePath string) ([]File, error) {
 		}
 
 		filemap = append(filemap, File{
-			ImagePath:  filepath.Join(imageBasePath, rel),
+			ImagePath:  stdpath.Join(imageBasePath, filepath.ToSlash(rel)),
 			SourcePath: path,
 			ImageMode:  int64(statInfo.Mode().Perm()),
 		})

--- a/website/content/v1.10/reference/cli.md
+++ b/website/content/v1.10/reference/cli.md
@@ -1795,7 +1795,7 @@ talosctl image cache-create [flags]
 ### Examples
 
 ```
-talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:1.33.0-beta.0 --image-cache-path=/tmp/talos-image-cache
+talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:v1.33.0-beta.0 --image-cache-path=/tmp/talos-image-cache
 
 Alternatively, stdin can be piped to the command:
 talosctl images default | talosctl images cache-create --image-cache-path=/tmp/talos-image-cache --images=-


### PR DESCRIPTION
Fixes #10558

The core issue is mix of path separators: the resulting image layer should contain `/` (UNIX), while native separator might be different (`\` on Windows).
