### PR TITLE
feat: use the id of the `VolumeConfig` in the mapped name when decrypting

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -27,6 +27,14 @@ systemd-udevd: 257.8
 Talos is built with Go 1.25.0.
 """
 
+    [notes.luks2]
+        title = "Encrypted Volumes"
+        description = """\
+Talos Linux now consistently provides mapped names for encrypted volumes in the format `/dev/mapper/luks2-<volume-id>`.
+This change should not affect system or user volumes, but might allow easier identification of encrypted volumes,
+and specifically for raw encrypted volumes.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/close.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/close.go
@@ -7,7 +7,6 @@ package volumes
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
@@ -52,15 +51,15 @@ func CloseWithHandler(ctx context.Context, logger *zap.Logger, volumeContext Man
 	ctx, cancel := context.WithTimeout(ctx, encryptionTimeout)
 	defer cancel()
 
-	encryptedName := filepath.Base(volumeContext.Status.Location) + "-encrypted"
+	mappedName := handler.Name() + "-" + volumeContext.Cfg.Metadata().ID()
 
-	if err := handler.Close(ctx, encryptedName); err != nil {
-		return xerrors.NewTaggedf[Retryable]("error closing encrypted volume %q: %w", encryptedName, err)
+	if err := handler.Close(ctx, mappedName); err != nil {
+		return xerrors.NewTaggedf[Retryable]("error closing encrypted volume mapped to %q: %w", mappedName, err)
 	}
 
 	volumeContext.Status.Phase = block.VolumePhaseClosed
 
-	logger.Info("encrypted volume closed", zap.String("name", encryptedName))
+	logger.Info("encrypted volume closed", zap.String("name", mappedName))
 
 	return nil
 }

--- a/internal/pkg/encryption/encryption.go
+++ b/internal/pkg/encryption/encryption.go
@@ -101,9 +101,14 @@ type Handler struct {
 	saltGetter         helpers.SaltGetter
 }
 
+// Name returns the name of the handler.
+func (h *Handler) Name() string {
+	return block.EncryptionProviderLUKS2.String()
+}
+
 // Open encrypted partition.
-func (h *Handler) Open(ctx context.Context, logger *zap.Logger, devicePath, encryptedName string) (string, []string, error) {
-	isOpen, path, err := h.encryptionProvider.IsOpen(ctx, devicePath, encryptedName)
+func (h *Handler) Open(ctx context.Context, logger *zap.Logger, devicePath, mappedName string) (string, []string, error) {
+	isOpen, path, err := h.encryptionProvider.IsOpen(ctx, devicePath, mappedName)
 	if err != nil {
 		return "", nil, err
 	}
@@ -123,7 +128,7 @@ func (h *Handler) Open(ctx context.Context, logger *zap.Logger, devicePath, encr
 			}
 
 			// try to open with the key, if it fails, tryHandlers will try the next handler
-			path, err = h.encryptionProvider.Open(ctx, devicePath, encryptedName, slotKey)
+			path, err = h.encryptionProvider.Open(ctx, devicePath, mappedName, slotKey)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Fixes #11662 so that not only the raw partition has a name based on the encrypted RawVolumeConfig resource's name but also the mapped partition that ends up being used by the user. The new mapped path has the format `/dev/mapper/r-<name>-decrypted`.

I suspect this changes the mapped name for both `VolumeConfigs` and `UserVolumeConfigs`, is that a problem? Maybe we can filter for RawVolumeConfigs based on labels?

## Why? (reasoning)

The way to refer to a non-encrypted RawVolumeConfig is by the partition label `r-<name>`. But the point of an encrypted RawVolumeConfig is to provide the user with a block device _on top_ of the partition created by Talos. The underlying device is uninteresting. At the moment the only options to refer to this virtual device are the arbitrarily numbered name `/dev/dm-##` and the `/dev/mapper/<partition>-encrypted` where `partition` is the path-based name `/dev/mapper/nvme0n1p5-encrypted`. This PR changes the latter mapped name to be based on the name of the resource rather than the underlying partition path. This PR also changes the suffix `-encrypted` to `-decrypted` because this virtual device is the _decrypted_ block device, i.e. it contains the decrypted data.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
  - no new tests
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
  - but I get failing tests on `main` so not sure