### PR TITLE
feat: add full disk volumes

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -168,7 +168,17 @@ It should not be used for workloads requiring predictable storage quotas.
         title = "CRI Registry Configuration"
         description = """\
 The CRI registry configuration in v1apha1 legacy machine configuration under `.machine.registries` is now deprecated, but still supported for backwards compatibility.
-New configuration documents `RegistryMirrorConfig`, `RegistryAuthConfig` and `RegistryTLSConfig`  should be used instead.
+New configuration documents `RegistryMirrorConfig`, `RegistryAuthConfig` and `RegistryTLSConfig` should be used instead.
+"""
+
+    [notes.disk-user-volumes]
+        title = "New User Volume type - disk"
+        description = """\
+`volumeType` in UserVolumeConfig can be set to `disk`.
+When set to `disk`, a full block device is used for the volume.
+
+When `volumeType = "disk"`:
+- Size specific settings are not allowed in the provisioning block (`minSize`, `maxSize`, `grow`).
 """
 
 [make_deps]

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
@@ -115,7 +115,7 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 		makefsOptions = append(makefsOptions, makefs.WithConfigFile(quirks.New("").XFSMkfsConfig()))
 
 		if err = makefs.XFS(volumeContext.Status.MountLocation, makefsOptions...); err != nil {
-			return fmt.Errorf("error formatting XFS: %w", err)
+			return xerrors.NewTaggedf[Retryable]("error formatting XFS: %w", err)
 		}
 	case block.FilesystemTypeEXT4:
 		var makefsOptions []makefs.Option
@@ -125,14 +125,14 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 		}
 
 		if err = makefs.Ext4(volumeContext.Status.MountLocation, makefsOptions...); err != nil {
-			return fmt.Errorf("error formatting ext4: %w", err)
+			return xerrors.NewTaggedf[Retryable]("error formatting ext4: %w", err)
 		}
 	case block.FilesystemTypeSwap:
 		if err = swap.Format(volumeContext.Status.MountLocation, swap.FormatOptions{
 			Label: volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label,
 			UUID:  uuid.New(),
 		}); err != nil {
-			return fmt.Errorf("error formatting swap: %w", err)
+			return xerrors.NewTaggedf[Retryable]("error formatting swap: %w", err)
 		}
 	default:
 		return fmt.Errorf("unsupported filesystem type: %s", volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Type)

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -265,32 +265,7 @@ func (suite *VolumesSuite) TestLVMActivation() {
 
 	suite.Require().Contains(stdout, "Logical volume \"lv1\" created.")
 
-	defer func() {
-		suite.T().Logf("removing LVM volumes %s/%s", node, nodeName)
-
-		deletePodDef, err := suite.NewPrivilegedPod("pv-destroy")
-		suite.Require().NoError(err)
-
-		deletePodDef = deletePodDef.WithNodeName(nodeName)
-
-		suite.Require().NoError(deletePodDef.Create(suite.ctx, 5*time.Minute))
-
-		defer deletePodDef.Delete(suite.ctx) //nolint:errcheck
-
-		if _, _, err := deletePodDef.Exec(
-			suite.ctx,
-			"nsenter --mount=/proc/1/ns/mnt -- vgremove --nolocking --yes vg0",
-		); err != nil {
-			suite.T().Logf("failed to remove pv vg0: %v", err)
-		}
-
-		if _, _, err := deletePodDef.Exec(
-			suite.ctx,
-			fmt.Sprintf("nsenter --mount=/proc/1/ns/mnt -- pvremove --nolocking --yes %s", userDisksJoined),
-		); err != nil {
-			suite.T().Logf("failed to remove pv backed by volumes %s: %v", userDisksJoined, err)
-		}
-	}()
+	defer suite.deleteLVMVolumes(node, nodeName, userDisksJoined)
 
 	suite.T().Logf("rebooting node %s/%s", node, nodeName)
 
@@ -307,6 +282,33 @@ func (suite *VolumesSuite) TestLVMActivation() {
 	suite.Require().Eventually(func() bool {
 		return suite.lvmVolumeExists(node, []string{"lv0", "lv1"})
 	}, 5*time.Second, 1*time.Second, "LVM volume group was not activated after reboot")
+}
+
+func (suite *VolumesSuite) deleteLVMVolumes(node, nodeName, userDisksJoined string) {
+	suite.T().Logf("removing LVM volumes %s/%s", node, nodeName)
+
+	deletePodDef, err := suite.NewPrivilegedPod("pv-destroy")
+	suite.Require().NoError(err)
+
+	deletePodDef = deletePodDef.WithNodeName(nodeName)
+
+	suite.Require().NoError(deletePodDef.Create(suite.ctx, 5*time.Minute))
+
+	defer deletePodDef.Delete(suite.ctx) //nolint:errcheck
+
+	if _, _, err := deletePodDef.Exec(
+		suite.ctx,
+		"nsenter --mount=/proc/1/ns/mnt -- vgremove --nolocking --yes vg0",
+	); err != nil {
+		suite.T().Logf("failed to remove pv vg0: %v", err)
+	}
+
+	if _, _, err := deletePodDef.Exec(
+		suite.ctx,
+		fmt.Sprintf("nsenter --mount=/proc/1/ns/mnt -- pvremove --nolocking --yes %s", userDisksJoined),
+	); err != nil {
+		suite.T().Logf("failed to remove pv backed by volumes %s: %v", userDisksJoined, err)
+	}
 }
 
 func (suite *VolumesSuite) lvmVolumeExists(node string, expectedVolumes []string) bool {
@@ -436,7 +438,7 @@ func (suite *VolumesSuite) TestUserVolumesStatus() {
 			rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI,
 				userVolumeIDs,
 				func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-					asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+					asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 				},
 			)
 
@@ -468,7 +470,7 @@ func (suite *VolumesSuite) TestVolumesStatus() {
 	}
 }
 
-// TestUserVolumesPartition performs a series of operations on user volumes (partition type): creating, destroying, verifying, etc.
+// TestUserVolumesPartition performs a series of operations on user volumes: creating, destroying, verifying, etc.
 func (suite *VolumesSuite) TestUserVolumesPartition() {
 	if testing.Short() {
 		suite.T().Skip("skipping test in short mode.")
@@ -527,7 +529,7 @@ func (suite *VolumesSuite) TestUserVolumesPartition() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -612,7 +614,7 @@ func (suite *VolumesSuite) TestUserVolumesPartition() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -650,8 +652,179 @@ func (suite *VolumesSuite) TestUserVolumesPartition() {
 		})
 }
 
-// TestUserVolumesBind performs a series of operations on user volumes (bind type): creating, destroying, verifying, etc.
-func (suite *VolumesSuite) TestUserVolumesBind() {
+// TestUserVolumesDisk performs a series of operations on user volumes: creating, destroying, verifying, etc.
+func (suite *VolumesSuite) TestUserVolumesDisk() {
+	if testing.Short() {
+		suite.T().Skip("skipping test in short mode.")
+	}
+
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping test for non-qemu provisioner")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	k8sNode, err := suite.GetK8sNodeByInternalIP(suite.ctx, node)
+	suite.Require().NoError(err)
+
+	nodeName := k8sNode.Name
+
+	userDisks := suite.UserDisks(suite.ctx, node)
+
+	if len(userDisks) < 1 {
+		suite.T().Skipf("skipping test, not enough user disks available on node %s/%s: %q", node, nodeName, userDisks)
+	}
+
+	suite.T().Logf("verifying user volumes on node %s/%s with disk %s", node, nodeName, userDisks[0])
+
+	ctx := client.WithNode(suite.ctx, node)
+
+	disk, err := safe.StateGetByID[*block.Disk](ctx, suite.Client.COSI, filepath.Base(userDisks[0]))
+	suite.Require().NoError(err)
+
+	volumeName := fmt.Sprintf("%04x", rand.Int31()) + "-"
+
+	const numVolumes = 1
+
+	volumeIDs := make([]string, numVolumes)
+
+	for i := range numVolumes {
+		volumeIDs[i] = volumeName + strconv.Itoa(i)
+	}
+
+	userVolumeIDs := xslices.Map(volumeIDs, func(volumeID string) string { return constants.UserVolumePrefix + volumeID })
+
+	configDocs := xslices.Map(volumeIDs, func(volumeID string) any {
+		doc := blockcfg.NewUserVolumeConfigV1Alpha1()
+		doc.MetaName = volumeID
+		doc.VolumeType = pointer.To(block.VolumeTypeDisk)
+		doc.ProvisioningSpec.DiskSelectorSpec.Match = cel.MustExpression(
+			cel.ParseBooleanExpression(fmt.Sprintf("'%s' in disk.symlinks", disk.TypedSpec().Symlinks[0]), celenv.DiskLocator()),
+		)
+
+		return doc
+	})
+
+	// create user volumes
+	suite.PatchMachineConfig(ctx, configDocs...)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
+		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
+		},
+	)
+
+	// check that the volumes are mounted
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
+		func(vs *block.MountStatus, _ *assert.Assertions) {})
+
+	// create a pod using user volumes
+	podDef, err := suite.NewPod("user-volume-test")
+	suite.Require().NoError(err)
+
+	// using subdirectory here to test that the hostPath mount is properly propagated into the kubelet
+	podDef = podDef.WithNodeName(nodeName).
+		WithNamespace("kube-system").
+		WithHostVolumeMount(filepath.Join(constants.UserVolumeMountPoint, volumeIDs[0], "data"), "/mnt/data")
+
+	suite.Require().NoError(podDef.Create(suite.ctx, 1*time.Minute))
+
+	_, _, err = podDef.Exec(suite.ctx, "mkdir -p /mnt/data/test")
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(podDef.Delete(suite.ctx))
+
+	// verify that directory exists
+	expectedPath := filepath.Join(constants.UserVolumeMountPoint, volumeIDs[0], "data", "test")
+
+	stream, err := suite.Client.LS(ctx, &machineapi.ListRequest{
+		Root:  expectedPath,
+		Types: []machineapi.ListRequest_Type{machineapi.ListRequest_DIRECTORY},
+	})
+
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(helpers.ReadGRPCStream(stream, func(info *machineapi.FileInfo, _ string, _ bool) error {
+		suite.T().Logf("found %s on node %s", info.Name, node)
+		suite.Require().Equal(expectedPath, info.Name, "expected %s to exist", expectedPath)
+
+		return nil
+	}))
+
+	// now, remove one of the volumes, wipe the partition and re-create the volume
+	vs, err := safe.ReaderGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, userVolumeIDs[0])
+	suite.Require().NoError(err)
+
+	suite.RemoveMachineConfigDocumentsByName(ctx, blockcfg.UserVolumeConfigKind, volumeIDs[0])
+
+	rtestutils.AssertNoResource[*block.VolumeStatus](ctx, suite.T(), suite.Client.COSI, userVolumeIDs[0])
+
+	suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+		// a little retry loop, as the device might be considered busy for a little while after unmounting
+		asrt := assert.New(collect)
+
+		asrt.NoError(suite.Client.BlockDeviceWipe(ctx, &storage.BlockDeviceWipeRequest{
+			Devices: []*storage.BlockDeviceWipeDescriptor{
+				{
+					Device:        filepath.Base(vs.TypedSpec().Location),
+					Method:        storage.BlockDeviceWipeDescriptor_FAST,
+					DropPartition: true,
+				},
+			},
+		}))
+	}, time.Minute, time.Second, "failed to wipe partition %s", vs.TypedSpec().Location)
+
+	// wait for the discovered volume to lose filesystem
+	rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI, filepath.Base(vs.TypedSpec().Location), func(r *block.DiscoveredVolume, asrt *assert.Assertions) {
+		asrt.Empty(r.TypedSpec().Name) // no filesystem
+	})
+
+	// re-create the volume with project quota support
+	configDocs[0].(*blockcfg.UserVolumeConfigV1Alpha1).FilesystemSpec.ProjectQuotaSupportConfig = pointer.To(true)
+	suite.PatchMachineConfig(ctx, configDocs[0])
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
+		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
+		},
+	)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
+		func(vs *block.MountStatus, asrt *assert.Assertions) {
+			if vs.Metadata().ID() == userVolumeIDs[0] {
+				// check that the project quota support is enabled
+				asrt.True(vs.TypedSpec().ProjectQuotaSupport, "project quota support should be enabled for %s", vs.Metadata().ID())
+			} else {
+				// check that the project quota support is disabled
+				asrt.False(vs.TypedSpec().ProjectQuotaSupport, "project quota support should be disabled for %s", vs.Metadata().ID())
+			}
+		})
+
+	// clean up
+	suite.RemoveMachineConfigDocumentsByName(ctx, blockcfg.UserVolumeConfigKind, volumeIDs...)
+
+	for _, userVolumeID := range userVolumeIDs {
+		rtestutils.AssertNoResource[*block.VolumeStatus](ctx, suite.T(), suite.Client.COSI, userVolumeID)
+	}
+
+	suite.Require().NoError(suite.Client.BlockDeviceWipe(ctx, &storage.BlockDeviceWipeRequest{
+		Devices: []*storage.BlockDeviceWipeDescriptor{
+			{
+				Device: filepath.Base(userDisks[0]),
+				Method: storage.BlockDeviceWipeDescriptor_FAST,
+			},
+		},
+	}))
+
+	// wait for the discovered volume reflect wiped status
+	rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI, filepath.Base(userDisks[0]),
+		func(dv *block.DiscoveredVolume, asrt *assert.Assertions) {
+			asrt.Empty(dv.TypedSpec().Name, "expected discovered volume %s to be wiped", dv.Metadata().ID())
+		})
+}
+
+// TestUserVolumesDirectory performs a series of operations on user volumes: creating, destroying, verifying, etc.
+func (suite *VolumesSuite) TestUserVolumesDirectory() {
 	if testing.Short() {
 		suite.T().Skip("skipping test in short mode.")
 	}
@@ -694,7 +867,7 @@ func (suite *VolumesSuite) TestUserVolumesBind() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -745,7 +918,7 @@ func (suite *VolumesSuite) TestUserVolumesBind() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -816,7 +989,7 @@ func (suite *VolumesSuite) TestRawVolumes() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, rawVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -862,7 +1035,7 @@ func (suite *VolumesSuite) TestRawVolumes() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, rawVolumeIDs,
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -938,7 +1111,7 @@ func (suite *VolumesSuite) TestExistingVolumes() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []resource.ID{userVolumeID},
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 
@@ -964,7 +1137,7 @@ func (suite *VolumesSuite) TestExistingVolumes() {
 	// wait for the existing volume to be discovered
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []resource.ID{existingVolumeID},
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 			asrt.Equal(userDisks[0], vs.TypedSpec().ParentLocation)
 		},
 	)
@@ -1056,7 +1229,7 @@ func (suite *VolumesSuite) TestSwapStatus() {
 					return sv.Metadata().ID()
 				}),
 				func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-					asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+					asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 				},
 			)
 
@@ -1135,7 +1308,7 @@ func (suite *VolumesSuite) TestSwapOnOff() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []string{swapVolumeID},
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
-			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			asrt.Equalf(block.VolumePhaseReady, vs.TypedSpec().Phase, "Expected %q, but got %q (%s)", block.VolumePhaseReady, vs.TypedSpec().Phase, vs.Metadata().ID())
 		},
 	)
 

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -451,8 +451,9 @@
         },
         "volumeType": {
           "enum": [
-            "partition",
-            "directory"
+            "directory",
+            "disk",
+            "partition"
           ],
           "title": "volumeType",
           "description": "Volume type.\n",

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -506,8 +506,9 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Description: "Volume type.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Volume type." /* encoder.LineComment */, "" /* encoder.FootComment */},
 				Values: []string{
-					"partition",
 					"directory",
+					"disk",
+					"partition",
 				},
 			},
 			{
@@ -535,6 +536,8 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 	}
 
 	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Directory())
+
+	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Disk())
 
 	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Partition())
 

--- a/pkg/machinery/config/types/block/raw_volume_config.go
+++ b/pkg/machinery/config/types/block/raw_volume_config.go
@@ -140,7 +140,7 @@ func (s *RawVolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation
 		validationErrors = errors.Join(validationErrors, errors.New("name can only contain lowercase and uppercase ASCII letters, digits, and hyphens"))
 	}
 
-	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(true)
+	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(true, true)
 
 	warnings = append(warnings, extraWarnings...)
 	validationErrors = errors.Join(validationErrors, extraErrors)

--- a/pkg/machinery/config/types/block/swap_volume_config.go
+++ b/pkg/machinery/config/types/block/swap_volume_config.go
@@ -151,7 +151,7 @@ func (s *SwapVolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validatio
 		validationErrors = errors.Join(validationErrors, errors.New("name can only contain lowercase and uppercase ASCII letters, digits, and hyphens"))
 	}
 
-	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(true)
+	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(true, true)
 
 	warnings = append(warnings, extraWarnings...)
 	validationErrors = errors.Join(validationErrors, extraErrors)

--- a/pkg/machinery/config/types/block/user_volume_config_test.go
+++ b/pkg/machinery/config/types/block/user_volume_config_test.go
@@ -341,6 +341,24 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 			expectedErrors: "encryption spec is invalid for volumeType directory",
 		},
 		{
+			name: "size for disk",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDisk)
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustByteSize("2.5TiB")
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+
+				return c
+			},
+
+			expectedErrors: "min size, max size and grow are not supported",
+		},
+		{
 			name: "filesystem spec for directory",
 
 			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
@@ -417,6 +435,20 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				c := block.NewUserVolumeConfigV1Alpha1()
 				c.MetaName = constants.EphemeralPartitionLabel
 				c.VolumeType = pointer.To(blockres.VolumeTypeDirectory)
+
+				return c
+			},
+		},
+		{
+			name: "valid disk",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = pointer.To(blockres.VolumeTypeDisk)
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
+				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
 
 				return c
 			},

--- a/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
+++ b/website/content/v1.12/reference/configuration/block/uservolumeconfig.md
@@ -52,6 +52,58 @@ volumeType: directory # Volume type.
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-data # Name of the volume.
+volumeType: disk # Volume type.
+# The provisioning describes how the volume is provisioned.
+provisioning:
+    # The disk selector expression.
+    diskSelector:
+        match: disk.transport == "nvme" # The Common Expression Language (CEL) expression to match the disk.
+
+    # # The minimum size of the volume.
+    # minSize: 2.5GiB
+
+    # # The maximum size of the volume, if not specified the volume can grow to the size of the
+    # maxSize: 50GiB
+# The filesystem describes how the volume is formatted.
+filesystem:
+    type: xfs # Filesystem type. Default is `xfs`.
+# The encryption describes how the volume is encrypted.
+encryption:
+    provider: luks2 # Encryption provider to use for the encryption.
+    # Defines the encryption keys generation and storage method.
+    keys:
+        - slot: 0 # Key slot number for LUKS2 encryption.
+          # Enable TPM based disk encryption.
+          tpm: {}
+
+          # # KMS managed encryption key.
+          # kms:
+          #     endpoint: https://192.168.88.21:4443 # KMS endpoint to Seal/Unseal the key.
+        - slot: 1 # Key slot number for LUKS2 encryption.
+          # Key which value is stored in the configuration file.
+          static:
+            passphrase: topsecret # Defines the static passphrase value.
+
+          # # KMS managed encryption key.
+          # kms:
+          #     endpoint: https://192.168.88.21:4443 # KMS endpoint to Seal/Unseal the key.
+
+    # # Cipher to use for the encryption. Depends on the encryption provider.
+    # cipher: aes-xts-plain64
+
+    # # Defines the encryption sector size.
+    # blockSize: 4096
+
+    # # Additional --perf parameters for the LUKS2 encryption.
+    # options:
+    #     - no_read_workqueue
+    #     - no_write_workqueue
+{{< /highlight >}}
+
+{{< highlight yaml >}}
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: local-data # Name of the volume.
 volumeType: partition # Volume type.
 # The provisioning describes how the volume is provisioned.
 provisioning:
@@ -102,7 +154,7 @@ encryption:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`name` |string |Name of the volume.<br><br>Name might be between 1 and 34 characters long and can only contain:<br>lowercase and uppercase ASCII letters, digits, and hyphens.  | |
-|`volumeType` |VolumeType |Volume type.  |`partition`<br />`directory`<br /> |
+|`volumeType` |VolumeType |Volume type.  |`directory`<br />`disk`<br />`partition`<br /> |
 |`provisioning` |<a href="#UserVolumeConfig.provisioning">ProvisioningSpec</a> |The provisioning describes how the volume is provisioned.  | |
 |`filesystem` |<a href="#UserVolumeConfig.filesystem">FilesystemSpec</a> |The filesystem describes how the volume is formatted.  | |
 |`encryption` |<a href="#UserVolumeConfig.encryption">EncryptionSpec</a> |The encryption describes how the volume is encrypted.  | |

--- a/website/content/v1.12/schemas/config.schema.json
+++ b/website/content/v1.12/schemas/config.schema.json
@@ -451,8 +451,9 @@
         },
         "volumeType": {
           "enum": [
-            "partition",
-            "directory"
+            "directory",
+            "disk",
+            "partition"
           ],
           "title": "volumeType",
           "description": "Volume type.\n",


### PR DESCRIPTION
`volumeType` in UserVolumeConfig can be set to `disk`.
When set to `disk`, a full block device is used for the volume.

When `volumeType = "disk"`:
- Size specific settings are not allowed in the provisioning block (`minSize`, `maxSize`, `grow`).

Closes #11847