### PR TITLE
fix: deny apply config requests without v1alpha1 in "normal" mode

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -180,6 +180,13 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// as we are not in maintenance mode, the v1alpha1 config should be always present
+	// in the future we should allow to remove v1alpha1, but for now for better UX we deny
+	// such requests to avoid confusion
+	if cfgProvider.RawV1Alpha1() == nil {
+		return nil, status.Error(codes.InvalidArgument, "the applied machine configuration doesn't contain v1alpha1 config, did you mean to patch the machine config instead?")
+	}
+
 	validationMode := modeWrapper{
 		Mode:      s.Controller.Runtime().State().Platform().Mode(),
 		installed: s.Controller.Runtime().State().Machine().Installed(),


### PR DESCRIPTION
In maintenance mode, we still accept any config.

Fixes #10897

As "normal" mode requires v1alpha1 config today, it should be an easy fix to require it part of the applied config always.
