### PR TITLE
feat: release cloud image using factory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-25T16:16:48Z by kres fdbc9fc.
+# Generated on 2025-09-29T11:30:50Z by kres eb905b6-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -5030,16 +5030,10 @@ jobs:
           PLATFORM: linux/amd64,linux/arm64
         run: |
           make images
-      - name: cloud-images
-        env:
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make cloud-images
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
       - name: Sign artifacts
         run: |
-          cosign sign-blob --output-signature _out/cloud-images.json.sig --yes _out/cloud-images.json
           cosign sign-blob --output-signature _out/initramfs-amd64.xz.sig --yes _out/initramfs-amd64.xz
           cosign sign-blob --output-signature _out/initramfs-arm64.xz.sig --yes _out/initramfs-arm64.xz
           cosign sign-blob --output-signature _out/metal-amd64.iso.sig --yes _out/metal-amd64.iso
@@ -5068,20 +5062,19 @@ jobs:
       - name: Generate Checksums
         run: |
           cd _out
-          sha256sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
-          sha512sum cloud-images.json initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
+          sha256sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
+          sha512sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
       - name: Sign checksums
         run: |
           cd _out
           cosign sign-blob --output-signature sha256sum.txt.sig --yes sha256sum.txt
           cosign sign-blob --output-signature sha512sum.txt.sig --yes sha512sum.txt
       - name: release
-        uses: crazy-max/ghaction-github-release@v2
+        uses: softprops/action-gh-release@v2
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"
           files: |-
-            _out/cloud-images.json
             _out/initramfs-amd64.xz
             _out/initramfs-arm64.xz
             _out/metal-amd64.iso

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,0 +1,77 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-09-29T14:15:51Z by kres df5079a-dirty.
+
+"on":
+  workflow_dispatch:
+    inputs:
+      release:
+        description: ""
+        type: string
+        required: false
+      tag:
+        description: ""
+        type: string
+        required: false
+name: dispatch
+jobs:
+  cloud-images:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: generic
+    if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: cloud-images
+        env:
+          CLOUD_IMAGES_EXTRA_ARGS: --use-factory
+          PLATFORM: linux/amd64,linux/arm64
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          make cloud-images
+      - name: attach-images
+        env:
+          RELEASE: ${{ github.event.inputs.release }}
+        run: |
+          gh release upload "${RELEASE}" \
+            _out/cloud-images.json

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -180,14 +180,10 @@ spec:
         - name: images
           environment:
             PLATFORM: linux/amd64,linux/arm64
-        - name: cloud-images
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
         - name: release
           releaseStep:
             baseDirectory: _out
             artifacts:
-              - cloud-images.json
               - initramfs-amd64.xz
               - initramfs-arm64.xz
               - metal-amd64.iso
@@ -216,6 +212,28 @@ spec:
             generateChecksums: true
             generateSignatures: true
             releaseNotes: RELEASE_NOTES.md
+    - name: cloud-images
+      dispatchable: true
+      sops: true
+      runnerGroup: generic # this is not compute intensive - we are pulling images from factory
+      inputs:
+        - tag
+        - release
+      steps:
+        - name: cloud-images
+          environment:
+            CLOUD_IMAGES_EXTRA_ARGS: |-
+              --use-factory
+            PLATFORM: linux/amd64,linux/arm64
+            TAG: ${{ github.event.inputs.tag }}
+        - name: attach-images
+          nonMakeStep: true
+          environment:
+            RELEASE: ${{ github.event.inputs.release }}
+            GH_TOKEN: ${{ github.token }}
+          command: |-
+            gh release upload "${RELEASE}" \
+              _out/cloud-images.json
     - name: base-unit-tests
       buildxOptions:
         enabled: true

--- a/hack/cloud-image-uploader/factory.go
+++ b/hack/cloud-image-uploader/factory.go
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var extensions = map[string]string{
+	"aws": ".raw.xz",
+	"gcp": ".raw.tar.gz",
+}
+
+// FactoryDownloader is helper for downloading images from Image Factory.
+type FactoryDownloader struct {
+	Target  string
+	Options Options
+}
+
+func (f *FactoryDownloader) Download(ctx context.Context) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, arch := range f.Options.Architectures {
+		g.Go(func() error {
+			artifact := fmt.Sprintf("%s-%s%s", f.Target, arch, extensions[f.Target])
+
+			r, err := f.getArtifact(ctx, artifact)
+			if err != nil {
+				return err
+			}
+			defer r.Close() //nolint:errcheck
+
+			return f.saveArtifact(artifact, r)
+		})
+	}
+
+	return g.Wait()
+}
+
+func (f *FactoryDownloader) getArtifact(ctx context.Context, name string) (io.ReadCloser, error) {
+	url, err := url.JoinPath(
+		f.Options.FactoryHost,
+		"images",
+		f.Options.SchematicFor(f.Target),
+		f.Options.Tag,
+		name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download image from %q: %w", url, err)
+	}
+
+	return resp.Body, nil
+}
+
+func (f *FactoryDownloader) saveArtifact(name string, r io.Reader) error {
+	artifact := filepath.Join(f.Options.ArtifactsPath, name)
+
+	of, err := os.OpenFile(artifact, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", artifact, err)
+	}
+	defer of.Close() //nolint:errcheck
+
+	_, err = io.Copy(of, r)
+	if err != nil {
+		return fmt.Errorf("failed to write image to file %q: %w", artifact, err)
+	}
+
+	return nil
+}

--- a/hack/cloud-image-uploader/options.go
+++ b/hack/cloud-image-uploader/options.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // Options for the cli.
@@ -16,6 +17,11 @@ type Options struct {
 	NamePrefix    string
 	Architectures []string
 	TargetClouds  []string
+
+	// ImageFactory options.
+	UseFactory        bool
+	FactoryHost       string
+	FactorySchematics []string
 
 	// AWS options.
 	AWSRegions   []string
@@ -27,6 +33,10 @@ var DefaultOptions = Options{
 	ArtifactsPath: "_out/",
 	Architectures: []string{"amd64", "arm64"},
 	TargetClouds:  []string{"aws"},
+	FactoryHost:   "https://factory.talos.dev",
+	FactorySchematics: []string{
+		"aws:10e276a06c1f86b182757a962258ac00655d3425e5957f617bdc82f06894e39b",
+	},
 }
 
 // AWSImage returns path to AWS pre-built image.
@@ -37,4 +47,23 @@ func (o *Options) AWSImage(architecture string) string {
 // GCPImage returns path to GCP pre-built image.
 func (o *Options) GCPImage(architecture string) string {
 	return filepath.Join(o.ArtifactsPath, fmt.Sprintf("gcp-%s.raw.tar.gz", architecture))
+}
+
+// SchematicFor returns the schematic for the given cloud.
+func (o *Options) SchematicFor(cloud string) string {
+	for _, schematic := range o.FactorySchematics {
+		parts := strings.Split(schematic, ":")
+		if len(parts) != 2 {
+			continue
+		}
+
+		cloudPart := parts[0]
+		schematicPart := parts[1]
+
+		if cloudPart == cloud {
+			return schematicPart
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
Rather than building images manually, retrieve them from the image factory to guarantee that the correct base schematic is applied and that all required default extensions are consistently included.

Fixes #11454

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>