### PR TITLE
chore: correct condition for running k8s integration tests

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -360,7 +360,7 @@ case "${TEST_MODE:-default}" in
     get_kubeconfig
     run_talos_integration_test
 
-    if [[ ${QEMU_MEMORY_WORKERS:-2048} -le 1024 ]]; then
+    if [[ ${QEMU_MEMORY_WORKERS:-2048} -gt 1024 ]]; then
         run_kubernetes_integration_test
     fi
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

74d35900af0f6451426b70eec3b6db4b72eb993c was supposed to disable the k8s tests on memory-restricted workers, but instead made the tests only run on memory-restricted workers.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
