### PR TITLE
fix: image cache lockup on a missing volume

### DIFF
--- a/internal/app/machined/pkg/controllers/cri/image_cache_config.go
+++ b/internal/app/machined/pkg/controllers/cri/image_cache_config.go
@@ -342,7 +342,7 @@ func (ctrl *ImageCacheConfigController) analyzeImageCacheVolumes(ctx context.Con
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				// wait for volume statuses to be present
-				return &imageCacheVolumeStatus{}, nil
+				continue
 			}
 
 			return nil, fmt.Errorf("error getting volume status: %w", err)
@@ -362,10 +362,6 @@ func (ctrl *ImageCacheConfigController) analyzeImageCacheVolumes(ctx context.Con
 		case VolumeImageCacheDISK:
 			diskStatus = volumeStatus.TypedSpec().Phase
 		}
-	}
-
-	if isoStatus != block.VolumePhaseMissing && isoStatus != block.VolumePhaseReady {
-		return &imageCacheVolumeStatus{}, nil
 	}
 
 	isoPresent := isoStatus == block.VolumePhaseReady

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -282,13 +282,17 @@ func launchVM(config *LaunchConfig) error {
 	}
 
 	if !diskBootable || !config.BootloaderEnabled {
+		// if the disk is bootable, and we were forced to disable disk bootloader,
+		// we need to skip ISO/USB boot, as it will fall back to boot from disk
+		skipBootloader := diskBootable && !config.BootloaderEnabled
+
 		switch {
-		case config.ISOPath != "":
+		case config.ISOPath != "" && !skipBootloader:
 			args = append(args,
 				"-drive",
 				fmt.Sprintf("id=cdrom0,file=%s,media=cdrom", config.ISOPath),
 			)
-		case config.USBPath != "":
+		case config.USBPath != "" && !skipBootloader:
 			args = append(args,
 				"-drive", fmt.Sprintf("if=none,id=stick,format=raw,read-only=on,file=%s", config.USBPath),
 				"-device", "nec-usb-xhci,id=xhci",


### PR DESCRIPTION
When one of the image cache volumes (ISO/disk) is missing, the controller locks up on shutdown as one of the `VolumeStatus`es is gone, while other one is locked up on the mount status which is being held by the finalizer from the controller.

Drop the early exit from the controller to ensure it will keep processing volumes even if one of them is missing, so that we reach the code which removes the finalizer.

Fixes #11341

Fixes #11540

Also, unrelated fix for the problem in `talosctl cluster create` with ISO and bootloader disabled: on reboot QEMU still boots from disk, while we want to boot from compiled initramfs.
