### PR TITLE
chore: make qemu config server bind work on darwin

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -73,7 +74,7 @@ type LaunchConfig struct {
 	IPXEBootFileName string
 
 	// API
-	APIPort int
+	APIBindAddress *net.TCPAddr
 
 	// sd-stub
 	sdStubExtraCmdline       string
@@ -402,7 +403,12 @@ func Launch() error {
 	config.c = vm.ConfigureSignals()
 	config.controller = NewController()
 
-	httpServer, err := vm.NewHTTPServer(config.GatewayAddrs[0], config.APIPort, []byte(config.Config), config.controller)
+	apiBindAddrs, err := netip.ParseAddr(config.APIBindAddress.IP.String())
+	if err != nil {
+		return err
+	}
+
+	httpServer, err := vm.NewHTTPServer(apiBindAddrs, config.APIBindAddress.Port, []byte(config.Config), config.controller)
 	if err != nil {
 		return err
 	}

--- a/pkg/provision/providers/qemu/launch_darwin.go
+++ b/pkg/provision/providers/qemu/launch_darwin.go
@@ -17,7 +17,7 @@ func checkPartitions(config *LaunchConfig) (bool, error) {
 	panic("not implemented")
 }
 
-// startQemuCmd on darwin just runs cmd.Start
+// startQemuCmd on darwin just runs cmd.Start.
 func startQemuCmd(_ *LaunchConfig, cmd *exec.Cmd) error {
 	return cmd.Start()
 }

--- a/pkg/provision/providers/qemu/node_darwin.go
+++ b/pkg/provision/providers/qemu/node_darwin.go
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"net"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+// findAPIBindAddrs returns the 0.0.0.0 address to bind to all interfaces on macos with a random port on macos.
+// The bridge interface address is not used as the bridge is not yet created at this stage.
+func (p *provisioner) findAPIBindAddrs(_ provision.ClusterRequest) (*net.TCPAddr, error) {
+	l, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", "0"))
+	if err != nil {
+		return nil, err
+	}
+
+	return l.Addr().(*net.TCPAddr), l.Close()
+}

--- a/pkg/provision/providers/qemu/node_linux.go
+++ b/pkg/provision/providers/qemu/node_linux.go
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"net"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+func (p *provisioner) findAPIBindAddrs(clusterReq provision.ClusterRequest) (*net.TCPAddr, error) {
+	l, err := net.Listen("tcp", net.JoinHostPort(clusterReq.Network.GatewayAddrs[0].String(), "0"))
+	if err != nil {
+		return nil, err
+	}
+
+	return l.Addr().(*net.TCPAddr), l.Close()
+}


### PR DESCRIPTION
A part of https://github.com/siderolabs/talos/issues/10537

This very is simuilar to ab7e693. The api is bound to all interfaces on macos. The bridge interface address is not used as the bridge is not yet created at this stage.

