### PR TITLE
chore: cross platform qemu preflight checks

### DIFF
--- a/pkg/provision/providers/qemu/arch_darwin.go
+++ b/pkg/provision/providers/qemu/arch_darwin.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+const accelerator = "hvf"
+
+func (arch Arch) acceleratorAvailable() bool {
+	return true
+}

--- a/pkg/provision/providers/qemu/arch_linux.go
+++ b/pkg/provision/providers/qemu/arch_linux.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import "runtime"
+
+const accelerator = "kvm"
+
+func (arch Arch) acceleratorAvailable() bool {
+	if err := checkKVM(); err != nil {
+		return false
+	}
+
+	// kvm only supports emulating native architectures
+	return string(arch) == runtime.GOARCH
+}

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -27,8 +27,8 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 	}
 
 	arch := Arch(options.TargetArch)
-	if !arch.Valid() {
-		return nil, fmt.Errorf("unsupported arch: %q", options.TargetArch)
+	if err := arch.Valid(); err != nil {
+		return nil, err
 	}
 
 	if err := p.preflightChecks(ctx, request, options, arch); err != nil {

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -44,7 +44,6 @@ type LaunchConfig struct {
 	KernelArgs        string
 	MonitorPath       string
 	DefaultBootOrder  string
-	EnableKVM         bool
 	BootloaderEnabled bool
 	TPM2Config        tpm2Config
 	NodeUUID          uuid.UUID
@@ -213,7 +212,7 @@ func launchVM(config *LaunchConfig) error {
 		}
 	}
 
-	args = append(args, config.ArchitectureData.KVMArgs(config.EnableKVM, config.IOMMUEnabled)...)
+	args = append(args, config.ArchitectureData.getMachineArgs(config.IOMMUEnabled)...)
 
 	pflashArgs := make([]string, 2*len(config.PFlashImages))
 	for i := range config.PFlashImages {

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -169,7 +168,6 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		ExtraISOPath:      extraISOPath,
 		PFlashImages:      pflashImages,
 		MonitorPath:       state.GetRelativePath(fmt.Sprintf("%s.monitor", nodeReq.Name)),
-		EnableKVM:         opts.TargetArch == runtime.GOARCH,
 		BadRTC:            nodeReq.BadRTC,
 		DefaultBootOrder:  defaultBootOrder,
 		BootloaderEnabled: opts.BootloaderEnabled,

--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -9,16 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"slices"
-	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
-	"github.com/hashicorp/go-getter/v2"
-
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
@@ -31,20 +22,15 @@ func (p *provisioner) preflightChecks(ctx context.Context, request provision.Clu
 
 	for _, check := range []func(ctx context.Context) error{
 		checkContext.verifyRoot,
-		checkContext.checkKVM,
 		checkContext.qemuExecutable,
 		checkContext.checkFlashImages,
-		checkContext.swtpmExecutable,
-		checkContext.cniDirectories,
-		checkContext.cniBundle,
-		checkContext.checkIptables,
 	} {
 		if err := check(ctx); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return checkContext.verifyPlatformSpecific(ctx)
 }
 
 type preflightCheckContext struct {
@@ -55,19 +41,10 @@ type preflightCheckContext struct {
 
 func (check *preflightCheckContext) verifyRoot(context.Context) error {
 	if os.Geteuid() != 0 {
-		return errors.New("error: please run as root user (CNI requirement), we recommend running with `sudo -E`")
+		return errors.New("error: please run as root user (CNI, qemu hvf requirement), we recommend running with `sudo -E`")
 	}
 
 	return nil
-}
-
-func (check *preflightCheckContext) checkKVM(context.Context) error {
-	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
-	if err != nil {
-		return fmt.Errorf("error opening /dev/kvm, please make sure KVM support is enabled in Linux kernel: %w", err)
-	}
-
-	return f.Close()
 }
 
 func (check *preflightCheckContext) qemuExecutable(context.Context) error {
@@ -99,105 +76,6 @@ func (check *preflightCheckContext) checkFlashImages(context.Context) error {
 			return fmt.Errorf("the required flash image was not found in any of the expected paths for (%q), "+
 				"please install it with the package manager or specify --extra-uefi-search-paths", flashImage.SourcePaths)
 		}
-	}
-
-	return nil
-}
-
-func (check *preflightCheckContext) swtpmExecutable(context.Context) error {
-	if check.options.TPM2Enabled {
-		if _, err := exec.LookPath("swtpm"); err != nil {
-			return fmt.Errorf("swtpm not found in PATH, please install swtpm-tools with the package manager: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (check *preflightCheckContext) cniDirectories(context.Context) error {
-	cniDirs := slices.Clone(check.request.Network.CNI.BinPath)
-	cniDirs = append(cniDirs, check.request.Network.CNI.CacheDir, check.request.Network.CNI.ConfDir)
-
-	for _, cniDir := range cniDirs {
-		st, err := os.Stat(cniDir)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("error checking CNI directory %q: %w", cniDir, err)
-			}
-
-			fmt.Fprintf(check.options.LogWriter, "creating %q\n", cniDir)
-
-			err = os.MkdirAll(cniDir, 0o777)
-			if err != nil {
-				return err
-			}
-
-			continue
-		}
-
-		if !st.IsDir() {
-			return fmt.Errorf("CNI path %q exists, but it's not a directory", cniDir)
-		}
-	}
-
-	return nil
-}
-
-func (check *preflightCheckContext) cniBundle(ctx context.Context) error {
-	var missing bool
-
-	requiredCNIPlugins := []string{"bridge", "firewall", "static", "tc-redirect-tap"}
-
-	for _, cniPlugin := range requiredCNIPlugins {
-		missing = true
-
-		for _, binPath := range check.request.Network.CNI.BinPath {
-			_, err := os.Stat(filepath.Join(binPath, cniPlugin))
-			if err == nil {
-				missing = false
-
-				break
-			}
-		}
-
-		if missing {
-			break
-		}
-	}
-
-	if !missing {
-		return nil
-	}
-
-	if check.request.Network.CNI.BundleURL == "" {
-		return fmt.Errorf("error: required CNI plugins %q were not found in %q", requiredCNIPlugins, check.request.Network.CNI.BinPath)
-	}
-
-	pwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	client := getter.Client{}
-	src := strings.ReplaceAll(check.request.Network.CNI.BundleURL, constants.ArchVariable, runtime.GOARCH)
-	dst := check.request.Network.CNI.BinPath[0]
-
-	fmt.Fprintf(check.options.LogWriter, "downloading CNI bundle from %q to %q\n", src, dst)
-
-	_, err = client.Get(ctx, &getter.Request{
-		Src:     src,
-		Dst:     dst,
-		Pwd:     pwd,
-		GetMode: getter.ModeDir,
-	})
-
-	return err
-}
-
-func (check *preflightCheckContext) checkIptables(ctx context.Context) error {
-	_, err := iptables.New()
-	if err != nil {
-		return fmt.Errorf("error accessing iptables: %w", err)
 	}
 
 	return nil

--- a/pkg/provision/providers/qemu/preflight_darwin.go
+++ b/pkg/provision/providers/qemu/preflight_darwin.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"errors"
+	"runtime"
+)
+
+func (check *preflightCheckContext) verifyPlatformSpecific(ctx context.Context) error {
+	return check.verifyAppleMachine(ctx)
+}
+
+func (check *preflightCheckContext) verifyAppleMachine(context.Context) error {
+	if runtime.GOARCH != "arm64" {
+		return errors.New("currently qemu on darwin is supported only on arm machines")
+	}
+
+	return nil
+}

--- a/pkg/provision/providers/qemu/preflight_linux.go
+++ b/pkg/provision/providers/qemu/preflight_linux.go
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/hashicorp/go-getter/v2"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func (check *preflightCheckContext) verifyPlatformSpecific(ctx context.Context) error {
+	for _, check := range []func(ctx context.Context) error{
+		check.cniDirectories,
+		check.cniBundle,
+		check.checkIptables,
+		check.swtpmExecutable,
+		check.checkKVM,
+	} {
+		if err := check(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) cniDirectories(ctx context.Context) error {
+	cniDirs := append([]string{}, check.request.Network.CNI.BinPath...)
+	cniDirs = append(cniDirs, check.request.Network.CNI.CacheDir, check.request.Network.CNI.ConfDir)
+
+	for _, cniDir := range cniDirs {
+		st, err := os.Stat(cniDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("error checking CNI directory %q: %w", cniDir, err)
+			}
+
+			fmt.Fprintf(check.options.LogWriter, "creating %q\n", cniDir)
+
+			err = os.MkdirAll(cniDir, 0o777)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if !st.IsDir() {
+			return fmt.Errorf("CNI path %q exists, but it's not a directory", cniDir)
+		}
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) cniBundle(ctx context.Context) error {
+	var missing bool
+
+	requiredCNIPlugins := []string{"bridge", "firewall", "static", "tc-redirect-tap"}
+
+	for _, cniPlugin := range requiredCNIPlugins {
+		missing = true
+
+		for _, binPath := range check.request.Network.CNI.BinPath {
+			_, err := os.Stat(filepath.Join(binPath, cniPlugin))
+			if err == nil {
+				missing = false
+
+				break
+			}
+		}
+
+		if missing {
+			break
+		}
+	}
+
+	if !missing {
+		return nil
+	}
+
+	if check.request.Network.CNI.BundleURL == "" {
+		return fmt.Errorf("error: required CNI plugins %q were not found in %q", requiredCNIPlugins, check.request.Network.CNI.BinPath)
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	client := getter.Client{}
+	src := strings.ReplaceAll(check.request.Network.CNI.BundleURL, constants.ArchVariable, runtime.GOARCH)
+	dst := check.request.Network.CNI.BinPath[0]
+
+	fmt.Fprintf(check.options.LogWriter, "downloading CNI bundle from %q to %q\n", src, dst)
+
+	_, err = client.Get(ctx, &getter.Request{
+		Src:     src,
+		Dst:     dst,
+		Pwd:     pwd,
+		GetMode: getter.ModeDir,
+	})
+
+	return err
+}
+
+func (check *preflightCheckContext) checkIptables(ctx context.Context) error {
+	_, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("error accessing iptables: %w", err)
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) swtpmExecutable(ctx context.Context) error {
+	if check.options.TPM2Enabled {
+		if _, err := exec.LookPath("swtpm"); err != nil {
+			return fmt.Errorf("swtpm not found in PATH, please install swtpm-tools with the package manager: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) checkKVM(ctx context.Context) error {
+	err := checkKVM()
+	if err != nil {
+		fmt.Printf("error opening /dev/kvm, please make sure KVM support is enabled in Linux kernel: %s\n", err)
+		fmt.Println("running without KVM")
+	}
+
+	return nil
+}
+
+func checkKVM() error {
+	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}


### PR DESCRIPTION
* split platform specific preflight checks into platform specific files
* error on darwin if target is amd64
* error on darwin if host platform is amd64
* add darwin specific var-file and pflash file locations
* remove hard kvm requirement (so linux logic can be tested on machines without kvm)
