### PR TITLE
refactor create cluster commands internal logic

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -84,15 +84,31 @@ type commonOps struct {
 }
 
 func getDefaultCommonOptions() commonOps {
+	memory2GB := bytesize.WithDefaultUnit("MiB")
+	cli.Should(memory2GB.Set("2.0GiB"))
+	defaultResources := nodeResources{
+		cpu:    "2.0",
+		memory: *memory2GB,
+	}
+
 	return commonOps{
-		controlplanes:      1,
-		networkMTU:         1500,
-		clusterWaitTimeout: 15 * time.Minute,
-		clusterWait:        true,
-		dnsDomain:          "cluster.local",
-		controlPlanePort:   constants.DefaultControlPlanePort,
-		rootOps:            &clustercmd.PersistentFlags,
-		networkIPv4:        true,
+		controlplanes:         1,
+		controlplaneResources: defaultResources,
+		workers:               1,
+		workerResources:       defaultResources,
+
+		networkCIDR:            "10.5.0.0/24",
+		kubernetesVersion:      constants.DefaultKubernetesVersion,
+		networkMTU:             1500,
+		clusterWaitTimeout:     20 * time.Minute,
+		clusterWait:            true,
+		dnsDomain:              "cluster.local",
+		controlPlanePort:       constants.DefaultControlPlanePort,
+		rootOps:                &clustercmd.PersistentFlags,
+		networkIPv4:            true,
+		kubePrismPort:          constants.DefaultKubePrismPort,
+		enableClusterDiscovery: true,
+		talosVersion:           helpers.GetTag(),
 	}
 }
 
@@ -133,22 +149,18 @@ func addTalosconfigDestinationFlag(flagset *pflag.FlagSet, bind *string, flagNam
 }
 
 func addControlplaneCpusFlag(flagset *pflag.FlagSet, bind *string, flagName string) {
-	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction for each control plane/VM")
+	flagset.StringVar(bind, flagName, *bind, "the share of CPUs as fraction for each control plane/VM")
 }
 
 func addWorkersCpusFlag(flagset *pflag.FlagSet, bind *string, flagName string) {
-	flagset.StringVar(bind, flagName, "2.0", "the share of CPUs as fraction for each worker/VM")
+	flagset.StringVar(bind, flagName, *bind, "the share of CPUs as fraction for each worker/VM")
 }
 
 func addControlPlaneMemoryFlag(flagset *pflag.FlagSet, bind *bytesize.ByteSize, flagName string) {
-	cli.Should(bind.Set("2.0GiB")) // set default value
-	bind.SetDefaultUnit("MiB")
 	flagset.Var(bind, flagName, "the limit on memory usage for each control plane/VM")
 }
 
 func addWorkersMemoryFlag(flagset *pflag.FlagSet, bind *bytesize.ByteSize, flagName string) {
-	cli.Should(bind.Set("2.0GiB")) // set default value
-	bind.SetDefaultUnit("MiB")
 	flagset.Var(bind, flagName, "the limit on memory usage for each worker/VM")
 }
 
@@ -165,15 +177,15 @@ func addConfigPatchWorkerFlag(flagset *pflag.FlagSet, bind *[]string, flagName s
 }
 
 func addWorkersFlag(flagset *pflag.FlagSet, bind *int) {
-	flagset.IntVar(bind, workersFlagName, 1, "the number of workers to create")
+	flagset.IntVar(bind, workersFlagName, *bind, "the number of workers to create")
 }
 
 func addControlplanesFlag(flagset *pflag.FlagSet, bind *int) {
-	flagset.IntVar(bind, controlplanesFlagName, 1, "the number of controlplanes to create")
+	flagset.IntVar(bind, controlplanesFlagName, *bind, "the number of controlplanes to create")
 }
 
 func addKubernetesVersionFlag(flagset *pflag.FlagSet, bind *string) {
-	flagset.StringVar(bind, kubernetesVersionFlagName, constants.DefaultKubernetesVersion, "desired kubernetes version to run")
+	flagset.StringVar(bind, kubernetesVersionFlagName, *bind, "desired kubernetes version to run")
 }
 
 func addRegistryMirrorFlag(flagset *pflag.FlagSet, bind *[]string) {
@@ -181,11 +193,11 @@ func addRegistryMirrorFlag(flagset *pflag.FlagSet, bind *[]string) {
 }
 
 func addNetworkMTUFlag(flagset *pflag.FlagSet, bind *int) {
-	flagset.IntVar(bind, networkMTUFlagName, 1500, "MTU of the cluster network")
+	flagset.IntVar(bind, networkMTUFlagName, *bind, "MTU of the cluster network")
 }
 
 func addTalosVersionFlag(flagset *pflag.FlagSet, bind *string, description string) {
-	flagset.StringVar(bind, talosVersionFlagName, helpers.GetTag(), description)
+	flagset.StringVar(bind, talosVersionFlagName, *bind, description)
 }
 
 // qemu flags

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
@@ -29,7 +29,10 @@ type dockerOps struct {
 func init() {
 	ops := &createOps{
 		common: getDefaultCommonOptions(),
-		docker: dockerOps{},
+		docker: dockerOps{
+			hostIP:     "0.0.0.0",
+			talosImage: helpers.DefaultImage(images.DefaultTalosImageRepository),
+		},
 	}
 
 	const (
@@ -43,19 +46,19 @@ func init() {
 	getDockerFlags := func() *pflag.FlagSet {
 		docker := pflag.NewFlagSet("docker", pflag.PanicOnError)
 
-		docker.StringVarP(&ops.docker.ports, portsFlag, "p", "",
+		docker.StringVarP(&ops.docker.ports, portsFlag, "p", ops.docker.ports,
 			"comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)>")
-		docker.StringVar(&ops.docker.hostIP, dockerHostIPFlag, "0.0.0.0", "Host IP to forward exposed ports to")
-		docker.BoolVar(&ops.docker.disableIPv6, dockerDisableIPv6Flag, false, "skip enabling IPv6 in containers")
+		docker.StringVar(&ops.docker.hostIP, dockerHostIPFlag, ops.docker.hostIP, "Host IP to forward exposed ports to")
+		docker.BoolVar(&ops.docker.disableIPv6, dockerDisableIPv6Flag, ops.docker.disableIPv6, "skip enabling IPv6 in containers")
 		cli.Should(docker.MarkHidden(dockerDisableIPv6Flag))
 		docker.Var(&ops.docker.mountOpts, mountOptsFlag, "attach a mount to the container (docker --mount syntax)")
-		docker.StringVar(&ops.docker.talosImage, "image", helpers.DefaultImage(images.DefaultTalosImageRepository), "the talos image to run")
+		docker.StringVar(&ops.docker.talosImage, "image", ops.docker.talosImage, "the talos image to run")
 
 		return docker
 	}
 
 	commonFlags := getCommonUserFacingFlags(&ops.common)
-	commonFlags.StringVar(&ops.common.networkCIDR, subnetFlag, "10.5.0.0/24", "Docker network subnet CIDR")
+	commonFlags.StringVar(&ops.common.networkCIDR, subnetFlag, ops.common.networkCIDR, "Docker network subnet CIDR")
 
 	createDockerCmd := &cobra.Command{
 		Use:   "docker",
@@ -77,7 +80,7 @@ func init() {
 				if err != nil {
 					return err
 				}
-				// Create and save the talosctl configuration file.
+
 				err = postCreate(ctx, ops.common, data.talosconfig, cluster, data.provisionOptions, data.clusterRequest)
 				if err != nil {
 					return err

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_qemu.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"slices"
+
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate"
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+//nolint:gocyclo,cyclop
+func getQemuClusterRequest(
+	ctx context.Context,
+	cOps commonOps,
+	qOps qemuOps,
+	cqOps createQemuOps,
+	provisioner provision.Provisioner,
+) (clusterCreateRequestData, error) {
+	if cOps.talosVersion == "" || cOps.talosVersion[0] != 'v' {
+		return clusterCreateRequestData{}, fmt.Errorf("failed to parse talos version: version string must start with a 'v'")
+	}
+
+	_, err := config.ParseContractFromVersion(cOps.talosVersion)
+	if err != nil {
+		return clusterCreateRequestData{}, fmt.Errorf("failed to parse talos version: %s", err)
+	}
+
+	if cqOps.schematicID == "" {
+		cqOps.schematicID = emptySchemanticID
+	}
+
+	factoryURL, err := url.Parse(cqOps.imageFactoryURL)
+	if err != nil {
+		return clusterCreateRequestData{}, fmt.Errorf("malformed Image Factory URL: %q: %w", cqOps.imageFactoryURL, err)
+	}
+
+	if factoryURL.Scheme == "" || factoryURL.Host == "" {
+		return clusterCreateRequestData{}, fmt.Errorf("image Factory URL must include scheme and host: %q", cqOps.imageFactoryURL)
+	}
+
+	qOps.nodeISOPath, err = url.JoinPath(factoryURL.String(), "image", cqOps.schematicID, cOps.talosVersion, "metal-"+qOps.targetArch+".iso")
+	cli.Should(err)
+	qOps.nodeInstallImage, err = url.JoinPath(factoryURL.Host, "metal-installer", cqOps.schematicID+":"+cOps.talosVersion)
+	cli.Should(err)
+
+	if err := downloadBootAssets(ctx, &qOps); err != nil {
+		return clusterCreateRequestData{}, err
+	}
+
+	return createClusterRequest(createClusterRequestOps{
+		commonOps:   cOps,
+		provisioner: provisioner,
+		withExtraGenOpts: func(cr provision.ClusterRequest) []generate.Option {
+			genOptions := []generate.Option{
+				generate.WithInstallImage(qOps.nodeInstallImage),
+			}
+
+			endpointList := xslices.Map(cr.Nodes.ControlPlaneNodes(), func(n provision.NodeRequest) string { return n.IPs[0].String() })
+
+			genOptions = append(genOptions, generate.WithEndpointList(endpointList))
+
+			return genOptions
+		},
+		withExtraProvisionOpts: func(cr provision.ClusterRequest) []provision.Option {
+			return []provision.Option{
+				provision.WithUEFI(qOps.uefiEnabled),
+				provision.WithTargetArch(qOps.targetArch),
+				provision.WithSiderolinkAgent(qOps.withSiderolinkAgent.IsEnabled()),
+			}
+		},
+		modifyClusterRequest: func(cr provision.ClusterRequest) (provision.ClusterRequest, error) {
+			nameserverIPs, err := getNameserverIPs(qOps)
+			if err != nil {
+				return cr, err
+			}
+
+			cr.Network.Nameservers = nameserverIPs
+			cr.ISOPath = qOps.nodeISOPath
+
+			cr.Network.CNI = provision.CNIConfig{
+				BinPath:  qOps.cniBinPath,
+				ConfDir:  qOps.cniConfDir,
+				CacheDir: qOps.cniCacheDir,
+
+				BundleURL: qOps.cniBundleURL,
+			}
+
+			return cr, nil
+		},
+		modifyNodes: func(cr provision.ClusterRequest, cp, w []provision.NodeRequest) (controlplanes, workers []provision.NodeRequest, err error) {
+			primaryDisks, workerDisks, err := getDisks(qOps)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			for i := range cp {
+				cp[i].Disks = primaryDisks
+			}
+
+			for i := range w {
+				w[i].Disks = slices.Concat(primaryDisks, workerDisks)
+			}
+
+			return cp, w, nil
+		},
+	})
+}


### PR DESCRIPTION
Split common code between `create docker` and `create qemu` commands into a helper. The dev command stays as is due to big differences between the user oriented commands.

part of #11404