### PR TITLE
fix: stop returning EINVAL on remount of detached mounts

### DIFF
--- a/internal/pkg/mount/v3/point.go
+++ b/internal/pkg/mount/v3/point.go
@@ -259,7 +259,7 @@ func (p *Point) Root() xfs.Root {
 // RemountReadOnly remounts the mount point as read-only.
 func (p *Point) RemountReadOnly() error {
 	if p.detached {
-		return syscall.EINVAL
+		return nil
 	}
 
 	return p.setattr(&unix.MountAttr{


### PR DESCRIPTION
When RemountReadOnly was called on detached mount, it returned EINVAL.
This is not an expected behaviour.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
