### PR TITLE
fix: Avoid printing terminating null byte in SELinux context

### DIFF
--- a/cmd/talosctl/cmd/talos/list.go
+++ b/cmd/talosctl/cmd/talos/list.go
@@ -16,6 +16,7 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -153,7 +154,7 @@ var lsCmd = &cobra.Command{
 				if info.Xattrs != nil {
 					for _, l := range info.Xattrs {
 						if l.Name == "security.selinux" {
-							label = string(l.Data)
+							label = unix.ByteSliceToString(l.Data)
 
 							break
 						}


### PR DESCRIPTION
SELinux context (file extended attribute `security.selinux`) is a null-terminated string. We need to properly convert the C-string inside the byte slice into a Golang string to avoid also printing the null byte in the ls command output.

Discovered when piping talosctl ls output to grep:

    $ talosctl ls /lib/modules/ -r -l | grep '\.ko'
    grep: (standard input): binary file matches
