### PR TITLE
fix: grub efi platform install

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
@@ -149,7 +149,11 @@ func (c *Config) install(opts options.InstallOptions) (*options.InstallResult, e
 
 	switch opts.Arch {
 	case amd64:
-		platforms = []string{"x86_64-efi", "i386-pc"}
+		if c.installEFI {
+			platforms = append(platforms, "x86_64-efi")
+		}
+
+		platforms = append(platforms, "i386-pc")
 	case arm64:
 		platforms = []string{"arm64-efi"}
 	}


### PR DESCRIPTION
Only select `x86_64-efi` if EFI needs to be installed.