### PR TITLE
fix: enable support for VMWare arm64

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
@@ -36,7 +36,13 @@ func (v *VMware) KernelArgs(arch string, _ quirks.Quirks) procfs.Parameters {
 			procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),
 			procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 		}
+	case "arm64":
+		return []*procfs.Parameter{
+			procfs.NewParameter(constants.KernelParamConfig).Append(constants.ConfigGuestInfo),
+			procfs.NewParameter("console").Append("tty0").Append("ttyAMA0"),
+			procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
+		}
 	default:
-		return nil // not supported on !amd64
+		return nil // not supported
 	}
 }

--- a/pkg/machinery/platforms/platforms.go
+++ b/pkg/machinery/platforms/platforms.go
@@ -249,7 +249,7 @@ func CloudPlatforms() []Platform {
 			Label:       "VMWare",
 			Description: "Runs on VMWare ESXi virtual machines",
 
-			Architectures:   []Arch{ArchAmd64},
+			Architectures:   []Arch{ArchAmd64, ArchArm64},
 			Documentation:   "/talos-guides/install/virtualized-platforms/vmware/",
 			DiskImageSuffix: "ova",
 			BootMethods: []BootMethod{


### PR DESCRIPTION
Talos 1.11 adds support for arm64-compatible VMWare interface, so now Talos should work on arm64.

Provide correct kernel args and enable in the Image Factory.

Fixes #11729

Fixes #11733
