### PR TITLE
docs: fix typo in hugo config: pre-releaase

### DIFF
--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -143,7 +143,7 @@ prism_syntax_highlighting = false
 
 [[params.versions]]
 url = "/v1.11/"
-version = "v1.11 (pre-releaase)"
+version = "v1.11 (pre-release)"
 
 [[params.versions]]
 url = "/v1.10/"


### PR DESCRIPTION
# Pull Request

## What? (description)
Simple typo fix, `pre-relea<a>se`, appearing in the Release top button on website.

## Why? (reasoning)
To fix the typo.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
