### PR TITLE
Update kvm.md

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/kvm.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/kvm.md
@@ -1,6 +1,6 @@
 ---
 title: "KVM"
-aliases: 
+aliases:
   - ../../../virtualized-platforms/kvm
 ---
 
@@ -9,4 +9,6 @@ Talos is known to work on KVM.
 We don't yet have a documented guide specific to KVM; however, you can have a look at our
 [Vagrant & Libvirt guide]({{< relref "./vagrant-libvirt" >}}) which uses KVM for virtualization.
 
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+Also [`talosctl cluster create` with QEMU]({{< relref "../local-platforms/qemu" >}}) uses KVM under the hood.
+
+> Note: For the network interface emulation, `virtio` and `e1000` are supported.

--- a/website/content/v1.11/talos-guides/install/virtualized-platforms/kvm.md
+++ b/website/content/v1.11/talos-guides/install/virtualized-platforms/kvm.md
@@ -1,6 +1,6 @@
 ---
 title: "KVM"
-aliases: 
+aliases:
   - ../../../virtualized-platforms/kvm
 ---
 
@@ -9,4 +9,6 @@ Talos is known to work on KVM.
 We don't yet have a documented guide specific to KVM; however, you can have a look at our
 [Vagrant & Libvirt guide]({{< relref "./vagrant-libvirt" >}}) which uses KVM for virtualization.
 
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+Also [`talosctl cluster create` with QEMU]({{< relref "../local-platforms/qemu" >}}) uses KVM under the hood.
+
+> Note: For the network interface emulation, `virtio` and `e1000` are supported.


### PR DESCRIPTION
Adding a note about Virtual Network Interface Device model

I'm setting talos up on a QEMU/KVM server and it wouldn't detect the NIC. After some trial and error, I realized the VM was defaulting to rtl8139, but that either of the other two options in my QEMU/KVM install (e1000, and virtio) would work. Suggest a note to help others.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
