### PR TITLE
feat: allow Ed25119 in FIPS mode

### DIFF
--- a/internal/app/trustd/internal/reg/reg_test.go
+++ b/internal/app/trustd/internal/reg/reg_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/trustd/internal/reg"
 	"github.com/siderolabs/talos/pkg/machinery/api/security"
 	gensecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
@@ -86,12 +85,7 @@ func TestCertificate(t *testing.T) {
 				serverCert *x509.PEMEncodedCertificateAndKey
 			)
 
-			if fipsmode.Enabled() {
-				serverCSR, serverCert, err = x509.NewECDSACSRAndIdentity(tt.csrSetters...)
-			} else {
-				serverCSR, serverCert, err = x509.NewEd25519CSRAndIdentity(tt.csrSetters...)
-			}
-
+			serverCSR, serverCert, err = x509.NewEd25519CSRAndIdentity(tt.csrSetters...)
 			require.NoError(t, err)
 
 			resp, err := r.Certificate(ctx, &security.CertificateRequest{

--- a/pkg/machinery/config/generate/secrets/ca.go
+++ b/pkg/machinery/config/generate/secrets/ca.go
@@ -11,7 +11,6 @@ import (
 	"github.com/siderolabs/crypto/x509"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
@@ -58,10 +57,6 @@ func NewTalosCA(currentTime time.Time) (ca *x509.CertificateAuthority, err error
 		x509.Organization("talos"),
 		x509.NotAfter(currentTime.Add(CAValidityTime)),
 		x509.NotBefore(currentTime),
-	}
-
-	if fipsmode.Enabled() {
-		opts = append(opts, x509.ECDSA(true))
 	}
 
 	return x509.NewSelfSignedCertificateAuthority(opts...)

--- a/pkg/machinery/config/generate/secrets/generate_test.go
+++ b/pkg/machinery/config/generate/secrets/generate_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 )
 
 func TestNewBundle(t *testing.T) {
@@ -63,11 +62,7 @@ func TestNewBundleFromConfig(t *testing.T) {
 	osCA, err := x509.NewCertificateAuthorityFromCertificateAndKey(bundle.Certs.OS)
 	require.NoError(t, err)
 
-	if fipsmode.Enabled() {
-		assert.Equal(t, stdx509.ECDSA, osCA.Crt.PublicKeyAlgorithm, "expected ECDSA signature algorithm in FIPS mode")
-	} else {
-		assert.Equal(t, stdx509.Ed25519, osCA.Crt.PublicKeyAlgorithm, "expected Ed25519 signature algorithm in non-FIPS mode")
-	}
+	assert.Equal(t, stdx509.Ed25519, osCA.Crt.PublicKeyAlgorithm, "expected Ed25519 signature algorithm")
 
 	input, err := generate.NewInput("test", "https://localhost:6443", constants.DefaultKubernetesVersion, generate.WithSecretsBundle(bundle))
 	require.NoError(t, err)


### PR DESCRIPTION
Go 1.25 has update FIPS-140-3 requirements, and Ed25119 is now whitelisted.
