### PR TITLE
fix(ci): use a random suffix for ami names

### DIFF
--- a/.github/workflows/integration-aws-nvidia-oss-lts-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-lts-cron.yaml
@@ -1,13 +1,13 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-22T04:25:57Z by kres b869533.
+# Generated on 2025-07-30T03:57:19Z by kres dd1ed6f.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 5 * * *
+    - cron: 30 7 * * *
 name: integration-aws-nvidia-oss-lts-cron
 jobs:
   default:

--- a/.github/workflows/integration-aws-nvidia-oss-production-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-production-cron.yaml
@@ -1,13 +1,13 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-22T04:25:57Z by kres b869533.
+# Generated on 2025-07-30T03:57:19Z by kres dd1ed6f.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 5 * * *
+    - cron: 30 7 * * *
 name: integration-aws-nvidia-oss-production-cron
 jobs:
   default:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2608,7 +2608,7 @@ spec:
         - self-hosted
         - generic # we can use generic here since the tests run against a remote talos cluster
       crons:
-        - '30 5 * * *'
+        - '30 7 * * *'
       triggerLabels:
         - integration/aws-nvidia-oss-lts
         - integration/aws-nvidia-oss
@@ -2708,7 +2708,7 @@ spec:
         - self-hosted
         - generic # we can use generic here since the tests run against a remote talos cluster
       crons:
-        - '30 5 * * *'
+        - '30 7 * * *'
       triggerLabels:
         - integration/aws-nvidia-oss-production
         - integration/aws-nvidia-oss

--- a/hack/test/e2e-aws-prepare.sh
+++ b/hack/test/e2e-aws-prepare.sh
@@ -7,7 +7,9 @@ source ./hack/test/e2e.sh
 REGION="us-east-1"
 
 function cloud_image_upload() {
-  CLOUD_IMAGES_EXTRA_ARGS=("--name-prefix=${1}" "--target-clouds=aws" "--architectures=amd64" "--aws-regions=${REGION}")
+  RANDOM_SUFFIX=$(openssl rand -hex 4)
+
+  CLOUD_IMAGES_EXTRA_ARGS=("--name-prefix=${1}-${RANDOM_SUFFIX}" "--target-clouds=aws" "--architectures=amd64" "--aws-regions=${REGION}")
 
   case "${1}" in
     talos-e2e-nvidia-oss-*)


### PR DESCRIPTION
Use a random suffix for AMI names so that names don't conflict in parallel runs.