### PR TITLE
chore: add deadcode elimination linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,8 +560,8 @@ fmt: ## Formats the source code and protobuf files.
 lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdown (e.g. lint-go).
 	@$(MAKE) target-lint-$* PLATFORM=linux/$(ARCH)
 
-lint: ## Runs linters on go, vulncheck, protobuf, and markdown file types.
-	@$(MAKE) lint-go lint-vulncheck lint-protobuf lint-markdown
+lint: ## Runs linters on go, vulncheck, deadcode, protobuf, and markdown file types.
+	@$(MAKE) lint-go lint-vulncheck lint-deadcode lint-protobuf lint-markdown
 
 check-dirty: ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,6 +3,7 @@ module github.com/siderolabs/talos/tools
 go 1.24.5
 
 tool (
+	github.com/aarzilli/whydeadcode
 	github.com/anchore/grype/cmd/grype
 	github.com/anchore/syft/cmd/syft
 )
@@ -42,6 +43,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v1.2.0 // indirect
 	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/aarzilli/whydeadcode v0.0.0-20241226171816-ed86f8ea0a6f // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect
 	github.com/adrg/xdg v0.5.3 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -664,6 +664,8 @@ github.com/ProtonMail/go-crypto v1.2.0 h1:+PhXXn4SPGd+qk76TlEePBfOfivE0zkWFenhGh
 github.com/ProtonMail/go-crypto v1.2.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
+github.com/aarzilli/whydeadcode v0.0.0-20241226171816-ed86f8ea0a6f h1:S9nWL2BVcrC0teJDsnP+HLWqnOlGl9cz/a5rlsUh4cc=
+github.com/aarzilli/whydeadcode v0.0.0-20241226171816-ed86f8ea0a6f/go.mod h1:rHV6WbQI4oOtjbl+J0d9UYVs8eBU9bqZIp9UB5QACiQ=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=


### PR DESCRIPTION
Assert that `machined` build does deadcode elimination.

Fixes #11296
