### PR TITLE
fix: remove CoreDNS cpu limit

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/coredns.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/coredns.go
@@ -294,7 +294,6 @@ func CoreDNSDeployment(spec *k8s.BootstrapManifestsConfigSpec) runtime.Object {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
 									corev1.ResourceMemory: resource.MustParse("170Mi"),
 								},
 								Requests: corev1.ResourceList{

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/coredns-deployment.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/coredns-deployment.yaml
@@ -68,7 +68,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 200m
             memory: 170Mi
           requests:
             cpu: 100m


### PR DESCRIPTION
This reverts the deployment to match 1.10.

Fixes #11812
