### PR TITLE
fix: drop 'ro' falg from defaults

### DIFF
--- a/internal/app/machined/pkg/controllers/block/mount.go
+++ b/internal/app/machined/pkg/controllers/block/mount.go
@@ -495,7 +495,6 @@ func (ctrl *MountController) handleDiskMountOperation(
 
 		if mountRequest.TypedSpec().ReadOnly {
 			opts = append(opts, mount.WithReadOnly())
-			fsOpts = append(fsOpts, fsopen.WithBoolParameter("ro"))
 		}
 
 		if mountRequest.TypedSpec().Detached {


### PR DESCRIPTION
Flag 'ro' should not be applied as default to ReadOnly filesystems.