### PR TITLE
fix: correct condition to use UKI cmdline in GRUB

### DIFF
--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -77,7 +77,10 @@ func runInstallCmd(ctx context.Context) (err error) {
 			options.LegacyBIOSSupport = true
 		}
 
-		if config.Machine() != nil && config.Machine().Install().GrubUseUKICmdline() {
+		// if we don't have v1alpha1 config (we are in maintenance mode),
+		// or if we have v1alpha1 config, and GrubUseUKICmdline is set to true,
+		// then we should set the option to true
+		if config.Machine() == nil || config.Machine().Install().GrubUseUKICmdline() {
 			options.GrubUseUKICmdline = true
 		}
 	}


### PR DESCRIPTION
Use UKI cmdline either if the config is missing completely, or if the incomplete machine config is present (we are in maintenance mode).

Fixes #12349
