### PR TITLE
fix: disable swap for system services

### DIFF
--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -6,18 +6,15 @@
 package runner
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
-	ocicontainers "github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/gen/optional"
-	"github.com/siderolabs/go-pointer"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/logging"
@@ -242,23 +239,6 @@ func WithCtty(ctty int) Option {
 func WithUID(uid uint32) Option {
 	return func(args *Options) {
 		args.UID = uid
-	}
-}
-
-// WithMemoryReservation sets the memory reservation limit as on OCI spec.
-func WithMemoryReservation(limit uint64) oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *ocicontainers.Container, s *oci.Spec) error {
-		if s.Linux.Resources == nil {
-			s.Linux.Resources = &specs.LinuxResources{}
-		}
-
-		if s.Linux.Resources.Memory == nil {
-			s.Linux.Resources.Memory = &specs.LinuxMemory{}
-		}
-
-		s.Linux.Resources.Memory.Reservation = pointer.To(int64(limit))
-
-		return nil
 	}
 }
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -36,7 +36,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/restart"
-	"github.com/siderolabs/talos/internal/pkg/cgroup"
 	"github.com/siderolabs/talos/internal/pkg/containers/image"
 	"github.com/siderolabs/talos/internal/pkg/environment"
 	"github.com/siderolabs/talos/internal/pkg/etcd"
@@ -221,8 +220,6 @@ func (e *Etcd) Runner(r runtime.Runtime) (runner.Runner, error) {
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 			oci.WithUser(fmt.Sprintf("%d:%d", constants.EtcdUserID, constants.EtcdUserID)),
-			runner.WithMemoryReservation(constants.CgroupEtcdReservedMemory),
-			oci.WithCPUShares(uint64(cgroup.MilliCoresToShares(constants.CgroupEtcdMillicores))),
 		),
 		runner.WithOOMScoreAdj(-998),
 	),

--- a/internal/pkg/cgroup/cgroup.go
+++ b/internal/pkg/cgroup/cgroup.go
@@ -88,8 +88,9 @@ func getCgroupV2Resources(name string) *cgroup2.Resources {
 	case constants.CgroupInit:
 		return &cgroup2.Resources{
 			Memory: &cgroup2.Memory{
-				Min: pointer.To[int64](constants.CgroupInitReservedMemory),
-				Low: pointer.To[int64](constants.CgroupInitReservedMemory * 2),
+				Min:  pointer.To[int64](constants.CgroupInitReservedMemory),
+				Low:  pointer.To[int64](constants.CgroupInitReservedMemory * 2),
+				Swap: pointer.To[int64](0),
 			},
 			CPU: &cgroup2.CPU{
 				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupInitMillicores))),
@@ -108,8 +109,9 @@ func getCgroupV2Resources(name string) *cgroup2.Resources {
 	case constants.CgroupSystemRuntime:
 		return &cgroup2.Resources{
 			Memory: &cgroup2.Memory{
-				Min: pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory),
-				Low: pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory * 2),
+				Min:  pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory),
+				Low:  pointer.To[int64](constants.CgroupSystemRuntimeReservedMemory * 2),
+				Swap: pointer.To[int64](0),
 			},
 			CPU: &cgroup2.CPU{
 				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupSystemRuntimeMillicores))),
@@ -118,8 +120,9 @@ func getCgroupV2Resources(name string) *cgroup2.Resources {
 	case constants.CgroupUdevd:
 		return &cgroup2.Resources{
 			Memory: &cgroup2.Memory{
-				Min: pointer.To[int64](constants.CgroupUdevdReservedMemory),
-				Low: pointer.To[int64](constants.CgroupUdevdReservedMemory * 2),
+				Min:  pointer.To[int64](constants.CgroupUdevdReservedMemory),
+				Low:  pointer.To[int64](constants.CgroupUdevdReservedMemory * 2),
+				Swap: pointer.To[int64](0),
 			},
 			CPU: &cgroup2.CPU{
 				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupUdevdMillicores))),
@@ -134,8 +137,9 @@ func getCgroupV2Resources(name string) *cgroup2.Resources {
 	case constants.CgroupPodRuntime:
 		return &cgroup2.Resources{
 			Memory: &cgroup2.Memory{
-				Min: pointer.To[int64](constants.CgroupPodRuntimeReservedMemory),
-				Low: pointer.To[int64](constants.CgroupPodRuntimeReservedMemory * 2),
+				Min:  pointer.To[int64](constants.CgroupPodRuntimeReservedMemory),
+				Low:  pointer.To[int64](constants.CgroupPodRuntimeReservedMemory * 2),
+				Swap: pointer.To[int64](0),
 			},
 			CPU: &cgroup2.CPU{
 				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupPodRuntimeMillicores))),
@@ -144,11 +148,22 @@ func getCgroupV2Resources(name string) *cgroup2.Resources {
 	case constants.CgroupKubelet:
 		return &cgroup2.Resources{
 			Memory: &cgroup2.Memory{
-				Min: pointer.To[int64](constants.CgroupKubeletReservedMemory),
-				Low: pointer.To[int64](constants.CgroupKubeletReservedMemory * 2),
+				Min:  pointer.To[int64](constants.CgroupKubeletReservedMemory),
+				Low:  pointer.To[int64](constants.CgroupKubeletReservedMemory * 2),
+				Swap: pointer.To[int64](0),
 			},
 			CPU: &cgroup2.CPU{
 				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupKubeletMillicores))),
+			},
+		}
+	case constants.CgroupEtcd:
+		return &cgroup2.Resources{
+			Memory: &cgroup2.Memory{
+				Low:  pointer.To[int64](constants.CgroupEtcdReservedMemory),
+				Swap: pointer.To[int64](0),
+			},
+			CPU: &cgroup2.CPU{
+				Weight: pointer.To[uint64](MillicoresToCPUWeight(MilliCores(constants.CgroupEtcdMillicores))),
 			},
 		}
 	case constants.CgroupDashboard:


### PR DESCRIPTION
If system services including kubelet/CRI start using swap, it might lead to extreme performance degradation.

Disable swap for all system services except for dashboard (which is not critical).

```
NAME                                                                          SwapCurrent   SwapPeak   SwapHigh   SwapMax    ZswapCurrent   ZswapMax   ZswapWriteback
.                                                                                unset         unset      unset      unset      unset          unset   1
├──init                                                                            0 B           0 B        max        0 B        0 B            max   1
├──podruntime                                                                      0 B           0 B        max        max        0 B            max   1
│   ├──etcd                                                                        0 B           0 B        max        0 B        0 B            max   1
│   ├──kubelet                                                                     0 B           0 B        max        0 B        0 B            max   1
│   └──runtime                                                                     0 B           0 B        max        0 B        0 B            max   1
└──system                                                                          0 B           0 B        max        max        0 B            max   1
    ├──apid                                                                        0 B           0 B        max        0 B        0 B            max   1
    ├──dashboard                                                                   0 B           0 B        max        max        0 B            max   1
    ├──runtime                                                                     0 B           0 B        max        0 B        0 B            max   1
    ├──trustd                                                                      0 B           0 B        max        0 B        0 B            max   1
    └──udevd                                                                       0 B           0 B        max        0 B        0 B            max   1
```

Refactor etcd cgroup to use same common pattern while keeping same settings (but limit swap).
