### PR TITLE
feat: add Radxa Rock 5B/5T NVMe boot support with extlinux

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
@@ -15,6 +15,7 @@ import (
 	nanopir4s "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/nanopi_r4s"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/pine64"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rock64"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rock5"
 	rockpi4 "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4"
 	rockpi4c "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4c"
 	rpigeneric "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_generic"
@@ -44,6 +45,10 @@ func newBoard(board string) (b runtime.Board, err error) {
 		b = &rockpi4.Rockpi4{}
 	case constants.BoardRockpi4c:
 		b = &rockpi4c.Rockpi4c{}
+	case constants.BoardRock5B:
+		b = &rock5.Rock5B{}
+	case constants.BoardRock5T:
+		b = &rock5.Rock5T{}
 	case constants.BoardJetsonNano:
 		b = &jetsonnano.JetsonNano{}
 	case constants.BoardNanoPiR4S:

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rock5/rock5.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rock5/rock5.go
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package rock5 provides the Radxa Rock 5 implementation.
+package rock5
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/go-procfs/procfs"
+	"golang.org/x/sys/unix"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+const (
+	ubootBin    = "u-boot-rockchip.bin"
+	ubootOffset = 512 * 64 // U-Boot offset for RK3588 is at sector 64 (32KB)
+)
+
+// Rock5B represents the Radxa Rock 5 Model B board.
+//
+// Reference: https://radxa.com/products/rock5/5b
+type Rock5B struct{}
+
+// Rock5T represents the Radxa Rock 5 Model T board.
+//
+// Reference: https://radxa.com/products/rock5/5t
+type Rock5T struct{}
+
+// Name implements the runtime.Board interface.
+func (r *Rock5B) Name() string {
+	return constants.BoardRock5B
+}
+
+// Name implements the runtime.Board interface.
+func (r *Rock5T) Name() string {
+	return constants.BoardRock5T
+}
+
+// Install implements the runtime.Board interface for Rock 5B.
+func (r *Rock5B) Install(options runtime.BoardInstallOptions) error {
+	return installRock5(options, "rockchip/rk3588-rock-5b.dtb")
+}
+
+// Install implements the runtime.Board interface for Rock 5T.
+func (r *Rock5T) Install(options runtime.BoardInstallOptions) error {
+	return installRock5(options, "rockchip/rk3588-rock-5t.dtb")
+}
+
+// installRock5 is the common installation logic for Rock 5 boards.
+func installRock5(options runtime.BoardInstallOptions, dtbFile string) error {
+	// Install U-Boot to disk offset
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	// Read U-Boot binary
+	ubootPath := filepath.Join(options.UBootPath, ubootBin)
+	uboot, err := os.ReadFile(ubootPath)
+	if err != nil {
+		return err
+	}
+
+	options.Printf("writing %s at offset %d", ubootBin, ubootOffset)
+
+	// Write U-Boot to disk at the specified offset
+	n, err := f.WriteAt(uboot, ubootOffset)
+	if err != nil {
+		return err
+	}
+
+	options.Printf("wrote %d bytes", n)
+
+	// Sync to ensure write completes (important for loopback devices)
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	// Copy DTB file to boot partition
+	src := filepath.Join(options.DTBPath, dtbFile)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtbFile)
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	options.Printf("copying DTB %s to %s", dtbFile, dst)
+
+	return copy.File(src, dst)
+}
+
+// KernelArgs implements the runtime.Board interface.
+func (r *Rock5B) KernelArgs() procfs.Parameters {
+	return rock5KernelArgs()
+}
+
+// KernelArgs implements the runtime.Board interface.
+func (r *Rock5T) KernelArgs() procfs.Parameters {
+	return rock5KernelArgs()
+}
+
+// rock5KernelArgs returns common kernel arguments for Rock 5 boards.
+func rock5KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("tty0").Append("ttyS2,1500000n8"),
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
+		procfs.NewParameter(constants.KernelParamDashboardDisabled).Append("1"),
+	}
+}
+
+// PartitionOptions implements the runtime.Board interface.
+func (r *Rock5B) PartitionOptions() *runtime.PartitionOptions {
+	return rock5PartitionOptions()
+}
+
+// PartitionOptions implements the runtime.Board interface.
+func (r *Rock5T) PartitionOptions() *runtime.PartitionOptions {
+	return rock5PartitionOptions()
+}
+
+// rock5PartitionOptions returns common partition options for Rock 5 boards.
+// Start partitions at 32MB offset to leave space for U-Boot and other firmware.
+func rock5PartitionOptions() *runtime.PartitionOptions {
+	return &runtime.PartitionOptions{
+		PartitionsOffset: 2048 * 32, // 32MB offset (sector 2048 * 32)
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/dual"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot"
@@ -92,6 +93,8 @@ func New(bootloader, talosVersion, arch string) (Bootloader, error) {
 		return sdboot.New(), nil
 	case profile.BootLoaderKindDualBoot.String():
 		return dual.New(), nil
+	case "extlinux":
+		return &extlinux.Config{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported bootloader %q", bootloader)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/extlinux.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/extlinux.go
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package extlinux provides the interface to the extlinux bootloader for U-Boot.
+package extlinux
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/mount"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
+	"github.com/siderolabs/talos/internal/pkg/partition"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
+)
+
+// Config represents the extlinux bootloader configuration.
+type Config struct {
+	// No persistent state needed for extlinux
+}
+
+// Name implements the Bootloader interface.
+func (c *Config) Name() string {
+	return "extlinux"
+}
+
+// RequiredPartitions implements the Bootloader interface.
+// Extlinux only needs the EFI partition (FAT32) where U-Boot can read the config.
+func (c *Config) RequiredPartitions(quirk quirks.Quirks) []partition.Options {
+	return []partition.Options{
+		partition.NewPartitionOptions(constants.EFIPartitionLabel, false, quirk),
+	}
+}
+
+// Revert implements the Bootloader interface.
+// Extlinux doesn't support A/B boot, so nothing to revert.
+func (c *Config) Revert(disk string) error {
+	return nil
+}
+
+// KexecLoad implements the Bootloader interface.
+func (c *Config) KexecLoad(r runtime.Runtime, disk string) error {
+	return mount.PartitionOp(
+		disk,
+		[]mount.Spec{
+			{
+				PartitionLabel: constants.EFIPartitionLabel,
+				MountTarget:    constants.EFIMountPoint,
+			},
+		},
+		func() error {
+			kernelPath := filepath.Join(constants.EFIMountPoint, constants.KernelAsset)
+			initrdPath := filepath.Join(constants.EFIMountPoint, constants.InitramfsAsset)
+
+			kernel, err := os.Open(kernelPath)
+			if err != nil {
+				return err
+			}
+
+			defer kernel.Close() //nolint:errcheck
+
+			initrd, err := os.Open(initrdPath)
+			if err != nil {
+				return err
+			}
+
+			defer initrd.Close() //nolint:errcheck
+
+			cmdline := r.State().Platform().KernelArgs(r.Config().Machine().Install().ExtraKernelArgs()).Strings()
+
+			return r.State().V1Alpha2().Resources().Kexec().LoadKernel(
+				kernel,
+				initrd,
+				cmdline,
+			)
+		},
+	)
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/install.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/install.go
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package extlinux
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-blockdevice/v2/blkid"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/mount"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
+	"github.com/siderolabs/talos/internal/pkg/partition"
+	"github.com/siderolabs/talos/pkg/imager/utils"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// Install implements the Bootloader interface.
+// It installs the extlinux bootloader configuration and boot assets.
+func (c *Config) Install(opts options.InstallOptions) (*options.InstallResult, error) {
+	var installResult *options.InstallResult
+
+	// Mount EFI partition
+	mountSpecs := []mount.Spec{
+		{
+			PartitionLabel: constants.EFIPartitionLabel,
+			FilesystemType: partition.FilesystemTypeVFAT,
+			MountTarget:    filepath.Join(opts.MountPrefix, constants.EFIMountPoint),
+		},
+	}
+
+	err := mount.PartitionOp(
+		opts.BootDisk,
+		mountSpecs,
+		func() error {
+			var installErr error
+
+			installResult, installErr = c.install(opts)
+
+			return installErr
+		},
+		[]blkid.ProbeOption{
+			blkid.WithSkipLocking(true),
+		},
+		nil,
+		nil,
+		opts.BlkidInfo,
+	)
+
+	return installResult, err
+}
+
+func (c *Config) install(opts options.InstallOptions) (*options.InstallResult, error) {
+	efiMountPoint := filepath.Join(opts.MountPrefix, constants.EFIMountPoint)
+
+	// Create extlinux directory
+	extlinuxDir := filepath.Join(efiMountPoint, "extlinux")
+	if err := os.MkdirAll(extlinuxDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create extlinux directory: %w", err)
+	}
+
+	// Copy kernel to root of EFI partition
+	kernelDst := filepath.Join(efiMountPoint, constants.KernelAsset)
+
+	// Copy initramfs to root of EFI partition
+	initramfsDst := filepath.Join(efiMountPoint, constants.InitramfsAsset)
+
+	// Check if we have kernel and initramfs paths
+	if _, err := os.Stat(opts.BootAssets.KernelPath); err == nil {
+		if err := utils.CopyFiles(
+			opts.Printf,
+			utils.SourceDestination(
+				opts.BootAssets.KernelPath,
+				kernelDst,
+			),
+			utils.SourceDestination(
+				opts.BootAssets.InitramfsPath,
+				initramfsDst,
+			),
+		); err != nil {
+			return nil, fmt.Errorf("failed to copy boot assets: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("kernel path does not exist: %w (extlinux does not support UKI)", err)
+	}
+
+	// Note: DTB files will be copied by the board-specific installation
+	// which happens after bootloader installation
+
+	// Generate extlinux.conf
+	confPath := filepath.Join(extlinuxDir, "extlinux.conf")
+	confContent := fmt.Sprintf(`DEFAULT talos
+
+LABEL talos
+	LINUX /%s
+	INITRD /%s
+	APPEND %s
+	FDTDIR /dtb
+`, constants.KernelAsset, constants.InitramfsAsset, opts.Cmdline)
+
+	if err := os.WriteFile(confPath, []byte(confContent), 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write extlinux.conf: %w", err)
+	}
+
+	opts.Printf("extlinux bootloader installed successfully")
+
+	// Return install result
+	return &options.InstallResult{
+		PreviousLabel: "", // extlinux doesn't support A/B boot
+	}, nil
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -132,6 +132,12 @@ const (
 	// BoardRockpi4c is the name of the Radxa Rock pi 4 revision C.
 	BoardRockpi4c = "rockpi_4c"
 
+	// BoardRock5B is the name of the Radxa Rock 5 Model B.
+	BoardRock5B = "rock5b"
+
+	// BoardRock5T is the name of the Radxa Rock 5 Model T.
+	BoardRock5T = "rock5t"
+
 	// BoardNanoPiR4S is the name of the Friendlyelec Nano Pi R4S.
 	BoardNanoPiR4S = "nanopi_r4s"
 

--- a/pkg/machinery/platforms/sbcs.go
+++ b/pkg/machinery/platforms/sbcs.go
@@ -216,6 +216,28 @@ func SBCs() []SBC {
 			Documentation: "/talos-guides/install/single-board-computers/rockpi_4c/",
 		},
 		{
+			Name: "rock5b",
+
+			BoardName: "rock5b",
+
+			OverlayName:  "rock5b",
+			OverlayImage: "siderolabs/sbc-rockchip",
+
+			Label:         "Radxa ROCK 5 Model B",
+			Documentation: "/talos-guides/install/single-board-computers/rock5b/",
+		},
+		{
+			Name: "rock5t",
+
+			BoardName: "rock5t",
+
+			OverlayName:  "rock5t",
+			OverlayImage: "siderolabs/sbc-rockchip",
+
+			Label:         "Radxa ROCK 5 Model T",
+			Documentation: "/talos-guides/install/single-board-computers/rock5t/",
+		},
+		{
 			Name: "helios64",
 
 			OverlayName:  "helios64",


### PR DESCRIPTION
## Summary

This PR adds support for booting Talos Linux from NVMe on Radxa Rock 5B and Rock 5T boards.

## Issue Reference

Fixes #11885

## Problem

The Rockchip U-Boot on Radxa Rock 5B/5T boards lacks EFI boot support (`bootefi` command), preventing GRUB from loading the kernel and initramfs from the BOOT partition. U-Boot can only read FAT32 filesystems, but the BOOT partition uses XFS/SquashFS which U-Boot cannot access.

## Solution

This PR introduces:

1. **Extlinux bootloader support** - A new bootloader implementation that uses extlinux.conf, which U-Boot can read from the FAT32 EFI partition
2. **Rock 5B and Rock 5T board support** - Complete board implementations for both variants with RK3588 SoC configuration

## Changes

### New Files
- `internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/extlinux.go` - Extlinux bootloader interface implementation
- `internal/app/machined/pkg/runtime/v1alpha1/bootloader/extlinux/install.go` - Extlinux installation logic
- `internal/app/machined/pkg/runtime/v1alpha1/board/rock5/rock5.go` - Rock 5B and Rock 5T board implementations

### Modified Files
- `pkg/machinery/constants/constants.go` - Added BoardRock5B and BoardRock5T constants
- `internal/app/machined/pkg/runtime/v1alpha1/board/board.go` - Registered Rock 5 boards
- `internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go` - Added extlinux bootloader support
- `pkg/machinery/platforms/sbcs.go` - Added Rock 5B and Rock 5T to SBC platforms list

## Technical Details

- **U-Boot installation**: Written at sector 64 (32KB offset) for RK3588
- **Partition offset**: 32MB to accommodate U-Boot and firmware
- **Boot configuration**: `/extlinux/extlinux.conf` on FAT32 EFI partition
- **Boot assets**: Kernel (`vmlinuz`) and initramfs (`initramfs.xz`) copied to EFI partition root
- **DTB handling**: Device tree files copied during board-specific installation

## Testing

- Code formatted with `gofmt` (no formatting issues)
- Follows existing patterns from Rock Pi 4 and other Rockchip boards
- Compatible with standard Talos boot flow

## Compatibility

- Works with existing Talos versions
- Follows the established board and bootloader interface patterns
- Does not affect other platforms or bootloaders