### PR TITLE
fix: tpm2 luks header metadata

### DIFF
--- a/internal/pkg/encryption/keys/tpm2.go
+++ b/internal/pkg/encryption/keys/tpm2.go
@@ -84,7 +84,7 @@ func (h *TPMKeyHandler) NewKey(ctx context.Context) (*encryption.Key, token.Toke
 			KeySlots:          []int{h.slot},
 			SealedBlobPrivate: resp.SealedBlobPrivate,
 			SealedBlobPublic:  resp.SealedBlobPublic,
-			PCRs:              []int{constants.UKIPCR},
+			PCRs:              []int{tpm2.SecureBootStatePCR, constants.UKIPCR},
 			Alg:               "sha256",
 			PolicyHash:        resp.PolicyDigest,
 			KeyName:           resp.KeyName,


### PR DESCRIPTION
Talos TPM2 based disk encryprion was locking to both PCR7 and PCR11, but we were only showing PCR11 in the luks header metadata. Fix it to include both PCR7 and PCR11. This data was never used anywhere, but we would need this for implementing #10677.