### PR TITLE
docs: fix typo in doc v1.11

### DIFF
--- a/website/content/v1.11/introduction/prodnotes.md
+++ b/website/content/v1.11/introduction/prodnotes.md
@@ -70,7 +70,7 @@ You can include as many IP addresses as needed:
    If your control plane nodes IP addresses are `192.168.0.2`, `192.168.0.3`, `192.168.0.4`, your command would be:
 
     ```bash
-    CONTROL_PLANE_IP= ("192.168.0.2" "192.168.0.3" "192.168.0.4")
+    CONTROL_PLANE_IP=("192.168.0.2" "192.168.0.3" "192.168.0.4")
     ```
 
 1. If you have worker nodes, store their IP addresses in a Bash array.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
I found a typo in this section:
Step 2: Store Your IP Addresses in a Variable
There shouldn’t be a space after the =
```bash
CONTROL_PLANE_IP= ("192.168.0.2" "192.168.0.3" "192.168.0.4")
```

## Why? (reasoning)
If there is a space, you will get this error:
```bash
-bash: syntax error near unexpected token `('
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
