### PR TITLE
feat: expose more SSA options in the upgrade-k8s command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/siderolabs/go-debug v0.6.1
 	github.com/siderolabs/go-kmsg v0.1.4
 	github.com/siderolabs/go-kubeconfig v0.1.1
-	github.com/siderolabs/go-kubernetes v0.2.29
+	github.com/siderolabs/go-kubernetes v0.2.30
 	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pcidb v0.3.2
 	github.com/siderolabs/go-pointer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -657,8 +657,8 @@ github.com/siderolabs/go-kmsg v0.1.4 h1:RLAa90O9bWuhA3pXPAYAdrI+kzcqTshZASRA5yso
 github.com/siderolabs/go-kmsg v0.1.4/go.mod h1:BLkt2N2DHT0wsFMz32lMw6vNEZL90c8ZnBjpIUoBb/M=
 github.com/siderolabs/go-kubeconfig v0.1.1 h1:tZlgpelj/OqrcHVUwISPN0NRgObcflpH9WtE41mtQZ0=
 github.com/siderolabs/go-kubeconfig v0.1.1/go.mod h1:QaGp4i9L95oDbcU7jDn30aw4gnREkb3O5otgxw8imOk=
-github.com/siderolabs/go-kubernetes v0.2.29 h1:Kak66iJjIIFwqcr7iP2EB4cPDhO2bE9ci61p6gH74Jc=
-github.com/siderolabs/go-kubernetes v0.2.29/go.mod h1:D6b6O6oVFXPUBTN+euLTF3llSw5GmUqP749brODKF5s=
+github.com/siderolabs/go-kubernetes v0.2.30 h1:sqOulDpkdTRtqTIn7odFAe5tz8ea12kZgNz0BOnxUb0=
+github.com/siderolabs/go-kubernetes v0.2.30/go.mod h1:D6b6O6oVFXPUBTN+euLTF3llSw5GmUqP749brODKF5s=
 github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
 github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pcidb v0.3.2 h1:18KMjsc+AO2r6/pl0KLBR9xOXO0ULLCXwmGhIukoAbw=

--- a/internal/integration/k8s/manifests.go
+++ b/internal/integration/k8s/manifests.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/siderolabs/go-kubernetes/kubernetes/manifests"
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
@@ -115,7 +116,8 @@ func (suite *ManifestsSuite) TestSync() {
 		clusterAccess,
 		true,
 		kubernetes.UpgradeOptions{
-			LogOutput: manifestSyncWriter{t: suite.T()},
+			LogOutput:              manifestSyncWriter{t: suite.T()},
+			SSApplyBehaviorOptions: manifests.DefaultSSApplyBehaviorOptions(),
 		},
 	))
 

--- a/machineconfig.yaml
+++ b/machineconfig.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: grpc://10.5.0.1:8090?jointoken=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD # SideroLink API URL to connect to.

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -508,12 +508,23 @@ func syncManifestsSSA(ctx context.Context, objects []*unstructured.Unstructured,
 		return err
 	}
 
+	ssaOptions := manifests.SSAOptions{
+		FieldManagerName:   constants.KubernetesFieldManagerName,
+		InventoryNamespace: constants.KubernetesInventoryNamespace,
+		InventoryName:      constants.KubernetesBootstrapManifestsInventoryName,
+		SSApplyBehaviorOptions: manifests.SSApplyBehaviorOptions{
+			DryRun:           options.DryRun,
+			InventoryPolicy:  options.InventoryPolicy,
+			ReconcileTimeout: options.ReconcileTimeout,
+			PruneTimeout:     options.PruneTimeout,
+			ForceConflicts:   options.ForceConflicts,
+			NoPrune:          options.NoPrune,
+		},
+	}
+
 	options.Log("comparing with live objects")
 
-	result, err := manifests.DiffSSA(ctx, objects, config,
-		constants.KubernetesFieldManagerName,
-		constants.KubernetesInventoryNamespace,
-		constants.KubernetesBootstrapManifestsInventoryName)
+	result, err := manifests.DiffSSA(ctx, objects, config, ssaOptions)
 	if err != nil {
 		return err
 	}
@@ -538,10 +549,7 @@ func syncManifestsSSA(ctx context.Context, objects []*unstructured.Unstructured,
 		ctx,
 		objects,
 		config,
-		options.DryRun,
-		constants.KubernetesFieldManagerName,
-		constants.KubernetesInventoryNamespace,
-		constants.KubernetesBootstrapManifestsInventoryName,
+		ssaOptions,
 		options.Log,
 	)
 }

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/siderolabs/go-kubernetes/kubernetes/manifests"
 	"github.com/siderolabs/go-kubernetes/kubernetes/upgrade"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
@@ -23,13 +24,14 @@ const (
 
 // UpgradeOptions represents Kubernetes control plane upgrade settings.
 type UpgradeOptions struct {
+	manifests.SSApplyBehaviorOptions
+
 	Path *upgrade.Path
 
 	ControlPlaneEndpoint string
 	LogOutput            io.Writer
 	PrePullImages        bool
 	UpgradeKubelet       bool
-	DryRun               bool
 	EncoderOpt           encoder.Option
 
 	KubeletImage           string

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -3291,26 +3291,31 @@ talosctl upgrade-k8s [flags]
 ### Options
 
 ```
-      --apiserver-image string            kube-apiserver image to use (default "registry.k8s.io/kube-apiserver")
-  -c, --cluster string                    Cluster to connect to if a proxy endpoint is used.
-      --context string                    Context to be used in command
-      --controller-manager-image string   kube-controller-manager image to use (default "registry.k8s.io/kube-controller-manager")
-      --dry-run                           skip the actual upgrade and show the upgrade plan instead
-      --endpoint string                   the cluster control plane endpoint
-  -e, --endpoints strings                 override default endpoints in Talos configuration
-      --from string                       the Kubernetes control plane version to upgrade from
-  -h, --help                              help for upgrade-k8s
-      --kubelet-image string              kubelet image to use (default "ghcr.io/siderolabs/kubelet")
-  -n, --nodes strings                     target the specified nodes
-      --pre-pull-images                   pre-pull images before upgrade (default true)
-      --proxy-image string                kube-proxy image to use (default "registry.k8s.io/kube-proxy")
-      --scheduler-image string            kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
-      --siderov1-keys-dir string          The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
-      --to string                         the Kubernetes control plane version to upgrade to (default "1.35.0")
-      --upgrade-kubelet                   upgrade kubelet service (default true)
-      --with-docs                         patch all machine configs adding the documentation for each field (default true)
-      --with-examples                     patch all machine configs with the commented examples (default true)
+      --apiserver-image string                 kube-apiserver image to use (default "registry.k8s.io/kube-apiserver")
+  -c, --cluster string                         Cluster to connect to if a proxy endpoint is used.
+      --context string                         Context to be used in command
+      --controller-manager-image string        kube-controller-manager image to use (default "registry.k8s.io/kube-controller-manager")
+      --dry-run                                skip the actual upgrade and show the upgrade plan instead
+      --endpoint string                        the cluster control plane endpoint
+  -e, --endpoints strings                      override default endpoints in Talos configuration
+      --from string                            the Kubernetes control plane version to upgrade from
+  -h, --help                                   help for upgrade-k8s
+      --kubelet-image string                   kubelet image to use (default "ghcr.io/siderolabs/kubelet")
+      --manifests-force-conflicts              overwrite the fields when applying even if the field manager differs
+      --manifests-inventory-policy string      kubernetes SSA inventory policy (one of 'MustMatch', 'AdoptIfNoInventory' or 'AdoptAll') (default "AdoptIfNoInventory")
+      --manifests-no-prune                     whether pruning of previously applied objects should happen after apply
+      --manifests-prune-timeout duration       how long to wait for resources to be fully deleted (set to zero to disable waiting) (default 3m0s)
+      --manifests-reconcile-timeout duration   how long to wait for resources to be fully reconciled (set to zero to disable waiting) (default 3m0s)
+  -n, --nodes strings                          target the specified nodes
+      --pre-pull-images                        pre-pull images before upgrade (default true)
+      --proxy-image string                     kube-proxy image to use (default "registry.k8s.io/kube-proxy")
+      --scheduler-image string                 kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
+      --siderov1-keys-dir string               The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string                     The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --to string                              the Kubernetes control plane version to upgrade to (default "1.35.0")
+      --upgrade-kubelet                        upgrade kubelet service (default true)
+      --with-docs                              patch all machine configs adding the documentation for each field (default true)
+      --with-examples                          patch all machine configs with the commented examples (default true)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
add the following flags to the upgrade-k8s command:
* `--force-conflicts`            overwrite the fields when applying even if the field manager differs
* `--inventory-policy` string    kubernetes SSA inventory policy (one of 'MustMatch', 'AdoptIfNoInventory' or 'AdoptAll') (default "AdoptIfNoInventory")
* `--no-prune`                   whether pruning of previously applied objects should happen after apply
* `--prune-timeout` int          how long to wait for resources to be pruned in secunds (set to zero to disable waiting for resources to be fully deleted) (default 180)
* `--reconcile-timeout` int      how long to wait for resources to be prfully reconciled in secunds (set to zero to disable waiting for resources to be fully reoondiled) (default 180)

This should be merged once https://github.com/siderolabs/go-kubernetes/pull/39 is merged and released
closes [#12495](https://github.com/siderolabs/talos/issues/12495)