### PR TITLE
fix: use proper read-only bind mounts in init

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -196,7 +196,7 @@ func mountRootFS() error {
 		return err
 	}
 
-	return unix.Mount(constants.ExtensionsConfigFile, filepath.Join(constants.NewRoot, constants.ExtensionsRuntimeConfigFile), "", unix.MS_BIND|unix.MS_RDONLY, "")
+	return mount.BindReadonly(constants.ExtensionsConfigFile, filepath.Join(constants.NewRoot, constants.ExtensionsRuntimeConfigFile))
 }
 
 func bindMountFirmware() error {
@@ -211,7 +211,7 @@ func bindMountFirmware() error {
 
 	log.Printf("bind mounting %s", firmwarePath)
 
-	return unix.Mount(firmwarePath, filepath.Join(constants.NewRoot, firmwarePath), "", unix.MS_BIND|unix.MS_RDONLY, "")
+	return mount.BindReadonly(firmwarePath, filepath.Join(constants.NewRoot, firmwarePath))
 }
 
 func bindMountExtra() error {
@@ -225,7 +225,7 @@ func bindMountExtra() error {
 
 	log.Printf("bind mounting %s", constants.SDStubDynamicInitrdPath)
 
-	return unix.Mount(constants.SDStubDynamicInitrdPath, filepath.Join(constants.NewRoot, constants.SDStubDynamicInitrdPath), "", unix.MS_BIND|unix.MS_RDONLY, "")
+	return mount.BindReadonly(constants.SDStubDynamicInitrdPath, filepath.Join(constants.NewRoot, constants.SDStubDynamicInitrdPath))
 }
 
 func cpuInfo() {

--- a/internal/pkg/mount/v2/bind.go
+++ b/internal/pkg/mount/v2/bind.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mount
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// BindReadonly creates a common way to create a readonly bind mounted destination.
+func BindReadonly(src, dst string) error {
+	sourceFD, err := unix.OpenTree(unix.AT_FDCWD, src, unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC)
+	if err != nil {
+		return fmt.Errorf("failed to opentree source %s: %w", src, err)
+	}
+
+	defer unix.Close(sourceFD) //nolint:errcheck
+
+	if err := unix.MountSetattr(sourceFD, "", unix.AT_EMPTY_PATH, &unix.MountAttr{
+		Attr_set: unix.MOUNT_ATTR_RDONLY,
+	}); err != nil {
+		return fmt.Errorf("failed to set mount attribute: %w", err)
+	}
+
+	if err := unix.MoveMount(sourceFD, "", unix.AT_FDCWD, dst, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+		return fmt.Errorf("failed to move mount from %s to %s: %w", src, dst, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Extract common code from `etcfile` controller and use it to mount files from initramfs into the new root actually as read-only.

```
rootfs /usr/lib/firmware rootfs ro,seclabel,size=1920152k,nr_inodes=480038 0 0
rootfs /etc/extensions.yaml rootfs ro,seclabel,size=1920152k,nr_inodes=480038 0 0
```
