### PR TITLE
feat: add --airgapped flag to talosctl cluster create

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-16T09:22:23Z by kres 7a9d88c.
+# Generated on 2025-10-22T12:39:45Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -625,6 +625,20 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
+      - name: integration-images-list
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make integration-images-list
+      - name: e2e-airgapped-no-proxy
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-no-proxy
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          WITH_AIRGAPPED: no-proxy
+          WITH_CLUSTER_DISCOVERY: "false"
+        run: |
+          sudo -E make e2e-qemu
       - name: e2e-airgapped-http-proxy
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-http-proxy

--- a/.github/workflows/integration-airgapped-cron.yaml
+++ b/.github/workflows/integration-airgapped-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-01T17:01:09Z by kres bc281a9.
+# Generated on 2025-10-22T12:39:45Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -77,6 +77,20 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           make talosctl-cni-bundle
+      - name: integration-images-list
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make integration-images-list
+      - name: e2e-airgapped-no-proxy
+        env:
+          GITHUB_STEP_NAME: ${{ github.job}}-e2e-no-proxy
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          WITH_AIRGAPPED: no-proxy
+          WITH_CLUSTER_DISCOVERY: "false"
+        run: |
+          sudo -E make e2e-qemu
       - name: e2e-airgapped-http-proxy
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-http-proxy

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -998,6 +998,19 @@ spec:
         - name: talosctl-cni-bundle
           conditions:
             - only-on-schedule
+        - name: integration-images-list
+          command: integration-images-list
+          environment:
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: e2e-airgapped-no-proxy
+          command: e2e-qemu
+          withSudo: true
+          environment:
+            GITHUB_STEP_NAME: ${{ github.job}}-e2e-no-proxy
+            SHORT_INTEGRATION_TEST: yes
+            WITH_AIRGAPPED: no-proxy
+            WITH_CLUSTER_DISCOVERY: "false"
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-airgapped-http-proxy
           command: e2e-qemu
           withSudo: true

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -140,6 +140,11 @@ type Qemu struct {
 	DebugShellEnabled         bool
 	WithIOMMU                 bool
 	ConfigInjectionMethod     string
+	Airgapped                 bool
+	ImageCachePath            string
+	ImageCacheTLSCertFile     string
+	ImageCacheTLSKeyFile      string
+	ImageCachePort            uint16
 }
 
 // GetCommon returns the default common options.
@@ -181,7 +186,7 @@ func GetQemu() Qemu {
 		PreallocateDisks:  false,
 		BootloaderEnabled: true,
 		UefiEnabled:       true,
-		Nameservers:       []string{"8.8.8.8", "1.1.1.1", "2001:4860:4860::8888", "2606:4700:4700::1111"},
+		Nameservers:       []string{},
 		DiskBlockSize:     512,
 		TargetArch:        runtime.GOARCH,
 		CniBinPath:        []string{filepath.Join(clustercmd.DefaultCNIDir, "bin")},
@@ -189,7 +194,8 @@ func GetQemu() Qemu {
 		CniCacheDir:       filepath.Join(clustercmd.DefaultCNIDir, "cache"),
 		CniBundleURL: fmt.Sprintf("https://github.com/%s/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz",
 			images.Username, version.Trim(version.Tag), constants.ArchVariable),
-		Disks: disks,
+		Disks:          disks,
+		ImageCachePort: 5000,
 	}
 }
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -98,6 +98,11 @@ func getCreateCmd() *cobra.Command {
 		withUUIDHostnamesFlag         = "with-uuid-hostnames"
 		withSiderolinkAgentFlag       = "with-siderolink"
 		configInjectionMethodFlag     = "config-injection-method"
+		airgappedFlag                 = "airgapped"
+		imageCachePathFlag            = "image-cache-path"
+		imageCacheTLSCertFileFlag     = "image-cache-tls-cert-file"
+		imageCacheTLSKeyFileFlag      = "image-cache-tls-key-file"
+		imageCachePortFlag            = "image-cache-port"
 
 		// The following flags are the gen options - the options that are only used in machine configuration (i.e., not during the qemu/docker provisioning).
 		// They are not applicable when no machine configuration is generated, hence mutually exclusive with the --input-dir flag.
@@ -131,6 +136,7 @@ func getCreateCmd() *cobra.Command {
 		packetReorderFlag,
 		packetCorruptFlag,
 		bandwidthFlag,
+		airgappedFlag,
 
 		// The following might work but need testing first.
 		configInjectionMethodFlag,
@@ -209,7 +215,7 @@ func getCreateCmd() *cobra.Command {
 		qemu.MarkHidden("with-debug-shell") //nolint:errcheck
 		qemu.StringSliceVar(&qOps.ExtraUEFISearchPaths, extraUEFISearchPathsFlag, qOps.ExtraUEFISearchPaths, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 		qemu.StringSliceVar(&qOps.NetworkNoMasqueradeCIDRs, networkNoMasqueradeCIDRsFlag, qOps.NetworkNoMasqueradeCIDRs, "list of CIDRs to exclude from NAT")
-		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use")
+		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use, by default use embedded DNS forwarder")
 		qemu.UintVar(&qOps.DiskBlockSize, diskBlockSizeFlag, qOps.DiskBlockSize, "disk block size")
 		qemu.StringVar(&qOps.TargetArch, targetArchFlag, qOps.TargetArch, "cluster architecture")
 		qemu.StringSliceVar(&qOps.CniBinPath, cniBinPathFlag, qOps.CniBinPath, "search path for CNI binaries")
@@ -239,6 +245,11 @@ func getCreateCmd() *cobra.Command {
 			"enables the use of siderolink agent as configuration apply mechanism. `true` or `wireguard` enables the agent, `tunnel` enables the agent with grpc tunneling")
 		qemu.StringVar(&qOps.ConfigInjectionMethod,
 			configInjectionMethodFlag, qOps.ConfigInjectionMethod, "a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO")
+		qemu.BoolVar(&qOps.Airgapped, airgappedFlag, qOps.Airgapped, "limit VM network access to the provisioning network only")
+		qemu.StringVar(&qOps.ImageCachePath, imageCachePathFlag, qOps.ImageCachePath, "path to image cache")
+		qemu.StringVar(&qOps.ImageCacheTLSCertFile, imageCacheTLSCertFileFlag, qOps.ImageCacheTLSCertFile, "path to image cache TLS cert")
+		qemu.StringVar(&qOps.ImageCacheTLSKeyFile, imageCacheTLSKeyFileFlag, qOps.ImageCacheTLSKeyFile, "path to image cache TLS key")
+		qemu.Uint16Var(&qOps.ImageCachePort, imageCachePortFlag, qOps.ImageCachePort, "port on which to serve image cache")
 
 		return qemu
 	}

--- a/cmd/talosctl/cmd/mgmt/dhcpd_launch.go
+++ b/cmd/talosctl/cmd/mgmt/dhcpd_launch.go
@@ -33,7 +33,7 @@ var dhcpdLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var ips []net.IP
 
-		for _, ip := range strings.Split(dhcpdLaunchCmdFlags.addr, ",") {
+		for ip := range strings.SplitSeq(dhcpdLaunchCmdFlags.addr, ",") {
 			ips = append(ips, net.ParseIP(ip))
 		}
 

--- a/cmd/talosctl/cmd/mgmt/dnsd_launch.go
+++ b/cmd/talosctl/cmd/mgmt/dnsd_launch.go
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build linux || darwin
+
+package mgmt
+
+import (
+	"net"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/talos/pkg/provision/providers/vm"
+)
+
+var dnsdLaunchCmdFlags struct {
+	addr       string
+	resolvConf string
+}
+
+// dnsdLaunchCmd represents the dnsd-launch command.
+var dnsdLaunchCmd = &cobra.Command{
+	Use:    "dnsd-launch",
+	Short:  "Internal command used by VM provisioners",
+	Long:   ``,
+	Args:   cobra.NoArgs,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var ips []net.IP
+
+		for ip := range strings.SplitSeq(dnsdLaunchCmdFlags.addr, ",") {
+			ips = append(ips, net.ParseIP(ip))
+		}
+
+		var eg errgroup.Group
+
+		eg.Go(func() error {
+			return vm.DNSd(ips, dnsdLaunchCmdFlags.resolvConf)
+		})
+
+		return eg.Wait()
+	},
+}
+
+func init() {
+	dnsdLaunchCmd.Flags().StringVar(&dnsdLaunchCmdFlags.addr, "addr", "localhost:53", "IP addresses to listen on")
+	dnsdLaunchCmd.Flags().StringVar(&dnsdLaunchCmdFlags.resolvConf, "resolv-conf", "/etc/resolv.conf", "path to resolv file")
+	addCommand(dnsdLaunchCmd)
+}

--- a/cmd/talosctl/pkg/mgmt/helpers/airgapped.go
+++ b/cmd/talosctl/pkg/mgmt/helpers/airgapped.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	stdx509 "crypto/x509"
+	"net"
+
+	"github.com/siderolabs/crypto/x509"
+)
+
+// GenerateSelfSignedCert generates self-signed certificate.
+func GenerateSelfSignedCert(sanIPs []net.IP) ([]byte, []byte, []byte, error) {
+	ca, err := x509.NewSelfSignedCertificateAuthority(x509.ECDSA(true))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	serverIdentity, err := x509.NewKeyPair(ca,
+		x509.Organization("test"),
+		x509.CommonName("server"),
+		x509.IPAddresses(sanIPs),
+		x509.ExtKeyUsage([]stdx509.ExtKeyUsage{stdx509.ExtKeyUsageServerAuth}),
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return ca.CrtPEM, serverIdentity.CrtPEM, serverIdentity.KeyPEM, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -238,6 +238,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dnstap/golang-dnstap v0.4.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -245,6 +246,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
+	github.com/farsightsec/golang-framestream v0.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
+github.com/dnstap/golang-dnstap v0.4.0 h1:KRHBoURygdGtBjDI2w4HifJfMAhhOqDuktAokaSa234=
+github.com/dnstap/golang-dnstap v0.4.0/go.mod h1:FqsSdH58NAmkAvKcpyxht7i4FoBjKu8E4JUPt8ipSUs=
 github.com/docker/cli v28.4.0+incompatible h1:RBcf3Kjw2pMtwui5V0DIMdyeab8glEw5QY0UUU4C9kY=
 github.com/docker/cli v28.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
@@ -207,6 +209,8 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
+github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
+github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -478,6 +482,7 @@ github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
 github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
+github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.68 h1:jsSRkNozw7G/mnmXULynzMNIsgY2dHC8LO6U6Ij2JEA=
 github.com/miekg/dns v1.1.68/go.mod h1:fujopn7TB3Pu3JM69XaawiU0wqjpL9/8xGop5UrTPps=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
@@ -822,6 +827,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -867,6 +873,7 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -935,6 +942,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -264,30 +264,39 @@ case "${WITH_ENFORCING:-false}" in
 esac
 
 case "${WITH_AIRGAPPED:-false}" in
+  no-proxy)
+    INSTALLER_IMAGE="${INSTALLER_IMAGE/registry.dev.siderolabs.io/172.20.1.1:5000}"
+
+    QEMU_FLAGS+=("--config-patch=@hack/test/patches/airgapped-timesync.yaml")
+    QEMU_FLAGS+=("--config-patch=@${TMP}/image-cache-patch.yaml")
+    QEMU_FLAGS+=("--airgapped")
+    QEMU_FLAGS+=("--image-cache-path=${TMP}/image-cache")
+    QEMU_FLAGS+=("--image-cache-tls-cert-file=${TMP}/image-cache-tls.crt")
+    QEMU_FLAGS+=("--image-cache-tls-key-file=${TMP}/image-cache-tls.key")
+    ;;
   http-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 >/tmp/airgapped.log 2>&1 &
+    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 > /tmp/airgapped.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
-    mv air-gapped-patch.yaml /tmp/air-gapped-patch.yaml
+    mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"
 
-    QEMU_FLAGS+=("--config-patch=@/tmp/air-gapped-patch.yaml")
+    QEMU_FLAGS+=("--config-patch=@${TMP}/air-gapped-patch.yaml")
     ;;
   secure-http-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --use-secure-proxy >/tmp/airgapped-secure.log 2>&1 &
+    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --use-secure-proxy > /tmp/airgapped-secure.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
-    mv air-gapped-patch.yaml /tmp/air-gapped-patch.yaml
+    mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"
 
-    QEMU_FLAGS+=("--config-patch=@/tmp/air-gapped-patch.yaml")
+    QEMU_FLAGS+=("--config-patch=@${TMP}/air-gapped-patch.yaml")
     ;;
   https-reverse-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --inject-http-proxy=false --https-reverse-proxy-target=https://registry.dev.siderolabs.io >/tmp/airgapped-reverse-proxy.log 2>&1 &
+    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --inject-http-proxy=false --https-reverse-proxy-target=https://registry.dev.siderolabs.io > /tmp/airgapped-reverse-proxy.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
-    mv air-gapped-patch.yaml /tmp/air-gapped-patch.yaml
+    mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"
 
-    QEMU_FLAGS+=("--config-patch=@/tmp/air-gapped-patch.yaml")
-    QEMU_FLAGS+=("--config-patch=@hack/test/patches/proxied-registry.yaml")
+    QEMU_FLAGS+=("--config-patch=@${TMP}/air-gapped-patch.yaml")
     ;;
   false)
     ;;

--- a/hack/test/patches/airgapped-timesync.yaml
+++ b/hack/test/patches/airgapped-timesync.yaml
@@ -1,0 +1,4 @@
+machine:
+  time:
+    servers:
+      - /dev/ptp0

--- a/internal/integration/api/common.go
+++ b/internal/integration/api/common.go
@@ -101,6 +101,10 @@ file locks                      (-x) unlimited
 
 // TestDNSResolver verifies that external DNS resolving works from a pod.
 func (suite *CommonSuite) TestDNSResolver() {
+	if suite.Airgapped {
+		suite.T().Skip("skipping test in airgapped mode")
+	}
+
 	if suite.Cluster != nil {
 		// cluster should be healthy for kube-dns resolving to work
 		suite.AssertClusterHealthy(suite.ctx)

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -60,6 +60,8 @@ type TalosSuite struct {
 	CSITestName string
 	// CSITestTimeout is the timeout for the CSI test
 	CSITestTimeout string
+	// Airgapped marks that cluster has no access to external networks
+	Airgapped bool
 
 	discoveredNodes cluster.Info
 }

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -134,7 +134,7 @@ func (suite *ImageSuite) TestList() {
 
 // TestPull verifies pulling images to the CRI.
 func (suite *ImageSuite) TestPull() {
-	const image = "registry.k8s.io/kube-apiserver:v1.27.0"
+	const image = "registry.k8s.io/kube-apiserver:v1.27.0" // sync this to e2e.sh `build_image_cache`
 
 	node := suite.RandomDiscoveredNodeInternalIP()
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -40,6 +40,7 @@ var (
 	extensionsQEMU   bool
 	extensionsNvidia bool
 	verifyUKIBooted  bool
+	airgapped        bool
 
 	talosConfig       string
 	endpoint          string
@@ -116,6 +117,7 @@ func TestIntegration(t *testing.T) {
 				TalosImage:       talosImage,
 				CSITestName:      csiTestName,
 				CSITestTimeout:   csiTestTimeout,
+				Airgapped:        airgapped,
 			})
 		}
 
@@ -175,6 +177,7 @@ func init() {
 	flag.StringVar(&talosImage, "talos.image", images.DefaultTalosImageRepository, "The default 'talos' container image")
 	flag.StringVar(&csiTestName, "talos.csi", "", "CSI test to run")
 	flag.StringVar(&csiTestTimeout, "talos.csi.timeout", "15m", "CSI test timeout")
+	flag.BoolVar(&airgapped, "talos.airgapped", false, "Marker to skip tests that should not be run on airgapped talos cluster")
 
 	flag.StringVar(&provision_test.DefaultSettings.CIDR, "talos.provision.cidr", provision_test.DefaultSettings.CIDR, "CIDR to use to provision clusters (provision tests only)")
 	flag.Var(&provision_test.DefaultSettings.RegistryMirrors, "talos.provision.registry-mirror", "registry mirrors to use (provision tests only)")

--- a/pkg/imager/cache/cache.go
+++ b/pkg/imager/cache/cache.go
@@ -8,6 +8,7 @@ package cache
 import (
 	"cmp"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -122,7 +123,13 @@ func Generate(images []string, platforms []string, insecure bool, imageLayerCach
 
 			err := r.Retry(func() error {
 				if err := processImage(src, tmpDir, imageLayerCachePath, nameOptions, craneOpts, remoteOpts); err != nil {
-					return retry.ExpectedError(err)
+					switch {
+					case errors.Is(err, new(name.ErrBadName)):
+						return err
+
+					default:
+						return retry.ExpectedError(err)
+					}
 				}
 
 				return nil

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -28,9 +28,13 @@ var (
 	// DefaultInstallerImage is the default installer image.
 	DefaultInstallerImage = DefaultInstallerImageRepository + ":" + version.Tag
 
+	// DefaultTalosImageName is the default container image name for
+	// the talos image.
+	DefaultTalosImageName = Username + "/talos"
+
 	// DefaultTalosImageRepository is the default container repository for
 	// the talos image.
-	DefaultTalosImageRepository = Registry + "/" + Username + "/talos"
+	DefaultTalosImageRepository = Registry + "/" + DefaultTalosImageName
 
 	// DefaultTalosImage is the default talos image.
 	DefaultTalosImage = DefaultTalosImageRepository + ":" + version.Tag

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -70,6 +70,20 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		return nil, fmt.Errorf("error creating loadbalancer: %w", err)
 	}
 
+	fmt.Fprintln(options.LogWriter, "creating dnsd")
+
+	if err = p.CreateDNSd(state, request); err != nil {
+		return nil, fmt.Errorf("error creating dnsd: %w", err)
+	}
+
+	if request.Network.ImageCachePath != "" {
+		fmt.Fprintln(options.LogWriter, "creating image cache")
+
+		if err = p.CreateImageCache(state, request); err != nil {
+			return nil, fmt.Errorf("error creating image cache: %w", err)
+		}
+	}
+
 	if options.KMSEndpoint != "" {
 		fmt.Fprintln(options.LogWriter, "creating KMS server")
 

--- a/pkg/provision/providers/qemu/destroy.go
+++ b/pkg/provision/providers/qemu/destroy.go
@@ -71,6 +71,18 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return fmt.Errorf("error stopping dhcpd: %w", err)
 	}
 
+	fmt.Fprintln(options.LogWriter, "removing image cache")
+
+	if err = p.DestroyImageCache(state); err != nil {
+		return fmt.Errorf("error stopping image cache: %w", err)
+	}
+
+	fmt.Fprintln(options.LogWriter, "removing dnsd")
+
+	if err := p.DestroyDNSd(state); err != nil {
+		return fmt.Errorf("error stopping dnsd: %w", err)
+	}
+
 	fmt.Fprintln(options.LogWriter, "removing load balancer")
 
 	if err := p.DestroyLoadBalancer(state); err != nil {

--- a/pkg/provision/providers/vm/dnsd.go
+++ b/pkg/provision/providers/vm/dnsd.go
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+
+	"github.com/miekg/dns"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+// DNSd entrypoint.
+func DNSd(ips []net.IP, resolvConfPath string) error {
+	var eg errgroup.Group
+
+	config, err := dns.ClientConfigFromFile(resolvConfPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %q: %v", resolvConfPath, err)
+	}
+
+	initLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
+	defer initLog.Info("bye")
+
+	dnsServe := func(ip net.IP, mode string) error {
+		addr := net.JoinHostPort(ip.String(), "53")
+
+		log := initLog.With("mode", mode, "addr", addr)
+
+		server := &dns.Server{
+			Addr:    addr,
+			Net:     mode,
+			Handler: dns.HandlerFunc(forwardHandler(mode, log, config)),
+		}
+
+		log.Info("starting DNS forwarder server")
+
+		return server.ListenAndServe()
+	}
+
+	for _, ip := range ips {
+		eg.Go(func() error {
+			return dnsServe(ip, "udp")
+		})
+
+		eg.Go(func() error {
+			return dnsServe(ip, "tcp")
+		})
+	}
+
+	return eg.Wait()
+}
+
+const (
+	dnsPid = "dnsd.pid"
+	dnsLog = "dnsd.log"
+)
+
+// CreateDNSd creates the DNSd server.
+func (p *Provisioner) CreateDNSd(state *State, clusterReq provision.ClusterRequest) error {
+	return p.startDNSd(state, clusterReq)
+}
+
+// DestroyDNSd destoys DNSd server.
+func (p *Provisioner) DestroyDNSd(state *State) error {
+	return p.stopDNSd(state)
+}
+
+func forwardHandler(mode string, log *slog.Logger, config *dns.ClientConfig) func(w dns.ResponseWriter, r *dns.Msg) {
+	return func(w dns.ResponseWriter, r *dns.Msg) {
+		slog.Debug("handling DNS request", "request", r.String())
+
+		c := new(dns.Client)
+		c.Net = mode
+
+		var (
+			resp *dns.Msg
+			err  error
+		)
+
+		for _, serverAddr := range config.Servers {
+			log.Debug("making DNS request", "target", serverAddr+":"+config.Port)
+
+			resp, _, err = c.Exchange(r, net.JoinHostPort(serverAddr, config.Port))
+			if err != nil {
+				log.Debug("DNS request failed", "error", err)
+
+				continue
+			}
+
+			if resp != nil && (resp.Rcode == dns.RcodeServerFailure || resp.Rcode == dns.RcodeRefused) {
+				log.Debug("DNS request succeeded, but RCODE reports failure", "response", resp.String())
+
+				continue
+			}
+
+			break
+		}
+
+		if resp == nil {
+			log.Error("DNS exchange failed", "error", err)
+			dns.HandleFailed(w, r)
+
+			return
+		}
+
+		log.Debug("writing DNS response", "response", resp.String())
+
+		if err := w.WriteMsg(resp); err != nil {
+			log.Error("failed to write response", "error", err)
+		}
+	}
+}

--- a/pkg/provision/providers/vm/dnsd_darwin.go
+++ b/pkg/provision/providers/vm/dnsd_darwin.go
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+func (p *Provisioner) startDNSd(_ *State, _ provision.ClusterRequest) error {
+	return nil
+}
+
+func (p *Provisioner) stopDNSd(_ *State) error {
+	return nil
+}

--- a/pkg/provision/providers/vm/dnsd_linux.go
+++ b/pkg/provision/providers/vm/dnsd_linux.go
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+func (p *Provisioner) startDNSd(state *State, clusterReq provision.ClusterRequest) error {
+	pidPath := state.GetRelativePath(dnsPid)
+
+	logFile, err := os.OpenFile(state.GetRelativePath(dnsLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return err
+	}
+
+	defer logFile.Close() //nolint:errcheck
+
+	gatewayAddrs := xslices.Map(clusterReq.Network.GatewayAddrs, netip.Addr.String)
+
+	args := []string{
+		"dnsd-launch",
+		"--addr", strings.Join(gatewayAddrs, ","),
+		"--resolv-conf", "/etc/resolv.conf",
+	}
+
+	cmd := exec.Command(clusterReq.SelfExecutable, args...) //nolint:noctx // runs in background
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // daemonize
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing dns PID file: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Provisioner) stopDNSd(state *State) error {
+	pidPath := state.GetRelativePath(dnsPid)
+
+	return StopProcessByPidfile(pidPath)
+}

--- a/pkg/provision/providers/vm/image_cache.go
+++ b/pkg/provision/providers/vm/image_cache.go
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+const (
+	imageCachePid = "image-cache.pid"
+	imageCacheLog = "image-cache.log"
+)
+
+// CreateImageCache creates the Image Cache server.
+func (p *Provisioner) CreateImageCache(state *State, clusterReq provision.ClusterRequest) error {
+	pidPath := state.GetRelativePath(imageCachePid)
+
+	logFile, err := os.OpenFile(state.GetRelativePath(imageCacheLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return err
+	}
+
+	defer logFile.Close() //nolint:errcheck
+
+	gatewayAddrs := xslices.Map(clusterReq.Network.GatewayAddrs, netip.Addr.String)
+	gatewayAddrs = xslices.Map(gatewayAddrs, func(s string) string { return net.JoinHostPort(s, fmt.Sprint(clusterReq.Network.ImageCachePort)) })
+
+	args := []string{
+		"image", "cache-serve",
+		"--address", gatewayAddrs[0],
+		"--image-cache-path", clusterReq.Network.ImageCachePath,
+		"--tls-cert-file", clusterReq.Network.ImageCacheTLSCertFile,
+		"--tls-key-file", clusterReq.Network.ImageCacheTLSKeyFile,
+	}
+
+	cmd := exec.Command(clusterReq.SelfExecutable, args...) //nolint:noctx // runs in background
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // daemonize
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing imageCache PID file: %w", err)
+	}
+
+	return nil
+}
+
+// DestroyImageCache destoys Image Cache server.
+func (p *Provisioner) DestroyImageCache(state *State) error {
+	pidPath := state.GetRelativePath(imageCachePid)
+
+	return StopProcessByPidfile(pidPath)
+}

--- a/pkg/provision/providers/vm/network_linux.go
+++ b/pkg/provision/providers/vm/network_linux.go
@@ -52,10 +52,12 @@ func (p *Provisioner) CreateNetwork(ctx context.Context, state *State, network p
 		NetworkName   string
 		InterfaceName string
 		MTU           string
+		IPMasquerade  bool
 	}{
 		NetworkName:   network.Name,
 		InterfaceName: state.BridgeName,
 		MTU:           strconv.Itoa(network.MTU),
+		IPMasquerade:  !network.Airgapped,
 	})
 	if err != nil {
 		return fmt.Errorf("error templating bridge CNI config: %w", err)
@@ -124,10 +126,12 @@ func (p *Provisioner) CreateNetwork(ctx context.Context, state *State, network p
 		NetworkName   string
 		InterfaceName string
 		MTU           string
+		IPMasquerade  bool
 	}{
 		NetworkName:   network.Name,
 		InterfaceName: state.BridgeName,
 		MTU:           strconv.Itoa(network.MTU),
+		IPMasquerade:  !network.Airgapped,
 	})
 	if err != nil {
 		return fmt.Errorf("error templating VM CNI config: %w", err)
@@ -368,7 +372,7 @@ const bridgeTemplate = `
 	"cniVersion": "0.4.0",
 	"type": "bridge",
 	"bridge": "{{ .InterfaceName }}",
-	"ipMasq": true,
+	"ipMasq": {{ .IPMasquerade }},
 	"isGateway": true,
 	"isDefaultGateway": true,
 	"ipam": {
@@ -386,7 +390,7 @@ const networkTemplate = `
 		{
 			"type": "bridge",
 			"bridge": "{{ .InterfaceName }}",
-			"ipMasq": true,
+			"ipMasq": {{ .IPMasquerade }},
 			"isGateway": true,
 			"isDefaultGateway": true,
 			"ipam": {

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -87,6 +87,13 @@ type NetworkRequest struct {
 	PacketReorder float64
 	PacketCorrupt float64
 	Bandwidth     int
+
+	// Airgapped limits VM network access to the provisioning network only (qemu/linux).
+	Airgapped             bool
+	ImageCachePath        string
+	ImageCacheTLSCertFile string
+	ImageCacheTLSKeyFile  string
+	ImageCachePort        uint16
 }
 
 // NodeRequests is a list of NodeRequest.

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -225,6 +225,7 @@ talosctl cluster create [flags]
 ### Options
 
 ```
+      --airgapped                                limit VM network access to the provisioning network only
       --arch string                              cluster architecture (default "amd64")
       --bad-rtc                                  launch VM with bad RTC state
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
@@ -258,6 +259,10 @@ talosctl cluster create [flags]
       --extra-disks-size int                     default limit on disk size in MB (each VM) (default 5120)
       --extra-uefi-search-paths strings          additional search paths for UEFI firmware (only applies when UEFI is enabled)
   -h, --help                                     help for create
+      --image-cache-path string                  path to image cache
+      --image-cache-port uint16                  port on which to serve image cache (default 5000)
+      --image-cache-tls-cert-file string         path to image cache TLS cert
+      --image-cache-tls-key-file string          path to image cache TLS key
       --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
       --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
       --install-image string                     the installer image to use (default "ghcr.io/siderolabs/installer:latest")
@@ -270,7 +275,7 @@ talosctl cluster create [flags]
       --memory string(mb,gb)                     the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mtu int                                  MTU of the cluster network (default 1500)
-      --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
+      --nameservers strings                      list of nameservers to use, by default use embedded DNS forwarder
       --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT
       --omni-api-endpoint string                 the Omni API endpoint (must include a scheme, a port and a join token)
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
@@ -1855,6 +1860,44 @@ talosctl health [flags]
 
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 
+## talosctl image cache-cert-gen
+
+Generate TLS certificates and CA patch required for securing image cache to Talos communication
+
+### Synopsis
+
+Generate TLS certificates and CA patch required for securing image cache to Talos communication
+
+```
+talosctl image cache-cert-gen [flags]
+```
+
+### Options
+
+```
+      --advertised-address ipSlice   The address to advertise to the cluster. (default [])
+  -h, --help                         help for cache-cert-gen
+      --tls-ca-file string           TLS certificate authority file (default "ca.crt")
+      --tls-cert-file string         TLS certificate file to use for serving (default "tls.crt")
+      --tls-key-file string          TLS key file to use for serving (default "tls.key")
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             Cluster to connect to if a proxy endpoint is used.
+      --context string             Context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+      --namespace system           namespace to use: system (etcd and kubelet images) or `cri` for all Kubernetes workloads (default "cri")
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
+
 ## talosctl image cache-create
 
 Create a cache of images in OCI format into a directory
@@ -2085,6 +2128,7 @@ Manage CRI container images
 ### SEE ALSO
 
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
+* [talosctl image cache-cert-gen](#talosctl-image-cache-cert-gen)	 - Generate TLS certificates and CA patch required for securing image cache to Talos communication
 * [talosctl image cache-create](#talosctl-image-cache-create)	 - Create a cache of images in OCI format into a directory
 * [talosctl image cache-serve](#talosctl-image-cache-serve)	 - Serve an OCI image cache directory over HTTP(S) as a container registry
 * [talosctl image default](#talosctl-image-default)	 - List the default images used by Talos


### PR DESCRIPTION
Add new `--airgapped` flag to talos cluster create (qemu)
to disable NAT in the VMs to effectively become airgapped.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>

---

1. Generating minimal image cache can be done using following chain of commands:
    ```bash
    talosctl images default |\
      talosctl images cache-create --images=- --image-cache-path=/tmp/cache --layout=flat
    ```

1. Additionally, it needs a set of certificates. You can generate them (and required patch) using the following command:
    ```bash
    talosctl image cache-cert-gen --advertise-address=172.20.0.1 \
      --tls-ca-file=/tmp/ca.crt \
      --tls-cert-file=/tmp/tls.crt \
      --tls-key-file=/tmp/tls.key
    ```

1. After that you can start a cluster using the following command. There is no need to launch the image-cache manually, it's handled once `--image-cache-path` is passed. The directory must exist, and must contain image cache with flat layout.
    ```bash
    sudo --preserve-env=HOME talosctl cluster create \
      --with-cluster-discovery=false --provisioner=qemu \
      --cidr=172.20.0.0/24 \
      --install-image="172.20.0.1:12000/siderolabs/installer:${TALOS_VERSION}" \
      --controlplanes 3 \
      --workers 2 \
      --with-bootloader=false \
      --disk-preallocate=false \
      --with-cluster-discovery=false \
      --airgapped \
      --config-patch='@hack/test/patches/airgapped-timesync.yaml' \
      --config-patch='@image-cache-patch.yaml' \
      --image-cache-path=/tmp/cache \
      --image-cache-tls-cert-file=/tmp/tls.crt \
      --image-cache-tls-key-file=/tmp/tls.key \
      --image-cache-port=12000 \
      --registry-mirror=docker.io=https://172.20.0.1:12000 \
      --registry-mirror=registry.k8s.io=https://172.20.0.1:12000 \
      --registry-mirror=gcr.io=https://172.20.0.1:12000 \
      --registry-mirror=ghcr.io=https://172.20.0.1:12000
    ```

---

Patches explained:

1. `image-cache-patch.yaml` - Talos requires HTTPS to pull installer image. In airgapped setups, images are hosted in an internal OCI registry using a self-signed or private TLS certificate. Because Talos does not trust this certificate by default, it will fail with `x509: certificate signed by unknown authority`. This patch adds the certificate of private registry to Talos trusted CAs so it can securely pull images.
    ```yaml
    apiVersion: v1alpha1
    kind: TrustedRootsConfig
    name: image-cache-ca
    certificates: |
      -----BEGIN CERTIFICATE-----
      ...
      -----END CERTIFICATE-----
    ```

3. `airgapped-timesync.yaml` - Talos uses time.cloudflare.com by default for NTP. In airgapped environments there is no internet access, which means NTP sync fails and time drifts. That breaks TLS validation and can block Talos bootstrap. This patch replaces the public NTP server with a local time source like `/dev/ptp0` (bare metal/QEMU) or an internal NTP server.
    ```yaml
    machine:
      time:
        servers:
          - /dev/ptp0 # or internal NTP server
    ```

4. `registry-mirror` - Talos and Kubernetes components normally pull images from public registries like `docker.io`, `ghcr.io`, and `registry.k8s.io`. These are unreachable in airgapped environments. This patch tells Talos to redirect all image pulls to local registry mirror at `https://172.20.0.1:12000`. This is the same registry as the one hosting installer image, thus we need to specify HTTPS and not HTTP as it's often showed in Talos docs.
    ```yaml
    machine:
      registries:
        mirrors:
          docker.io:
            endpoints:
              - https://172.20.0.1:12000 # note that it is HTTPS not HTTP
          gcr.io:
            endpoints:
              - https://172.20.0.1:12000 # note that it is HTTPS not HTTP
          ghcr.io:
            endpoints:
              - https://172.20.0.1:12000 # note that it is HTTPS not HTTP
          registry.k8s.io:
            endpoints:
              - https://172.20.0.1:12000 # note that it is HTTPS not HTTP
    ```

