### PR TITLE
feat: add human readable byte size cli flags

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -13,6 +13,7 @@ import (
 
 	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
+	"github.com/siderolabs/talos/pkg/bytesize"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -131,19 +132,23 @@ func addTalosconfigDestinationFlag(flagset *pflag.FlagSet, bind *string, flagNam
 }
 
 func addControlplaneCpusFlag(flagset *pflag.FlagSet, bind *string, flagName string) {
-	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction (each control plane/VM)")
+	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction for each control plane/VM")
 }
 
 func addWorkersCpusFlag(flagset *pflag.FlagSet, bind *string, flagName string) {
-	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction (each worker/VM)")
+	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction for each worker/VM")
 }
 
-func addControlPlaneMemoryFlag(flagset *pflag.FlagSet, bind *int, flagName string) {
-	flagset.IntVar(bind, flagName, 2048, "the limit on memory usage in MB (each control plane/VM)")
+func addControlPlaneMemoryFlag(flagset *pflag.FlagSet, bind *bytesize.ByteSize, flagName string) {
+	cli.Should(bind.Set("2.0GiB")) // set default value
+	bind.SetDefaultUnit("MB")
+	flagset.Var(bind, flagName, "the limit on memory usage for each control plane/VM")
 }
 
-func addWorkersMemoryFlag(flagset *pflag.FlagSet, bind *int, flagName string) {
-	flagset.IntVar(bind, flagName, 2048, "the limit on memory usage in MB (each worker/VM)")
+func addWorkersMemoryFlag(flagset *pflag.FlagSet, bind *bytesize.ByteSize, flagName string) {
+	cli.Should(bind.Set("2.0GiB")) // set default value
+	bind.SetDefaultUnit("MB")
+	flagset.Var(bind, flagName, "the limit on memory usage for each worker/VM")
 }
 
 func addConfigPatchFlag(flagset *pflag.FlagSet, bind *[]string, flagName string) {
@@ -186,5 +191,5 @@ func addTalosVersionFlag(flagset *pflag.FlagSet, bind *string, description strin
 
 func addDisksFlag(flagset *pflag.FlagSet, bind *[]string, defaultVal []string) {
 	flagset.StringSliceVar(bind, disksFlagName, defaultVal,
-		`list of disks to create in format "<driver1>:<size1>" (size is specified in megabytes) (disks after the first one are added only to worker machines)`)
+		`list of disks to create in format "<driver1>:<size1>" (disks after the first one are added only to worker machines)`)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -58,7 +57,7 @@ func init() {
 	getQemuFlags := func() *pflag.FlagSet {
 		qemu := pflag.NewFlagSet("qemu", pflag.PanicOnError)
 
-		addDisksFlag(qemu, &ops.qemu.disks, []string{"virtio:" + strconv.Itoa(10*1024), "virtio:" + strconv.Itoa(6*1024)})
+		addDisksFlag(qemu, &ops.qemu.disks, []string{"virtio:10GB", "virtio:6GB"})
 		qemu.StringVar(&schematicID, "schematic-id", "", "image factory schematic id (defaults to an empty schematic)")
 		qemu.StringVar(&imageFactoryURL, "image-factory-url", "https://factory.talos.dev/", "image factory url")
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
+	"github.com/siderolabs/talos/pkg/bytesize"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
@@ -133,7 +134,7 @@ func TestGetDisks(t *testing.T) {
 	}
 }
 
-func TestCreateNodeRequestsNames(t *testing.T) {
+func TestCreateNodeRequests(t *testing.T) {
 	cOps := commonOps{
 		rootOps: &cluster.CmdOps{
 			ClusterName: "test-cluster",
@@ -141,9 +142,13 @@ func TestCreateNodeRequestsNames(t *testing.T) {
 		controlplanes: 2,
 		workers:       2,
 	}
+	memory := bytesize.New()
+	err := memory.Set("2mb")
+	assert.NoError(t, err)
+
 	resources := parsedNodeResources{
 		nanoCPUs: 2000,
-		memoryMb: 2000,
+		memory:   *memory,
 	}
 	cidr1, err := netip.ParsePrefix("10.5.0.0/24")
 	assert.NoError(t, err)

--- a/pkg/bytesize/bytesize.go
+++ b/pkg/bytesize/bytesize.go
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package bytesize adds logic to help parse byte sizes in various forms such as gb, mb, GiB, etc.
+package bytesize
+
+import (
+	"fmt"
+	"unicode"
+
+	"github.com/dustin/go-humanize"
+)
+
+// ByteSize implements pflag.Value interface and is meant to be used with flags specifying a size in bytes.
+// A value can be set before assigning to a flag to function as a default value.
+type ByteSize struct {
+	valBytes    uint64
+	val         string
+	defaultUnit string
+}
+
+// WithDefaultUnit creates a New ByteSize with a default unit.
+func WithDefaultUnit(unit string) *ByteSize {
+	return &ByteSize{defaultUnit: unit}
+}
+
+// New creates a New ByteSize without a default unit.
+func New() *ByteSize {
+	return &ByteSize{}
+}
+
+// Bytes returns the value in bytes.
+func (bs *ByteSize) Bytes() uint64 {
+	return bs.valBytes
+}
+
+// Megabytes returns the value in megabytes.
+func (bs *ByteSize) Megabytes() uint64 {
+	return bs.valBytes / (1000 * 1000)
+}
+
+// Gigabytes returns the value in gigabytes.
+func (bs *ByteSize) Gigabytes() uint64 {
+	return bs.valBytes / (1000 * 1000 * 1000)
+}
+
+// Mebibytetes returns the value in binary megabytes.
+func (bs *ByteSize) Mebibytetes() uint64 {
+	return bs.valBytes / (1024 * 1024)
+}
+
+// Gibibytes returns the value in binary gigabytes.
+func (bs *ByteSize) Gibibytes() uint64 {
+	return bs.valBytes / (1024 * 1024 * 1024)
+}
+
+// String returns the string representation of the value with the default unit if set.
+func (bs *ByteSize) String() string {
+	return bs.val
+}
+
+// SetDefaultUnit sets the default unit to use in case one wasn't specifies.
+func (bs *ByteSize) SetDefaultUnit(unit string) {
+	bs.defaultUnit = unit
+}
+
+// Set implements pflag.Value interface.
+func (bs *ByteSize) Set(in string) error {
+	if in == "" || in == "0" {
+		bs.val = "0"
+		bs.valBytes = 0
+
+		return nil
+	}
+
+	// if no unit is specified
+	if unicode.IsDigit(rune(in[len(in)-1])) {
+		if bs.defaultUnit == "" {
+			return fmt.Errorf("no unit specified for %q", in)
+		}
+
+		in += bs.defaultUnit
+	}
+
+	valBytes, err := humanize.ParseBytes(in)
+	if err != nil {
+		return err
+	}
+
+	bs.val = in
+	bs.valBytes = valBytes
+
+	return nil
+}
+
+// Type implements pflag.Value interface (this will show up as the type next to the flag description).
+func (bs *ByteSize) Type() string { return "string(mb,gb)" }

--- a/pkg/bytesize/bytesize_test.go
+++ b/pkg/bytesize/bytesize_test.go
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package bytesize_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/bytesize"
+)
+
+func TestBytesizeNoDefaultUnit(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		bs := bytesize.New()
+		assert.NoError(t, bs.Set(""))
+
+		assert.EqualValues(t, 0, bs.Bytes())
+		assert.Equal(t, "0", bs.String())
+
+		assert.NoError(t, bs.Set("0"))
+		assert.EqualValues(t, 0, bs.Bytes())
+		assert.Equal(t, "0", bs.String())
+	})
+
+	t.Run("no unit specified", func(t *testing.T) {
+		bs := bytesize.New()
+		assert.ErrorContains(t, bs.Set("10"), "no unit specified")
+	})
+
+	t.Run("explicit unit provided", func(t *testing.T) {
+		bs := bytesize.New()
+		assert.NoError(t, bs.Set("0.5mb"))
+		assert.Equal(t, "0.5mb", bs.String())
+		assert.Equal(t, uint64(500000), bs.Bytes())
+	})
+}
+
+func TestBytesizeWithDefaultUnit(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		bs := bytesize.WithDefaultUnit("mb")
+		assert.NoError(t, bs.Set(""))
+
+		assert.EqualValues(t, 0, bs.Bytes())
+		assert.Equal(t, "0", bs.String())
+
+		assert.NoError(t, bs.Set("0"))
+		assert.EqualValues(t, 0, bs.Bytes())
+		assert.Equal(t, "0", bs.String())
+	})
+
+	t.Run("no unit specified", func(t *testing.T) {
+		bs := bytesize.WithDefaultUnit("mb")
+		assert.NoError(t, bs.Set("10"))
+
+		assert.Equal(t, "10mb", bs.String())
+		assert.EqualValues(t, 10*1000*1000, bs.Bytes())
+	})
+
+	t.Run("explicit unit provided", func(t *testing.T) {
+		bs := bytesize.WithDefaultUnit("mb")
+		assert.NoError(t, bs.Set("0.5gb"))
+
+		assert.Equal(t, "0.5gb", bs.String())
+		assert.EqualValues(t, 500000000, bs.Bytes())
+	})
+}
+
+func TestByteSizeUnits(t *testing.T) {
+	bs := bytesize.New()
+	assert.NoError(t, bs.Set("3000000000b"))
+
+	assert.EqualValues(t, 3000, bs.Megabytes())
+	assert.EqualValues(t, 3, bs.Gigabytes())
+
+	assert.EqualValues(t, 2861, bs.Mebibytetes()) // 3,000,000,000 / 1024^2 = 2861 MiB
+	assert.EqualValues(t, 2, bs.Gibibytes())      // 3,000,000,000 / 1024^3 = 2 GiB
+}

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -131,15 +131,15 @@ talosctl cluster create docker [flags]
       --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
       --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
-      --cpus-controlplanes string                the share of CPUs as fraction (each control plane/VM) (default "2.0")
-      --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
+      --cpus-controlplanes string                the share of CPUs as fraction for each control plane/VM (default "2.0")
+      --cpus-workers string                      the share of CPUs as fraction for each worker/VM (default "2.0")
   -p, --exposed-ports string                     comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)>
   -h, --help                                     help for docker
       --host-ip string                           Host IP to forward exposed ports to (default "0.0.0.0")
       --image string                             the talos image to run (default "ghcr.io/siderolabs/talos:latest")
       --kubernetes-version string                desired kubernetes version to run (default "1.34.0-rc.2")
-      --memory-controlplanes int                 the limit on memory usage in MB (each control plane/VM) (default 2048)
-      --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
+      --memory-controlplanes string(mb,gb)       the limit on memory usage for each control plane/VM (default 2.0GiB)
+      --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mount mount                              attach a mount to the container (docker --mount syntax)
       --subnet string                            Docker network subnet CIDR (default "10.5.0.0/24")
       --talosconfig-destination string           The location to save the generated Talos configuration file to. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
@@ -173,14 +173,14 @@ talosctl cluster create qemu [flags]
       --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
       --controlplanes int                        the number of controlplanes to create (default 1)
-      --cpus-controlplanes string                the share of CPUs as fraction (each control plane/VM) (default "2.0")
-      --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
-      --disks strings                            list of disks to create in format "<driver1>:<size1>" (size is specified in megabytes) (disks after the first one are added only to worker machines) (default [virtio:10240,virtio:6144])
+      --cpus-controlplanes string                the share of CPUs as fraction for each control plane/VM (default "2.0")
+      --cpus-workers string                      the share of CPUs as fraction for each worker/VM (default "2.0")
+      --disks strings                            list of disks to create in format "<driver1>:<size1>" (disks after the first one are added only to worker machines) (default [virtio:10GB,virtio:6GB])
   -h, --help                                     help for qemu
       --image-factory-url string                 image factory url (default "https://factory.talos.dev/")
       --kubernetes-version string                desired kubernetes version to run (default "1.34.0-rc.2")
-      --memory-controlplanes int                 the limit on memory usage in MB (each control plane/VM) (default 2048)
-      --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
+      --memory-controlplanes string(mb,gb)       the limit on memory usage for each control plane/VM (default 2.0GiB)
+      --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --schematic-id string                      image factory schematic id (defaults to an empty schematic)
       --talos-version string                     the desired talos version (default "latest")
       --talosconfig-destination string           The location to save the generated Talos configuration file to. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
@@ -222,8 +222,8 @@ talosctl cluster create [flags]
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
       --control-plane-port int                   control plane port (load balancer and local API port) (default 6443)
       --controlplanes int                        the number of controlplanes to create (default 1)
-      --cpus string                              the share of CPUs as fraction (each control plane/VM) (default "2.0")
-      --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
+      --cpus string                              the share of CPUs as fraction for each control plane/VM (default "2.0")
+      --cpus-workers string                      the share of CPUs as fraction for each worker/VM (default "2.0")
       --custom-cni-url string                    install custom CNI from the URL (Talos cluster)
       --disable-dhcp-hostname                    skip announcing hostname via DHCP
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
@@ -252,8 +252,8 @@ talosctl cluster create [flags]
       --iso-path string                          the ISO path to use for the initial boot
       --kubeprism-port int                       KubePrism port (set to 0 to disable) (default 7445)
       --kubernetes-version string                desired kubernetes version to run (default "1.34.0-rc.2")
-      --memory int                               the limit on memory usage in MB (each control plane/VM) (default 2048)
-      --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
+      --memory string(mb,gb)                     the limit on memory usage for each control plane/VM (default 2.0GiB)
+      --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mtu int                                  MTU of the cluster network (default 1500)
       --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
       --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT


### PR DESCRIPTION
Add flags for memory and disk sizes where people can specify the capacity freely in gb, mb tb etc. This change is backwards compatible and the values without units used previously still work.

requested here https://github.com/siderolabs/talos/pull/11623#discussion_r2287800355
