### PR TITLE
chore: update slack links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Ask a question about Talos Linux.
   - name: Community
     url: https://taloscommunity.slack.com
-    about: Join the community. (Not an official support channel.) Get your invite by visiting https://slack.dev.talos-systems.io.
+    about: Join the community. (Not an official support channel.) Get your invite by visiting https://inviter.co/sidero-labs-community.
   - name: Get Enterprise Support
     url: https://www.siderolabs.com/support/
     about: Get commercial support from the Sidero Labs team, with SLAs for every issue.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For instructions on deploying and managing Talos, see the [Documentation](https:
 ## Community
 
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/siderolabs/talos/discussions)
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://taloscommunity.slack.com/). Request access via [inviter.co](https://inviter.co/sidero-labs-community).
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/SideroLabs)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)


### PR DESCRIPTION
This PR updates the slack links to reference the auto-inviter at inviter.co.
