### PR TITLE
docs: improve references to config patches

### DIFF
--- a/website/content/v1.10/talos-guides/configuration/patching.md
+++ b/website/content/v1.10/talos-guides/configuration/patching.md
@@ -378,7 +378,11 @@ The format of the patch (JSON patch or strategic merge patch) is detected automa
 Talos machine configuration can be patched at the moment of generation with `talosctl gen config`:
 
 ```shell
-talosctl gen config test-cluster https://172.20.0.1:6443 --config-patch @all.yaml --config-patch-control-plane @cp.yaml --config-patch-worker @worker.yaml
+talosctl gen config test-cluster https://172.20.0.1:6443 \
+  --config-patch '[{"op": "add", "path": "/machine/certSANs", "value": ["10.0.0.10"]}]' \
+  --config-patch @all.yaml \
+  --config-patch-control-plane @cp.yaml \
+  --config-patch-worker @worker.yaml
 ```
 
 Generated machine configuration can also be patched after the fact with `talosctl machineconfig patch`

--- a/website/content/v1.10/talos-guides/install/bare-metal-platforms/matchbox.md
+++ b/website/content/v1.10/talos-guides/install/bare-metal-platforms/matchbox.md
@@ -27,7 +27,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
-Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
+Optionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}}) which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/v1.10/talos-guides/install/cloud-platforms/gcp.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/gcp.md
@@ -127,7 +127,7 @@ LB_PUBLIC_IP=$(gcloud compute forwarding-rules describe talos-fwd-rule \
 talosctl gen config talos-k8s-gcp-tutorial https://${LB_PUBLIC_IP}:443
 ```
 
-Additionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
+Additionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}}) which will be applied during the config generation.
 
 ### Compute Creation
 

--- a/website/content/v1.10/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/hetzner.md
@@ -211,7 +211,7 @@ created talosconfig
 Generating the config without examples and docs is necessary because otherwise you can easily exceed the 32 kb limit on uploadable userdata (see [issue 8805](https://github.com/siderolabs/talos/issues/8805)).
 
 At this point, you can modify the generated configs to your liking.
-Optionally, you can specify `--config-patch` with RFC6902 jsonpatches which will be applied during the config generation.
+Optionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}}) which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/v1.10/talos-guides/install/cloud-platforms/openstack.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/openstack.md
@@ -96,7 +96,7 @@ LB_PUBLIC_IP=$(openstack loadbalancer show talos-control-plane -f json | jq -r .
 talosctl gen config talos-k8s-openstack-tutorial https://${LB_PUBLIC_IP}:6443
 ```
 
-Additionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
+Additionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}}) which will be applied during the config generation.
 
 ### Compute Creation
 

--- a/website/content/v1.10/talos-guides/install/cloud-platforms/oracle.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/oracle.md
@@ -162,7 +162,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
-Optionally, you can specify `--config-patch` with RFC6902 jsonpatches which will be applied during the config generation.
+Optionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}}) which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/v1.10/talos-guides/install/cloud-platforms/upcloud.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/upcloud.md
@@ -150,7 +150,7 @@ At this point, you can modify the generated configs to your liking.
 Depending on the Kubernetes version you want to run, you might need to select a different Talos version, as not all versions are compatible.
  You can find the support matrix [here]({{< relref "../../../introduction/support-matrix" >}}).
 
-Optionally, you can specify `--config-patch` with RFC6902 jsonpatch or yamlpatch
+Optionally, you can specify [machine configuration patches]({{< relref "../../configuration/patching/#configuration-patching-with-talosctl-cli" >}})
 which will be applied during the config generation.
 
 #### Validate the Configuration Files


### PR DESCRIPTION
# Improve the documentation around use of inline patches and patches from files.

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Make the difference between inline patches and patches from files slightly clearer.

## Why? (reasoning)

Addresses https://github.com/siderolabs/talos/issues/10630.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`) - ℹ️ tested via `make docs-preview`
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
