### PR TITLE
fix: failing talosctl non-linux builds

### DIFF
--- a/internal/app/machined/pkg/system/services/registry/store.go
+++ b/internal/app/machined/pkg/system/services/registry/store.go
@@ -9,11 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
-	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
@@ -106,11 +103,3 @@ func (s *singleFileStore) blobPath(dgst digest.Digest) (string, error) {
 }
 
 var errUnimplemented = errors.New("unimplemented")
-
-func getATime(fi os.FileInfo) time.Time {
-	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(st.Atim.Unix())
-	}
-
-	return fi.ModTime()
-}

--- a/internal/app/machined/pkg/system/services/registry/store_linux.go
+++ b/internal/app/machined/pkg/system/services/registry/store_linux.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package registry
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getATime(fi os.FileInfo) time.Time {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return time.Unix(st.Atim.Unix())
+	}
+
+	return fi.ModTime()
+}

--- a/internal/app/machined/pkg/system/services/registry/store_unix.go
+++ b/internal/app/machined/pkg/system/services/registry/store_unix.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build darwin || freebsd || openbsd || netbsd || dragonfly
+
+package registry
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getATime(fi os.FileInfo) time.Time {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec))
+	}
+
+	return fi.ModTime()
+}

--- a/internal/app/machined/pkg/system/services/registry/store_windows.go
+++ b/internal/app/machined/pkg/system/services/registry/store_windows.go
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build windows
+
+package registry
+
+import (
+	"os"
+	"time"
+)
+
+func getATime(fi os.FileInfo) time.Time {
+	return fi.ModTime()
+}


### PR DESCRIPTION
Fix failing non-linux builds of talosctl