### PR TITLE
fix: allow HostnameConfig to be used with incomplete machine config

### DIFF
--- a/internal/app/machined/pkg/controllers/network/hostname_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config.go
@@ -90,7 +90,7 @@ func (ctrl *HostnameConfigController) Run(ctx context.Context, r controller.Runt
 			if !state.IsNotFoundError(err) {
 				return fmt.Errorf("error getting config: %w", err)
 			}
-		} else if cfg.Config().Machine() != nil {
+		} else {
 			cfgProvider = cfg.Config()
 		}
 


### PR DESCRIPTION
The controller incorrectly was waiting for `cfg.Machine()` which basically blocks `HostnameConfig` with partial machine config.

Fix that, add missing unit-tests.

Fixes #12564
