### PR TITLE
feat: present kernel log as `talosctl logs kernel`

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -205,6 +205,12 @@ This is in line with a set of best practices documented in CIS 1.12 benchmark.
 You can still expand the list of supported cipher suites via the `cluster.apiServer.extraArgs."tls-cipher-suites"` machine configuration field if needed.
 """
 
+    [notes.kernel-log]
+        title = "Kernel Log"
+        description = """\
+The kernel log (dmesg) is now also available as the service log named `kernel` (`talosctl logs kernel`).
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_storage.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_storage.go
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/siderolabs/go-kmsg"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+)
+
+// KmsgLogStorageController presents kernel message log as a 'kernel' log.
+type KmsgLogStorageController struct {
+	V1Alpha1Logging runtime.LoggingManager
+	V1Alpha1Mode    runtime.Mode
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *KmsgLogStorageController) Name() string {
+	return "runtime.KmsgLogStorageController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *KmsgLogStorageController) Inputs() []controller.Input {
+	return nil
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *KmsgLogStorageController) Outputs() []controller.Output {
+	return nil
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *KmsgLogStorageController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if ctrl.V1Alpha1Mode.InContainer() {
+		return nil
+	}
+
+	var err error
+
+	logWriter, err := ctrl.V1Alpha1Logging.ServiceLog("kernel").Writer()
+	if err != nil {
+		return fmt.Errorf("error opening logger: %w", err)
+	}
+	defer logWriter.Close() //nolint:errcheck
+
+	// initilalize kmsg reader early, so that we don't lose position on config changes
+	reader, err := kmsg.NewReader(kmsg.Follow())
+	if err != nil {
+		return fmt.Errorf("error reading kernel messages: %w", err)
+	}
+
+	defer reader.Close() //nolint:errcheck
+
+	kmsgCh := reader.Scan(ctx)
+
+	// wait for the initial event to start processing messages
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-r.EventCh():
+	}
+
+	for {
+		var msg kmsg.Packet
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg = <-kmsgCh:
+		}
+
+		if msg.Err != nil {
+			return fmt.Errorf("error receiving kernel logs: %w", msg.Err)
+		}
+
+		if _, err = logWriter.Write(
+			fmt.Appendf(nil, "%s: %7s: [%s]: %s", msg.Message.Facility, msg.Message.Priority, msg.Message.Timestamp.Format(time.RFC3339Nano), msg.Message.Message),
+		); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -423,6 +423,10 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&runtimecontrollers.KmsgLogDeliveryController{
 			Drainer: drainer,
 		},
+		&runtimecontrollers.KmsgLogStorageController{
+			V1Alpha1Logging: ctrl.v1alpha1Runtime.Logging(),
+			V1Alpha1Mode:    ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&runtimecontrollers.LoadedKernelModuleController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},


### PR DESCRIPTION
Extracted from #12115

The idea is that kernel log can be delivered/persisted along with any other service logs.
