### PR TITLE
fix: update LinkSelector to accept string or true

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2273,7 +2273,16 @@
     "network.LinkSelector": {
       "properties": {
         "match": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                true
+              ]
+            }
+          ],
           "title": "match",
           "description": "The Common Expression Language (CEL) expression to match the link.\n",
           "markdownDescription": "The Common Expression Language (CEL) expression to match the link.",

--- a/website/content/v1.12/schemas/config.schema.json
+++ b/website/content/v1.12/schemas/config.schema.json
@@ -2273,7 +2273,16 @@
     "network.LinkSelector": {
       "properties": {
         "match": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                true
+              ]
+            }
+          ],
           "title": "match",
           "description": "The Common Expression Language (CEL) expression to match the link.\n",
           "markdownDescription": "The Common Expression Language (CEL) expression to match the link.",


### PR DESCRIPTION
# Pull Request

## What?

Fixes the schema so the `selector.match` property on `LinkAliasConfig` accepts `true` or a CEL expression.

## Why?

As per the [documentation](https://docs.siderolabs.com/talos/v1.12/networking/configuration/aliases) it's valid to provide either `true` or a CEL expression.

## Acceptance

Uses [`check-yamlschema@0.0.7`](https://pypi.org/project/check-yamlschema/0.0.7/) for validation.

```yaml
apiVersion: v1alpha1
kind: LinkAliasConfig
name: net0
selector:
    match: mac(link.permanent_addr) == "00:1a:2b:3c:4d:5e"
```

✅ yields `document 0: validated`

```yaml
apiVersion: v1alpha1
kind: LinkAliasConfig
name: net0
selector:
    match: true
```

✅ yields `document 0: validated`

```yaml
apiVersion: v1alpha1
kind: LinkAliasConfig
name: net0
selector:
    match: false
```

❌ yields `{'apiVersion': 'v1alpha1', 'kind': 'LinkAliasConfig', 'name': 'net0', 'selector': {'match': False}} is not valid under any of the given schemas`

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

_P.S. hopefully I updated the code in all the right spots and did it the right way._