### PR TITLE
chore: use context when creating filesystems

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
@@ -114,7 +114,7 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 
 		makefsOptions = append(makefsOptions, makefs.WithConfigFile(quirks.New("").XFSMkfsConfig()))
 
-		if err = makefs.XFS(volumeContext.Status.MountLocation, makefsOptions...); err != nil {
+		if err = makefs.XFS(ctx, volumeContext.Status.MountLocation, makefsOptions...); err != nil {
 			return xerrors.NewTaggedf[Retryable]("error formatting XFS: %w", err)
 		}
 	case block.FilesystemTypeEXT4:
@@ -124,7 +124,7 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 			makefsOptions = append(makefsOptions, makefs.WithLabel(volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label))
 		}
 
-		if err = makefs.Ext4(volumeContext.Status.MountLocation, makefsOptions...); err != nil {
+		if err = makefs.Ext4(ctx, volumeContext.Status.MountLocation, makefsOptions...); err != nil {
 			return xerrors.NewTaggedf[Retryable]("error formatting ext4: %w", err)
 		}
 	case block.FilesystemTypeSwap:

--- a/internal/pkg/partition/format.go
+++ b/internal/pkg/partition/format.go
@@ -6,6 +6,7 @@
 package partition
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/siderolabs/go-blockdevice/v2/block"
@@ -82,7 +83,7 @@ func NewFormatOptions(opts ...FormatOption) *FormatOptions {
 }
 
 // Format zeroes the device and formats it using filesystem type provided.
-func Format(devname string, t *FormatOptions, talosVersion string, printf func(string, ...any)) error {
+func Format(ctx context.Context, devname string, t *FormatOptions, talosVersion string, printf func(string, ...any)) error {
 	opts := []makefs.Option{
 		makefs.WithForce(t.Force),
 		makefs.WithLabel(t.Label),
@@ -109,13 +110,13 @@ func Format(devname string, t *FormatOptions, talosVersion string, printf func(s
 	case FilesystemTypeZeroes:
 		return zeroPartition(devname)
 	case FilesystemTypeVFAT:
-		return makefs.VFAT(devname, opts...)
+		return makefs.VFAT(ctx, devname, opts...)
 	case FilesystemTypeXFS:
 		opts = append(opts, makefs.WithConfigFile(quirks.New(talosVersion).XFSMkfsConfig()))
 
-		return makefs.XFS(devname, opts...)
+		return makefs.XFS(ctx, devname, opts...)
 	case FileSystemTypeExt4:
-		return makefs.Ext4(devname, opts...)
+		return makefs.Ext4(ctx, devname, opts...)
 	default:
 		return fmt.Errorf("unsupported filesystem type: %q", t.FileSystemType)
 	}

--- a/pkg/imager/iso/hybrid.go
+++ b/pkg/imager/iso/hybrid.go
@@ -4,15 +4,18 @@
 
 package iso
 
-import "path/filepath"
+import (
+	"context"
+	"path/filepath"
+)
 
 // CreateHybrid creates an ISO image that supports both BIOS and UEFI booting.
-func (options Options) CreateHybrid(printf func(string, ...any)) (Generator, error) {
+func (options Options) CreateHybrid(ctx context.Context, printf func(string, ...any)) (Generator, error) {
 	if _, err := options.CreateGRUB(printf); err != nil {
 		return nil, err
 	}
 
-	if _, err := options.CreateUEFI(printf); err != nil {
+	if _, err := options.CreateUEFI(ctx, printf); err != nil {
 		return nil, err
 	}
 

--- a/pkg/imager/iso/uefi.go
+++ b/pkg/imager/iso/uefi.go
@@ -6,6 +6,7 @@ package iso
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
@@ -33,7 +34,7 @@ var loaderConfigTemplate string
 // The ISO created supports only booting in UEFI mode, and supports SecureBoot.
 //
 //nolint:gocyclo,cyclop
-func (options Options) CreateUEFI(printf func(string, ...any)) (Generator, error) {
+func (options Options) CreateUEFI(ctx context.Context, printf func(string, ...any)) (Generator, error) {
 	if err := os.MkdirAll(options.ScratchDir, 0o755); err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (options Options) CreateUEFI(printf func(string, ...any)) (Generator, error
 		makefs.WithReproducible(true),
 	}
 
-	if err := makefs.VFAT(efiBootImg, fopts...); err != nil {
+	if err := makefs.VFAT(ctx, efiBootImg, fopts...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -180,7 +180,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 			options.SignatureKeyPath = i.prof.Input.SecureBoot.SignatureKeyPath
 		}
 
-		generator, err = options.CreateUEFI(printf)
+		generator, err = options.CreateUEFI(ctx, printf)
 		if err != nil {
 			return err
 		}
@@ -204,12 +204,12 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		switch i.prof.Output.ISOOptions.Bootloader {
 		case profile.BootLoaderKindDualBoot:
-			generator, err = options.CreateHybrid(printf)
+			generator, err = options.CreateHybrid(ctx, printf)
 			if err != nil {
 				return err
 			}
 		case profile.BootLoaderKindSDBoot:
-			generator, err = options.CreateUEFI(printf)
+			generator, err = options.CreateUEFI(ctx, printf)
 			if err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 			OutPath:    path,
 		}
 
-		generator, err = options.CreateHybrid(printf)
+		generator, err = options.CreateHybrid(ctx, printf)
 		if err != nil {
 			return err
 		}

--- a/pkg/makefs/ext4.go
+++ b/pkg/makefs/ext4.go
@@ -5,6 +5,7 @@
 package makefs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -17,7 +18,7 @@ const (
 )
 
 // Ext4 creates a ext4 filesystem on the specified partition.
-func Ext4(partname string, setters ...Option) error {
+func Ext4(ctx context.Context, partname string, setters ...Option) error {
 	if partname == "" {
 		return errors.New("missing path to disk")
 	}
@@ -53,7 +54,7 @@ func Ext4(partname string, setters ...Option) error {
 
 	opts.Printf("creating ext4 filesystem on %s with args: %v", partname, args)
 
-	_, err := cmd.Run("mkfs.ext4", args...)
+	_, err := cmd.RunContext(ctx, "mkfs.ext4", args...)
 
 	return err
 }

--- a/pkg/makefs/ext4_test.go
+++ b/pkg/makefs/ext4_test.go
@@ -31,7 +31,8 @@ func TestExt4Reproducibility(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := makefs.Ext4(tempFile,
+	if err := makefs.Ext4(t.Context(),
+		tempFile,
 		makefs.WithReproducible(true),
 		makefs.WithLabel("TESTLABEL"),
 	); err != nil {
@@ -47,7 +48,8 @@ func TestExt4Reproducibility(t *testing.T) {
 	sum1 := sha256.Sum256(fileData)
 
 	// create the filesystem again
-	if err := makefs.Ext4(tempFile,
+	if err := makefs.Ext4(t.Context(),
+		tempFile,
 		makefs.WithReproducible(true),
 		makefs.WithLabel("TESTLABEL"),
 		makefs.WithForce(true)); err != nil {
@@ -81,7 +83,7 @@ func TestExt4Resize(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := makefs.Ext4(tempFile); err != nil {
+	if err := makefs.Ext4(t.Context(), tempFile); err != nil {
 		t.Fatalf("failed to create ext4 filesystem: %v", err)
 	}
 

--- a/pkg/makefs/vfat.go
+++ b/pkg/makefs/vfat.go
@@ -5,6 +5,7 @@
 package makefs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ const (
 )
 
 // VFAT creates a VFAT filesystem on the specified partition.
-func VFAT(partname string, setters ...Option) error {
+func VFAT(ctx context.Context, partname string, setters ...Option) error {
 	opts := NewDefaultOptions(setters...)
 
 	var args []string
@@ -36,7 +37,7 @@ func VFAT(partname string, setters ...Option) error {
 
 	args = append(args, partname)
 
-	_, err := cmd.Run("mkfs.vfat", args...)
+	_, err := cmd.RunContext(ctx, "mkfs.vfat", args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/makefs/vfat_test.go
+++ b/pkg/makefs/vfat_test.go
@@ -43,7 +43,7 @@ func TestVFATWithSourceDirectory(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Format and populate VFAT
-	err = makefs.VFAT(vfatImg, makefs.WithLabel("TEST"), makefs.WithSourceDirectory(sourceDir))
+	err = makefs.VFAT(t.Context(), vfatImg, makefs.WithLabel("TEST"), makefs.WithSourceDirectory(sourceDir))
 	require.NoError(t, err)
 
 	// Verify file contents using mcopy

--- a/pkg/makefs/xfs.go
+++ b/pkg/makefs/xfs.go
@@ -5,6 +5,7 @@
 package makefs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -38,7 +39,7 @@ func XFSRepair(partname string) error {
 }
 
 // XFS creates a XFS filesystem on the specified partition.
-func XFS(partname string, setters ...Option) error {
+func XFS(ctx context.Context, partname string, setters ...Option) error {
 	if partname == "" {
 		return errors.New("missing path to disk")
 	}
@@ -82,7 +83,7 @@ func XFS(partname string, setters ...Option) error {
 
 	opts.Printf("creating xfs filesystem on %s with args: %v", partname, args)
 
-	_, err := cmd.Run("mkfs.xfs", args...)
+	_, err := cmd.RunContext(ctx, "mkfs.xfs", args...)
 
 	return err
 }

--- a/pkg/makefs/xfs_test.go
+++ b/pkg/makefs/xfs_test.go
@@ -104,7 +104,7 @@ realtime =none                   extsz=4096   blocks=0, rtextents=0
 			require.NoError(t, os.WriteFile(tempFile, nil, 0o644))
 			require.NoError(t, os.Truncate(tempFile, test.size))
 
-			require.NoError(t, makefs.XFS(tempFile))
+			require.NoError(t, makefs.XFS(t.Context(), tempFile))
 
 			var stdout bytes.Buffer
 
@@ -136,7 +136,8 @@ func TestXFSReproducibility(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := makefs.XFS(tempFile,
+	if err := makefs.XFS(t.Context(),
+		tempFile,
 		makefs.WithReproducible(true),
 		makefs.WithLabel("TESTLABEL"),
 	); err != nil {
@@ -152,7 +153,8 @@ func TestXFSReproducibility(t *testing.T) {
 	sum1 := sha256.Sum256(fileData)
 
 	// create the filesystem again
-	if err := makefs.XFS(tempFile,
+	if err := makefs.XFS(t.Context(),
+		tempFile,
 		makefs.WithReproducible(true),
 		makefs.WithForce(true),
 		makefs.WithLabel("TESTLABEL"),


### PR DESCRIPTION
Pass in context when creating filesystems with `mkfs.*` commands.