### PR TITLE
Feat/dashboard console parameter

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -87,6 +87,9 @@ const (
 	// KernelParamDashboardDisabled is the kernel parameter name for disabling the dashboard.
 	KernelParamDashboardDisabled = "talos.dashboard.disabled"
 
+	// KernelParamDashboardConsole is the kernel parameter name for specifying the dashboard console.
+	KernelParamDashboardConsole = "talos.dashboard.console"
+
 	// KernelParamEnvironment is the kernel parameter name for passing process environment.
 	KernelParamEnvironment = "talos.environment"
 

--- a/website/content/v1.12/reference/kernel.md
+++ b/website/content/v1.12/reference/kernel.md
@@ -257,6 +257,28 @@ Kernel logs will be sent to the currently active console and the dashboard will 
 
 It is set to be `1` by default on SBCs.
 
+#### `talos.dashboard.console`
+
+By default, the Talos dashboard runs on `/dev/tty2` with automatic TTY switching.
+You can specify a custom console device for the dashboard using this parameter.
+
+For example, to run the dashboard on a serial console:
+
+```text
+talos.dashboard.console=ttyS0
+```
+
+When this parameter is specified:
+
+* The dashboard will run on `/dev/ttyS0`
+* TTY switching will be disabled (no automatic switching between tty1 and tty2)
+* The console name must start with "tty"
+
+This is useful for headless servers or systems where you want the dashboard accessible through a serial console connection.
+
+> Note: If Talos dashboard is set to use ttyS0, make sure that Linux kernel command line doesn't include
+> `console=ttyS0` or similar, as it will conflict with the dashboard output.
+
 #### `talos.environment`
 
 Each value of the argument sets a default environment variable.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Issue URL : https://github.com/siderolabs/talos/issues/12070
This PR implements support for running the Talos dashboard on a custom console device by adding a new kernel parameter talos.dashboard.console. 

## Why? (reasoning)
-  Headless systems need serial console access instead of virtual terminals.
-  Remote management via serial consoles for out-of-band access.
-  Before there was automatic system change for available tty, but we can set this to a fixed tty using this kernel param.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
