### PR TITLE
fix: don't disable LACP by default

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -410,6 +410,7 @@ func TestCmdlineParse(t *testing.T) {
 							UseCarrier:      true,
 							PrimaryIndex:    pointer.To[uint32](0),
 							MissedMax:       2,
+							ADLACPActive:    nethelpers.ADLACPActiveOn,
 						},
 					},
 					{

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -458,6 +458,7 @@ func (suite *LinkConfigSuite) TestMachineConfigurationWithAliases() {
 				asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
 				asrt.Equal(nethelpers.BondModeXOR, r.TypedSpec().BondMaster.Mode)
 				asrt.True(r.TypedSpec().BondMaster.UseCarrier)
+				asrt.Equal(nethelpers.ADLACPActiveOn, r.TypedSpec().BondMaster.ADLACPActive)
 			}
 		},
 	)
@@ -560,6 +561,7 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyle() {
 				asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
 				asrt.Equal(nethelpers.BondModeActiveBackup, r.TypedSpec().BondMaster.Mode)
 				asrt.EqualValues(200, r.TypedSpec().BondMaster.UpDelay)
+				asrt.Equal(nethelpers.ADLACPActiveOn, r.TypedSpec().BondMaster.ADLACPActive)
 			case "br0":
 				asrt.True(r.TypedSpec().Up)
 				asrt.True(r.TypedSpec().Logical)

--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -46,7 +46,7 @@ func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConf
 	link.BondMaster.ADSelect = bond.ADSelect().ValueOrZero()
 	link.BondMaster.ADActorSysPrio = bond.ADActorSysPrio().ValueOrZero()
 	link.BondMaster.ADUserPortKey = bond.ADUserPortKey().ValueOrZero()
-	link.BondMaster.ADLACPActive = bond.ADLACPActive().ValueOrZero()
+	link.BondMaster.ADLACPActive = bond.ADLACPActive().ValueOr(nethelpers.ADLACPActiveOn)
 	link.BondMaster.PrimaryReselect = bond.PrimaryReselect().ValueOrZero()
 	link.BondMaster.ResendIGMP = bond.ResendIGMP().ValueOrZero()
 	link.BondMaster.MinLinks = bond.MinLinks().ValueOrZero()
@@ -147,6 +147,7 @@ func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond) erro
 		ADActorSysPrio:  bond.ADActorSysPrio(),
 		ADUserPortKey:   bond.ADUserPortKey(),
 		PeerNotifyDelay: bond.PeerNotifyDelay(),
+		ADLACPActive:    nethelpers.ADLACPActiveOn,
 	}
 	networkadapter.BondMasterSpec(&link.BondMaster).FillDefaults()
 


### PR DESCRIPTION
Fixes #12315

As part of bond config refactoring, new LACP active setting was added which unfortunately defaults to 'off' as zero value disabling LACP.

Fix that by enabling LACP by default:

* unconditionally for legacy config
* by default for new style config if no value was specified in the config
