### PR TITLE
fix: bond config via platform

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config_apply.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config_apply.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"go.uber.org/zap"
 
+	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -200,6 +201,10 @@ func (ctrl *PlatformConfigApplyController) apply(ctx context.Context, r controll
 
 					*spec = newSpec.(network.LinkSpecSpec) //nolint:forcetypeassert
 					spec.ConfigLayer = network.ConfigPlatform
+
+					if spec.Kind == network.LinkKindBond {
+						networkadapter.BondMasterSpec(&spec.BondMaster).FillDefaults()
+					}
 
 					return nil
 				}


### PR DESCRIPTION
Call `FillDefaults` on platform-acquired bond config.

As platform config controller might have cached (saved) representation of bond config, we need to ensure we adapt it to the latest bond configuration.

In particular, new fields introduced in v1.12 require some values to be set which `.FillDefaults()` does for us.

Otherwise, Talos enters a loop trying to reconfigure the bond in a loop.

Prove with a unit-test (it fails if `.FillDefaults()` is removed).

Fixes #12561
