### PR TITLE
feat: support TALOS_HOME env var

### DIFF
--- a/cmd/talosctl/cmd/completion.go
+++ b/cmd/talosctl/cmd/completion.go
@@ -38,11 +38,11 @@ Note for zsh users: [1] zsh completions are only supported in versions of zsh >=
 ## Load the talosctl completion code for bash into the current shell
 	source <(talosctl completion bash)
 ## Write bash completion code to a file and source if from .bash_profile
-	talosctl completion bash > ~/.talos/completion.bash.inc
-	printf "
+	talosctl completion bash > "${TALOS_HOME:-$HOME/.talos}/completion.bash.inc"
+	printf '
 		# talosctl shell completion
-		source '$HOME/.talos/completion.bash.inc'
-		" >> $HOME/.bash_profile
+		source "${TALOS_HOME:-$HOME/.talos}/completion.bash.inc"
+		' >> $HOME/.bash_profile
 	source $HOME/.bash_profile
 # Load the talosctl completion code for fish[1] into the current shell
 	talosctl completion fish | source

--- a/pkg/machinery/client/config/path.go
+++ b/pkg/machinery/client/config/path.go
@@ -20,8 +20,12 @@ type Path struct {
 	WriteAllowed bool
 }
 
-// GetTalosDirectory returns path to Talos directory (~/.talos).
+// GetTalosDirectory returns path to Talos directory ($TALOS_HOME or ~/.talos).
 func GetTalosDirectory() (string, error) {
+	if path, ok := os.LookupEnv(constants.TalosHomeEnvVar); ok && filepath.IsAbs(path) {
+		return path, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -602,6 +602,9 @@ const (
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 
+	// TalosHomeEnvVar is the environment variable for setting the Talos state directory file path.
+	TalosHomeEnvVar = "TALOS_HOME"
+
 	// APISocketPath is the path to file socket of apid.
 	APISocketPath = SystemRunPath + "/apid/apid.sock"
 

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -432,11 +432,11 @@ talosctl completion SHELL [flags]
 ## Load the talosctl completion code for bash into the current shell
 	source <(talosctl completion bash)
 ## Write bash completion code to a file and source if from .bash_profile
-	talosctl completion bash > ~/.talos/completion.bash.inc
-	printf "
+	talosctl completion bash > "${TALOS_HOME:-$HOME/.talos}/completion.bash.inc"
+	printf '
 		# talosctl shell completion
-		source '$HOME/.talos/completion.bash.inc'
-		" >> $HOME/.bash_profile
+		source "${TALOS_HOME:-$HOME/.talos}/completion.bash.inc"
+		' >> $HOME/.bash_profile
 	source $HOME/.bash_profile
 # Load the talosctl completion code for fish[1] into the current shell
 	talosctl completion fish | source


### PR DESCRIPTION


# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Use TALOS_HOME for state instead of ~/.talos, when defined to an absolute filepath.
This resolves #12222.

## Why? (reasoning)
Currently talosctl always puts state data in the ~/.talos directory.
This makes it difficult to test infrastructure tooling in an isolated manner, because the contents of the state directory are not fully isolated from the rest of the system.

It also makes it difficult to have multiple different filesystem locations for different state directories.
For example, a user might have two different disk drives, each containing talos state data for different clusters.
Currently it is impossible to use both state directories at the same time in different ttys (as the current workaround requires a symlink), but with this feature each tty can define the environment variable to use the corresponding location.

The path referenced must be an abolute path to help avoid user error.

## Acceptance
The conformance fails GPG Identity; I'm not sure if this is because the commit is not signed-off by a sidero developer.

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
