### PR TITLE
fix: trim trailing dots from certificate SANs

### DIFF
--- a/pkg/machinery/resources/secrets/cert_sans.go
+++ b/pkg/machinery/resources/secrets/cert_sans.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
@@ -95,9 +96,12 @@ func (spec *CertSANSpec) AppendIPs(ips ...netip.Addr) {
 // AppendDNSNames skipping duplicates.
 func (spec *CertSANSpec) AppendDNSNames(dnsNames ...string) {
 	for _, dnsName := range dnsNames {
+		// remove trailing dot from the DNS name, as it shouldn't be stored in the cert SANs
+		dnsName = strings.TrimRight(dnsName, ".")
+
 		found := slices.Contains(spec.DNSNames, dnsName)
 
-		if !found {
+		if !found && dnsName != "" {
 			spec.DNSNames = append(spec.DNSNames, dnsName)
 		}
 	}


### PR DESCRIPTION
Trailing dots are not supposed to be in the cert SANs, but most implementations allow it. Go 1.25.2 introduced strict validation for DNS names in cert SANs, which leads to CoreDNS issue on GCP: as CoreDNS 1.13.1 was build with Go 1.25.2, it rejects a certSAN:

```
tls: failed to parse certificate from server: x509: SAN dNSName is malformed
```

The FQDN on GCP looks like: `<vm>.c.project.internal.` (note trailing dot). Trim trailing dots when building SANs on all levels.
