### PR TITLE
docs: split talosctl commands into groups

### DIFF
--- a/cmd/talosctl/cmd/root.go
+++ b/cmd/talosctl/cmd/root.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt"
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	_ "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create" // import to get the command registered via the init() function.
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
 )
@@ -49,7 +49,27 @@ func Execute() error {
 }
 
 func init() {
-	for _, cmd := range slices.Concat(talos.Commands, mgmt.Commands) {
+	const (
+		talosGroup   = "talos"
+		mgmtGroup    = "mgmt"
+		clusterGroup = "cluster"
+	)
+
+	rootCmd.AddGroup(&cobra.Group{ID: talosGroup, Title: "Manage running Talos clusters:"})
+	rootCmd.AddGroup(&cobra.Group{ID: mgmtGroup, Title: "Commands to generate and manage machine configuration offline:"})
+	rootCmd.AddGroup(&cobra.Group{ID: clusterGroup, Title: "Local Talos cluster commands:"})
+
+	for _, cmd := range mgmt.Commands {
+		cmd.GroupID = mgmtGroup
+		if cmd == cluster.Cmd {
+			cmd.GroupID = clusterGroup
+		}
+
+		rootCmd.AddCommand(cmd)
+	}
+
+	for _, cmd := range talos.Commands {
+		cmd.GroupID = talosGroup
 		rootCmd.AddCommand(cmd)
 	}
 }


### PR DESCRIPTION
Use the grouping feature to reflect internal command structure better in the `--help` output.

```
$ talosctl --help
A CLI for out-of-band management of Kubernetes nodes created by Talos

Usage:
  talosctl [command]

Manage running Talos clusters:
  apply-config        Apply a new configuration to a node
  bootstrap           Bootstrap the etcd cluster on the specified node.
  cgroups             Retrieve cgroups usage information
  config              Manage the client configuration file (talosconfig)
  conformance         Run conformance tests
  containers          List containers
  copy                Copy data out from the node
  dashboard           Cluster dashboard with node overview, logs and real-time metrics
  dmesg               Retrieve kernel logs
  edit                Edit Talos node machine configuration with the default editor.
  etcd                Manage etcd
  events              Stream runtime events
  get                 Get a specific resource or list of resources (use 'talosctl get rd' to see all available resource types).
  health              Check cluster health
  image               Manage CRI container images
  inspect             Inspect internals of Talos
  kubeconfig          Download the admin kubeconfig from the node
  list                Retrieve a directory listing
  logs                Retrieve logs for a service
  memory              Show memory usage
  meta                Write and delete keys in the META partition
  mounts              List mounts
  netstat             Show network connections and sockets
  patch               Patch machine configuration of a Talos node with a local patch.
  pcap                Capture the network packets from the node.
  processes           List running processes
  read                Read a file on the machine
  reboot              Reboot a node
  reset               Reset a node
  restart             Restart a process
  rollback            Rollback a node to the previous installation
  rotate-ca           Rotate cluster CAs (Talos and Kubernetes APIs).
  service             Retrieve the state of a service (or all services), control service state
  shutdown            Shutdown a node
  stats               Get container stats
  support             Dump debug information about the cluster
  time                Gets current server time
  upgrade             Upgrade Talos on the target node
  upgrade-k8s         Upgrade Kubernetes control plane in the Talos cluster.
  usage               Retrieve a disk usage
  version             Prints the version
  wipe                Wipe block device or volumes

Commands to generate and manage machine configuration offline:
  gen                 Generate CAs, certificates, and private keys
  inject              Inject Talos API resources into Kubernetes manifests
  machineconfig       Machine config related commands
  validate            Validate config

Local Talos cluster commands:
  cluster             A collection of commands for managing local docker-based or QEMU-based clusters

Additional Commands:
  completion          Output shell completion code for the specified shell (bash, fish or zsh)
  help                Help about any command

Flags:
  -h, --help   help for talosctl

Use "talosctl [command] --help" for more information about a command.
```
