### PR TITLE
fix: generate OCI-compliant image config

### DIFF
--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -450,10 +450,12 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 	newInstallerImg := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
 	newInstallerImg = mutate.ConfigMediaType(newInstallerImg, types.OCIConfigJSON)
 
-	newInstallerImg, err = mutate.ConfigFile(newInstallerImg, &v1.ConfigFile{
-		Architecture: i.prof.Arch,
-		OS:           "linux",
-	})
+	// `empty.Image` won't error, so no need to check
+	newCfgFile, _ := empty.Image.ConfigFile() //nolint:errcheck
+	newCfgFile.Architecture = i.prof.Arch
+	newCfgFile.OS = "linux"
+
+	newInstallerImg, err = mutate.ConfigFile(newInstallerImg, newCfgFile)
 	if err != nil {
 		return fmt.Errorf("failed to set image architecture: %w", err)
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Instead of initializing a `v1.ConfigFile`, we can use the `empty` package to get a "correct", empty image config, which includes the `Type: "layers"` field in `RootFS` ([see here](https://github.com/google/go-containerregistry/blob/e075f209120b2467fd1b7d24727f1890a0edb74a/pkg/v1/empty/image.go#L41-L48)).

## Why? (reasoning)

Related: https://github.com/siderolabs/talos/issues/12537

According to the OCI image spec, the `RootFS` MUST have a `Type` with a value of `layers` (see [spec](https://github.com/opencontainers/image-spec/blob/26647a49f642c7d22a1cd3aa0a48e4650a542269/config.md?plain=1#L215))

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
