### PR TITLE
fix: make --with-uuid-hostnames functionality available to qemu provider

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -64,6 +64,7 @@ type commonOps struct {
 	skipK8sNodeReadinessCheck bool
 	withJSONLogs              bool
 	wireguardCIDR             string
+	withUUIDHostnames         bool
 }
 
 func addTalosconfigDestinationFlag(flagset *pflag.FlagSet, bind *string, flagName string) {

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -65,7 +65,6 @@ type qemuOps struct {
 	bandwidth                 int
 	diskEncryptionKeyTypes    []string
 	withFirewall              string
-	withUUIDHostnames         bool
 	withSiderolinkAgent       agentFlag
 	debugShellEnabled         bool
 	withIOMMU                 bool
@@ -244,6 +243,7 @@ func getCreateCmd() *cobra.Command {
 		common.BoolVar(&ops.common.skipK8sNodeReadinessCheck, skipK8sNodeReadinessCheckFlag, false, "skip k8s node readiness checks")
 		common.BoolVar(&ops.common.withJSONLogs, withJSONLogsFlag, false, "enable JSON logs receiver and configure Talos to send logs there")
 		common.StringVar(&ops.common.talosVersion, talosconfigVersionFlag, helpers.GetTag(), "the desired Talos version to generate config for")
+		common.BoolVar(&ops.common.withUUIDHostnames, withUUIDHostnamesFlag, false, "use machine UUIDs as default hostnames")
 
 		return common
 	}
@@ -302,7 +302,6 @@ func getCreateCmd() *cobra.Command {
 			"specify percent of corrupt packets on the bridge interface. e.g. 50% = 0.50 (default: 0.0)")
 		qemu.IntVar(&ops.qemu.bandwidth, bandwidthFlag, 0, "specify bandwidth restriction (in kbps) on the bridge interface")
 		qemu.StringVar(&ops.qemu.withFirewall, firewallFlag, "", "inject firewall rules into the cluster, value is default policy - accept/block")
-		qemu.BoolVar(&ops.qemu.withUUIDHostnames, withUUIDHostnamesFlag, false, "use machine UUIDs as default hostnames")
 		qemu.Var(&ops.qemu.withSiderolinkAgent, withSiderolinkAgentFlag,
 			"enables the use of siderolink agent as configuration apply mechanism. `true` or `wireguard` enables the agent, `tunnel` enables the agent with grpc tunneling")
 		qemu.StringVar(&ops.qemu.configInjectionMethod,

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -644,9 +644,7 @@ func create(ctx context.Context, ops createOps) error {
 	for i, node := range controlplanes {
 		var cfg config.Provider
 
-		nodeUUID := uuid.New()
-
-		err = slb.DefineIPv6ForUUID(nodeUUID)
+		err = slb.DefineIPv6ForUUID(*node.UUID)
 		if err != nil {
 			return err
 		}
@@ -657,7 +655,6 @@ func create(ctx context.Context, ops createOps) error {
 		node.ConfigInjectionMethod = configInjectionMethod
 		node.BadRTC = qOps.badRTC
 		node.ExtraKernelArgs = extraKernelArgs
-		node.UUID = pointer.To(nodeUUID)
 
 		if cOps.withInitNode && i == 0 {
 			cfg = configBundle.Init()
@@ -689,9 +686,7 @@ func create(ctx context.Context, ops createOps) error {
 			}
 		}
 
-		nodeUUID := uuid.New()
-
-		err = slb.DefineIPv6ForUUID(nodeUUID)
+		err = slb.DefineIPv6ForUUID(*node.UUID)
 		if err != nil {
 			return err
 		}
@@ -703,7 +698,6 @@ func create(ctx context.Context, ops createOps) error {
 		node.SkipInjectingConfig = cOps.skipInjectingConfig
 		node.BadRTC = qOps.badRTC
 		node.ExtraKernelArgs = extraKernelArgs
-		node.UUID = pointer.To(nodeUUID)
 
 		request.Nodes = append(request.Nodes, node)
 	}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_test.go
@@ -6,6 +6,7 @@ package create //nolint:testpackage
 
 import (
 	"net/netip"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -177,4 +178,13 @@ func TestCreateNodeRequestsNames(t *testing.T) {
 	assert.Equal(t, "127.5.0.4", workers[0].IPs[1].String())
 	assert.Equal(t, "10.5.0.5", workers[1].IPs[0].String())
 	assert.Equal(t, "127.5.0.5", workers[1].IPs[1].String())
+
+	cOps.withUUIDHostnames = true
+	controlplanes, workers, err = createNodeRequests(cOps, resources, resources, [][]netip.Addr{nodeIps1, nodeIps2})
+	assert.NoError(t, err)
+
+	assert.Regexp(t, regexp.MustCompile("^machine-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), controlplanes[0].Name)
+	assert.Regexp(t, regexp.MustCompile("^machine-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), controlplanes[1].Name)
+	assert.Regexp(t, regexp.MustCompile("^machine-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), workers[0].Name)
+	assert.Regexp(t, regexp.MustCompile("^machine-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), workers[1].Name)
 }


### PR DESCRIPTION
Make --with-uuid-hostnames flag functionality available to qemu provider on `talosctl cluster create`

