### PR TITLE
chore(machined): remove deprecated Endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/siderolabs/crypto v0.6.3
 	github.com/siderolabs/discovery-api v0.1.6
 	github.com/siderolabs/discovery-client v0.1.12
-	github.com/siderolabs/gen v0.8.4
+	github.com/siderolabs/gen v0.8.5
 	github.com/siderolabs/go-api-signature v0.3.6
 	github.com/siderolabs/go-blockdevice v0.4.8
 	github.com/siderolabs/go-blockdevice/v2 v2.0.18
@@ -189,6 +189,7 @@ require (
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.76
 	sigs.k8s.io/hydrophone v0.7.0
 	sigs.k8s.io/yaml v1.5.0
@@ -359,7 +360,6 @@ require (
 	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/cli-runtime v0.34.0-beta.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 // indirect
 	rsc.io/qr v0.2.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/siderolabs/discovery-client v0.1.12/go.mod h1:kojlX4Kk0o9wsbJU1XOy4BH
 github.com/siderolabs/ethtool v0.4.0-sidero h1:Ls/M4bFUjfcB1RDVviPZlL3kWcXaEVVSbKke+EZ2A9U=
 github.com/siderolabs/ethtool v0.4.0-sidero/go.mod h1:nOIR88fiFTdBfakYLEUAhxdy75Ih/fgnSlsSKAHRpfc=
 github.com/siderolabs/gen v0.8.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=
-github.com/siderolabs/gen v0.8.4 h1:1Xj/YvKTXgpnr9ZC7heKcskJo5wHvWOybwjQSCfEmsQ=
-github.com/siderolabs/gen v0.8.4/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
+github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
+github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
 github.com/siderolabs/go-api-signature v0.3.6 h1:wDIsXbpl7Oa/FXvxB6uz4VL9INA9fmr3EbmjEZYFJrU=
 github.com/siderolabs/go-api-signature v0.3.6/go.mod h1:hoH13AfunHflxbXfh+NoploqV13ZTDfQ1mQJWNVSW9U=
 github.com/siderolabs/go-blockdevice v0.4.8 h1:KfdWvIx0Jft5YVuCsFIJFwjWEF1oqtzkgX9PeU9cX4c=

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -199,6 +199,7 @@ func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scr
 		{"01-csr-approver-role-binding", csrApproverRoleBindingTemplate},
 		{"01-csr-renewal-role-binding", csrRenewalRoleBindingTemplate},
 		{"11-kube-config-in-cluster", kubeConfigInClusterTemplate},
+		{"11-talos-node-rbac-template", talosNodesRBACTemplate},
 	}
 
 	if cfg.CoreDNSEnabled {

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -137,6 +137,7 @@ func (suite *ManifestSuite) TestReconcileDefaults() {
 						"11-core-dns",
 						"11-core-dns-svc",
 						"11-kube-config-in-cluster",
+						"11-talos-node-rbac-template",
 					},
 				)
 			},
@@ -168,6 +169,7 @@ func (suite *ManifestSuite) TestReconcileDisableKubeProxy() {
 						"11-core-dns",
 						"11-core-dns-svc",
 						"11-kube-config-in-cluster",
+						"11-talos-node-rbac-template",
 					},
 				)
 			},
@@ -200,6 +202,7 @@ func (suite *ManifestSuite) TestReconcileKubeProxyExtraArgs() {
 						"11-core-dns",
 						"11-core-dns-svc",
 						"11-kube-config-in-cluster",
+						"11-talos-node-rbac-template",
 					},
 				)
 			},
@@ -256,6 +259,7 @@ func (suite *ManifestSuite) TestReconcileIPv6() {
 						"11-core-dns",
 						"11-core-dns-svc",
 						"11-kube-config-in-cluster",
+						"11-talos-node-rbac-template",
 					},
 				)
 			},
@@ -338,6 +342,7 @@ func (suite *ManifestSuite) TestReconcileDisablePSP() {
 						"11-core-dns",
 						"11-core-dns-svc",
 						"11-kube-config-in-cluster",
+						"11-talos-node-rbac-template",
 					},
 				)
 			},

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -78,3 +78,10 @@ var flannelTemplate = string(flannel.Template)
 //
 //go:embed templates/talos-service-account-crd-template.yaml
 var talosServiceAccountCRDTemplate string
+
+// talosNodeRBACTemplate is the template of the RBAC rules which allow
+// Talos to discover the nodes in the Kubernetes cluster and assign
+// endpoints for the internal discovery.
+//
+//go:embed templates/talos-nodes-rbac-template.yaml
+var talosNodesRBACTemplate string

--- a/internal/app/machined/pkg/controllers/k8s/templates/talos-nodes-rbac-template.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/templates/talos-nodes-rbac-template.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: system:talos-nodes
+    labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+    annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:talos-nodes
+subjects:
+    - kind: Group
+      name: system:nodes
+      apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: system:talos-nodes
+    labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+rules:
+    - apiGroups:
+          - discovery.k8s.io
+      resources:
+          - endpointslices
+      verbs:
+          - get
+          - list
+          - watch

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/siderolabs/crypto v0.6.3
-	github.com/siderolabs/gen v0.8.4
+	github.com/siderolabs/gen v0.8.5
 	github.com/siderolabs/go-api-signature v0.3.6
 	github.com/siderolabs/go-pointer v1.0.1
 	github.com/siderolabs/net v0.4.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -113,8 +113,8 @@ github.com/siderolabs/crypto v0.6.3 h1:9eGHzAJQg7FvPcjVANLQKnepc0nrl5IkLJ3FxhMvs
 github.com/siderolabs/crypto v0.6.3/go.mod h1:LEhGuXlvwElMgh+rYjCFw6JgfOgyaC+sqsl/YwWU+EM=
 github.com/siderolabs/ethtool v0.4.0-sidero h1:Ls/M4bFUjfcB1RDVviPZlL3kWcXaEVVSbKke+EZ2A9U=
 github.com/siderolabs/ethtool v0.4.0-sidero/go.mod h1:nOIR88fiFTdBfakYLEUAhxdy75Ih/fgnSlsSKAHRpfc=
-github.com/siderolabs/gen v0.8.4 h1:1Xj/YvKTXgpnr9ZC7heKcskJo5wHvWOybwjQSCfEmsQ=
-github.com/siderolabs/gen v0.8.4/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
+github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
+github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
 github.com/siderolabs/go-api-signature v0.3.6 h1:wDIsXbpl7Oa/FXvxB6uz4VL9INA9fmr3EbmjEZYFJrU=
 github.com/siderolabs/go-api-signature v0.3.6/go.mod h1:hoH13AfunHflxbXfh+NoploqV13ZTDfQ1mQJWNVSW9U=
 github.com/siderolabs/go-pointer v1.0.1 h1:f7Yi4IK1jptS8yrT9GEbwhmGcVxvPQgBUG/weH3V3DM=


### PR DESCRIPTION
Remove deprecated core/v1.Endpoints in favor of discovery/v1.EndpointSlices.

Fixes #11322

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
