### PR TITLE
feat: allow SideroLink unique token in machine config

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/unique_token.go
+++ b/internal/app/machined/pkg/controllers/runtime/unique_token.go
@@ -6,51 +6,110 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/controller/generic/transform"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/pkg/machinery/meta"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
 
-// UniqueMachineTokenController provides a unique token the machine.
-type UniqueMachineTokenController = transform.Controller[*runtime.MetaLoaded, *runtime.UniqueMachineToken]
+// UniqueMachineTokenController is a controller that manages SideroLink unique token.
+type UniqueMachineTokenController struct{}
 
-// NewUniqueMachineTokenController instanciates the controller.
-func NewUniqueMachineTokenController() *UniqueMachineTokenController {
-	return transform.NewController(
-		transform.Settings[*runtime.MetaLoaded, *runtime.UniqueMachineToken]{
-			Name: "runtime.UniqueMachineTokenController",
-			MapMetadataFunc: func(in *runtime.MetaLoaded) *runtime.UniqueMachineToken {
-				return runtime.NewUniqueMachineToken()
-			},
-			TransformFunc: func(ctx context.Context, r controller.Reader, logger *zap.Logger, _ *runtime.MetaLoaded, out *runtime.UniqueMachineToken) error {
-				uniqueToken, err := safe.ReaderGetByID[*runtime.MetaKey](ctx, r, runtime.MetaKeyTagToID(meta.UniqueMachineToken))
-				if state.IsNotFoundError(err) {
-					out.TypedSpec().Token = ""
+// Name implements controller.Controller interface.
+func (ctrl *UniqueMachineTokenController) Name() string {
+	return "runtime.UniqueMachineTokenController"
+}
 
-					return nil
-				} else if err != nil {
-					return err
+// Inputs implements controller.Controller interface.
+func (ctrl *UniqueMachineTokenController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: runtime.NamespaceName,
+			Type:      runtime.MetaKeyType,
+			ID:        optional.Some(runtime.MetaKeyTagToID(meta.UniqueMachineToken)),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: runtime.NamespaceName,
+			Type:      runtime.MetaLoadedType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        optional.Some(config.ActiveID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *UniqueMachineTokenController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: runtime.UniqueMachineTokenType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *UniqueMachineTokenController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		r.StartTrackingOutputs()
+
+		metaLoaded, err := safe.ReaderGetByID[*runtime.MetaLoaded](ctx, r, runtime.MetaLoadedID)
+		if err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("failed to get meta loaded: %w", err)
+		}
+
+		metaKey, err := safe.ReaderGetByID[*runtime.MetaKey](ctx, r, runtime.MetaKeyTagToID(meta.UniqueMachineToken))
+		if err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("failed to get unique token meta key: %w", err)
+		}
+
+		cfg, err := safe.ReaderGetByID[*config.MachineConfig](ctx, r, config.ActiveID)
+		if err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("failed to get machine config: %w", err)
+		}
+
+		if metaLoaded != nil {
+			var token string
+
+			if metaKey != nil {
+				token = metaKey.TypedSpec().Value
+			} else if cfg != nil {
+				if cfg.Config().SideroLink() != nil {
+					token = cfg.Config().SideroLink().UniqueToken()
 				}
+			}
 
-				out.TypedSpec().Token = uniqueToken.TypedSpec().Value
+			if err = safe.WriterModify(ctx, r, runtime.NewUniqueMachineToken(), func(out *runtime.UniqueMachineToken) error {
+				out.TypedSpec().Token = token
 
 				return nil
-			},
-		},
-		transform.WithExtraInputs(
-			controller.Input{
-				Namespace: runtime.NamespaceName,
-				Type:      runtime.MetaKeyType,
-				ID:        optional.Some(runtime.MetaKeyTagToID(meta.UniqueMachineToken)),
-				Kind:      controller.InputWeak,
-			},
-		),
-	)
+			}); err != nil {
+				return fmt.Errorf("failed to update unique token: %w", err)
+			}
+		}
+
+		if err = safe.CleanupOutputs[*runtime.UniqueMachineToken](ctx, r); err != nil {
+			return fmt.Errorf("failed to cleanup outputs: %w", err)
+		}
+	}
 }

--- a/internal/app/machined/pkg/controllers/runtime/unique_token_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/unique_token_test.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
+	runtimectrls "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
+	"github.com/siderolabs/talos/pkg/machinery/meta"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+type UniqueMachineTokenSuite struct {
+	ctest.DefaultSuite
+}
+
+func TestUniqueMachineTokenSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &UniqueMachineTokenSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 5 * time.Second,
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(&runtimectrls.UniqueMachineTokenController{}))
+			},
+		},
+	})
+}
+
+func (suite *UniqueMachineTokenSuite) TestReconcileNoConfig() {
+	ctest.AssertNoResource[*runtime.UniqueMachineToken](suite, runtime.UniqueMachineTokenID)
+
+	suite.Create(runtime.NewMetaLoaded())
+
+	ctest.AssertResource(suite, runtime.UniqueMachineTokenID, func(token *runtime.UniqueMachineToken, asrt *assert.Assertions) {
+		asrt.Empty(token.TypedSpec().Token)
+	})
+
+	metaKey := runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(meta.UniqueMachineToken))
+	metaKey.TypedSpec().Value = "token1"
+	suite.Create(metaKey)
+
+	ctest.AssertResource(suite, runtime.UniqueMachineTokenID, func(token *runtime.UniqueMachineToken, asrt *assert.Assertions) {
+		asrt.Equal("token1", token.TypedSpec().Token)
+	})
+}
+
+func (suite *UniqueMachineTokenSuite) TestReconcileWithConfig() {
+	sideroLinkConfig := siderolink.NewConfigV1Alpha1()
+	sideroLinkConfig.UniqueTokenConfig = "token2"
+
+	ctr, err := container.New(sideroLinkConfig)
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(ctr)
+	suite.Create(cfg)
+
+	ctest.AssertNoResource[*runtime.UniqueMachineToken](suite, runtime.UniqueMachineTokenID)
+
+	suite.Create(runtime.NewMetaLoaded())
+
+	ctest.AssertResource(suite, runtime.UniqueMachineTokenID, func(token *runtime.UniqueMachineToken, asrt *assert.Assertions) {
+		asrt.Equal("token2", token.TypedSpec().Token)
+	})
+
+	metaKey := runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(meta.UniqueMachineToken))
+	metaKey.TypedSpec().Value = "token1"
+	suite.Create(metaKey)
+
+	ctest.AssertResource(suite, runtime.UniqueMachineTokenID, func(token *runtime.UniqueMachineToken, asrt *assert.Assertions) {
+		asrt.Equal("token1", token.TypedSpec().Token)
+	})
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -354,7 +354,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&runtimecontrollers.SecurityStateController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
-		runtimecontrollers.NewUniqueMachineTokenController(),
+		&runtimecontrollers.UniqueMachineTokenController{},
 		&runtimecontrollers.VersionController{},
 		&runtimecontrollers.WatchdogTimerConfigController{},
 		&runtimecontrollers.WatchdogTimerController{},

--- a/pkg/machinery/config/config/siderolink.go
+++ b/pkg/machinery/config/config/siderolink.go
@@ -9,4 +9,5 @@ import "net/url"
 // SideroLinkConfig defines the interface to access SideroLink configuration.
 type SideroLinkConfig interface {
 	APIUrl() *url.URL
+	UniqueToken() string
 }

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -1004,6 +1004,13 @@
           "description": "SideroLink API URL to connect to.\n",
           "markdownDescription": "SideroLink API URL to connect to.",
           "x-intellij-html-description": "\u003cp\u003eSideroLink API URL to connect to.\u003c/p\u003e\n"
+        },
+        "uniqueToken": {
+          "type": "string",
+          "title": "uniqueToken",
+          "description": "SideroLink unique token to use for the connection (optional).\n\nThis value is overridden with META key UniqueMachineToken.\n",
+          "markdownDescription": "SideroLink unique token to use for the connection (optional).\n\nThis value is overridden with META key UniqueMachineToken.",
+          "x-intellij-html-description": "\u003cp\u003eSideroLink unique token to use for the connection (optional).\u003c/p\u003e\n\n\u003cp\u003eThis value is overridden with META key UniqueMachineToken.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/siderolink/siderolink.go
+++ b/pkg/machinery/config/types/siderolink/siderolink.go
@@ -62,6 +62,11 @@ type ConfigV1Alpha1 struct {
 	//     type: string
 	//     pattern: "^(https|grpc)://"
 	APIUrlConfig meta.URL `yaml:"apiUrl"`
+	//   description: |
+	//     SideroLink unique token to use for the connection (optional).
+	//
+	//     This value is overridden with META key UniqueMachineToken.
+	UniqueTokenConfig string `yaml:"uniqueToken,omitempty"`
 }
 
 // NewConfigV1Alpha1 creates a new siderolink config document.
@@ -110,6 +115,15 @@ func (s *ConfigV1Alpha1) APIUrl() *url.URL {
 	}
 
 	return s.APIUrlConfig.URL
+}
+
+// UniqueToken implements config.SideroLink interface.
+func (s *ConfigV1Alpha1) UniqueToken() string {
+	if s == nil {
+		return ""
+	}
+
+	return s.UniqueTokenConfig
 }
 
 // Validate implements config.Validator interface.

--- a/pkg/machinery/config/types/siderolink/siderolink_doc.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_doc.go
@@ -16,12 +16,20 @@ func (ConfigV1Alpha1) Doc() *encoder.Doc {
 		Comments:    [3]string{"" /* encoder.HeadComment */, "SideroLinkConfig is a SideroLink connection machine configuration document." /* encoder.LineComment */, "" /* encoder.FootComment */},
 		Description: "SideroLinkConfig is a SideroLink connection machine configuration document.",
 		Fields: []encoder.Doc{
-			{}, {
+			{},
+			{
 				Name:        "apiUrl",
 				Type:        "URL",
 				Note:        "",
 				Description: "SideroLink API URL to connect to.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "SideroLink API URL to connect to." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "uniqueToken",
+				Type:        "string",
+				Note:        "",
+				Description: "SideroLink unique token to use for the connection (optional).\n\nThis value is overridden with META key UniqueMachineToken.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "SideroLink unique token to use for the connection (optional)." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 		},
 	}

--- a/website/content/v1.10/reference/configuration/siderolink/siderolinkconfig.md
+++ b/website/content/v1.10/reference/configuration/siderolink/siderolinkconfig.md
@@ -25,6 +25,7 @@ apiUrl: https://siderolink.api/jointoken?token=secret # SideroLink API URL to co
 |`apiUrl` |URL |SideroLink API URL to connect to. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 apiUrl: https://siderolink.api/?jointoken=secret
 {{< /highlight >}}</details> | |
+|`uniqueToken` |string |<details><summary>SideroLink unique token to use for the connection (optional).</summary><br />This value is overridden with META key UniqueMachineToken.</details>  | |
 
 
 

--- a/website/content/v1.10/schemas/config.schema.json
+++ b/website/content/v1.10/schemas/config.schema.json
@@ -1004,6 +1004,13 @@
           "description": "SideroLink API URL to connect to.\n",
           "markdownDescription": "SideroLink API URL to connect to.",
           "x-intellij-html-description": "\u003cp\u003eSideroLink API URL to connect to.\u003c/p\u003e\n"
+        },
+        "uniqueToken": {
+          "type": "string",
+          "title": "uniqueToken",
+          "description": "SideroLink unique token to use for the connection (optional).\n\nThis value is overridden with META key UniqueMachineToken.\n",
+          "markdownDescription": "SideroLink unique token to use for the connection (optional).\n\nThis value is overridden with META key UniqueMachineToken.",
+          "x-intellij-html-description": "\u003cp\u003eSideroLink unique token to use for the connection (optional).\u003c/p\u003e\n\n\u003cp\u003eThis value is overridden with META key UniqueMachineToken.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Allow unique token to be specified in machine config, this way we can workaround a problem with META being non-persistend/wiped.

Fixes #10570
