### PR TITLE
chore: remove spammy 'clean up unused volumes' logs

### DIFF
--- a/internal/app/machined/pkg/controllers/block/volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config.go
@@ -131,7 +131,7 @@ func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtim
 			}
 		}
 
-		if err := ctrl.cleanupUnusedVolumes(ctx, r, volumeConfigsByID, volumeMountRequestsByID, logger); err != nil {
+		if err := ctrl.cleanupUnusedVolumes(ctx, r, volumeConfigsByID, volumeMountRequestsByID); err != nil {
 			return fmt.Errorf("error cleaning up unused volumes: %w", err)
 		}
 	}
@@ -281,10 +281,7 @@ func (ctrl *VolumeConfigController) cleanupUnusedVolumes(
 	r controller.Runtime,
 	volumeConfigsByID map[string]*block.VolumeConfig,
 	volumeMountRequestsByID map[string]*block.VolumeMountRequest,
-	l *zap.Logger,
 ) error {
-	l.Info("cleaning up unused volumes")
-	// Clean up unused volume configs
 	for _, volumeConfig := range volumeConfigsByID {
 		okToDestroy, err := r.Teardown(ctx, volumeConfig.Metadata())
 		if err != nil {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Remove the `cleaning up unused volumes` log entry introduced in 43f4e317f1976762f2999e71ccd6761248a85f12.

## Why? (reasoning)

This entry is logged whenever the controller runs, regardless of whether it cleans up any unused logs or not – it's spammy and clutters the logs without adding relevant information.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
