### PR TITLE
docs: fix error in kernel module guide

### DIFF
--- a/website/content/v1.10/advanced/kernel-module.md
+++ b/website/content/v1.10/advanced/kernel-module.md
@@ -221,15 +221,15 @@ make installer-base imager PLATFORM=linux/amd64 \
   PUSH=true
 ```
 
-This will create an imager image and push it to your local registry.
-Export the image and save it as `$IMAGER_IMAGE`.
+This will create two images - installer-base and imager and push them to your local registry.
+Export the installer-base image and save it as `$BASE_INSTALLER_IMAGE`.
 
-Create a installer image from your extension and the imager you just created with the following command.
+Create an installer image from your extension and the installer-base you just created with the following command.
 
 ```bash
 make image-installer \
   REGISTRY=127.0.0.1:5005 \
-  IMAGER_ARGS="--base-installer-image=${IMAGER_IMAGE} \
+  IMAGER_ARGS="--base-installer-image=${BASE_INSTALLER_IMAGE} \
     --system-extension-image=${EXTENSION_IMAGE}"
 ```
 

--- a/website/content/v1.11/advanced/kernel-module.md
+++ b/website/content/v1.11/advanced/kernel-module.md
@@ -221,15 +221,15 @@ make installer-base imager PLATFORM=linux/amd64 \
   PUSH=true
 ```
 
-This will create an imager image and push it to your local registry.
-Export the image and save it as `$IMAGER_IMAGE`.
+This will create two images - installer-base and imager and push them to your local registry.
+Export the installer-base image and save it as `$BASE_INSTALLER_IMAGE`.
 
-Create a installer image from your extension and the imager you just created with the following command.
+Create an installer image from your extension and the installer-base you just created with the following command.
 
 ```bash
 make image-installer \
   REGISTRY=127.0.0.1:5005 \
-  IMAGER_ARGS="--base-installer-image=${IMAGER_IMAGE} \
+  IMAGER_ARGS="--base-installer-image=${BASE_INSTALLER_IMAGE} \
     --system-extension-image=${EXTENSION_IMAGE}"
 ```
 


### PR DESCRIPTION
Fixes #11426

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Docs article [Adding a Kernel Module](https://www.talos.dev/v1.10/advanced/kernel-module/#test-the-extension) contained had a mistake in `Test the extension` section. This mistake made it impossible to succeed when following the article.

## Why? (reasoning)

Following the article should produce the desired result.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
