### PR TITLE
fix: discard better klog message from Kubernetes client

### DIFF
--- a/pkg/kubernetes/klog.go
+++ b/pkg/kubernetes/klog.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	// Kubernetes client likes to do calls to `klog` in random places which are not configurable.
 	// For Talos this means those logs are going to the console which doesn't look good.
+	klog.EnableContextualLogging(false)
 	klog.SetOutput(io.Discard)
 	klog.LogToStderr(false)
 }


### PR DESCRIPTION
This silences now properly messages like:

```
E1210 14:54:05.283069       1 reflector.go:429] "The watchlist request ended with an error, falling back to the standard LIST/WATCH semantics because making progress is better than deadlocking" err="client rate limiter Wait returned an error: context canceled - error from a previous attempt: EOF"
```
