### PR TITLE
fix: re-create cgroups when restarting runners

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr"
+	"github.com/siderolabs/talos/internal/pkg/containermode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -67,7 +68,7 @@ const (
 
 // CurrentPlatform is a helper func for discovering the current platform.
 func CurrentPlatform() (p runtime.Platform, err error) {
-	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
+	if containermode.InContainer() {
 		return newPlatform("container")
 	}
 

--- a/internal/app/machined/pkg/startup/cgroups.go
+++ b/internal/app/machined/pkg/startup/cgroups.go
@@ -8,14 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/containerd/cgroups/v3"
-	"github.com/containerd/cgroups/v3/cgroup1"
-	"github.com/containerd/cgroups/v3/cgroup2"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/siderolabs/go-debug"
-	"github.com/siderolabs/go-pointer"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -23,19 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
-func zeroIfRace[T any](v T) T {
-	if debug.RaceEnabled {
-		var zeroT T
-
-		return zeroT
-	}
-
-	return v
-}
-
 // CreateSystemCgroups creates system cgroups.
-//
-//nolint:gocyclo
 func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtime, next NextTaskFunc) error {
 	// in container mode cgroups mode depends on cgroups provided by the container runtime
 	if !rt.State().Platform().Mode().InContainer() {
@@ -53,163 +35,16 @@ func CreateSystemCgroups(ctx context.Context, log *zap.Logger, rt runtime.Runtim
 
 	log.Info("initializing cgroups", zap.String("root", cgroup.Root()))
 
-	groups := []struct {
-		name      string
-		resources *cgroup2.Resources
-	}{
-		{
-			name: constants.CgroupInit,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupInitReservedMemory),
-					Low: pointer.To[int64](constants.CgroupInitReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupInitMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupSystem,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupSystemReservedMemory),
-					Low: pointer.To[int64](constants.CgroupSystemReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupSystemMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupSystemRuntime,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory),
-					Low: pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupSystemRuntimeMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupUdevd,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupUdevdReservedMemory),
-					Low: pointer.To[int64](constants.CgroupUdevdReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupUdevdMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupPodRuntimeRoot,
-			resources: &cgroup2.Resources{
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupPodRuntimeRootMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupPodRuntime,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupPodRuntimeReservedMemory),
-					Low: pointer.To[int64](constants.CgroupPodRuntimeReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupPodRuntimeMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupKubelet,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min: pointer.To[int64](constants.CgroupKubeletReservedMemory),
-					Low: pointer.To[int64](constants.CgroupKubeletReservedMemory * 2),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupKubeletMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupDashboard,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Max: zeroIfRace(pointer.To[int64](constants.CgroupDashboardMaxMemory)),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupDashboardMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupApid,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min:  pointer.To[int64](constants.CgroupApidReservedMemory),
-					Low:  pointer.To[int64](constants.CgroupApidReservedMemory * 2),
-					Max:  zeroIfRace(pointer.To[int64](constants.CgroupApidMaxMemory)),
-					Swap: pointer.To[int64](0),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupApidMillicores))),
-				},
-			},
-		},
-		{
-			name: constants.CgroupTrustd,
-			resources: &cgroup2.Resources{
-				Memory: &cgroup2.Memory{
-					Min:  pointer.To[int64](constants.CgroupTrustdReservedMemory),
-					Low:  pointer.To[int64](constants.CgroupTrustdReservedMemory * 2),
-					Max:  zeroIfRace(pointer.To[int64](constants.CgroupTrustdMaxMemory)),
-					Swap: pointer.To[int64](0),
-				},
-				CPU: &cgroup2.CPU{
-					Weight: pointer.To[uint64](cgroup.MillicoresToCPUWeight(cgroup.MilliCores(constants.CgroupTrustdMillicores))),
-				},
-			},
-		},
+	groups := []string{
+		constants.CgroupInit,
+		constants.CgroupSystem,
+		constants.CgroupPodRuntimeRoot,
 	}
 
 	for _, c := range groups {
-		if cgroups.Mode() == cgroups.Unified {
-			resources := c.resources
-
-			if rt.State().Platform().Mode().InContainer() {
-				// don't attempt to set resources in container mode, as they might conflict with the parent cgroup tree
-				resources = &cgroup2.Resources{}
-			}
-
-			cg, err := cgroup2.NewManager(constants.CgroupMountPath, cgroup.Path(c.name), resources)
-			if err != nil {
-				return fmt.Errorf("failed to create cgroup: %w", err)
-			}
-
-			if c.name == constants.CgroupInit {
-				if err := cg.AddProc(uint64(os.Getpid())); err != nil {
-					return fmt.Errorf("failed to move init process to cgroup: %w", err)
-				}
-			}
-		} else {
-			cg, err := cgroup1.New(cgroup1.StaticPath(c.name), &specs.LinuxResources{})
-			if err != nil {
-				return fmt.Errorf("failed to create cgroup: %w", err)
-			}
-
-			if c.name == constants.CgroupInit {
-				if err := cg.Add(cgroup1.Process{
-					Pid: os.Getpid(),
-				}); err != nil {
-					return fmt.Errorf("failed to move init process to cgroup: %w", err)
-				}
-			}
+		_, err := cgroup.CreateCgroup(c)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -177,12 +177,7 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: filepath.Dir(constants.APISocketPath), Source: filepath.Dir(constants.APISocketPath), Options: []string{"rbind", "rw"}},
 	}
 
-	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
-		mounts = append(
-			mounts,
-			specs.Mount{Type: "bind", Destination: "/usr/etc/in-container", Source: "/usr/etc/in-container", Options: []string{"bind", "ro"}},
-		)
-	}
+	mounts = bindMountContainerMarker(mounts)
 
 	env := []string{
 		constants.TcellMinimizeEnvironment,

--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -176,12 +176,7 @@ func (svc *Extension) Runner(r runtime.Runtime) (runner.Runner, error) {
 
 	mounts := append([]specs.Mount{}, svc.Spec.Container.Mounts...)
 
-	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
-		mounts = append(
-			mounts,
-			specs.Mount{Type: "bind", Destination: "/usr/etc/in-container", Source: "/usr/etc/in-container", Options: []string{"bind", "ro"}},
-		)
-	}
+	mounts = bindMountContainerMarker(mounts)
 
 	envVars, err := svc.parseEnvironment()
 	if err != nil {

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -154,12 +154,7 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: filepath.Dir(constants.TrustdRuntimeSocketPath), Source: filepath.Dir(constants.TrustdRuntimeSocketPath), Options: []string{"rbind", "ro"}},
 	}
 
-	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
-		mounts = append(
-			mounts,
-			specs.Mount{Type: "bind", Destination: "/usr/etc/in-container", Source: "/usr/etc/in-container", Options: []string{"bind", "ro"}},
-		)
-	}
+	mounts = bindMountContainerMarker(mounts)
 
 	env := environment.Get(r.Config())
 	env = append(env,

--- a/internal/app/machined/pkg/system/services/utils.go
+++ b/internal/app/machined/pkg/system/services/utils.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"path/filepath"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 
+	"github.com/siderolabs/talos/internal/pkg/containermode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -33,4 +35,16 @@ func prepareRootfs(id string) error {
 	}
 
 	return nil
+}
+
+// bindMountContainerMarker bind-mounts a file used for container detection into a container service.
+func bindMountContainerMarker(mounts []specs.Mount) []specs.Mount {
+	if containermode.InContainer() {
+		mounts = append(
+			mounts,
+			specs.Mount{Type: "bind", Destination: constants.ContainerMarkerFilePath, Source: constants.ContainerMarkerFilePath, Options: []string{"bind", "ro"}},
+		)
+	}
+
+	return mounts
 }

--- a/internal/pkg/containermode/containermode.go
+++ b/internal/pkg/containermode/containermode.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package containermode contains a utility function to detect if Talos is running in a container.
+package containermode
+
+import (
+	"os"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// InContainer checks whether or not Talos is running in a container.
+func InContainer() bool {
+	if _, err := os.Stat(constants.ContainerMarkerFilePath); err == nil {
+		return true
+	}
+
+	return false
+}

--- a/internal/pkg/selinux/selinux.go
+++ b/internal/pkg/selinux/selinux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/xattr"
 	"github.com/siderolabs/go-procfs/procfs"
 
+	"github.com/siderolabs/talos/internal/pkg/containermode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -28,7 +29,7 @@ var policy []byte
 // otherwise it returns false. It also ensures we're not in a container.
 // By default SELinux is disabled.
 var IsEnabled = sync.OnceValue(func() bool {
-	if _, err := os.Stat("/usr/etc/in-container"); err == nil {
+	if containermode.InContainer() {
 		return false
 	}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1291,6 +1291,9 @@ const (
 
 	// SideroV1KeysDir is the default directory containing user PGP keys for SideroV1 auth.
 	SideroV1KeysDir = "keys"
+
+	// ContainerMarkerFilePath is the path to the file added to container builds of Talos for platform detection.
+	ContainerMarkerFilePath = "/usr/etc/in-container"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Make sure processes are only launched into freshly-created cgroups
with all limits set when they are restarted.

This also allows processes to restart after cgroup being killed via the
cgroup.kill mechanism.

Fixes #11785

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
