### PR TITLE
feat: enforce more KSPP and hardening sysctls

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -55,6 +55,13 @@ Signed PCR policies will still be bound to PCR 11.
 The currently used PCR's can be seen with `talosctl get volumestatus <volume> -o yaml` command.
 """
 
+    [notes.kspp]
+        title = "Kernel Security Posture Profile (KSPP)"
+        description = """\
+Talos now enables a stricter set of KSPP sysctl settings by default.
+The list of overridden settings is available with `talosctl get kernelparamstatus` command.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -78,6 +78,14 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 			Key:   "proc.sys.net.ipv4.ip_forward",
 			Value: "1",
 		},
+		{
+			Key:   "proc.sys.net.ipv4.icmp_ignore_bogus_error_responses",
+			Value: "1",
+		},
+		{
+			Key:   "proc.sys.net.ipv4.icmp_echo_ignore_broadcasts",
+			Value: "1",
+		},
 	}
 
 	if ctrl.V1Alpha1Mode != v1alpha1runtime.ModeContainer {

--- a/pkg/kernel/kspp/kspp.go
+++ b/pkg/kernel/kspp/kspp.go
@@ -51,8 +51,36 @@ func EnforceKSPPKernelParameters() error {
 func GetKernelParams() []*kernel.Param {
 	return []*kernel.Param{
 		{
-			Key:   "proc.sys.kernel.kptr_restrict",
+			Key:   "proc.sys.dev.tty.ldisc_autoload",
+			Value: "0",
+		},
+		{
+			Key:   "proc.sys.dev.tty.legacy_tiocsti",
+			Value: "0",
+		},
+		{
+			Key:   "proc.sys.fs.protected_symlinks",
 			Value: "1",
+		},
+		{
+			Key:   "proc.sys.fs.protected_hardlinks",
+			Value: "1",
+		},
+		{
+			Key:   "proc.sys.fs.protected_fifos",
+			Value: "2",
+		},
+		{
+			Key:   "proc.sys.fs.protected_regular",
+			Value: "2",
+		},
+		{
+			Key:   "proc.sys.fs.suid_dumpable",
+			Value: "0",
+		},
+		{
+			Key:   "proc.sys.kernel.kptr_restrict",
+			Value: "2",
 		},
 		{
 			Key:   "proc.sys.kernel.dmesg_restrict",
@@ -63,8 +91,14 @@ func GetKernelParams() []*kernel.Param {
 			Value: "3",
 		},
 		{
+			Key:   "proc.sys.kernel.randomize_va_space",
+			Value: "2",
+		},
+		{
+			// Bumping this to 3 (https://www.kernel.org/doc/Documentation/security/Yama.txt)
+			// breaks Kubernetes pods with user namespaces, which are not enabled by default, but still supported.
 			Key:   "proc.sys.kernel.yama.ptrace_scope",
-			Value: "1",
+			Value: "2",
 		},
 		{
 			Key:   "proc.sys.user.max_user_namespaces",


### PR DESCRIPTION
Source: https://github.com/a13xp0p0v/kernel-hardening-checker/blob/76821aabeb62a9bf4130bae65d467ca2561bebd5/kernel_hardening_checker/checks.py

Filter some sysctls (if we don't need them because of kernel config), or try not to break things too much.
