### PR TITLE
fix: bond configuration with new settings

### DIFF
--- a/internal/app/machined/pkg/adapters/network/bond_master_spec.go
+++ b/internal/app/machined/pkg/adapters/network/bond_master_spec.go
@@ -35,6 +35,8 @@ type bondMaster struct {
 func (a bondMaster) FillDefaults() {
 	bond := a.BondMasterSpec
 
+	bond.UseCarrier = true // Linux 6.18 locks this value to true
+
 	if bond.ResendIGMP == 0 {
 		bond.ResendIGMP = 1
 	}
@@ -59,8 +61,10 @@ func (a bondMaster) FillDefaults() {
 		bond.ADActorSysPrio = 65535
 	}
 
-	if bond.MissedMax == 0 {
-		bond.MissedMax = 2
+	if bond.Mode != nethelpers.BondMode8023AD && bond.Mode != nethelpers.BondModeALB && bond.Mode != nethelpers.BondModeTLB {
+		if bond.MissedMax == 0 {
+			bond.MissedMax = 2
+		}
 	}
 
 	if bond.Mode != nethelpers.BondMode8023AD {

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -409,7 +409,6 @@ func TestCmdlineParse(t *testing.T) {
 							TLBDynamicLB:    1,
 							UseCarrier:      true,
 							PrimaryIndex:    pointer.To[uint32](0),
-							MissedMax:       2,
 							ADLACPActive:    nethelpers.ADLACPActiveOn,
 						},
 					},

--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -34,7 +34,6 @@ func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConf
 	link.BondMaster.MIIMon = bond.MIIMon().ValueOrZero()
 	link.BondMaster.UpDelay = bond.UpDelay().ValueOrZero()
 	link.BondMaster.DownDelay = bond.DownDelay().ValueOrZero()
-	link.BondMaster.UseCarrier = true // Linux 6.18 locks this value to true
 	link.BondMaster.HashPolicy = bond.XmitHashPolicy().ValueOrZero()
 	link.BondMaster.ARPInterval = bond.ARPInterval().ValueOrZero()
 	link.BondMaster.ARPIPTargets = bond.ARPIPTargets()
@@ -143,7 +142,6 @@ func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond) erro
 		NumPeerNotif:    bond.NumPeerNotif(),
 		TLBDynamicLB:    bond.TLBDynamicLB(),
 		AllSlavesActive: bond.AllSlavesActive(),
-		UseCarrier:      true, // Linux 6.18 locks this value to true
 		ADActorSysPrio:  bond.ADActorSysPrio(),
 		ADUserPortKey:   bond.ADUserPortKey(),
 		PeerNotifyDelay: bond.PeerNotifyDelay(),

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/equinix.go
@@ -224,6 +224,10 @@ func (p *EquinixMetal) ParseMetadata(ctx context.Context, equinixMetadata *Metad
 			},
 		}
 
+		if bondMode == nethelpers.BondMode8023AD {
+			bondLink.BondMaster.ADLACPActive = nethelpers.ADLACPActiveOn
+		}
+
 		networkadapter.BondMasterSpec(&bondLink.BondMaster).FillDefaults()
 
 		networkConfig.Links = append(networkConfig.Links, bondLink)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
@@ -74,8 +74,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
     - name: bond1
       logical: true
@@ -99,8 +100,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
 routes:
     - family: inet4

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
@@ -57,8 +57,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
 routes:
     - family: inet4

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/metadata.go
@@ -464,6 +464,10 @@ func (n *Nocloud) applyNetworkConfigV1(ctx context.Context, config *NetworkConfi
 				},
 			}
 
+			if mode == nethelpers.BondMode8023AD {
+				bondLink.BondMaster.ADLACPActive = nethelpers.ADLACPActiveOn
+			}
+
 			if ntwrk.MTU != 0 {
 				bondLink.MTU = ntwrk.MTU
 			}
@@ -868,6 +872,10 @@ func (n *Nocloud) applyNetworkConfigV2(ctx context.Context, config *NetworkConfi
 				DownDelay:  bond.Params.DownDelay,
 				LACPRate:   lacpRate,
 			},
+		}
+
+		if mode == nethelpers.BondMode8023AD {
+			bondLink.BondMaster.ADLACPActive = nethelpers.ADLACPActiveOn
 		}
 
 		networkadapter.BondMasterSpec(&bondLink.BondMaster).FillDefaults()

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1-pnap.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1-pnap.yaml
@@ -49,8 +49,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
     - name: bond0.2
       logical: true

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2-serverscom.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2-serverscom.yaml
@@ -68,8 +68,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
     - name: aggi
       logical: true
@@ -93,8 +94,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
 routes:
     - family: inet4

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
@@ -83,8 +83,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
     - name: bond0.4
       logical: true

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -132,6 +132,10 @@ func (o *OpenStack) ParseMetadata(
 			},
 		}
 
+		if mode == nethelpers.BondMode8023AD {
+			bondLink.BondMaster.ADLACPActive = nethelpers.ADLACPActiveOn
+		}
+
 		networkadapter.BondMasterSpec(&bondLink.BondMaster).FillDefaults()
 		networkConfig.Links = append(networkConfig.Links, bondLink)
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -52,8 +52,9 @@ links:
         packetsPerSlave: 1
         numPeerNotif: 1
         tlbLogicalLb: 1
+        useCarrier: true
         adActorSysPrio: 65535
-        missedMax: 2
+        adLacpActive: "on"
       layer: platform
     - name: eth0
       logical: false

--- a/pkg/machinery/resources/network/link.go
+++ b/pkg/machinery/resources/network/link.go
@@ -219,8 +219,10 @@ func (spec *BondMasterSpec) Equal(other *BondMasterSpec) bool {
 		return false
 	}
 
-	if spec.MissedMax != other.MissedMax {
-		return false
+	if spec.Mode != nethelpers.BondMode8023AD && spec.Mode != nethelpers.BondModeALB && spec.Mode != nethelpers.BondModeTLB {
+		if spec.MissedMax != other.MissedMax {
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
This was manually verified on Equinix Metal box.

Two fixes:

1. `missed_max` should be treated specially - it can't be set for some bond types, but at the same time kernel returns value '2' for it.

2. Fix default configuration for bonds set via platform config for Equinix Metal, nocloud and OpenStack.

See https://github.com/siderolabs/talos/issues/12315
