### PR TITLE
feat: add version compatibility for Talos 1.11

### DIFF
--- a/pkg/machinery/compatibility/kubernetes_version.go
+++ b/pkg/machinery/compatibility/kubernetes_version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/siderolabs/gen/pair/ordered"
 
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos110"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos111"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
@@ -67,6 +68,8 @@ func (v *KubernetesVersion) SupportedWith(target *TalosVersion) error {
 		minK8sVersion, maxK8sVersion = talos19.MinimumKubernetesVersion, talos19.MaximumKubernetesVersion
 	case talos110.MajorMinor: // upgrades to 1.10.x
 		minK8sVersion, maxK8sVersion = talos110.MinimumKubernetesVersion, talos110.MaximumKubernetesVersion
+	case talos111.MajorMinor: // upgrades to 1.11.x
+		minK8sVersion, maxK8sVersion = talos111.MinimumKubernetesVersion, talos111.MaximumKubernetesVersion
 	default:
 		return fmt.Errorf("compatibility with version %s is not supported", target.String())
 	}

--- a/pkg/machinery/compatibility/kubernetes_version_test.go
+++ b/pkg/machinery/compatibility/kubernetes_version_test.go
@@ -319,12 +319,45 @@ func TestKubernetesCompatibility110(t *testing.T) {
 	}
 }
 
+func TestKubernetesCompatibility111(t *testing.T) {
+	for _, tt := range []kubernetesVersionTest{
+		{
+			kubernetesVersion: "1.30.1",
+			target:            "1.11.0",
+		},
+		{
+			kubernetesVersion: "1.29.1",
+			target:            "1.11.0",
+		},
+		{
+			kubernetesVersion: "1.33.3",
+			target:            "1.11.0-beta.0",
+		},
+		{
+			kubernetesVersion: "1.34.0-rc.0",
+			target:            "1.11.7",
+		},
+		{
+			kubernetesVersion: "1.35.0-alpha.0",
+			target:            "1.11.0",
+			expectedError:     "version of Kubernetes 1.35.0-alpha.0 is too new to be used with Talos 1.11.0",
+		},
+		{
+			kubernetesVersion: "1.28.1",
+			target:            "1.11.0",
+			expectedError:     "version of Kubernetes 1.28.1 is too old to be used with Talos 1.11.0",
+		},
+	} {
+		runKubernetesVersionTest(t, tt)
+	}
+}
+
 func TestKubernetesCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []kubernetesVersionTest{
 		{
 			kubernetesVersion: "1.25.0",
-			target:            "1.11.0-alpha.0",
-			expectedError:     "compatibility with version 1.11.0-alpha.0 is not supported",
+			target:            "1.12.0-alpha.0",
+			expectedError:     "compatibility with version 1.12.0-alpha.0 is not supported",
 		},
 		{
 			kubernetesVersion: "1.25.0",

--- a/pkg/machinery/compatibility/talos111/talos111.go
+++ b/pkg/machinery/compatibility/talos111/talos111.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package talos111 provides compatibility constants for Talos 1.11.
+package talos111
+
+import (
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinor is the major.minor version of Talos 1.11.
+var MajorMinor = [2]uint64{1, 11}
+
+// MinimumHostUpgradeVersion is the minimum version of Talos that can be upgraded to 1.11.
+var MinimumHostUpgradeVersion = semver.MustParse("1.9.0")
+
+// MaximumHostDowngradeVersion is the maximum (not inclusive) version of Talos that can be downgraded to 1.11.
+var MaximumHostDowngradeVersion = semver.MustParse("1.13.0")
+
+// DeniedHostUpgradeVersions are the versions of Talos that cannot be upgraded to 1.11.
+var DeniedHostUpgradeVersions []semver.Version
+
+// MinimumKubernetesVersion is the minimum version of Kubernetes is supported with 1.11.
+var MinimumKubernetesVersion = semver.MustParse("1.29.0")
+
+// MaximumKubernetesVersion is the maximum version of Kubernetes is supported with 1.11.
+var MaximumKubernetesVersion = semver.MustParse("1.34.99")

--- a/pkg/machinery/compatibility/talos_version.go
+++ b/pkg/machinery/compatibility/talos_version.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos110"
+	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos111"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos12"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos13"
 	"github.com/siderolabs/talos/pkg/machinery/compatibility/talos14"
@@ -102,6 +103,9 @@ func (v *TalosVersion) UpgradeableFrom(host *TalosVersion) error {
 	case talos110.MajorMinor: // upgrades to 1.10.x
 		minHostUpgradeVersion, maxHostDowngradeVersion = talos110.MinimumHostUpgradeVersion, talos110.MaximumHostDowngradeVersion
 		deniedHostUpgradeVersions = talos110.DeniedHostUpgradeVersions
+	case talos111.MajorMinor: // upgrades to 1.11.x
+		minHostUpgradeVersion, maxHostDowngradeVersion = talos111.MinimumHostUpgradeVersion, talos111.MaximumHostDowngradeVersion
+		deniedHostUpgradeVersions = talos111.DeniedHostUpgradeVersions
 	default:
 		return fmt.Errorf("upgrades to version %s are not supported", v.version.String())
 	}

--- a/pkg/machinery/compatibility/talos_version_test.go
+++ b/pkg/machinery/compatibility/talos_version_test.go
@@ -368,17 +368,58 @@ func TestTalosUpgradeCompatibility110(t *testing.T) {
 	}
 }
 
+func TestTalosUpgradeCompatibility111(t *testing.T) {
+	for _, tt := range []talosVersionTest{
+		{
+			host:   "1.9.0",
+			target: "1.11.0",
+		},
+		{
+			host:   "1.10.0-alpha.0",
+			target: "1.11.0",
+		},
+		{
+			host:   "1.9.0",
+			target: "1.11.0-alpha.0",
+		},
+		{
+			host:   "1.10.3",
+			target: "1.11.1",
+		},
+		{
+			host:   "1.11.0-beta.0",
+			target: "1.11.0",
+		},
+		{
+			host:   "1.11.5",
+			target: "1.11.3",
+		},
+		{
+			host:          "1.8.0",
+			target:        "1.11.0",
+			expectedError: `host version 1.8.0 is too old to upgrade to Talos 1.11.0`,
+		},
+		{
+			host:          "1.13.0-alpha.0",
+			target:        "1.11.0",
+			expectedError: `host version 1.13.0-alpha.0 is too new to downgrade to Talos 1.11.0`,
+		},
+	} {
+		runTalosVersionTest(t, tt)
+	}
+}
+
 func TestTalosUpgradeCompatibilityUnsupported(t *testing.T) {
 	for _, tt := range []talosVersionTest{
 		{
 			host:          "1.3.0",
-			target:        "1.11.0-alpha.0",
-			expectedError: `upgrades to version 1.11.0-alpha.0 are not supported`,
+			target:        "1.12.0-alpha.0",
+			expectedError: `upgrades to version 1.12.0-alpha.0 are not supported`,
 		},
 		{
 			host:          "1.4.0",
-			target:        "1.12.0-alpha.0",
-			expectedError: `upgrades to version 1.12.0-alpha.0 are not supported`,
+			target:        "1.13.0-alpha.0",
+			expectedError: `upgrades to version 1.13.0-alpha.0 are not supported`,
 		},
 	} {
 		runTalosVersionTest(t, tt)


### PR DESCRIPTION
This is future compatibility to make upgrades to future Talos 1.11 easier.
