### PR TITLE
fix: drop the persist config flag from gen config

### DIFF
--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -70,7 +70,6 @@ var genConfigCmdFlags struct {
 	configPatchControlPlane []string
 	configPatchWorker       []string
 	registryMirrors         []string
-	persistConfig           bool
 	withExamples            bool
 	withDocs                bool
 	withClusterDiscovery    bool
@@ -233,7 +232,6 @@ func writeConfig(args []string) error {
 		generate.WithInstallImage(genConfigCmdFlags.installImage),
 		generate.WithAdditionalSubjectAltNames(genConfigCmdFlags.additionalSANs),
 		generate.WithDNSDomain(genConfigCmdFlags.dnsDomain),
-		generate.WithPersist(genConfigCmdFlags.persistConfig),
 		generate.WithClusterDiscovery(genConfigCmdFlags.withClusterDiscovery),
 	)
 
@@ -442,7 +440,6 @@ func init() {
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatchControlPlane, "config-patch-control-plane", nil, "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatchWorker, "config-patch-worker", nil, "patch generated machineconfigs (applied to 'worker' type)")
 	genConfigCmd.Flags().StringSliceVar(&genConfigCmdFlags.registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
-	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.persistConfig, "persist", "p", true, "the desired persist value for configs")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withExamples, "with-examples", "", true, "renders all machine configs with the commented examples")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withDocs, "with-docs", "", true, "renders all machine configs adding the documentation for each field")
 	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withClusterDiscovery, "with-cluster-discovery", "", true, "enable cluster discovery feature")

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -23,7 +23,7 @@ func (in *Input) init() ([]config.Document, error) {
 	v1alpha1Config := &v1alpha1.Config{
 		ConfigVersion: "v1alpha1",
 		ConfigDebug:   pointer.To(in.Options.Debug),
-		ConfigPersist: pointer.To(in.Options.Persist),
+		ConfigPersist: pointer.To(true),
 	}
 
 	networkConfig := &v1alpha1.NetworkConfig{}

--- a/pkg/machinery/config/generate/options.go
+++ b/pkg/machinery/config/generate/options.go
@@ -151,15 +151,6 @@ func WithDebug(enable bool) Option {
 	}
 }
 
-// WithPersist enables persistence of machine config across reboots.
-func WithPersist(enable bool) Option {
-	return func(o *Options) error {
-		o.Persist = enable
-
-		return nil
-	}
-}
-
 // WithClusterCNIConfig specifies custom cluster CNI config.
 func WithClusterCNIConfig(config *v1alpha1.CNIConfig) Option {
 	return func(o *Options) error {
@@ -255,8 +246,7 @@ type Options struct {
 	SecretsBundle *secrets.Bundle
 
 	// Base settings.
-	Debug   bool
-	Persist bool
+	Debug bool
 
 	// Machine settings: install.
 	InstallDisk            string
@@ -298,7 +288,6 @@ type Options struct {
 func DefaultOptions() Options {
 	return Options{
 		DNSDomain: "cluster.local",
-		Persist:   true,
 		Roles:     role.MakeSet(role.Admin),
 	}
 }

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -24,7 +24,7 @@ func (in *Input) worker() ([]config.Document, error) {
 	v1alpha1Config := &v1alpha1.Config{
 		ConfigVersion: "v1alpha1",
 		ConfigDebug:   pointer.To(in.Options.Debug),
-		ConfigPersist: pointer.To(in.Options.Persist),
+		ConfigPersist: pointer.To(true),
 	}
 
 	networkConfig := &v1alpha1.NetworkConfig{}

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -1728,7 +1728,6 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --kubernetes-version string                desired kubernetes version to run (default "1.35.0")
   -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
   -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
-  -p, --persist                                  the desired persist value for configs (default true)
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
       --talos-version string                     the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
       --version string                           the desired machine config version to generate (default "v1alpha1")


### PR DESCRIPTION
The `persist` value was locked to be true for a long time now, and Talos doesn't support any other mode (machine config is persisted).

Drop the `gen config` flag and related generate options, as modern Talos doesn't accept `persist: false`.
