### PR TITLE
feat(machined): use configured resolvers only instead of appending to defaults

### DIFF
--- a/internal/app/machined/pkg/controllers/network/resolver_config.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config.go
@@ -225,6 +225,10 @@ func (ctrl *ResolverConfigController) parseMachineConfiguration(logger *zap.Logg
 		return spec, false
 	}
 
+	if len(resolvers) > 0 {
+		spec.DNSServers = make([]netip.Addr, 0, len(resolvers))
+	}
+
 	for _, resolver := range resolvers {
 		server, err := netip.ParseAddr(resolver)
 		if err != nil {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

- Do not use default resolvers when user-configured ones are provided

## Why? (reasoning)

- User provided resolvers should override defaults. This is especially useful for IPv6-only networks where [default nameservers](https://github.com/siderolabs/talos/blob/a791bbe568bba4f9675ef820fd4ce4671a481f5a/internal/app/machined/pkg/controllers/network/resolver_config.go#L180) might be unreachable, as well as many other cases such as air-gapped environments.
- Related to #9372 

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`) (used SSH key for signing, will rewrite if a mergeable fix is found)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

## Notes

- This does not look sufficient for [kernel command line](https://www.talos.dev/v1.10/reference/kernel/#ip), default resolvers are still used . I must have missed something
- Further documentation on IPv6-only network would be useful