### PR TITLE
docs: fix search on base talos.dev

### DIFF
--- a/website/layouts/partials/hooks/body-end.html
+++ b/website/layouts/partials/hooks/body-end.html
@@ -13,7 +13,7 @@
 this targets the facets of algolia search to only return the version you're actively looking at
 except in the case of not having a version (being on the main page) and then it'll return "latest".
 -->
-{{ if ne $currentVersion "" }}
+{{ if and (ne $currentVersion "") (ne $currentVersion "404") }}
 <script>
   docsearch({
     appId: "D72DGJBSSA",


### PR DESCRIPTION
Because talos.dev doesn't have a version of any kind in the URL (i.e. talos.dev/v1.9/xxx), the `currentVersion` gets set to "404" when we try to grab the index after splitting. This PR should work around that, but we should find a better function to use later.
