### PR TITLE
docs: make readme badges consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@
   <h1 align="center">Talos Linux</h1>
   <p align="center">A modern OS for Kubernetes.</p>
   <p align="center">
-    <a href="https://github.com/talos-systems/talos/releases/latest">
-      <img alt="Release" src="https://img.shields.io/github/release/talos-systems/talos.svg?logo=github&logoColor=white&style=flat-square">
-    </a>
-    <a href="https://github.com/talos-systems/talos/releases/latest">
-      <img alt="Pre-release" src="https://img.shields.io/github/release-pre/talos-systems/talos.svg?label=pre-release&logo=GitHub&logoColor=white&style=flat-square">
-    </a>
-    <a href="https://www.bestpractices.dev/projects/7340">
-      <img src="https://www.bestpractices.dev/projects/7340/badge" alt="OpenSSF badge">
-    </a>
+    <a href="https://github.com/talos-systems/talos/releases/latest"><img alt="Release" src="https://img.shields.io/github/release/talos-systems/talos.svg?logo=github&logoColor=white"></a>
+    <a href="https://github.com/talos-systems/talos/releases/latest"><img alt="Pre-release" src="https://img.shields.io/github/release-pre/talos-systems/talos.svg?label=pre-release&logo=GitHub&logoColor=white"></a>
+    <a href="https://www.bestpractices.dev/projects/7340"><img src="https://www.bestpractices.dev/projects/7340/badge" alt="OpenSSF badge"></a>
   </p>
 </p>
 


### PR DESCRIPTION
The badges used two different styles. This change unifies the style.
Additionally it fixes the artifact created by hyperlink spaces between the link and image.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
