### PR TITLE
fix: mark secureboot as supported for metal

### DIFF
--- a/pkg/machinery/platforms/platforms.go
+++ b/pkg/machinery/platforms/platforms.go
@@ -139,6 +139,7 @@ func MetalPlatform() Platform {
 			BootMethodDiskImage,
 			BootMethodPXE,
 		},
+		SecureBootSupported: true,
 	}
 }
 


### PR DESCRIPTION
Mark SecureBootSupported as true for MetalPlatform.

Assuming this is correct based on https://github.com/siderolabs/image-factory/blob/fa266e0b201a1e7f564dafb31692dda905ddb319/internal/frontend/http/ui.go#L453