### PR TITLE
feat: rename `image default` and `image source-bundle`

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,7 +22,7 @@ function release-notes {
   release-tool "${2}" --gfm > "${1}"
 
   echo -e '\n## Images\n\n```' >> ${1}
-  ${ARTIFACTS}/talosctl-linux-amd64 image default >> ${1}
+  ${ARTIFACTS}/talosctl-linux-amd64 image k8s-bundle >> ${1}
   echo -e '```\n' >> ${1}
 }
 

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -30,14 +30,14 @@ func (suite *ImageSuite) SuiteName() string {
 
 // TestDefault verifies default Talos list of images.
 func (suite *ImageSuite) TestDefault() {
-	suite.RunCLI([]string{"image", "default"},
+	suite.RunCLI([]string{"image", "k8s-bundle"},
 		base.StdoutShouldMatch(regexp.MustCompile(regexp.QuoteMeta("registry.k8s.io/kube-apiserver"))),
 	)
 }
 
-// TestSourceBundle verifies source-bundle Talos list of images.
+// TestSourceBundle verifies talos-bundle Talos list of images.
 func (suite *ImageSuite) TestSourceBundle() {
-	suite.RunCLI([]string{"image", "source-bundle", "v1.11.2"},
+	suite.RunCLI([]string{"image", "talos-bundle", "v1.11.2"},
 		base.StdoutShouldMatch(regexp.MustCompile(regexp.QuoteMeta(`ghcr.io/siderolabs/installer:v1.11.2
 ghcr.io/siderolabs/installer-base:v1.11.2
 ghcr.io/siderolabs/imager:v1.11.2
@@ -162,7 +162,7 @@ func (suite *ImageSuite) TestCacheCreateOCI() {
 		suite.T().Skip("skipping in short mode")
 	}
 
-	stdOut, _ := suite.RunCLI([]string{"image", "default"})
+	stdOut, _ := suite.RunCLI([]string{"image", "k8s-bundle"})
 
 	imagesList := strings.Split(strings.Trim(stdOut, "\n"), "\n")
 
@@ -187,7 +187,7 @@ func (suite *ImageSuite) TestCacheCreateFlat() {
 		suite.T().Skip("skipping in short mode")
 	}
 
-	stdOut, _ := suite.RunCLI([]string{"image", "default"})
+	stdOut, _ := suite.RunCLI([]string{"image", "k8s-bundle"})
 
 	imagesList := strings.Split(strings.Trim(stdOut, "\n"), "\n")
 

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -1982,18 +1982,18 @@ talosctl image cache-serve [flags]
 
 * [talosctl image](#talosctl-image)	 - Manage CRI container images
 
-## talosctl image default
+## talosctl image k8s-bundle
 
-List the default images used by Talos
+List the default Kubernetes images used by Talos
 
 ```
-talosctl image default [flags]
+talosctl image k8s-bundle [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help                 help for default
+  -h, --help                 help for k8s-bundle
       --provisioner string   include provisioner specific images (default "installer")
 ```
 
@@ -2073,18 +2073,18 @@ talosctl image pull <image> [flags]
 
 * [talosctl image](#talosctl-image)	 - Manage CRI container images
 
-## talosctl image source-bundle
+## talosctl image talos-bundle
 
-List the source images used for building Talos
+List the default system images and extensions used for Talos
 
 ```
-talosctl image source-bundle <talos-version> [flags]
+talosctl image talos-bundle [talos-version] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for source-bundle
+  -h, --help   help for talos-bundle
 ```
 
 ### Options inherited from parent commands
@@ -2126,10 +2126,10 @@ Manage CRI container images
 * [talosctl image cache-cert-gen](#talosctl-image-cache-cert-gen)	 - Generate TLS certificates and CA patch required for securing image cache to Talos communication
 * [talosctl image cache-create](#talosctl-image-cache-create)	 - Create a cache of images in OCI format into a directory
 * [talosctl image cache-serve](#talosctl-image-cache-serve)	 - Serve an OCI image cache directory over HTTP(S) as a container registry
-* [talosctl image default](#talosctl-image-default)	 - List the default images used by Talos
+* [talosctl image k8s-bundle](#talosctl-image-k8s-bundle)	 - List the default Kubernetes images used by Talos
 * [talosctl image list](#talosctl-image-list)	 - List CRI images
 * [talosctl image pull](#talosctl-image-pull)	 - Pull an image into CRI
-* [talosctl image source-bundle](#talosctl-image-source-bundle)	 - List the source images used for building Talos
+* [talosctl image talos-bundle](#talosctl-image-talos-bundle)	 - List the default system images and extensions used for Talos
 
 ## talosctl inject serviceaccount
 


### PR DESCRIPTION
s/default/k8s-bundle
s/source-bundle/talos-bundle

For UX consistency when generating lists of images used by talos and kubernetes. Also makes arguments to source-bundle optional and uses current version. It won't work for local, untagged builds, but should work the same with releases.