### PR TITLE
fix: upgrades with bios

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -27,6 +27,8 @@ type Config struct {
 	Fallback       BootLabel
 	Entries        map[BootLabel]MenuEntry
 	AddResetOption bool
+
+	installEFI bool
 }
 
 // MenuEntry represents a grub menu entry in the grub config file.


### PR DESCRIPTION
Add EFI mount for GRUB install only if EFI mount is present, since starting Talos v1.10 if we boot of a dual-boot image EFI is wiped in BIOS mode.
