### PR TITLE
docs: clarify that talos does not support intermediate ca

### DIFF
--- a/website/content/v1.10/advanced/migrating-from-kubeadm.md
+++ b/website/content/v1.10/advanced/migrating-from-kubeadm.md
@@ -148,3 +148,14 @@ you can do the following:
     ```
 
     If the are not, modify all the labels fields, save the file, delete your current kube-proxy daemonset, and apply the one you modified.
+
+## Limitations on Custom PKI
+
+Talos always uses a per-cluster PKI model.
+During bootstrap, Talos expects a single root CA to issue all other certificates, including those for etcd, the Kubernetes API server, and the front-proxy.
+
+Talos does not support kubeadm PKIs that rely on intermediate CAs (for example, a root CA with separate intermediates for different components).
+By design, both `--cluster-signing-cert-file` and `--root-ca-file` point to the same CA certificate, and these values cannot be overridden.
+
+If your kubeadm cluster uses an intermediate CA hierarchy, you cannot directly reuse that PKI with Talos.
+Instead, you must regenerate certificates using the Talos per-cluster CA model.

--- a/website/content/v1.10/talos-guides/configuration/certificate-authorities.md
+++ b/website/content/v1.10/talos-guides/configuration/certificate-authorities.md
@@ -5,7 +5,7 @@ aliases:
   - ../../guides/configuring-certificate-authorities
 ---
 
-## Appending the Certificate Authority
+## Appending the Certificate Authority (CA)
 
 Append additional certificate authorities to the system's trusted certificate store by [patching]({{< relref "./patching" >}}) the machine configuration with the following
 [document]({{< relref "../../reference/configuration/security/trustedrootsconfig" >}}):

--- a/website/content/v1.11/advanced/migrating-from-kubeadm.md
+++ b/website/content/v1.11/advanced/migrating-from-kubeadm.md
@@ -148,3 +148,14 @@ you can do the following:
     ```
 
     If the are not, modify all the labels fields, save the file, delete your current kube-proxy daemonset, and apply the one you modified.
+
+## Limitations on Custom PKI
+
+Talos always uses a per-cluster PKI model.
+During bootstrap, Talos expects a single root CA to issue all other certificates, including those for etcd, the Kubernetes API server, and the front-proxy.
+
+Talos does not support kubeadm PKIs that rely on intermediate CAs (for example, a root CA with separate intermediates for different components).
+By design, both `--cluster-signing-cert-file` and `--root-ca-file` point to the same CA certificate, and these values cannot be overridden.
+
+If your kubeadm cluster uses an intermediate CA hierarchy, you cannot directly reuse that PKI with Talos.
+Instead, you must regenerate certificates using the Talos per-cluster CA model.

--- a/website/content/v1.12/advanced/migrating-from-kubeadm.md
+++ b/website/content/v1.12/advanced/migrating-from-kubeadm.md
@@ -148,3 +148,14 @@ you can do the following:
     ```
 
     If the are not, modify all the labels fields, save the file, delete your current kube-proxy daemonset, and apply the one you modified.
+
+## Limitations on Custom PKI
+
+Talos always uses a per-cluster PKI model.
+During bootstrap, Talos expects a single root CA to issue all other certificates, including those for etcd, the Kubernetes API server, and the front-proxy.
+
+Talos does not support kubeadm PKIs that rely on intermediate CAs (for example, a root CA with separate intermediates for different components).
+By design, both `--cluster-signing-cert-file` and `--root-ca-file` point to the same CA certificate, and these values cannot be overridden.
+
+If your kubeadm cluster uses an intermediate CA hierarchy, you cannot directly reuse that PKI with Talos.
+Instead, you must regenerate certificates using the Talos per-cluster CA model.


### PR DESCRIPTION
explained that you would need reissue cluster certificates if you are migrating from kubeadm as talos does not support intermediate ca

sorts #11691 