### PR TITLE
chore: add sbom step to the release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-06-13T13:26:36Z by kres 5128bc1.
+# Generated on 2025-07-02T11:24:50Z by kres 5128bc1.
 
 name: default
 concurrency:
@@ -4455,6 +4455,9 @@ jobs:
       - name: release-notes
         run: |
           make release-notes
+      - name: sbom
+        run: |
+          make sbom
       - name: login-to-registry
         uses: docker/login-action@v3
         with:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -181,6 +181,7 @@ spec:
           environment:
             PLATFORM: linux/amd64,linux/arm64
         - name: release-notes
+        - name: sbom
         - name: login-to-registry
           registryLoginStep:
             registry: ghcr.io


### PR DESCRIPTION
Otherwise release fails to upload the `sbom.json` artifact.
