### PR TITLE
feat: add SBOMs to the imager container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1028,12 +1028,14 @@ COPY --from=pkg-kernel-amd64 /boot/vmlinuz /usr/install/amd64/vmlinuz
 COPY --from=initramfs-archive-amd64 /initramfs.xz /usr/install/amd64/initramfs.xz
 COPY --from=pkg-sd-boot-amd64 /linuxx64.efi.stub /usr/install/amd64/systemd-stub.efi
 COPY --from=pkg-sd-boot-amd64 /systemd-bootx64.efi /usr/install/amd64/systemd-boot.efi
+COPY --from=sbom-amd64 /talos-amd64.spdx.json /usr/install/amd64/talos.spdx.json
 
 FROM scratch AS install-artifacts-arm64
 COPY --from=pkg-kernel-arm64 /boot/vmlinuz /usr/install/arm64/vmlinuz
 COPY --from=initramfs-archive-arm64 /initramfs.xz /usr/install/arm64/initramfs.xz
 COPY --from=pkg-sd-boot-arm64 /linuxaa64.efi.stub /usr/install/arm64/systemd-stub.efi
 COPY --from=pkg-sd-boot-arm64 /systemd-bootaa64.efi /usr/install/arm64/systemd-boot.efi
+COPY --from=sbom-arm64 /talos-arm64.spdx.json /usr/install/arm64/talos.spdx.json
 
 FROM scratch AS install-artifacts-all
 COPY --from=install-artifacts-amd64 / /

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ docker-%: ## Builds the specified target defined in the Dockerfile using the doc
 	@$(MAKE) target-$* TARGET_ARGS="--output type=docker,dest=$(DEST)/$*.tar,name=$(REGISTRY_AND_USERNAME)/$*:$(IMAGE_TAG_OUT) $(TARGET_ARGS)"
 
 registry-%: ## Builds the specified target defined in the Dockerfile using the image/registry output type. The build result will be pushed to the registry if PUSH=true.
-	@$(MAKE) target-$* TARGET_ARGS="--output type=image,name=$(REGISTRY_AND_USERNAME)/$*:$(IMAGE_TAG_OUT) $(TARGET_ARGS)"
+	@$(MAKE) target-$* TARGET_ARGS="--output type=image,name=$(REGISTRY_AND_USERNAME)/$*:$(IMAGE_TAG_OUT),rewrite-timestamp=true $(TARGET_ARGS)"
 
 hack-test-%: ## Runs the specified script in ./hack/test with well known environment variables.
 	@./hack/test/$*.sh

--- a/internal/integration/api/sbom.go
+++ b/internal/integration/api/sbom.go
@@ -87,6 +87,16 @@ func (suite *SBOMSuite) TestCommon() {
 		},
 	)
 
+	// Assert on Go version.
+	rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI,
+		"golang",
+		func(item *runtime.SBOMItem, asrt *assert.Assertions) {
+			goVersion := strings.TrimPrefix(constants.GoVersion, "go")
+
+			asrt.Equal(goVersion, item.TypedSpec().Version)
+		},
+	)
+
 	if suite.Capabilities().RunsTalosKernel {
 		// Assert on Talos kernel version.
 		rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI,


### PR DESCRIPTION
Fixes #10939

E.g. we can consume it from the Image Factory side.

Also enable timestamp rewriting for output images, goes from `SOURCE_DATE_EPOCH`.

See https://github.com/moby/buildkit/blob/master/docs/build-repro.md#source_date_epoch
