### PR TITLE
chore: disable k8s integration tests for 1GiB worker nodes

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -359,7 +359,10 @@ case "${TEST_MODE:-default}" in
   *)
     get_kubeconfig
     run_talos_integration_test
-    run_kubernetes_integration_test
+
+    if [[ ${QEMU_MEMORY_WORKERS:-2048} -le 1024 ]]; then
+        run_kubernetes_integration_test
+    fi
 
     if [ "${WITH_TEST:-none}" != "none" ]; then
       "${WITH_TEST}"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Disable `talosctl health --run-e2e` for worker nodes with <= 1GiB of memory.

Closes https://github.com/siderolabs/talos/issues/12229.

## Why? (reasoning)

Kubernetes E2E tests have had a bump in memory usage, making running these on 1GiB worker nodes unreliable.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.