### PR TITLE
fix: provide nocloud metadata with missing network config

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud.go
@@ -61,17 +61,19 @@ func (n *Nocloud) ParseMetadata(ctx context.Context, unmarshalledNetworkConfig *
 		err            error
 	)
 
-	switch unmarshalledNetworkConfig.Version {
-	case 1:
-		if needsReconcile, err = n.applyNetworkConfigV1(ctx, unmarshalledNetworkConfig, st, networkConfig); err != nil {
-			return nil, false, err
+	if unmarshalledNetworkConfig != nil {
+		switch unmarshalledNetworkConfig.Version {
+		case 1:
+			if needsReconcile, err = n.applyNetworkConfigV1(ctx, unmarshalledNetworkConfig, st, networkConfig); err != nil {
+				return nil, false, err
+			}
+		case 2:
+			if needsReconcile, err = n.applyNetworkConfigV2(ctx, unmarshalledNetworkConfig, st, networkConfig); err != nil {
+				return nil, false, err
+			}
+		default:
+			return nil, false, fmt.Errorf("network-config metadata version=%d is not supported", unmarshalledNetworkConfig.Version)
 		}
-	case 2:
-		if needsReconcile, err = n.applyNetworkConfigV2(ctx, unmarshalledNetworkConfig, st, networkConfig); err != nil {
-			return nil, false, err
-		}
-	default:
-		return nil, false, fmt.Errorf("network-config metadata version=%d is not supported", unmarshalledNetworkConfig.Version)
 	}
 
 	networkConfig.Metadata = &runtimeres.PlatformMetadataSpec{
@@ -141,14 +143,13 @@ func (n *Nocloud) NetworkConfiguration(ctx context.Context, st state.State, ch c
 		return err
 	}
 
-	if metadataNetworkConfigDl == nil {
-		// no data, use cached network configuration if available
-		return nil
-	}
+	var unmarshalledNetworkConfig *NetworkConfig
 
-	unmarshalledNetworkConfig, err := DecodeNetworkConfig(metadataNetworkConfigDl)
-	if err != nil {
-		return err
+	if metadataNetworkConfigDl != nil {
+		unmarshalledNetworkConfig, err = DecodeNetworkConfig(metadataNetworkConfigDl)
+		if err != nil {
+			return err
+		}
 	}
 
 	// do a loop to retry network config remap in case of missing links

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -243,3 +243,23 @@ https://metadataserver3/userdata
 		})
 	}
 }
+
+func TestEmptyNetworkConfig(t *testing.T) {
+	t.Parallel()
+
+	n := &nocloud.Nocloud{}
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var md nocloud.MetadataConfig
+
+	networkConfig, needsReconcile, err := n.ParseMetadata(t.Context(), nil, st, &md)
+	require.NoError(t, err)
+	assert.False(t, needsReconcile)
+
+	assert.Equal(t, &network.PlatformConfigSpec{
+		Metadata: &runtime.PlatformMetadataSpec{
+			Platform: "nocloud",
+		},
+	}, networkConfig)
+}


### PR DESCRIPTION
Even if network config is missing, provide metadata always.

This way `PlatformMetadata` resource is properly populated, even if it just contains the platform information.

See https://github.com/siderolabs/omni/discussions/1633#discussioncomment-14577048
