### PR TITLE
feat: enforce `proc_mem.force_override=never` by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -35,6 +35,14 @@ These virtiofs external volumes are not supported when SELinux is running
 in enforcing mode.
 """
 
+    [notes.procpidmem]
+        title = "/proc/PID/mem Access Hardening"
+        description = """\
+A new kernel parameter `proc_mem.force_override=never` has been introduced by default to enhance system security
+by preventing unwanted writes to protected process memory via `/proc/PID/mem`.
+If the kernel parameter is removed, default behavior is restored, allowing access only if the process is traced.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -310,3 +310,15 @@ func (q Quirks) ISOSupportsSettingBootloader() bool {
 
 	return q.v.GTE(minTalosVersionISOSupportsSettingBootloader)
 }
+
+var minTalosVersionProcMemOverrideNever = semver.MustParse("1.13.0")
+
+// ProcMemOverrideNever returns true if the Talos version should enforce 'proc_mem.force_override=never'.
+func (q Quirks) ProcMemOverrideNever() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minTalosVersionProcMemOverrideNever)
+}

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -52,6 +52,10 @@ func DefaultArgs(quirks quirks.Quirks) []string {
 		result = append(result, constants.KernelParamEnforceModuleSigVerify+"=1") // see https://github.com/siderolabs/talos/issues/11989
 	}
 
+	if quirks.ProcMemOverrideNever() {
+		result = append(result, "proc_mem.force_override=never")
+	}
+
 	return result
 }
 

--- a/pkg/machinery/kernel/kernel_test.go
+++ b/pkg/machinery/kernel/kernel_test.go
@@ -91,6 +91,7 @@ func TestDefaultKernelArgs(t *testing.T) {
 				"printk.devkmsg=on",
 				"selinux=1",
 				"module.sig_enforce=1",
+				"proc_mem.force_override=never",
 			},
 		},
 		{
@@ -108,6 +109,39 @@ func TestDefaultKernelArgs(t *testing.T) {
 				"ima_template=ima-ng",
 				"ima_appraise=fix",
 				"ima_hash=sha512",
+			},
+		},
+		{
+			name: "v1.12",
+
+			quirks: quirks.New("v1.12.0"),
+
+			expected: []string{
+				"init_on_alloc=1",
+				"slab_nomerge=",
+				"pti=on",
+				"consoleblank=0",
+				"nvme_core.io_timeout=4294967295",
+				"printk.devkmsg=on",
+				"selinux=1",
+				"module.sig_enforce=1",
+			},
+		},
+		{
+			name: "v1.13",
+
+			quirks: quirks.New("v1.13.0"),
+
+			expected: []string{
+				"init_on_alloc=1",
+				"slab_nomerge=",
+				"pti=on",
+				"consoleblank=0",
+				"nvme_core.io_timeout=4294967295",
+				"printk.devkmsg=on",
+				"selinux=1",
+				"module.sig_enforce=1",
+				"proc_mem.force_override=never",
 			},
 		},
 	} {


### PR DESCRIPTION
Note: this is Talos 1.13 only, and will only be enabled once we get to release v1.13.0-alpha.0.

See https://github.com/siderolabs/pkgs/pull/1412#issuecomment-3665787378 for more details.
