### PR TITLE
chore: deprecate interactive installer mode

### DIFF
--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -64,7 +64,10 @@ service MachineService {
   // EtcdDowngradeCancel cancels etcd cluster downgrade that is in progress.
   // This method is available only on control plane nodes (which run etcd).
   rpc EtcdDowngradeCancel(google.protobuf.Empty) returns (EtcdDowngradeCancelResponse);
-  rpc GenerateConfiguration(GenerateConfigurationRequest) returns (GenerateConfigurationResponse);
+  rpc GenerateConfiguration(GenerateConfigurationRequest) returns (GenerateConfigurationResponse) {
+    option (common.remove_deprecated_method) = "v1.13";
+    option deprecated = true;
+  }
   rpc Hostname(google.protobuf.Empty) returns (HostnameResponse);
   rpc Kubeconfig(google.protobuf.Empty) returns (stream common.Data);
   rpc List(ListRequest) returns (stream FileInfo);

--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -90,7 +90,7 @@ var applyConfigCmd = &cobra.Command{
 					return err
 				}
 			}
-		} else if applyConfigCmdFlags.Mode.Mode != helpers.InteractiveMode {
+		} else if applyConfigCmdFlags.Mode.Mode != helpers.InteractiveMode { //nolint:staticcheck
 			return errors.New("no filename supplied for configuration")
 		}
 
@@ -103,7 +103,7 @@ var applyConfigCmd = &cobra.Command{
 		}
 
 		return withClient(func(ctx context.Context, c *client.Client) error {
-			if applyConfigCmdFlags.Mode.Mode == helpers.InteractiveMode {
+			if applyConfigCmdFlags.Mode.Mode == helpers.InteractiveMode { //nolint:staticcheck
 				install := installer.NewInstaller()
 				node := GlobalArgs.Nodes[0]
 

--- a/cmd/talosctl/pkg/talos/helpers/mode.go
+++ b/cmd/talosctl/pkg/talos/helpers/mode.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/siderolabs/gen/maps"
+	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
@@ -19,6 +20,9 @@ import (
 
 // InteractiveMode fake mode value for the interactive config mode.
 // Should be never passed to the API.
+//
+// Deprecated: Interactive configuration mode will be removed and
+// should no longer be used.
 const InteractiveMode machine.ApplyConfigurationRequest_Mode = -1
 
 // Mode apply, patch, edit config update mode.
@@ -62,6 +66,9 @@ func (m *Mode) Set(value string) error {
 func (m *Mode) Type() string {
 	options := maps.Keys(m.options)
 	slices.Sort(options)
+	options = xslices.Filter(options, func(opt string) bool {
+		return opt != modeInteractive
+	})
 
 	return strings.Join(options, ", ")
 }

--- a/pkg/machinery/api/machine/machine.pb.go
+++ b/pkg/machinery/api/machine/machine.pb.go
@@ -12688,7 +12688,7 @@ const file_machine_machine_proto_rawDesc = "" +
 	"\tImagePull\x12,\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x10.common.MetadataR\bmetadata\"C\n" +
 	"\x11ImagePullResponse\x12.\n" +
-	"\bmessages\x18\x01 \x03(\v2\x12.machine.ImagePullR\bmessages2\xad\x1e\n" +
+	"\bmessages\x18\x01 \x03(\v2\x12.machine.ImagePullR\bmessages2\xbb\x1e\n" +
 	"\x0eMachineService\x12]\n" +
 	"\x12ApplyConfiguration\x12\".machine.ApplyConfigurationRequest\x1a#.machine.ApplyConfigurationResponse\x12B\n" +
 	"\tBootstrap\x12\x19.machine.BootstrapRequest\x1a\x1a.machine.BootstrapResponse\x12E\n" +
@@ -12713,8 +12713,8 @@ const file_machine_machine_proto_rawDesc = "" +
 	"EtcdStatus\x12\x16.google.protobuf.Empty\x1a\x1b.machine.EtcdStatusResponse\x12f\n" +
 	"\x15EtcdDowngradeValidate\x12%.machine.EtcdDowngradeValidateRequest\x1a&.machine.EtcdDowngradeValidateResponse\x12`\n" +
 	"\x13EtcdDowngradeEnable\x12#.machine.EtcdDowngradeEnableRequest\x1a$.machine.EtcdDowngradeEnableResponse\x12S\n" +
-	"\x13EtcdDowngradeCancel\x12\x16.google.protobuf.Empty\x1a$.machine.EtcdDowngradeCancelResponse\x12f\n" +
-	"\x15GenerateConfiguration\x12%.machine.GenerateConfigurationRequest\x1a&.machine.GenerateConfigurationResponse\x12=\n" +
+	"\x13EtcdDowngradeCancel\x12\x16.google.protobuf.Empty\x1a$.machine.EtcdDowngradeCancelResponse\x12t\n" +
+	"\x15GenerateConfiguration\x12%.machine.GenerateConfigurationRequest\x1a&.machine.GenerateConfigurationResponse\"\f\xea\xbb-\x05v1.13\x88\x02\x01\x12=\n" +
 	"\bHostname\x12\x16.google.protobuf.Empty\x1a\x19.machine.HostnameResponse\x124\n" +
 	"\n" +
 	"Kubeconfig\x12\x16.google.protobuf.Empty\x1a\f.common.Data0\x01\x121\n" +

--- a/pkg/machinery/api/machine/machine_grpc.pb.go
+++ b/pkg/machinery/api/machine/machine_grpc.pb.go
@@ -137,6 +137,7 @@ type MachineServiceClient interface {
 	// EtcdDowngradeCancel cancels etcd cluster downgrade that is in progress.
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdDowngradeCancel(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*EtcdDowngradeCancelResponse, error)
+	// Deprecated: Do not use.
 	GenerateConfiguration(ctx context.Context, in *GenerateConfigurationRequest, opts ...grpc.CallOption) (*GenerateConfigurationResponse, error)
 	Hostname(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HostnameResponse, error)
 	Kubeconfig(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[common.Data], error)
@@ -446,6 +447,7 @@ func (c *machineServiceClient) EtcdDowngradeCancel(ctx context.Context, in *empt
 	return out, nil
 }
 
+// Deprecated: Do not use.
 func (c *machineServiceClient) GenerateConfiguration(ctx context.Context, in *GenerateConfigurationRequest, opts ...grpc.CallOption) (*GenerateConfigurationResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GenerateConfigurationResponse)
@@ -896,6 +898,7 @@ type MachineServiceServer interface {
 	// EtcdDowngradeCancel cancels etcd cluster downgrade that is in progress.
 	// This method is available only on control plane nodes (which run etcd).
 	EtcdDowngradeCancel(context.Context, *emptypb.Empty) (*EtcdDowngradeCancelResponse, error)
+	// Deprecated: Do not use.
 	GenerateConfiguration(context.Context, *GenerateConfigurationRequest) (*GenerateConfigurationResponse, error)
 	Hostname(context.Context, *emptypb.Empty) (*HostnameResponse, error)
 	Kubeconfig(*emptypb.Empty, grpc.ServerStreamingServer[common.Data]) error

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -249,7 +249,7 @@ func (c *Client) ApplyConfiguration(ctx context.Context, req *machineapi.ApplyCo
 
 // GenerateConfiguration implements proto.MachineServiceClient interface.
 func (c *Client) GenerateConfiguration(ctx context.Context, req *machineapi.GenerateConfigurationRequest, callOptions ...grpc.CallOption) (resp *machineapi.GenerateConfigurationResponse, err error) {
-	resp, err = c.MachineClient.GenerateConfiguration(ctx, req, callOptions...)
+	resp, err = c.MachineClient.GenerateConfiguration(ctx, req, callOptions...) //nolint:staticcheck
 
 	return FilterMessages(resp, err)
 }

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -16,20 +16,20 @@ talosctl apply-config [flags]
 ### Options
 
 ```
-      --cert-fingerprint strings                                 list of server certificate fingeprints to accept (defaults to no check)
-  -c, --cluster string                                           Cluster to connect to if a proxy endpoint is used.
-  -p, --config-patch stringArray                                 the list of config patches to apply to the local config file before sending it to the node
-      --context string                                           Context to be used in command
-      --dry-run                                                  check how the config change will be applied in dry-run mode
-  -e, --endpoints strings                                        override default endpoints in Talos configuration
-  -f, --file string                                              the filename of the updated configuration
-  -h, --help                                                     help for apply-config
-  -i, --insecure                                                 apply the config using the insecure (encrypted with no auth) maintenance service
-  -m, --mode auto, interactive, no-reboot, reboot, staged, try   apply config mode (default auto)
-  -n, --nodes strings                                            target the specified nodes
-      --siderov1-keys-dir string                                 The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                                       The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
-      --timeout duration                                         the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
+      --cert-fingerprint strings                    list of server certificate fingeprints to accept (defaults to no check)
+  -c, --cluster string                              Cluster to connect to if a proxy endpoint is used.
+  -p, --config-patch stringArray                    the list of config patches to apply to the local config file before sending it to the node
+      --context string                              Context to be used in command
+      --dry-run                                     check how the config change will be applied in dry-run mode
+  -e, --endpoints strings                           override default endpoints in Talos configuration
+  -f, --file string                                 the filename of the updated configuration
+  -h, --help                                        help for apply-config
+  -i, --insecure                                    apply the config using the insecure (encrypted with no auth) maintenance service
+  -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
+  -n, --nodes strings                               target the specified nodes
+      --siderov1-keys-dir string                    The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string                          The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Closes https://github.com/siderolabs/talos/issues/12168

Deprecate interactive installer (`talosctl apply-config --mode interactive`) and related APIs.

Removed `interactive` from `talosctl apply-config --help`.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
