### PR TITLE
fix(talosctl): correct --help output for dashboard command

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -26,14 +26,14 @@ var dashboardCmd = &cobra.Command{
 
 Keyboard shortcuts:
 
- - h, &lt;Left&gt; - switch one node to the left
- - l, &lt;Right&gt; - switch one node to the right
- - j, &lt;Down&gt; - scroll logs/process list down
- - k, &lt;Up&gt; - scroll logs/process list up
- - &lt;C-d&gt; - scroll logs/process list half page down
- - &lt;C-u&gt; - scroll logs/process list half page up
- - &lt;C-f&gt; - scroll logs/process list one page down
- - &lt;C-b&gt; - scroll logs/process list one page up
+ - h, <Left> - switch one node to the left
+ - l, <Right> - switch one node to the right
+ - j, <Down> - scroll logs/process list down
+ - k, <Up> - scroll logs/process list up
+ - <C-d> - scroll logs/process list half page down
+ - <C-u> - scroll logs/process list half page up
+ - <C-f> - scroll logs/process list one page down
+ - <C-b> - scroll logs/process list one page up
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/website/content/v1.11/reference/cli.md
+++ b/website/content/v1.11/reference/cli.md
@@ -843,14 +843,14 @@ Provide a text-based UI to navigate node overview, logs and real-time metrics.
 
 Keyboard shortcuts:
 
- - h, &lt;Left&gt; - switch one node to the left
- - l, &lt;Right&gt; - switch one node to the right
- - j, &lt;Down&gt; - scroll logs/process list down
- - k, &lt;Up&gt; - scroll logs/process list up
- - &lt;C-d&gt; - scroll logs/process list half page down
- - &lt;C-u&gt; - scroll logs/process list half page up
- - &lt;C-f&gt; - scroll logs/process list one page down
- - &lt;C-b&gt; - scroll logs/process list one page up
+ - h, <Left> - switch one node to the left
+ - l, <Right> - switch one node to the right
+ - j, <Down> - scroll logs/process list down
+ - k, <Up> - scroll logs/process list up
+ - <C-d> - scroll logs/process list half page down
+ - <C-u> - scroll logs/process list half page up
+ - <C-f> - scroll logs/process list one page down
+ - <C-b> - scroll logs/process list one page up
 
 
 ```


### PR DESCRIPTION
Ensure the --help output is human readable.

# Pull Request
This fixes #11130 

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.


After running make docs, I'm seeing a changed file: `website/content/v1.11/reference/cli.md`, but I guess the HTML encoding was here in the first place for the docs? Should I also commit this? I've not checked the file in (yet).


```
diff --git a/website/content/v1.11/reference/cli.md b/website/content/v1.11/reference/cli.md
index 818872f9f..d50b3b70a 100644
--- a/website/content/v1.11/reference/cli.md
+++ b/website/content/v1.11/reference/cli.md
@@ -843,14 +843,14 @@ Provide a text-based UI to navigate node overview, logs and real-time metrics.

 Keyboard shortcuts:

- - h, &lt;Left&gt; - switch one node to the left
- - l, &lt;Right&gt; - switch one node to the right
- - j, &lt;Down&gt; - scroll logs/process list down
- - k, &lt;Up&gt; - scroll logs/process list up
- - &lt;C-d&gt; - scroll logs/process list half page down
- - &lt;C-u&gt; - scroll logs/process list half page up
- - &lt;C-f&gt; - scroll logs/process list one page down
- - &lt;C-b&gt; - scroll logs/process list one page up
+ - h, <Left> - switch one node to the left
+ - l, <Right> - switch one node to the right
+ - j, <Down> - scroll logs/process list down
+ - k, <Up> - scroll logs/process list up
+ - <C-d> - scroll logs/process list half page down
+ - <C-u> - scroll logs/process list half page up
+ - <C-f> - scroll logs/process list one page down
+ - <C-b> - scroll logs/process list one page up
```