### PR TITLE
fix: rework NFT rules for KubeSpan

### DIFF
--- a/internal/app/machined/pkg/adapters/network/nftables_rule.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule.go
@@ -655,8 +655,13 @@ func (a nftablesRule) Compile() (*NfTablesCompiled, error) {
 	}
 
 	if a.NfTablesRule.ClampMSS != nil {
-		rule4 = append(rule4, clampMSS(nftables.TableFamilyIPv4, a.NfTablesRule.ClampMSS.MTU)...)
-		rule6 = append(rule6, clampMSS(nftables.TableFamilyIPv6, a.NfTablesRule.ClampMSS.MTU)...)
+		if rule4 != nil {
+			rule4 = append(rule4, clampMSS(nftables.TableFamilyIPv4, a.NfTablesRule.ClampMSS.MTU)...)
+		}
+
+		if rule6 != nil {
+			rule6 = append(rule6, clampMSS(nftables.TableFamilyIPv6, a.NfTablesRule.ClampMSS.MTU)...)
+		}
 	}
 
 	if a.NfTablesRule.SetMark != nil {

--- a/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
@@ -375,15 +375,20 @@ func TestNfTablesRuleCompile(t *testing.T) { //nolint:tparallel
 				},
 			},
 		},
-		{
-			name: "clamp MSS",
+		{ //nolint:dupl
+			name: "clamp MSS v4",
 			spec: networkres.NfTablesRule{
+				MatchDestinationAddress: &networkres.NfTablesAddressMatch{
+					IncludeSubnets: []netip.Prefix{
+						netip.MustParsePrefix("0.0.0.0/0"),
+					},
+				},
 				ClampMSS: &networkres.NfTablesClampMSS{
 					MTU: 1280,
 				},
 			},
 			expectedRules: [][]expr.Any{
-				{ //nolint:dupl
+				{
 					&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
 					&expr.Cmp{
 						Op:       expr.CmpOpEq,
@@ -441,7 +446,22 @@ func TestNfTablesRuleCompile(t *testing.T) { //nolint:tparallel
 						Op:             expr.ExthdrOpTcpopt,
 					},
 				},
-				{ //nolint:dupl
+			},
+		},
+		{ //nolint:dupl
+			name: "clamp MSS v6",
+			spec: networkres.NfTablesRule{
+				MatchDestinationAddress: &networkres.NfTablesAddressMatch{
+					IncludeSubnets: []netip.Prefix{
+						netip.MustParsePrefix("::/0"),
+					},
+				},
+				ClampMSS: &networkres.NfTablesClampMSS{
+					MTU: 1280,
+				},
+			},
+			expectedRules: [][]expr.Any{
+				{
 					&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
 					&expr.Cmp{
 						Op:       expr.CmpOpEq,

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
@@ -353,6 +353,9 @@ func (s *NfTablesChainSuite) TestClampMSS() {
 	chain.TypedSpec().Policy = nethelpers.VerdictAccept
 	chain.TypedSpec().Rules = []network.NfTablesRule{
 		{
+			MatchDestinationAddress: &network.NfTablesAddressMatch{
+				Invert: true, // match all addresses
+			},
 			ClampMSS: &network.NfTablesClampMSS{
 				MTU: constants.KubeSpanLinkMTU,
 			},


### PR DESCRIPTION
Don't attach nft rules to the IPv6 KubeSpan addresses, as Linux can route these packets natively, they are directly assigned to the `kubespan` interface.

Also fix the way MSS clamping is applied: previous implementation incorrectly triggered clamping to all addresses if the list of IPv4 or IPv6 addresses is empty.

Previous rules:

```
table inet talos {
        chain kubespan_outgoing {
                type route hook output priority filter; policy accept;
                meta mark & 0x00000060 == 0x00000020 accept
                oifname "lo" accept
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } tcp flags & (syn | rst) == syn tcp option maxseg size > 1368 tcp option maxseg size set 1368
                ip6 daddr { fd4e:cae:686b:1902:87f:e8ff:fe1e:b4e3, fd4e:cae:686b:1902:a44b:28ff:febf:e664, fd4e:cae:686b:1902:c049:f2ff:fe84:1785, fd4e:cae:686b:1902:c8c9:75ff:fe4c:5ba8 } tcp flags & (syn | rst) == syn tcp option maxseg size > 1348 tcp option maxseg size set 1348
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
                ip6 daddr { fd4e:cae:686b:1902:87f:e8ff:fe1e:b4e3, fd4e:cae:686b:1902:a44b:28ff:febf:e664, fd4e:cae:686b:1902:c049:f2ff:fe84:1785, fd4e:cae:686b:1902:c8c9:75ff:fe4c:5ba8 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
        }

        chain kubespan_prerouting {
                type filter hook prerouting priority filter; policy accept;
                meta mark & 0x00000060 == 0x00000020 accept
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
                ip6 daddr { fd4e:cae:686b:1902:87f:e8ff:fe1e:b4e3, fd4e:cae:686b:1902:a44b:28ff:febf:e664, fd4e:cae:686b:1902:c049:f2ff:fe84:1785, fd4e:cae:686b:1902:c8c9:75ff:fe4c:5ba8 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
        }
}
```

New rules:

```
table inet talos {
        chain kubespan_outgoing {
                type route hook output priority filter; policy accept;
                meta mark & 0x00000060 == 0x00000020 accept
                oifname "lo" accept
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } tcp flags & (syn | rst) == syn tcp option maxseg size > 1368 tcp option maxseg size set 1368
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
        }

        chain kubespan_prerouting {
                type filter hook prerouting priority filter; policy accept;
                meta mark & 0x00000060 == 0x00000020 accept
                ip daddr { 172.20.0.2, 172.20.0.4-172.20.0.6 } meta mark set meta mark & 0xffffffdf | 0x00000040 accept
        }
}
```
