### PR TITLE
change talosctl reset --system-labels-to-wipe to wipe partitions

### DIFF
--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -190,7 +190,7 @@ func init() {
 	resetCmd.Flags().BoolVar(&resetCmdFlags.insecure, "insecure", false, "reset using the insecure (encrypted with no auth) maintenance service")
 	resetCmd.Flags().Var(&resetCmdFlags.wipeMode, "wipe-mode", "disk reset mode")
 	resetCmd.Flags().StringSliceVar(&resetCmdFlags.userDisksToWipe, "user-disks-to-wipe", nil, "if set, wipes defined devices in the list")
-	resetCmd.Flags().StringSliceVar(&resetCmdFlags.systemLabelsToWipe, "system-labels-to-wipe", nil, "if set, just wipe selected system disk partitions by label but keep other partitions intact")
+	resetCmd.Flags().StringSliceVar(&resetCmdFlags.systemLabelsToWipe, "system-labels-to-wipe", nil, "wipe and re-create selected system disk partitions by label (e.g., STATE, EPHEMERAL)")
 	resetCmdFlags.addTrackActionFlags(resetCmd)
 	addCommand(resetCmd)
 }


### PR DESCRIPTION
# Pull Request

## What? (description)

Issue URL: https://github.com/siderolabs/talos/issues/12090
Update the --system-labels-to-wipe flag description in talosctl reset to clarify that it wipes and re-creates selected system disk partitions by label.

## Why? (reasoning)

Improve documentation

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
