### PR TITLE
docs: fix search

### DIFF
--- a/website/layouts/partials/hooks/body-end.html
+++ b/website/layouts/partials/hooks/body-end.html
@@ -3,7 +3,7 @@
     <script src="/js/clipboard.js"></script>
 {{ end }}
 
-{{ $currentVersion := index (split .Page.Path "/" ) 0 }}
+{{ $currentVersion := index (split .Page.Path "/" ) 1 }}
 {{ $currentVersionDir := $currentVersion | printf "/%s"}}
 
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>


### PR DESCRIPTION
The search in the documentation page no longer works due to changes made in https://github.com/siderolabs/talos/pull/10672 by yours truly

The issue lies in the change of behavior of the `split` function. After the hugo update the 0th index is a whitespace, not the docs version.
https://github.com/siderolabs/talos/blob/f0ea478cb811675a450839b8dcd351e43404efd4/website/layouts/partials/hooks/body-end.html#L6

Just changing the index to one does result in the correct `$currentVersion` value, but the search results still don't appear.  This might be due to the a broken state of the [crawler data store](https://docsearch.algolia.com/docs/manage-your-crawls/) because the meta tags used for the version assignments have been broken since #10672 was merged. I cannot confirm this theory as I don't have access to the crawler control panel.
https://github.com/siderolabs/talos/blob/f0ea478cb811675a450839b8dcd351e43404efd4/website/layouts/partials/hooks/body-end.html#L50-L61


This **might** fix the issue, but I am unable to confirm as I don't have access to the crawler!!!
