### PR TITLE
fix: bump kubelet credendial provider config to v1

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	kubeletv1config "k8s.io/kubelet/config/v1"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 
 	runtimetalos "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -368,7 +369,7 @@ func (ctrl *KubeletServiceController) writeKubeletCredentialProviderConfig(cfgSp
 		return os.RemoveAll(constants.KubeletCredentialProviderConfig)
 	}
 
-	var kubeletCredentialProviderConfig kubeletconfig.CredentialProviderConfig
+	var kubeletCredentialProviderConfig kubeletv1config.CredentialProviderConfig
 
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cfgSpec.CredentialProviderConfig, &kubeletCredentialProviderConfig); err != nil {
 		return fmt.Errorf("error converting kubelet credentialprovider configuration from unstructured: %w", err)


### PR DESCRIPTION
KubeletConfig itself is only `v1beta1`, while `CredentialProviderConfig` was `v1` for quite some time, including minimum Kubernetes 1.30 supported with Talos 1.12.

Fixes #12112
