### PR TITLE
feat(machined): add panic/force mode reboot

### DIFF
--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -143,6 +143,7 @@ message RebootRequest {
   enum Mode {
     DEFAULT = 0;
     POWERCYCLE = 1;
+    FORCE = 2;
   }
   Mode mode = 1;
 }

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -39,6 +39,8 @@ var rebootCmd = &cobra.Command{
 		// skips kexec and reboots with power cycle
 		case "powercycle":
 			opts = append(opts, client.WithPowerCycle)
+		case "force":
+			opts = append(opts, client.WithForce)
 		case "default":
 		default:
 			return fmt.Errorf("invalid reboot mode: %q", rebootCmdFlags.mode)
@@ -85,7 +87,7 @@ func rebootGetActorID(opts ...client.RebootMode) func(ctx context.Context, c *cl
 }
 
 func init() {
-	rebootCmd.Flags().StringVarP(&rebootCmdFlags.mode, "mode", "m", "default", "select the reboot mode: \"default\", \"powercycle\" (skips kexec)")
+	rebootCmd.Flags().StringVarP(&rebootCmdFlags.mode, "mode", "m", "default", "select the reboot mode: \"default\", \"powercycle\" (skips kexec), \"force\" (skips graceful teardown)")
 	rebootCmdFlags.addTrackActionFlags(rebootCmd)
 	addCommand(rebootCmd)
 }

--- a/cmd/talosctl/pkg/talos/action/node.go
+++ b/cmd/talosctl/pkg/talos/action/node.go
@@ -286,6 +286,10 @@ func (a *nodeTracker) handleEvent(event client.Event) error {
 			Status:  reporter.StatusRunning,
 		})
 
+		if msg.GetSequence() == "reboot" {
+			return retry.ExpectedErrorf("reboot sequence completed")
+		}
+
 		if errStr != "" {
 			return fmt.Errorf("sequence error: %s", msg.GetError().GetMessage())
 		}

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -121,6 +121,15 @@ Additionally `talosctl image cache-create` has some changes:
     * multiple instances (`--platform=linux/amd64 --platform=linux/arm64`);
 """
 
+   [notes.force-reboot]
+        title = "Talos force reboot"
+        description = """\
+Talos now supports a "force" reboot mode, which allows skipping the graceful userland termination.
+It can be used in situations where a userland service (e.g. the kubelet) gets stuck during graceful shutdown, causing the regular reboot flow to fail.
+
+In addition, `talosctl` was updated to support this feature via `talosctl reboot --mode force`.
+"""
+
     [notes.kernel-module]
         title = "Kernel Module"
         description = """\

--- a/internal/app/machined/pkg/runtime/sequencer.go
+++ b/internal/app/machined/pkg/runtime/sequencer.go
@@ -147,7 +147,7 @@ type Sequencer interface {
 	Boot(Runtime) []Phase
 	Initialize(Runtime) []Phase
 	Install(Runtime) []Phase
-	Reboot(Runtime) []Phase
+	Reboot(Runtime, *machine.RebootRequest) []Phase
 	Reset(Runtime, ResetOptions) []Phase
 	Shutdown(Runtime, *machine.ShutdownRequest) []Phase
 	StageUpgrade(Runtime, *machine.UpgradeRequest) []Phase

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -381,7 +381,14 @@ func (c *Controller) phases(seq runtime.Sequence, data any) ([]runtime.Phase, er
 
 		phases = c.s.Shutdown(c.r, in)
 	case runtime.SequenceReboot:
-		phases = c.s.Reboot(c.r)
+		var in *machine.RebootRequest
+		if req, ok := data.(*machine.RebootRequest); ok {
+			in = req
+		} else {
+			log.Printf("warning: API reboot missing reboot request")
+		}
+
+		phases = c.s.Reboot(c.r, in)
 	case runtime.SequenceUpgrade:
 		in, ok := data.(*machine.UpgradeRequest)
 		if !ok {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
@@ -44,7 +44,7 @@ func (m *mockSequencer) Install(r runtime.Runtime) []runtime.Phase {
 	return m.phases[runtime.SequenceInstall]
 }
 
-func (m *mockSequencer) Reboot(r runtime.Runtime) []runtime.Phase {
+func (m *mockSequencer) Reboot(r runtime.Runtime, _ *machine.RebootRequest) []runtime.Phase {
 	return m.phases[runtime.SequenceReboot]
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -233,18 +233,23 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 }
 
 // Reboot is the reboot sequence.
-func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
-	phases := PhaseList{}.Append(
-		"cleanup",
-		StopAllPods,
-	).Append(
-		"dbus",
-		StopDBus,
-	).
-		AppendList(stopAllPhaselist(r, true)).
-		Append("reboot", Reboot)
+func (*Sequencer) Reboot(r runtime.Runtime, in *machineapi.RebootRequest) []runtime.Phase {
+	phases := PhaseList{}
 
-	return phases
+	if in.GetMode() != machineapi.RebootRequest_FORCE {
+		phases = phases.
+			Append(
+				"cleanup",
+				StopAllPods,
+			).
+			Append(
+				"dbus",
+				StopDBus,
+			).
+			AppendList(stopAllPhaselist(r, true))
+	}
+
+	return phases.Append("reboot", Reboot)
 }
 
 // Reset is the reset sequence.

--- a/pkg/machinery/api/machine/machine.pb.go
+++ b/pkg/machinery/api/machine/machine.pb.go
@@ -88,6 +88,7 @@ type RebootRequest_Mode int32
 const (
 	RebootRequest_DEFAULT    RebootRequest_Mode = 0
 	RebootRequest_POWERCYCLE RebootRequest_Mode = 1
+	RebootRequest_FORCE      RebootRequest_Mode = 2
 )
 
 // Enum value maps for RebootRequest_Mode.
@@ -95,10 +96,12 @@ var (
 	RebootRequest_Mode_name = map[int32]string{
 		0: "DEFAULT",
 		1: "POWERCYCLE",
+		2: "FORCE",
 	}
 	RebootRequest_Mode_value = map[string]int32{
 		"DEFAULT":    0,
 		"POWERCYCLE": 1,
+		"FORCE":      2,
 	}
 )
 
@@ -11823,13 +11826,14 @@ const file_machine_machine_proto_rawDesc = "" +
 	"\x04mode\x18\x03 \x01(\x0e2'.machine.ApplyConfigurationRequest.ModeR\x04mode\x12!\n" +
 	"\fmode_details\x18\x04 \x01(\tR\vmodeDetails\"U\n" +
 	"\x1aApplyConfigurationResponse\x127\n" +
-	"\bmessages\x18\x01 \x03(\v2\x1b.machine.ApplyConfigurationR\bmessages\"e\n" +
+	"\bmessages\x18\x01 \x03(\v2\x1b.machine.ApplyConfigurationR\bmessages\"p\n" +
 	"\rRebootRequest\x12/\n" +
-	"\x04mode\x18\x01 \x01(\x0e2\x1b.machine.RebootRequest.ModeR\x04mode\"#\n" +
+	"\x04mode\x18\x01 \x01(\x0e2\x1b.machine.RebootRequest.ModeR\x04mode\".\n" +
 	"\x04Mode\x12\v\n" +
 	"\aDEFAULT\x10\x00\x12\x0e\n" +
 	"\n" +
-	"POWERCYCLE\x10\x01\"Q\n" +
+	"POWERCYCLE\x10\x01\x12\t\n" +
+	"\x05FORCE\x10\x02\"Q\n" +
 	"\x06Reboot\x12,\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x10.common.MetadataR\bmetadata\x12\x19\n" +
 	"\bactor_id\x18\x02 \x01(\tR\aactorId\"=\n" +

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -337,6 +337,11 @@ func WithPowerCycle(req *machineapi.RebootRequest) {
 	req.Mode = machineapi.RebootRequest_POWERCYCLE
 }
 
+// WithForce option runs the Reboot fun in force mode.
+func WithForce(req *machineapi.RebootRequest) {
+	req.Mode = machineapi.RebootRequest_FORCE
+}
+
 // Reboot implements the proto.MachineServiceClient interface.
 func (c *Client) Reboot(ctx context.Context, opts ...RebootMode) error {
 	_, err := c.RebootWithResponse(ctx, opts...)

--- a/pkg/machinery/client/events.go
+++ b/pkg/machinery/client/events.go
@@ -239,6 +239,7 @@ func UnmarshalEvent(event *machineapi.Event) (*Event, error) {
 		&machineapi.ConfigValidationErrorEvent{},
 		&machineapi.AddressEvent{},
 		&machineapi.MachineStatusEvent{},
+		&machineapi.RestartEvent{},
 	} {
 		if typeURL == "talos/runtime/"+string(eventType.ProtoReflect().Descriptor().FullName()) {
 			msg = eventType

--- a/website/content/v1.12/reference/api.md
+++ b/website/content/v1.12/reference/api.md
@@ -4253,6 +4253,7 @@ File type.
 | ---- | ------ | ----------- |
 | DEFAULT | 0 |  |
 | POWERCYCLE | 1 |  |
+| FORCE | 2 |  |
 
 
 

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -2721,7 +2721,7 @@ talosctl reboot [flags]
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for reboot
-  -m, --mode string                select the reboot mode: "default", "powercycle" (skips kexec) (default "default")
+  -m, --mode string                select the reboot mode: "default", "powercycle" (skips kexec), "force" (skips graceful teardown) (default "default")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
       --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.


### PR DESCRIPTION
# Pull Request

closes https://github.com/siderolabs/talos/issues/11782

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Add a forceful mode to the reboot sequence (`talosctl reboot --mode force`) that bypasses graceful userspace teardown.

## Why? (reasoning)

In certain situations, Talos's shutdown/reboot sequence hangs while waiting for services/mounts to be gracefully stopped (see: https://github.com/siderolabs/talos/issues/11775).

------------

I left a few questions as TODOs, PTAL at them if you review! Mainly I'm wondering about `*machine.RebootRequest` vs. `runtime.XxxOptions`, and whether to error out if we don't get a `*machine.RebootRequest` or just silently continue (which is fine for this, since any hypothetical older client wouldn't support force-reboot anyway, and the default is "graceful reboot".

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
