### PR TITLE
fix: stop attaching to tearing down mount parents

### DIFF
--- a/internal/app/machined/pkg/controllers/block/mount.go
+++ b/internal/app/machined/pkg/controllers/block/mount.go
@@ -198,7 +198,7 @@ func (ctrl *MountController) Run(ctx context.Context, r controller.Runtime, logg
 					}
 				}
 
-				if mountHasParent && !mountParentStatus.Metadata().Finalizers().Has(parentFinalizerName) {
+				if mountHasParent && !mountParentStatus.Metadata().Finalizers().Has(parentFinalizerName) && mountParentStatus.Metadata().Phase() == resource.PhaseRunning {
 					if err = r.AddFinalizer(ctx, mountParentStatus.Metadata(), parentFinalizerName); err != nil {
 						return fmt.Errorf("failed to add finalizer to parent mount status %q: %w", mountParentStatus.Metadata().ID(), err)
 					}


### PR DESCRIPTION
This bug showed up as a random deadlock on kubelet restart (might be any other service though).

With a chain of mount requests, like `/var/log` -> `/var/log/containers`, there was a chance that a new generation of mount requests might try to pick up a tearing down parent of the previous generation leading to a deadlock when the mount can't proceed for the parent.
