### PR TITLE
feat: support qemu provisioner on darwin

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -26,6 +26,12 @@ containerd: 2.1.1
 Talos is built with Go 1.24.3.
 """
 
+    [notes.macos-qemu]
+        title = "Qemu provisioner on MacOS"
+                description = """\
+On MacOS `talosctl cluster create` command now supports the Qemu provisioner in addition to the Docker provisioner.
+"""
+
 [make_deps]
 
     [make_deps.tools]


### PR DESCRIPTION
On MacOS `talosctl cluster create` command now supports the Qemu provisioner in addition to the Docker provisioner.

I'm still working on the [developing talos](https://www.talos.dev/v1.11/advanced/developing-talos/) docs but I guess we can close #10537 as done?
