### PR TITLE
Add Secure Boot to CloudStack platform config

### DIFF
--- a/pkg/machinery/platforms/platforms.go
+++ b/pkg/machinery/platforms/platforms.go
@@ -285,7 +285,8 @@ func CloudPlatforms() []Platform {
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
 			},
-			MinVersion: semver.MustParse("1.8.0-alpha.2"),
+			SecureBootSupported: true,
+			MinVersion:          semver.MustParse("1.8.0-alpha.2"),
 		},
 		{
 			Name: "hcloud",


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This change enables the option to use secure boot when creating images for the "CloudStack" platform.

## Why? (reasoning)

We tried to enable Secure Boot in our CloudStack environment, but noticed that the bootloaders are not signed, so booting the VMs would fail.

After replacing the bootloaders with signed ones, the cloud image worked immediately out of the box. In the discussion https://github.com/siderolabs/image-factory/discussions/338, it was said that no one had reported whether it worked or not. 

We can report that Secure Boot has been successfully tested (also in conjunction with TPM + LUKS encryption).

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
