### PR TITLE
fix: actually use SIDEROV1_KEYS_DIR env var if it's provided

### DIFF
--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -48,7 +48,7 @@ func (c *Args) WithClientNoNodes(action func(context.Context, *client.Client) er
 			opts := []client.OptionFunc{
 				client.WithConfig(cfg),
 				client.WithGRPCDialOptions(dialOptions...),
-				client.WithSideroV1KeysDir(c.SideroV1KeysDir),
+				client.WithSideroV1KeysDir(clientconfig.CustomSideroV1KeysDirPath(c.SideroV1KeysDir)),
 			}
 
 			if c.CmdContext != "" {

--- a/pkg/machinery/client/config/path.go
+++ b/pkg/machinery/client/config/path.go
@@ -61,6 +61,21 @@ func GetDefaultPaths() ([]Path, error) {
 	return result, nil
 }
 
+// CustomSideroV1KeysDirPath returns the custom SideroV1 auth keys directory path if it's provided as command line flag or with environment variable.
+// If not provided, it returns an empty string.
+func CustomSideroV1KeysDirPath(path string) string {
+	if path != "" {
+		return path
+	}
+
+	path = os.Getenv(constants.SideroV1KeysDirEnvVar)
+	if path != "" {
+		return path
+	}
+
+	return ""
+}
+
 // firstValidPath iterates over the default paths and returns the first one that exists and readable.
 // If no path is found, it will ensure that the first path that allows writes is created and returned.
 // If no path is found that is writable, an error is returned.


### PR DESCRIPTION
Use SIDEROV1_KEYS_DIR env var if it's provided
