### PR TITLE
docs: add remark about 'exclude-from-external-load-balancers'

### DIFF
--- a/website/content/v1.10/talos-guides/howto/workers-on-controlplane.md
+++ b/website/content/v1.10/talos-guides/howto/workers-on-controlplane.md
@@ -9,7 +9,7 @@ By default, Talos Linux taints control plane nodes so that workloads are not sch
 
 In order to allow workloads to run on the control plane nodes (useful for single node clusters, or non-production clusters), follow the procedure below.
 
-Modify the MachineConfig for the controlplane nodes to add `allowSchedulingOnControlPlanes: true`:
+Modify the machine configuration for the controlplane nodes to add `allowSchedulingOnControlPlanes: true`:
 
 ```yaml
 cluster:
@@ -17,3 +17,17 @@ cluster:
 ```
 
 This may be done via editing the `controlplane.yaml` file before it is applied to the control plane nodes, by [editing the machine config]({{< relref "../configuration/editing-machine-configuration" >}}), or by [patching the machine config]({{< relref "../configuration/patching">}}).
+
+## Load Balancer configuration
+
+When a load balancer such as MetalLB is used, the nodeLabel `node.kubernetes.io/exclude-from-external-load-balancers` should also be removed from the control plane nodes.
+This label is added by default and instructs load balancers to exclude the node from the list of backend servers used by external load balancers.
+
+In order to remove this label, you can patch the machine configuration for the control plane nodes with the patch:
+
+```yaml
+machine:
+  nodeLabels:
+    node.kubernetes.io/exclude-from-external-load-balancers:
+      $patch: delete
+```

--- a/website/content/v1.11/talos-guides/howto/workers-on-controlplane.md
+++ b/website/content/v1.11/talos-guides/howto/workers-on-controlplane.md
@@ -9,7 +9,7 @@ By default, Talos Linux taints control plane nodes so that workloads are not sch
 
 In order to allow workloads to run on the control plane nodes (useful for single node clusters, or non-production clusters), follow the procedure below.
 
-Modify the MachineConfig for the controlplane nodes to add `allowSchedulingOnControlPlanes: true`:
+Modify the machine configuration for the controlplane nodes to add `allowSchedulingOnControlPlanes: true`:
 
 ```yaml
 cluster:
@@ -17,3 +17,17 @@ cluster:
 ```
 
 This may be done via editing the `controlplane.yaml` file before it is applied to the control plane nodes, by [editing the machine config]({{< relref "../configuration/editing-machine-configuration" >}}), or by [patching the machine config]({{< relref "../configuration/patching">}}).
+
+## Load Balancer configuration
+
+When a load balancer such as MetalLB is used, the nodeLabel `node.kubernetes.io/exclude-from-external-load-balancers` should also be removed from the control plane nodes.
+This label is added by default and instructs load balancers to exclude the node from the list of backend servers used by external load balancers.
+
+In order to remove this label, you can patch the machine configuration for the control plane nodes with the patch:
+
+```yaml
+machine:
+  nodeLabels:
+    node.kubernetes.io/exclude-from-external-load-balancers:
+      $patch: delete
+```


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
This pull request adds documentation on how to remove the `exclude-from-external-load-balancers` label from control plane nodes on the page about enabling workloads on control plane nodes.

## Why? (reasoning)
According to https://github.com/siderolabs/talos/issues/8749, the label `exclude-from-external-load-balancers` is added to the machineconfig by default since machine config 1.8+.  However, when talos users want to enable workloads on controlplane nodes they will probably also want to be able to route to it when a load balancer is used. Therefore it would be beneficial to mention that the nodeLabel that is added by default and excludes control plane nodes from external load balancers should be removed.

## Acceptance

Please use the following checklist:

- [x] `(N/A)` you linked an issue (if applicable)
- [x] `(N/A)` you included tests (if applicable)
- [x] `(N/A)` you ran conformance (`make conformance`)
- [x] `(N/A)` you formatted your code (`make fmt`)
- [x] `(N/A)` you linted your code (`make lint`)
- [x] `(N/A)` you generated documentation (`make docs`)
- [x] `(N/A)` you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
