### PR TITLE
feat: allow taloscl disk wipe in maintenance mode

### DIFF
--- a/api/storage/storage.proto
+++ b/api/storage/storage.proto
@@ -93,6 +93,8 @@ message BlockDeviceWipeDescriptor {
   Method method = 2;
   // Skip the volume in use check.
   bool skip_volume_check = 3;
+  // Skip the secondary disk check (e.g. underlying disk for RAID or LVM).
+  bool skip_secondary_check = 5;
   // Drop the partition (only applies if the device is a partition).
   bool drop_partition = 4;
 }

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -97,6 +97,12 @@ Talos now publishes Software Bill of Materials (SBOM) in the SPDX format.
 The SBOM is available in the `/usr/share/sbom` directory on the machine and can be retrieved using `talosctl get sbom`.
 """
 
+    [notes.disk_wipe]
+        title = "Disk Wipe"
+        description = """\
+Talos now supports `talosctl disk wipe` command in maintenance mode (`talosctl disk wipe <disk> --insecure`).
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/api/storage/storage.pb.go
+++ b/pkg/machinery/api/storage/storage.pb.go
@@ -441,6 +441,8 @@ type BlockDeviceWipeDescriptor struct {
 	Method BlockDeviceWipeDescriptor_Method `protobuf:"varint,2,opt,name=method,proto3,enum=storage.BlockDeviceWipeDescriptor_Method" json:"method,omitempty"`
 	// Skip the volume in use check.
 	SkipVolumeCheck bool `protobuf:"varint,3,opt,name=skip_volume_check,json=skipVolumeCheck,proto3" json:"skip_volume_check,omitempty"`
+	// Skip the secondary disk check (e.g. underlying disk for RAID or LVM).
+	SkipSecondaryCheck bool `protobuf:"varint,5,opt,name=skip_secondary_check,json=skipSecondaryCheck,proto3" json:"skip_secondary_check,omitempty"`
 	// Drop the partition (only applies if the device is a partition).
 	DropPartition bool `protobuf:"varint,4,opt,name=drop_partition,json=dropPartition,proto3" json:"drop_partition,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -494,6 +496,13 @@ func (x *BlockDeviceWipeDescriptor) GetMethod() BlockDeviceWipeDescriptor_Method
 func (x *BlockDeviceWipeDescriptor) GetSkipVolumeCheck() bool {
 	if x != nil {
 		return x.SkipVolumeCheck
+	}
+	return false
+}
+
+func (x *BlockDeviceWipeDescriptor) GetSkipSecondaryCheck() bool {
+	if x != nil {
+		return x.SkipSecondaryCheck
 	}
 	return false
 }
@@ -628,11 +637,12 @@ const file_storage_storage_proto_rawDesc = "" +
 	"\rDisksResponse\x12*\n" +
 	"\bmessages\x18\x01 \x03(\v2\x0e.storage.DisksR\bmessages\"V\n" +
 	"\x16BlockDeviceWipeRequest\x12<\n" +
-	"\adevices\x18\x01 \x03(\v2\".storage.BlockDeviceWipeDescriptorR\adevices\"\xe9\x01\n" +
+	"\adevices\x18\x01 \x03(\v2\".storage.BlockDeviceWipeDescriptorR\adevices\"\x9b\x02\n" +
 	"\x19BlockDeviceWipeDescriptor\x12\x16\n" +
 	"\x06device\x18\x01 \x01(\tR\x06device\x12A\n" +
 	"\x06method\x18\x02 \x01(\x0e2).storage.BlockDeviceWipeDescriptor.MethodR\x06method\x12*\n" +
-	"\x11skip_volume_check\x18\x03 \x01(\bR\x0fskipVolumeCheck\x12%\n" +
+	"\x11skip_volume_check\x18\x03 \x01(\bR\x0fskipVolumeCheck\x120\n" +
+	"\x14skip_secondary_check\x18\x05 \x01(\bR\x12skipSecondaryCheck\x12%\n" +
 	"\x0edrop_partition\x18\x04 \x01(\bR\rdropPartition\"\x1e\n" +
 	"\x06Method\x12\b\n" +
 	"\x04FAST\x10\x00\x12\n" +

--- a/pkg/machinery/api/storage/storage_vtproto.pb.go
+++ b/pkg/machinery/api/storage/storage_vtproto.pb.go
@@ -335,6 +335,16 @@ func (m *BlockDeviceWipeDescriptor) MarshalToSizedBufferVT(dAtA []byte) (int, er
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.SkipSecondaryCheck {
+		i--
+		if m.SkipSecondaryCheck {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
 	if m.DropPartition {
 		i--
 		if m.DropPartition {
@@ -603,6 +613,9 @@ func (m *BlockDeviceWipeDescriptor) SizeVT() (n int) {
 		n += 2
 	}
 	if m.DropPartition {
+		n += 2
+	}
+	if m.SkipSecondaryCheck {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -1481,6 +1494,26 @@ func (m *BlockDeviceWipeDescriptor) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.DropPartition = bool(v != 0)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipSecondaryCheck", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SkipSecondaryCheck = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/website/content/v1.11/reference/api.md
+++ b/website/content/v1.11/reference/api.md
@@ -9280,6 +9280,7 @@ The device should not be used as a secondary (e.g. part of LVM).
 The name should be submitted without `/dev/` prefix. |
 | method | [BlockDeviceWipeDescriptor.Method](#storage.BlockDeviceWipeDescriptor.Method) |  | Wipe method to use. |
 | skip_volume_check | [bool](#bool) |  | Skip the volume in use check. |
+| skip_secondary_check | [bool](#bool) |  | Skip the secondary disk check (e.g. underlying disk for RAID or LVM). |
 | drop_partition | [bool](#bool) |  | Drop the partition (only applies if the device is a partition). |
 
 

--- a/website/content/v1.11/reference/cli.md
+++ b/website/content/v1.11/reference/cli.md
@@ -3162,6 +3162,7 @@ talosctl wipe disk <device names>... [flags]
 ```
       --drop-partition   drop partition after wipe (if applicable)
   -h, --help             help for disk
+  -i, --insecure         use Talos maintenance mode API
       --method string    wipe method to use [FAST ZEROES] (default "FAST")
 ```
 


### PR DESCRIPTION
Fixes #10011

Also implement a hidden option to skip secondary disks check which allows to wipe disks which are used as part of active LVM volume. This is unsafe in general, but sometimes if you know what you're doing, it's fine.
