### PR TITLE
test: refactor various merge controller tests

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_merge_test.go
@@ -2,117 +2,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:dupl
 package network_test
 
 import (
-	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
-	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
-	"github.com/siderolabs/go-retry/retry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap/zaptest"
-	"golang.org/x/sync/errgroup"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
 type OperatorMergeSuite struct {
-	suite.Suite
-
-	state state.State
-
-	runtime *runtime.Runtime
-	wg      sync.WaitGroup
-
-	ctx       context.Context //nolint:containedctx
-	ctxCancel context.CancelFunc
+	ctest.DefaultSuite
 }
 
-func (suite *OperatorMergeSuite) SetupTest() {
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
-
-	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var err error
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
-	suite.Require().NoError(err)
-
-	suite.Require().NoError(suite.runtime.RegisterController(netctrl.NewOperatorMergeController()))
-
-	suite.startRuntime()
+func (suite *OperatorMergeSuite) assertOperators(requiredIDs []string, check func(*network.OperatorSpec, *assert.Assertions)) {
+	ctest.AssertResources(suite, requiredIDs, check)
 }
 
-func (suite *OperatorMergeSuite) startRuntime() {
-	suite.wg.Add(1)
-
-	go func() {
-		defer suite.wg.Done()
-
-		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
-	}()
-}
-
-func (suite *OperatorMergeSuite) assertOperators(requiredIDs []string, check func(*network.OperatorSpec) error) error {
-	missingIDs := make(map[string]struct{}, len(requiredIDs))
-
-	for _, id := range requiredIDs {
-		missingIDs[id] = struct{}{}
-	}
-
-	resources, err := suite.state.List(
-		suite.ctx,
-		resource.NewMetadata(network.NamespaceName, network.OperatorSpecType, "", resource.VersionUndefined),
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, res := range resources.Items {
-		_, required := missingIDs[res.Metadata().ID()]
-		if !required {
-			continue
-		}
-
-		delete(missingIDs, res.Metadata().ID())
-
-		if err = check(res.(*network.OperatorSpec)); err != nil {
-			return retry.ExpectedError(err)
-		}
-	}
-
-	if len(missingIDs) > 0 {
-		return retry.ExpectedErrorf("some resources are missing: %q", missingIDs)
-	}
-
-	return nil
-}
-
-func (suite *OperatorMergeSuite) assertNoOperator(id string) error {
-	resources, err := suite.state.List(
-		suite.ctx,
-		resource.NewMetadata(network.NamespaceName, network.OperatorSpecType, "", resource.VersionUndefined),
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, res := range resources.Items {
-		if res.Metadata().ID() == id {
-			return retry.ExpectedErrorf("operator %q is still there", id)
-		}
-	}
-
-	return nil
+func (suite *OperatorMergeSuite) assertNoOperator(id string) {
+	ctest.AssertNoResource[*network.OperatorSpec](suite, id)
 }
 
 func (suite *OperatorMergeSuite) TestMerge() {
@@ -140,56 +54,35 @@ func (suite *OperatorMergeSuite) TestMerge() {
 	}
 
 	for _, res := range []resource.Resource{dhcp1, dhcp2, dhcp6} {
-		suite.Require().NoError(suite.state.Create(suite.ctx, res), "%v", res.Spec())
+		suite.Create(res)
 	}
 
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertOperators(
-					[]string{
-						"dhcp4/eth0",
-						"dhcp6/eth0",
-					}, func(r *network.OperatorSpec) error {
-						switch r.Metadata().ID() {
-						case "dhcp4/eth0":
-							suite.Assert().Equal(*dhcp2.TypedSpec(), *r.TypedSpec())
-						case "dhcp6/eth0":
-							suite.Assert().Equal(*dhcp6.TypedSpec(), *r.TypedSpec())
-						}
-
-						return nil
-					},
-				)
-			},
-		),
+	suite.assertOperators(
+		[]string{
+			"dhcp4/eth0",
+			"dhcp6/eth0",
+		}, func(r *network.OperatorSpec, asrt *assert.Assertions) {
+			switch r.Metadata().ID() {
+			case "dhcp4/eth0":
+				asrt.Equal(*dhcp2.TypedSpec(), *r.TypedSpec())
+			case "dhcp6/eth0":
+				asrt.Equal(*dhcp6.TypedSpec(), *r.TypedSpec())
+			}
+		},
 	)
 
-	suite.Require().NoError(suite.state.Destroy(suite.ctx, dhcp6.Metadata()))
+	suite.Destroy(dhcp6)
 
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertOperators(
-					[]string{
-						"dhcp4/eth0",
-					}, func(r *network.OperatorSpec) error {
-						return nil
-					},
-				)
-			},
-		),
+	suite.assertOperators(
+		[]string{
+			"dhcp4/eth0",
+		}, func(r *network.OperatorSpec, asrt *assert.Assertions) {
+			asrt.Equal(*dhcp2.TypedSpec(), *r.TypedSpec())
+		},
 	)
-	suite.Assert().NoError(
-		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertNoOperator("dhcp6/eth0")
-			},
-		),
-	)
+	suite.assertNoOperator("dhcp6/eth0")
 }
 
-//nolint:gocyclo
 func (suite *OperatorMergeSuite) TestMergeFlapping() {
 	// simulate two conflicting operator definitions which are getting removed/added constantly
 	dhcp := network.NewOperatorSpec(network.ConfigNamespaceName, "default/dhcp4/eth0")
@@ -207,107 +100,18 @@ func (suite *OperatorMergeSuite) TestMergeFlapping() {
 		ConfigLayer: network.ConfigMachineConfiguration,
 	}
 
-	resources := []resource.Resource{dhcp, override}
-
-	flipflop := func(idx int) func() error {
-		return func() error {
-			for range 500 {
-				if err := suite.state.Create(suite.ctx, resources[idx]); err != nil {
-					return err
-				}
-
-				if err := suite.state.Destroy(suite.ctx, resources[idx].Metadata()); err != nil {
-					return err
-				}
-
-				time.Sleep(time.Millisecond)
-			}
-
-			return suite.state.Create(suite.ctx, resources[idx])
-		}
-	}
-
-	var eg errgroup.Group
-
-	eg.Go(flipflop(0))
-	eg.Go(flipflop(1))
-	eg.Go(
-		func() error {
-			// add/remove finalizer to the merged resource
-			for range 1000 {
-				if err := suite.state.AddFinalizer(
-					suite.ctx,
-					resource.NewMetadata(
-						network.NamespaceName,
-						network.OperatorSpecType,
-						"dhcp4/eth0",
-						resource.VersionUndefined,
-					),
-					"foo",
-				); err != nil {
-					if !state.IsNotFoundError(err) {
-						return err
-					}
-
-					continue
-				}
-
-				suite.T().Log("finalizer added")
-
-				time.Sleep(10 * time.Millisecond)
-
-				if err := suite.state.RemoveFinalizer(
-					suite.ctx,
-					resource.NewMetadata(
-						network.NamespaceName,
-						network.OperatorSpecType,
-						"dhcp4/eth0",
-						resource.VersionUndefined,
-					),
-					"foo",
-				); err != nil && !state.IsNotFoundError(err) {
-					return err
-				}
-			}
-
-			return nil
-		},
-	)
-
-	suite.Require().NoError(eg.Wait())
-
-	suite.Assert().NoError(
-		retry.Constant(15*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-			func() error {
-				return suite.assertOperators(
-					[]string{
-						"dhcp4/eth0",
-					}, func(r *network.OperatorSpec) error {
-						if r.Metadata().Phase() != resource.PhaseRunning {
-							return retry.ExpectedErrorf("resource phase is %s", r.Metadata().Phase())
-						}
-
-						if *override.TypedSpec() != *r.TypedSpec() {
-							// using retry here, as it might not be reconciled immediately
-							return retry.ExpectedErrorf("not equal yet")
-						}
-
-						return nil
-					},
-				)
-			},
-		),
-	)
-}
-
-func (suite *OperatorMergeSuite) TearDownTest() {
-	suite.T().Log("tear down")
-
-	suite.ctxCancel()
-
-	suite.wg.Wait()
+	testMergeFlapping(&suite.DefaultSuite, []*network.OperatorSpec{dhcp, override}, "dhcp4/eth0", override)
 }
 
 func TestOperatorMergeSuite(t *testing.T) {
-	suite.Run(t, new(OperatorMergeSuite))
+	t.Parallel()
+
+	suite.Run(t, &OperatorMergeSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 5 * time.Second,
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(netctrl.NewOperatorMergeController()))
+			},
+		},
+	})
 }

--- a/internal/app/machined/pkg/controllers/network/timeserver_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_merge_test.go
@@ -2,71 +2,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:dupl
 package network_test
 
 import (
-	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
-	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap/zaptest"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
 type TimeServerMergeSuite struct {
-	suite.Suite
-
-	state state.State
-
-	runtime *runtime.Runtime
-	wg      sync.WaitGroup
-
-	ctx       context.Context //nolint:containedctx
-	ctxCancel context.CancelFunc
-}
-
-func (suite *TimeServerMergeSuite) SetupTest() {
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
-
-	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var err error
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
-	suite.Require().NoError(err)
-
-	suite.Require().NoError(suite.runtime.RegisterController(netctrl.NewTimeServerMergeController()))
-
-	suite.startRuntime()
-}
-
-func (suite *TimeServerMergeSuite) startRuntime() {
-	suite.wg.Add(1)
-
-	go func() {
-		defer suite.wg.Done()
-
-		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
-	}()
+	ctest.DefaultSuite
 }
 
 func (suite *TimeServerMergeSuite) assertTimeServers(
 	requiredIDs []string,
 	check func(*network.TimeServerSpec, *assert.Assertions),
 ) {
-	assertResources(suite.ctx, suite.T(), suite.state, requiredIDs, check)
+	ctest.AssertResources(suite, requiredIDs, check)
 }
 
 func (suite *TimeServerMergeSuite) TestMerge() {
@@ -95,7 +55,7 @@ func (suite *TimeServerMergeSuite) TestMerge() {
 	}
 
 	for _, res := range []resource.Resource{def, dhcp1, dhcp2, static} {
-		suite.Require().NoError(suite.state.Create(suite.ctx, res), "%v", res.Spec())
+		suite.Create(res)
 	}
 
 	suite.assertTimeServers(
@@ -106,7 +66,7 @@ func (suite *TimeServerMergeSuite) TestMerge() {
 		},
 	)
 
-	suite.Require().NoError(suite.state.Destroy(suite.ctx, static.Metadata()))
+	suite.Destroy(static)
 
 	suite.assertTimeServers(
 		[]string{
@@ -117,14 +77,15 @@ func (suite *TimeServerMergeSuite) TestMerge() {
 	)
 }
 
-func (suite *TimeServerMergeSuite) TearDownTest() {
-	suite.T().Log("tear down")
-
-	suite.ctxCancel()
-
-	suite.wg.Wait()
-}
-
 func TestTimeServerMergeSuite(t *testing.T) {
-	suite.Run(t, new(TimeServerMergeSuite))
+	t.Parallel()
+
+	suite.Run(t, &TimeServerMergeSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 5 * time.Second,
+			AfterSetup: func(s *ctest.DefaultSuite) {
+				s.Require().NoError(s.Runtime().RegisterController(netctrl.NewTimeServerMergeController()))
+			},
+		},
+	})
 }


### PR DESCRIPTION
Use ctest suite, rtestutils assertions.

Simplifying code, making tests run faster and in parallel, and also reducing test flakiness.
