### PR TITLE
feat: add disk.EnableUUID to generated ova

### DIFF
--- a/pkg/imager/ova/ova.go
+++ b/pkg/imager/ova/ova.go
@@ -133,6 +133,7 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
       <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
       <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="soft"/>
       <vmw:ExtraConfig ovf:required="false" vmw:key="nvram" vmw:value="talos.nvram"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.EnableUUID" vmw:value="true"/>
     </VirtualHardwareSection>
   </VirtualSystem>
 </Envelope>


### PR DESCRIPTION
This change adds the extra config `disk.EnableUIUD` to the generated OVA files. This flag is needed to be able to use VMware's CSI implementations.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Adds the `disk.EnableUUID` extra config flag to generated OVA files.
## Why? (reasoning)
This flag is required for VMware CSI (Cloud Storage Interface) implementations to function properly. When enabled, it ensures that disk UUIDs are exposed to the guest OS, which is necessary for persistent volume management in Kubernetes on vSphere environments.

See [VMware documentation](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/kubernetes-on-vsphere-with-kubeadm.html#:~:text=Virtual%20Machine%20Hardware%20requirements)
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
