### PR TITLE
chore: disable VIP operator test

### DIFF
--- a/internal/integration/api/network-config.go
+++ b/internal/integration/api/network-config.go
@@ -301,6 +301,8 @@ func (suite *NetworkConfigSuite) TestLinkAliasConfig() {
 
 // TestVirtualIPConfig tests configuring virtual IPs.
 func (suite *NetworkConfigSuite) TestVirtualIPConfig() {
+	suite.T().Skip("[TODO]: this test causes kube-apiserver to restart causing random failure")
+
 	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
 		suite.T().Skip("skipping if cluster is not qemu")
 	}


### PR DESCRIPTION
It might restart kube-apiserver (due to cert change) at a random moment.
