### PR TITLE
fix: suppress duplicate platform config updates

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -169,7 +169,12 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 
 		// prefer live network config over cached config always
 		if networkConfig != nil {
-			activeNetworkConfig = networkConfig
+			if activeNetworkConfig != nil && activeNetworkConfig.Equal(networkConfig) {
+				// network config has no changes, skip applying
+				networkConfig = nil
+			} else {
+				activeNetworkConfig = networkConfig
+			}
 		}
 
 		// cached network is only used as last resort

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -575,10 +575,12 @@ func (mock *platformMock) NetworkConfiguration(
 
 	networkConfig.Metadata = mock.metadata
 
-	select {
-	case ch <- networkConfig:
-	case <-ctx.Done():
-		return ctx.Err()
+	for range 5 { // send the network config multiple times to test duplicate suppression
+		select {
+		case ch <- networkConfig:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	return nil

--- a/internal/app/machined/pkg/runtime/platform.go
+++ b/internal/app/machined/pkg/runtime/platform.go
@@ -5,11 +5,13 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-procfs/procfs"
+	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -61,4 +63,20 @@ type PlatformNetworkConfig struct {
 	Probes []network.ProbeSpecSpec `yaml:"probes,omitempty"`
 
 	Metadata *runtime.PlatformMetadataSpec `yaml:"metadata,omitempty"`
+}
+
+// Equal compares two network configurations.
+func (p *PlatformNetworkConfig) Equal(other *PlatformNetworkConfig) bool {
+	// we will compare by marshaling to YAML
+	// and then comparing the bytes
+	// this is not the most efficient way to do this,
+	// but it will handle omitting empty fields
+	m1, err1 := yaml.Marshal(p)
+	m2, err2 := yaml.Marshal(other)
+
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	return bytes.Equal(m1, m2)
 }

--- a/internal/app/machined/pkg/runtime/platform_test.go
+++ b/internal/app/machined/pkg/runtime/platform_test.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+func TestPlatformConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&runtime.PlatformNetworkConfig{}).Equal(&runtime.PlatformNetworkConfig{}))
+	assert.True(t, (&runtime.PlatformNetworkConfig{Addresses: []network.AddressSpecSpec{}}).Equal(&runtime.PlatformNetworkConfig{}))
+	assert.True(t, (&runtime.PlatformNetworkConfig{Addresses: []network.AddressSpecSpec{
+		{
+			Address:  netip.MustParsePrefix("192.168.68.54/22"),
+			LinkName: "eth0",
+			Family:   nethelpers.FamilyInet4,
+			Scope:    nethelpers.ScopeGlobal,
+		},
+	}}).Equal(&runtime.PlatformNetworkConfig{Addresses: []network.AddressSpecSpec{
+		{
+			Address:  netip.MustParsePrefix("192.168.68.54/22"),
+			LinkName: "eth0",
+			Family:   nethelpers.FamilyInet4,
+			Scope:    nethelpers.ScopeGlobal,
+		},
+	}}))
+
+	assert.False(t, (&runtime.PlatformNetworkConfig{}).Equal(nil))
+	assert.False(t, (&runtime.PlatformNetworkConfig{Addresses: []network.AddressSpecSpec{
+		{
+			Address:  netip.MustParsePrefix("192.168.68.1/22"),
+			LinkName: "eth0",
+			Family:   nethelpers.FamilyInet4,
+			Scope:    nethelpers.ScopeGlobal,
+		},
+	}}).Equal(&runtime.PlatformNetworkConfig{Addresses: []network.AddressSpecSpec{
+		{
+			Address:  netip.MustParsePrefix("192.168.68.2/22"),
+			LinkName: "eth1",
+			Family:   nethelpers.FamilyInet4,
+			Scope:    nethelpers.ScopeGlobal,
+		},
+	}}))
+}


### PR DESCRIPTION
Fixes #10845

See also #10865

If the platform code emits duplicate network configuration, we don't need to trigger the code which mounts STATE and saves new platform configuration.
