### PR TITLE
Update vagrant-libvirt.md to streamline patching

### DIFF
--- a/website/content/v1.12/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
+++ b/website/content/v1.12/talos-guides/install/virtualized-platforms/vagrant-libvirt.md
@@ -174,13 +174,7 @@ DEV        MODEL   SERIAL   TYPE   UUID   WWID   MODALIAS                    NAM
 
 Pick an endpoint IP in the `vagrant-libvirt` subnet but not used by any nodes, for example `192.168.121.100`.
 
-Generate a machine configuration:
-
-```bash
-talosctl gen config my-cluster https://192.168.121.100:6443 --install-disk /dev/vda
-```
-
-Edit `controlplane.yaml` to add the virtual IP you picked to a network interface under `.machine.network.interfaces`, for example:
+Create a patch.yaml file with the following contents and add the virtual IP you picked to a network interface under `.machine.network.interfaces`:
 
 ```yaml
 machine:
@@ -191,6 +185,12 @@ machine:
         dhcp: true
         vip:
           ip: 192.168.121.100
+```
+
+Generate a machine configuration:
+
+```bash
+talosctl gen config my-cluster https://192.168.121.100:6443 --install-disk /dev/vda --config-patch-control-plane @patch.yaml
 ```
 
 Apply the configuration to the initial control plane node:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Update of documentation of the Vagrant & Libvirt howto.

## Why? (reasoning)
In order to make bootstrapping a Libvirt cluster more comfortable. The `--config-patch-control-plane` looks very much like the perfect fit here and introduces potential newcomers early to the powerful patching mechanic here.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
