### PR TITLE
chore: push `latest` tag only on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-15T17:53:19Z by kres 7a9d88c.
+# Generated on 2025-10-16T09:22:23Z by kres 7a9d88c.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -5048,7 +5048,7 @@ jobs:
         run: |
           make push
       - name: push-latest
-        if: '!startsWith(github.ref, ''refs/tags/'')'
+        if: github.ref == 'refs/heads/main'
         env:
           PLATFORM: linux/amd64,linux/arm64
         run: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -157,7 +157,7 @@ spec:
           environment:
             PLATFORM: linux/amd64,linux/arm64
           conditions:
-            - not-on-tag
+            - only-on-main-branch
     - name: tag
       sops: true
       buildxOptions:


### PR DESCRIPTION
Otherwise we push latest from `release-*` branches which makes it confusing and broken, as it jumps between versions.
