### PR TITLE
chore: dump qemu pachine ipam records on darwin

### DIFF
--- a/pkg/provision/providers/qemu/launch_darwin.go
+++ b/pkg/provision/providers/qemu/launch_darwin.go
@@ -9,8 +9,9 @@ import (
 	"os/exec"
 )
 
+// withNetworkContext runs the f on the host network on darwin.
 func withNetworkContext(ctx context.Context, config *LaunchConfig, f func(config *LaunchConfig) error) error {
-	panic("not implemented")
+	return f(config)
 }
 
 func checkPartitions(config *LaunchConfig) (bool, error) {


### PR DESCRIPTION
* rename `config.vmMAC` -> `config.VMMAC` so it can be marshaled and passed to the launch process
* implement withNetworkContext which just runs the function on the host network on darwin

