### PR TITLE
fix: resolve SideroLink Wireguard endpoint on reconnect

### DIFF
--- a/internal/app/machined/pkg/controllers/siderolink/config_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/config_test.go
@@ -29,6 +29,8 @@ type ConfigSuite struct {
 }
 
 func TestConfigSuite(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, &ConfigSuite{
 		DefaultSuite: ctest.DefaultSuite{
 			AfterSetup: func(suite *ctest.DefaultSuite) {

--- a/internal/app/machined/pkg/controllers/siderolink/manager_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager_test.go
@@ -10,13 +10,13 @@ import (
 	"net"
 	"net/netip"
 	"testing"
-	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/go-procfs/procfs"
-	"github.com/siderolabs/go-retry/retry"
 	pb "github.com/siderolabs/siderolink/api/siderolink"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 
@@ -33,31 +33,13 @@ import (
 )
 
 func TestManagerSuite(t *testing.T) {
+	t.Parallel()
+
 	if fipsmode.Strict() {
 		t.Skip("skipping test in strict FIPS mode")
 	}
 
-	var m ManagerSuite
-
-	m.AfterSetup = func(suite *ctest.DefaultSuite) {
-		lis, err := (&net.ListenConfig{}).Listen(suite.Ctx(), "tcp", "localhost:0")
-		suite.Require().NoError(err)
-
-		m.s = grpc.NewServer()
-		pb.RegisterProvisionServiceServer(m.s, mockServer{})
-
-		go func() {
-			suite.Require().NoError(m.s.Serve(lis))
-		}()
-
-		cmdline := procfs.NewCmdline(fmt.Sprintf("%s=%s", constants.KernelParamSideroLink, lis.Addr().String()))
-		configController := siderolinkctrl.ConfigController{Cmdline: cmdline}
-
-		suite.Require().NoError(suite.Runtime().RegisterController(&siderolinkctrl.ManagerController{}))
-		suite.Require().NoError(suite.Runtime().RegisterController(&configController))
-	}
-
-	suite.Run(t, &m)
+	suite.Run(t, &ManagerSuite{})
 }
 
 type ManagerSuite struct {
@@ -68,94 +50,114 @@ type ManagerSuite struct {
 
 type mockServer struct {
 	pb.UnimplementedProvisionServiceServer
+
+	suite     *ManagerSuite
+	endpoints []string
 }
 
 const (
-	mockServerEndpoint    = "127.0.0.11:51820"
+	mockNodeUUID          = "71233efd-7a07-43f8-b6ba-da90fae0e88b"
+	mockUniqueToken       = "random-token"
+	mockServerEndpoint1   = "127.0.0.11:51820"
+	mockServerEndpoint2   = "localhost:51821"
 	mockServerAddress     = "fdae:41e4:649b:9303:b6db:d99c:215e:dfc4"
 	mockServerPublicKey   = "2aq/V91QyrHAoH24RK0bldukgo2rWk+wqE5Eg6TArCM="
 	mockNodeAddressPrefix = "fdae:41e4:649b:9303:2a07:9c7:5b08:aef7/64"
 )
 
-func (srv mockServer) Provision(_ context.Context, _ *pb.ProvisionRequest) (*pb.ProvisionResponse, error) {
+func (srv mockServer) Provision(_ context.Context, req *pb.ProvisionRequest) (*pb.ProvisionResponse, error) {
+	srv.suite.Assert().Equal(mockNodeUUID, req.GetNodeUuid())
+	srv.suite.Assert().Empty(req.GetJoinToken())
+	srv.suite.Assert().False(req.GetWireguardOverGrpc())
+	srv.suite.Assert().Equal(mockUniqueToken, req.GetNodeUniqueToken())
+
 	return &pb.ProvisionResponse{
-		ServerEndpoint:    pb.MakeEndpoints(mockServerEndpoint),
+		ServerEndpoint:    pb.MakeEndpoints(srv.endpoints...),
 		ServerAddress:     mockServerAddress,
 		ServerPublicKey:   mockServerPublicKey,
 		NodeAddressPrefix: mockNodeAddressPrefix,
 	}, nil
 }
 
-func (suite *ManagerSuite) TestReconcile() {
+func (suite *ManagerSuite) initialSetup(endpoints ...string) {
+	lis, err := (&net.ListenConfig{}).Listen(suite.Ctx(), "tcp", "localhost:0")
+	suite.Require().NoError(err)
+
+	suite.s = grpc.NewServer()
+	pb.RegisterProvisionServiceServer(suite.s, mockServer{
+		suite:     suite,
+		endpoints: endpoints,
+	})
+
+	suite.T().Cleanup(suite.s.Stop)
+
+	go func() {
+		suite.Require().NoError(suite.s.Serve(lis))
+	}()
+
+	cmdline := procfs.NewCmdline(fmt.Sprintf("%s=%s", constants.KernelParamSideroLink, lis.Addr().String()))
+	configController := siderolinkctrl.ConfigController{Cmdline: cmdline}
+
+	suite.Require().NoError(suite.Runtime().RegisterController(&siderolinkctrl.ManagerController{}))
+	suite.Require().NoError(suite.Runtime().RegisterController(&configController))
+
 	networkStatus := network.NewStatus(network.NamespaceName, network.StatusID)
 	networkStatus.TypedSpec().AddressReady = true
-
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), networkStatus))
+	suite.Create(networkStatus)
 
 	systemInformation := hardware.NewSystemInformation(hardware.SystemInformationID)
-	systemInformation.TypedSpec().UUID = "71233efd-7a07-43f8-b6ba-da90fae0e88b"
-
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), systemInformation))
+	systemInformation.TypedSpec().UUID = mockNodeUUID
+	suite.Create(systemInformation)
 
 	uniqToken := runtime.NewUniqueMachineToken()
-	uniqToken.TypedSpec().Token = "random-token"
+	uniqToken.TypedSpec().Token = mockUniqueToken
+	suite.Create(uniqToken)
+}
 
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), uniqToken))
+func (suite *ManagerSuite) TestReconcile() {
+	suite.initialSetup(mockServerEndpoint1)
 
 	nodeAddress := netip.MustParsePrefix(mockNodeAddressPrefix)
 
-	addressSpec := network.NewAddressSpec(network.ConfigNamespaceName, network.LayeredID(network.ConfigOperator, network.AddressID(constants.SideroLinkName, nodeAddress)))
-	linkSpec := network.NewLinkSpec(network.ConfigNamespaceName, network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)))
+	ctest.AssertResource(suite,
+		network.LayeredID(network.ConfigOperator, network.AddressID(constants.SideroLinkName, nodeAddress)),
+		func(r *network.AddressSpec, asrt *assert.Assertions) {
+			address := r.TypedSpec()
 
-	suite.AssertWithin(10*time.Second, 100*time.Millisecond, func() error {
-		addressResource, err := ctest.Get[*network.AddressSpec](suite, addressSpec.Metadata())
-		if err != nil {
-			if state.IsNotFoundError(err) {
-				return retry.ExpectedError(err)
-			}
+			asrt.Equal(nodeAddress, address.Address)
+			asrt.Equal(network.ConfigOperator, address.ConfigLayer)
+			asrt.Equal(nethelpers.FamilyInet6, address.Family)
+			asrt.Equal(constants.SideroLinkName, address.LinkName)
+		},
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
 
-			return err
-		}
+	ctest.AssertResource(suite,
+		network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)),
+		func(r *network.LinkSpec, asrt *assert.Assertions) {
+			link := r.TypedSpec()
 
-		address := addressResource.TypedSpec()
-
-		suite.Assert().Equal(nodeAddress, address.Address)
-		suite.Assert().Equal(network.ConfigOperator, address.ConfigLayer)
-		suite.Assert().Equal(nethelpers.FamilyInet6, address.Family)
-		suite.Assert().Equal(constants.SideroLinkName, address.LinkName)
-
-		linkResource, err := ctest.Get[*network.LinkSpec](suite, linkSpec.Metadata())
-		if err != nil {
-			if state.IsNotFoundError(err) {
-				return retry.ExpectedError(err)
-			}
-
-			return err
-		}
-
-		link := linkResource.TypedSpec()
-
-		suite.Assert().Equal("wireguard", link.Kind)
-		suite.Assert().Equal(network.ConfigOperator, link.ConfigLayer)
-		suite.Assert().NotEmpty(link.Wireguard.PrivateKey)
-		suite.Assert().Len(link.Wireguard.Peers, 1)
-		suite.Assert().Equal(mockServerEndpoint, link.Wireguard.Peers[0].Endpoint)
-		suite.Assert().Equal(mockServerPublicKey, link.Wireguard.Peers[0].PublicKey)
-		suite.Assert().Equal(
-			[]netip.Prefix{
-				netip.PrefixFrom(
-					netip.MustParseAddr(mockServerAddress),
-					128,
-				),
-			}, link.Wireguard.Peers[0].AllowedIPs,
-		)
-		suite.Assert().Equal(
-			constants.SideroLinkDefaultPeerKeepalive,
-			link.Wireguard.Peers[0].PersistentKeepaliveInterval,
-		)
-
-		return nil
-	})
+			asrt.Equal("wireguard", link.Kind)
+			asrt.Equal(network.ConfigOperator, link.ConfigLayer)
+			asrt.NotEmpty(link.Wireguard.PrivateKey)
+			asrt.Len(link.Wireguard.Peers, 1)
+			asrt.Equal(mockServerEndpoint1, link.Wireguard.Peers[0].Endpoint)
+			asrt.Equal(mockServerPublicKey, link.Wireguard.Peers[0].PublicKey)
+			asrt.Equal(
+				[]netip.Prefix{
+					netip.PrefixFrom(
+						netip.MustParseAddr(mockServerAddress),
+						128,
+					),
+				}, link.Wireguard.Peers[0].AllowedIPs,
+			)
+			asrt.Equal(
+				constants.SideroLinkDefaultPeerKeepalive,
+				link.Wireguard.Peers[0].PersistentKeepaliveInterval,
+			)
+		},
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
 
 	// remove config
 	configPtr := siderolink.NewConfig(config.NamespaceName, siderolink.ConfigID).Metadata()
@@ -163,21 +165,45 @@ func (suite *ManagerSuite) TestReconcile() {
 		state.WithDestroyOwner(pointer.To(siderolinkctrl.ConfigController{}).Name()))
 	suite.Require().NoError(destroyErr)
 
-	suite.AssertWithin(10*time.Second, 100*time.Millisecond, func() error {
-		_, err := ctest.Get[*network.LinkSpec](suite, linkSpec.Metadata())
-		if err == nil {
-			return retry.ExpectedErrorf("link resource still exists")
-		}
+	ctest.AssertNoResource[*network.LinkSpec](suite,
+		network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)),
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
 
-		suite.Assert().Truef(state.IsNotFoundError(err), "unexpected error: %v", err)
+	ctest.AssertNoResource[*network.AddressSpec](suite,
+		network.LayeredID(network.ConfigOperator, network.AddressID(constants.SideroLinkName, nodeAddress)),
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
+}
 
-		_, err = ctest.Get[*network.AddressSpec](suite, addressSpec.Metadata())
-		if err == nil {
-			return retry.ExpectedErrorf("address resource still exists")
-		}
+func (suite *ManagerSuite) TestMultipleEndpoints() {
+	suite.initialSetup(mockServerEndpoint1, mockServerEndpoint2)
 
-		suite.Assert().Truef(state.IsNotFoundError(err), "unexpected error: %v", err)
+	ctest.AssertResource(suite,
+		network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)),
+		func(r *network.LinkSpec, asrt *assert.Assertions) {
+			link := r.TypedSpec()
 
-		return nil
-	})
+			asrt.Len(link.Wireguard.Peers, 1)
+			// Talos should pick the first endpoint from the list.
+			asrt.Equal(mockServerEndpoint1, link.Wireguard.Peers[0].Endpoint)
+		},
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
+}
+
+func (suite *ManagerSuite) TestResolveEndpoints() {
+	suite.initialSetup(mockServerEndpoint2)
+
+	ctest.AssertResource(suite,
+		network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)),
+		func(r *network.LinkSpec, asrt *assert.Assertions) {
+			link := r.TypedSpec()
+
+			asrt.Len(link.Wireguard.Peers, 1)
+			// Talos should resolve the hostname to an IP address.
+			asrt.Equal("127.0.0.1:51821", link.Wireguard.Peers[0].Endpoint)
+		},
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
 }

--- a/internal/app/machined/pkg/controllers/siderolink/status_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/status_test.go
@@ -27,6 +27,8 @@ type StatusSuite struct {
 }
 
 func TestStatusSuite(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, &StatusSuite{
 		DefaultSuite: ctest.DefaultSuite{
 			Timeout: 3 * time.Second,


### PR DESCRIPTION
It's not recommended to use DNS name for the Wireguard endpoint, as in-kernel Wireguard endpoint relies only on IP addresses, so either way DNS resolve will happen outside of any Wireguard networking operations.

Previously, the resolving would happen at the moment Wireguard config is applied to the Linux kernel, but SideroLink reconnect would not trigger Wireguard reconfiguration as there is no change to the spec if the hostname is used (even if it resolves to a different IP now).

With this change, on each SideroLink reconnect attempt the name will be resolved to an IP address, so the Wireguard config would actually trigger a change/reconfiguration if the DNS names resolves to a new IP now.
