### PR TITLE
docs: use the cilium-cli image repo in the job installation manifest

### DIFF
--- a/website/content/v1.10/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.10/kubernetes-guides/network/deploying-cilium.md
@@ -377,7 +377,7 @@ cluster:
               hostNetwork: true
               containers:
               - name: cilium-install
-                image: quay.io/cilium/cilium-cli-ci:latest
+                image: quay.io/cilium/cilium-cli:latest
                 env:
                 - name: KUBERNETES_SERVICE_HOST
                   valueFrom:

--- a/website/content/v1.11/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.11/kubernetes-guides/network/deploying-cilium.md
@@ -377,7 +377,7 @@ cluster:
               hostNetwork: true
               containers:
               - name: cilium-install
-                image: quay.io/cilium/cilium-cli-ci:latest
+                image: quay.io/cilium/cilium-cli:latest
                 env:
                 - name: KUBERNETES_SERVICE_HOST
                   valueFrom:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Replace the cilium-cli-ci  image repo used for CI builds with the recently added cilium-cli image repo intended for tagged releases.

## Why? (reasoning)

The cilium/cilium-cli-ci image is used for CI and is built and pushed on PR branches so breaking changes, bugs, and potential risks are more likely.

**_Disclaimer_**: I'm not a cilium maintainer or contributor, but found https://github.com/cilium/cilium-cli/issues/2755 where the cilium-cli repo was proposed, and https://github.com/cilium/cilium-cli/pull/2980 where the image push workflow was updated.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
