### PR TITLE
split the `cluster create` command into it's own package

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/cluster.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/cluster.go
@@ -6,45 +6,50 @@
 package cluster
 
 import (
-	"errors"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	"github.com/siderolabs/talos/pkg/provision/providers"
+)
+
+const (
+	// ProvisionerFlag is the flag with which the provisioner is configured.
+	ProvisionerFlag = "provisioner"
 )
 
 // Cmd represents the cluster command.
 var Cmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "A collection of commands for managing local docker-based or QEMU-based clusters",
-	Long:  ``,
-	PersistentPreRunE: func(*cobra.Command, []string) error {
-		if provisionerName == docker && !bootloaderEnabled {
-			return errors.New("docker provisioner requires bootloader to be enabled")
-		}
-
-		return nil
-	},
 }
 
-var (
-	provisionerName string
-	stateDir        string
-	clusterName     string
+// CmdOps are the options for the cluster command.
+type CmdOps struct {
+	ProvisionerName string
+	StateDir        string
+	ClusterName     string
+}
 
-	defaultStateDir string
-	defaultCNIDir   string
+// Flags are the flags of the cluster command.
+var Flags CmdOps
+
+var (
+	// DefaultStateDir is the default location of the cluster related file state.
+	DefaultStateDir string
+	// DefaultCNIDir is the default location of the CNI binaries.
+	DefaultCNIDir string
 )
 
 func init() {
 	talosDir, err := clientconfig.GetTalosDirectory()
 	if err == nil {
-		defaultStateDir = filepath.Join(talosDir, "clusters")
-		defaultCNIDir = filepath.Join(talosDir, "cni")
+		DefaultStateDir = filepath.Join(talosDir, "clusters")
+		DefaultCNIDir = filepath.Join(talosDir, "cni")
 	}
 
-	Cmd.PersistentFlags().StringVar(&provisionerName, "provisioner", docker, "Talos cluster provisioner to use")
-	Cmd.PersistentFlags().StringVar(&stateDir, "state", defaultStateDir, "directory path to store cluster state")
-	Cmd.PersistentFlags().StringVar(&clusterName, "name", "talos-default", "the name of the cluster")
+	Cmd.PersistentFlags().StringVar(&Flags.ProvisionerName, "provisioner", providers.DockerProviderName, "Talos cluster provisioner to use")
+	Cmd.PersistentFlags().StringVar(&Flags.StateDir, "state", DefaultStateDir, "directory path to store cluster state")
+	Cmd.PersistentFlags().StringVar(&Flags.ClusterName, "name", "talos-default", "the name of the cluster")
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_linux.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_linux.go
@@ -2,19 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build !linux
-
-package cluster
+package create
 
 import (
-	"errors"
 	"net/netip"
+
+	"github.com/siderolabs/siderolink/pkg/wireguard"
 )
 
 func generateRandomNodeAddr(prefix netip.Prefix) (netip.Prefix, error) {
-	return netip.Prefix{}, nil
+	return wireguard.GenerateRandomNodeAddr(prefix)
 }
 
 func networkPrefix(prefix string) (netip.Prefix, error) {
-	return netip.Prefix{}, errors.New("unsupported platform")
+	return wireguard.NetworkPrefix(prefix), nil
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_other.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_other.go
@@ -2,18 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package cluster
+//go:build !linux
+
+package create
 
 import (
+	"errors"
 	"net/netip"
-
-	"github.com/siderolabs/siderolink/pkg/wireguard"
 )
 
 func generateRandomNodeAddr(prefix netip.Prefix) (netip.Prefix, error) {
-	return wireguard.GenerateRandomNodeAddr(prefix)
+	return netip.Prefix{}, nil
 }
 
 func networkPrefix(prefix string) (netip.Prefix, error) {
-	return wireguard.NetworkPrefix(prefix), nil
+	return netip.Prefix{}, errors.New("unsupported platform")
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -32,14 +32,14 @@ var destroyCmd = &cobra.Command{
 }
 
 func destroy(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, provisionerName)
+	provisioner, err := providers.Factory(ctx, Flags.ProvisionerName)
 	if err != nil {
 		return err
 	}
 
 	defer provisioner.Close() //nolint:errcheck
 
-	cluster, err := provisioner.Reflect(ctx, clusterName, stateDir)
+	cluster, err := provisioner.Reflect(ctx, Flags.ClusterName, Flags.StateDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -35,22 +35,23 @@ var showCmd = &cobra.Command{
 }
 
 func show(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, provisionerName)
+	provisioner, err := providers.Factory(ctx, Flags.ProvisionerName)
 	if err != nil {
 		return err
 	}
 
 	defer provisioner.Close() //nolint:errcheck
 
-	cluster, err := provisioner.Reflect(ctx, clusterName, stateDir)
+	cluster, err := provisioner.Reflect(ctx, Flags.ClusterName, Flags.StateDir)
 	if err != nil {
 		return err
 	}
 
-	return showCluster(cluster)
+	return ShowCluster(cluster)
 }
 
-func showCluster(cluster provision.Cluster) error {
+// ShowCluster prints the details about the cluster to the terminal.
+func ShowCluster(cluster provision.Cluster) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintf(w, "PROVISIONER\t%s\n", cluster.Provisioner())
 	fmt.Fprintf(w, "NAME\t%s\n", cluster.Info().ClusterName)

--- a/cmd/talosctl/cmd/root.go
+++ b/cmd/talosctl/cmd/root.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt"
+	_ "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create" // import to get the command registered via the init() function.
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/constants"

--- a/pkg/provision/providers/factory.go
+++ b/pkg/provision/providers/factory.go
@@ -12,14 +12,35 @@ import (
 	"github.com/siderolabs/talos/pkg/provision/providers/docker"
 )
 
+const (
+	// QemuProviderName is the name of the qemu provider.
+	QemuProviderName = "qemu"
+	// DockerProviderName is the name of the docker provider.
+	DockerProviderName = "docker"
+)
+
 // Factory instantiates provision provider by name.
 func Factory(ctx context.Context, name string) (provision.Provisioner, error) {
-	switch name {
-	case "docker":
-		return docker.NewProvisioner(ctx)
-	case "qemu":
-		return newQemu(ctx)
-	default:
-		return nil, fmt.Errorf("unsupported provisioner %q", name)
+	if err := IsValidProvider(name); err != nil {
+		return nil, err
 	}
+
+	switch name {
+	case DockerProviderName:
+		return docker.NewProvisioner(ctx)
+	case QemuProviderName:
+		return newQemu(ctx)
+	}
+
+	panic("unknown valid provisioner")
+}
+
+// IsValidProvider returns an error if the passed provider doesn't exist.
+func IsValidProvider(name string) error {
+	switch name {
+	case QemuProviderName, DockerProviderName:
+		return nil
+	}
+
+	return fmt.Errorf("unsupported provisioner %q", name)
 }


### PR DESCRIPTION
Part of #10289

This is the first change in the cluster create command refactor project. The changes will be split into small parts to make review and catching bugs easier.

The command has to be imported in cmd/root.go because it can't be referenced in the mgmt/cluster package as that would create a cyclic import.
This can be fixed later by separating the logic between a third package.

I split this into two commits so the diff is easier to review. Please see 8b2b46a63e32f7ebe8c11b39aab60ec77d153f5b for the logic changes.