### PR TITLE
chore: make qemu lb address bind work on darwin

### DIFF
--- a/pkg/provision/providers/vm/loadbalancer.go
+++ b/pkg/provision/providers/vm/loadbalancer.go
@@ -38,7 +38,7 @@ func (p *Provisioner) CreateLoadBalancer(state *State, clusterReq provision.Clus
 
 	args := []string{
 		"loadbalancer-launch",
-		"--loadbalancer-addr", clusterReq.Network.GatewayAddrs[0].String(),
+		"--loadbalancer-addr", getLbBindIP(clusterReq.Network.GatewayAddrs[0]),
 		"--loadbalancer-upstreams", strings.Join(controlPlaneIPs, ","),
 	}
 

--- a/pkg/provision/providers/vm/loadbalancer_darwin.go
+++ b/pkg/provision/providers/vm/loadbalancer_darwin.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import "net/netip"
+
+// getLbBindIP returns the 0.0.0.0 address to bind to all interfaces on macos.
+// The bridge interface address is not used as the bridge is not yet created at this stage.
+// Multiple loadbalancers can be assigned via different ports.
+func getLbBindIP(_ netip.Addr) string {
+	return "0.0.0.0"
+}

--- a/pkg/provision/providers/vm/loadbalancer_linux.go
+++ b/pkg/provision/providers/vm/loadbalancer_linux.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import "net/netip"
+
+// getLbBindIP returns the gateway address to bind the loadbalancer to the bridge interface.
+func getLbBindIP(gateway netip.Addr) string {
+	return gateway.String()
+}


### PR DESCRIPTION
part of https://github.com/siderolabs/talos/issues/10537

The loadbalancer is bound to all interfaces on macos. The bridge interface address is not used as the bridge is not yet created at this stage. Multiple loadbalancers can be assigned via different ports.