### PR TITLE
feat: add directory backed UserVolumes

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -135,6 +135,7 @@ message MountSpec {
   int64 uid = 6;
   int64 gid = 7;
   bool recursive_relabel = 8;
+  string bind_target = 9;
 }
 
 // MountStatusSpec is the spec for MountStatus.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -130,11 +130,27 @@ When using Factory or Imager supply as `-module.sig_enfore module.sig_enforce=0`
     [notes.grub]
         title = "GRUB"
         description = """\
-Talos Linux introduces new machine configuration option `.machine.install.grubUseUKICmdline` to control whether GRUB should use the kernel command line 
+Talos Linux introduces new machine configuration option `.machine.install.grubUseUKICmdline` to control whether GRUB should use the kernel command line
 provided by the boot assets (UKI) or to use the command line constructed by Talos itself (legacy behavior).
 
 This option defaults to `true` for new installations, which means that GRUB will use the command line from the UKI, making it easier to customize kernel parameters via boot asset generation.
 For existing installations upgrading to v1.12, this option will default to `false` to preserve the legacy behavior.
+"""
+
+    [notes.directory-user-volumes]
+        title = "New User Volume type - bind"
+        description = """\
+New field in UserVolumeConfig - `volumeType` that defaults to `partition`, but can be set to `directory`.
+When set to `directory`, provisioning and filesystem operations are skipped and a directory is created under `/var/mnt/<name>`.
+
+The `directory` type enables lightweight storage volumes backed by a host directory, instead of requiring a full block device partition.
+
+When `volumeType = "directory"`:
+- A directory is created at `/var/mnt/<metadata.name>`;
+- `provisioning`, `filesystem` and `encryption` are prohibited.
+
+Note: this mode does not provide filesystem-level isolation and inherits the EPHEMERAL partition capacity limits.
+It should not be used for workloads requiring predictable storage quotas.
 """
 
 [make_deps]

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/close.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/close.go
@@ -19,7 +19,7 @@ import (
 func Close(ctx context.Context, logger *zap.Logger, volumeContext ManagerContext) error {
 	switch volumeContext.Cfg.TypedSpec().Type {
 	case block.VolumeTypeTmpfs, block.VolumeTypeDirectory, block.VolumeTypeSymlink, block.VolumeTypeOverlay:
-		// tmpfs, directory, symlink and overlay volumes can be always closed
+		// volume types can be always closed
 		volumeContext.Status.Phase = block.VolumePhaseClosed
 
 		return nil

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
@@ -30,7 +30,7 @@ func LocateAndProvision(ctx context.Context, logger *zap.Logger, volumeContext M
 
 	switch volumeType {
 	case block.VolumeTypeTmpfs, block.VolumeTypeDirectory, block.VolumeTypeSymlink, block.VolumeTypeOverlay:
-		// tmpfs, directory, symlink and overlays volumes are always ready
+		// volume types above are always ready
 		volumeContext.Status.Phase = block.VolumePhaseReady
 
 		return nil

--- a/internal/pkg/mount/v3/manager.go
+++ b/internal/pkg/mount/v3/manager.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/xfs"
 	"github.com/siderolabs/talos/pkg/xfs/fsopen"
+	"github.com/siderolabs/talos/pkg/xfs/opentree"
 )
 
 // Manager is the filesystem manager for mounting and unmounting filesystems.
@@ -187,6 +188,15 @@ func WithFsopen(fstype string, opts ...fsopen.Option) ManagerOption {
 	return ManagerOption{
 		set: func(m *Manager) {
 			m.fs = fsopen.New(fstype, opts...)
+		},
+	}
+}
+
+// WithOpentreeFromPath sets the opentree opener with the path.
+func WithOpentreeFromPath(path string) ManagerOption {
+	return ManagerOption{
+		set: func(m *Manager) {
+			m.fs = opentree.NewFromPath(path)
 		},
 	}
 }

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -1027,6 +1027,7 @@ type MountSpec struct {
 	Uid                 int64                  `protobuf:"varint,6,opt,name=uid,proto3" json:"uid,omitempty"`
 	Gid                 int64                  `protobuf:"varint,7,opt,name=gid,proto3" json:"gid,omitempty"`
 	RecursiveRelabel    bool                   `protobuf:"varint,8,opt,name=recursive_relabel,json=recursiveRelabel,proto3" json:"recursive_relabel,omitempty"`
+	BindTarget          string                 `protobuf:"bytes,9,opt,name=bind_target,json=bindTarget,proto3" json:"bind_target,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -1115,6 +1116,13 @@ func (x *MountSpec) GetRecursiveRelabel() bool {
 		return x.RecursiveRelabel
 	}
 	return false
+}
+
+func (x *MountSpec) GetBindTarget() string {
+	if x != nil {
+		return x.BindTarget
+	}
+	return ""
 }
 
 // MountStatusSpec is the spec for MountStatus.
@@ -2390,7 +2398,7 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"requesters\x12$\n" +
 	"\x0erequester_i_ds\x18\x04 \x03(\tR\frequesterIDs\x12\x1b\n" +
 	"\tread_only\x18\x05 \x01(\bR\breadOnly\x12\x1a\n" +
-	"\bdetached\x18\x06 \x01(\bR\bdetached\"\x90\x02\n" +
+	"\bdetached\x18\x06 \x01(\bR\bdetached\"\xb1\x02\n" +
 	"\tMountSpec\x12\x1f\n" +
 	"\vtarget_path\x18\x01 \x01(\tR\n" +
 	"targetPath\x12#\n" +
@@ -2400,7 +2408,9 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\tfile_mode\x18\x05 \x01(\rR\bfileMode\x12\x10\n" +
 	"\x03uid\x18\x06 \x01(\x03R\x03uid\x12\x10\n" +
 	"\x03gid\x18\a \x01(\x03R\x03gid\x12+\n" +
-	"\x11recursive_relabel\x18\b \x01(\bR\x10recursiveRelabel\"\xbd\x03\n" +
+	"\x11recursive_relabel\x18\b \x01(\bR\x10recursiveRelabel\x12\x1f\n" +
+	"\vbind_target\x18\t \x01(\tR\n" +
+	"bindTarget\"\xbd\x03\n" +
 	"\x0fMountStatusSpec\x12F\n" +
 	"\x04spec\x18\x01 \x01(\v22.talos.resource.definitions.block.MountRequestSpecR\x04spec\x12\x16\n" +
 	"\x06target\x18\x02 \x01(\tR\x06target\x12\x16\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -993,6 +993,13 @@ func (m *MountSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.BindTarget) > 0 {
+		i -= len(m.BindTarget)
+		copy(dAtA[i:], m.BindTarget)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BindTarget)))
+		i--
+		dAtA[i] = 0x4a
+	}
 	if m.RecursiveRelabel {
 		i--
 		if m.RecursiveRelabel {
@@ -2585,6 +2592,10 @@ func (m *MountSpec) SizeVT() (n int) {
 	}
 	if m.RecursiveRelabel {
 		n += 2
+	}
+	l = len(m.BindTarget)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5880,6 +5891,38 @@ func (m *MountSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.RecursiveRelabel = bool(v != 0)
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BindTarget", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BindTarget = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -85,6 +85,7 @@ func (emptyVolumeConfig) MaxSize() optional.Optional[uint64] {
 type UserVolumeConfig interface {
 	NamedDocument
 	UserVolumeConfigSignal()
+	Type() optional.Optional[block.VolumeType]
 	Provisioning() VolumeProvisioningConfig
 	Filesystem() FilesystemConfig
 	Encryption() EncryptionConfig

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -449,6 +449,16 @@
           "markdownDescription": "Name of the volume.\n\nName might be between 1 and 34 characters long and can only contain:\nlowercase and uppercase ASCII letters, digits, and hyphens.",
           "x-intellij-html-description": "\u003cp\u003eName of the volume.\u003c/p\u003e\n\n\u003cp\u003eName might be between 1 and 34 characters long and can only contain:\nlowercase and uppercase ASCII letters, digits, and hyphens.\u003c/p\u003e\n"
         },
+        "volumeType": {
+          "enum": [
+            "partition",
+            "directory"
+          ],
+          "title": "volumeType",
+          "description": "Volume type.\n",
+          "markdownDescription": "Volume type.",
+          "x-intellij-html-description": "\u003cp\u003eVolume type.\u003c/p\u003e\n"
+        },
         "provisioning": {
           "$ref": "#/$defs/block.ProvisioningSpec",
           "title": "provisioning",

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -500,6 +500,17 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Name of the volume." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
+				Name:        "volumeType",
+				Type:        "VolumeType",
+				Note:        "",
+				Description: "Volume type.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Volume type." /* encoder.LineComment */, "" /* encoder.FootComment */},
+				Values: []string{
+					"partition",
+					"directory",
+				},
+			},
+			{
 				Name:        "provisioning",
 				Type:        "ProvisioningSpec",
 				Note:        "",
@@ -523,7 +534,9 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 		},
 	}
 
-	doc.AddExample("", exampleUserVolumeConfigV1Alpha1())
+	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Directory())
+
+	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Partition())
 
 	return doc
 }

--- a/pkg/machinery/config/types/block/deep_copy.generated.go
+++ b/pkg/machinery/config/types/block/deep_copy.generated.go
@@ -155,6 +155,10 @@ func (o *SwapVolumeConfigV1Alpha1) DeepCopy() *SwapVolumeConfigV1Alpha1 {
 // DeepCopy generates a deep copy of *UserVolumeConfigV1Alpha1.
 func (o *UserVolumeConfigV1Alpha1) DeepCopy() *UserVolumeConfigV1Alpha1 {
 	var cp UserVolumeConfigV1Alpha1 = *o
+	if o.VolumeType != nil {
+		cp.VolumeType = new(VolumeType)
+		*cp.VolumeType = *o.VolumeType
+	}
 	if o.ProvisioningSpec.ProvisioningGrow != nil {
 		cp.ProvisioningSpec.ProvisioningGrow = new(bool)
 		*cp.ProvisioningSpec.ProvisioningGrow = *o.ProvisioningSpec.ProvisioningGrow

--- a/pkg/machinery/config/types/block/encryption.go
+++ b/pkg/machinery/config/types/block/encryption.go
@@ -83,6 +83,11 @@ func exampleEncryptionSpec() *EncryptionSpec {
 	}
 }
 
+// IsZero checks if the encryption spec is zero.
+func (s EncryptionSpec) IsZero() bool {
+	return s.EncryptionProvider == block.EncryptionProviderNone && len(s.EncryptionKeys) == 0
+}
+
 // EncryptionKey represents configuration for disk encryption key.
 type EncryptionKey struct {
 	//   description: >
@@ -159,7 +164,7 @@ func exampleKMSKey() *EncryptionKeyKMS {
 //
 //nolint:gocyclo
 func (s EncryptionSpec) Validate() ([]string, error) {
-	if s.EncryptionProvider == block.EncryptionProviderNone && len(s.EncryptionKeys) == 0 {
+	if s.IsZero() {
 		return nil, nil
 	}
 

--- a/pkg/machinery/config/types/block/user_volume_config_test.go
+++ b/pkg/machinery/config/types/block/user_volume_config_test.go
@@ -303,6 +303,83 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 			expectedErrors: "project quota support is only available for xfs filesystem",
 		},
 		{
+			name: "provisioning spec for directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDirectory)
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`system_disk`)))
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+
+				return c
+			},
+
+			expectedErrors: "provisioning spec is invalid for volumeType directory",
+		},
+		{
+			name: "encryption spec for directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDirectory)
+
+				c.EncryptionSpec.EncryptionProvider = blockres.EncryptionProviderLUKS2
+				c.EncryptionSpec.EncryptionCipher = "aes-xts-plain64"
+				c.EncryptionSpec.EncryptionKeys = []block.EncryptionKey{
+					{
+						KeySlot: 0,
+						KeyTPM:  &block.EncryptionKeyTPM{},
+					},
+				}
+
+				return c
+			},
+
+			expectedErrors: "encryption spec is invalid for volumeType directory",
+		},
+		{
+			name: "filesystem spec for directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDirectory)
+
+				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeVFAT
+
+				return c
+			},
+
+			expectedErrors: "filesystem spec is invalid for volumeType directory",
+		},
+		{
+			name: "invalid volumeType",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeTmpfs)
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`system_disk`)))
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+				c.EncryptionSpec.EncryptionProvider = blockres.EncryptionProviderLUKS2
+				c.EncryptionSpec.EncryptionCipher = "aes-xts-plain64"
+				c.EncryptionSpec.EncryptionKeys = []block.EncryptionKey{
+					{
+						KeySlot: 0,
+						KeyTPM:  &block.EncryptionKeyTPM{},
+					},
+				}
+
+				return c
+			},
+
+			expectedErrors: "unsupported volume type \"tmpfs\"",
+		},
+		{
 			name: "valid",
 
 			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
@@ -313,6 +390,33 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustByteSize("2.5TiB")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
 				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+
+				return c
+			},
+		},
+		{
+			name: "valid partition",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypePartition)
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustByteSize("2.5TiB")
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+
+				return c
+			},
+		},
+		{
+			name: "valid directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDirectory)
 
 				return c
 			},

--- a/pkg/machinery/resources/block/deep_copy.generated.go
+++ b/pkg/machinery/resources/block/deep_copy.generated.go
@@ -122,6 +122,10 @@ func (o VolumeConfigSpec) DeepCopy() VolumeConfigSpec {
 		cp.Encryption.PerfOptions = make([]string, len(o.Encryption.PerfOptions))
 		copy(cp.Encryption.PerfOptions, o.Encryption.PerfOptions)
 	}
+	if o.Mount.BindTarget != nil {
+		cp.Mount.BindTarget = new(string)
+		*cp.Mount.BindTarget = *o.Mount.BindTarget
+	}
 	return cp
 }
 
@@ -165,6 +169,10 @@ func (o VolumeStatusSpec) DeepCopy() VolumeStatusSpec {
 	if o.TPMEncryptionOptions.PubKeyPCRs != nil {
 		cp.TPMEncryptionOptions.PubKeyPCRs = make([]int, len(o.TPMEncryptionOptions.PubKeyPCRs))
 		copy(cp.TPMEncryptionOptions.PubKeyPCRs, o.TPMEncryptionOptions.PubKeyPCRs)
+	}
+	if o.MountSpec.BindTarget != nil {
+		cp.MountSpec.BindTarget = new(string)
+		*cp.MountSpec.BindTarget = *o.MountSpec.BindTarget
 	}
 	return cp
 }

--- a/pkg/machinery/resources/block/volume_config.go
+++ b/pkg/machinery/resources/block/volume_config.go
@@ -173,6 +173,8 @@ type MountSpec struct {
 	GID int `yaml:"gid,omitempty" protobuf:"7"`
 	// RecursiveRelabel is the recursive relabel/chown flag for the mount target.
 	RecursiveRelabel bool `yaml:"recursiveRelabel,omitempty" protobuf:"8"`
+	// BindTarget is an optional path on the host to bind-mount the volume onto.
+	BindTarget *string `yaml:"bindTarget,omitempty" protobuf:"9"`
 }
 
 // SymlinkProvisioningSpec is the spec for volume symlink.

--- a/website/content/v1.12/reference/api.md
+++ b/website/content/v1.12/reference/api.md
@@ -5738,6 +5738,7 @@ MountSpec is the spec for volume mount.
 | uid | [int64](#int64) |  |  |
 | gid | [int64](#int64) |  |  |
 | recursive_relabel | [bool](#bool) |  |  |
+| bind_target | [string](#string) |  |  |
 
 
 

--- a/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
+++ b/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
@@ -21,6 +21,38 @@ title: UserVolumeConfig
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-data # Name of the volume.
+volumeType: directory # Volume type.
+
+# # The encryption describes how the volume is encrypted.
+# encryption:
+#     provider: luks2 # Encryption provider to use for the encryption.
+#     # Defines the encryption keys generation and storage method.
+#     keys:
+#         - slot: 0 # Key slot number for LUKS2 encryption.
+#           # Key which value is stored in the configuration file.
+#           static:
+#             passphrase: exampleKey # Defines the static passphrase value.
+#
+#           # # KMS managed encryption key.
+#           # kms:
+#           #     endpoint: https://192.168.88.21:4443 # KMS endpoint to Seal/Unseal the key.
+#         - slot: 1 # Key slot number for LUKS2 encryption.
+#           # KMS managed encryption key.
+#           kms:
+#             endpoint: https://example-kms-endpoint.com # KMS endpoint to Seal/Unseal the key.
+#     cipher: aes-xts-plain64 # Cipher to use for the encryption. Depends on the encryption provider.
+#     blockSize: 4096 # Defines the encryption sector size.
+#     # Additional --perf parameters for the LUKS2 encryption.
+#     options:
+#         - no_read_workqueue
+#         - no_write_workqueue
+{{< /highlight >}}
+
+{{< highlight yaml >}}
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: local-data # Name of the volume.
+volumeType: partition # Volume type.
 # The provisioning describes how the volume is provisioned.
 provisioning:
     # The disk selector expression.
@@ -70,6 +102,7 @@ encryption:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`name` |string |Name of the volume.<br><br>Name might be between 1 and 34 characters long and can only contain:<br>lowercase and uppercase ASCII letters, digits, and hyphens.  | |
+|`volumeType` |VolumeType |Volume type.  |`partition`<br />`directory`<br /> |
 |`provisioning` |<a href="#UserVolumeConfig.provisioning">ProvisioningSpec</a> |The provisioning describes how the volume is provisioned.  | |
 |`filesystem` |<a href="#UserVolumeConfig.filesystem">FilesystemSpec</a> |The filesystem describes how the volume is formatted.  | |
 |`encryption` |<a href="#UserVolumeConfig.encryption">EncryptionSpec</a> |The encryption describes how the volume is encrypted.  | |

--- a/website/content/v1.12/schemas/config.schema.json
+++ b/website/content/v1.12/schemas/config.schema.json
@@ -449,6 +449,16 @@
           "markdownDescription": "Name of the volume.\n\nName might be between 1 and 34 characters long and can only contain:\nlowercase and uppercase ASCII letters, digits, and hyphens.",
           "x-intellij-html-description": "\u003cp\u003eName of the volume.\u003c/p\u003e\n\n\u003cp\u003eName might be between 1 and 34 characters long and can only contain:\nlowercase and uppercase ASCII letters, digits, and hyphens.\u003c/p\u003e\n"
         },
+        "volumeType": {
+          "enum": [
+            "partition",
+            "directory"
+          ],
+          "title": "volumeType",
+          "description": "Volume type.\n",
+          "markdownDescription": "Volume type.",
+          "x-intellij-html-description": "\u003cp\u003eVolume type.\u003c/p\u003e\n"
+        },
         "provisioning": {
           "$ref": "#/$defs/block.ProvisioningSpec",
           "title": "provisioning",


### PR DESCRIPTION
New field in UserVolumeConfig - `volumeType` that defaults to `partition`, but can be set to `directory`.
When set to `directory`, provisioning and filesystem operations are skipped and a directory is created under `/var/mnt/<name>`.

The `directory` type enables lightweight storage volumes backed by a host directory, instead of requiring a full block device partition.

When `volumeType = "directory"`:
- A directory is created at `/var/mnt/<metadata.name>`;
- `provisioning`, `filesystem` and `encryption` are prohibited.

Note: this mode does not provide filesystem-level isolation and inherits the EPHEMERAL partition capacity limits.
It should not be used for workloads requiring predictable storage quotas.

```yaml
apiVersion: v1alpha1
kind: UserVolumeConfig
name: test
volumeType: directory
```

Resolves #11848