### PR TITLE
docs: fix clone URL to include `.git`

### DIFF
--- a/website/content/v1.10/advanced/kernel-module.md
+++ b/website/content/v1.10/advanced/kernel-module.md
@@ -20,7 +20,7 @@ Let's create an example package to walk through each step.
 Clone the repo and create a folder.
 
 ```bash
-git clone https://github.com/siderolabs/pkgs
+git clone https://github.com/siderolabs/pkgs.git
 cd pkgs
 mkdir my-module
 ```

--- a/website/content/v1.11/advanced/kernel-module.md
+++ b/website/content/v1.11/advanced/kernel-module.md
@@ -20,7 +20,7 @@ Let's create an example package to walk through each step.
 Clone the repo and create a folder.
 
 ```bash
-git clone https://github.com/siderolabs/pkgs
+git clone https://github.com/siderolabs/pkgs.git
 cd pkgs
 mkdir my-module
 ```


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Fixed the git clone command for the `Adding a Kernel Module` section.

## Why? (reasoning)
The old clone command would cause the `make rekres` step to fail with logs:
```
gen started
Error: failed to parse remote URL: origin	https://github.com/siderolabs/
```

With this change we now get:
```
gen started
GITHUB_TOKEN is missing, GitHub API integration is disabled
success
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
