### PR TITLE
test: fix flaky LinkSpec/Wireguard test

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -659,7 +659,6 @@ func (suite *LinkSpecSuite) TestWireguard() {
 		Logical: true,
 		Wireguard: network.WireguardSpec{
 			PrivateKey:   priv.String(),
-			ListenPort:   30000,
 			FirewallMark: 1,
 			Peers: []network.WireguardPeer{
 				{


### PR DESCRIPTION
It tried to allocate listen address on a fixed port. When running tests it's hard to predict which port will be available, so skip specifying a port, and Wireguard should allocate a port on its own.
