### PR TITLE
chore: small developer improvements

### DIFF
--- a/.github/workflows/integration-aws-nvidia-oss-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-01T08:14:24Z by kres d903dae.
+# Generated on 2025-04-04T11:30:51Z by kres d903dae.
 
 name: integration-aws-nvidia-oss-cron
 concurrency:
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 7 * * *
+    - cron: 30 5 * * *
 jobs:
   default:
     runs-on:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2482,7 +2482,7 @@ spec:
         - self-hosted
         - generic # we can use generic here since the tests run against a remote talos cluster
       crons:
-        - '30 7 * * *'
+        - '30 5 * * *'
       triggerLabels:
         - integration/aws-nvidia-oss
       steps:

--- a/Makefile
+++ b/Makefile
@@ -370,13 +370,13 @@ hack-test-%: ## Runs the specified script in ./hack/test with well known environ
 
 .PHONY: generate
 generate: ## Generates code from protobuf service definitions and machinery config.
-	@$(MAKE) local-$@ DEST=./ PLATFORM=linux/amd64 EMBED_TARGET=embed-abbrev
+	@$(MAKE) local-$@ DEST=./ PLATFORM=$(OPERATING_SYSTEM)/$(ARCH) EMBED_TARGET=embed-abbrev
 
 .PHONY: docs
 docs: ## Generates the documentation for machine config, and talosctl.
 	@rm -rf docs/configuration/*
 	@rm -rf docs/talosctl/*
-	@$(MAKE) local-$@ DEST=./ PLATFORM=linux/amd64
+	@$(MAKE) local-$@ DEST=./ PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 .PHONY: docs-preview
 docs-preview: ## Starts a local preview of the documentation using Hugo in docker
@@ -456,7 +456,7 @@ image-%: ## Builds the specified image. Valid options are aws, azure, digital-oc
 	@docker pull $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG_IN)
 	@for platform in $(subst $(,),$(space),$(PLATFORM)); do \
 		arch=$$(basename "$${platform}") && \
-		docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/secureboot:ro -v $(PWD)/$(ARTIFACTS):/out -e SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG_IN) $* --arch $$arch $(IMAGER_ARGS) ; \
+		docker run --rm -t -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/secureboot:ro -v $(PWD)/$(ARTIFACTS):/out -e SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) --network=host --privileged $(REGISTRY_AND_USERNAME)/imager:$(IMAGE_TAG_IN) $* --arch $$arch --base-installer-image $(REGISTRY_AND_USERNAME)/installer-base:$(IMAGE_TAG_IN) $(IMAGER_ARGS) ; \
 	done
 
 .PHONY: images-essential
@@ -530,19 +530,19 @@ cache-create: installer imager ## Generate image cache.
 # Code Quality
 
 api-descriptors: ## Generates API descriptors used to detect breaking API changes.
-	@$(MAKE) local-api-descriptors DEST=./ PLATFORM=linux/amd64
+	@$(MAKE) local-api-descriptors DEST=./ PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 fmt-go: ## Formats the source code.
 	@docker run --rm -it -v $(PWD):/src -w /src -e GOTOOLCHAIN=local golang:$(GO_VERSION) bash -c "go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION) && goimports -w -local github.com/siderolabs/talos . && go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION) && gofumpt -w ."
 
 fmt-protobuf: ## Formats protobuf files.
-	@$(MAKE) local-fmt-protobuf DEST=./ PLATFORM=linux/amd64
+	@$(MAKE) local-fmt-protobuf DEST=./ PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 fmt: ## Formats the source code and protobuf files.
 	@$(MAKE) fmt-go fmt-protobuf
 
 lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdown (e.g. lint-go).
-	@$(MAKE) target-lint-$* PLATFORM=linux/amd64
+	@$(MAKE) target-lint-$* PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 lint: ## Runs linters on go, vulncheck, protobuf, and markdown file types.
 	@$(MAKE) lint-go lint-vulncheck lint-protobuf lint-markdown
@@ -551,17 +551,17 @@ check-dirty: ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
 
 go-mod-outdated: ## Runs the go-mod-oudated to show outdated dependencies.
-	@$(MAKE) target-go-mod-outdated PLATFORM=linux/amd64
+	@$(MAKE) target-go-mod-outdated PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 # Tests
 
 .PHONY: unit-tests
 unit-tests: ## Performs unit tests.
-	@$(MAKE) local-$@ DEST=$(ARTIFACTS) TARGET_ARGS="--allow security.insecure" PLATFORM=linux/amd64
+	@$(MAKE) local-$@ DEST=$(ARTIFACTS) TARGET_ARGS="--allow security.insecure" PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 .PHONY: unit-tests-race
 unit-tests-race: ## Performs unit tests with race detection enabled.
-	@$(MAKE) target-$@ TARGET_ARGS="--allow security.insecure" PLATFORM=linux/amd64
+	@$(MAKE) target-$@ TARGET_ARGS="--allow security.insecure" PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64:
 	@$(MAKE) local-$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 DEST=$(ARTIFACTS) PLATFORM=linux/amd64 WITH_RACE=true PUSH=false
@@ -711,8 +711,8 @@ sign-images: ## Run cosign to sign all images built by this Makefile.
 .PHONY: reproducibility-test
 reproducibility-test:
 	@$(MAKE) reproducibility-test-local-initramfs
-	@$(MAKE) reproducibility-test-docker-installer-base INSTALLER_ARCH=targetarch PLATFORM=linux/amd64
-	@$(MAKE) reproducibility-test-docker-talos reproducibility-test-docker-imager reproducibility-test-docker-talosctl PLATFORM=linux/amd64
+	@$(MAKE) reproducibility-test-docker-installer-base INSTALLER_ARCH=targetarch PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
+	@$(MAKE) reproducibility-test-docker-talos reproducibility-test-docker-imager reproducibility-test-docker-talosctl PLATFORM=$(OPERATING_SYSTEM)/$(ARCH)
 
 reproducibility-test-docker-%:
 	@rm -rf _out1/ _out2/


### PR DESCRIPTION
- Use `make` variables to auto-detect target platform and not hardcode it.
- Separate one of the aws tests to a little different cron time so it works (running both parallely never worked).
- Pass in `--base-installer-image` so when a developer runs `make image-installer` with some extensions `IMAGE_REGISTRY` is honored.