### PR TITLE
feat: add static registry to talosctl

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/flags.go
+++ b/cmd/talosctl/pkg/talos/helpers/flags.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -50,18 +49,5 @@ func StringChoice(defaultValue string, otherChoices ...string) pflag.Value {
 
 			return fmt.Errorf("must be one of %v", choices)
 		},
-	}
-}
-
-// ChainCobraPositionalArgs chains multiple cobra.PositionalArgs validators together.
-func ChainCobraPositionalArgs(validators ...cobra.PositionalArgs) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		for _, validator := range validators {
-			if err := validator(cmd, args); err != nil {
-				return err
-			}
-		}
-
-		return nil
 	}
 }

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -103,6 +103,21 @@ These fields were removed from the default machine configuration schema in v1.12
 etcd container image is now pulled from `registry.k8s.io/etcd` instead of `gcr.io/etcd-development/etcd`.
 """
 
+    [notes.talosctl]
+        title = "talosctl image cache-serve"
+        description = """\
+`talosctl` includes new subcommand `image cache-serve`.
+It allows serving the created OCI image registry over HTTP/HTTPS.
+It is a read-only registry, meaning images cannot be pushed to it, but the backing storage can be updated by re-running the `cache-create` command;
+
+Additionally `talosctl image cache-create` has some changes:
+  * new flag `--layout`: `oci` (_default_), `flat`:
+    * `oci` preserves current behavior;
+    * `flat` does not repack artifact layer, but moves it to a destination directory, allowing it to be served by `talosctl image cache-serve`;
+  * changed flag `--platform`: now can accept multiple os/arch combinations:
+    * comma separated (`--platform=linux/amd64,linux/arm64`);
+    * multiple instances (`--platform=linux/amd64 --platform=linux/arm64`);
+"""
 
 [make_deps]
 

--- a/internal/app/machined/pkg/system/services/registry/params.go
+++ b/internal/app/machined/pkg/system/services/registry/params.go
@@ -15,9 +15,6 @@ import (
 
 func extractParams(req *http.Request) (params, error) {
 	registry := req.URL.Query().Get("ns")
-	if registry == "" {
-		return params{}, xerrors.NewTaggedf[badRequestTag]("missing ns")
-	}
 
 	value := req.PathValue("args")
 

--- a/internal/app/machined/pkg/system/services/registry/registry_test.go
+++ b/internal/app/machined/pkg/system/services/registry/registry_test.go
@@ -48,7 +48,7 @@ func TestRegistry(t *testing.T) {
 	platform, err := v1.ParsePlatform("linux/amd64")
 	assert.NoError(t, err)
 
-	assert.NoError(t, cache.Generate(images, platform.String(), false, "", cacheDir))
+	assert.NoError(t, cache.Generate(images, []string{platform.String()}, false, "", cacheDir, false))
 
 	l, err := layout.ImageIndexFromPath(cacheDir)
 	assert.NoError(t, err)

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -181,6 +181,34 @@ func (suite *ImageSuite) TestCacheCreate() {
 	assert.FileExistsf(suite.T(), cacheDir+"/index.json", "index.json should exist in the image cache directory")
 }
 
+// TestRegistryCreate verifies creating a registry cache.
+func (suite *ImageSuite) TestRegistryCreate() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	stdOut, _ := suite.RunCLI([]string{"image", "source-bundle", "v1.11.2"})
+
+	imagesList := strings.Split(strings.Trim(stdOut, "\n"), "\n")
+
+	imagesArgs := xslices.Map(imagesList[:2], func(image string) string {
+		return "--images=" + image
+	})
+
+	storageDir := suite.T().TempDir()
+
+	args := []string{"image", "registry", "create", storageDir}
+
+	args = append(args, imagesArgs...)
+
+	suite.RunCLI(args, base.StdoutEmpty(), base.StderrNotEmpty())
+
+	assert.FileExistsf(suite.T(), storageDir+"pause/index.json", "pause/index.json should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"pause/oci-layout", "pause/oci-layout should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"siderolabs/kubelet/index.json", "siderolabs/kubelet/index.json should exist in the image cache directory")
+	assert.FileExistsf(suite.T(), storageDir+"siderolabs/kubelet/oci-layout", "siderolabs/kubelet/oci-layout should exist in the image cache directory")
+}
+
 func init() {
 	allSuites = append(allSuites, new(ImageSuite))
 }

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -1870,7 +1870,46 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
       --image-layer-cache-path string   directory to save the image layer cache
       --images strings                  images to cache
       --insecure                        allow insecure registries
-      --platform string                 platform to use for the cache (default "linux/amd64")
+      --layout string                   Specifies the cache layout format: "oci" for an OCI image layout directory, or "flat" for a registry-like flat file structure (default "oci")
+      --platform strings                platform to use for the cache (default [linux/amd64])
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             Cluster to connect to if a proxy endpoint is used.
+      --context string             Context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+      --namespace system           namespace to use: system (etcd and kubelet images) or `cri` for all Kubernetes workloads (default "cri")
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+```
+
+### SEE ALSO
+
+* [talosctl image](#talosctl-image)	 - Manage CRI container images
+
+## talosctl image cache-serve
+
+Serve an OCI image cache directory over HTTP(S) as a container registry
+
+### Synopsis
+
+Serve an OCI image cache directory over HTTP(S) as a container registry
+
+```
+talosctl image cache-serve [flags]
+```
+
+### Options
+
+```
+      --address string            address to serve the registry on (default "127.0.0.1:3172")
+  -h, --help                      help for cache-serve
+      --image-cache-path string   directory to save the image cache in OCI format
+      --tls-cert-file string      TLS certificate file to use for serving
+      --tls-key-file string       TLS key file to use for serving
 ```
 
 ### Options inherited from parent commands
@@ -2031,6 +2070,7 @@ Manage CRI container images
 
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl image cache-create](#talosctl-image-cache-create)	 - Create a cache of images in OCI format into a directory
+* [talosctl image cache-serve](#talosctl-image-cache-serve)	 - Serve an OCI image cache directory over HTTP(S) as a container registry
 * [talosctl image default](#talosctl-image-default)	 - List the default images used by Talos
 * [talosctl image list](#talosctl-image-list)	 - List CRI images
 * [talosctl image pull](#talosctl-image-pull)	 - Pull an image into CRI


### PR DESCRIPTION
* `talosctl image cache-serve` allows serving the created OCI image registry over HTTP. It is a read-only registry, meaning images cannot be pushed to it, but the backing storage can be updated by re-running the `cache-create` command;

* `talosctl image cache-create`:
  * new flag `--layout`: `oci` (_default_), `flat`:
    * `oci` preserves current behavior;
    * `flat` does not repack artifact layer, but moves it to a destination directory, allowing it to be served by `talosctl image cache-serve`;
  * changed flag `--platform`: now can accept multiple os/arch combinations:
    * comma separated (`--platform=linux/amd64,linux/arm64`);
    * multiple instances (`--platform=linux/amd64 --platform=linux/arm64`);

Fixes #11928
Fixes #11929

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
