### PR TITLE
fix: provide refreshing CA pool (resolvers)

### DIFF
--- a/internal/pkg/containers/image/resolver.go
+++ b/internal/pkg/containers/image/resolver.go
@@ -60,6 +60,11 @@ func RegistryHosts(reg config.Registries) docker.RegistryHosts {
 				if err != nil {
 					return nil, fmt.Errorf("error preparing TLS config for %q: %w", u.Host, err)
 				}
+
+				// set up refreshing Root CAs if none were provided
+				if transport.TLSClientConfig.RootCAs == nil {
+					transport.TLSClientConfig.RootCAs = httpdefaults.RootCAs()
+				}
 			}
 
 			if u.Path == "" {


### PR DESCRIPTION
When a registry has _some_ TLS config included, the refreshing CA pool was overwritten with the result returned from the config provider.

Ensure that is is restored back to the default value (unless explicitly set by the provider if the registry CA is set).
