### PR TITLE
docs: set apiServer.extraArgs.enable-aggregator-routing

### DIFF
--- a/website/content/v1.10/kubernetes-guides/network/deploying-cilium.md
+++ b/website/content/v1.10/kubernetes-guides/network/deploying-cilium.md
@@ -43,6 +43,10 @@ cluster:
   network:
     cni:
       name: none
+  apiServer:
+    extraArgs:
+      # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
+      enable-aggregator-routing: true
   proxy:
     disabled: true
 ```
@@ -262,6 +266,10 @@ cluster:
   network:
     cni:
       name: none
+  apiServer:
+    extraArgs:
+      # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
+      enable-aggregator-routing: true
   proxy:
     disabled: true
 ```


### PR DESCRIPTION
If you are not running kube-proxy on a host running the API server, then you must make sure that the system is enabled with the following kube-apiserver flag -https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
