### PR TITLE
feat: shorthand for generating secrets to stdout

### DIFF
--- a/cmd/talosctl/cmd/mgmt/gen/secrets.go
+++ b/cmd/talosctl/cmd/mgmt/gen/secrets.go
@@ -78,6 +78,12 @@ func writeSecretsBundleToFile(bundle *secrets.Bundle) error {
 		return err
 	}
 
+	if genSecretsCmdFlags.outputFile == stdoutOutput {
+		_, err = os.Stdout.Write(bundleBytes)
+
+		return err
+	}
+
 	if err = validateFileExists(genSecretsCmdFlags.outputFile); err != nil {
 		return err
 	}
@@ -86,7 +92,7 @@ func writeSecretsBundleToFile(bundle *secrets.Bundle) error {
 }
 
 func init() {
-	genSecretsCmd.Flags().StringVarP(&genSecretsCmdFlags.outputFile, "output-file", "o", "secrets.yaml", "path of the output file")
+	genSecretsCmd.Flags().StringVarP(&genSecretsCmdFlags.outputFile, "output-file", "o", "secrets.yaml", `path of the output file, or "-" for stdout`)
 	genSecretsCmd.Flags().StringVar(&genSecretsCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate secrets bundle for (backwards compatibility, e.g. v0.8)")
 	genSecretsCmd.Flags().StringVar(&genSecretsCmdFlags.fromControlplaneConfig, "from-controlplane-config", "", "use the provided controlplane Talos machine configuration as input")
 	genSecretsCmd.Flags().StringVarP(&genSecretsCmdFlags.fromKubernetesPki, "from-kubernetes-pki", "p", "", "use a Kubernetes PKI directory (e.g. /etc/kubernetes/pki) as input")

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -1648,7 +1648,7 @@ talosctl gen secrets [flags]
   -p, --from-kubernetes-pki string          use a Kubernetes PKI directory (e.g. /etc/kubernetes/pki) as input
   -h, --help                                help for secrets
   -t, --kubernetes-bootstrap-token string   use the provided bootstrap token as input
-  -o, --output-file string                  path of the output file (default "secrets.yaml")
+  -o, --output-file string                  path of the output file, or "-" for stdout (default "secrets.yaml")
       --talos-version string                the desired Talos version to generate secrets bundle for (backwards compatibility, e.g. v0.8)
 ```
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Fixes #12190, adding a shorthand for outputting `talosctl gen secrets` to stdout.

## Why? (reasoning)

When outputting to stdout the output option needs to specify the full path, and it needs to be forced since the file already exists, i.e:

```bash
talosctl gen secrets --output-file /dev/stdout --force
```

Instead this patch will enable this:

```bash
talosctl gen secrets --output-file -
```

This is on-par with `talosctl gen config --output -`.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
