### PR TITLE
docs: drop machine.network example

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
@@ -86,13 +86,6 @@ func kubeletImageExample() string {
 	return (&KubeletConfig{}).Image()
 }
 
-func machineNetworkConfigExample() *NetworkConfig {
-	return &NetworkConfig{
-		NameServers: []string{"9.8.7.6", "8.7.6.5"},
-		Searches:    []string{"example.org", "example.com"},
-	}
-}
-
 func machineInstallExample() *InstallConfig {
 	return &InstallConfig{
 		InstallDisk:              "/dev/sda",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -171,9 +171,6 @@ type MachineConfig struct {
 	MachinePods []Unstructured `yaml:"pods,omitempty"`
 	//   description: |
 	//     Provides machine specific network configuration options.
-	//   examples:
-	//     - name: Network definition example.
-	//       value: machineNetworkConfigExample()
 	MachineNetwork *NetworkConfig `yaml:"network,omitempty"`
 	// docgen:nodoc
 	//

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -264,7 +264,6 @@ func (MachineConfig) Doc() *encoder.Doc {
 	doc.Fields[5].AddExample("ControlPlane definition example.", machineControlplaneExample())
 	doc.Fields[6].AddExample("Kubelet definition example.", machineKubeletExample())
 	doc.Fields[7].AddExample("nginx static pod.", machinePodsExample())
-	doc.Fields[8].AddExample("Network definition example.", machineNetworkConfigExample())
 	doc.Fields[10].AddExample("MachineInstall config usage example.", machineInstallExample())
 	doc.Fields[11].AddExample("MachineFiles usage example.", machineFilesExample())
 	doc.Fields[12].AddExample("Environment variables definition examples.", machineEnvExamples0())
@@ -923,8 +922,6 @@ func (NetworkConfig) Doc() *encoder.Doc {
 			{},
 		},
 	}
-
-	doc.AddExample("Network definition example.", machineNetworkConfigExample())
 
 	doc.Fields[5].AddExample("", networkKubeSpanExample())
 

--- a/website/content/v1.12/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.12/reference/configuration/v1alpha1/config.md
@@ -142,19 +142,7 @@ pods:
             - image: nginx
               name: nginx
 {{< /highlight >}}</details> | |
-|`network` |<a href="#Config.machine.network">NetworkConfig</a> |Provides machine specific network configuration options. <details><summary>Show example(s)</summary>Network definition example.:{{< highlight yaml >}}
-network:
-    nameservers:
-        - 9.8.7.6
-        - 8.7.6.5
-    searchDomains:
-        - example.org
-        - example.com
-
-    # # Configures KubeSpan feature.
-    # kubespan:
-    #     enabled: true # Enable the KubeSpan feature.
-{{< /highlight >}}</details> | |
+|`network` |<a href="#Config.machine.network">NetworkConfig</a> |Provides machine specific network configuration options.  | |
 |`install` |<a href="#Config.machine.install">InstallConfig</a> |Used to provide instructions for installations.<br><br>Note that this configuration section gets silently ignored by Talos images that are considered pre-installed.<br>To make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted. <details><summary>Show example(s)</summary>MachineInstall config usage example.:{{< highlight yaml >}}
 install:
     disk: /dev/sda # The disk used for installations.
@@ -546,21 +534,6 @@ machine:
 NetworkConfig represents the machine's networking config values.
 
 
-
-{{< highlight yaml >}}
-machine:
-    network:
-        nameservers:
-            - 9.8.7.6
-            - 8.7.6.5
-        searchDomains:
-            - example.org
-            - example.com
-
-        # # Configures KubeSpan feature.
-        # kubespan:
-        #     enabled: true # Enable the KubeSpan feature.
-{{< /highlight >}}
 
 
 | Field | Type | Description | Value(s) |


### PR DESCRIPTION
This documents deprecated fields, drop it.

I noticed this while working on the docs.
