### PR TITLE
fix: handle correctly changing platform network config

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -168,7 +168,7 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 		}
 
 		// prefer live network config over cached config always
-		if activeNetworkConfig == nil {
+		if networkConfig != nil {
 			activeNetworkConfig = networkConfig
 		}
 


### PR DESCRIPTION
The bug was with incorrect condition: if `activeNetworkConfig` was ever set to non-nil value, it was stuck with this value forever, despite new network config being available with `networkConfig`.

In `talosctl dashboard` case, Talos `metal` platform always reports initial data (before META is available) which doesn't have any network config, but later on sends updates (if something updates META), so this bug leads to Talos being stuck with initial empty network config.

Fixes #10787
