### PR TITLE
feat: add a cgroup preset for PSI and --skip-cri-resolve

### DIFF
--- a/cmd/talosctl/cmd/talos/cgroupsprinter/presets/psi.yaml
+++ b/cmd/talosctl/cmd/talos/cgroupsprinter/presets/psi.yaml
@@ -1,0 +1,12 @@
+# PSI-related cgroup metrics
+columns:
+  - name: MemCurrent
+    template: '{{ .MemoryCurrent.HumanizeIBytes | printf "%8s" }}'
+  - name: MemPsiSome10
+    template: '{{ .MemoryPressure.some.avg10 | printf "%6s" }}'
+  - name: MemPsi10
+    template: '{{ .MemoryPressure.full.avg10 | printf "%6s" }}'
+  - name: CpuPsi10
+    template: '{{ .CPUPressure.full.avg10 | printf "%6s" }}'
+  - name: IoPsi10
+    template: '{{ .IOPressure.full.avg10 | printf "%6s" }}'

--- a/cmd/talosctl/cmd/talos/cgroupsprinter/presets_test.go
+++ b/cmd/talosctl/cmd/talos/cgroupsprinter/presets_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetPresetNames(t *testing.T) {
-	assert.Equal(t, []string{"cpu", "cpuset", "io", "memory", "process", "swap"}, cgroupsprinter.GetPresetNames())
+	assert.Equal(t, []string{"cpu", "cpuset", "io", "memory", "process", "psi", "swap"}, cgroupsprinter.GetPresetNames())
 }
 
 func TestGetPreset(t *testing.T) {

--- a/website/content/v1.12/advanced/cgroups-analysis.md
+++ b/website/content/v1.12/advanced/cgroups-analysis.md
@@ -252,6 +252,57 @@ In the swap view, the following columns are displayed:
 * `SwapHigh`: the high swap limit of the cgroup
 * `SwapMax`: the maximum swap limit of the cgroup
 
+### `psi`
+
+```bash
+$ talosctl cgroups --preset=psi
+NAME                                                                          MemCurrent   MemPsiSome10   MemPsi10   CpuPsi10   IoPsi10
+.                                                                                unset       0.00           0.00       0.00       0.00
+├──init                                                                         62 MiB       0.00           0.00       0.00       0.00
+├──kubepods                                                                    693 MiB       0.00           0.00       0.00       0.00
+│   ├──besteffort                                                               57 MiB       0.00           0.00       0.00       0.00
+│   │   └──kube-system/kube-proxy-mfrjg                                         57 MiB       0.00           0.00       0.00       0.00
+│   │       ├──kube-proxy                                                       57 MiB       0.00           0.00       0.00       0.00
+│   │       └──sandbox                                                         204 KiB       0.00           0.00       0.00       0.00
+│   └──burstable                                                               635 MiB       0.00           0.00       0.00       0.00
+│       ├──kube-system/coredns-7bb49dc74c-fms26                                 50 MiB       0.00           0.00       0.00       0.00
+│       │   ├──coredns                                                          50 MiB       0.00           0.00       0.00       0.00
+│       │   └──sandbox                                                         244 KiB       0.00           0.00       0.00       0.00
+│       ├──kube-system/coredns-7bb49dc74c-zmcn7                                 26 MiB       0.00           0.00       0.00       0.00
+│       │   ├──coredns                                                          26 MiB       0.00           0.00       0.00       0.00
+│       │   └──sandbox                                                         248 KiB       0.00           0.00       0.00       0.00
+│       ├──kube-system/kube-apiserver-talos-default-controlplane-1             337 MiB       0.00           0.00       0.00       0.00
+│       │   ├──kube-apiserver                                                  336 MiB       0.00           0.00       0.00       0.00
+│       │   └──sandbox                                                         956 KiB       0.00           0.00       0.00       0.00
+│       ├──kube-system/kube-controller-manager-talos-default-controlplane-1    106 MiB       0.00           0.00       0.00       0.00
+│       │   ├──kube-controller-manager                                         106 MiB       0.00           0.00       0.00       0.00
+│       │   └──sandbox                                                         240 KiB       0.00           0.00       0.00       0.00
+│       ├──kube-system/kube-flannel-sbv76                                       56 MiB       0.00           0.00       0.00       0.00
+│       │   ├──kube-flannel                                                     55 MiB       0.00           0.00       0.00       0.00
+│       │   └──sandbox                                                         236 KiB       0.00           0.00       0.00       0.00
+│       └──kube-system/kube-scheduler-talos-default-controlplane-1              60 MiB       0.00           0.00       0.00       0.00
+│           ├──kube-scheduler                                                   60 MiB       0.00           0.00       0.00       0.00
+│           └──sandbox                                                         232 KiB       0.00           0.00       0.00       0.00
+├──podruntime                                                                  279 MiB       0.00           0.00       0.00       0.00
+│   ├──etcd                                                                     96 MiB       0.00           0.00       0.00       0.00
+│   ├──kubelet                                                                  95 MiB       0.00           0.00       0.00       0.00
+│   └──runtime                                                                  88 MiB       0.00           0.00       0.00       0.00
+└──system                                                                      196 MiB       0.00           0.00       0.00       0.00
+    ├──apid                                                                     21 MiB       0.00           0.00       0.00       0.00
+    ├──dashboard                                                                82 MiB       0.00           0.00       0.00       0.00
+    ├──runtime                                                                  70 MiB       0.00           0.00       0.00       0.00
+    ├──trustd                                                                   12 MiB       0.00           0.00       0.00       0.00
+    └──udevd                                                                    11 MiB       0.00           0.00       0.00       0.00
+```
+
+In the PSI view, the following columns are displayed:
+
+* `MemCurrent`: the current memory usage of the cgroup and its children
+* `MemPsiSome10`: avg10 of the `some` PSI value for memory pressure (at least one process is waiting on memory)
+* `MemPsi10`: avg10 of the `full` PSI value for memory pressure
+* `CpuPsi10`: avg10 of the `full` PSI value for CPU pressure
+* `IoPsi10`: avg10 of the `full` PSI value for I/O pressure
+
 ## Custom Schemas
 
 The `talosctl cgroups` command allows you to define custom schemas to display the cgroups information in a specific way.

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -107,9 +107,10 @@ talosctl cgroups [flags]
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for cgroups
   -n, --nodes strings              target the specified nodes
-      --preset string              preset name (one of: [cpu cpuset io memory process swap])
+      --preset string              preset name (one of: [cpu cpuset io memory process psi swap])
       --schema-file string         path to the columns schema file
       --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --skip-cri-resolve           do not resolve cgroup names via a request to CRI
       --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
 ```
 


### PR DESCRIPTION
This flag helps debug in situations when containerd is responding slowly

Fixes #11587

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
