### PR TITLE
test: fix the image-factory test to pass IF endpoint

### DIFF
--- a/hack/test/e2e-image-factory.sh
+++ b/hack/test/e2e-image-factory.sh
@@ -59,6 +59,7 @@ function create_cluster {
     --cpus-controlplanes="${QEMU_CPUS:-2}" \
     --cpus-workers="${QEMU_CPUS_WORKERS:-2}" \
     --cidr=172.20.1.0/24 \
+    --image-factory-url="${FACTORY_SCHEME}://${FACTORY_HOSTNAME}/" \
     --talos-version="${FACTORY_VERSION}" \
     --schematic-id="${FACTORY_SCHEMATIC}" \
     "${REGISTRY_MIRROR_FLAGS[@]}" \


### PR DESCRIPTION
Pass the IF endpoint to `talosctl cluster create qemu`.

It matches the default value, but if we change the hostname, the test
breaks as it starts using different image factories for
provisioning/upgrade.