### PR TITLE
fix: talos import on non-linux

### DIFF
--- a/pkg/xfs/fsopen/fsopen_other.go
+++ b/pkg/xfs/fsopen/fsopen_other.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+
+// Package fsopen provides a simple interface to create and manage a filesystem
+// using the Linux syscalls for filesystem operations.
+package fsopen


### PR DESCRIPTION
Otherwise it fails to import talos on linux machines due to build constraints.