### PR TITLE
docs: deprecate JSON6902 patches and interactive installer

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
+++ b/internal/app/machined/pkg/controllers/runtime/maintenance_service.go
@@ -296,8 +296,6 @@ func (ctrl *MaintenanceServiceController) Run(ctx context.Context, r controller.
 
 			logger.Sugar().Info("upload configuration using talosctl:")
 			logger.Sugar().Infof("\ttalosctl apply-config --insecure --nodes %s --file <config.yaml>", firstIP)
-			logger.Sugar().Info("or apply configuration using talosctl interactive installer:")
-			logger.Sugar().Infof("\ttalosctl apply-config --insecure --nodes %s --mode=interactive", firstIP)
 			logger.Sugar().Info("optionally with node fingerprint check:")
 			logger.Sugar().Infof("\ttalosctl apply-config --insecure --nodes %s --cert-fingerprint '%s' --file <config.yaml>", firstIP, lastCertificateFingerprint)
 

--- a/website/content/v1.12/talos-guides/configuration/editing-machine-configuration.md
+++ b/website/content/v1.12/talos-guides/configuration/editing-machine-configuration.md
@@ -21,7 +21,6 @@ Each of these commands can operate in one of four modes:
 * apply change immediately (`--mode=no-reboot` flag): change is applied immediately without a reboot, fails if the change contains any fields that can not be updated without a reboot
 * apply change on next reboot (`--mode=staged`): change is staged to be applied after a reboot, but node is not rebooted
 * apply change with automatic revert (`--mode=try`): change is applied immediately (if not possible, returns an error), and reverts it automatically in 1 minute if no configuration update is applied
-* apply change in the interactive mode (`--mode=interactive`; only for `talosctl apply-config`): launches TUI based interactive installer
 
 > Note: applying change on next reboot (`--mode=staged`) doesn't modify current node configuration, so next call to
 > `talosctl edit machineconfig --mode=staged` will not see changes
@@ -79,12 +78,6 @@ Applying machine configuration immediately (without a reboot):
 
 ```bash
 talosctl -n IP apply machineconfig -f config.yaml --mode=no-reboot
-```
-
-Starting the interactive installer:
-
-```bash
-talosctl -n IP apply machineconfig --mode=interactive
 ```
 
 > Note: when a Talos node is running in the maintenance mode it's necessary to provide `--insecure (-i)` flag to connect to the API and apply the config.

--- a/website/content/v1.12/talos-guides/install/virtualized-platforms/vmware.md
+++ b/website/content/v1.12/talos-guides/install/virtualized-platforms/vmware.md
@@ -28,21 +28,20 @@ More information regarding virtual machine hardware versions can be found in the
 
 Using the VIP chosen in the prereq steps, we will now generate the base configuration files for the Talos machines.
 This can be done with the `talosctl gen config ...` command.
-Take note that we will also use a JSON6902 patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
+Take note that we will also use a machine configuration patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
 
 First, download `cp.patch.yaml` to your local machine and edit the VIP to match your chosen IP.
 You can do this by issuing: `curl -fsSLO https://raw.githubusercontent.com/siderolabs/talos/master/website/content/{{< version >}}/talos-guides/install/virtualized-platforms/vmware/cp.patch.yaml`.
 It's contents should look like the following:
 
 ```yaml
-- op: add
-  path: /machine/network
-  value:
+machine:
+  network:
     interfaces:
-      - interface: eth0
-        dhcp: true
-        vip:
-          ip: <VIP>
+    - interface: eth0
+      dhcp: true
+      vip:
+        ip: <VIP>
 ```
 
 With the patch in hand, generate machine configs with:


### PR DESCRIPTION
Deprecate by removing the most visible references in the documentation/code, but still support both internally.
