### PR TITLE
docs: correct flannel extra args example

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/vmware.md
@@ -75,8 +75,10 @@ If you apply the patch you can save this to a separate file (e.g. cni-patch.yaml
 cluster:
   network:
     cni:
-      extraArgs:
-        - --flannel-backend=host-gw
+      name: flannel
+      flannel:
+        extraArgs:
+          - --flannel-backend=host-gw
 ```
 
 ## Set Environment Variables

--- a/website/content/v1.9/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.9/talos-guides/install/virtualized-platforms/vmware.md
@@ -75,8 +75,10 @@ If you apply the patch you can save this to a separate file (e.g. cni-patch.yaml
 cluster:
   network:
     cni:
-      extraArgs:
-        - --flannel-backend=host-gw
+      name: flannel
+      flannel:
+        extraArgs:
+          - --flannel-backend=host-gw
 ```
 
 ## Set Environment Variables


### PR DESCRIPTION
Correct the configuration example for using flannel `extraArgs`.

Thanks to Cameron in the [community Slack](https://taloscommunity.slack.com/archives/CMARMBC4E/p1745300100041919?thread_ts=1745299857.476909&cid=CMARMBC4E).

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
