### PR TITLE
fix: stop populating apiserver cert SANs

### DIFF
--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -192,3 +192,8 @@ func (contract *VersionContract) HideDisablePSP() bool {
 func (contract *VersionContract) HideRBACAndKeyUsage() bool {
 	return contract.Greater(TalosVersion1_11)
 }
+
+// PopulateClusterSANsFromEndpoint returns true if version of Talos should populate cluster SANs from ControlPlaneEndpoint.
+func (contract *VersionContract) PopulateClusterSANsFromEndpoint() bool {
+	return !contract.Greater(TalosVersion1_11)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -69,6 +69,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.MultidocNetworkConfigSupported())
 	assert.True(t, contract.HideDisablePSP())
 	assert.True(t, contract.HideRBACAndKeyUsage())
+	assert.False(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_12(t *testing.T) {
@@ -96,6 +97,7 @@ func TestContract1_12(t *testing.T) {
 	assert.True(t, contract.MultidocNetworkConfigSupported())
 	assert.True(t, contract.HideDisablePSP())
 	assert.True(t, contract.HideRBACAndKeyUsage())
+	assert.False(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_11(t *testing.T) {
@@ -123,6 +125,7 @@ func TestContract1_11(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_10(t *testing.T) {
@@ -150,6 +153,7 @@ func TestContract1_10(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_9(t *testing.T) {
@@ -177,6 +181,7 @@ func TestContract1_9(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_8(t *testing.T) {
@@ -204,6 +209,7 @@ func TestContract1_8(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_7(t *testing.T) {
@@ -231,6 +237,7 @@ func TestContract1_7(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_6(t *testing.T) {
@@ -258,6 +265,7 @@ func TestContract1_6(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_5(t *testing.T) {
@@ -285,6 +293,7 @@ func TestContract1_5(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_4(t *testing.T) {
@@ -312,6 +321,7 @@ func TestContract1_4(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -339,6 +349,7 @@ func TestContract1_3(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -366,6 +377,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -393,6 +405,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -420,4 +433,5 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.MultidocNetworkConfigSupported())
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
+	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
 }

--- a/pkg/machinery/config/generate/generate.go
+++ b/pkg/machinery/config/generate/generate.go
@@ -49,9 +49,11 @@ type Input struct {
 func (in *Input) GetAPIServerSANs() []string {
 	var list []string
 
-	endpointURL, err := url.Parse(in.ControlPlaneEndpoint)
-	if err == nil {
-		list = append(list, endpointURL.Hostname())
+	if in.Options.VersionContract.PopulateClusterSANsFromEndpoint() {
+		endpointURL, err := url.Parse(in.ControlPlaneEndpoint)
+		if err == nil {
+			list = append(list, endpointURL.Hostname())
+		}
 	}
 
 	list = append(list, in.AdditionalSubjectAltNames...)

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-controlplane.yaml
@@ -49,8 +49,6 @@ cluster:
         key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUlHVElBQjZZUzV0cFcrUnYxeDBPY09Jb1h0SXgzdGZteVFZNGxOWWRCbmpvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFQ3drbVVTUmtrbnlOc0NjTFJNUTlmZWx6cFY0dDdIdlNRcnp6ZGRvK2pWYmlqd2kwVVE1YQp0VW8vZkxQbDlBckVNOHNRWTVOSlgraVdxYjFkQWFXa2VnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
     apiServer:
         image: registry.k8s.io/kube-apiserver:v1.28.0
-        certSANs:
-            - base
         admissionControl:
             - name: PodSecurity
               configuration:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-controlplane.yaml
@@ -74,7 +74,6 @@ cluster:
     apiServer:
         image: registry.k8s.io/kube-apiserver:v1.28.0
         certSANs:
-            - base
             - foo
             - bar
         admissionControl:


### PR DESCRIPTION
This affects machine config generation 1.12+: Talos for a long time automatically pushes controlplane endpoint hostname into certificate SANs, there is no reason to populate this field in the machine config.
