### PR TITLE
fix: version contract parsing in encryption keys handling

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -338,7 +338,7 @@ func create(ctx context.Context, ops createOps) error {
 			return err
 		}
 
-		genOptions = append(genOptions, versionContractGenOps)
+		genOptions = append(genOptions, versionContractGenOps...)
 
 		extraDisks, userVolumePatches, err := getExtraDisks(provisioner, cidr4, versionContract, &provisionOptions, qOps)
 		if err != nil {

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_docker.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_docker.go
@@ -68,7 +68,7 @@ func getDockerClusterRequest(
 
 	clusterRequest := getBaseClusterRequest(cOps, []netip.Prefix{cidr}, []netip.Addr{gatewayIP})
 
-	genOptions := []generate.Option{}
+	var genOptions []generate.Option
 
 	registryMirrorOps, err := getRegistryMirrorGenOps(cOps)
 	if err != nil {
@@ -83,7 +83,7 @@ func getDockerClusterRequest(
 		return clusterCreateRequestData{}, err
 	}
 
-	genOptions = append(genOptions, versionContractGenOps)
+	genOptions = append(genOptions, versionContractGenOps...)
 	genOptions = append(genOptions, provisioner.GenOptions(clusterRequest.Network)...)
 
 	endpointList := provisioner.GetTalosAPIEndpoints(clusterRequest.Network)

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -50,7 +50,7 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 	nodeIP := controlPlaneNodes[0].IPs[0]
 	nodeCtx := client.WithNodes(ctx, nodeIP.String())
 
-	fmt.Fprintln(out, "waiting for API")
+	fmt.Fprintln(out, "waiting for Talos API (to bootstrap the cluster)")
 
 	err = retry.Constant(10*time.Minute, retry.WithUnits(500*time.Millisecond)).RetryWithContext(nodeCtx, func(nodeCtx context.Context) error {
 		retryCtx, cancel := context.WithTimeout(nodeCtx, 2*time.Second)


### PR DESCRIPTION
Fix issue introduced in #11532 (`main` only) with versionContract parsing: wrong variable was returned (overwritten).

Also some small cleanups/nits (with Albert).
