### PR TITLE
feat: support optionally disabling module sig verification

### DIFF
--- a/api/resource/definitions/runtime/runtime.proto
+++ b/api/resource/definitions/runtime/runtime.proto
@@ -156,6 +156,7 @@ message SecurityStateSpec {
   talos.resource.definitions.enums.RuntimeSELinuxState se_linux_state = 4;
   bool booted_with_uki = 5;
   talos.resource.definitions.enums.RuntimeFIPSState fips_state = 6;
+  bool module_signature_enforced = 7;
 }
 
 // UniqueMachineTokenSpec is the spec for the machine unique token. Token can be empty if machine wasn't assigned any.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -119,6 +119,14 @@ Additionally `talosctl image cache-create` has some changes:
     * multiple instances (`--platform=linux/amd64 --platform=linux/arm64`);
 """
 
+    [notes.kernel-module]
+        title = "Kernel Module"
+        description = """\
+Talos now supports optionally disabling kernel module signature verification by setting `module.sig_enforce=0` kernel parameter.
+By default module signature verification is enabled (`module.sig_enforce=1`).
+When using Factory or Imager supply as `-module.sig_enfore module.sig_enforce=0` kernel parameters to disable module signature enforcement.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/api/security.go
+++ b/internal/integration/api/security.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_api
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+// SecuritySuite verifies the security state resource.
+type SecuritySuite struct {
+	base.APISuite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+}
+
+// SuiteName returns the name of the suite.
+func (suite *SecuritySuite) SuiteName() string {
+	return "api.SecuritySuite"
+}
+
+// SetupTest sets up the test.
+func (suite *SecuritySuite) SetupTest() {
+	// make sure API calls have timeout
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 1*time.Minute)
+
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping Security test since provisioner is not qemu")
+	}
+}
+
+// TearDownTest tears down the test.
+func (suite *SecuritySuite) TearDownTest() {
+	if suite.ctxCancel != nil {
+		suite.ctxCancel()
+	}
+}
+
+// TestSecurityState verifies that the security state resource is present and has valid values.
+func (suite *SecuritySuite) TestSecurityState() {
+	node := suite.RandomDiscoveredNodeInternalIP()
+	ctx := client.WithNode(suite.ctx, node)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []resource.ID{runtimeres.SecurityStateID},
+		func(r *runtimeres.SecurityState, asrt *assert.Assertions) {
+			asrt.True(r.TypedSpec().ModuleSignatureEnforced, "module signature enforcement should be enabled")
+		},
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, &SecuritySuite{})
+}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -160,6 +160,7 @@ func RunInstallerContainer(
 		constants.KernelParamAuditdDisabled,
 		constants.KernelParamDashboardDisabled,
 		constants.KernelParamNetIfnames,
+		constants.KernelParamEnforceModuleSigVerify,
 	} {
 		if c := procfs.ProcCmdline().Get(preservedArg).First(); c != nil {
 			args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", preservedArg, *c))

--- a/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
@@ -1252,6 +1252,7 @@ type SecurityStateSpec struct {
 	SeLinuxState             enums.RuntimeSELinuxState `protobuf:"varint,4,opt,name=se_linux_state,json=seLinuxState,proto3,enum=talos.resource.definitions.enums.RuntimeSELinuxState" json:"se_linux_state,omitempty"`
 	BootedWithUki            bool                      `protobuf:"varint,5,opt,name=booted_with_uki,json=bootedWithUki,proto3" json:"booted_with_uki,omitempty"`
 	FipsState                enums.RuntimeFIPSState    `protobuf:"varint,6,opt,name=fips_state,json=fipsState,proto3,enum=talos.resource.definitions.enums.RuntimeFIPSState" json:"fips_state,omitempty"`
+	ModuleSignatureEnforced  bool                      `protobuf:"varint,7,opt,name=module_signature_enforced,json=moduleSignatureEnforced,proto3" json:"module_signature_enforced,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -1326,6 +1327,13 @@ func (x *SecurityStateSpec) GetFipsState() enums.RuntimeFIPSState {
 		return x.FipsState
 	}
 	return enums.RuntimeFIPSState(0)
+}
+
+func (x *SecurityStateSpec) GetModuleSignatureEnforced() bool {
+	if x != nil {
+		return x.ModuleSignatureEnforced
+	}
+	return false
 }
 
 // UniqueMachineTokenSpec is the spec for the machine unique token. Token can be empty if machine wasn't assigned any.
@@ -1629,7 +1637,7 @@ const file_resource_definitions_runtime_runtime_proto_rawDesc = "" +
 	"\alicense\x18\x03 \x01(\tR\alicense\x12\x13\n" +
 	"\x05cp_es\x18\x04 \x03(\tR\x04cpEs\x12\x15\n" +
 	"\x06pur_ls\x18\x05 \x03(\tR\x05purLs\x12\x1c\n" +
-	"\textension\x18\x06 \x01(\bR\textension\"\x8a\x03\n" +
+	"\textension\x18\x06 \x01(\bR\textension\"\xc6\x03\n" +
 	"\x11SecurityStateSpec\x12\x1f\n" +
 	"\vsecure_boot\x18\x01 \x01(\bR\n" +
 	"secureBoot\x12=\n" +
@@ -1638,7 +1646,8 @@ const file_resource_definitions_runtime_runtime_proto_rawDesc = "" +
 	"\x0ese_linux_state\x18\x04 \x01(\x0e25.talos.resource.definitions.enums.RuntimeSELinuxStateR\fseLinuxState\x12&\n" +
 	"\x0fbooted_with_uki\x18\x05 \x01(\bR\rbootedWithUki\x12Q\n" +
 	"\n" +
-	"fips_state\x18\x06 \x01(\x0e22.talos.resource.definitions.enums.RuntimeFIPSStateR\tfipsState\".\n" +
+	"fips_state\x18\x06 \x01(\x0e22.talos.resource.definitions.enums.RuntimeFIPSStateR\tfipsState\x12:\n" +
+	"\x19module_signature_enforced\x18\a \x01(\bR\x17moduleSignatureEnforced\".\n" +
 	"\x16UniqueMachineTokenSpec\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\"<\n" +
 	"\x0eUnmetCondition\x12\x12\n" +

--- a/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
@@ -1226,6 +1226,16 @@ func (m *SecurityStateSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.ModuleSignatureEnforced {
+		i--
+		if m.ModuleSignatureEnforced {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
 	if m.FipsState != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FipsState))
 		i--
@@ -1954,6 +1964,9 @@ func (m *SecurityStateSpec) SizeVT() (n int) {
 	}
 	if m.FipsState != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.FipsState))
+	}
+	if m.ModuleSignatureEnforced {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5021,6 +5034,26 @@ func (m *SecurityStateSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ModuleSignatureEnforced", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ModuleSignatureEnforced = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -159,6 +159,10 @@ const (
 	// This param is injected by Equinix Metal and depends on the device ID and datacenter.
 	KernelParamEquinixMetalEvents = "em.events_url"
 
+	// KernelParamEnforceModuleSigVerify is the kernel parameter name to specify module signature verification enforcement.
+	// see https://github.com/siderolabs/talos/issues/11989
+	KernelParamEnforceModuleSigVerify = "module.sig_enforce"
+
 	// NewRoot is the path where the switchroot target is mounted.
 	NewRoot = "/root"
 

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -286,3 +286,15 @@ func (q Quirks) SupportsEmbeddedConfig() bool {
 
 	return q.v.GTE(minTalosVersionEmbeddedConfig)
 }
+
+var minTalosVersionDisableModSigVerify = semver.MustParse("1.12.0")
+
+// SupportsDisablingModuleSignatureVerification returns true if the Talos version supports disabling module signature verification.
+func (q Quirks) SupportsDisablingModuleSignatureVerification() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minTalosVersionDisableModSigVerify)
+}

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -48,6 +48,10 @@ func DefaultArgs(quirks quirks.Quirks) []string {
 		result = append(result, constants.KernelParamSELinux+"=1")
 	}
 
+	if quirks.SupportsDisablingModuleSignatureVerification() {
+		result = append(result, constants.KernelParamEnforceModuleSigVerify+"=1") // see https://github.com/siderolabs/talos/issues/11989
+	}
+
 	return result
 }
 

--- a/pkg/machinery/kernel/kernel_test.go
+++ b/pkg/machinery/kernel/kernel_test.go
@@ -90,6 +90,7 @@ func TestDefaultKernelArgs(t *testing.T) {
 				"nvme_core.io_timeout=4294967295",
 				"printk.devkmsg=on",
 				"selinux=1",
+				"module.sig_enforce=1",
 			},
 		},
 		{

--- a/pkg/machinery/resources/runtime/security_status.go
+++ b/pkg/machinery/resources/runtime/security_status.go
@@ -58,6 +58,7 @@ type SecurityStateSpec struct {
 	SELinuxState             SELinuxState `yaml:"selinuxState,omitempty" protobuf:"4"`
 	FIPSState                FIPSState    `yaml:"fipsState,omitempty" protobuf:"6"`
 	BootedWithUKI            bool         `yaml:"bootedWithUKI,omitempty" protobuf:"5"`
+	ModuleSignatureEnforced  bool         `yaml:"moduleSignatureEnforced,omitempty" protobuf:"7"`
 }
 
 // NewSecurityStateSpec initializes a security state resource.
@@ -92,6 +93,10 @@ func (SecurityStateExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 			{
 				Name:     "SELinuxState",
 				JSONPath: `{.selinuxState}`,
+			},
+			{
+				Name:     "ModuleSignatureEnforced",
+				JSONPath: `{.moduleSignatureEnforced}`,
 			},
 		},
 	}

--- a/website/content/v1.12/reference/api.md
+++ b/website/content/v1.12/reference/api.md
@@ -8136,6 +8136,7 @@ SecurityStateSpec describes the security state resource properties.
 | se_linux_state | [talos.resource.definitions.enums.RuntimeSELinuxState](#talos.resource.definitions.enums.RuntimeSELinuxState) |  |  |
 | booted_with_uki | [bool](#bool) |  |  |
 | fips_state | [talos.resource.definitions.enums.RuntimeFIPSState](#talos.resource.definitions.enums.RuntimeFIPSState) |  |  |
+| module_signature_enforced | [bool](#bool) |  |  |
 
 
 


### PR DESCRIPTION
Support disabling kernel module signature verification. Note that this does not work when SecureBoot is enabled.

Fixes: #11989