### PR TITLE
fix: provide minimal platform metadata always

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -176,10 +176,8 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 			ctrl.networkConfigToPersist = networkConfig
 		}
 
-		if ctrl.activeNetworkConfig != nil {
-			if err := ctrl.apply(ctx, r); err != nil {
-				return err
-			}
+		if err := ctrl.apply(ctx, r); err != nil {
+			return err
 		}
 
 		// we either need to save new network config, or we don't have any and we need to load cached config
@@ -256,6 +254,14 @@ func (ctrl *PlatformConfigController) loadStore() func(
 //nolint:dupl,gocyclo
 func (ctrl *PlatformConfigController) apply(ctx context.Context, r controller.Runtime) error {
 	networkConfig := ctrl.activeNetworkConfig
+
+	if networkConfig == nil {
+		networkConfig = &v1alpha1runtime.PlatformNetworkConfig{
+			Metadata: &runtimeres.PlatformMetadataSpec{
+				Platform: ctrl.V1alpha1Platform.Name(),
+			},
+		}
+	}
 
 	metadataLength := 0
 

--- a/internal/app/machined/pkg/controllers/network/platform_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_test.go
@@ -417,6 +417,24 @@ func (suite *PlatformConfigSuite) TestLoadConfig() {
 	}, rtestutils.WithNamespace(network.ConfigNamespaceName))
 }
 
+func (suite *PlatformConfigSuite) TestNoNetworkConfig() {
+	suite.Require().NoError(
+		suite.Runtime().RegisterController(
+			&netctrl.PlatformConfigController{
+				V1alpha1Platform: &platformMock{
+					noData: true,
+				},
+				PlatformState: suite.State(),
+			},
+		),
+	)
+
+	ctest.AssertResource(suite, runtimeres.PlatformMetadataID,
+		func(r *runtimeres.PlatformMetadata, asrt *assert.Assertions) {
+			asrt.Equal("mock", r.TypedSpec().Platform)
+		})
+}
+
 func TestPlatformConfigSuite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/nocloud_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
-	platformruntime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -243,24 +242,4 @@ https://metadataserver3/userdata
 			}
 		})
 	}
-}
-
-func TestEmptyNetworkConfig(t *testing.T) {
-	t.Parallel()
-
-	n := &nocloud.Nocloud{}
-
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var md nocloud.MetadataConfig
-
-	networkConfig, needsReconcile, err := n.ParseMetadata(t.Context(), nil, st, &md)
-	require.NoError(t, err)
-	assert.False(t, needsReconcile)
-
-	assert.Equal(t, &platformruntime.PlatformNetworkConfig{
-		Metadata: &runtime.PlatformMetadataSpec{
-			Platform: "nocloud",
-		},
-	}, networkConfig)
 }


### PR DESCRIPTION
Fixes #12097

This is same change as #12134, but adapted to release-1.11 code around platform network config.

Revert "fix: provide nocloud metadata with missing network config"

This reverts commit 0fbb0b0280c1f8a4da954237e765c7682cea4402.
