### PR TITLE
fix: handling of encryption type mismatch

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -652,8 +652,8 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 				return nil, fmt.Errorf("failed to get volume status with label %q: %w", spec.Label, err)
 			}
 
-			if volumeStatus.TypedSpec().Phase != block.VolumePhaseReady {
-				return nil, fmt.Errorf("failed to reset: volume %q is not ready", spec.Label)
+			if volumeStatus.TypedSpec().Location == "" {
+				return nil, fmt.Errorf("failed to reset: volume %q is not located", spec.Label)
 			}
 
 			target := partition.VolumeWipeTargetFromVolumeStatus(volumeStatus)

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -209,12 +209,22 @@ func DiskSizeCheck(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 			return nil
 		}
 
-		ephemeralStatus, err := waitForVolumeReady(ctx, r, constants.EphemeralPartitionLabel)
+		volumeStatus, err := r.State().V1Alpha2().Resources().WatchFor(ctx,
+			blockres.NewVolumeStatus(blockres.NamespaceName, constants.EphemeralPartitionLabel).Metadata(),
+			state.WithCondition(func(r resource.Resource) (bool, error) {
+				volumeStatus, ok := r.(*blockres.VolumeStatus)
+				if !ok {
+					return false, nil
+				}
+
+				return volumeStatus.TypedSpec().Size > 0, nil
+			}),
+		)
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for volume %q to be discovered: %w", constants.EphemeralPartitionLabel, err)
 		}
 
-		diskSize := ephemeralStatus.TypedSpec().Size
+		diskSize := volumeStatus.(*blockres.VolumeStatus).TypedSpec().Size
 
 		if minimum := minimal.DiskSize(); diskSize < minimum {
 			logger.Println("WARNING: disk size is less than recommended")


### PR DESCRIPTION
Fixes #10653

If the configuration was changed from non-encrypted to encrypted, Talos was failing in a bit mysterious way.

Changing from not encrypted to encrypted is not supported, but still we should fail more gracefully.

1. Don't be stuck in `diskSizeCheck`, Talos will be stuck in `mountEphemeralPartition` which is a bit more obvious.
2. Allow resetting non-ready volumes, as we don't need them to be ready, we just need to know the location.
