### PR TITLE
Add note for default `dataDirHostPath`

### DIFF
--- a/website/content/v1.10/kubernetes-guides/configuration/ceph-with-rook.md
+++ b/website/content/v1.10/kubernetes-guides/configuration/ceph-with-rook.md
@@ -221,7 +221,7 @@ customresourcedefinition.apiextensions.k8s.io "objectbuckets.objectbucket.io" de
 
 If the Rook Operator is cleanly removed following the above process, the node metadata and disks should be clean and ready to be re-used.
 In the case of an unclean cluster removal, there may be still a few instances of metadata stored on the system disk, as well as the partition information on the storage disks.
-First the node metadata needs to be removed, make sure to update the `nodeName` with the actual name of a storage node that needs cleaning, and `path` with the Rook configuration `dataDirHostPath` set when installing the chart.
+First the node metadata needs to be removed, make sure to update the `nodeName` with the actual name of a storage node that needs cleaning, and `path` with the Rook configuration `dataDirHostPath` (this is `/var/lib/rook` when using the default values.yaml) set when installing the chart.
 The following will need to be repeated for each node used in the Rook Ceph cluster.
 
 ```shell

--- a/website/content/v1.11/kubernetes-guides/configuration/ceph-with-rook.md
+++ b/website/content/v1.11/kubernetes-guides/configuration/ceph-with-rook.md
@@ -221,7 +221,7 @@ customresourcedefinition.apiextensions.k8s.io "objectbuckets.objectbucket.io" de
 
 If the Rook Operator is cleanly removed following the above process, the node metadata and disks should be clean and ready to be re-used.
 In the case of an unclean cluster removal, there may be still a few instances of metadata stored on the system disk, as well as the partition information on the storage disks.
-First the node metadata needs to be removed, make sure to update the `nodeName` with the actual name of a storage node that needs cleaning, and `path` with the Rook configuration `dataDirHostPath` set when installing the chart.
+First the node metadata needs to be removed, make sure to update the `nodeName` with the actual name of a storage node that needs cleaning, and `path` with the Rook configuration `dataDirHostPath` (this is `/var/lib/rook` when using the default values.yaml) set when installing the chart.
 The following will need to be repeated for each node used in the Rook Ceph cluster.
 
 ```shell


### PR DESCRIPTION
# Pull Request

## What?
Add a note in the documentation for the default data dir host path for cleanup.

## Why?
Documentation currently refers to `dataDirHostPath` but users won't know what the value of that is unless they explicitly set it. The default in the templates is `/var/lib/rook`.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
