### PR TITLE
test: skip the source bundle on exact tag

### DIFF
--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -139,6 +139,10 @@ ghcr.io/siderolabs/zfs:2.3.3-v1.11.2@sha256:73782571f334b18995ddf324d24b86ea9a11
 	suite.T().Log(normalizeTag(version.Tag))
 	suite.T().Log(version.Tag)
 
+	if strings.TrimLeft(version.Tag, "v") == normalizeTag(version.Tag) {
+		suite.T().Skip("skipping the test for the exact version tag")
+	}
+
 	suite.RunCLI([]string{"image", "talos-bundle", "v" + tag.String()},
 		base.StdoutShouldMatch(regexp.MustCompile(regexp.QuoteMeta("ghcr.io/siderolabs/talos:v"+tag.String()))),
 	)


### PR DESCRIPTION
When building for the release, as the release hasn't been finalized yet, the test might fail.

```
    run.go:146: Running "/home/runner/_work/talos/talos/_out/talosctl-linux-amd64 --talosconfig /tmp/e2e/docker/talosconfig image talos-bundle v1.13.0-alpha.0"
    run.go:210:
        	Error Trace:	/src/internal/integration/base/run.go:210
        	            				/src/internal/integration/base/cli.go:107
        	            				/src/internal/integration/cli/image.go:142
        	            				/go/src/runtime/asm_amd64.s:1693
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestIntegration/cli.ImageSuite/TestSourceBundle
        	Messages:   	command failed, stdout: "", stderr: "error fetching official extensions for v1.13.0-alpha.0: HEAD https://ghcr.io/v2/ghcr.io/siderolabs/extensions/manifests/v1.13.0-alpha.0: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)\n"
```
