### PR TITLE
fix: containerd auth hostname in the config

### DIFF
--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -75,6 +75,12 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 					},
 				},
 			},
+			"docker.io": {
+				RegistryAuth: &v1alpha1.RegistryAuthConfig{
+					RegistryUsername: "root",
+					RegistryPassword: "topsecret",
+				},
+			},
 		},
 	}
 

--- a/internal/pkg/containers/cri/containerd/testdata/cri.toml
+++ b/internal/pkg/containers/cri/containerd/testdata/cri.toml
@@ -4,6 +4,13 @@
       config_path = '/etc/cri/conf.d/hosts'
 
       [plugins.'io.containerd.cri.v1.images'.registry.configs]
+        [plugins.'io.containerd.cri.v1.images'.registry.configs.'registry-1.docker.io']
+          [plugins.'io.containerd.cri.v1.images'.registry.configs.'registry-1.docker.io'.auth]
+            username = 'root'
+            password = 'topsecret'
+            auth = ''
+            identitytoken = ''
+
         [plugins.'io.containerd.cri.v1.images'.registry.configs.'some.host:123']
           [plugins.'io.containerd.cri.v1.images'.registry.configs.'some.host:123'.auth]
             username = 'root'


### PR DESCRIPTION
A special case, for `docker.io`, use `registry-1.docker.io`.

Fixes #10617
