### PR TITLE
fix: reserve the apid and trustd ports from the ephemeral port range

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -15,6 +16,7 @@ import (
 
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/kernel/kspp"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/kernel"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
@@ -87,6 +89,14 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 			Value: "1",
 		},
 	}
+
+	// block apid and trustd from the ephemeral port range
+	res = append(res, []*kernel.Param{
+		{
+			Key:   "proc.sys.net.ipv4.ip_local_reserved_ports",
+			Value: fmt.Sprintf("%d,%d", constants.ApidPort, constants.TrustdPort),
+		},
+	}...)
 
 	if ctrl.V1Alpha1Mode != v1alpha1runtime.ModeContainer {
 		res = append(res, []*kernel.Param{

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -48,6 +48,10 @@ func getParams(mode runtime.Mode) []*kernel.Param {
 			Key:   "proc.sys.vm.overcommit_memory",
 			Value: "1",
 		},
+		{
+			Key:   "proc.sys.net.ipv4.ip_local_reserved_ports",
+			Value: "50000,50001",
+		},
 	}
 
 	if mode != runtime.ModeContainer {


### PR DESCRIPTION
The problem is that ports 50000 and 50001 are part of the ephemeral port range, so they might be occupied by outgoing connections before `apid`/`trustd` has a chance to bind to it.

So ensure these two ports are always excluded from the ephemeral port range.
