### PR TITLE
chore: add user-space InfiniBand modules

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -60,6 +60,9 @@ kernel/drivers/hwmon/k8temp.ko
 kernel/drivers/i2c/algos/i2c-algo-bit.ko
 kernel/drivers/i2c/busses/i2c-i801.ko
 kernel/drivers/i2c/i2c-smbus.ko
+kernel/drivers/infiniband/core/ib_umad.ko
+kernel/drivers/infiniband/core/ib_uverbs.ko
+kernel/drivers/infiniband/core/rdma_ucm.ko
 kernel/drivers/infiniband/hw/mlx4/mlx4_ib.ko
 kernel/drivers/infiniband/hw/mlx5/mlx5_ib.ko
 kernel/drivers/infiniband/sw/rxe/rdma_rxe.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -45,6 +45,9 @@ kernel/drivers/hwmon/i5k_amb.ko
 kernel/drivers/i2c/algos/i2c-algo-bit.ko
 kernel/drivers/i2c/busses/i2c-i801.ko
 kernel/drivers/i2c/i2c-mux.ko
+kernel/drivers/infiniband/core/ib_umad.ko
+kernel/drivers/infiniband/core/ib_uverbs.ko
+kernel/drivers/infiniband/core/rdma_ucm.ko
 kernel/drivers/infiniband/hw/hns/hns-roce-hw-v2.ko
 kernel/drivers/infiniband/hw/mlx4/mlx4_ib.ko
 kernel/drivers/infiniband/hw/mlx5/mlx5_ib.ko


### PR DESCRIPTION
This PR pulls in siderolabs/pkgs#1245 to enable ib_umad and ib_uverbs as modules.