### PR TITLE
fix: skip PCR extension if TPM1.2 is found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-04T13:37:33Z by kres 6cbcbd1.
+# Generated on 2025-05-05T04:55:03Z by kres 6cbcbd1.
 
 name: default
 concurrency:
@@ -2390,6 +2390,14 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
           WITH_CONFIG_PATCH: '@hack/test/patches/node-address-v2.yaml'
+        run: |
+          sudo -E make e2e-qemu
+      - name: e2e-tpm1_2
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-tpm1_2
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          WITH_TPM1_2: "true"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-04T12:28:10Z by kres d903dae.
+# Generated on 2025-05-05T04:55:03Z by kres 6cbcbd1.
 
 name: integration-misc-2-cron
 concurrency:
@@ -147,6 +147,14 @@ jobs:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           SHORT_INTEGRATION_TEST: "yes"
           WITH_CONFIG_PATCH: '@hack/test/patches/node-address-v2.yaml'
+        run: |
+          sudo -E make e2e-qemu
+      - name: e2e-tpm1_2
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-tpm1_2
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          WITH_TPM1_2: "true"
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1246,6 +1246,14 @@ spec:
             SHORT_INTEGRATION_TEST: yes
             WITH_CONFIG_PATCH: "@hack/test/patches/node-address-v2.yaml"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: e2e-tpm1_2
+          command: e2e-qemu
+          withSudo: true
+          environment:
+            GITHUB_STEP_NAME: ${{ github.job}}-e2e-tpm1_2
+            SHORT_INTEGRATION_TEST: yes
+            WITH_TPM1_2: true
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: save-talos-logs
           conditions:
             - always

--- a/cmd/talosctl/cmd/mgmt/cluster/create/command.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/command.go
@@ -37,6 +37,7 @@ const (
 	bootloaderEnabledFlag        = "with-bootloader"
 	controlPlanePortFlag         = "control-plane-port"
 	firewallFlag                 = "with-firewall"
+	tpmEnabledFlag               = "with-tpm1_2"
 	tpm2EnabledFlag              = "with-tpm2"
 	withDebugShellFlag           = "with-debug-shell"
 	withIOMMUFlag                = "with-iommu"
@@ -117,6 +118,7 @@ type qemuOps struct {
 	nodeIPXEBootScript           string
 	bootloaderEnabled            bool
 	uefiEnabled                  bool
+	tpm1_2Enabled                bool
 	tpm2Enabled                  bool
 	extraUEFISearchPaths         []string
 	networkNoMasqueradeCIDRs     []string
@@ -249,7 +251,8 @@ func init() {
 	createCmd.Flags().StringVar(&ops.qemu.nodeIPXEBootScript, "ipxe-boot-script", "", "iPXE boot script (URL) to use")
 	createCmd.Flags().BoolVar(&ops.qemu.bootloaderEnabled, bootloaderEnabledFlag, true, "enable bootloader to load kernel and initramfs from disk image after install")
 	createCmd.Flags().BoolVar(&ops.qemu.uefiEnabled, "with-uefi", true, "enable UEFI on x86_64 architecture")
-	createCmd.Flags().BoolVar(&ops.qemu.tpm2Enabled, tpm2EnabledFlag, false, "enable TPM2 emulation support using swtpm")
+	createCmd.Flags().BoolVar(&ops.qemu.tpm1_2Enabled, tpmEnabledFlag, false, "enable TPM 1.2 emulation support using swtpm")
+	createCmd.Flags().BoolVar(&ops.qemu.tpm2Enabled, tpm2EnabledFlag, false, "enable TPM 2.0 emulation support using swtpm")
 	createCmd.Flags().BoolVar(&ops.qemu.debugShellEnabled, withDebugShellFlag, false, "drop talos into a maintenance shell on boot, this is for advanced debugging for developers only")
 	createCmd.Flags().BoolVar(&ops.qemu.withIOMMU, withIOMMUFlag, false, "enable IOMMU support, this also add a new PCI root port and an interface attached to it (qemu only)")
 	createCmd.Flags().MarkHidden("with-debug-shell") //nolint:errcheck
@@ -316,6 +319,8 @@ func init() {
 	createCmd.MarkFlagsMutuallyExclusive(inputDirFlag, forceEndpointFlag)
 	createCmd.MarkFlagsMutuallyExclusive(inputDirFlag, kubePrismFlag)
 	createCmd.MarkFlagsMutuallyExclusive(inputDirFlag, diskEncryptionKeyTypesFlag)
+
+	createCmd.MarkFlagsMutuallyExclusive(tpmEnabledFlag, tpm2EnabledFlag)
 
 	clustercmd.Cmd.AddCommand(createCmd)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create.go
@@ -417,6 +417,7 @@ func create(ctx context.Context, ops createOps) error {
 		provision.WithDockerPortsHostIP(dockerOps.dockerHostIP),
 		provision.WithBootlader(qOps.bootloaderEnabled),
 		provision.WithUEFI(qOps.uefiEnabled),
+		provision.WithTPM1_2(qOps.tpm1_2Enabled),
 		provision.WithTPM2(qOps.tpm2Enabled),
 		provision.WithDebugShell(qOps.debugShellEnabled),
 		provision.WithIOMMU(qOps.withIOMMU),

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -187,6 +187,14 @@ case "${WITH_TRUSTED_BOOT_ISO:-false}" in
     ;;
 esac
 
+case "${WITH_TPM1_2:-false}" in
+  false)
+    ;;
+  *)
+    QEMU_FLAGS+=("--with-tpm1_2")
+    ;;
+esac
+
 case "${WITH_SIDEROLINK_AGENT:-false}" in
   false)
     ;;

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -70,7 +70,16 @@ func WithUEFI(enabled bool) Option {
 	}
 }
 
-// WithTPM2 enables or disables TPM2 emulation.
+// WithTPM1_2 enables or disables TPM1.2 emulation.
+func WithTPM1_2(enabled bool) Option {
+	return func(o *Options) error {
+		o.TPM1_2Enabled = enabled
+
+		return nil
+	}
+}
+
+// WithTPM2 enables or disables TPM2.0 emulation.
 func WithTPM2(enabled bool) Option {
 	return func(o *Options) error {
 		o.TPM2Enabled = enabled
@@ -200,7 +209,9 @@ type Options struct {
 
 	// Enable UEFI (for amd64), arm64 can only boot UEFI
 	UEFIEnabled bool
-	// Enable TPM2 emulation using swtpm.
+	// Enable TPM 1.2 emulation using swtpm.
+	TPM1_2Enabled bool
+	// Enable TPM 2.0 emulation using swtpm.
 	TPM2Enabled bool
 	// Enable debug shell in the bootloader.
 	WithDebugShell bool

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -56,7 +56,7 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
-	if err := p.destroyVirtualTPM2s(cluster.Info()); err != nil {
+	if err := p.destroyVirtualTPMs(cluster.Info()); err != nil {
 		return err
 	}
 

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -210,14 +210,14 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		APIPort: apiPort,
 	}
 
-	if opts.TPM2Enabled {
-		tpm2, tpm2Err := p.createVirtualTPM2State(state, nodeReq.Name)
+	if opts.TPM1_2Enabled || opts.TPM2Enabled {
+		tpmConfig, tpm2Err := p.createVirtualTPMState(state, nodeReq.Name, opts.TPM2Enabled)
 		if tpm2Err != nil {
 			return provision.NodeInfo{}, tpm2Err
 		}
 
-		launchConfig.TPM2Config = tpm2
-		nodeInfo.TPM2StateDir = tpm2.StateDir
+		launchConfig.TPMConfig = tpmConfig
+		nodeInfo.TPMStateDir = tpmConfig.StateDir
 	}
 
 	if !clusterReq.Network.DHCPSkipHostname {

--- a/pkg/provision/providers/qemu/preflight_linux.go
+++ b/pkg/provision/providers/qemu/preflight_linux.go
@@ -125,7 +125,7 @@ func (check *preflightCheckContext) checkIptables(ctx context.Context) error {
 }
 
 func (check *preflightCheckContext) swtpmExecutable(ctx context.Context) error {
-	if check.options.TPM2Enabled {
+	if check.options.TPM1_2Enabled || check.options.TPM2Enabled {
 		if _, err := exec.LookPath("swtpm"); err != nil {
 			return fmt.Errorf("swtpm not found in PATH, please install swtpm-tools with the package manager: %w", err)
 		}

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -61,6 +61,6 @@ type NodeInfo struct {
 
 	IPs []netip.Addr
 
-	APIPort      int
-	TPM2StateDir string
+	APIPort     int
+	TPMStateDir string
 }

--- a/website/content/v1.11/reference/cli.md
+++ b/website/content/v1.11/reference/cli.md
@@ -225,7 +225,8 @@ talosctl cluster create [flags]
       --with-network-packet-loss float           specify percent of packet loss on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
       --with-network-packet-reorder float        specify percent of reordered packets on the bridge interface when creating a qemu cluster. e.g. 50% = 0.50 (default: 0.0)
       --with-siderolink true                     enables the use of siderolink agent as configuration apply mechanism. true or `wireguard` enables the agent, `tunnel` enables the agent with grpc tunneling (default none)
-      --with-tpm2                                enable TPM2 emulation support using swtpm
+      --with-tpm1_2                              enable TPM 1.2 emulation support using swtpm
+      --with-tpm2                                enable TPM 2.0 emulation support using swtpm
       --with-uefi                                enable UEFI on x86_64 architecture (default true)
       --with-uuid-hostnames                      use machine UUIDs as default hostnames (QEMU only)
       --workers int                              the number of workers to create (default 1)


### PR DESCRIPTION
When extending PCR or trying to seed entropy pool from TPM if the found device is a TPM1.2 device, skip it, since Talos only supports TPM2.0

Fixes: #10847