### PR TITLE
fix: rename instances to referenceCount

### DIFF
--- a/api/resource/definitions/runtime/runtime.proto
+++ b/api/resource/definitions/runtime/runtime.proto
@@ -73,12 +73,11 @@ message KmsgLogConfigSpec {
 
 // LoadedKernelModuleSpec describes Linux kernel module to load.
 message LoadedKernelModuleSpec {
-  string name = 1;
-  int64 size = 2;
-  int64 instances = 3;
-  repeated string dependencies = 4;
-  string state = 5;
-  string address = 6;
+  int64 size = 1;
+  int64 reference_count = 2;
+  repeated string dependencies = 3;
+  string state = 4;
+  string address = 5;
 }
 
 // MachineStatusSpec describes status of the defined sysctls.

--- a/internal/app/machined/pkg/controllers/runtime/loaded_kernel_module_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/loaded_kernel_module_test.go
@@ -47,7 +47,7 @@ func (suite *LoadedKernelModuleSuite) TestParseModules() {
 			name:  "single module",
 			input: `module1 12345 0 - Live 0x00000000`,
 			expected: []runtimectrl.Module{
-				{Name: "module1", Size: 12345, Instances: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
+				{Name: "module1", Size: 12345, ReferenceCount: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
 			},
 		},
 		{
@@ -56,9 +56,9 @@ func (suite *LoadedKernelModuleSuite) TestParseModules() {
 module2 67890 1 module1 Live 0x00000001
 module3 54321 2 module1,module2 Live 0x00000002`,
 			expected: []runtimectrl.Module{
-				{Name: "module1", Size: 12345, Instances: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
-				{Name: "module2", Size: 67890, Instances: 1, Dependencies: []string{"module1"}, State: "Live", Address: "0x00000001"},
-				{Name: "module3", Size: 54321, Instances: 2, Dependencies: []string{"module1", "module2"}, State: "Live", Address: "0x00000002"},
+				{Name: "module1", Size: 12345, ReferenceCount: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
+				{Name: "module2", Size: 67890, ReferenceCount: 1, Dependencies: []string{"module1"}, State: "Live", Address: "0x00000001"},
+				{Name: "module3", Size: 54321, ReferenceCount: 2, Dependencies: []string{"module1", "module2"}, State: "Live", Address: "0x00000002"},
 			},
 		},
 		{
@@ -69,10 +69,10 @@ module3 54321 2 module1,module2 Live 0x00000002
 invalid_line
 module4 11111 0 - Live 0x00000003`,
 			expected: []runtimectrl.Module{
-				{Name: "module1", Size: 12345, Instances: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
-				{Name: "module2", Size: 67890, Instances: 1, Dependencies: []string{"module1"}, State: "Live", Address: "0x00000001"},
-				{Name: "module3", Size: 54321, Instances: 2, Dependencies: []string{"module1", "module2"}, State: "Live", Address: "0x00000002"},
-				{Name: "module4", Size: 11111, Instances: 0, Dependencies: []string{}, State: "Live", Address: "0x00000003"},
+				{Name: "module1", Size: 12345, ReferenceCount: 0, Dependencies: []string{}, State: "Live", Address: "0x00000000"},
+				{Name: "module2", Size: 67890, ReferenceCount: 1, Dependencies: []string{"module1"}, State: "Live", Address: "0x00000001"},
+				{Name: "module3", Size: 54321, ReferenceCount: 2, Dependencies: []string{"module1", "module2"}, State: "Live", Address: "0x00000002"},
+				{Name: "module4", Size: 11111, ReferenceCount: 0, Dependencies: []string{}, State: "Live", Address: "0x00000003"},
 			},
 		},
 	} {

--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -597,10 +597,9 @@ func (suite *ExtensionsSuiteQEMU) TestLoadedKernelModule() {
 		"virtio_pci_modern_dev",
 	},
 		func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
-			asrt.NotEmpty(res.TypedSpec().Name, "kernel module name should not be empty")
 			asrt.NotEmpty(res.TypedSpec().Size, "kernel module size should not be empty")
 			asrt.NotEmpty(res.TypedSpec().Address, "kernel module address should not be empty")
-			asrt.GreaterOrEqual(res.TypedSpec().Instances, 0, "kernel module instances should be non-negative")
+			asrt.GreaterOrEqual(res.TypedSpec().ReferenceCount, 0, "kernel module instances should be non-negative")
 		},
 	)
 }

--- a/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
@@ -579,15 +579,14 @@ func (x *KmsgLogConfigSpec) GetDestinations() []*common.URL {
 
 // LoadedKernelModuleSpec describes Linux kernel module to load.
 type LoadedKernelModuleSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Size          int64                  `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
-	Instances     int64                  `protobuf:"varint,3,opt,name=instances,proto3" json:"instances,omitempty"`
-	Dependencies  []string               `protobuf:"bytes,4,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
-	State         string                 `protobuf:"bytes,5,opt,name=state,proto3" json:"state,omitempty"`
-	Address       string                 `protobuf:"bytes,6,opt,name=address,proto3" json:"address,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Size           int64                  `protobuf:"varint,1,opt,name=size,proto3" json:"size,omitempty"`
+	ReferenceCount int64                  `protobuf:"varint,2,opt,name=reference_count,json=referenceCount,proto3" json:"reference_count,omitempty"`
+	Dependencies   []string               `protobuf:"bytes,3,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
+	State          string                 `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
+	Address        string                 `protobuf:"bytes,5,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *LoadedKernelModuleSpec) Reset() {
@@ -620,13 +619,6 @@ func (*LoadedKernelModuleSpec) Descriptor() ([]byte, []int) {
 	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *LoadedKernelModuleSpec) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
 func (x *LoadedKernelModuleSpec) GetSize() int64 {
 	if x != nil {
 		return x.Size
@@ -634,9 +626,9 @@ func (x *LoadedKernelModuleSpec) GetSize() int64 {
 	return 0
 }
 
-func (x *LoadedKernelModuleSpec) GetInstances() int64 {
+func (x *LoadedKernelModuleSpec) GetReferenceCount() int64 {
 	if x != nil {
-		return x.Instances
+		return x.ReferenceCount
 	}
 	return 0
 }
@@ -1531,14 +1523,13 @@ const file_resource_definitions_runtime_runtime_proto_rawDesc = "" +
 	"\adefault\x18\x02 \x01(\tR\adefault\x12 \n" +
 	"\vunsupported\x18\x03 \x01(\bR\vunsupported\"D\n" +
 	"\x11KmsgLogConfigSpec\x12/\n" +
-	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\"\xb2\x01\n" +
+	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\"\xa9\x01\n" +
 	"\x16LoadedKernelModuleSpec\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
-	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x1c\n" +
-	"\tinstances\x18\x03 \x01(\x03R\tinstances\x12\"\n" +
-	"\fdependencies\x18\x04 \x03(\tR\fdependencies\x12\x14\n" +
-	"\x05state\x18\x05 \x01(\tR\x05state\x12\x18\n" +
-	"\aaddress\x18\x06 \x01(\tR\aaddress\"\xb1\x01\n" +
+	"\x04size\x18\x01 \x01(\x03R\x04size\x12'\n" +
+	"\x0freference_count\x18\x02 \x01(\x03R\x0ereferenceCount\x12\"\n" +
+	"\fdependencies\x18\x03 \x03(\tR\fdependencies\x12\x14\n" +
+	"\x05state\x18\x04 \x01(\tR\x05state\x12\x18\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress\"\xb1\x01\n" +
 	"\x11MachineStatusSpec\x12K\n" +
 	"\x05stage\x18\x01 \x01(\x0e25.talos.resource.definitions.enums.RuntimeMachineStageR\x05stage\x12O\n" +
 	"\x06status\x18\x02 \x01(\v27.talos.resource.definitions.runtime.MachineStatusStatusR\x06status\"\x8a\x01\n" +

--- a/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
@@ -586,14 +586,14 @@ func (m *LoadedKernelModuleSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		copy(dAtA[i:], m.Address)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Address)))
 		i--
-		dAtA[i] = 0x32
+		dAtA[i] = 0x2a
 	}
 	if len(m.State) > 0 {
 		i -= len(m.State)
 		copy(dAtA[i:], m.State)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.State)))
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x22
 	}
 	if len(m.Dependencies) > 0 {
 		for iNdEx := len(m.Dependencies) - 1; iNdEx >= 0; iNdEx-- {
@@ -601,25 +601,18 @@ func (m *LoadedKernelModuleSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error
 			copy(dAtA[i:], m.Dependencies[iNdEx])
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Dependencies[iNdEx])))
 			i--
-			dAtA[i] = 0x22
+			dAtA[i] = 0x1a
 		}
 	}
-	if m.Instances != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Instances))
+	if m.ReferenceCount != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ReferenceCount))
 		i--
-		dAtA[i] = 0x18
+		dAtA[i] = 0x10
 	}
 	if m.Size != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Size))
 		i--
-		dAtA[i] = 0x10
-	}
-	if len(m.Name) > 0 {
-		i -= len(m.Name)
-		copy(dAtA[i:], m.Name)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
-		i--
-		dAtA[i] = 0xa
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -1628,15 +1621,11 @@ func (m *LoadedKernelModuleSpec) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	l = len(m.Name)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	if m.Size != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Size))
 	}
-	if m.Instances != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.Instances))
+	if m.ReferenceCount != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ReferenceCount))
 	}
 	if len(m.Dependencies) > 0 {
 		for _, s := range m.Dependencies {
@@ -3118,38 +3107,6 @@ func (m *LoadedKernelModuleSpec) UnmarshalVT(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Name = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Size", wireType)
 			}
@@ -3168,11 +3125,11 @@ func (m *LoadedKernelModuleSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
-		case 3:
+		case 2:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Instances", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ReferenceCount", wireType)
 			}
-			m.Instances = 0
+			m.ReferenceCount = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -3182,12 +3139,12 @@ func (m *LoadedKernelModuleSpec) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Instances |= int64(b&0x7F) << shift
+				m.ReferenceCount |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-		case 4:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Dependencies", wireType)
 			}
@@ -3219,7 +3176,7 @@ func (m *LoadedKernelModuleSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Dependencies = append(m.Dependencies, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
-		case 5:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
 			}
@@ -3251,7 +3208,7 @@ func (m *LoadedKernelModuleSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.State = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 6:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
 			}

--- a/pkg/machinery/resources/runtime/loaded_kernel_module.go
+++ b/pkg/machinery/resources/runtime/loaded_kernel_module.go
@@ -23,12 +23,11 @@ type LoadedKernelModule = typed.Resource[LoadedKernelModuleSpec, LoadedKernelMod
 //
 //gotagsrewrite:gen
 type LoadedKernelModuleSpec struct {
-	Name         string   `yaml:"name" protobuf:"1"`
-	Size         int      `yaml:"size" protobuf:"2"`
-	Instances    int      `yaml:"instances" protobuf:"3"`
-	Dependencies []string `yaml:"dependencies,omitempty" protobuf:"4"`
-	State        string   `yaml:"state" protobuf:"5"`
-	Address      string   `yaml:"address" protobuf:"6"`
+	Size           int      `yaml:"size" protobuf:"1"`
+	ReferenceCount int      `yaml:"referenceCount" protobuf:"2"`
+	Dependencies   []string `yaml:"dependencies,omitempty" protobuf:"3"`
+	State          string   `yaml:"state" protobuf:"4"`
+	Address        string   `yaml:"address" protobuf:"5"`
 }
 
 // NewLoadedKernelModule initializes a LoadedKernelModule resource.
@@ -49,10 +48,6 @@ func (LoadedKernelModuleExtension) ResourceDefinition() meta.ResourceDefinitionS
 		Aliases:          []resource.Type{"module", "modules"},
 		DefaultNamespace: NamespaceName,
 		PrintColumns: []meta.PrintColumn{
-			{
-				Name:     "Name",
-				JSONPath: "{.name}",
-			},
 			{
 				Name:     "State",
 				JSONPath: "{.state}",

--- a/website/content/v1.11/reference/api.md
+++ b/website/content/v1.11/reference/api.md
@@ -5217,9 +5217,8 @@ LoadedKernelModuleSpec describes Linux kernel module to load.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  |  |
 | size | [int64](#int64) |  |  |
-| instances | [int64](#int64) |  |  |
+| reference_count | [int64](#int64) |  |  |
 | dependencies | [string](#string) | repeated |  |
 | state | [string](#string) |  |  |
 | address | [string](#string) |  |  |


### PR DESCRIPTION
`ReferenceCount` is a more common name, so replacing `Instances` will provide better UX and will match online resources.

Additionally drop `Name` which is duplicated from ID.
