### PR TITLE
fix: add video kernel module to arm

### DIFF
--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -6,6 +6,7 @@ kernel/crypto/async_tx/async_tx.ko
 kernel/crypto/async_tx/async_xor.ko
 kernel/crypto/hkdf.ko
 kernel/crypto/xor.ko
+kernel/drivers/acpi/video.ko
 kernel/drivers/ata/ahci.ko
 kernel/drivers/ata/pata_amd.ko
 kernel/drivers/ata/pata_marvell.ko


### PR DESCRIPTION
Allows for NVIDIA kernel modules to load on arm arch

# Pull Request

Trying to load nvidia kernel modules on arm leads to the following crash

```nvidia_modeset: Unknown symbol acpi_video_register_backlight (err -2)
nvidia_modeset: Unknown symbol __acpi_video_get_backlight_type (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF32ToF16 (err -2)
nvidia_drm: Unknown symbol nvKmsKapiUI32ToF32 (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF32Div (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF16ToF32 (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF32Add (err -2)
nvidia_drm: Unknown symbol nvKmsKapiGetFunctionsTable (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF32Mul (err -2)
nvidia_drm: Unknown symbol nvKmsKapiF32ToUI32RMinMag (err -2)
nvidia_modeset: Unknown symbol acpi_video_register_backlight (err -2)
nvidia_modeset: Unknown symbol __acpi_video_get_backlight_type (err -2)
```

## What? (description)


## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
