### PR TITLE
fix: bond setting change detection

### DIFF
--- a/pkg/machinery/resources/network/link.go
+++ b/pkg/machinery/resources/network/link.go
@@ -115,10 +115,6 @@ func (spec *BondMasterSpec) Equal(other *BondMasterSpec) bool {
 		return false
 	}
 
-	if (spec.PrimaryIndex == nil) != (other.PrimaryIndex == nil) {
-		return false
-	}
-
 	if spec.PrimaryIndex != nil && other.PrimaryIndex != nil && *spec.PrimaryIndex != *other.PrimaryIndex {
 		return false
 	}


### PR DESCRIPTION
Ignore primaryIndex unless it's both configured and set in the kernel.

I think we should never actually set primaryIndex in any case, but this fixes an issue with Talos gets into a loop trying to reconcile primaryIndex (when kernel reports it, and we don't have it set).

This comes from a private user report.
