### PR TITLE
docs: hetzner: add note about public iso

### DIFF
--- a/website/content/v1.10/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.10/talos-guides/install/cloud-platforms/hetzner.md
@@ -7,8 +7,10 @@ aliases:
 
 ## Upload image
 
-Hetzner Cloud does not support uploading custom images.
-You can email their support to get a Talos ISO uploaded by following [issues:3599](https://github.com/siderolabs/talos/issues/3599#issuecomment-841172018) or you can prepare image snapshot by yourself.
+**NOTE:** Hetzner Cloud provides Talos as Public ISO with the schematic id `ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515` (Hetzner + qemu-guest-agent) since 2025-04-23.
+Minor updates of the ISO will be provided by Hetzner Cloud on a best effort.
+
+If you need an ISO with a different schematic id, please email the support team to get a Talos ISO uploaded by following [issues:3599](https://github.com/siderolabs/talos/issues/3599#issuecomment-841172018) or you can prepare image snapshot by yourself.
 
 There are three options to upload your own.
 

--- a/website/content/v1.9/talos-guides/install/cloud-platforms/hetzner.md
+++ b/website/content/v1.9/talos-guides/install/cloud-platforms/hetzner.md
@@ -7,8 +7,10 @@ aliases:
 
 ## Upload image
 
-Hetzner Cloud does not support uploading custom images.
-You can email their support to get a Talos ISO uploaded by following [issues:3599](https://github.com/siderolabs/talos/issues/3599#issuecomment-841172018) or you can prepare image snapshot by yourself.
+**NOTE:** Hetzner Cloud provides Talos as Public ISO with the schematic id `ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515` (Hetzner + qemu-guest-agent) since 2025-04-23.
+Minor updates of the ISO will be provided by Hetzner Cloud on a best effort.
+
+If you need an ISO with a different schematic id, please email the support team to get a Talos ISO uploaded by following [issues:3599](https://github.com/siderolabs/talos/issues/3599#issuecomment-841172018) or you can prepare image snapshot by yourself.
 
 There are three options to upload your own.
 


### PR DESCRIPTION
# Pull Request

## What? (description)

This commit adds a note that Hetzner Cloud now provides Talos Linux as ISO in their public cloud ISO library.

## Why? (reasoning)

Due to the increased demand of Talos Linux, Hetzner is now providing Talos Linux as ISO in their public ISO library.

```
hcloud iso list --type public
119702   hcloud-amd64.iso   Talos Linux 1.9.5 (amd64 / Hetzner + qemu-guest-agent)   public   x86
119703   hcloud-arm64.iso   Talos Linux 1.9.5 (arm64 / Hetzner + qemu-guest-agent)   public   arm
```

Edit 2025-04-23 13:23 CEST: We've published a [changelog entry](https://docs.hetzner.cloud/changelog#2025-04-23-talos-linux-v195-iso-now-available) on the Hetzner Cloud docs page.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
  I guess it's an expected fail?
  ```
  commit         GPG Identity                 FAILED        openpgp: signature made by unknown entity
  ```
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
  yes and no. The `docs-build` process fails on `arm64` because `talosctl` is apparently not an arm64 binary.
  ```
   => ERROR [docs-build 3/4] RUN env HOME=/home/user TAG=latest /bin/talosctl docs --config /tmp/configuration     && env HOME=/home/user TAG=latest /bin/talosctl docs --cli /tmp
  ------
   > [docs-build 3/4] RUN env HOME=/home/user TAG=latest /bin/talosctl docs --config /tmp/configuration     && env HOME=/home/user TAG=latest /bin/talosctl docs --cli /tmp:
  0.156 env: ‘/bin/talosctl’: Exec format error
  ------
  Dockerfile:1209
  --------------------
   1208 |     COPY --from=talosctl-targetarch /talosctl-${TARGETOS}-${TARGETARCH} /bin/talosctl
   1209 | >>> RUN env HOME=/home/user TAG=latest /bin/talosctl docs --config /tmp/configuration \
   1210 | >>>     && env HOME=/home/user TAG=latest /bin/talosctl docs --cli /tmp
   1211 |     COPY ./pkg/machinery/config/schemas/*.schema.json /tmp/schemas/
  --------------------
  ```
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
