### PR TITLE
fix: kubernetes upgrade options

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -75,7 +75,7 @@ func (options *UpgradeOptions) Validate() error {
 
 // Upgrade the Kubernetes control plane components, manifests, kubelets.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func Upgrade(ctx context.Context, cluster UpgradeProvider, options UpgradeOptions) error {
 	if err := options.Validate(); err != nil {
 		return fmt.Errorf("invalid upgrade options: %w", err)
@@ -151,8 +151,10 @@ func Upgrade(ctx context.Context, cluster UpgradeProvider, options UpgradeOption
 		return fmt.Errorf("failed updating kube-proxy: %w", err)
 	}
 
-	if err = upgradeKubelet(ctx, cluster, options); err != nil {
-		return fmt.Errorf("failed upgrading kubelet: %w", err)
+	if options.UpgradeKubelet {
+		if err = upgradeKubelet(ctx, cluster, options); err != nil {
+			return fmt.Errorf("failed upgrading kubelet: %w", err)
+		}
 	}
 
 	objects, err := getManifests(ctx, cluster)


### PR DESCRIPTION

## What? (description)

The PR aims to fix and enhance the Kubernetes upgrade options.

## Why? (reasoning)

Currently, the upgradeKubelet option is tied to the worker nodes, which I believe is a mistake. Instead, it should be tied to the upgradeKubelet function, with a separate option added to toggle the upgrade of worker nodes.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
