### PR TITLE
fix: clear provisioning data on SideroLink config change

### DIFF
--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -166,6 +166,10 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 				continue
 			}
 		case <-r.EventCh():
+			// if the SideroLink configuration changed (either config itself, or machine UUID or Unique Token),
+			// clear any previous provision data we had so that Talos doesn't cycle through endpoints from
+			// stale provisioning data until it reaches out to SideroLink Provision API again
+			ctrl.pd = provisionData{}
 		}
 
 		if ctrl.pd.IsEmpty() {


### PR DESCRIPTION
If any inputs for the SideroLink provision API change, call the API immediately instead of cycling through the endpoints which belong to old provision data.

This issue was specifically causing issue on join to Omni with secure join token flow:

* Talos performs initial join, and Omni puts it to 'limbo state' while giving out two WG endpoints
* Omni finishes the join process, writes unique join token, and kicks out the WG peer, as it expectes Talos to reconnect with the token
* Talos instead of doing immediate provision API call, cycles to the second endpoint it learned previously
* once Talos detects WG connection down, as is it out of endpoints, it calls provision API with unique token now, and the connection succeeds finally.
