### PR TITLE
feat: add extra tags to kernel logging

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_config_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_config_test.go
@@ -41,7 +41,7 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigNone() {
 
 func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 	cmdline := procfs.NewCmdline("")
-	cmdline.Append(constants.KernelParamLoggingKernel, "https://10.0.0.1:3333/logs")
+	cmdline.Append(constants.KernelParamLoggingKernel, "https://10.0.0.1:3333/logs?extraField=value1&otherExtraField=value2")
 
 	suite.Require().NoError(suite.Runtime().RegisterController(&runtimectrls.KmsgLogConfigController{
 		Cmdline: cmdline,
@@ -50,14 +50,14 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 	kmsgLogConfig1 := &runtimecfg.KmsgLogV1Alpha1{
 		MetaName: "1",
 		KmsgLogURL: meta.URL{
-			URL: must(url.Parse("https://10.0.0.2:4444/logs")),
+			URL: must(url.Parse("https://10.0.0.2:4444/logs?extraField=value1&otherExtraField=value2")),
 		},
 	}
 
 	kmsgLogConfig2 := &runtimecfg.KmsgLogV1Alpha1{
 		MetaName: "2",
 		KmsgLogURL: meta.URL{
-			URL: must(url.Parse("https://10.0.0.1:3333/logs")),
+			URL: must(url.Parse("https://10.0.0.1:3333/logs?extraField=value1&otherExtraField=value2")),
 		},
 	}
 
@@ -70,8 +70,8 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 		func(cfg *runtime.KmsgLogConfig, asrt *assert.Assertions) {
 			asrt.Equal(
 				[]string{
-					"https://10.0.0.1:3333/logs",
-					"https://10.0.0.2:4444/logs",
+					"https://10.0.0.1:3333/logs?extraField=value1&otherExtraField=value2",
+					"https://10.0.0.2:4444/logs?extraField=value1&otherExtraField=value2",
 				},
 				xslices.Map(cfg.TypedSpec().Destinations, func(u *url.URL) string { return u.String() }),
 			)
@@ -80,7 +80,7 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 
 func (suite *KmsgLogConfigSuite) TestKmsgLogConfigCmdline() {
 	cmdline := procfs.NewCmdline("")
-	cmdline.Append(constants.KernelParamLoggingKernel, "https://10.0.0.1:3333/logs")
+	cmdline.Append(constants.KernelParamLoggingKernel, "https://10.0.0.1:3333/logs?extraField=value1&otherExtraField=value2")
 
 	suite.Require().NoError(suite.Runtime().RegisterController(&runtimectrls.KmsgLogConfigController{
 		Cmdline: cmdline,
@@ -89,7 +89,7 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigCmdline() {
 	rtestutils.AssertResources[*runtime.KmsgLogConfig](suite.Ctx(), suite.T(), suite.State(), []resource.ID{runtime.KmsgLogConfigID},
 		func(cfg *runtime.KmsgLogConfig, asrt *assert.Assertions) {
 			asrt.Equal(
-				[]string{"https://10.0.0.1:3333/logs"},
+				[]string{"https://10.0.0.1:3333/logs?extraField=value1&otherExtraField=value2"},
 				xslices.Map(cfg.TypedSpec().Destinations, func(u *url.URL) string { return u.String() }),
 			)
 		})

--- a/pkg/machinery/config/types/runtime/kmsg_log.go
+++ b/pkg/machinery/config/types/runtime/kmsg_log.go
@@ -57,9 +57,10 @@ type KmsgLogV1Alpha1 struct {
 	//     The scheme must be tcp:// or udp://.
 	//     The path must be empty.
 	//     The port is required.
+	//	   The queries arguments can be set to pass optional extra tags.
 	//   examples:
 	//     - value: >
-	//        "udp://10.3.7.3:2810"
+	//        "udp://10.3.7.3:2810?extraField=value1&otherExtraField=value2"
 	//   schema:
 	//     type: string
 	//     pattern: "^(tcp|udp)://"
@@ -79,7 +80,7 @@ func NewKmsgLogV1Alpha1() *KmsgLogV1Alpha1 {
 func exampleKmsgLogV1Alpha1() *KmsgLogV1Alpha1 {
 	cfg := NewKmsgLogV1Alpha1()
 	cfg.MetaName = "remote-log"
-	cfg.KmsgLogURL.URL = ensure.Value(url.Parse("tcp://192.168.3.7:3478/"))
+	cfg.KmsgLogURL.URL = ensure.Value(url.Parse("tcp://192.168.3.7:3478/?extraField=value1&otherExtraField=value2"))
 
 	return cfg
 }

--- a/website/content/v1.12/reference/configuration/runtime/kmsglogconfig.md
+++ b/website/content/v1.12/reference/configuration/runtime/kmsglogconfig.md
@@ -17,15 +17,15 @@ title: KmsgLogConfig
 apiVersion: v1alpha1
 kind: KmsgLogConfig
 name: remote-log # Name of the config document.
-url: tcp://192.168.3.7:3478/ # The URL encodes the log destination.
+url: tcp://192.168.3.7:3478/?extraField=value1&otherExtraField=value2 # The URL encodes the log destination.
 {{< /highlight >}}
 
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`name` |string |Name of the config document.  | |
-|`url` |URL |The URL encodes the log destination.<br>The scheme must be tcp:// or udp://.<br>The path must be empty.<br>The port is required. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-url: udp://10.3.7.3:2810
+|`url` |URL |The URL encodes the log destination.<br>The scheme must be tcp:// or udp://.<br>The path must be empty.<br>The port is required. <br>Optional queries arguments can be passed to configure extra args to be send. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+url: udp://10.3.7.3:2810?extraField=value1&otherExtraField=value2
 {{< /highlight >}}</details> | |
 
 


### PR DESCRIPTION
# Pull Request

## What? (description)

To simply add the possibility to add extra args to the kernel logging url, without changing the model 

## Why? (reasoning)

To be aligned with the service logging that also allow this option

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

Documentation PR : https://github.com/siderolabs/docs/pull/181
