### PR TITLE
docs: remove 'ceph-data' from volume examples/docs

### DIFF
--- a/pkg/machinery/config/types/block/raw_volume_config.go
+++ b/pkg/machinery/config/types/block/raw_volume_config.go
@@ -85,7 +85,7 @@ func NewRawVolumeConfigV1Alpha1() *RawVolumeConfigV1Alpha1 {
 
 func exampleRawVolumeConfigV1Alpha1() *RawVolumeConfigV1Alpha1 {
 	cfg := NewRawVolumeConfigV1Alpha1()
-	cfg.MetaName = "ceph-data"
+	cfg.MetaName = "local-data"
 	cfg.ProvisioningSpec = ProvisioningSpec{
 		DiskSelectorSpec: DiskSelector{
 			Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.transport == "nvme"`, celenv.DiskLocator())),

--- a/pkg/machinery/config/types/block/user_volume_config.go
+++ b/pkg/machinery/config/types/block/user_volume_config.go
@@ -90,7 +90,7 @@ func NewUserVolumeConfigV1Alpha1() *UserVolumeConfigV1Alpha1 {
 
 func exampleUserVolumeConfigV1Alpha1() *UserVolumeConfigV1Alpha1 {
 	cfg := NewUserVolumeConfigV1Alpha1()
-	cfg.MetaName = "ceph-data"
+	cfg.MetaName = "local-data"
 	cfg.ProvisioningSpec = ProvisioningSpec{
 		DiskSelectorSpec: DiskSelector{
 			Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.transport == "nvme"`, celenv.DiskLocator())),

--- a/website/content/v1.11/talos-guides/configuration/disk-management/layout.md
+++ b/website/content/v1.11/talos-guides/configuration/disk-management/layout.md
@@ -132,12 +132,12 @@ Talos supports creating additional user volumes to be used for different purpose
 +-------------------------------------------------------------------------------------------------------+
 | Physical Disk (1TB)                                                                                   |
 +=============+===========+==========+============+===========+===============+=========================+
-| EFI (boot)  | META      | STATE    | EPHEMERAL  | ceph-data | local-storage | << Unallocated Space >> |
+| EFI (boot)  | META      | STATE    | EPHEMERAL  | csi-data  | local-storage | << Unallocated Space >> |
 | [~1GB]      | [~1MB]    | [~100MB] | [~200GB]   | [~100GB]  | [~200GB]      | [~500GB]                |
 +-------------+-----------+----------+------------+-----------+---------------+-------------------------+
 ```
 
-In this layout, the `EPHEMERAL` partition was limited to 200GB, and two additional partitions were created for `ceph-data` and `local-storage`.
+In this layout, the `EPHEMERAL` partition was limited to 200GB, and two additional partitions were created for `csi-data` and `local-storage`.
 
 ### Multiple Disk Layout
 
@@ -145,7 +145,7 @@ In this layout, the `EPHEMERAL` partition was limited to 200GB, and two addition
 +---------------------------------------------------------------------------------------+
 | Physical Disk 1 (1TB)                                                                 |
 +=============+===========+==========+============+===========+=========================+
-| EFI (boot)  | META      | STATE    | EPHEMERAL  | ceph-data | << Unallocated Space >> |
+| EFI (boot)  | META      | STATE    | EPHEMERAL  | csi-data  | << Unallocated Space >> |
 | [~1GB]      | [~1MB]    | [~100MB] | [~500GB]   | [~100GB]  | [~400GB]                |
 +-------------+-----------+----------+------------+-----------+-------------------------+
 | Physical Disk 2 (1TB)                                                                 |
@@ -155,5 +155,5 @@ In this layout, the `EPHEMERAL` partition was limited to 200GB, and two addition
 +---------------+-----------------------------------------------------------------------+
 ```
 
-In this layout, the `EPHEMERAL` partition was limited to 500GB, and two additional partitions were created for `ceph-data` and `local-storage`,
+In this layout, the `EPHEMERAL` partition was limited to 500GB, and two additional partitions were created for `csi-data` and `local-storage`,
 and they were created on different disks.

--- a/website/content/v1.11/talos-guides/configuration/disk-management/raw.md
+++ b/website/content/v1.11/talos-guides/configuration/disk-management/raw.md
@@ -53,6 +53,8 @@ NODE         NAMESPACE   TYPE           ID               VERSION   TYPE        P
 
 This volume can be referenced using a stable symlink `/dev/disk/by-partlabel/r-openebs-vol1`, which is created automatically by Talos Linux.
 
+> Note: Ceph will not create a partition if the partition label contains the substring `ceph`. Avoid using such names for your labels.
+
 ### Removing Raw Volumes
 
 Before removing a raw volume, ensure that it is not used anymore.

--- a/website/content/v1.11/talos-guides/configuration/disk-management/user.md
+++ b/website/content/v1.11/talos-guides/configuration/disk-management/user.md
@@ -26,7 +26,7 @@ To create a user volume, append the following [document]({{< relref "../../../re
 # user-volume.patch.yaml
 apiVersion: v1alpha1
 kind: UserVolumeConfig
-name: ceph-data
+name: local-volume
 provisioning:
   diskSelector:
     match: disk.transport == 'nvme'
@@ -40,25 +40,25 @@ For example, this machine configuration patch can be applied using the following
 talosctl --nodes <NODE> patch mc --patch @user-volume.patch.yaml
 ```
 
-In this example, a user volume named `ceph-data` is created on the first NVMe disk which has `100GB` of disk space available, and it will be created as maximum
+In this example, a user volume named `local-volume` is created on the first NVMe disk which has `100GB` of disk space available, and it will be created as maximum
 of `200GB` if that space is available.
 
 The status of the volume can be checked using the following command:
 
 ```bash
-$ talosctl get volumestatus u-ceph-data # note u- prefix
+$ talosctl get volumestatus u-local-volume # note u- prefix
 NAMESPACE   TYPE           ID            VERSION   TYPE        PHASE   LOCATION         SIZE
-runtime     VolumeStatus   u-ceph-data   2         partition   ready   /dev/nvme0n1p2   200 GB
+runtime     VolumeStatus   u-local-volume   2         partition   ready   /dev/nvme0n1p2   200 GB
 ```
 
 If the volume fails to be provisioned, use the `-o yaml` flag to get additional details.
 
-The volume is immediately mounted to `/var/mnt/ceph-data`:
+The volume is immediately mounted to `/var/mnt/local-volume`:
 
 ```bash
 $ talosctl get mountstatus
 NAMESPACE   TYPE          ID           VERSION   SOURCE           TARGET               FILESYSTEM   VOLUME
-runtime     MountStatus   u-ceph-data  2         /dev/nvme0n1p2   /var/mnt/ceph-data   xfs          u-ceph-data
+runtime     MountStatus   u-local-volume  2         /dev/nvme0n1p2   /var/mnt/local-volume   xfs          u-local-volume
 ```
 
 It can be used in a Kubernetes pod as a `hostPath` mount:
@@ -70,11 +70,11 @@ spec:
     - name: ceph
       volumeMounts:
         - mountPath: /var/lib/ceph
-          name: ceph-data
+          name: local-volume
   volumes:
-    - name: ceph-data
+    - name: local-volume
       hostPath:
-        path: /var/mnt/ceph-data
+        path: /var/mnt/local-volume
 ```
 
 Please note, the path inside the container can be different from the path on the host.

--- a/website/content/v1.12/reference/configuration/block/rawvolumeconfig.md
+++ b/website/content/v1.12/reference/configuration/block/rawvolumeconfig.md
@@ -21,7 +21,7 @@ title: RawVolumeConfig
 {{< highlight yaml >}}
 apiVersion: v1alpha1
 kind: RawVolumeConfig
-name: ceph-data # Name of the volume.
+name: local-data # Name of the volume.
 # The provisioning describes how the volume is provisioned.
 provisioning:
     # The disk selector expression.

--- a/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
+++ b/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
@@ -20,7 +20,7 @@ title: UserVolumeConfig
 {{< highlight yaml >}}
 apiVersion: v1alpha1
 kind: UserVolumeConfig
-name: ceph-data # Name of the volume.
+name: local-data # Name of the volume.
 # The provisioning describes how the volume is provisioned.
 provisioning:
     # The disk selector expression.

--- a/website/content/v1.12/talos-guides/configuration/disk-management/layout.md
+++ b/website/content/v1.12/talos-guides/configuration/disk-management/layout.md
@@ -132,12 +132,12 @@ Talos supports creating additional user volumes to be used for different purpose
 +-------------------------------------------------------------------------------------------------------+
 | Physical Disk (1TB)                                                                                   |
 +=============+===========+==========+============+===========+===============+=========================+
-| EFI (boot)  | META      | STATE    | EPHEMERAL  | ceph-data | local-storage | << Unallocated Space >> |
+| EFI (boot)  | META      | STATE    | EPHEMERAL  | csi-data  | local-storage | << Unallocated Space >> |
 | [~1GB]      | [~1MB]    | [~100MB] | [~200GB]   | [~100GB]  | [~200GB]      | [~500GB]                |
 +-------------+-----------+----------+------------+-----------+---------------+-------------------------+
 ```
 
-In this layout, the `EPHEMERAL` partition was limited to 200GB, and two additional partitions were created for `ceph-data` and `local-storage`.
+In this layout, the `EPHEMERAL` partition was limited to 200GB, and two additional partitions were created for `csi-data` and `local-storage`.
 
 ### Multiple Disk Layout
 
@@ -145,7 +145,7 @@ In this layout, the `EPHEMERAL` partition was limited to 200GB, and two addition
 +---------------------------------------------------------------------------------------+
 | Physical Disk 1 (1TB)                                                                 |
 +=============+===========+==========+============+===========+=========================+
-| EFI (boot)  | META      | STATE    | EPHEMERAL  | ceph-data | << Unallocated Space >> |
+| EFI (boot)  | META      | STATE    | EPHEMERAL  | csi-data  | << Unallocated Space >> |
 | [~1GB]      | [~1MB]    | [~100MB] | [~500GB]   | [~100GB]  | [~400GB]                |
 +-------------+-----------+----------+------------+-----------+-------------------------+
 | Physical Disk 2 (1TB)                                                                 |
@@ -155,5 +155,5 @@ In this layout, the `EPHEMERAL` partition was limited to 200GB, and two addition
 +---------------+-----------------------------------------------------------------------+
 ```
 
-In this layout, the `EPHEMERAL` partition was limited to 500GB, and two additional partitions were created for `ceph-data` and `local-storage`,
+In this layout, the `EPHEMERAL` partition was limited to 500GB, and two additional partitions were created for `csi-data` and `local-storage`,
 and they were created on different disks.

--- a/website/content/v1.12/talos-guides/configuration/disk-management/raw.md
+++ b/website/content/v1.12/talos-guides/configuration/disk-management/raw.md
@@ -53,6 +53,8 @@ NODE         NAMESPACE   TYPE           ID               VERSION   TYPE        P
 
 This volume can be referenced using a stable symlink `/dev/disk/by-partlabel/r-openebs-vol1`, which is created automatically by Talos Linux.
 
+> Note: Ceph will not create a partition if the partition label contains the substring `ceph`. Avoid using such names for your labels.
+
 ### Removing Raw Volumes
 
 Before removing a raw volume, ensure that it is not used anymore.

--- a/website/content/v1.12/talos-guides/configuration/disk-management/user.md
+++ b/website/content/v1.12/talos-guides/configuration/disk-management/user.md
@@ -26,7 +26,7 @@ To create a user volume, append the following [document]({{< relref "../../../re
 # user-volume.patch.yaml
 apiVersion: v1alpha1
 kind: UserVolumeConfig
-name: ceph-data
+name: local-volume
 provisioning:
   diskSelector:
     match: disk.transport == 'nvme'
@@ -40,25 +40,25 @@ For example, this machine configuration patch can be applied using the following
 talosctl --nodes <NODE> patch mc --patch @user-volume.patch.yaml
 ```
 
-In this example, a user volume named `ceph-data` is created on the first NVMe disk which has `100GB` of disk space available, and it will be created as maximum
+In this example, a user volume named `local-volume` is created on the first NVMe disk which has `100GB` of disk space available, and it will be created as maximum
 of `200GB` if that space is available.
 
 The status of the volume can be checked using the following command:
 
 ```bash
-$ talosctl get volumestatus u-ceph-data # note u- prefix
+$ talosctl get volumestatus u-local-volume # note u- prefix
 NAMESPACE   TYPE           ID            VERSION   TYPE        PHASE   LOCATION         SIZE
-runtime     VolumeStatus   u-ceph-data   2         partition   ready   /dev/nvme0n1p2   200 GB
+runtime     VolumeStatus   u-local-volume   2         partition   ready   /dev/nvme0n1p2   200 GB
 ```
 
 If the volume fails to be provisioned, use the `-o yaml` flag to get additional details.
 
-The volume is immediately mounted to `/var/mnt/ceph-data`:
+The volume is immediately mounted to `/var/mnt/local-volume`:
 
 ```bash
 $ talosctl get mountstatus
 NAMESPACE   TYPE          ID           VERSION   SOURCE           TARGET               FILESYSTEM   VOLUME
-runtime     MountStatus   u-ceph-data  2         /dev/nvme0n1p2   /var/mnt/ceph-data   xfs          u-ceph-data
+runtime     MountStatus   u-local-volume  2         /dev/nvme0n1p2   /var/mnt/local-volume   xfs          u-local-volume
 ```
 
 It can be used in a Kubernetes pod as a `hostPath` mount:
@@ -70,11 +70,11 @@ spec:
     - name: ceph
       volumeMounts:
         - mountPath: /var/lib/ceph
-          name: ceph-data
+          name: local-volume
   volumes:
-    - name: ceph-data
+    - name: local-volume
       hostPath:
-        path: /var/mnt/ceph-data
+        path: /var/mnt/local-volume
 ```
 
 Please note, the path inside the container can be different from the path on the host.


### PR DESCRIPTION
Ceph doesn't like name `ceph` in the partition labels.

See https://github.com/siderolabs/talos/issues/11778

