### PR TITLE
test: fix the Image Factory PXE boot test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-19T12:49:21Z by kres d1ef768.
+# Generated on 2025-08-20T17:20:56Z by kres 18c31cf.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -2202,7 +2202,7 @@ jobs:
           sudo -E make e2e-image-factory
       - name: factory-1.10-pxe
         env:
-          FACTORY_BOOT_METHOD: pxe
+          FACTORY_BOOT_METHOD: ipxe
           FACTORY_SCHEMATIC: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
           FACTORY_VERSION: v1.10.4
           GITHUB_STEP_NAME: ${{ github.job}}-factory-1.10-pxe

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-19T08:41:30Z by kres 8d5a3f6.
+# Generated on 2025-08-20T17:20:56Z by kres 18c31cf.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -110,7 +110,7 @@ jobs:
           sudo -E make e2e-image-factory
       - name: factory-1.10-pxe
         env:
-          FACTORY_BOOT_METHOD: pxe
+          FACTORY_BOOT_METHOD: ipxe
           FACTORY_SCHEMATIC: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
           FACTORY_VERSION: v1.10.4
           GITHUB_STEP_NAME: ${{ github.job}}-factory-1.10-pxe

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2458,7 +2458,7 @@ spec:
           withSudo: true
           environment:
             GITHUB_STEP_NAME: ${{ github.job}}-factory-1.10-pxe
-            FACTORY_BOOT_METHOD: pxe
+            FACTORY_BOOT_METHOD: ipxe
             FACTORY_VERSION: v1.10.4
             FACTORY_SCHEMATIC: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
             KUBERNETES_VERSION: 1.33.2

--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -28,6 +28,10 @@ case "${FACTORY_BOOT_METHOD:-iso}" in
     QEMU_FLAGS+=("--iso-path=${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/image/${FACTORY_SCHEMATIC}/${FACTORY_VERSION}/metal-amd64-secureboot.iso" "--with-tpm2" "--encrypt-ephemeral" "--encrypt-state" "--disk-encryption-key-types=tpm")
     INSTALLER_IMAGE_NAME=installer-secureboot
     ;;
+  *)
+    echo "unknown factory boot method: ${FACTORY_BOOT_METHOD}"
+    exit 1
+    ;;
 esac
 
 function assert_secureboot {


### PR DESCRIPTION
The shell script expected `ipxe`, but we passed `pxe`, and it silently worked.
