### PR TITLE
fix: update test for PCI driver rebind/IOMMU

### DIFF
--- a/internal/integration/api/pci_driver_rebind.go
+++ b/internal/integration/api/pci_driver_rebind.go
@@ -95,15 +95,15 @@ func (suite *PCIDriverRebindSuite) TestIOMMURebind() {
 		pci, ok := item.(*hardware.PCIDevice)
 		suite.Require().True(ok, "expected PCI device, got %T", item)
 
-		if pci.TypedSpec().Product == "Virtio 1.0 network device" {
+		if pci.TypedSpec().Product == "82540EM Gigabit Ethernet Controller" {
 			pciDeviceID = pci.Metadata().ID()
 
 			break
 		}
 	}
 
-	// validate that the driver is bound to virtio-pci initially
-	suite.validateDriver(nodeCtx, pciDeviceID, "virtio-pci")
+	// validate that the driver is bound to e1000 initially
+	suite.validateDriver(nodeCtx, pciDeviceID, "e1000")
 
 	cfgDocument := hardwareconfigtype.NewPCIDriverRebindConfigV1Alpha1()
 	cfgDocument.MetaName = pciDeviceID
@@ -141,7 +141,7 @@ func (suite *PCIDriverRebindSuite) TestIOMMURebind() {
 	// after applying the patch the device should be bound to vfio-pci
 	suite.validateDriver(nodeCtx, pciDeviceID, "vfio-pci")
 
-	cfgDocument.PCITargetDriver = "virtio-pci"
+	cfgDocument.PCITargetDriver = "e1000"
 
 	suite.PatchMachineConfig(nodeCtx, cfgDocument)
 
@@ -149,7 +149,7 @@ func (suite *PCIDriverRebindSuite) TestIOMMURebind() {
 	suite.Require().NoError(err)
 
 	// verify that an update to the target driver takes effect
-	suite.validateDriver(nodeCtx, pciDeviceID, "virtio-pci")
+	suite.validateDriver(nodeCtx, pciDeviceID, "e1000")
 
 	// switch back to vfio-pci
 	cfgDocument.PCITargetDriver = "vfio-pci"
@@ -169,7 +169,7 @@ func (suite *PCIDriverRebindSuite) TestIOMMURebind() {
 	suite.Require().NoError(err)
 
 	// verify that the device is back to original host driver
-	suite.validateDriver(nodeCtx, pciDeviceID, "virtio-pci")
+	suite.validateDriver(nodeCtx, pciDeviceID, "e1000")
 }
 
 func (suite *PCIDriverRebindSuite) validateDriver(nodeCtx context.Context, pciDeviceID, driver string) {

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -276,7 +276,7 @@ func launchVM(config *LaunchConfig) error {
 		args = append(args,
 			"-device", "intel-iommu,intremap=on,device-iotlb=on",
 			"-device", "ioh3420,id=pcie.1,chassis=1",
-			"-device", "virtio-net-pci,bus=pcie.1,netdev=net1,disable-legacy=on,disable-modern=off,iommu_platform=on,ats=on",
+			"-device", "e1000,bus=pcie.1,netdev=net1",
 			"-netdev", "tap,id=net1,vhostforce=on,script=no,downscript=no",
 		)
 	}


### PR DESCRIPTION
Use `e1000` emulation instead of `virtio-net`, as with new network config if we create another `virtion-net` link, Talos is confused which one should be aliased, and networking config is broken.
