### PR TITLE
feat(talosctl): support tpm operation on mac

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/command.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/command.go
@@ -239,8 +239,6 @@ func init() {
 	)
 
 	unImplementedQemuFlagsDarwin := []string{
-		tpmEnabledFlag,
-		tpm2EnabledFlag,
 		networkNoMasqueradeCIDRsFlag,
 		cniBinPathFlag,
 		cniConfDirFlag,


### PR DESCRIPTION
Support TPM operations when developing on Mac.

`brew install swtpm` is all that is needed.