### PR TITLE
fix: don't bootstrap talos cluster if there's no config present

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create.go
@@ -432,6 +432,10 @@ func postCreate(
 }
 
 func bootstrapCluster(ctx context.Context, clusterAccess *access.Adapter, cOps commonOps) error {
+	if cOps.skipInjectingConfig && !cOps.applyConfigEnabled {
+		return nil
+	}
+
 	if !cOps.withInitNode {
 		if err := clusterAccess.Bootstrap(ctx, os.Stdout); err != nil {
 			return fmt.Errorf("bootstrap error: %w", err)


### PR DESCRIPTION
If the config is not provided to the nodes skip bootstrapping the Talos cluster, otherwise the bootstrap will hand until timed out.
