### PR TITLE
fix: provide minimal platform metadata always

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config_apply_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_apply_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/metal"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -297,6 +298,13 @@ func (suite *PlatformConfigApplySuite) TestMetadata() {
 		})
 }
 
+func (suite *PlatformConfigApplySuite) TestNoPlatformConfig() {
+	ctest.AssertResource(suite, runtimeres.PlatformMetadataID,
+		func(r *runtimeres.PlatformMetadata, asrt *assert.Assertions) {
+			asrt.Equal("metal", r.TypedSpec().Platform)
+		})
+}
+
 func TestPlatformConfigApplySuite(t *testing.T) {
 	t.Parallel()
 
@@ -306,7 +314,9 @@ func TestPlatformConfigApplySuite(t *testing.T) {
 			AfterSetup: func(suite *ctest.DefaultSuite) {
 				suite.Require().NoError(
 					suite.Runtime().RegisterController(
-						&netctrl.PlatformConfigApplyController{},
+						&netctrl.PlatformConfigApplyController{
+							V1alpha1Platform: &metal.Metal{},
+						},
 					))
 			},
 		},

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -243,23 +243,3 @@ https://metadataserver3/userdata
 		})
 	}
 }
-
-func TestEmptyNetworkConfig(t *testing.T) {
-	t.Parallel()
-
-	n := &nocloud.Nocloud{}
-
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var md nocloud.MetadataConfig
-
-	networkConfig, needsReconcile, err := n.ParseMetadata(t.Context(), nil, st, &md)
-	require.NoError(t, err)
-	assert.False(t, needsReconcile)
-
-	assert.Equal(t, &network.PlatformConfigSpec{
-		Metadata: &runtime.PlatformMetadataSpec{
-			Platform: "nocloud",
-		},
-	}, networkConfig)
-}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -346,7 +346,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&network.OperatorVIPConfigController{
 			Cmdline: procfs.ProcCmdline(),
 		},
-		&network.PlatformConfigApplyController{},
+		&network.PlatformConfigApplyController{
+			V1alpha1Platform: ctrl.v1alpha1Runtime.State().Platform(),
+		},
 		&network.PlatformConfigController{
 			V1alpha1Platform: ctrl.v1alpha1Runtime.State().Platform(),
 			PlatformState:    ctrl.v1alpha1Runtime.State().V1Alpha2().Resources(),


### PR DESCRIPTION
Fixes #12097

Reverts "fix: provide nocloud metadata with missing network config"

This reverts commit 435dcbf820cd9f8cc9fecc0f7d42819acef36106.

The reverted commit fixes #12097, while minimal platform metadata fixes issue
https://github.com/siderolabs/omni/discussions/1633#discussioncomment-14577048.
