### PR TITLE
fix: apply 'ro' flag to iso9660 filesystems

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -180,7 +180,6 @@ func readConfigFromISO(ctx context.Context, r state.State) ([]byte, error) {
 		mount.WithFsopen(
 			volumeStatus.TypedSpec().Filesystem.String(),
 			fsopen.WithSource(volumeStatus.TypedSpec().MountLocation),
-			fsopen.WithBoolParameter("ro"),
 			fsopen.WithPrinter(log.Printf),
 		),
 	)

--- a/internal/pkg/xfs/fsopen/fsopen_linux.go
+++ b/internal/pkg/xfs/fsopen/fsopen_linux.go
@@ -52,11 +52,23 @@ func New(fstype string, opts ...Option) *FS {
 		binaryParams: make(map[string][][]byte),
 	}
 
-	for _, opt := range opts {
+	for _, opt := range defaultOpts(fstype, opts...) {
 		opt.set(fs)
 	}
 
 	return fs
+}
+
+// defaultOpts applies default options for filesystems.
+func defaultOpts(fstype string, opts ...Option) []Option {
+	if fstype == "iso9660" {
+		opts = append(
+			opts,
+			WithBoolParameter("ro"),
+		)
+	}
+
+	return opts
 }
 
 // Open initializes the filesystem and returns the file descriptor for the mounted filesystem.


### PR DESCRIPTION
Fixes #11807
