### PR TITLE
fix: etcd recover with multiple advertised addresses

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -561,7 +561,7 @@ func (e *Etcd) recoverFromSnapshot(spec *etcdresource.SpecSpec) error {
 
 		PeerURLs: getEtcdURLs(spec.AdvertisedAddresses, constants.EtcdPeerPort),
 
-		InitialCluster: fmt.Sprintf("%s=%s", spec.Name, formatEtcdURLs(spec.AdvertisedAddresses, constants.EtcdPeerPort)),
+		InitialCluster: formatClusterURLs(spec.Name, getEtcdURLs(spec.AdvertisedAddresses, constants.EtcdPeerPort)),
 
 		SkipHashCheck: e.RecoverSkipHashCheck,
 	}); err != nil {


### PR DESCRIPTION
Fixes #11257

This applies a fix from #6759 to recover code flow, which was missed in that PR.
