### PR TITLE
chore(ci): add provision test with bios

### DIFF
--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -266,7 +266,6 @@ func (suite *BaseSuite) readVersion(nodeCtx context.Context, client *talosclient
 
 type upgradeOptions struct {
 	TargetInstallerImage string
-	UpgradePreserve      bool
 	UpgradeStage         bool
 	TargetVersion        string
 }
@@ -290,7 +289,6 @@ func (suite *BaseSuite) upgradeNode(client *talosclient.Client, node provision.N
 			resp, err = client.Upgrade(
 				nodeCtx,
 				options.TargetInstallerImage,
-				options.UpgradePreserve,
 				options.UpgradeStage,
 				false,
 			)
@@ -429,6 +427,7 @@ type clusterOptions struct {
 	SourceK8sVersion     string
 
 	WithEncryption bool
+	WithBios       bool
 }
 
 // setupCluster provisions source clusters and waits for health.
@@ -597,7 +596,7 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 	suite.Cluster, err = suite.provisioner.Create(
 		suite.ctx, request,
 		provision.WithBootlader(true),
-		provision.WithUEFI(true),
+		provision.WithUEFI(!options.WithBios),
 		provision.WithTalosConfig(suite.configBundle.TalosConfig()),
 	)
 	suite.Require().NoError(err)

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -572,12 +572,11 @@ func WithUpgradeGRPCCallOptions(opts ...grpc.CallOption) UpgradeOption {
 }
 
 // Upgrade initiates a Talos upgrade and implements the proto.MachineServiceClient interface.
-func (c *Client) Upgrade(ctx context.Context, image string, preserve, stage, force bool, callOptions ...grpc.CallOption) (*machineapi.UpgradeResponse, error) {
+func (c *Client) Upgrade(ctx context.Context, image string, stage, force bool, callOptions ...grpc.CallOption) (*machineapi.UpgradeResponse, error) {
 	return c.UpgradeWithOptions(
 		ctx,
 		WithUpgradeImage(image),
 		WithUpgradeRebootMode(machineapi.UpgradeRequest_DEFAULT),
-		WithUpgradePreserve(preserve),
 		WithUpgradeStage(stage),
 		WithUpgradeForce(force),
 		WithUpgradeGRPCCallOptions(callOptions...),


### PR DESCRIPTION
Add a provision test without UEFI boot.
Drop preserve upgrade test since it's the default now.

Fixes: #10777