### PR TITLE
docs: add secure boot setup mode note for Xen

### DIFF
--- a/website/content/v1.10/talos-guides/install/virtualized-platforms/xen.md
+++ b/website/content/v1.10/talos-guides/install/virtualized-platforms/xen.md
@@ -7,3 +7,6 @@ aliases:
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide]({{< relref "../../../introduction/getting-started" >}}).
 If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+
+> Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
+> Don't forget to re-enable Secure Boot after the first boot.

--- a/website/content/v1.11/talos-guides/install/virtualized-platforms/xen.md
+++ b/website/content/v1.11/talos-guides/install/virtualized-platforms/xen.md
@@ -7,3 +7,6 @@ aliases:
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide]({{< relref "../../../introduction/getting-started" >}}).
 If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+
+> Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
+> Don't forget to re-enable Secure Boot after the first boot.


### PR DESCRIPTION
# Pull Request

## What? (description)
Added a note about Secure Boot setup mode on the documentation page for Xen platform.
I used the same note format as the KVM page [here](https://github.com/siderolabs/talos/blob/main/website/content/v1.10/talos-guides/install/virtualized-platforms/kvm.md?plain=1).

## Why? (reasoning)
I setuped Talos on XCP-ng (based on XenServer) and had no problem except for Secure Boot where I struggled a bit to enroll the keys, since my VM was not starting in setup mode. The given command is not specific to XCP-ng, it's from XenServer.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
