### PR TITLE
fix: update containerd 2.2.0 with cgroups patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EMBED_TARGET ?= embed
 TOOLS_PREFIX ?= ghcr.io/siderolabs/tools
 TOOLS ?= v1.13.0-alpha.0-1-ge283ec8
 PKGS_PREFIX ?= ghcr.io/siderolabs
-PKGS ?= v1.13.0-alpha.0-6-gb8edf01
+PKGS ?= v1.13.0-alpha.0-9-gb961ff8
 GENERATE_VEX_PREFIX ?= ghcr.io/siderolabs/generate-vex
 GENERATE_VEX ?= latest
 

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.13.0-alpha.0-6-gb8edf01
+v1.13.0-alpha.0-9-gb961ff8


### PR DESCRIPTION
Resolve cgroups issue with Linux 6.18.
