### PR TITLE
docs: remove `preserve` flag mention in upgrade notes

### DIFF
--- a/website/content/v1.10/talos-guides/upgrading-talos.md
+++ b/website/content/v1.10/talos-guides/upgrading-talos.md
@@ -107,9 +107,6 @@ It then starts to drain its existing workload.
 
 Once all of the workload Pods are drained, Talos will start shutting down its
 internal processes.
-If it is a control node, this will include etcd.
-If `preserve` is not enabled, Talos will leave etcd membership.
-(Talos ensures the etcd cluster is healthy and will remain healthy after our node leaves the etcd cluster, before allowing a control plane node to be upgraded.)
 
 Once all the processes are stopped and the services are shut down, the filesystems will be unmounted.
 This allows Talos to produce a very clean upgrade, as close as possible to a pristine system.

--- a/website/content/v1.11/talos-guides/upgrading-talos.md
+++ b/website/content/v1.11/talos-guides/upgrading-talos.md
@@ -98,9 +98,6 @@ It then starts to drain its existing workload.
 
 Once all of the workload Pods are drained, Talos will start shutting down its
 internal processes.
-If it is a control node, this will include etcd.
-If `preserve` is not enabled, Talos will leave etcd membership.
-(Talos ensures the etcd cluster is healthy and will remain healthy after our node leaves the etcd cluster, before allowing a control plane node to be upgraded.)
 
 Once all the processes are stopped and the services are shut down, the filesystems will be unmounted.
 This allows Talos to produce a very clean upgrade, as close as possible to a pristine system.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

remove leftover of the `preserve` flag in the documentation. cf issue https://github.com/siderolabs/talos/issues/10172


## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
