### PR TITLE
docs: activate Talos v1.11 docs by default

### DIFF
--- a/website/content/v1.10/_index.md
+++ b/website/content/v1.10/_index.md
@@ -10,7 +10,6 @@ kubernetesRelease: "1.33.3"
 prevKubernetesRelease: "1.32.0"
 nvidiaContainerToolkitRelease: "v1.17.5"
 nvidiaDriverRelease: "535.230.02"
-menu: main
 ---
 
 ## Welcome

--- a/website/content/v1.11/_index.md
+++ b/website/content/v1.11/_index.md
@@ -10,7 +10,7 @@ kubernetesRelease: "1.34.0"
 prevKubernetesRelease: "1.33.0"
 nvidiaContainerToolkitRelease: "v1.17.8"
 nvidiaDriverRelease: "535.247.01"
-preRelease: true
+menu: main
 ---
 
 ## Welcome

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -114,7 +114,7 @@ version_menu = "Releases"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "/v1.10"
+url_latest_version = "/v1.11"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/siderolabs/talos"
@@ -147,11 +147,11 @@ version = "v1.12 (pre-release)"
 
 [[params.versions]]
 url = "/v1.11/"
-version = "v1.11 (pre-release)"
+version = "v1.11 (latest)"
 
 [[params.versions]]
 url = "/v1.10/"
-version = "v1.10 (latest)"
+version = "v1.10"
 
 [[params.versions]]
 url = "/v1.9/"


### PR DESCRIPTION
See https://github.com/siderolabs/talos/issues/11574
