### PR TITLE
Support RSA keys for the Talos API

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -200,6 +200,7 @@ var (
 	withIOMMU                 bool
 	configInjectionMethodFlag string
 	mountOpts                 opts.MountOpt
+	rsa                       bool
 )
 
 // createCmd represents the cluster up command.
@@ -737,6 +738,7 @@ func create(ctx context.Context) error {
 					Endpoint:    inClusterEndpoint,
 					KubeVersion: strings.TrimPrefix(kubernetesVersion, "v"),
 					GenOptions:  genOptions,
+					Rsa:         rsa,
 				}),
 		)
 	}
@@ -1353,6 +1355,7 @@ func init() {
 	createCmd.Flags().BoolVar(&withJSONLogs, "with-json-logs", false, "enable JSON logs receiver and configure Talos to send logs there")
 	createCmd.Flags().StringVar(&configInjectionMethodFlag, "config-injection-method", "", "a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO (QEMU only)")
 	createCmd.Flags().Var(&mountOpts, "mount", "attach a mount to the container (Docker only)")
+	createCmd.Flags().BoolVar(&rsa, "rsa", false, "generate RSA keys instead of Ed25519 for the Talos API CA")
 
 	createCmd.MarkFlagsMutuallyExclusive(inputDirFlag, nodeInstallImageFlag)
 	createCmd.MarkFlagsMutuallyExclusive(inputDirFlag, configDebugFlag)

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -76,6 +76,7 @@ var genConfigCmdFlags struct {
 	withClusterDiscovery    bool
 	withKubeSpan            bool
 	withSecrets             string
+	rsa                     bool
 }
 
 // NewConfigCmd builds the config generation subcommand with the given name.
@@ -130,6 +131,7 @@ func GenerateConfigBundle(genOptions []generate.Option,
 	configPatch []string,
 	configPatchControlPlane []string,
 	configPatchWorker []string,
+	rsa bool,
 ) (*bundle.Bundle, error) {
 	configBundleOpts := []bundle.Option{
 		bundle.WithInputOptions(
@@ -138,6 +140,7 @@ func GenerateConfigBundle(genOptions []generate.Option,
 				Endpoint:    endpoint,
 				KubeVersion: strings.TrimPrefix(kubernetesVersion, "v"),
 				GenOptions:  genOptions,
+				Rsa:         rsa,
 			},
 		),
 	}
@@ -250,7 +253,8 @@ func writeConfig(args []string) error {
 		genConfigCmdFlags.kubernetesVersion,
 		genConfigCmdFlags.configPatch,
 		genConfigCmdFlags.configPatchControlPlane,
-		genConfigCmdFlags.configPatchWorker)
+		genConfigCmdFlags.configPatchWorker,
+		genConfigCmdFlags.rsa)
 	if err != nil {
 		return err
 	}
@@ -445,6 +449,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withClusterDiscovery, "with-cluster-discovery", "", true, "enable cluster discovery feature")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withKubeSpan, "with-kubespan", "", false, "enable KubeSpan feature")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.withSecrets, "with-secrets", "", "use a secrets file generated using 'gen secrets'")
+	genConfigCmd.Flags().BoolVar(&genConfigCmdFlags.rsa, "rsa", false, "generate RSA keys instead of Ed25519 for the Talos API CA")
 
 	genConfigCmd.Flags().StringSliceVarP(&genConfigCmdFlags.outputTypes, "output-types", "t", allOutputTypes, fmt.Sprintf("types of outputs to be generated. valid types are: %q", allOutputTypes))
 	genConfigCmd.Flags().StringVarP(&genConfigCmdFlags.output, "output", "o", "",

--- a/cmd/talosctl/cmd/mgmt/gen/secrets.go
+++ b/cmd/talosctl/cmd/mgmt/gen/secrets.go
@@ -23,6 +23,7 @@ var genSecretsCmdFlags struct {
 	fromKubernetesPki        string
 	fromControlplaneConfig   string
 	kubernetesBootstrapToken string
+	rsa                      bool
 }
 
 // genSecretsCmd represents the `gen secrets` command.
@@ -60,6 +61,7 @@ var genSecretsCmd = &cobra.Command{
 			secretsBundle = secrets.NewBundleFromConfig(secrets.NewFixedClock(time.Now()), cfg)
 		default:
 			secretsBundle, err = secrets.NewBundle(secrets.NewFixedClock(time.Now()),
+				genSecretsCmdFlags.rsa,
 				versionContract,
 			)
 		}
@@ -91,6 +93,7 @@ func init() {
 	genSecretsCmd.Flags().StringVar(&genSecretsCmdFlags.fromControlplaneConfig, "from-controlplane-config", "", "use the provided controlplane Talos machine configuration as input")
 	genSecretsCmd.Flags().StringVarP(&genSecretsCmdFlags.fromKubernetesPki, "from-kubernetes-pki", "p", "", "use a Kubernetes PKI directory (e.g. /etc/kubernetes/pki) as input")
 	genSecretsCmd.Flags().StringVarP(&genSecretsCmdFlags.kubernetesBootstrapToken, "kubernetes-bootstrap-token", "t", "", "use the provided bootstrap token as input")
+	genSecretsCmd.Flags().BoolVarP(&genSecretsCmdFlags.rsa, "rsa", "", false, "generate RSA keys instead of Ed25519 for the Talos API CA")
 
 	Cmd.AddCommand(genSecretsCmd)
 }

--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -30,6 +30,7 @@ var rotateCACmdFlags struct {
 	dryRun           bool
 	rotateTalos      bool
 	rotateKubernetes bool
+	rsa              bool
 }
 
 // rotateCACmd represents the rotate-ca command.
@@ -70,7 +71,7 @@ func rotateCA(ctx context.Context, c *client.Client) error {
 		return err
 	}
 
-	newBundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), config.TalosVersionCurrent)
+	newBundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), rotateCACmdFlags.rsa, config.TalosVersionCurrent)
 	if err != nil {
 		return fmt.Errorf("error generating new Talos CA: %w", err)
 	}
@@ -184,4 +185,5 @@ func init() {
 	rotateCACmd.Flags().BoolVarP(&rotateCACmdFlags.dryRun, "dry-run", "", true, "dry-run mode (no changes to the cluster)")
 	rotateCACmd.Flags().BoolVarP(&rotateCACmdFlags.rotateTalos, "talos", "", true, "rotate Talos API CA")
 	rotateCACmd.Flags().BoolVarP(&rotateCACmdFlags.rotateKubernetes, "kubernetes", "", true, "rotate Kubernetes API CA")
+	rotateCACmd.Flags().BoolVarP(&rotateCACmdFlags.rsa, "rsa", "", false, "generate RSA keys instead of Ed25519 for the Talos API CA")
 }

--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -345,11 +345,23 @@ func (ctrl *APIController) generateWorker(ctx context.Context, r controller.Runt
 
 	defer remoteGen.Close() //nolint:errcheck
 
-	serverCSR, serverCert, err := x509.NewEd25519CSRAndIdentity(
-		x509.IPAddresses(certSANs.StdIPs()),
-		x509.DNSNames(certSANs.DNSNames),
-		x509.CommonName(certSANs.FQDN),
-	)
+	var serverCSR *x509.CertificateSigningRequest
+	var serverCert *x509.PEMEncodedCertificateAndKey
+
+	if rootSpec.Rsa {
+		serverCSR, serverCert, err = x509.NewRSACSRAndIdentity(
+			x509.IPAddresses(certSANs.StdIPs()),
+			x509.DNSNames(certSANs.DNSNames),
+			x509.CommonName(certSANs.FQDN),
+		)
+	} else {
+		serverCSR, serverCert, err = x509.NewEd25519CSRAndIdentity(
+			x509.IPAddresses(certSANs.StdIPs()),
+			x509.DNSNames(certSANs.DNSNames),
+			x509.CommonName(certSANs.FQDN),
+		)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to generate API server CSR: %w", err)
 	}

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -6,6 +6,7 @@ package secrets
 
 import (
 	"context"
+	stdlibx509 "crypto/x509"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -165,6 +166,15 @@ func NewRootOSController() *RootOSController {
 					osSecrets.AcceptedCAs = append(osSecrets.AcceptedCAs, &x509.PEMEncodedCertificate{
 						Crt: osSecrets.IssuingCA.Crt,
 					})
+
+					issuingCert, err := osSecrets.IssuingCA.GetCert()
+					if err != nil {
+						return err
+					}
+
+					if issuingCert.PublicKeyAlgorithm == stdlibx509.RSA {
+						osSecrets.Rsa = true
+					}
 
 					if len(osSecrets.IssuingCA.Key) == 0 {
 						// drop incomplete issuing CA, as the machine config for workers contains just the cert

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -123,7 +123,7 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 
 		switch {
 		case os.IsNotExist(err):
-			secretsBundle, err = secrets.NewBundle(clock, config.TalosVersionCurrent)
+			secretsBundle, err = secrets.NewBundle(clock, false, config.TalosVersionCurrent)
 			if err != nil {
 				return nil, err
 			}
@@ -139,6 +139,7 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 			in.ClusterConfig.Name,
 			in.ClusterConfig.ControlPlane.Endpoint,
 			in.MachineConfig.KubernetesVersion,
+			false,
 			options...,
 		)
 		if err != nil {

--- a/pkg/machinery/config/bundle/bundle.go
+++ b/pkg/machinery/config/bundle/bundle.go
@@ -115,6 +115,7 @@ func NewBundle(opts ...Option) (*Bundle, error) {
 		options.InputOptions.ClusterName,
 		options.InputOptions.Endpoint,
 		options.InputOptions.KubeVersion,
+		options.InputOptions.Rsa,
 		options.InputOptions.GenOptions...,
 	)
 	if err != nil {

--- a/pkg/machinery/config/bundle/options.go
+++ b/pkg/machinery/config/bundle/options.go
@@ -17,6 +17,7 @@ type InputOptions struct {
 	ClusterName string
 	Endpoint    string
 	KubeVersion string
+	Rsa         bool
 	GenOptions  []generate.Option
 }
 

--- a/pkg/machinery/config/generate/generate.go
+++ b/pkg/machinery/config/generate/generate.go
@@ -60,7 +60,7 @@ func (in *Input) GetAPIServerSANs() []string {
 }
 
 // NewInput prepares a new Input struct to perform machine config generation.
-func NewInput(clustername, endpoint, kubernetesVersion string, opts ...Option) (*Input, error) {
+func NewInput(clustername, endpoint, kubernetesVersion string, rsa bool, opts ...Option) (*Input, error) {
 	input := &Input{}
 	input.Options = DefaultOptions()
 
@@ -83,7 +83,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, opts ...Option) (
 	if input.Options.SecretsBundle == nil {
 		var err error
 
-		input.Options.SecretsBundle, err = secrets.NewBundle(secrets.NewFixedClock(time.Now()), input.Options.VersionContract)
+		input.Options.SecretsBundle, err = secrets.NewBundle(secrets.NewFixedClock(time.Now()), rsa, input.Options.VersionContract)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/machinery/config/generate/secrets/bundle.go
+++ b/pkg/machinery/config/generate/secrets/bundle.go
@@ -21,12 +21,12 @@ import (
 )
 
 // NewBundle creates secrets bundle generating all secrets.
-func NewBundle(clock Clock, versionContract *config.VersionContract) (*Bundle, error) {
+func NewBundle(clock Clock, rsa bool, versionContract *config.VersionContract) (*Bundle, error) {
 	bundle := &Bundle{
 		Clock: clock,
 	}
 
-	err := bundle.populate(versionContract)
+	err := bundle.populate(rsa, versionContract)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func NewBundleFromKubernetesPKI(pkiDir, bootstrapToken string, versionContract *
 		},
 	}
 
-	err = bundle.populate(versionContract)
+	err = bundle.populate(false, versionContract)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func NewBundleFromConfig(clock Clock, c config.Config) *Bundle {
 // populate fills all the missing fields in the secrets bundle.
 //
 //nolint:gocyclo,cyclop
-func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
+func (bundle *Bundle) populate(rsa bool, versionContract *config.VersionContract) error {
 	if bundle.Clock == nil {
 		bundle.Clock = NewClock()
 	}
@@ -259,7 +259,7 @@ func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
 	}
 
 	if bundle.Certs.OS == nil {
-		talosCA, err := NewTalosCA(bundle.Clock.Now())
+		talosCA, err := NewTalosCA(bundle.Clock.Now(), rsa)
 		if err != nil {
 			return err
 		}

--- a/pkg/machinery/config/generate/secrets/ca.go
+++ b/pkg/machinery/config/generate/secrets/ca.go
@@ -52,11 +52,15 @@ func NewAggregatorCA(currentTime time.Time, contract *config.VersionContract) (c
 }
 
 // NewTalosCA generates a CA for the Talos PKI.
-func NewTalosCA(currentTime time.Time) (ca *x509.CertificateAuthority, err error) {
+func NewTalosCA(currentTime time.Time, rsa bool) (ca *x509.CertificateAuthority, err error) {
 	opts := []x509.Option{
 		x509.Organization("talos"),
 		x509.NotAfter(currentTime.Add(CAValidityTime)),
 		x509.NotBefore(currentTime),
+	}
+
+	if rsa {
+		opts = append(opts, x509.SignatureAlgorithm(stdx509.SHA256WithRSA))
 	}
 
 	return x509.NewSelfSignedCertificateAuthority(opts...)

--- a/pkg/machinery/resources/secrets/os_root.go
+++ b/pkg/machinery/resources/secrets/os_root.go
@@ -33,6 +33,7 @@ type OSRootSpec struct {
 	AcceptedCAs     []*x509.PEMEncodedCertificate     `yaml:"acceptedCAs" protobuf:"5"`
 	CertSANIPs      []netip.Addr                      `yaml:"certSANIPs" protobuf:"2"`
 	CertSANDNSNames []string                          `yaml:"certSANDNSNames" protobuf:"3"`
+	Rsa             bool                              `yaml:"rsa" protobuf:"6"`
 
 	Token string `yaml:"token" protobuf:"4"`
 }


### PR DESCRIPTION
# Pull Request

Fixes #10668.

The code does not pass conformance checks has no tests yet, and compilation probably breaks with non-default build flags. 

That will of course be fixed, but I wanted to propose this here first before doing anything major.

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

1. Make worker nodes generate RSA keys for the Talos API if the CA uses an RSA certificate
2. Add a cli flag `--rsa` to talosctl commands that generate secrets, to generate an RSA CA instead of an Ed25519 one for the Talos API

## Why? (reasoning)

As mentioned in #10668, some languages/environments don't have Ed21159 support, which makes it difficult to write tooling that consumes the Talos API in such languages. 

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)