### PR TITLE
fix: update KubeSpan MSS clamping

### DIFF
--- a/internal/app/machined/pkg/adapters/network/network.go
+++ b/internal/app/machined/pkg/adapters/network/network.go
@@ -4,3 +4,11 @@
 
 // Package network implements adapters wrapping resources/network to provide additional functionality.
 package network
+
+// MSS calculation constants.
+const (
+	IPv4HeaderLen = 20 // IPv4 fixed header length
+	IPv6HeaderLen = 40 // IPv6 fixed header length
+	TCPHeaderLen  = 20 // fixed TCP header length, without options
+	TCPOptionsLen = 12 // assuming typical options like SACK, timestamps, etc. used by default in Linux
+)

--- a/internal/app/machined/pkg/adapters/network/nftables_rule.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule.go
@@ -584,9 +584,9 @@ func (a nftablesRule) Compile() (*NfTablesCompiled, error) {
 
 		switch family { //nolint:exhaustive
 		case nftables.TableFamilyIPv4:
-			mss = mtu - 40 // TCP + IPv4 overhead
+			mss = mtu - (IPv4HeaderLen + TCPHeaderLen + TCPOptionsLen) // TCP + IPv4 overhead
 		case nftables.TableFamilyIPv6:
-			mss = mtu - 60 // TCP + IPv6 overhead
+			mss = mtu - (IPv6HeaderLen + TCPHeaderLen + TCPOptionsLen) // TCP + IPv6 overhead
 		default:
 			panic("unexpected IP family")
 		}

--- a/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
@@ -427,11 +427,11 @@ func TestNfTablesRuleCompile(t *testing.T) { //nolint:tparallel
 					&expr.Cmp{
 						Op:       expr.CmpOpGt,
 						Register: 1,
-						Data:     []byte{0x04, 0xd8},
+						Data:     []byte{0x04, 0xcc},
 					},
 					&expr.Immediate{
 						Register: 1,
-						Data:     []byte{0x04, 0xd8},
+						Data:     []byte{0x04, 0xcc},
 					},
 					&expr.Exthdr{
 						SourceRegister: 1,
@@ -485,11 +485,11 @@ func TestNfTablesRuleCompile(t *testing.T) { //nolint:tparallel
 					&expr.Cmp{
 						Op:       expr.CmpOpGt,
 						Register: 1,
-						Data:     []byte{0x04, 0xc4},
+						Data:     []byte{0x04, 0xb8},
 					},
 					&expr.Immediate{
 						Register: 1,
-						Data:     []byte{0x04, 0xc4},
+						Data:     []byte{0x04, 0xb8},
 					},
 					&expr.Exthdr{
 						SourceRegister: 1,

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
@@ -365,14 +365,14 @@ func (s *NfTablesChainSuite) TestClampMSS() {
 	s.checkNftOutput(`table inet talos-test {
 	chain test1 {
 		type filter hook input priority filter; policy accept;
-		meta nfproto ipv4 tcp flags syn / syn,rst tcp option maxseg size > 1380 tcp option maxseg size set 1380
-		meta nfproto ipv6 tcp flags syn / syn,rst tcp option maxseg size > 1360 tcp option maxseg size set 1360
+		meta nfproto ipv4 tcp flags syn / syn,rst tcp option maxseg size > 1368 tcp option maxseg size set 1368
+		meta nfproto ipv6 tcp flags syn / syn,rst tcp option maxseg size > 1348 tcp option maxseg size set 1348
 	}
 }`, `table inet talos-test {
 	chain test1 {
 		type filter hook input priority filter; policy accept;
-		meta nfproto ipv4 tcp flags & (syn | rst) == syn tcp option maxseg size > 1380 tcp option maxseg size set 1380
-		meta nfproto ipv6 tcp flags & (syn | rst) == syn tcp option maxseg size > 1360 tcp option maxseg size set 1360
+		meta nfproto ipv4 tcp flags & (syn | rst) == syn tcp option maxseg size > 1368 tcp option maxseg size set 1368
+		meta nfproto ipv6 tcp flags & (syn | rst) == syn tcp option maxseg size > 1348 tcp option maxseg size set 1348
 	}
 }`)
 }


### PR DESCRIPTION
Subtract 12 bytes more from the MTU to build correct MSS clamping for TCP. Linux by default adds TCP options (timestamps, etc.) which seems to occupy 12 bytes (3 options).

This zeroes out TCP retransmissions on `iperf3` testing with KubeSpan, but has no effect on throughput.

Fixes #12311
