### PR TITLE
fix(broadcast): don't set broadcast for /31 and /32 addresses

### DIFF
--- a/internal/app/machined/pkg/controllers/network/internal/addressutil/broadcast.go
+++ b/internal/app/machined/pkg/controllers/network/internal/addressutil/broadcast.go
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package addressutil
+
+import (
+	"net"
+	"net/netip"
+
+	"go4.org/netipx"
+)
+
+// BroadcastAddr calculates the broadcast address for the given IPv4 prefix.
+//
+// If the address is not IPv4 or the prefix length is 31 or 32, nil is returned.
+func BroadcastAddr(addr netip.Prefix) net.IP {
+	if !addr.Addr().Is4() {
+		return nil
+	}
+
+	if addr.Bits() >= 31 {
+		return nil
+	}
+
+	ipnet := netipx.PrefixIPNet(addr)
+
+	ip := ipnet.IP.To4()
+	if ip == nil {
+		return nil
+	}
+
+	mask := net.IP(ipnet.Mask).To4()
+
+	n := len(ip)
+	if n != len(mask) {
+		return nil
+	}
+
+	out := make(net.IP, n)
+
+	for i := range n {
+		out[i] = ip[i] | ^mask[i]
+	}
+
+	return out
+}

--- a/internal/app/machined/pkg/controllers/network/internal/addressutil/broadcast_test.go
+++ b/internal/app/machined/pkg/controllers/network/internal/addressutil/broadcast_test.go
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package addressutil_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/internal/addressutil"
+)
+
+func TestBroadcastAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prefix  string
+		want    string
+		wantNil bool
+	}{
+		{
+			name:   "IPv4 /24 network",
+			prefix: "10.255.255.231/24",
+			want:   "10.255.255.255",
+		},
+		{
+			name:   "IPv4 /16 network",
+			prefix: "192.168.0.1/16",
+			want:   "192.168.255.255",
+		},
+		{
+			name:    "IPv4 /32 host route (VIP case)",
+			prefix:  "10.255.255.230/32",
+			wantNil: true, // Should return nil, not set broadcast
+		},
+		{
+			name:    "Another /32 host route",
+			prefix:  "192.168.1.100/32",
+			wantNil: true, // Should return nil, not set broadcast
+		},
+		{
+			name:    "IPv4 /31 point-to-point",
+			prefix:  "10.0.0.1/31",
+			wantNil: true, // RFC 3021 - /31 is point-to-point, no broadcast
+		},
+		{
+			name:   "IPv4 /8 network",
+			prefix: "10.0.0.1/8",
+			want:   "10.255.255.255",
+		},
+		{
+			name:    "IPv6 address (no broadcast)",
+			prefix:  "2001:db8::1/64",
+			wantNil: true, // IPv6 doesn't have broadcast
+		},
+		{
+			name:    "IPv6 /128 address",
+			prefix:  "2001:db8::1/128",
+			wantNil: true, // IPv6 doesn't have broadcast
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prefix, err := netip.ParsePrefix(tt.prefix)
+			require.NoError(t, err)
+
+			got := addressutil.BroadcastAddr(prefix)
+
+			if tt.wantNil {
+				assert.Nil(t, got, "expected nil broadcast for %s", tt.prefix)
+			} else {
+				assert.NotNil(t, got, "expected broadcast address for %s", tt.prefix)
+
+				want := net.ParseIP(tt.want)
+				assert.True(t, got.Equal(want), "expected %v, got %v for %s", want, got, tt.prefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
RFC 3021 defines /31 as point-to-point links without broadcast. /32 addresses are host routes that don't need broadcast addresses.

Setting broadcast=IP for these prefixes confuses kernel routing decisions, causing packets to be incorrectly broadcast instead
of routed through the gateway.

On a single node test cluster this results in intermittent failure of all network connections.

See Issue: https://github.com/siderolabs/talos/issues/11900

TL'DR: Broadcast address is getting set to the IP address on the VIP which is causing intermittent failures on at least single node clusters. Omitting the broadcast on a `/32` works fine and would seem to be the expected configuration. This small patch applies no broadcast for either /31 or /32

Please use the following checklist:

- [x ] you linked an issue (if applicable)
- [x ] you included tests (if applicable)
- [x ] you ran conformance (`make conformance`)
- [x ] you formatted your code (`make fmt`)
- [x ] you linted your code (`make lint`)
- [x ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

I was having issues getting podman to run unit-tests sorry about that.

> See `make help` for a description of the available targets.
