### PR TITLE
fix: lock down etcd listen address to IPv4 localhost

### DIFF
--- a/internal/app/machined/pkg/controllers/etcd/spec.go
+++ b/internal/app/machined/pkg/controllers/etcd/spec.go
@@ -155,17 +155,8 @@ func (ctrl *SpecController) Run(ctx context.Context, r controller.Runtime, _ *za
 			xslices.Map(etcdConfig.TypedSpec().ListenExcludeSubnets, func(cidr string) string { return "!" + cidr }),
 		)
 
-		defaultListenAddress := netip.AddrFrom4([4]byte{0, 0, 0, 0})
+		defaultListenAddress := netip.IPv4Unspecified()
 		loopbackAddress := netip.AddrFrom4([4]byte{127, 0, 0, 1})
-
-		for _, ip := range routedAddrs {
-			if ip.Is6() {
-				defaultListenAddress = netip.IPv6Unspecified()
-				loopbackAddress = netip.MustParseAddr("::1")
-
-				break
-			}
-		}
 
 		var (
 			advertisedIPs   []netip.Addr

--- a/internal/app/machined/pkg/controllers/etcd/spec_test.go
+++ b/internal/app/machined/pkg/controllers/etcd/spec_test.go
@@ -92,10 +92,10 @@ func (suite *SpecSuite) TestReconcile() {
 					netip.MustParseAddr("10.0.0.5"),
 				},
 				ListenPeerAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 				ListenClientAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 			},
 		},
@@ -114,10 +114,10 @@ func (suite *SpecSuite) TestReconcile() {
 					netip.MustParseAddr("192.168.1.1"),
 				},
 				ListenPeerAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 				ListenClientAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 			},
 		},
@@ -139,10 +139,10 @@ func (suite *SpecSuite) TestReconcile() {
 					netip.MustParseAddr("1.3.5.7"),
 				},
 				ListenPeerAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 				ListenClientAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 			},
 		},
@@ -165,10 +165,10 @@ func (suite *SpecSuite) TestReconcile() {
 					netip.MustParseAddr("192.168.1.1"),
 				},
 				ListenPeerAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 				ListenClientAddresses: []netip.Addr{
-					netip.IPv6Unspecified(),
+					netip.IPv4Unspecified(),
 				},
 			},
 		},
@@ -197,7 +197,7 @@ func (suite *SpecSuite) TestReconcile() {
 					netip.MustParseAddr("192.168.1.50"),
 				},
 				ListenClientAddresses: []netip.Addr{
-					netip.MustParseAddr("::1"),
+					netip.MustParseAddr("127.0.0.1"),
 					netip.MustParseAddr("192.168.1.1"),
 					netip.MustParseAddr("192.168.1.50"),
 				},

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -192,7 +192,7 @@ func NewControlPlaneAPIServerController() *ControlPlaneAPIServerController {
 					Image:                cfgProvider.Cluster().APIServer().Image(),
 					CloudProvider:        cloudProvider,
 					ControlPlaneEndpoint: cfgProvider.Cluster().Endpoint().String(),
-					EtcdServers:          []string{fmt.Sprintf("https://%s", nethelpers.JoinHostPort("localhost", constants.EtcdClientPort))},
+					EtcdServers:          []string{fmt.Sprintf("https://%s", nethelpers.JoinHostPort("127.0.0.1", constants.EtcdClientPort))},
 					LocalPort:            cfgProvider.Cluster().LocalAPIServerPort(),
 					ServiceCIDRs:         cfgProvider.Cluster().Network().ServiceCIDRs(),
 					ExtraArgs:            cfgProvider.Cluster().APIServer().ExtraArgs(),

--- a/internal/pkg/etcd/certs.go
+++ b/internal/pkg/etcd/certs.go
@@ -30,15 +30,10 @@ func (gen *CertificateGenerator) buildOptions(autoSANs, includeLocalhost bool) [
 	addresses := gen.NodeAddresses.TypedSpec().IPs()
 
 	if includeLocalhost {
-		addresses = append(addresses, netip.MustParseAddr("127.0.0.1"))
-
-		for _, addr := range addresses {
-			if addr.Is6() {
-				addresses = append(addresses, netip.MustParseAddr("::1"))
-
-				break
-			}
-		}
+		addresses = append(addresses,
+			netip.MustParseAddr("127.0.0.1"),
+			netip.MustParseAddr("::1"),
+		)
 	}
 
 	hostname := gen.HostnameStatus.TypedSpec().Hostname


### PR DESCRIPTION
Use literal IP address instead of `localhost` to make `kube-apiserver` connect to etcd member instead of relying on IPv4/IPv6 resolving of `localhost`.

Simplify configuration for listening on 127.0.0.1 only, generate cert SANs uncoditionally for etcd loopback IPs.

Fixes #12542
