### PR TITLE
chore: re-enable vulncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdo
 	@$(MAKE) target-lint-$* PLATFORM=linux/$(ARCH)
 
 lint: ## Runs linters on go, vulncheck, deadcode, protobuf, and markdown file types.
-	@$(MAKE) lint-go lint-deadcode lint-protobuf lint-markdown
+	@$(MAKE) lint-go lint-vulncheck lint-deadcode lint-protobuf lint-markdown
 
 check-dirty: ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi


### PR DESCRIPTION
This reverts commit 6186d182189d229e3065631076f435d34bfc4f53.

It was disabled to make v1.11.0-beta.2 out, depends on https://github.com/golang/vulndb/issues/3860