### PR TITLE
test: ignore one leaking goroutine

### DIFF
--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
@@ -250,7 +249,7 @@ func (suite *DNSServer) TestResolveMembers() {
 }
 
 func TestDNSServer(t *testing.T) {
-	goleak.VerifyNone(t)
+	t.Parallel()
 
 	suite.Run(t, &DNSServer{
 		DefaultSuite: ctest.DefaultSuite{
@@ -343,7 +342,7 @@ func (suite *DNSUpstreams) TestOrder() {
 }
 
 func TestDNSUpstreams(t *testing.T) {
-	goleak.VerifyNone(t)
+	t.Parallel()
 
 	suite.Run(t, &DNSUpstreams{
 		DefaultSuite: ctest.DefaultSuite{

--- a/internal/app/machined/pkg/controllers/network/network_test.go
+++ b/internal/app/machined/pkg/controllers/network/network_test.go
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/thejerf/suture/v4.(*Supervisor).removeService.func1.1"),
+	)
+}


### PR DESCRIPTION
I believe it's a bug in the `suture` library itself, relevant code is:

https://github.com/thejerf/suture/blob/8a2561c661dce2a30c484b08e865676059c1e63e/supervisor.go#L779-L816

If the global context is canceled, nothing consumes from the notification channel, so the goroutine trying to send there will never have a chance to complete.

Also avoid parallel issues by moving goleak check into `TestMain`.

