### PR TITLE
chore: rename+improve `client.ErrEventNotSupported`

### DIFF
--- a/cmd/talosctl/cmd/talos/events.go
+++ b/cmd/talosctl/cmd/talos/events.go
@@ -66,7 +66,8 @@ var eventsCmd = &cobra.Command{
 
 				event, err := client.UnmarshalEvent(ev)
 				if err != nil {
-					if errors.Is(err, client.ErrEventNotSupported) {
+					var errBadEvent client.EventNotSupportedError
+					if errors.As(err, &errBadEvent) {
 						return nil
 					}
 

--- a/pkg/machinery/client/events.go
+++ b/pkg/machinery/client/events.go
@@ -20,8 +20,15 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/proto"
 )
 
-// ErrEventNotSupported is returned from the event decoder when we encounter an unknown event.
-var ErrEventNotSupported = errors.New("event is not supported")
+// EventNotSupportedError is returned from the event decoder when we encounter an unknown event.
+type EventNotSupportedError struct {
+	TypeURL string
+}
+
+// Error implements the error interface.
+func (e EventNotSupportedError) Error() string {
+	return fmt.Sprintf("event is not supported: %s", e.TypeURL)
+}
 
 // EventsOptionFunc defines the options for the Events API.
 type EventsOptionFunc func(opts *machineapi.EventsRequest)
@@ -250,7 +257,9 @@ func UnmarshalEvent(event *machineapi.Event) (*Event, error) {
 
 	if msg == nil {
 		// We haven't implemented the handling of this event yet.
-		return nil, ErrEventNotSupported
+		return nil, EventNotSupportedError{
+			TypeURL: typeURL,
+		}
 	}
 
 	if err := proto.Unmarshal(event.GetData().GetValue(), msg); err != nil {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Improve `client.ErrEventNotSupported` to include the unsupported event.

Split off of https://github.com/siderolabs/talos/pull/12049.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
