### PR TITLE
feat: include packages into SBOM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-02T15:29:45Z by kres b282c9b.
+# Generated on 2025-07-07T16:49:31Z by kres b282c9b.
 
 name: default
 concurrency:
@@ -4493,7 +4493,10 @@ jobs:
           cosign sign-blob --output _out/metal-arm64-uki.efi.sig --yes _out/metal-arm64-uki.efi
           cosign sign-blob --output _out/metal-amd64.raw.zst.sig --yes _out/metal-amd64.raw.zst
           cosign sign-blob --output _out/metal-arm64.raw.zst.sig --yes _out/metal-arm64.raw.zst
-          cosign sign-blob --output _out/sbom.json.sig --yes _out/sbom.json
+          cosign sign-blob --output _out/talos-arm64.spdx.json.sig --yes _out/talos-arm64.spdx.json
+          cosign sign-blob --output _out/talos-amd64.spdx.json.sig --yes _out/talos-amd64.spdx.json
+          cosign sign-blob --output _out/talos-container-arm64.spdx.json.sig --yes _out/talos-container-arm64.spdx.json
+          cosign sign-blob --output _out/talos-container-amd64.spdx.json.sig --yes _out/talos-container-amd64.spdx.json
           cosign sign-blob --output _out/talosctl-cni-bundle-amd64.tar.gz.sig --yes _out/talosctl-cni-bundle-amd64.tar.gz
           cosign sign-blob --output _out/talosctl-cni-bundle-arm64.tar.gz.sig --yes _out/talosctl-cni-bundle-arm64.tar.gz
           cosign sign-blob --output _out/talosctl-darwin-amd64.sig --yes _out/talosctl-darwin-amd64
@@ -4510,8 +4513,8 @@ jobs:
       - name: Generate Checksums
         run: |
           cd _out
-          sha256sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst sbom.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
-          sha512sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst sbom.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
+          sha256sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
+          sha512sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
       - name: Sign checksums
         run: |
           cosign sign-blob --output sha256sum.txt.sig --yes sha256sum.txt
@@ -4531,7 +4534,10 @@ jobs:
             _out/metal-arm64-uki.efi
             _out/metal-amd64.raw.zst
             _out/metal-arm64.raw.zst
-            _out/sbom.json
+            _out/talos-arm64.spdx.json
+            _out/talos-amd64.spdx.json
+            _out/talos-container-arm64.spdx.json
+            _out/talos-container-amd64.spdx.json
             _out/talosctl-cni-bundle-amd64.tar.gz
             _out/talosctl-cni-bundle-arm64.tar.gz
             _out/talosctl-darwin-amd64

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -207,7 +207,10 @@ spec:
               - metal-arm64-uki.efi
               - metal-amd64.raw.zst
               - metal-arm64.raw.zst
-              - sbom.json
+              - talos-arm64.spdx.json
+              - talos-amd64.spdx.json
+              - talos-container-arm64.spdx.json
+              - talos-container-amd64.spdx.json
               - talosctl-cni-bundle-amd64.tar.gz
               - talosctl-cni-bundle-arm64.tar.gz
               - talosctl-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EMBED_TARGET ?= embed
 TOOLS_PREFIX ?= ghcr.io/siderolabs/tools
 TOOLS ?= v1.11.0-alpha.0-3-g1dfd14b
 PKGS_PREFIX ?= ghcr.io/siderolabs
-PKGS ?= v1.11.0-alpha.0-40-g03bb94c
+PKGS ?= v1.11.0-alpha.0-41-g9cec45c
 
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest

--- a/hack/sbom.sh
+++ b/hack/sbom.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+SYFT_FORMAT_PRETTY=1 SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID=1 \
+	go tool -modfile=tools/go.mod \
+	github.com/anchore/syft/cmd/syft \
+	scan --from dir "$1" \
+	--select-catalogers "+sbom-cataloger,go" \
+	--source-name "$2" --source-version "$TAG" \
+	-o spdx-json > "/rootfs/usr/share/spdx/$3"

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.11.0-alpha.0-40-g03bb94c
+v1.11.0-alpha.0-41-g9cec45c


### PR DESCRIPTION
Also generate multiple SBOMs for variants including different
sets of packages and different architectures.

Generated SBOMs (you can use this [web app](https://apps.rancher.io/sbom-viewer) to view them):

[talos-container-arm64.spdx.json](https://github.com/user-attachments/files/21107055/talos-container-arm64.spdx.json)
[talos-container-amd64.spdx.json](https://github.com/user-attachments/files/21107057/talos-container-amd64.spdx.json)
[talos-arm64.spdx.json](https://github.com/user-attachments/files/21107058/talos-arm64.spdx.json)
[talos-amd64.spdx.json](https://github.com/user-attachments/files/21107059/talos-amd64.spdx.json)

Scan: `grype sbom:talos-container-arm64.spdx.json`: `No vulnerabilities found`

Then patch with this to replace versions with known bad ones (only change format for Linux as NVD will report even current as vulnerable, if you scan a full image) (v prefix in version doesn't matter to Grype):

<details>
<summary>Details</summary>

```patch
19c19
<    "versionInfo": "v3.1.7",
---
>    "versionInfo": "3.1.5",
31c31
<      "referenceLocator": "cpe:2.3:a:apparmor:apparmor:v3.1.7:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:a:apparmor:apparmor:3.1.5:*:*:*:*:*:*:*"
36c36
<      "referenceLocator": "cpe:2.3:a:canonical:apparmor:v3.1.7:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:a:canonical:apparmor:3.1.5:*:*:*:*:*:*:*"
105c105
<    "versionInfo": "v2.1.3",
---
>    "versionInfo": "1.6.0",
117c117
<      "referenceLocator": "cpe:2.3:a:containerd:containerd:v2.1.3:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:a:containerd:containerd:1.6.0:*:*:*:*:*:*:*"
122c122
<      "referenceLocator": "cpe:2.3:a:linuxfoundation:containerd:v2.1.3:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:a:linuxfoundation:containerd:1.6.0:*:*:*:*:*:*:*"
127c127
<      "referenceLocator": "pkg:github/containerd/containerd@v2.1.3"
---
>      "referenceLocator": "pkg:github/containerd/containerd@1.6.0"
134c134
<    "versionInfo": "2.7.5",
---
>    "versionInfo": "v2.4.1",
146c146
<      "referenceLocator": "cpe:2.3:a:cryptsetup_project:cryptsetup:2.7.5:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:a:cryptsetup_project:cryptsetup:v2.4.1:*:*:*:*:*:*:*"
8538c8538
<    "versionInfo": "6.12.35",
---
>    "versionInfo": "v6.12.35",
8550c8550
<      "referenceLocator": "cpe:2.3:o:linux:linux_kernel:6.12.35:*:*:*:*:*:*:*"
---
>      "referenceLocator": "cpe:2.3:o:linux:linux_kernel:v6.12.35:*:*:*:*:*:*:*"
```

</details>

Scan once more - grype sees the packages, which means it recognized them by their CPEs and read the version correctly:

```
 ✔ Scanned for vulnerabilities     [8 vulnerability matches]  
   ├── by severity: 1 critical, 2 high, 5 medium, 0 low, 0 negligible
   └── by status:   8 fixed, 0 not-fixed, 0 ignored 
NAME                INSTALLED  FIXED IN                TYPE            VULNERABILITY   SEVERITY  EPSS %  RISK   
containerd-aarch64  1.6.0      1.4.13, 1.5.10, 1.6.1   UnknownPackage  CVE-2022-23648  High      90.37   4.4    
containerd-aarch64  1.6.0      1.5.16, 1.6.12          UnknownPackage  CVE-2022-23471  Medium    42.24   0.1    
apparmor-aarch64    3.1.5      2.13.10, 3.0.12, 3.1.6                  CVE-2016-1585   Critical  24.04   < 0.1  
containerd-aarch64  1.6.0      1.5.18, 1.6.18          UnknownPackage  CVE-2023-25153  Medium    31.08   < 0.1  
containerd-aarch64  1.6.0      1.5.13, 1.6.6           UnknownPackage  CVE-2022-31030  Medium    30.06   < 0.1  
cryptsetup-aarch64  v2.4.1     2.3.7, 2.4.3                            CVE-2021-4122   Medium    15.82   < 0.1  
containerd-aarch64  1.6.0      1.5.18, 1.6.18          UnknownPackage  CVE-2023-25173  High      4.27    < 0.1  
containerd-aarch64  1.6.0      1.6.38, 1.7.27, 2.0.4   UnknownPackage  CVE-2024-40635  Medium    0.62    < 0.1
```