### PR TITLE
fix: treat context canceled as expected error on image pull

### DIFF
--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -106,7 +106,7 @@ func Pull(ctx context.Context, registryBuilder RegistriesBuilder, client *contai
 		); err != nil {
 			err = fmt.Errorf("failed to pull image %q: %w", ref, err)
 
-			if errdefs.IsNotFound(err) || errdefs.IsCanceled(err) {
+			if errdefs.IsNotFound(err) {
 				return err
 			}
 


### PR DESCRIPTION
The containerd pull process might internally generate context canceled error while our "external" `ctx` is not canceled.

Don't treat context canceled as non-retriable, as `retry` package stops retrying when the outer `ctx` is canceled, so we don't need to handle it in any specific way.
