### PR TITLE
feat: add static registry to talosctl

### DIFF
--- a/cmd/talosctl/pkg/talos/artifacts/copy.go
+++ b/cmd/talosctl/pkg/talos/artifacts/copy.go
@@ -1,0 +1,208 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package artifacts
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/siderolabs/go-retry/retry"
+)
+
+// Mirror mirrors the given images to the destination registry.
+func Mirror(ctx context.Context, options []crane.Option, images []string, destRegistry string) error {
+	// TODO:
+	// - do not use crane, but puller/pusher directly
+	// - validate signatures on copy
+	// - rewrite signatures
+	for i, image := range images {
+		ref, err := name.ParseReference(image)
+		if err != nil {
+			return fmt.Errorf("error parsing image reference %q: %w", image, err)
+		}
+
+		registry := ref.Context().RegistryStr()
+		repo := ref.Context().RepositoryStr()
+		tag := extractTagAndDigest(image)
+
+		slog.Info("mirroring image",
+			"src", registry,
+			"dest", destRegistry,
+			"image", repo,
+			"tag", tag,
+			"progress", fmt.Sprintf("%d/%d", i+1, len(images)),
+		)
+
+		destRef, err := rewriteRegistry(ref, destRegistry)
+		if err != nil {
+			return fmt.Errorf("error rewriting registry for image %q: %w", image, err)
+		}
+
+		srcImage := ref.Name()
+		destImage := destRef.Name()
+
+		digest, err := copyManifest(ctx, options, srcImage, destImage)
+		if err != nil {
+			return fmt.Errorf("error mirroring image %d/%d (%q to %q): %w", i+1, len(images), srcImage, destImage, err)
+		}
+
+		srcSigRef, destSigRef, err := makeSignature(ref, digest, destRegistry)
+		if err != nil {
+			return fmt.Errorf("error getting signature for image %q (%d/%d): %w", srcImage, i+1, len(images), err)
+		}
+
+		srcSigRegistry := srcSigRef.Context().RegistryStr()
+		destSigRegistry := destSigRef.Context().RegistryStr()
+		sigRepo := srcSigRef.Context().RepositoryStr()
+		sigTag := extractTagAndDigest(srcSigRef.Name())
+
+		slog.Info("mirroring signature",
+			"src", srcSigRegistry,
+			"dest", destSigRegistry,
+			"image", sigRepo,
+			"tag", sigTag,
+			"progress", fmt.Sprintf("%d/%d", i+1, len(images)),
+		)
+
+		srcSig := srcSigRef.Name()
+		destSig := destSigRef.Name()
+
+		if _, err := copyManifest(ctx, options, srcSig, destSig); err != nil {
+			// We only log the error, not all images will have signatures
+			slog.Debug("error mirroring signature",
+				"error", err,
+				"src", srcSigRegistry,
+				"dest", destSigRegistry,
+				"image", sigRepo,
+				"tag", sigTag,
+				"progress", fmt.Sprintf("%d/%d", i+1, len(images)),
+			)
+		}
+	}
+
+	return nil
+}
+
+func extractTagAndDigest(image string) string {
+	// Find the repository/image separator
+	lastSlash := strings.LastIndex(image, "/")
+	if lastSlash == -1 {
+		lastSlash = -1
+	}
+
+	remainder := image[lastSlash+1:]
+
+	// Look for both tag and digest: name:tag@digest
+	if tagIdx := strings.Index(remainder, ":"); tagIdx != -1 {
+		if digestIdx := strings.Index(remainder, "@"); digestIdx != -1 {
+			// Both present: :tag@digest
+			return remainder[tagIdx:]
+		}
+		// Only tag: :tag
+		return remainder[tagIdx:]
+	}
+
+	// Only digest: @digest
+	if digestIdx := strings.Index(remainder, "@"); digestIdx != -1 {
+		return remainder[digestIdx:]
+	}
+
+	return ""
+}
+
+func rewriteRegistry(ref name.Reference, newRegistry string) (name.Reference, error) {
+	repo := ref.Context().RepositoryStr()
+
+	// Create new repository with the new registry
+	newRepo, err := name.NewRepository(newRegistry + "/" + repo)
+	if err != nil {
+		return nil, err
+	}
+
+	// Recreate the reference with the new repository
+	switch r := ref.(type) {
+	case name.Tag:
+		return name.NewTag(newRepo.String() + ":" + r.TagStr())
+	case name.Digest:
+		return name.NewDigest(newRepo.String() + "@" + r.DigestStr())
+	default:
+		return name.NewTag(newRepo.String() + ":latest")
+	}
+}
+
+func makeSignature(ref name.Reference, digest, destRegistry string) (name.Reference, name.Reference, error) {
+	sigTag := strings.ReplaceAll(digest, ":", "-") + ".sig"
+
+	// Create signature reference with the same repository but signature tag
+	repo := ref.Context()
+
+	srcSigRef, err := name.NewTag(repo.String() + ":" + sigTag)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	destSigRef, err := rewriteRegistry(srcSigRef, destRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return srcSigRef, destSigRef, nil
+}
+
+func copyManifest(ctx context.Context, options []crane.Option, src, dest string) (string, error) {
+	r := retry.Exponential(
+		30*time.Minute,
+		retry.WithUnits(time.Second),
+		retry.WithJitter(time.Second),
+		retry.WithErrorLogging(true),
+	)
+
+	isChecksum := strings.HasSuffix(src, ".sig")
+
+	var digest string
+
+	if err := r.RetryWithContext(
+		ctx, func(ctx context.Context) error {
+			options = append(options,
+				crane.WithContext(ctx),
+			)
+
+			srcByDigest := src
+
+			if !strings.Contains(src, "@sha256:") {
+				d, err := crane.Digest(src, options...)
+				if err != nil {
+					if isChecksum && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+						// Signatures are not available for all images, do not retry
+						return fmt.Errorf("signature not found for %s", src)
+					}
+
+					return retry.ExpectedError(err)
+				}
+
+				srcByDigest = fmt.Sprintf("%s@%s", src, d)
+			}
+
+			if err := crane.Copy(
+				srcByDigest, dest,
+				options...,
+			); err != nil {
+				return retry.ExpectedError(err)
+			}
+
+			digest = strings.Split(srcByDigest, "@")[1]
+
+			return nil
+		}); err != nil {
+		return digest, fmt.Errorf("error copying manifest: %w", err)
+	}
+
+	return digest, nil
+}

--- a/cmd/talosctl/pkg/talos/helpers/flags.go
+++ b/cmd/talosctl/pkg/talos/helpers/flags.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -50,18 +49,5 @@ func StringChoice(defaultValue string, otherChoices ...string) pflag.Value {
 
 			return fmt.Errorf("must be one of %v", choices)
 		},
-	}
-}
-
-// ChainCobraPositionalArgs chains multiple cobra.PositionalArgs validators together.
-func ChainCobraPositionalArgs(validators ...cobra.PositionalArgs) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		for _, validator := range validators {
-			if err := validator(cmd, args); err != nil {
-				return err
-			}
-		}
-
-		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/miekg/dns v1.1.68
 	github.com/nberlee/go-netstat v0.1.2
+	github.com/olareg/olareg v0.1.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/nberlee/go-netstat v0.1.2 h1:wgPV1YOUo+kDFypqiKgfxMtnSs1Wb42c7ahI4qyE
 github.com/nberlee/go-netstat v0.1.2/go.mod h1:GvDCRLsUKMRN1wULkt7tpnDmjSIE6YGf5zeVq+mBO64=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/olareg/olareg v0.1.2 h1:75G8X6E9FUlzL/CSjgFcYfMgNzlc7CxULpUUNsZBIvI=
+github.com/olareg/olareg v0.1.2/go.mod h1:TWs+N6pO1S4bdB6eerzUm/ITRQ6kw91mVf9ZYeGtw+Y=
 github.com/onsi/ginkgo/v2 v2.25.1 h1:Fwp6crTREKM+oA6Cz4MsO8RhKQzs2/gOIVOUscMAfZY=
 github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSDnFxK7Sk=
 github.com/onsi/gomega v1.38.1 h1:FaLA8GlcpXDwsb7m0h2A9ew2aTk3vnZMlzFgg5tz/pk=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -103,6 +103,17 @@ These fields were removed from the default machine configuration schema in v1.12
 etcd container image is now pulled from `registry.k8s.io/etcd` instead of `gcr.io/etcd-development/etcd`.
 """
 
+    [notes.talosctl]
+        title = "talosctl image registry create|serve"
+        description = """\
+talosctl includes two new subcommands `image registry create` and `image registry serve`.
+
+`talosctl image registry create` allows creating a local OCI image registry containing Talos images for speeding up installations, upgrades,
+and deployments in air-gapped environments.
+
+`talosctl image registry serve` allows serving the created OCI image registry over HTTP.
+It is a read-only registry, meaning images cannot be pushed to it, but the backing storage can be updated by re-running the `create` command.
+"""
 
 [make_deps]
 

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -181,6 +181,34 @@ func (suite *ImageSuite) TestCacheCreate() {
 	assert.FileExistsf(suite.T(), cacheDir+"/index.json", "index.json should exist in the image cache directory")
 }
 
+// TestRegistryCreate verifies creating a registry cache.
+func (suite *ImageSuite) TestRegistryCreate() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	stdOut, _ := suite.RunCLI([]string{"image", "source-bundle", "v1.11.2"})
+
+	imagesList := strings.Split(strings.Trim(stdOut, "\n"), "\n")
+
+	imagesArgs := xslices.Map(imagesList[:2], func(image string) string {
+		return "--images=" + image
+	})
+
+	storageDir := suite.T().TempDir()
+
+	args := []string{"image", "registry", "create", storageDir}
+
+	args = append(args, imagesArgs...)
+
+	suite.RunCLI(args, base.StdoutEmpty(), base.StderrNotEmpty())
+
+	assert.FileExistsf(suite.T(), storageDir+"pause/index.json", "pause/index.json should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"pause/oci-layout", "pause/oci-layout should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"siderolabs/kubelet/index.json", "siderolabs/kubelet/index.json should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"siderolabs/kubelet/oci-layout", "siderolabs/kubelet/oci-layout should exist in the image cache directory")
+}
+
 func init() {
 	allSuites = append(allSuites, new(ImageSuite))
 }

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -1980,6 +1980,113 @@ talosctl image pull <image> [flags]
 
 * [talosctl image](#talosctl-image)	 - Manage CRI container images
 
+## talosctl image registry create
+
+Create a local OCI from a list of images
+
+### Synopsis
+
+Create a local OCI from a list of images
+
+```
+talosctl image registry create <path> [flags]
+```
+
+### Examples
+
+```
+talosctl images registry create --images=ghcr.io/siderolabs/kubelet:v1.34.1 /tmp/registry
+
+Alternatively, stdin can be piped to the command:
+talosctl images source-bundle | talosctl images registry create /tmp/registry --images=-
+
+```
+
+### Options
+
+```
+      --debug            enable debug logging
+  -h, --help             help for create
+      --images strings   images to cache
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             Cluster to connect to if a proxy endpoint is used.
+      --context string             Context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+      --namespace system           namespace to use: system (etcd and kubelet images) or `cri` for all Kubernetes workloads (default "cri")
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl image registry](#talosctl-image-registry)	 - Commands for working with a local image registry
+
+## talosctl image registry serve
+
+Serve images from a local storage
+
+```
+talosctl image registry serve <path> [flags]
+```
+
+### Options
+
+```
+      --addr string            address to serve the registry on (default ":5000")
+  -h, --help                   help for serve
+      --tls-cert-file string   path to TLS certificate file
+      --tls-key-file string    path to TLS key file
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             Cluster to connect to if a proxy endpoint is used.
+      --context string             Context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+      --namespace system           namespace to use: system (etcd and kubelet images) or `cri` for all Kubernetes workloads (default "cri")
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl image registry](#talosctl-image-registry)	 - Commands for working with a local image registry
+
+## talosctl image registry
+
+Commands for working with a local image registry
+
+### Options
+
+```
+  -h, --help   help for registry
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             Cluster to connect to if a proxy endpoint is used.
+      --context string             Context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+      --namespace system           namespace to use: system (etcd and kubelet images) or `cri` for all Kubernetes workloads (default "cri")
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
+* [talosctl image registry create](#talosctl-image-registry-create)	 - Create a local OCI from a list of images
+* [talosctl image registry serve](#talosctl-image-registry-serve)	 - Serve images from a local storage
+
 ## talosctl image source-bundle
 
 List the source images used for building Talos
@@ -2034,6 +2141,7 @@ Manage CRI container images
 * [talosctl image default](#talosctl-image-default)	 - List the default images used by Talos
 * [talosctl image list](#talosctl-image-list)	 - List CRI images
 * [talosctl image pull](#talosctl-image-pull)	 - Pull an image into CRI
+* [talosctl image registry](#talosctl-image-registry)	 - Commands for working with a local image registry
 * [talosctl image source-bundle](#talosctl-image-source-bundle)	 - List the source images used for building Talos
 
 ## talosctl inject serviceaccount


### PR DESCRIPTION
`talosctl` includes two new subcommands `talosctl image registry create` and `talosctlimage registry serve`.

* `talosctl image registry create` allows creating a local OCI image registry containing Talos images for speeding up installations, upgrades, and deployments in air-gapped environments.

* `talosctl image registry serve` allows serving the created OCI image registry over HTTP. It is a read-only registry, meaning images cannot be pushed to it, but the backing storage can be updated by re-running the `create` command.

Fixes #11928
Fixes #11929

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>