### PR TITLE
chore: remove unrelated machineconfig

### DIFF
--- a/machineconfig.yaml
+++ b/machineconfig.yaml
@@ -1,3 +1,0 @@
-apiVersion: v1alpha1
-kind: SideroLinkConfig
-apiUrl: grpc://10.5.0.1:8090?jointoken=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD # SideroLink API URL to connect to.


### PR DESCRIPTION
was commited by accident

the join token is to my local omni instance so don't bother trying to use it :)
