### PR TITLE
fix: enforce minimum size on user volumes if not set explicitly

### DIFF
--- a/internal/app/machined/pkg/controllers/block/user_volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/user_volume_config.go
@@ -5,6 +5,7 @@
 package block
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 
@@ -22,6 +23,12 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+)
+
+// Size constants.
+const (
+	MiB               = 1024 * 1024
+	MinUserVolumeSize = 100 * MiB
 )
 
 // UserVolumeConfigController provides user volume configuration based on UserVolumeConfig, SwapVolumeConfig, etc. documents.
@@ -309,7 +316,7 @@ func (ctrl *UserVolumeConfigController) handleUserVolumeConfig(
 			Match: diskSelector,
 		},
 		PartitionSpec: block.PartitionSpec{
-			MinSize:  userVolumeConfig.Provisioning().MinSize().ValueOrZero(),
+			MinSize:  cmp.Or(userVolumeConfig.Provisioning().MinSize().ValueOrZero(), MinUserVolumeSize),
 			MaxSize:  userVolumeConfig.Provisioning().MaxSize().ValueOrZero(),
 			Grow:     userVolumeConfig.Provisioning().Grow().ValueOrZero(),
 			Label:    volumeID,
@@ -356,7 +363,7 @@ func (ctrl *UserVolumeConfigController) handleRawVolumeConfig(
 			Match: diskSelector,
 		},
 		PartitionSpec: block.PartitionSpec{
-			MinSize:  rawVolumeConfig.Provisioning().MinSize().ValueOrZero(),
+			MinSize:  cmp.Or(rawVolumeConfig.Provisioning().MinSize().ValueOrZero(), MinUserVolumeSize),
 			MaxSize:  rawVolumeConfig.Provisioning().MaxSize().ValueOrZero(),
 			Grow:     rawVolumeConfig.Provisioning().Grow().ValueOrZero(),
 			Label:    volumeID,
@@ -423,8 +430,7 @@ func (ctrl *UserVolumeConfigController) handleSwapVolumeConfig(
 			Match: diskSelector,
 		},
 		PartitionSpec: block.PartitionSpec{
-			MinSize:  swapVolumeConfig.Provisioning().MinSize().ValueOrZero(),
-			MaxSize:  swapVolumeConfig.Provisioning().MaxSize().ValueOrZero(),
+			MaxSize:  cmp.Or(swapVolumeConfig.Provisioning().MaxSize().ValueOrZero(), MinUserVolumeSize),
 			Grow:     swapVolumeConfig.Provisioning().Grow().ValueOrZero(),
 			Label:    volumeID,
 			TypeUUID: partition.LinkSwap,

--- a/internal/app/machined/pkg/controllers/block/user_volume_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/user_volume_config_test.go
@@ -93,6 +93,13 @@ func (suite *UserVolumeConfigSuite) TestReconcileUserVolumesSwapVolumes() {
 
 		asrt.Contains([]string{"data1", "data2"}, vc.TypedSpec().Mount.TargetPath)
 		asrt.Equal(constants.UserVolumeMountPoint, vc.TypedSpec().Mount.ParentID)
+
+		switch vc.Metadata().ID() {
+		case userVolumes[0]:
+			asrt.EqualValues(10*1024*1024*1024, vc.TypedSpec().Provisioning.PartitionSpec.MinSize)
+		case userVolumes[1]:
+			asrt.EqualValues(100*1024*1024, vc.TypedSpec().Provisioning.PartitionSpec.MinSize)
+		}
 	})
 
 	ctest.AssertResources(suite, userVolumes, func(vmr *block.VolumeMountRequest, asrt *assert.Assertions) {


### PR DESCRIPTION
See https://github.com/siderolabs/talos/discussions/11468#discussioncomment-13933856

With minSize of zero, volume manager might pick a disk which has zero disk space available leading to subsequent failures to allocate a partition.
