### PR TITLE
fix: simplify OOM expression

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
@@ -41,7 +41,7 @@ func TestCalculateScore(t *testing.T) {
 				MemoryPeak:    cgroups.Value{Val: 50, IsSet: true},
 				MemoryMax:     cgroups.Value{IsSet: true, IsMax: true},
 			},
-			expect: 2.625,
+			expect: 21,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -79,14 +79,14 @@ func TestRankCgroups(t *testing.T) {
 					MemoryCurrent: cgroups.Value{Val: 222593024, IsSet: true},
 					MemoryPeak:    cgroups.Value{Val: 371011584, IsSet: true},
 					MemoryMax:     cgroups.Value{IsMax: true, IsSet: true},
-				}: 1.499765420173865,
+				}: 2.22593024e+08,
 				{
 					Class:         runtime.QoSCgroupClassBurstable,
 					Path:          "testdata/rank1/kubepods/burstable/podABC",
 					MemoryCurrent: cgroups.Value{Val: 42, IsSet: true},
 					MemoryPeak:    cgroups.Value{Val: 50, IsSet: true},
 					MemoryMax:     cgroups.Value{IsSet: true, IsMax: true},
-				}: 2.625,
+				}: 21,
 			},
 		},
 	} {

--- a/pkg/machinery/config/types/runtime/testdata/oom.yaml
+++ b/pkg/machinery/config/types/runtime/testdata/oom.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: memory_full_avg10 > 12.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("500ms")
-cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)) / double(memory_peak.orValue(0u) - memory_current.orValue(0u)))'
+cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))'
 sampleInterval: 100ms

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1322,7 +1322,7 @@ const (
 	// DefaultOOMCgroupRankingExpression is the default CEL expression used to rank cgroups for OOM killer.
 	DefaultOOMCgroupRankingExpression = `memory_max.hasValue() ? 0.0 :
 		{Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] *
-		   double(memory_current.orValue(0u)) / double(memory_peak.orValue(0u) - memory_current.orValue(0u))`
+		   double(memory_current.orValue(0u))`
 
 	// SDStubCmdlineExtraOEMVar is the name of the SMBIOS OEM variable that can be used to pass extra kernel command line parameters to systemd-stub.
 	SDStubCmdlineExtraOEMVar = "io.systemd.stub.kernel-cmdline-extra"

--- a/website/content/v1.12/reference/configuration/runtime/oomconfig.md
+++ b/website/content/v1.12/reference/configuration/runtime/oomconfig.md
@@ -17,7 +17,7 @@ title: OOMConfig
 apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: memory_full_avg10 > 12.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("500ms") # This expression defines when to trigger OOM action.
-cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)) / double(memory_peak.orValue(0u) - memory_current.orValue(0u)))' # This expression defines how to rank cgroups for OOM handler.
+cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))' # This expression defines how to rank cgroups for OOM handler.
 sampleInterval: 100ms # How often should the trigger expression be evaluated.
 {{< /highlight >}}
 


### PR DESCRIPTION
Remove denominator that was supposed to scale based on difference between peak and current memory usage, and score simply based on current memory usage.
