### PR TITLE
Language improvement for production notes

### DIFF
--- a/website/content/v1.10/introduction/prodnotes.md
+++ b/website/content/v1.10/introduction/prodnotes.md
@@ -329,7 +329,7 @@ The `<cluster-name>` you chose above will be used as the context name.
 
 ## Kubernetes Bootstrap
 
-Bootstrapping your Kubernetes cluster by simply calling the `bootstrap` command against any of your control plane nodes (or the loadbalancer, if used for the Talos API endpoint).:
+Bootstrapping your Kubernetes cluster by simply calling the `bootstrap` command against any one of your control plane nodes (or the loadbalancer, if used for the Talos API endpoint).:
 
 ```sh
   talosctl bootstrap --nodes 192.168.0.2


### PR DESCRIPTION
The term "any one" makes it clear that you should bootstrap only one of your control plane nodes.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Make language a bit more explicit regarding bootstrapping only one control plane node.
## Why? (reasoning)
People like clear language.
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
