### PR TITLE
chore: stop requiring single commits in PRs

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -12,7 +12,6 @@ policies:
           gitHubOrganization: siderolabs
       spellcheck:
         locale: US
-      maximumOfOneCommit: true
       header:
         length: 89
         imperative: true


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Drop the single-commit-per-PR requirement from `.conform.yaml`.
