### PR TITLE
test: add talosctl:latest to the image cache

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -201,6 +201,7 @@ var imageIntegrationCmd = &cobra.Command{
 			imgs.Pause,
 			"registry.k8s.io/conformance:v" + constants.DefaultKubernetesVersion,
 			"docker.io/library/alpine:latest",
+			"ghcr.io/siderolabs/talosctl:latest",
 			imageIntegrationCmdFlags.registryAndUser + "/installer:" +
 				imageIntegrationCmdFlags.installerTag,
 		}


### PR DESCRIPTION
It is used in the Talos API from Kubernetes access test.

