### PR TITLE
fix: userspace wireguard handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ GO_BUILDFLAGS ?=
 GO_BUILDTAGS ?= tcell_minimal,grpcnotrace
 GO_BUILDTAGS_TALOSCTL ?= grpcnotrace
 GO_LDFLAGS ?=
-GO_MACHINED_LDFLAGS ?= -X golang.zx2c4.com/wireguard/ipc.socketPath=/system/wireguard-sock # see https://github.com/siderolabs/talos/issues/8514
+GO_MACHINED_LDFLAGS ?= -X golang.zx2c4.com/wireguard/ipc.socketDirectory=/system/wireguard-sock # see https://github.com/siderolabs/talos/issues/8514
 GOAMD64 ?= v2
 GOFIPS140 ?= off
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,9 @@ replace (
 	// Use nested module.
 	github.com/siderolabs/talos/pkg/machinery => ./pkg/machinery
 
+	// fork to add Talos-specific userspace socket location: https://github.com/siderolabs/talos/issues/8514
+	golang.zx2c4.com/wireguard/wgctrl => github.com/siderolabs/wgctrl-go v0.0.0-20251029173431-c4fd5f6a4e72
+
 	// forked go-yaml that introduces RawYAML interface, which can be used to populate YAML fields using bytes
 	// which are then encoded as a valid YAML blocks with proper indentiation
 	gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20220527175918-f17b0f05cf2c

--- a/go.sum
+++ b/go.sum
@@ -665,6 +665,8 @@ github.com/siderolabs/siderolink v0.3.15 h1:WSsgKQGJY/ObIKjTcYYGEaGfRMyox+r/Ft+9
 github.com/siderolabs/siderolink v0.3.15/go.mod h1:iWdlsHji90zotgDg4+a2zJL2ZMNJckQ8/VwqR39ThBM=
 github.com/siderolabs/tcpproxy v0.1.0 h1:IbkS9vRhjMOscc1US3M5P1RnsGKFgB6U5IzUk+4WkKA=
 github.com/siderolabs/tcpproxy v0.1.0/go.mod h1:onn6CPPj/w1UNqQ0U97oRPF0CqbrgEApYCw4P9IiCW8=
+github.com/siderolabs/wgctrl-go v0.0.0-20251029173431-c4fd5f6a4e72 h1:Boabco/vhoFVTUlPcLr4B27NnYUq1QMZVgMtPvyaDzk=
+github.com/siderolabs/wgctrl-go v0.0.0-20251029173431-c4fd5f6a4e72/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smira/containerd/v2 v2.0.0-20250806103510-dcf2fc86e156 h1:vxHt7VLqjFtY3c80Al/RTPAxxu7XVQuTeTNkRZb2AOQ=
@@ -953,8 +955,6 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeu
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
-golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
-golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=

--- a/internal/app/machined/pkg/controllers/network/link_alias_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_alias_spec.go
@@ -107,8 +107,6 @@ func (ctrl *LinkAliasSpecController) Run(ctx context.Context, r controller.Runti
 				continue
 			}
 
-			logger.Debug("checking link for alias", zap.String("link", link.Attributes.Name), zap.Any("link", link))
-
 			if link.Attributes.Info != nil || nethelpers.LinkType(link.Type) != nethelpers.LinkEther {
 				// skip non-physical links
 				continue


### PR DESCRIPTION
This is a fix for the wrong fix in #11204, which was wrong in two ways:

* the ldflags -X override had a wrong variable name, so it had no effect
* but the above even if it worked, only covered "management" part of things, while `wgctrl-go` which configures things still has a hardcoded location of `/var/run/`.

So the fix is two ways:

* replace the location where the socket is created properly
* use updated forked wgctrl-go which looks in both locations

This keeps all fixes of #11204 - `talosctl cluster create` siderolink agent works properly with `wg` on the host, and Talos uses proper location.

Before the fix the location was actually `/var/run` and it randomly failed depending on the race condition of Talos booting up and managing `/var`.
