### PR TITLE
chore: enable --with-siderolink-agent on Darwin

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/command.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/command.go
@@ -256,7 +256,6 @@ func init() {
 		bandwidthFlag,
 
 		// The following might work but need testing first.
-		withSiderolinkAgentFlag,
 		configInjectionMethodFlag,
 	}
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_other.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_other.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build !linux
+//go:build !linux && !darwin
 
 package create
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_supported.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_supported.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build linux || darwin
+
 package create
 
 import (

--- a/cmd/talosctl/cmd/mgmt/siderolink_launch.go
+++ b/cmd/talosctl/cmd/mgmt/siderolink_launch.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build linux || darwin
+
 package mgmt
 
 import (


### PR DESCRIPTION
It requires #11204 to function correctly.
