### PR TITLE
fix: only set default bootloader if none is set

### DIFF
--- a/pkg/imager/profile/output.go
+++ b/pkg/imager/profile/output.go
@@ -157,6 +157,11 @@ func (o *Output) FillDefaults(arch, version string, secureboot bool) {
 }
 
 func (o *Output) selectBootloader(current BootloaderKind, arch, version string, secureboot bool) BootloaderKind {
+	// If already set, return the current value, secureboot shouldn't allow changing it.
+	if current != BootLoaderKindNone && !secureboot {
+		return current
+	}
+
 	useSDBoot := quirks.New(version).UseSDBootForUEFI()
 
 	switch {
@@ -171,10 +176,6 @@ func (o *Output) selectBootloader(current BootloaderKind, arch, version string, 
 		return BootLoaderKindGrub
 	default:
 		// Default to dual-boot if not overridden.
-		if current == BootLoaderKindNone {
-			return BootLoaderKindDualBoot
-		}
-
-		return current
+		return BootLoaderKindDualBoot
 	}
 }

--- a/pkg/xfs/opentree/opentree_other.go
+++ b/pkg/xfs/opentree/opentree_other.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+
+// Package opentree provides a simple interface to create and manage a subfilesystem
+// using the `open_tree` syscall. It allows for creating a new subfilesystem
+// by cloning an existing filesystem tree and provides a method to close the filesystem
+// when it is no longer needed.
+package opentree


### PR DESCRIPTION
Only set a default bootloader if none is set, secureboot still always return `sd-boot`.