### PR TITLE
test: fix flaky TestDNS

### DIFF
--- a/internal/pkg/dns/dns_test.go
+++ b/internal/pkg/dns/dns_test.go
@@ -90,7 +90,11 @@ func TestDNS(t *testing.T) {
 
 				time.Sleep(10 * time.Millisecond)
 
-				r, err := dnssrv.Exchange(createQuery(test.hostname), dnsAddr)
+				c := dnssrv.Client{
+					Timeout: time.Second,
+				}
+
+				r, _, err := c.Exchange(createQuery(test.hostname), dnsAddr)
 				test.errCheck(t, err)
 
 				if r != nil {


### PR DESCRIPTION
Fixes #10853

I think the issue is that we do DNS client request to the DNS caching server, and expect the request to fail on client side, as caching server doesn't respond in time (as the server is waiting for a response).

Make sure we use a short timeout on our client side, so that we time out before a server does.
