### PR TITLE
fix: one more attempt to fix volume mount race on restart

### DIFF
--- a/internal/app/machined/pkg/system/volumes.go
+++ b/internal/app/machined/pkg/system/volumes.go
@@ -7,6 +7,7 @@ package system
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -15,10 +16,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
-func (svcrunner *ServiceRunner) createVolumeMountRequest(ctx context.Context, volumeID string) (string, error) {
+func (svcrunner *ServiceRunner) createVolumeMountRequest(ctx context.Context, volumeID string, generation int64) (string, error) {
 	st := svcrunner.runtime.State().V1Alpha2().Resources()
 	requester := "service/" + svcrunner.id
-	requestID := requester + "-" + volumeID
+	requestID := requester + "-" + volumeID + "-" + strconv.FormatInt(generation, 10)
 
 	mountRequest := block.NewVolumeMountRequest(block.NamespaceName, requestID)
 	mountRequest.TypedSpec().Requester = requester


### PR DESCRIPTION
The issue seems to be around still racy service restarts which leads to a potential hang on a conflicting state.

By not re-using the mount request IDs on each restart, hopefully we can improve on it.
