### PR TITLE
fix: set default MTU on Azure to 1400

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -54,6 +54,13 @@ This feature can be enable by using [SwapVolumeConfig](https://www.talos.dev/v1.
 Talos VMWare platform now supports `arm64` architecture in addition to `amd64`.
 """
 
+    [notes.azure]
+        title = "Azure"
+        description = """\
+Talos on Azure now defaults to MTU of 1400 bytes for the `eth0` interface to avoid packet fragmentation issues.
+The default MTU can be overriden with machine configuration.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -124,6 +124,7 @@ func (a *Azure) ParseMetadata(metadata *ComputeMetadata, interfaceAddresses []Ne
 				DHCP6: network.DHCP6OperatorSpec{
 					RouteMetric: 2 * network.DefaultRouteMetric,
 				},
+				ConfigLayer: network.ConfigPlatform,
 			})
 
 			// If accept_ra is not set, use the default gateway.
@@ -159,6 +160,22 @@ func (a *Azure) ParseMetadata(metadata *ComputeMetadata, interfaceAddresses []Ne
 	if err != nil {
 		return nil, err
 	}
+
+	networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
+		Operator:    network.OperatorDHCP4,
+		LinkName:    "eth0",
+		RequireUp:   true,
+		ConfigLayer: network.ConfigPlatform,
+	})
+
+	networkConfig.Links = append(networkConfig.Links,
+		network.LinkSpecSpec{
+			Name:        "eth0",
+			Up:          true,
+			MTU:         1400,
+			ConfigLayer: network.ConfigPlatform,
+		},
+	)
 
 	networkConfig.Metadata = &runtimeres.PlatformMetadataSpec{
 		Platform:     a.Name(),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/testdata/expected.yaml
@@ -1,5 +1,12 @@
 addresses: []
-links: []
+links:
+    - name: eth0
+      logical: false
+      up: true
+      mtu: 1400
+      kind: ""
+      type: netrom
+      layer: platform
 routes:
     - family: inet6
       dst: ""
@@ -25,7 +32,11 @@ operators:
       requireUp: true
       dhcp6:
         routeMetric: 2048
-      layer: default
+      layer: platform
+    - operator: dhcp4
+      linkName: eth0
+      requireUp: true
+      layer: platform
 externalIPs:
     - 1.2.3.4
     - 2603:1020:10:5::34


### PR DESCRIPTION
Azure documentation is very confusing, but the tests and the issues we observed show that 1400 is a more safe default than 1500, reducing packet fragmentation and timeouts.

See e.g. https://www.reddit.com/r/networking/comments/puowuy/do_anyone_know_the_default_tcp_mss_between_two/
