### PR TITLE
chore(ci): skip multipath extension tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-11-17T11:29:04Z by kres e1d6dac.
+# Generated on 2025-11-27T15:52:53Z by kres e1d6dac.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -4120,7 +4120,7 @@ jobs:
           make iscsi-tools util-linux-tools extensions-metadata -C _out/extensions
       - name: installer extensions
         env:
-          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools'
+          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools|trident-iscsi-tools'
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           make installer-with-extensions

--- a/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-23T15:10:44Z by kres 46e133d.
+# Generated on 2025-11-27T15:52:53Z by kres e1d6dac.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -99,7 +99,7 @@ jobs:
           make iscsi-tools util-linux-tools extensions-metadata -C _out/extensions
       - name: installer extensions
         env:
-          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools'
+          EXTENSIONS_FILTER_COMMAND: grep -E 'iscsi-tools|util-linux-tools|trident-iscsi-tools'
           IMAGE_REGISTRY: registry.dev.siderolabs.io
         run: |
           make installer-with-extensions

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2196,7 +2196,7 @@ spec:
         - name: installer extensions
           command: installer-with-extensions
           environment:
-            EXTENSIONS_FILTER_COMMAND: "grep -E 'iscsi-tools|util-linux-tools'"
+            EXTENSIONS_FILTER_COMMAND: "grep -E 'iscsi-tools|util-linux-tools|trident-iscsi-tools'"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: kubelet-fat-patch
         - name: e2e-qemu-csi-longhorn

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ COMMON_ARGS += --build-arg=ZSTD_COMPRESSION_LEVEL=$(ZSTD_COMPRESSION_LEVEL)
 
 CI_ARGS ?=
 
-EXTENSIONS_FILTER_COMMAND ?= grep -vE 'tailscale|xen-guest-agent|nvidia|vmtoolsd-guest-agent|metal-agent|cloudflared|zerotier|nebula|newt|netbird'
+EXTENSIONS_FILTER_COMMAND ?= grep -vE 'tailscale|xen-guest-agent|nvidia|vmtoolsd-guest-agent|metal-agent|cloudflared|zerotier|nebula|newt|netbird|multipath-tools|trident-iscsi-tools'
 
 all: initramfs kernel installer imager talosctl talosctl-image talos
 


### PR DESCRIPTION
Skip multipath and trident specific extensions from tests. We could add a multipath test later on.