### PR TITLE
feat: add a user-facing create qemu command 

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/cluster.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/cluster.go
@@ -27,13 +27,14 @@ var Cmd = &cobra.Command{
 
 // CmdOps are the options for the cluster command.
 type CmdOps struct {
-	ProvisionerName string
-	StateDir        string
-	ClusterName     string
+	StateDir    string
+	ClusterName string
 }
 
-// Flags are the flags of the cluster command.
-var Flags CmdOps
+// PersistentFlags are the persistent flags of the cluster command.
+var PersistentFlags CmdOps
+
+var provisionerName string
 
 var (
 	// DefaultStateDir is the default location of the cluster related file state.
@@ -49,7 +50,11 @@ func init() {
 		DefaultCNIDir = filepath.Join(talosDir, "cni")
 	}
 
-	Cmd.PersistentFlags().StringVar(&Flags.ProvisionerName, ProvisionerFlag, providers.DockerProviderName, "Talos cluster provisioner to use")
-	Cmd.PersistentFlags().StringVar(&Flags.StateDir, "state", DefaultStateDir, "directory path to store cluster state")
-	Cmd.PersistentFlags().StringVar(&Flags.ClusterName, "name", "talos-default", "the name of the cluster")
+	Cmd.PersistentFlags().StringVar(&PersistentFlags.StateDir, "state", DefaultStateDir, "directory path to store cluster state")
+	Cmd.PersistentFlags().StringVar(&PersistentFlags.ClusterName, "name", "talos-default", "the name of the cluster")
+}
+
+// AddProvisionerFlag adds the provisioner flag to a command.
+func AddProvisionerFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&provisionerName, ProvisionerFlag, providers.DockerProviderName, "Talos cluster provisioner to use")
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/pflag"
 
 	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
+	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -21,14 +23,26 @@ var (
 	kubernetesVersionFlagName = "kubernetes-version"
 	registryMirrorFlagName    = "registry-mirror"
 	networkMTUFlagName        = "mtu"
+	networkCIDRFlagName       = "cidr"
+	talosVersionFlagName      = "talos-version"
 
-	// user facing command flags.
-	talosconfigDestinationFlagName = "talosconfig-destination"
+	// Flags that have been renamed in the user-facing commands.
+	controlPlaneCpusFlagName        = "cpus-controlplanes"
+	controlPlaneMemoryFlagName      = "memory-controlplanes"
+	workersCpusFlagName             = "cpus-workers"
+	workersMemoryFlagName           = "memory-workers"
+	configPatchFlagName             = "config-patch"
+	configPatchControlPlaneFlagName = "config-patch-controlplanes"
+	configPatchWorkerFlagName       = "config-patch-workers"
+	talosconfigDestinationFlagName  = "talosconfig-destination"
+
+	// Qemu flags.
+	disksFlagName = "disks"
 )
 
 // commonOps are the options that are not specific to a single provider.
 type commonOps struct {
-	// RootOps are the options from the root cluster command
+	// rootOps are the options from the root cluster command
 	rootOps                   *clustercmd.CmdOps
 	talosconfigDestination    string
 	registryMirrors           []string
@@ -67,6 +81,45 @@ type commonOps struct {
 	withUUIDHostnames         bool
 }
 
+func getDefaultCommonOptions() commonOps {
+	return commonOps{
+		controlplanes:      1,
+		networkMTU:         1500,
+		clusterWaitTimeout: 15 * time.Minute,
+		clusterWait:        true,
+		dnsDomain:          "cluster.local",
+		controlPlanePort:   constants.DefaultControlPlanePort,
+		rootOps:            &clustercmd.PersistentFlags,
+		networkIPv4:        true,
+	}
+}
+
+func getCommonUserFacingFlags(pointer *commonOps) *pflag.FlagSet {
+	common := pflag.NewFlagSet("common", pflag.PanicOnError)
+
+	addWorkersFlag(common, &pointer.workers)
+	addKubernetesVersionFlag(common, &pointer.kubernetesVersion)
+	addTalosconfigDestinationFlag(common, &pointer.talosconfigDestination, talosconfigDestinationFlagName)
+	addConfigPatchFlag(common, &pointer.configPatch, configPatchFlagName)
+	addConfigPatchControlPlaneFlag(common, &pointer.configPatchControlPlane, configPatchControlPlaneFlagName)
+	addConfigPatchWorkerFlag(common, &pointer.configPatchWorker, configPatchWorkerFlagName)
+
+	addControlplaneCpusFlag(common, &pointer.controlplaneResources.cpu, controlPlaneCpusFlagName)
+	addWorkersCpusFlag(common, &pointer.workerResources.cpu, workersCpusFlagName)
+	addControlPlaneMemoryFlag(common, &pointer.controlplaneResources.memory, controlPlaneMemoryFlagName)
+	addWorkersMemoryFlag(common, &pointer.workerResources.memory, workersMemoryFlagName)
+
+	// The following flags are used in tests and development
+	addNetworkMTUFlag(common, &pointer.networkMTU)
+	cli.Should(common.MarkHidden(networkMTUFlagName))
+	addRegistryMirrorFlag(common, &pointer.registryMirrors)
+	cli.Should(common.MarkHidden(registryMirrorFlagName))
+
+	return common
+}
+
+// Common flags
+
 func addTalosconfigDestinationFlag(flagset *pflag.FlagSet, bind *string, flagName string) {
 	flagset.StringVar(bind, flagName, "",
 		fmt.Sprintf("The location to save the generated Talos configuration file to. Defaults to '%s' env variable if set, otherwise '%s' and '%s' in order.",
@@ -98,7 +151,7 @@ func addConfigPatchFlag(flagset *pflag.FlagSet, bind *[]string, flagName string)
 }
 
 func addConfigPatchControlPlaneFlag(flagset *pflag.FlagSet, bind *[]string, flagName string) {
-	flagset.StringArrayVar(bind, flagName, nil, "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
+	flagset.StringArrayVar(bind, flagName, nil, "patch generated machineconfigs (applied to 'controlplane' type)")
 }
 
 func addConfigPatchWorkerFlag(flagset *pflag.FlagSet, bind *[]string, flagName string) {
@@ -123,4 +176,15 @@ func addRegistryMirrorFlag(flagset *pflag.FlagSet, bind *[]string) {
 
 func addNetworkMTUFlag(flagset *pflag.FlagSet, bind *int) {
 	flagset.IntVar(bind, networkMTUFlagName, 1500, "MTU of the cluster network")
+}
+
+func addTalosVersionFlag(flagset *pflag.FlagSet, bind *string, description string) {
+	flagset.StringVar(bind, talosVersionFlagName, helpers.GetTag(), description)
+}
+
+// qemu flags
+
+func addDisksFlag(flagset *pflag.FlagSet, bind *[]string, defaultVal []string) {
+	flagset.StringSliceVar(bind, disksFlagName, defaultVal,
+		`list of disks to create in format "<driver1>:<size1>" (size is specified in megabytes) (disks after the first one are added only to worker machines)`)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
+	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/images"
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/version"
+	"github.com/siderolabs/talos/pkg/provision/providers"
+)
+
+const emptySchemanticID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
+func init() {
+	var (
+		schematicID     string
+		imageFactoryURL string
+	)
+
+	ops := &createOps{
+		common: getDefaultCommonOptions(),
+		qemu: qemuOps{
+			preallocateDisks: false,
+			uefiEnabled:      true,
+			nameservers:      []string{"8.8.8.8", "1.1.1.1", "2001:4860:4860::8888", "2606:4700:4700::1111"},
+			diskBlockSize:    512,
+			targetArch:       runtime.GOARCH,
+			cniBinPath:       []string{filepath.Join(clustercmd.DefaultCNIDir, "bin")},
+			cniConfDir:       filepath.Join(clustercmd.DefaultCNIDir, "conf.d"),
+			cniCacheDir:      filepath.Join(clustercmd.DefaultCNIDir, "cache"),
+			cniBundleURL: fmt.Sprintf("https://github.com/%s/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz",
+				images.Username, version.Trim(version.Tag), constants.ArchVariable),
+		},
+	}
+	ops.common.skipInjectingConfig = true
+	ops.common.applyConfigEnabled = true
+
+	commonFlags := getCommonUserFacingFlags(&ops.common)
+	addControlplanesFlag(commonFlags, &ops.common.controlplanes)
+	addTalosVersionFlag(commonFlags, &ops.common.talosVersion, "the desired talos version")
+	commonFlags.StringVar(&ops.common.networkCIDR, networkCIDRFlagName, "10.5.0.0/24", "CIDR of the cluster network")
+
+	getQemuFlags := func() *pflag.FlagSet {
+		qemu := pflag.NewFlagSet("qemu", pflag.PanicOnError)
+
+		addDisksFlag(qemu, &ops.qemu.disks, []string{"virtio:" + strconv.Itoa(10*1024), "virtio:" + strconv.Itoa(6*1024)})
+		qemu.StringVar(&schematicID, "schematic-id", "", "image factory schematic id (defaults to an empty schematic)")
+		qemu.StringVar(&imageFactoryURL, "image-factory-url", "https://factory.talos.dev/", "image factory url")
+
+		return qemu
+	}
+
+	createQemuCmd := &cobra.Command{
+		Use:   providers.QemuProviderName,
+		Short: "Create a local QEMU based Talos cluster",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithContext(context.Background(), func(ctx context.Context) error {
+				if ops.common.talosVersion == "" || ops.common.talosVersion[0] != 'v' {
+					return fmt.Errorf("failed to parse talos version: version string must start with a 'v'")
+				}
+
+				_, err := config.ParseContractFromVersion(ops.common.talosVersion)
+				if err != nil {
+					return fmt.Errorf("failed to parse talos version: %s", err)
+				}
+
+				if schematicID == "" {
+					schematicID = emptySchemanticID
+				}
+
+				factoryURL, err := url.Parse(imageFactoryURL)
+				if err != nil {
+					return fmt.Errorf("malformed Image Factory URL: %q: %w", imageFactoryURL, err)
+				}
+
+				if factoryURL.Scheme == "" || factoryURL.Host == "" {
+					return fmt.Errorf("image Factory URL must include scheme and host: %q", imageFactoryURL)
+				}
+
+				ops.qemu.nodeISOPath, err = url.JoinPath(factoryURL.String(), "image", schematicID, ops.common.talosVersion, "metal-"+ops.qemu.targetArch+".iso")
+				cli.Should(err)
+				ops.qemu.nodeInstallImage, err = url.JoinPath(factoryURL.Host, "metal-installer", schematicID+":"+ops.common.talosVersion)
+				cli.Should(err)
+
+				return create(ctx, *ops)
+			})
+		},
+	}
+
+	createQemuCmd.Flags().AddFlagSet(commonFlags)
+	createQemuCmd.Flags().AddFlagSet(getQemuFlags())
+
+	createCmd.AddCommand(createQemuCmd)
+}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -333,7 +333,7 @@ func create(ctx context.Context, ops createOps) error {
 			cOps.talosVersion = parts[len(parts)-1]
 		}
 
-		versionContractGenOps, versionContract, err := getVersionContractGenOps(cOps) // THIS
+		versionContractGenOps, versionContract, err := getVersionContractGenOps(cOps)
 		if err != nil {
 			return err
 		}

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -32,14 +32,14 @@ var destroyCmd = &cobra.Command{
 }
 
 func destroy(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, Flags.ProvisionerName)
+	provisioner, err := providers.Factory(ctx, provisionerName)
 	if err != nil {
 		return err
 	}
 
 	defer provisioner.Close() //nolint:errcheck
 
-	cluster, err := provisioner.Reflect(ctx, Flags.ClusterName, Flags.StateDir)
+	cluster, err := provisioner.Reflect(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
 	if err != nil {
 		return err
 	}
@@ -57,6 +57,7 @@ func init() {
 	destroyCmd.PersistentFlags().BoolVarP(&destroyCmdFlags.forceDelete, "force", "f", false, "force deletion of cluster directory if there were errors")
 	destroyCmd.PersistentFlags().StringVarP(&destroyCmdFlags.saveSupportArchivePath, "save-support-archive-path", "", "", "save support archive to the specified file on destroy")
 	destroyCmd.PersistentFlags().StringVarP(&destroyCmdFlags.saveClusterLogsArchivePath, "save-cluster-logs-archive-path", "", "", "save cluster logs archive to the specified file on destroy")
+	AddProvisionerFlag(destroyCmd)
 
 	Cmd.AddCommand(destroyCmd)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -35,14 +35,14 @@ var showCmd = &cobra.Command{
 }
 
 func show(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, Flags.ProvisionerName)
+	provisioner, err := providers.Factory(ctx, provisionerName)
 	if err != nil {
 		return err
 	}
 
 	defer provisioner.Close() //nolint:errcheck
 
-	cluster, err := provisioner.Reflect(ctx, Flags.ClusterName, Flags.StateDir)
+	cluster, err := provisioner.Reflect(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
 	if err != nil {
 		return err
 	}
@@ -112,5 +112,7 @@ func ShowCluster(cluster provision.Cluster) error {
 }
 
 func init() {
+	AddProvisionerFlag(showCmd)
+
 	Cmd.AddCommand(showCmd)
 }

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -129,7 +129,7 @@ talosctl cluster create docker [flags]
 
 ```
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
-      --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
       --cpus-controlplanes string                the share of CPUs as fraction (each control plane/VM) (default "2.0")
       --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
@@ -149,9 +149,49 @@ talosctl cluster create docker [flags]
 ### Options inherited from parent commands
 
 ```
-      --name string          the name of the cluster (default "talos-default")
-      --provisioner string   Talos cluster provisioner to use (default "docker")
-      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
+```
+
+### SEE ALSO
+
+* [talosctl cluster create](#talosctl-cluster-create)	 - Creates a local qemu based cluster for Talos development
+
+## talosctl cluster create qemu
+
+Create a local QEMU based Talos cluster
+
+```
+talosctl cluster create qemu [flags]
+```
+
+### Options
+
+```
+      --cidr string                              CIDR of the cluster network (default "10.5.0.0/24")
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
+      --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
+      --controlplanes int                        the number of controlplanes to create (default 1)
+      --cpus-controlplanes string                the share of CPUs as fraction (each control plane/VM) (default "2.0")
+      --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
+      --disks strings                            list of disks to create in format "<driver1>:<size1>" (size is specified in megabytes) (disks after the first one are added only to worker machines) (default [virtio:10240,virtio:6144])
+  -h, --help                                     help for qemu
+      --image-factory-url string                 image factory url (default "https://factory.talos.dev/")
+      --kubernetes-version string                desired kubernetes version to run (default "1.34.0-rc.1")
+      --memory-controlplanes int                 the limit on memory usage in MB (each control plane/VM) (default 2048)
+      --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
+      --schematic-id string                      image factory schematic id (defaults to an empty schematic)
+      --talos-version string                     the desired talos version (default "latest")
+      --talosconfig-destination string           The location to save the generated Talos configuration file to. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --workers int                              the number of workers to create (default 1)
+```
+
+### Options inherited from parent commands
+
+```
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### SEE ALSO
@@ -178,7 +218,7 @@ talosctl cluster create [flags]
       --cni-conf-dir string                      CNI config directory path (default "/home/user/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
-      --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
       --control-plane-port int                   control plane port (load balancer and local API port) (default 6443)
       --controlplanes int                        the number of controlplanes to create (default 1)
@@ -259,15 +299,15 @@ talosctl cluster create [flags]
 ### Options inherited from parent commands
 
 ```
-      --name string          the name of the cluster (default "talos-default")
-      --provisioner string   Talos cluster provisioner to use (default "docker")
-      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### SEE ALSO
 
 * [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
 * [talosctl cluster create docker](#talosctl-cluster-create-docker)	 - Create a local Docker based kubernetes cluster
+* [talosctl cluster create qemu](#talosctl-cluster-create-qemu)	 - Create a local QEMU based Talos cluster
 
 ## talosctl cluster destroy
 
@@ -282,6 +322,7 @@ talosctl cluster destroy [flags]
 ```
   -f, --force                                   force deletion of cluster directory if there were errors
   -h, --help                                    help for destroy
+      --provisioner string                      Talos cluster provisioner to use (default "docker")
       --save-cluster-logs-archive-path string   save cluster logs archive to the specified file on destroy
       --save-support-archive-path string        save support archive to the specified file on destroy
 ```
@@ -289,9 +330,8 @@ talosctl cluster destroy [flags]
 ### Options inherited from parent commands
 
 ```
-      --name string          the name of the cluster (default "talos-default")
-      --provisioner string   Talos cluster provisioner to use (default "docker")
-      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### SEE ALSO
@@ -309,15 +349,15 @@ talosctl cluster show [flags]
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help                 help for show
+      --provisioner string   Talos cluster provisioner to use (default "docker")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --name string          the name of the cluster (default "talos-default")
-      --provisioner string   Talos cluster provisioner to use (default "docker")
-      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### SEE ALSO
@@ -331,10 +371,9 @@ A collection of commands for managing local docker-based or QEMU-based clusters
 ### Options
 
 ```
-  -h, --help                 help for cluster
-      --name string          the name of the cluster (default "talos-default")
-      --provisioner string   Talos cluster provisioner to use (default "docker")
-      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
+  -h, --help           help for cluster
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
part of [#11404](https://github.com/siderolabs/talos/issues/11404)

I've split the changes into two commits for ease of review. Will squash before merging.

Stuff yet to do:
* extract more common logic and create a separate simplified code path for the this command (like already done for the docker command in [create_docker.go](https://github.com/siderolabs/talos/blob/main/cmd/talosctl/cmd/mgmt/cluster/create/create_docker.go))
* Change applicable e2e tests to use this command instead
* documentation updates (also need to update the docker docs)