### PR TITLE
feat: unify cmdline handling GRUB/systemd-boot

### DIFF
--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 }
 
+//nolint:gocyclo
 func runInstallCmd(ctx context.Context) (err error) {
 	log.Printf("running Talos installer %s", version.NewVersion().Tag)
 
@@ -50,6 +51,9 @@ func runInstallCmd(ctx context.Context) (err error) {
 	if err != nil {
 		if errors.Is(err, configloader.ErrNoConfig) {
 			log.Printf("machine configuration missing, skipping validation")
+
+			// machine configuration can be only missing while running an upgrade in maintenance mode, assume that we should follow GrubUseUKICmdline
+			options.GrubUseUKICmdline = true
 		} else {
 			return fmt.Errorf("error loading machine configuration: %w", err)
 		}
@@ -71,6 +75,10 @@ func runInstallCmd(ctx context.Context) (err error) {
 
 		if config.Machine() != nil && config.Machine().Install().LegacyBIOSSupport() {
 			options.LegacyBIOSSupport = true
+		}
+
+		if config.Machine() != nil && config.Machine().Install().GrubUseUKICmdline() {
+			options.GrubUseUKICmdline = true
 		}
 	}
 

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -53,6 +53,7 @@ type Options struct {
 	Force               bool
 	Zero                bool
 	LegacyBIOSSupport   bool
+	GrubUseUKICmdline   bool
 	MetaValues          MetaValues
 	OverlayInstaller    overlay.Installer[overlay.ExtraOptions]
 	OverlayName         string
@@ -118,6 +119,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		opts.ExtraOptions = extraOptions
 	}
 
+	// NOTE: this is legacy code which is only used when running in GRUB mode with GrubUseUKICmdline set to false.
 	cmdline := procfs.NewCmdline("")
 	cmdline.Append(constants.KernelParamPlatform, p.Name())
 
@@ -347,15 +349,16 @@ func (i *Installer) Install(ctx context.Context, mode Mode) (err error) {
 
 	// Install the bootloader.
 	bootInstallResult, err := bootlder.Install(bootloaderoptions.InstallOptions{
-		BootDisk:    i.options.Disk,
-		Arch:        i.options.Arch,
-		Cmdline:     i.cmdline.String(),
-		Version:     i.options.Version,
-		ImageMode:   mode.IsImage(),
-		MountPrefix: i.options.MountPrefix,
-		BootAssets:  i.options.BootAssets,
-		Printf:      i.options.Printf,
-		BlkidInfo:   info,
+		BootDisk:          i.options.Disk,
+		Arch:              i.options.Arch,
+		Cmdline:           i.cmdline.String(),
+		GrubUseUKICmdline: i.options.GrubUseUKICmdline,
+		Version:           i.options.Version,
+		ImageMode:         mode.IsImage(),
+		MountPrefix:       i.options.MountPrefix,
+		BootAssets:        i.options.BootAssets,
+		Printf:            i.options.Printf,
+		BlkidInfo:         info,
 
 		ExtraInstallStep: func() error {
 			if i.options.Board != constants.BoardNone {

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -211,7 +211,7 @@ func (m *Maker[T]) initVersionContract() error {
 // logic has been run.
 func (m *Maker[T]) GetClusterConfigs() (clusterops.ClusterConfigs, error) {
 	// These options needs to be generated after the implementing maker has made changes to the cluster request.
-	m.GenOps = slices.Concat(m.GenOps, m.Provisioner.GenOptions(m.ClusterRequest.Network))
+	m.GenOps = slices.Concat(m.GenOps, m.Provisioner.GenOptions(m.ClusterRequest.Network, m.VersionContract))
 	m.GenOps = slices.Concat(m.GenOps, []generate.Option{generate.WithEndpointList(m.Endpoints)})
 
 	m.ConfigBundleOps = append(m.ConfigBundleOps,

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
@@ -24,7 +24,7 @@ type testProvisioner struct {
 	provision.Provisioner
 }
 
-func (p testProvisioner) GenOptions(r provision.NetworkRequest) []generate.Option {
+func (p testProvisioner) GenOptions(r provision.NetworkRequest, _ *config.VersionContract) []generate.Option {
 	return []generate.Option{func(o *generate.Options) error { return nil }}
 }
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -127,6 +127,16 @@ By default module signature verification is enabled (`module.sig_enforce=1`).
 When using Factory or Imager supply as `-module.sig_enfore module.sig_enforce=0` kernel parameters to disable module signature enforcement.
 """
 
+    [notes.grub]
+        title = "GRUB"
+        description = """\
+Talos Linux introduces new machine configuration option `.machine.install.grubUseUKICmdline` to control whether GRUB should use the kernel command line 
+provided by the boot assets (UKI) or to use the command line constructed by Talos itself (legacy behavior).
+
+This option defaults to `true` for new installations, which means that GRUB will use the command line from the UKI, making it easier to customize kernel parameters via boot asset generation.
+For existing installations upgrading to v1.12, this option will default to `false` to preserve the legacy behavior.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -207,17 +207,10 @@ case "${WITH_APPARMOR_LSM_ENABLED:-false}" in
   false)
     ;;
   *)
-    cat <<EOF > "${TMP}/kernel-security.patch"
-machine:
-  install:
-    extraKernelArgs:
-      - -selinux
-      - lsm=lockdown,capability,yama,apparmor,bpf
-      - apparmor=1
-EOF
+    # build disk image with specific kernel args to enable AppArmor LSM
+    make image-metal PLATFORM=linux/amd64 IMAGER_ARGS="--extra-kernel-arg -selinux --extra-kernel-arg lsm=lockdown,capability,yama,apparmor,bpf --extra-kernel-arg apparmor=1"
 
-    QEMU_FLAGS+=("--config-patch=@${TMP}/kernel-security.patch")
-    QEMU_FLAGS+=("--extra-boot-kernel-args=-selinux")
+    QEMU_FLAGS+=("--disk-image-path=_out/metal-amd64.raw.zst" "--skip-injecting-config" "--with-apply-config")
     ;;
 esac
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/dual/dual.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/dual/dual.go
@@ -7,6 +7,7 @@ package dual
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,7 +136,18 @@ func (c *Config) installGrub(opts options.InstallOptions) error {
 		return err
 	}
 
-	if err := grubConfig.Put(grubConfig.Default, opts.Cmdline, opts.Version); err != nil {
+	cmdline := opts.Cmdline
+
+	if opts.GrubUseUKICmdline {
+		cmdlineBytes, err := io.ReadAll(assetInfo.Cmdline)
+		if err != nil {
+			return fmt.Errorf("failed to read cmdline from UKI: %w", err)
+		}
+
+		cmdline = string(cmdlineBytes)
+	}
+
+	if err := grubConfig.Put(grubConfig.Default, cmdline, opts.Version); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
@@ -19,8 +19,10 @@ type InstallOptions struct {
 	BootDisk string
 	// Target architecture.
 	Arch string
-	// Kernel command line (grub only).
+	// Kernel command line (grub only, and only if GrubUseUKICmdline is false).
 	Cmdline string
+	// Whether to use the UKI cmdline instead of building it on the host (grub only).
+	GrubUseUKICmdline bool
 	// Talos version.
 	Version string
 

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -497,7 +497,10 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 
 	suite.controlPlaneEndpoint = suite.provisioner.GetExternalKubernetesControlPlaneEndpoint(request.Network, constants.DefaultControlPlanePort)
 
-	genOptions := suite.provisioner.GenOptions(request.Network)
+	versionContract, err := config.ParseContractFromVersion(options.SourceVersion)
+	suite.Require().NoError(err)
+
+	genOptions := suite.provisioner.GenOptions(request.Network, versionContract)
 
 	for _, registryMirror := range DefaultSettings.RegistryMirrors {
 		parts := strings.Split(registryMirror, "=")
@@ -523,9 +526,6 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 	}
 
 	var extraPatches []configpatcher.Patch
-
-	versionContract, err := config.ParseContractFromVersion(options.SourceVersion)
-	suite.Require().NoError(err)
 
 	if options.WithEncryption {
 		if versionContract.VolumeConfigEncryptionSupported() {

--- a/internal/pkg/smbios/oem.go
+++ b/internal/pkg/smbios/oem.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package smbios
+
+import (
+	"strings"
+)
+
+// ReadOEMVariable reads the OEM variable from SMBIOS and returns its value.
+func ReadOEMVariable(name string) ([]string, error) {
+	smbiosInfo, err := GetSMBIOSInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+
+	for _, str := range smbiosInfo.OEMStrings.Strings {
+		key, val, ok := strings.Cut(str, "=")
+		if !ok {
+			continue
+		}
+
+		if key == name {
+			result = append(result, val)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -100,6 +100,7 @@ type Install interface {
 	ExtraKernelArgs() []string
 	Zero() bool
 	LegacyBIOSSupport() bool
+	GrubUseUKICmdline() bool
 }
 
 // Extension defines the system extension.

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -197,3 +197,8 @@ func (contract *VersionContract) HideRBACAndKeyUsage() bool {
 func (contract *VersionContract) PopulateClusterSANsFromEndpoint() bool {
 	return !contract.Greater(TalosVersion1_11)
 }
+
+// GrubUseUKICmdlineDefault returns true if version of Talos should use UKI cmdline by default.
+func (contract *VersionContract) GrubUseUKICmdlineDefault() bool {
+	return contract.Greater(TalosVersion1_11)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -70,6 +70,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.HideDisablePSP())
 	assert.True(t, contract.HideRBACAndKeyUsage())
 	assert.False(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.True(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_12(t *testing.T) {
@@ -98,6 +99,7 @@ func TestContract1_12(t *testing.T) {
 	assert.True(t, contract.HideDisablePSP())
 	assert.True(t, contract.HideRBACAndKeyUsage())
 	assert.False(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.True(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_11(t *testing.T) {
@@ -126,6 +128,7 @@ func TestContract1_11(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_10(t *testing.T) {
@@ -154,6 +157,7 @@ func TestContract1_10(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_9(t *testing.T) {
@@ -182,6 +186,7 @@ func TestContract1_9(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_8(t *testing.T) {
@@ -210,6 +215,7 @@ func TestContract1_8(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_7(t *testing.T) {
@@ -238,6 +244,7 @@ func TestContract1_7(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_6(t *testing.T) {
@@ -266,6 +273,7 @@ func TestContract1_6(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_5(t *testing.T) {
@@ -294,6 +302,7 @@ func TestContract1_5(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_4(t *testing.T) {
@@ -322,6 +331,7 @@ func TestContract1_4(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -350,6 +360,7 @@ func TestContract1_3(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -378,6 +389,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -406,6 +418,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -434,4 +447,5 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.HideDisablePSP())
 	assert.False(t, contract.HideRBACAndKeyUsage())
 	assert.True(t, contract.PopulateClusterSANsFromEndpoint())
+	assert.False(t, contract.GrubUseUKICmdlineDefault())
 }

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -58,6 +58,10 @@ func (in *Input) init() ([]config.Document, error) {
 		MachineFeatures: &v1alpha1.FeaturesConfig{},
 	}
 
+	if in.Options.VersionContract.GrubUseUKICmdlineDefault() {
+		machine.MachineInstall.InstallGrubUseUKICmdline = pointer.To(true)
+	}
+
 	if in.Options.VersionContract.StableHostnameEnabled() && !in.Options.VersionContract.MultidocNetworkConfigSupported() {
 		machine.MachineFeatures.StableHostname = pointer.To(true) //nolint:staticcheck // using legacy field for older Talos versions
 	}

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -59,6 +59,10 @@ func (in *Input) worker() ([]config.Document, error) {
 		MachineFeatures: &v1alpha1.FeaturesConfig{},
 	}
 
+	if in.Options.VersionContract.GrubUseUKICmdlineDefault() {
+		machine.MachineInstall.InstallGrubUseUKICmdline = pointer.To(true)
+	}
+
 	if in.Options.VersionContract.StableHostnameEnabled() && !in.Options.VersionContract.MultidocNetworkConfigSupported() {
 		machine.MachineFeatures.StableHostname = pointer.To(true) //nolint:staticcheck // using legacy field for older Talos versions
 	}

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -3242,16 +3242,6 @@
           "markdownDescription": "Look up disk using disk attributes like model, size, serial and others.\nAlways has priority over `disk`.",
           "x-intellij-html-description": "\u003cp\u003eLook up disk using disk attributes like model, size, serial and others.\nAlways has priority over \u003ccode\u003edisk\u003c/code\u003e.\u003c/p\u003e\n"
         },
-        "extraKernelArgs": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "title": "extraKernelArgs",
-          "description": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a -.\nFor example -console removes all console=\u0026lt;value\u0026gt; arguments, whereas -console=tty0 removes the console=tty0 default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.\n",
-          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=\u003cvalue\u003e` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.",
-          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a \u003ccode\u003e-\u003c/code\u003e.\nFor example \u003ccode\u003e-console\u003c/code\u003e removes all \u003ccode\u003econsole=\u0026lt;value\u0026gt;\u003c/code\u003e arguments, whereas \u003ccode\u003e-console=tty0\u003c/code\u003e removes the \u003ccode\u003econsole=tty0\u003c/code\u003e default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.\u003c/p\u003e\n"
-        },
         "image": {
           "type": "string",
           "title": "image",
@@ -3272,6 +3262,13 @@
           "description": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn’t support GPT partitioning scheme.\n",
           "markdownDescription": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.",
           "x-intellij-html-description": "\u003cp\u003eIndicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn\u0026rsquo;t support GPT partitioning scheme.\u003c/p\u003e\n"
+        },
+        "grubUseUKICmdline": {
+          "type": "boolean",
+          "title": "grubUseUKICmdline",
+          "description": "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.\n",
+          "markdownDescription": "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.",
+          "x-intellij-html-description": "\u003cp\u003eIndicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-controlplane.yaml
@@ -15,6 +15,7 @@ machine:
     network: {}
     install:
         wipe: false
+        grubUseUKICmdline: true
     features:
         diskQuotaSupport: true
         kubePrism:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/base-worker.yaml
@@ -15,6 +15,7 @@ machine:
     network: {}
     install:
         wipe: false
+        grubUseUKICmdline: true
     features:
         diskQuotaSupport: true
         kubePrism:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-controlplane.yaml
@@ -27,6 +27,7 @@ machine:
             - foo=bar
             - bar=baz
         wipe: false
+        grubUseUKICmdline: true
     sysctls:
         foo: bar
     registries:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.12/overrides-worker.yaml
@@ -27,6 +27,7 @@ machine:
             - foo=bar
             - bar=baz
         wipe: false
+        grubUseUKICmdline: true
     sysctls:
         foo: bar
     registries:

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
@@ -167,10 +167,10 @@ func machineNetworkConfigExample() *NetworkConfig {
 
 func machineInstallExample() *InstallConfig {
 	return &InstallConfig{
-		InstallDisk:            "/dev/sda",
-		InstallExtraKernelArgs: []string{"console=ttyS1", "panic=10"},
-		InstallImage:           "ghcr.io/siderolabs/installer:latest",
-		InstallWipe:            pointer.To(false),
+		InstallDisk:              "/dev/sda",
+		InstallImage:             "ghcr.io/siderolabs/installer:latest",
+		InstallWipe:              pointer.To(false),
+		InstallGrubUseUKICmdline: pointer.To(true),
 	}
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1431,6 +1431,11 @@ func (i *InstallConfig) LegacyBIOSSupport() bool {
 	return pointer.SafeDeref(i.InstallLegacyBIOSSupport)
 }
 
+// GrubUseUKICmdline implements the config.Provider interface.
+func (i *InstallConfig) GrubUseUKICmdline() bool {
+	return pointer.SafeDeref(i.InstallGrubUseUKICmdline)
+}
+
 // Image implements the config.Provider interface.
 func (i InstallExtensionConfig) Image() string {
 	return i.ExtensionImage

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -801,13 +801,9 @@ type InstallConfig struct {
 	//   examples:
 	//     - value: machineInstallDiskSelectorExample()
 	InstallDiskSelector *InstallDiskSelector `yaml:"diskSelector,omitempty"`
-	//   description: |
-	//     Allows for supplying extra kernel args via the bootloader.
-	//     Existing kernel args can be removed by prefixing the argument with a `-`.
-	//     For example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.
-	//     If Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.
-	//   examples:
-	//     - value: '[]string{"talos.platform=metal", "reboot=k"}'
+	// docgen:nodoc
+	//
+	// Deprecated: Use Image Factory/imager instead to build a proper installer.
 	InstallExtraKernelArgs []string `yaml:"extraKernelArgs,omitempty"`
 	//   description: |
 	//     Allows for supplying the image used to perform the installation.
@@ -837,6 +833,10 @@ type InstallConfig struct {
 	//     Indicates if MBR partition should be marked as bootable (active).
 	//     Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.
 	InstallLegacyBIOSSupport *bool `yaml:"legacyBIOSSupport,omitempty"`
+	//   description: |
+	//     Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
+	//     This changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.
+	InstallGrubUseUKICmdline *bool `yaml:"grubUseUKICmdline,omitempty"`
 }
 
 // InstallDiskSizeMatcher disk size condition parser.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1004,13 +1004,7 @@ func (InstallConfig) Doc() *encoder.Doc {
 				Description: "Look up disk using disk attributes like model, size, serial and others.\nAlways has priority over `disk`.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Look up disk using disk attributes like model, size, serial and others." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
-			{
-				Name:        "extraKernelArgs",
-				Type:        "[]string",
-				Note:        "",
-				Description: "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.",
-				Comments:    [3]string{"" /* encoder.HeadComment */, "Allows for supplying extra kernel args via the bootloader." /* encoder.LineComment */, "" /* encoder.FootComment */},
-			},
+			{},
 			{
 				Name:        "image",
 				Type:        "string",
@@ -1040,6 +1034,13 @@ func (InstallConfig) Doc() *encoder.Doc {
 				Description: "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Indicates if MBR partition should be marked as bootable (active)." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "grubUseUKICmdline",
+				Type:        "bool",
+				Note:        "",
+				Description: "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 
@@ -1048,7 +1049,6 @@ func (InstallConfig) Doc() *encoder.Doc {
 	doc.Fields[0].AddExample("", "/dev/sda")
 	doc.Fields[0].AddExample("", "/dev/nvme0")
 	doc.Fields[1].AddExample("", machineInstallDiskSelectorExample())
-	doc.Fields[2].AddExample("", []string{"talos.platform=metal", "reboot=k"})
 	doc.Fields[3].AddExample("", "ghcr.io/siderolabs/installer:latest")
 
 	return doc

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -109,6 +109,10 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 			if c.MachineConfig.MachineInstall.InstallDisk == "" && matcher == nil {
 				result = multierror.Append(result, errors.New("either install disk or diskSelector should be defined"))
 			}
+
+			if len(c.MachineConfig.MachineInstall.InstallExtraKernelArgs) > 0 && c.MachineConfig.MachineInstall.GrubUseUKICmdline() {
+				result = multierror.Append(result, errors.New("install.extraKernelArgs and install.grubUseUKICmdline can't be used together"))
+			}
 		}
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -281,6 +281,32 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "MachineInstallExtraArgsAndGrubUseUKICmdline",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "worker",
+					MachineCA: &x509.PEMEncodedCertificateAndKey{
+						Crt: []byte("foo"),
+					},
+					MachineInstall: &v1alpha1.InstallConfig{
+						InstallDisk:              "/dev/vda",
+						InstallExtraKernelArgs:   []string{"foo=bar"},
+						InstallGrubUseUKICmdline: pointer.To(true),
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+				},
+			},
+			requiresInstall: true,
+			expectedError:   "1 error occurred:\n\t* install.extraKernelArgs and install.grubUseUKICmdline can't be used together\n\n",
+		},
+		{
 			name: "ExternalCloudProviderEnabled",
 			config: &v1alpha1.Config{
 				ConfigVersion: "v1alpha1",

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1317,6 +1317,9 @@ const (
 	DefaultOOMCgroupRankingExpression = `memory_max.hasValue() ? 0.0 :
 		{Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] *
 		   double(memory_current.orValue(0u)) / double(memory_peak.orValue(0u) - memory_current.orValue(0u))`
+
+	// SDStubCmdlineExtraOEMVar is the name of the SMBIOS OEM variable that can be used to pass extra kernel command line parameters to systemd-stub.
+	SDStubCmdlineExtraOEMVar = "io.systemd.stub.kernel-cmdline-extra"
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/client"
 
+	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -85,7 +86,7 @@ func (p *provisioner) Close() error {
 }
 
 // GenOptions provides a list of additional config generate options.
-func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.Option {
+func (p *provisioner) GenOptions(networkReq provision.NetworkRequest, _ *config.VersionContract) []generate.Option {
 	return []generate.Option{
 		generate.WithNetworkOptions(
 			v1alpha1.WithNetworkInterfaceIgnore(v1alpha1.IfaceByName("eth0")),

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/siderolabs/go-blockdevice/v2/blkid"
 
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
 
@@ -314,7 +315,7 @@ func launchVM(config *LaunchConfig) error {
 	}
 
 	args = append(args,
-		"-smbios", fmt.Sprintf("type=11,value=io.systemd.stub.kernel-cmdline-extra=%s", config.sdStubExtraCmdline),
+		"-smbios", fmt.Sprintf("type=11,value=%s=%s", constants.SDStubCmdlineExtraOEMVar, config.sdStubExtraCmdline),
 	)
 
 	if config.BadRTC {

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -8,6 +8,7 @@ package provision
 import (
 	"context"
 
+	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 )
@@ -19,7 +20,7 @@ type Provisioner interface {
 
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
 
-	GenOptions(NetworkRequest) []generate.Option
+	GenOptions(NetworkRequest, *config.VersionContract) []generate.Option
 
 	GetInClusterKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string
 	GetExternalKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string

--- a/website/content/v1.12/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.12/reference/configuration/v1alpha1/config.md
@@ -42,12 +42,9 @@ machine:
     # InstallConfig represents the installation options for preparing a node.
     install:
         disk: /dev/sda # The disk used for installations.
-        # Allows for supplying extra kernel args via the bootloader.
-        extraKernelArgs:
-            - console=ttyS1
-            - panic=10
         image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
+        grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 
         # # Look up disk using disk attributes like model, size, serial and others.
         # diskSelector:
@@ -256,12 +253,9 @@ network:
 |`install` |<a href="#Config.machine.install">InstallConfig</a> |Used to provide instructions for installations.<br><br>Note that this configuration section gets silently ignored by Talos images that are considered pre-installed.<br>To make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted. <details><summary>Show example(s)</summary>MachineInstall config usage example.:{{< highlight yaml >}}
 install:
     disk: /dev/sda # The disk used for installations.
-    # Allows for supplying extra kernel args via the bootloader.
-    extraKernelArgs:
-        - console=ttyS1
-        - panic=10
     image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
     wipe: false # Indicates if the installation disk should be wiped at installation time.
+    grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 
     # # Look up disk using disk attributes like model, size, serial and others.
     # diskSelector:
@@ -1752,12 +1746,9 @@ InstallConfig represents the installation options for preparing a node.
 machine:
     install:
         disk: /dev/sda # The disk used for installations.
-        # Allows for supplying extra kernel args via the bootloader.
-        extraKernelArgs:
-            - console=ttyS1
-            - panic=10
         image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
+        grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 
         # # Look up disk using disk attributes like model, size, serial and others.
         # diskSelector:
@@ -1783,16 +1774,12 @@ diskSelector:
     # busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0
     # busPath: /pci0000:00/*
 {{< /highlight >}}</details> | |
-|`extraKernelArgs` |[]string |Allows for supplying extra kernel args via the bootloader.<br>Existing kernel args can be removed by prefixing the argument with a `-`.<br>For example `-console` removes all `console=<value>` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.<br>If Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-extraKernelArgs:
-    - talos.platform=metal
-    - reboot=k
-{{< /highlight >}}</details> | |
 |`image` |string |Allows for supplying the image used to perform the installation.<br>Image reference for each Talos release can be found on<br>[GitHub releases page](https://github.com/siderolabs/talos/releases). <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 image: ghcr.io/siderolabs/installer:latest
 {{< /highlight >}}</details> | |
 |`wipe` |bool |Indicates if the installation disk should be wiped at installation time.<br>Defaults to `true`.  |`true`<br />`yes`<br />`false`<br />`no`<br /> |
 |`legacyBIOSSupport` |bool |Indicates if MBR partition should be marked as bootable (active).<br>Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.  | |
+|`grubUseUKICmdline` |bool |Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.<br>This changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.  | |
 
 
 

--- a/website/content/v1.12/schemas/config.schema.json
+++ b/website/content/v1.12/schemas/config.schema.json
@@ -3242,16 +3242,6 @@
           "markdownDescription": "Look up disk using disk attributes like model, size, serial and others.\nAlways has priority over `disk`.",
           "x-intellij-html-description": "\u003cp\u003eLook up disk using disk attributes like model, size, serial and others.\nAlways has priority over \u003ccode\u003edisk\u003c/code\u003e.\u003c/p\u003e\n"
         },
-        "extraKernelArgs": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "title": "extraKernelArgs",
-          "description": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a -.\nFor example -console removes all console=\u0026lt;value\u0026gt; arguments, whereas -console=tty0 removes the console=tty0 default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.\n",
-          "markdownDescription": "Allows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a `-`.\nFor example `-console` removes all `console=\u003cvalue\u003e` arguments, whereas `-console=tty0` removes the `console=tty0` default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.",
-          "x-intellij-html-description": "\u003cp\u003eAllows for supplying extra kernel args via the bootloader.\nExisting kernel args can be removed by prefixing the argument with a \u003ccode\u003e-\u003c/code\u003e.\nFor example \u003ccode\u003e-console\u003c/code\u003e removes all \u003ccode\u003econsole=\u0026lt;value\u0026gt;\u003c/code\u003e arguments, whereas \u003ccode\u003e-console=tty0\u003c/code\u003e removes the \u003ccode\u003econsole=tty0\u003c/code\u003e default argument.\nIf Talos is using systemd-boot as a bootloader (default for UEFI) this setting will be ignored.\u003c/p\u003e\n"
-        },
         "image": {
           "type": "string",
           "title": "image",
@@ -3272,6 +3262,13 @@
           "description": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn’t support GPT partitioning scheme.\n",
           "markdownDescription": "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.",
           "x-intellij-html-description": "\u003cp\u003eIndicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn\u0026rsquo;t support GPT partitioning scheme.\u003c/p\u003e\n"
+        },
+        "grubUseUKICmdline": {
+          "type": "boolean",
+          "title": "grubUseUKICmdline",
+          "description": "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.\n",
+          "markdownDescription": "Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.",
+          "x-intellij-html-description": "\u003cp\u003eIndicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.\nThis changes the way cmdline is managed with GRUB bootloader to be more consistent with UKI/systemd-boot.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Use cmdline from the UKI in Talos 1.12+ by default for new installs.

This brings GRUB in line with systemd-boot vs. cmdline behavior.

Fixes #12019
