### PR TITLE
chore(docs): fixed typo at OpenEBS Mayastor worker patches

### DIFF
--- a/website/content/v1.9/kubernetes-guides/configuration/storage.md
+++ b/website/content/v1.9/kubernetes-guides/configuration/storage.md
@@ -89,7 +89,7 @@ machine:
         type: bind
         source: /var/local
         options:
-          - bind
+          - rbind
           - rshared
           - rw
 ```


### PR DESCRIPTION
What?
This commit tries to address an issue with the current documentation and the patches it provided for configuring the worker nodes in the OpenEBS Mayastor installation

Why?
While I was trying to follow the documentation I encountered an error in my deployment "FailedMount”, stating that a PVC doesn’t exist, checking at the video and also in this other [tutorial](https://blog.dalydays.com/post/kubernetes-storage-with-openebs/) I can confirm indeed there is an error with the patch in the documentation, very subtle but is there