### PR TITLE
fix: issue with volume remount on service restart

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -96,9 +96,10 @@ function run_talos_integration_test_docker {
 
   "${INTEGRATION_TEST}" \
     -test.v \
+    -talos.failfast \
     -talos.talosctlpath "${TALOSCTL}" \
     -talos.kubectlpath "${KUBECTL}" \
-     -talos.helmpath "${HELM}" \
+    -talos.helmpath "${HELM}" \
     -talos.kubestrpath "${KUBESTR}" \
     -talos.provisioner "${PROVISIONER}" \
     -talos.name "${CLUSTER_NAME}" \

--- a/internal/app/machined/pkg/system/volumes.go
+++ b/internal/app/machined/pkg/system/volumes.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/siderolabs/talos/pkg/conditions"
@@ -69,7 +70,11 @@ func (cond *volumeMountedCondition) Wait(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	_, err := cond.st.WatchFor(ctx, block.NewVolumeMountStatus(block.NamespaceName, cond.id).Metadata(), state.WithEventTypes(state.Created, state.Updated))
+	_, err := cond.st.WatchFor(ctx,
+		block.NewVolumeMountStatus(block.NamespaceName, cond.id).Metadata(),
+		state.WithEventTypes(state.Created, state.Updated),
+		state.WithPhases(resource.PhaseRunning),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This showed up in docker runs (not sure why only docker), but the issue is the following:

* a service is running which has some volume requirements
* `VolumeMountRequests` are created, and `VolumeMountStatus` were established
* the service put finalizers on `VolumeMountStatus`
* now the service is going to be restarted - so at first it's going to be shut down
* on shutdown, the service will remove `VolumeMountRequest`, and remove finalizers on `VolumeMountStatus`
* now it's job of other controllers to tear down and remove mounts
* as the service starts back up after restart, it will re-create `VolumeMountRequest`, and will try to wait and put finalizers on `VolumeMountStatus`
* here comes the race condition: it can be that the service sees tearing down `VolumeMountStatus` which is left from the shutdown time, so it puts a finalizer on it, and it blocks the proper teardown of the previous "generation" of the mount request/status, leading to a deadlock

So the fix is to wait for the new status to be created which is not tearing down.
