### PR TITLE
fix: do not override DNS on MacOS

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -187,7 +187,7 @@ func GetQemu() Qemu {
 		PreallocateDisks:  false,
 		BootloaderEnabled: true,
 		UefiEnabled:       true,
-		Nameservers:       []string{},
+		Nameservers:       defaultNameservers,
 		DiskBlockSize:     512,
 		TargetArch:        runtime.GOARCH,
 		CniBinPath:        []string{filepath.Join(clustercmd.DefaultCNIDir, "bin")},

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_linux.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_linux.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+package clusterops
+
+var defaultNameservers = []string{}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_other.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_other.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+
+package clusterops
+
+var defaultNameservers = []string{"8.8.8.8", "1.1.1.1", "2001:4860:4860::8888", "2606:4700:4700::1111"}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -222,7 +222,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		qemu.MarkHidden("with-debug-shell") //nolint:errcheck
 		qemu.StringSliceVar(&qOps.ExtraUEFISearchPaths, extraUEFISearchPathsFlag, qOps.ExtraUEFISearchPaths, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 		qemu.StringSliceVar(&qOps.NetworkNoMasqueradeCIDRs, networkNoMasqueradeCIDRsFlag, qOps.NetworkNoMasqueradeCIDRs, "list of CIDRs to exclude from NAT")
-		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use, by default use embedded DNS forwarder")
+		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use")
 		qemu.UintVar(&qOps.DiskBlockSize, diskBlockSizeFlag, qOps.DiskBlockSize, "disk block size")
 		qemu.StringVar(&qOps.TargetArch, targetArchFlag, qOps.TargetArch, "cluster architecture")
 		qemu.StringSliceVar(&qOps.CniBinPath, cniBinPathFlag, qOps.CniBinPath, "search path for CNI binaries")

--- a/website/content/v1.12/reference/cli.md
+++ b/website/content/v1.12/reference/cli.md
@@ -179,7 +179,7 @@ talosctl cluster create dev [flags]
       --memory string(mb,gb)                     the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mtu int                                  MTU of the cluster network (default 1500)
-      --nameservers strings                      list of nameservers to use, by default use embedded DNS forwarder
+      --nameservers strings                      list of nameservers to use
       --no-masquerade-cidrs strings              list of CIDRs to exclude from NAT
       --omni-api-endpoint string                 the Omni API endpoint (must include a scheme, a hostname and a join token, e.g. 'https://siderolink.omni.example?jointoken=foobar')
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for


### PR DESCRIPTION
When creating Talos with QEMU on Mac, do not override default DNS settings to Gateway IPs.

Reverts (partially): https://github.com/siderolabs/talos/commit/c0772b8eda429675a06899b9c4a4d1dd7d5f6a5f#diff-9e7463328a82c08aae57d1c6a1d157c13da886a3161d319178a156f265e44152L181-L184

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
