### PR TITLE
feat: extend flags of cache-cert-gen

### DIFF
--- a/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
+++ b/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
@@ -54,7 +54,7 @@ var airgappedCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cli.WithContext(
 			context.Background(), func(ctx context.Context) error {
-				caPEM, certPEM, keyPEM, err := helpers.GenerateSelfSignedCert([]net.IP{airgappedFlags.advertisedAddress})
+				caPEM, certPEM, keyPEM, err := helpers.GenerateSelfSignedCert([]net.IP{airgappedFlags.advertisedAddress}, nil)
 				if err != nil {
 					return nil
 				}

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -477,7 +477,10 @@ var imageCacheCertGenCmd = &cobra.Command{
 	Example: ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		caPEM, certPEM, keyPEM, err := mgmthelpers.GenerateSelfSignedCert(imageCacheCertGenCmdFlags.advertisedAddress)
+		caPEM, certPEM, keyPEM, err := mgmthelpers.GenerateSelfSignedCert(
+			imageCacheCertGenCmdFlags.advertisedAddresses,
+			imageCacheCertGenCmdFlags.advertisedNames,
+		)
 		if err != nil {
 			return nil
 		}
@@ -525,10 +528,11 @@ func generateConfigPatch(caPEM []byte) error {
 }
 
 var imageCacheCertGenCmdFlags struct {
-	advertisedAddress []net.IP
-	tlsCaFile         string
-	tlsCertFile       string
-	tlsKeyFile        string
+	advertisedAddresses []net.IP
+	advertisedNames     []string
+	tlsCaFile           string
+	tlsCertFile         string
+	tlsKeyFile          string
 }
 
 func init() {
@@ -565,7 +569,8 @@ func init() {
 	imageCacheCertGenCmd.PersistentFlags().StringVar(&imageCacheCertGenCmdFlags.tlsCaFile, "tls-ca-file", "ca.crt", "TLS certificate authority file")
 	imageCacheCertGenCmd.PersistentFlags().StringVar(&imageCacheCertGenCmdFlags.tlsCertFile, "tls-cert-file", "tls.crt", "TLS certificate file to use for serving")
 	imageCacheCertGenCmd.PersistentFlags().StringVar(&imageCacheCertGenCmdFlags.tlsKeyFile, "tls-key-file", "tls.key", "TLS key file to use for serving")
-	imageCacheCertGenCmd.PersistentFlags().IPSliceVar(&imageCacheCertGenCmdFlags.advertisedAddress, "advertised-address", []net.IP{}, "The address to advertise to the cluster.")
+	imageCacheCertGenCmd.PersistentFlags().IPSliceVar(&imageCacheCertGenCmdFlags.advertisedAddresses, "advertised-address", []net.IP{}, "The addresses to advertise.")
+	imageCacheCertGenCmd.PersistentFlags().StringSliceVar(&imageCacheCertGenCmdFlags.advertisedNames, "advertised-name", []string{}, "The DNS names to advertise.")
 	imageIntegrationCmd.MarkPersistentFlagRequired("advertised-address") //nolint:errcheck
 
 	imageCmd.AddCommand(imageIntegrationCmd)

--- a/cmd/talosctl/pkg/mgmt/helpers/airgapped.go
+++ b/cmd/talosctl/pkg/mgmt/helpers/airgapped.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GenerateSelfSignedCert generates self-signed certificate.
-func GenerateSelfSignedCert(sanIPs []net.IP) ([]byte, []byte, []byte, error) {
+func GenerateSelfSignedCert(sanIPs []net.IP, sanNames []string) ([]byte, []byte, []byte, error) {
 	ca, err := x509.NewSelfSignedCertificateAuthority(x509.ECDSA(true))
 	if err != nil {
 		return nil, nil, nil, err
@@ -22,6 +22,7 @@ func GenerateSelfSignedCert(sanIPs []net.IP) ([]byte, []byte, []byte, error) {
 		x509.Organization("test"),
 		x509.CommonName("server"),
 		x509.IPAddresses(sanIPs),
+		x509.DNSNames(sanNames),
 		x509.ExtKeyUsage([]stdx509.ExtKeyUsage{stdx509.ExtKeyUsageServerAuth}),
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -347,7 +347,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.44.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -795,8 +795,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.44.0 h1:A97SsFvM3AIwEEmTBiaxPPTYpDC47w720rdiiUvgoAU=
-golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -461,7 +461,7 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/siderolabs/deep-copy v0.5.8 // indirect
-	github.com/siderolabs/gen v0.8.5 // indirect
+	github.com/siderolabs/gen v0.8.6 // indirect
 	github.com/siderolabs/importvet v0.2.0 // indirect
 	github.com/siderolabs/talos/tools/docgen v0.0.0-20251112150910-859194e67800 // indirect
 	github.com/siderolabs/talos/tools/gotagsrewrite v0.0.0-20251112150910-859194e67800 // indirect
@@ -546,7 +546,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/crypto v0.44.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b // indirect
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.30.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1292,8 +1292,8 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/siderolabs/deep-copy v0.5.8 h1:43G8qJBTwGuKZX+UYNe29ZOtyDFqayS7/GfJVviz6RU=
 github.com/siderolabs/deep-copy v0.5.8/go.mod h1:PNX2/lqNu3oyDZGWe1eKW8bkYkhs583WcUBBB2EviX8=
-github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
-github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
+github.com/siderolabs/gen v0.8.6 h1:pE6shuqov3L+5rEcAUJ/kY6iJofimljQw5G95P8a5c4=
+github.com/siderolabs/gen v0.8.6/go.mod h1:J9IbusbES2W6QWjtSHpDV9iPGZHc978h1+KJ4oQRspQ=
 github.com/siderolabs/importvet v0.2.0 h1:oGQXke2/TnSg5xEFD/ktc+G59INzmgRU3yJ8wt++QRE=
 github.com/siderolabs/importvet v0.2.0/go.mod h1:X0AIl/3MnvlEeCzYRJe/t9YOk4FjPhT53doU4xOG4AU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -1561,8 +1561,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
-golang.org/x/crypto v0.44.0 h1:A97SsFvM3AIwEEmTBiaxPPTYpDC47w720rdiiUvgoAU=
-golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -1868,7 +1868,8 @@ talosctl image cache-cert-gen [flags]
 ### Options
 
 ```
-      --advertised-address ipSlice   The address to advertise to the cluster. (default [])
+      --advertised-address ipSlice   The addresses to advertise. (default [])
+      --advertised-name strings      The DNS names to advertise.
   -h, --help                         help for cache-cert-gen
       --tls-ca-file string           TLS certificate authority file (default "ca.crt")
       --tls-cert-file string         TLS certificate file to use for serving (default "tls.crt")


### PR DESCRIPTION
Add flags to add SAN names to generated certificate.

Additionally bump `golang.org/x/crypto` due to Security Advisory.