### PR TITLE
fix: live reload of TLS client config for discovery client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34
 	github.com/siderolabs/crypto v0.6.3
 	github.com/siderolabs/discovery-api v0.1.6
-	github.com/siderolabs/discovery-client v0.1.12
+	github.com/siderolabs/discovery-client v0.1.13
 	github.com/siderolabs/gen v0.8.5
 	github.com/siderolabs/go-api-signature v0.3.6
 	github.com/siderolabs/go-blockdevice v0.4.8

--- a/go.sum
+++ b/go.sum
@@ -618,8 +618,8 @@ github.com/siderolabs/crypto v0.6.3 h1:9eGHzAJQg7FvPcjVANLQKnepc0nrl5IkLJ3FxhMvs
 github.com/siderolabs/crypto v0.6.3/go.mod h1:LEhGuXlvwElMgh+rYjCFw6JgfOgyaC+sqsl/YwWU+EM=
 github.com/siderolabs/discovery-api v0.1.6 h1:/LhsF1ytqFEfWwV0UKfUgn90k9fk5+rhYMJ9yeUB2yc=
 github.com/siderolabs/discovery-api v0.1.6/go.mod h1:s5CnTyRMGid/vJNSJs8Jw9I4tnKHu/2SGqP2ytTaePQ=
-github.com/siderolabs/discovery-client v0.1.12 h1:DXCESqezMMRBLFyWawaJkVogAzvFuvdYyEeITTcD6uk=
-github.com/siderolabs/discovery-client v0.1.12/go.mod h1:kojlX4Kk0o9wsbJU1XOy4BH0W6RMg2I2d8WJ4ciK3qU=
+github.com/siderolabs/discovery-client v0.1.13 h1:s0iK2ixopCFFgQ5zZmzsQ8xf8Hd+SygrUdlhE+um6iQ=
+github.com/siderolabs/discovery-client v0.1.13/go.mod h1:kojlX4Kk0o9wsbJU1XOy4BH0W6RMg2I2d8WJ4ciK3qU=
 github.com/siderolabs/ethtool v0.4.0-sidero h1:Ls/M4bFUjfcB1RDVviPZlL3kWcXaEVVSbKke+EZ2A9U=
 github.com/siderolabs/ethtool v0.4.0-sidero/go.mod h1:nOIR88fiFTdBfakYLEUAhxdy75Ih/fgnSlsSKAHRpfc=
 github.com/siderolabs/gen v0.8.0/go.mod h1:an3a2Y53O7kUjnnK8Bfu3gewtvnIOu5RTU6HalFtXQQ=

--- a/internal/app/machined/pkg/controllers/cluster/discovery_service.go
+++ b/internal/app/machined/pkg/controllers/cluster/discovery_service.go
@@ -243,8 +243,10 @@ func (ctrl *DiscoveryServiceController) Run(ctx context.Context, r controller.Ru
 				TTL:           defaultDiscoveryTTL,
 				Insecure:      discoveryConfig.TypedSpec().ServiceEndpointInsecure,
 				ClientVersion: version.Tag,
-				TLSConfig: &tls.Config{
-					RootCAs: httpdefaults.RootCAs(),
+				TLSConfig: func() *tls.Config {
+					return &tls.Config{
+						RootCAs: httpdefaults.RootCAs(),
+					}
 				},
 				DialOptions: []grpc.DialOption{
 					grpc.WithContextDialer(dialer.DynamicProxyDialer),


### PR DESCRIPTION
See https://github.com/siderolabs/discovery-client/pull/19

This fixes a case when TrustedRoots are added while the discovery client is running, so that new trusted roots are picked up on reconnect.
