### PR TITLE
Update virtualbox.md - better workflow

### DIFF
--- a/website/content/v1.10/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.10/talos-guides/install/local-platforms/virtualbox.md
@@ -133,7 +133,8 @@ Talos will be installed to disk, the VM will reboot, and then Talos will configu
 
 Create at least a single worker node using a process similar to the control plane creation above.
 Start the worker node VM and wait for it to enter "maintenance mode".
-Take note of the worker node's IP address, which will be referred to as `$WORKER_IP`
+Take note of the worker node's IP address, which will be referred to as `$WORKER_IP`.
+If you wish to export this IP as a bash variable, simply issue a command like `export WORKER_IP=1.2.3.4`.
 
 Issue:
 
@@ -142,6 +143,25 @@ talosctl apply-config --insecure --nodes $WORKER_IP --file _out/worker.yaml
 ```
 
 > Note: This process can be repeated multiple times to add additional workers.
+
+### Bootstrap `etcd`
+
+Before the cluster is ready, the `etcd` has to be bootstrapped.
+The cluster will be in stage `Booting` and `healthy` state until this is stage is completed.
+
+Set the `endpoints` and `nodes`:
+
+```bash
+talosctl --talosconfig $TALOSCONFIG config endpoint <control plane 1 IP>
+talosctl --talosconfig $TALOSCONFIG config node <control plane 1 IP>
+```
+
+Bootstrap `etcd` by running the following command.
+You should see stage change to `Running` and your cluster is now ready.
+
+```bash
+talosctl --talosconfig $TALOSCONFIG bootstrap
+```
 
 ## Using the Cluster
 
@@ -157,21 +177,6 @@ talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP
 ```
 
-### Bootstrap Etcd
-
-Set the `endpoints` and `nodes`:
-
-```bash
-talosctl --talosconfig $TALOSCONFIG config endpoint <control plane 1 IP>
-talosctl --talosconfig $TALOSCONFIG config node <control plane 1 IP>
-```
-
-Bootstrap `etcd`:
-
-```bash
-talosctl --talosconfig $TALOSCONFIG bootstrap
-```
-
 ### Retrieve the `kubeconfig`
 
 At this point we can retrieve the admin `kubeconfig` by running:
@@ -179,6 +184,8 @@ At this point we can retrieve the admin `kubeconfig` by running:
 ```bash
 talosctl --talosconfig $TALOSCONFIG kubeconfig .
 ```
+
+Export the config so kubectl can find it: `export KUBECONFIG=$(pwd)/kubeconfig`.
 
 You can then use kubectl in this fashion:
 

--- a/website/content/v1.11/talos-guides/install/local-platforms/virtualbox.md
+++ b/website/content/v1.11/talos-guides/install/local-platforms/virtualbox.md
@@ -133,7 +133,8 @@ Talos will be installed to disk, the VM will reboot, and then Talos will configu
 
 Create at least a single worker node using a process similar to the control plane creation above.
 Start the worker node VM and wait for it to enter "maintenance mode".
-Take note of the worker node's IP address, which will be referred to as `$WORKER_IP`
+Take note of the worker node's IP address, which will be referred to as `$WORKER_IP`.
+If you wish to export this IP as a bash variable, simply issue a command like `export WORKER_IP=1.2.3.4`.
 
 Issue:
 
@@ -142,6 +143,25 @@ talosctl apply-config --insecure --nodes $WORKER_IP --file _out/worker.yaml
 ```
 
 > Note: This process can be repeated multiple times to add additional workers.
+
+### Bootstrap `etcd`
+
+Before the cluster is ready, the `etcd` has to be bootstrapped.
+The cluster will be in stage `Booting` and `healthy` state until this is stage is completed.
+
+Set the `endpoints` and `nodes`:
+
+```bash
+talosctl --talosconfig $TALOSCONFIG config endpoint <control plane 1 IP>
+talosctl --talosconfig $TALOSCONFIG config node <control plane 1 IP>
+```
+
+Bootstrap `etcd` by running the following command.
+You should see stage change to `Running` and your cluster is now ready.
+
+```bash
+talosctl --talosconfig $TALOSCONFIG bootstrap
+```
 
 ## Using the Cluster
 
@@ -157,21 +177,6 @@ talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP
 ```
 
-### Bootstrap Etcd
-
-Set the `endpoints` and `nodes`:
-
-```bash
-talosctl --talosconfig $TALOSCONFIG config endpoint <control plane 1 IP>
-talosctl --talosconfig $TALOSCONFIG config node <control plane 1 IP>
-```
-
-Bootstrap `etcd`:
-
-```bash
-talosctl --talosconfig $TALOSCONFIG bootstrap
-```
-
 ### Retrieve the `kubeconfig`
 
 At this point we can retrieve the admin `kubeconfig` by running:
@@ -179,6 +184,8 @@ At this point we can retrieve the admin `kubeconfig` by running:
 ```bash
 talosctl --talosconfig $TALOSCONFIG kubeconfig .
 ```
+
+Export the config so kubectl can find it: `export KUBECONFIG=$(pwd)/kubeconfig`.
 
 You can then use kubectl in this fashion:
 


### PR DESCRIPTION
## What?

This PR formats the documentation for better workflow for setting up Talos cluster with VirtualBox. It ensures that the user bootstraps the Etcd and highlights that it must be done before the cluster is ready.

The PR also adds a few helper command examples to ensure a newbie user (like me) is able to bootstrap a cluster based on this guide only.

## Why?

A newbie user like me was not able to fully bootstrap a cluster. I had some errors that I thought was related to misconfiguration (control-plane node was stuck in Booting for example). Turns out I just had to initialize the Etcd for the cluster to become healthy. Hopefully this change improves the workflow to better highlight whats needs to be completed in-order to use the cluster.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
