### PR TITLE
test: revert add direct connectivity CA rotation test

### DIFF
--- a/pkg/machinery/client/context.go
+++ b/pkg/machinery/client/context.go
@@ -37,15 +37,3 @@ func WithNode(ctx context.Context, node string) context.Context {
 
 	return metadata.NewOutgoingContext(ctx, md)
 }
-
-// ClearNodeMetadata removes any node/nodeS metadata from the context.
-func ClearNodeMetadata(ctx context.Context) context.Context {
-	md, _ := metadata.FromOutgoingContext(ctx)
-
-	// overwrite any previous nodes in the context metadata with new value
-	md = md.Copy()
-	md.Delete("nodes")
-	md.Delete("node")
-
-	return metadata.NewOutgoingContext(ctx, md)
-}


### PR DESCRIPTION
This reverts commit 2ffe538e7307f0ac3dbac2eba4b36ea98162ec78.

This change assumed we have direct connectivity to the workers, which is not the case e.g. when the firewall is enabled.

Drop the extra test for now.
