### PR TITLE
fix: handle correctly incomplete RegistryTLSConfig

### DIFF
--- a/internal/app/machined/pkg/controllers/cri/registries_config_test.go
+++ b/internal/app/machined/pkg/controllers/cri/registries_config_test.go
@@ -323,7 +323,10 @@ func (suite *ConfigSuite) TestRegistryNewStyle() {
 	}
 	tr1.TLSCA = "-----BEGIN CERTIFICATE-----\nMIID...IDAQAB\n-----END CERTIFICATE-----"
 
-	ctr, err := container.New(mr1, ar1, tr1)
+	tr2 := criconfig.NewRegistryTLSConfigV1Alpha1("another-registry")
+	tr2.TLSInsecureSkipVerify = pointer.To(true)
+
+	ctr, err := container.New(mr1, ar1, tr1, tr2)
 	suite.Require().NoError(err)
 
 	cfg := config.NewMachineConfig(ctr)
@@ -369,6 +372,9 @@ func (suite *ConfigSuite) TestRegistryNewStyle() {
 						Key: []byte("-----BEGIN PRIVATE KEY-----\nMIIE...AB\n-----END PRIVATE KEY-----"),
 					},
 					TLSCA: []byte("-----BEGIN CERTIFICATE-----\nMIID...IDAQAB\n-----END CERTIFICATE-----"),
+				},
+				"another-registry": {
+					TLSInsecureSkipVerify: true,
 				},
 			},
 			spec.RegistryTLSs,

--- a/pkg/machinery/config/types/cri/registry_tls.go
+++ b/pkg/machinery/config/types/cri/registry_tls.go
@@ -159,6 +159,10 @@ func (s *RegistryTLSConfigV1Alpha1) Validate(validation.RuntimeMode, ...validati
 
 // ClientIdentity implements config.RegistryTLSConfigDocument interface.
 func (s *RegistryTLSConfigV1Alpha1) ClientIdentity() *x509.PEMEncodedCertificateAndKey {
+	if s.TLSClientIdentity == nil {
+		return nil
+	}
+
 	return &x509.PEMEncodedCertificateAndKey{
 		Crt: []byte(s.TLSClientIdentity.Cert),
 		Key: []byte(s.TLSClientIdentity.Key),
@@ -167,6 +171,10 @@ func (s *RegistryTLSConfigV1Alpha1) ClientIdentity() *x509.PEMEncodedCertificate
 
 // CA implements config.RegistryTLSConfigDocument interface.
 func (s *RegistryTLSConfigV1Alpha1) CA() []byte {
+	if s.TLSCA == "" {
+		return nil
+	}
+
 	return []byte(s.TLSCA)
 }
 


### PR DESCRIPTION
Add some missing unit-test coverage.

Fixes #12571
