### PR TITLE
fix: add riscv64 talosctl to release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-31T17:08:03Z by kres cd5a938.
+# Generated on 2025-11-17T11:29:04Z by kres e1d6dac.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -5175,6 +5175,7 @@ jobs:
           cosign sign-blob --bundle _out/talosctl-linux-amd64.bundle --yes _out/talosctl-linux-amd64
           cosign sign-blob --bundle _out/talosctl-linux-arm64.bundle --yes _out/talosctl-linux-arm64
           cosign sign-blob --bundle _out/talosctl-linux-armv7.bundle --yes _out/talosctl-linux-armv7
+          cosign sign-blob --bundle _out/talosctl-linux-riscv64.bundle --yes _out/talosctl-linux-riscv64
           cosign sign-blob --bundle _out/talosctl-windows-amd64.exe.bundle --yes _out/talosctl-windows-amd64.exe
           cosign sign-blob --bundle _out/talosctl-windows-arm64.exe.bundle --yes _out/talosctl-windows-arm64.exe
           cosign sign-blob --bundle _out/vmlinuz-amd64.bundle --yes _out/vmlinuz-amd64
@@ -5182,8 +5183,8 @@ jobs:
       - name: Generate Checksums
         run: |
           cd _out
-          sha256sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
-          sha512sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
+          sha256sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-linux-riscv64 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha256sum.txt
+          sha512sum initramfs-amd64.xz initramfs-arm64.xz metal-amd64.iso metal-arm64.iso metal-amd64-uki.efi metal-arm64-uki.efi metal-amd64.raw.zst metal-arm64.raw.zst talos-arm64.spdx.json talos-amd64.spdx.json talos-container-arm64.spdx.json talos-container-amd64.spdx.json talosctl-cni-bundle-amd64.tar.gz talosctl-cni-bundle-arm64.tar.gz talosctl-darwin-amd64 talosctl-darwin-arm64 talosctl-freebsd-amd64 talosctl-freebsd-arm64 talosctl-linux-amd64 talosctl-linux-arm64 talosctl-linux-armv7 talosctl-linux-riscv64 talosctl-windows-amd64.exe talosctl-windows-arm64.exe vmlinuz-amd64 vmlinuz-arm64 > sha512sum.txt
       - name: Sign checksums
         run: |
           cd _out
@@ -5216,6 +5217,7 @@ jobs:
             _out/talosctl-linux-amd64
             _out/talosctl-linux-arm64
             _out/talosctl-linux-armv7
+            _out/talosctl-linux-riscv64
             _out/talosctl-windows-amd64.exe
             _out/talosctl-windows-arm64.exe
             _out/vmlinuz-amd64

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -206,6 +206,7 @@ spec:
               - talosctl-linux-amd64
               - talosctl-linux-arm64
               - talosctl-linux-armv7
+              - talosctl-linux-riscv64
               - talosctl-windows-amd64.exe
               - talosctl-windows-arm64.exe
               - vmlinuz-amd64


### PR DESCRIPTION
This was missed during adding riscv64 build for talosctl, thus artifact for this arch is missing from `1.12.0-beta.0` release.
