### PR TITLE
Small yaml typo fix

### DIFF
--- a/website/content/v1.10/advanced/install-kubevirt.md
+++ b/website/content/v1.10/advanced/install-kubevirt.md
@@ -41,6 +41,7 @@ This can be done in the machine config of your node:
 
 ```yaml
 machine:
+  network:
       interfaces:
       - interface: br0
         addresses:


### PR DESCRIPTION
## What? (description)

Small fix in the kubevirt documentation that shows an old yaml example concerning the multus configuration.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
