### PR TITLE
talosctl/cluster: use `/etc/resolv.conf` nameservers during cluster creation (for QEMU)

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
@@ -5,8 +5,11 @@
 package makers_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops"
@@ -28,4 +31,140 @@ func TestQemuMaker_MachineConfig(t *testing.T) {
 	desiredExtraGenOps := []generate.Option{}
 
 	assertConfigDefaultness(t, cOps, *m.Maker, desiredExtraGenOps...)
+}
+
+func TestQemuMaker_ParseDNSConfig(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		doc          string
+		fileContents string
+		expected     []string
+	}{
+		{
+			doc:          "properly configured",
+			fileContents: `nameserver 10.10.1.2`,
+			expected:     []string{"10.10.1.2"},
+		},
+		{
+			doc: "other options",
+			fileContents: `nameserver 10.10.1.2
+options edns0
+search .`,
+			expected: []string{"10.10.1.2"},
+		},
+		{
+			doc: "other options first",
+			fileContents: `options edns0
+search .
+nameserver 10.10.1.2`,
+			expected: []string{"10.10.1.2"},
+		},
+		{
+			doc: "multiple nameservers",
+			fileContents: `options edns0
+search .
+nameserver 10.10.1.2
+nameserver 10.10.1.3
+`,
+			expected: []string{"10.10.1.2", "10.10.1.3"},
+		},
+		{
+			doc: ">3 nameservers",
+			fileContents: `options edns0
+search .
+nameserver 10.10.1.2
+nameserver 10.10.1.3
+nameserver 10.10.1.4
+nameserver 10.10.1.5
+nameserver 10.10.1.6
+`,
+			expected: []string{
+				"10.10.1.2",
+				"10.10.1.3",
+				"10.10.1.4",
+			},
+		},
+		{
+			doc: "no nameserver",
+			fileContents: `options edns0
+search .`,
+			expected: nil,
+		},
+
+		{
+			doc: "ipv6",
+			fileContents: `search localdomain
+nameserver 2001:4860:4860::8888
+nameserver 2404:1a8:7f01:b::3
+`,
+			expected: []string{
+				"2001:4860:4860::8888",
+				"2404:1a8:7f01:b::3",
+			},
+		},
+		{
+			doc: "mixed ipv4/6",
+			fileContents: `options edns0
+search .
+nameserver 10.10.1.5
+nameserver 2001:4860:4860::8888`,
+			expected: []string{
+				"10.10.1.5",
+				"2001:4860:4860::8888",
+			},
+		},
+
+		{
+			doc: "comments",
+			fileContents: `options edns0
+search .
+nameserver 10.10.1.2	# a comment after a real value
+#nameserver 10.10.1.3
+nameserver 10.10.1.4
+;nameserver 10.10.1.5
+nameserver 10.10.1.6
+`,
+			expected: []string{
+				"10.10.1.2",
+				"10.10.1.4",
+				"10.10.1.6",
+			},
+		},
+		{
+			doc: "excludes loopback",
+			fileContents: `options edns0
+search .
+nameserver 127.0.0.53
+nameserver 10.96.0.10
+nameserver 127.0.0.1
+nameserver 192.168.1.1
+`,
+			expected: []string{
+				"10.96.0.10",
+				"192.168.1.1",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
+
+			testDir := t.TempDir()
+			testResolvPath := filepath.Join(testDir, "test_resolv.conf")
+
+			f, err := os.Create(testResolvPath)
+			assert.NoError(t, err, "create test file")
+			defer f.Close() //nolint:errcheck,wsl_v5
+
+			_, err = f.WriteString(tc.fileContents)
+			assert.NoError(t, err, "write test file")
+
+			actual, err := makers.ParseHostDNSConfig(testResolvPath)
+			assert.NoError(t, err)
+
+			require.EqualValues(t, tc.expected, actual)
+		})
+	}
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -110,6 +110,7 @@ type Qemu struct {
 	ExtraUEFISearchPaths      []string
 	NetworkNoMasqueradeCIDRs  []string
 	Nameservers               []string
+	AddHostNameservers        bool
 	Disks                     flags.Disks
 	DiskBlockSize             uint
 	PreallocateDisks          bool

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -209,7 +209,7 @@ func getCreateCmd() *cobra.Command {
 		qemu.MarkHidden("with-debug-shell") //nolint:errcheck
 		qemu.StringSliceVar(&qOps.ExtraUEFISearchPaths, extraUEFISearchPathsFlag, qOps.ExtraUEFISearchPaths, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 		qemu.StringSliceVar(&qOps.NetworkNoMasqueradeCIDRs, networkNoMasqueradeCIDRsFlag, qOps.NetworkNoMasqueradeCIDRs, "list of CIDRs to exclude from NAT")
-		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use")
+		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "nameservers to use (will also attempt to add resolvers from /etc/resolv.conf)")
 		qemu.UintVar(&qOps.DiskBlockSize, diskBlockSizeFlag, qOps.DiskBlockSize, "disk block size")
 		qemu.StringVar(&qOps.TargetArch, targetArchFlag, qOps.TargetArch, "cluster architecture")
 		qemu.StringSliceVar(&qOps.CniBinPath, cniBinPathFlag, qOps.CniBinPath, "search path for CNI binaries")
@@ -253,6 +253,10 @@ func getCreateCmd() *cobra.Command {
 			return cli.WithContext(context.Background(), func(ctx context.Context) error {
 				if err := validateQemuFlags(cmd.Flags(), unImplementedFlagsDarwin); err != nil {
 					return err
+				}
+
+				if nameServerFlag := cmd.Flag(nameserversFlag); nameServerFlag != nil && !nameServerFlag.Changed {
+					qOps.AddHostNameservers = true
 				}
 
 				disks := fmt.Sprintf("virtio:%d", legacyOps.clusterDiskSize)

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -255,7 +255,7 @@ talosctl cluster create [flags]
       --memory string(mb,gb)                     the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mtu int                                  MTU of the cluster network (default 1500)
-      --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
+      --nameservers strings                      nameservers to use (will also attempt to add resolvers from /etc/resolv.conf) (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
       --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This commit adds logic to read and parse configuration from `/etc/resolv.conf`. The parsing logic is adapted from the [Go stdlib](https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/net/dnsconfig_unix.go;l=18).

The current implementation does stream the file (I was thinking that in case something is really wrong and /etc/resolv.conf is way bigger than it should be, this would be better) but it might be better to keep it simple and just read the file and then pass it along for parsing (plus, if something is that wrong with your `/etc/resolv.conf`, you probably have bigger issues 😅).

If anything fails w/ reading/parsing, the previously configured defaults are used.

## Why? (reasoning)

`talosctl cluster create` uses the Google and CloudFlare nameservers as defaults for the QEMU config. This is generally fine, but can cause issues if these are unreachable from the user's network (see https://github.com/siderolabs/docs/issues/94), and it would generally be nicer to attempt to use the configured nameservers.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

## Bonus doc picture

<img width="922" height="1124" alt="Screenshot 2025-10-13 at 15 15 37" src="https://github.com/user-attachments/assets/e7f04c95-1e16-46a7-88c5-733033c34d71" />

