### PR TITLE
fix: disable automatic MAC assignment to bridge interfaces

### DIFF
--- a/hack/udevd/99-default.link
+++ b/hack/udevd/99-default.link
@@ -12,4 +12,4 @@ OriginalName=*
 [Link]
 NamePolicy=keep kernel database onboard slot path mac
 AlternativeNamesPolicy=database onboard slot path mac
-MACAddressPolicy=persistent
+MACAddressPolicy=none


### PR DESCRIPTION
Linux kernel has the following policy:

* initial bridge MAC is random
* if the bridge MAC is not set explicitly by userspace, bridge MAC is the smallest MAC address of all ports

But systemd-udevd which we use started to assign "stable" MACs to bridge interfaces (when they are created), which Linux kernel treats as userspace explicitly set, so the bridge no longer gets an automatic MAC of the ports.

This is a breaking change, so we need to revert it.

Fixes #10884

Fixes #11011
