### PR TITLE
docs: fix broken create qemu command v1.11 docs

### DIFF
--- a/website/content/v1.11/talos-guides/install/local-platforms/qemu.md
+++ b/website/content/v1.11/talos-guides/install/local-platforms/qemu.md
@@ -105,7 +105,7 @@ mkdir -p ~/.talos/clusters
 Create the cluster:
 
 ```bash
-sudo --preserve-env=HOME talosctl cluster create qemu
+sudo --preserve-env=HOME talosctl cluster create --provisioner=qemu
 ```
 
 On Linux, before the first cluster is created, `talosctl` will download the CNI bundle for the VM provisioning and install it to `~/.talos/cni` directory.


### PR DESCRIPTION
I introduced this broken command in #11107, but the create qemu command doesn't yet exist for v1.11 (needs to be backported)

