### PR TITLE
test: fix the process runner log collection

### DIFF
--- a/internal/app/machined/pkg/system/runner/process/process.go
+++ b/internal/app/machined/pkg/system/runner/process/process.go
@@ -5,7 +5,6 @@
 package process
 
 import (
-	"cmp"
 	"fmt"
 	"io"
 	"io/fs"
@@ -92,15 +91,14 @@ func (p *processRunner) Close() error {
 }
 
 type commandWrapper struct {
-	launcher         *cap.Launcher
-	ctty             optional.Optional[int]
-	selinuxLabel     string
-	cgroupFile       *os.File
-	stdin            *os.File
-	stdout           *os.File
-	stderr           *os.File
-	afterStart       func()
-	afterTermination func() error
+	launcher     *cap.Launcher
+	ctty         optional.Optional[int]
+	selinuxLabel string
+	cgroupFile   *os.File
+	stdin        *os.File
+	stdout       *os.File
+	stderr       *os.File
+	afterStart   func()
 }
 
 func dropCaps(droppedCapabilities []string, launcher *cap.Launcher) error {
@@ -195,16 +193,16 @@ func (p *processRunner) build() (commandWrapper, error) {
 	launcher.Callback(beforeExecCallback)
 
 	// Setup logging.
-	w, err := p.opts.LoggingManager.ServiceLog(p.args.ID).Writer()
+	logSink, err := p.opts.LoggingManager.ServiceLog(p.args.ID).Writer()
 	if err != nil {
 		return commandWrapper{}, fmt.Errorf("service log handler: %w", err)
 	}
 
-	var writer io.Writer
+	var logWriter io.Writer
 	if p.debug {
-		writer = io.MultiWriter(w, log.Writer())
+		logWriter = io.MultiWriter(logSink, log.Writer())
 	} else {
-		writer = w
+		logWriter = logSink
 	}
 
 	// As MultiWriter is not a file, we need to create a pipe
@@ -215,29 +213,28 @@ func (p *processRunner) build() (commandWrapper, error) {
 	}
 
 	go func() {
-		defer pr.Close() //nolint:errcheck
+		defer pr.Close()      //nolint:errcheck
+		defer logSink.Close() //nolint:errcheck
 
-		io.Copy(writer, pr) //nolint:errcheck
+		io.Copy(logWriter, pr) //nolint:errcheck
 	}()
 
 	// close the writer if we exit early due to an error
 	closeWriter := true
 
-	closeLogging := func() (e error) {
-		for _, closer := range []io.Closer{w, pw} {
-			e = cmp.Or(closer.Close(), e)
-		}
+	afterStartClosers := []io.Closer{pw}
 
-		return e
+	closeLogging := func() {
+		for _, closer := range afterStartClosers {
+			closer.Close() //nolint:errcheck
+		}
 	}
 
 	defer func() {
 		if closeWriter {
-			closeLogging() //nolint:errcheck
+			closeLogging()
 		}
 	}()
-
-	var afterStartClosers []io.Closer
 
 	if p.opts.StdinFile != "" {
 		stdin, err := os.Open(p.opts.StdinFile)
@@ -281,8 +278,7 @@ func (p *processRunner) build() (commandWrapper, error) {
 	closeWriter = false
 
 	wrapper.launcher = launcher
-	wrapper.afterStart = func() { xslices.Map(afterStartClosers, io.Closer.Close) }
-	wrapper.afterTermination = closeLogging
+	wrapper.afterStart = closeLogging
 	wrapper.ctty = p.opts.Ctty
 	wrapper.selinuxLabel = p.opts.SelinuxLabel
 
@@ -423,7 +419,7 @@ func (p *processRunner) run(eventSink events.Recorder) error {
 		return fmt.Errorf("error building command: %w", err)
 	}
 
-	defer cmdWrapper.afterTermination() //nolint:errcheck
+	defer cmdWrapper.afterStart()
 
 	notifyCh := make(chan reaper.ProcessInfo, 8)
 
@@ -483,7 +479,7 @@ func (p *processRunner) run(eventSink events.Recorder) error {
 	// wait for process to terminate
 	<-waitCh
 
-	return cmdWrapper.afterTermination()
+	return nil
 }
 
 func (p *processRunner) String() string {

--- a/internal/app/machined/pkg/system/runner/process/process_test.go
+++ b/internal/app/machined/pkg/system/runner/process/process_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/siderolabs/go-cmd/pkg/cmd/proc/reaper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/logging"
@@ -390,4 +391,8 @@ func TestProcessSuite(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
This is a follow-up fix for the PR
https://github.com/siderolabs/talos/pull/10964: there was one more case when the copying to the log was not synchronized with process stop - a log writer could be have been closed before process termination.

While looking into this, I figured out we don't need to close anything after process termination, as `pw` can be closed after the process start (Talos doesn't write there, only the child does), removing one more hook.

Also renamed some variables for clarity.
