### PR TITLE
fix: exclude new Virtual IPs configured with new config

### DIFF
--- a/internal/app/machined/pkg/controllers/etcd/config.go
+++ b/internal/app/machined/pkg/controllers/etcd/config.go
@@ -59,6 +59,10 @@ func NewConfigController() *ConfigController {
 					}
 				}
 
+				for _, doc := range machineConfig.Config().NetworkVirtualIPConfigs() {
+					cfg.TypedSpec().AdvertiseExcludeSubnets = append(cfg.TypedSpec().AdvertiseExcludeSubnets, doc.VIP().String())
+				}
+
 				cfg.TypedSpec().Image = machineConfig.Config().Cluster().Etcd().Image()
 				cfg.TypedSpec().ExtraArgs = machineConfig.Config().Cluster().Etcd().ExtraArgs()
 

--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
@@ -22,6 +22,8 @@ import (
 type NodeIPConfigController = transform.Controller[*config.MachineConfig, *k8s.NodeIPConfig]
 
 // NewNodeIPConfigController instanciates the controller.
+//
+//nolint:gocyclo
 func NewNodeIPConfigController() *NodeIPConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.NodeIPConfig]{
@@ -75,6 +77,10 @@ func NewNodeIPConfigController() *NodeIPConfigController {
 							spec.ExcludeSubnets = append(spec.ExcludeSubnets, vlan.VIPConfig().IP())
 						}
 					}
+				}
+
+				for _, doc := range cfgProvider.NetworkVirtualIPConfigs() {
+					spec.ExcludeSubnets = append(spec.ExcludeSubnets, doc.VIP().String())
 				}
 
 				return nil


### PR DESCRIPTION
Do same exclusions as we applied to "old-style" config:

* not a node IP
* not applicable as etcd endpoint

Fixes #12410
