### PR TITLE
docs: Replace Raspberry Pi 5 links with Talos builder

### DIFF
--- a/website/content/v1.10/talos-guides/install/single-board-computers/unofficial.md
+++ b/website/content/v1.10/talos-guides/install/single-board-computers/unofficial.md
@@ -12,8 +12,7 @@ If you need official support for SBC boards please contact sales@siderolabs.com 
 
 ## Raspberry Pi 5
 
-* [sbc-raspberrypi fork](https://github.com/skyssolutions/talos-sbc-raspberrypi)
-* [Image Factory with RPi5 support](https://factory.kryptonian.dev/)
+* [Talos builder](https://github.com/talos-rpi5/talos-builder)
 
 ## MIXTILE Blade 3
 

--- a/website/content/v1.11/talos-guides/install/single-board-computers/unofficial.md
+++ b/website/content/v1.11/talos-guides/install/single-board-computers/unofficial.md
@@ -12,8 +12,7 @@ If you need official support for SBC boards please contact sales@siderolabs.com 
 
 ## Raspberry Pi 5
 
-* [sbc-raspberrypi fork](https://github.com/skyssolutions/talos-sbc-raspberrypi)
-* [Image Factory with RPi5 support](https://factory.kryptonian.dev/)
+* [Talos builder](https://github.com/talos-rpi5/talos-builder)
 
 ## MIXTILE Blade 3
 

--- a/website/content/v1.12/talos-guides/install/single-board-computers/unofficial.md
+++ b/website/content/v1.12/talos-guides/install/single-board-computers/unofficial.md
@@ -12,8 +12,7 @@ If you need official support for SBC boards please contact sales@siderolabs.com 
 
 ## Raspberry Pi 5
 
-* [sbc-raspberrypi fork](https://github.com/skyssolutions/talos-sbc-raspberrypi)
-* [Image Factory with RPi5 support](https://factory.kryptonian.dev/)
+* [Talos builder](https://github.com/talos-rpi5/talos-builder)
 
 ## MIXTILE Blade 3
 


### PR DESCRIPTION
# Pull Request

## What? (description)

Change links to PI5 unofficial repos

## Why? (reasoning)

Factory was shut off with Pi5 support due to not wanting to play cat & mouse with changes. Repository was also moved to a different way as an talos-rpi5 GH organization.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
