### PR TITLE
fix: print talosctl images to release notes

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,6 +23,7 @@ function release-notes {
 
   echo -e '\n## Images\n\n```' >> ${1}
   ${ARTIFACTS}/talosctl-linux-amd64 image k8s-bundle >> ${1}
+  ${ARTIFACTS}/talosctl-linux-amd64 image talos-bundle --overlays=false --extensions=false >> ${1}
   echo -e '```\n' >> ${1}
 }
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -96,6 +96,13 @@ Purging of unneeded manifests is automatically performed.
 The switch and inventory backfill is automatic and no action is needed from the user.
 """
 
+    [notes.talosctl_images_talos_bundle]
+        title = "`talosctl images talos-bundle` can ignore reaching to the registry"
+        description = """\
+The `talosctl images talos-bundle` command now accepts optional `--ovelays` and `--extensions` flags.
+If those are set to `false`, the command will not attempt to reach out to the container registry to fetch the latest versions and digests of the overlays and extensions.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -2215,8 +2215,7 @@ talosctl image k8s-bundle [flags]
 ### Options
 
 ```
-  -h, --help                 help for k8s-bundle
-      --provisioner string   include provisioner specific images (default "installer")
+  -h, --help   help for k8s-bundle
 ```
 
 ### Options inherited from parent commands
@@ -2306,7 +2305,9 @@ talosctl image talos-bundle [talos-version] [flags]
 ### Options
 
 ```
-  -h, --help   help for talos-bundle
+      --extensions   Include images that belong to Talos extensions (default true)
+  -h, --help         help for talos-bundle
+      --overlays     Include images that belong to Talos overlays (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
After changing `talsoctl images k8s-bundle`/`talos-bundle` we stopped printing some of the images to release notes.
This fixes that issue.

Closes https://github.com/siderolabs/talos/issues/12511


Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
