### PR TITLE
refactor: fix deadcode elimination with godbus

### DIFF
--- a/internal/pkg/logind/dbus.go
+++ b/internal/pkg/logind/dbus.go
@@ -7,8 +7,9 @@ package logind
 import "github.com/godbus/dbus/v5"
 
 const (
-	dbusPath      = dbus.ObjectPath("/org/freedesktop/DBus")
-	dbusInterface = "org.freedesktop.DBus"
+	dbusPath       = dbus.ObjectPath("/org/freedesktop/DBus")
+	dbusInterface  = "org.freedesktop.DBus"
+	propsInterface = "org.freedesktop.DBus.Properties"
 )
 
 type dbusMock struct{}

--- a/internal/pkg/logind/logind.go
+++ b/internal/pkg/logind/logind.go
@@ -31,15 +31,6 @@ type logindMock struct {
 	inhibitPipe []int
 }
 
-var logindProps = map[string]map[string]*prop.Prop{
-	logindInterface: {
-		"InhibitDelayMaxUSec": {
-			Value:    uint64(InhibitMaxDelay / time.Microsecond),
-			Writable: false,
-		},
-	},
-}
-
 func (mock *logindMock) Inhibit(what, who, why, mode string) (dbus.UnixFD, *dbus.Error) {
 	mock.mu.Lock()
 	defer mock.mu.Unlock()
@@ -54,6 +45,18 @@ func (mock *logindMock) Inhibit(what, who, why, mode string) (dbus.UnixFD, *dbus
 	}
 
 	return dbus.UnixFD(mock.inhibitPipe[1]), nil
+}
+
+func (mock *logindMock) Get(iface, property string) (dbus.Variant, *dbus.Error) {
+	if iface != logindInterface {
+		return dbus.Variant{}, prop.ErrIfaceNotFound
+	}
+
+	if property != "InhibitDelayMaxUSec" {
+		return dbus.Variant{}, prop.ErrPropNotFound
+	}
+
+	return dbus.MakeVariant(uint64(InhibitMaxDelay / time.Microsecond)), nil
 }
 
 func (mock *logindMock) getPipe() []int {


### PR DESCRIPTION
It's a D-Bus client we use to communicate graceful shutdown with the kubelet.

Fixes #11300
