### PR TITLE
fix: consistently apply dynamic grpc proxy dialer

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/events_sink.go
+++ b/internal/app/machined/pkg/controllers/runtime/events_sink.go
@@ -22,6 +22,7 @@ import (
 
 	networkutils "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/utils"
 	machinedruntime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/grpc/dialer"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -165,6 +166,7 @@ func (ctrl *EventsSinkController) Run(ctx context.Context, r controller.Runtime,
 				cfg.TypedSpec().Endpoint,
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithSharedWriteBuffer(true),
+				grpc.WithContextDialer(dialer.DynamicProxyDialer),
 			)
 			if err != nil {
 				return fmt.Errorf("error establishing connection to event sink: %w", err)

--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	networkutils "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/utils"
+	"github.com/siderolabs/talos/pkg/grpc/dialer"
 	"github.com/siderolabs/talos/pkg/httpdefaults"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -345,6 +346,7 @@ func (ctrl *ManagerController) provision(ctx context.Context, r controller.Runti
 			cfg.TypedSpec().Host,
 			withTransportCredentials(cfg.TypedSpec().Insecure),
 			grpc.WithSharedWriteBuffer(true),
+			grpc.WithContextDialer(dialer.DynamicProxyDialer),
 		)
 		if connErr != nil {
 			return nil, fmt.Errorf("error dialing SideroLink endpoint %q: %w", cfg.TypedSpec().Host, connErr)

--- a/internal/pkg/encryption/keys/kms.go
+++ b/internal/pkg/encryption/keys/kms.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/pkg/encryption/helpers"
 	"github.com/siderolabs/talos/internal/pkg/endpoint"
+	"github.com/siderolabs/talos/pkg/grpc/dialer"
 	"github.com/siderolabs/talos/pkg/httpdefaults"
 )
 
@@ -144,5 +145,6 @@ func (h *KMSKeyHandler) getConn() (*grpc.ClientConn, error) {
 		endpoint.Host,
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithSharedWriteBuffer(true),
+		grpc.WithContextDialer(dialer.DynamicProxyDialer),
 	)
 }

--- a/pkg/grpc/middleware/auth/basic/basic.go
+++ b/pkg/grpc/middleware/auth/basic/basic.go
@@ -13,6 +13,8 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/siderolabs/talos/pkg/grpc/dialer"
 )
 
 // Credentials describes an authorization method.
@@ -42,6 +44,7 @@ func NewConnection(address string, creds credentials.PerRPCCredentials, accepted
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithPerRPCCredentials(creds),
 		grpc.WithSharedWriteBuffer(true),
+		grpc.WithContextDialer(dialer.DynamicProxyDialer),
 	}
 
 	conn, err = grpc.NewClient(address, grpcOpts...)

--- a/pkg/grpc/proxy/backend/local.go
+++ b/pkg/grpc/proxy/backend/local.go
@@ -65,6 +65,7 @@ func (l *Local) GetConnection(ctx context.Context, _ string) (context.Context, *
 			grpc.ForceCodecV2(proxy.Codec()),
 		),
 		grpc.WithSharedWriteBuffer(true),
+		grpc.WithNoProxy(),
 	)
 
 	return outCtx, l.conn, err


### PR DESCRIPTION
Use a dialer which picks up environment settings on the fly, which should allow consistent results when setting environment variables to control the proxy.

Fixes #10990

There was a race between the first gRPC dial and the moment environment variables are applied - as gRPC by default reads the environment variables just once, it might read incomplete state.
