### PR TITLE
fix: provide offset for partitions in discovered volumes

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -42,6 +42,7 @@ message DiscoveredVolumeSpec {
   string dev_path = 17;
   string parent_dev_path = 18;
   string pretty_size = 19;
+  uint64 offset = 20;
 }
 
 // DiscoveryRefreshRequestSpec is the spec for DiscoveryRefreshRequest.

--- a/internal/app/machined/pkg/controllers/block/discovery.go
+++ b/internal/app/machined/pkg/controllers/block/discovery.go
@@ -215,6 +215,7 @@ func (ctrl *DiscoveryController) rescan(ctx context.Context, r controller.Runtim
 				dv.TypedSpec().ParentDevPath = filepath.Join("/dev", device.TypedSpec().Parent)
 			}
 
+			dv.TypedSpec().Offset = 0
 			dv.TypedSpec().SetSize(info.Size)
 			dv.TypedSpec().SectorSize = info.SectorSize
 			dv.TypedSpec().IOSize = info.IOSize
@@ -238,6 +239,7 @@ func (ctrl *DiscoveryController) rescan(ctx context.Context, r controller.Runtim
 				dv.TypedSpec().Parent = id
 				dv.TypedSpec().ParentDevPath = filepath.Join("/dev", id)
 
+				dv.TypedSpec().Offset = nested.PartitionOffset
 				dv.TypedSpec().SetSize(nested.PartitionSize)
 
 				dv.TypedSpec().SectorSize = info.SectorSize

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -156,6 +156,7 @@ type DiscoveredVolumeSpec struct {
 	DevPath             string                 `protobuf:"bytes,17,opt,name=dev_path,json=devPath,proto3" json:"dev_path,omitempty"`
 	ParentDevPath       string                 `protobuf:"bytes,18,opt,name=parent_dev_path,json=parentDevPath,proto3" json:"parent_dev_path,omitempty"`
 	PrettySize          string                 `protobuf:"bytes,19,opt,name=pretty_size,json=prettySize,proto3" json:"pretty_size,omitempty"`
+	Offset              uint64                 `protobuf:"varint,20,opt,name=offset,proto3" json:"offset,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -321,6 +322,13 @@ func (x *DiscoveredVolumeSpec) GetPrettySize() string {
 		return x.PrettySize
 	}
 	return ""
+}
+
+func (x *DiscoveredVolumeSpec) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
 }
 
 // DiscoveryRefreshRequestSpec is the spec for DiscoveryRefreshRequest.
@@ -2293,7 +2301,7 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\vdevice_path\x18\a \x01(\tR\n" +
 	"devicePath\x12\x16\n" +
 	"\x06parent\x18\b \x01(\tR\x06parent\x12 \n" +
-	"\vsecondaries\x18\t \x03(\tR\vsecondaries\"\xe7\x04\n" +
+	"\vsecondaries\x18\t \x03(\tR\vsecondaries\"\xff\x04\n" +
 	"\x14DiscoveredVolumeSpec\x12\x12\n" +
 	"\x04size\x18\x01 \x01(\x04R\x04size\x12\x1f\n" +
 	"\vsector_size\x18\x02 \x01(\x04R\n" +
@@ -2319,7 +2327,8 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\bdev_path\x18\x11 \x01(\tR\adevPath\x12&\n" +
 	"\x0fparent_dev_path\x18\x12 \x01(\tR\rparentDevPath\x12\x1f\n" +
 	"\vpretty_size\x18\x13 \x01(\tR\n" +
-	"prettySize\"7\n" +
+	"prettySize\x12\x16\n" +
+	"\x06offset\x18\x14 \x01(\x04R\x06offset\"7\n" +
 	"\x1bDiscoveryRefreshRequestSpec\x12\x18\n" +
 	"\arequest\x18\x01 \x01(\x03R\arequest\"6\n" +
 	"\x1aDiscoveryRefreshStatusSpec\x12\x18\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -143,6 +143,13 @@ func (m *DiscoveredVolumeSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Offset != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Offset))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa0
+	}
 	if len(m.PrettySize) > 0 {
 		i -= len(m.PrettySize)
 		copy(dAtA[i:], m.PrettySize)
@@ -2261,6 +2268,9 @@ func (m *DiscoveredVolumeSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.Offset != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.Offset))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3851,6 +3861,25 @@ func (m *DiscoveredVolumeSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.PrettySize = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 20:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Offset", wireType)
+			}
+			m.Offset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Offset |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/resources/block/discovered_volume.go
+++ b/pkg/machinery/resources/block/discovered_volume.go
@@ -30,6 +30,9 @@ type DiscoveredVolumeSpec struct {
 	Parent        string `yaml:"parent,omitempty" protobuf:"16"`
 	ParentDevPath string `yaml:"parent_dev_path,omitempty" protobuf:"18"`
 
+	// Offset of the partition/volume inside Parent device (in bytes).
+	Offset uint64 `yaml:"offset" protobuf:"20"`
+
 	// Overall size of the probed device (in bytes).
 	Size       uint64 `yaml:"size" protobuf:"1"`
 	PrettySize string `yaml:"pretty_size" protobuf:"19"`

--- a/website/content/v1.12/reference/api.md
+++ b/website/content/v1.12/reference/api.md
@@ -5545,6 +5545,7 @@ DiscoveredVolumeSpec is the spec for DiscoveredVolumes resource.
 | dev_path | [string](#string) |  |  |
 | parent_dev_path | [string](#string) |  |  |
 | pretty_size | [string](#string) |  |  |
+| offset | [uint64](#uint64) |  |  |
 
 
 


### PR DESCRIPTION
This was missing in the resource which makes rendering partitions in the GUI hard.
