### PR TITLE
fix: drop the Omni API URL check on IP address

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -261,12 +261,7 @@ func (m *Maker[T]) applyOmniConfigs() error {
 
 	cfg.APIUrlConfig.URL = parsedURL
 
-	mode, err := runtime.ParseMode(runtime.ModeMetal.String())
-	if err != nil {
-		return err
-	}
-
-	_, err = cfg.Validate(mode)
+	_, err = cfg.Validate(runtime.ModeMetal)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I don't see much point in this check, as it's only valuable when joining to a local development instance of Omni, which is pretty nice usecase.

But this check breaks joining to "real" Omni which has hostname in the endpoint.
