### PR TITLE
fix: correctly predict interface name on darwin

### DIFF
--- a/pkg/provision/providers/vm/network_test.go
+++ b/pkg/provision/providers/vm/network_test.go
@@ -24,7 +24,7 @@ func TestGetVmnetInterfaceNameNoVmnetInterface(t *testing.T) {
 
 func TestGetVmnetInterfaceNameWithExistingVmnetInterfaces(t *testing.T) {
 	interfaces := []string{
-		"bridge", "bridge1", "eth0", "utun1", "bridge001", "bridge1001", "bridge100", "bridge101",
+		"bridge", "bridge1", "eth0", "utun1", "bridge001", "bridge1001", "bridge100", "bridge101", "bridge104",
 	}
 	result, err := vm.GetVmnetInterfaceName(interfaces)
 	assert.NoError(t, err)


### PR DESCRIPTION
Old implementation didn't work if the interface to be created wasn't the biggest index.

For example if interfaces `bridge100` and `bridge102` already existed, vmnet would create a `bridge 101`, but the old logic expected a `bridge103`.

This also slightly simplifies the code
