### PR TITLE
test: improve test stability

### DIFF
--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -200,6 +200,8 @@ func (suite *ApplyConfigSuite) TestApplyNoOpCRIPatch() {
 		suite.CleanupFailedPods,
 	)
 
+	suite.ClearConnectionRefused(suite.ctx, node)
+
 	// revert the patch
 	provider, err = suite.ReadConfigFromNode(nodeCtx)
 	suite.Require().NoErrorf(err, "failed to read existing config from node %q", node)


### PR DESCRIPTION
Fixes #11780

Couple of changes:

* clear connection refused before apply config with reboot (no-op CRI patch test)
* improve log output in volume tests
* drop locking in vgcreate, as it seems to conflict with background disk scans (by Talos or udevd)
