### PR TITLE
feat: add opaque mount options support for existing volumes

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -125,6 +125,8 @@ message MountRequestSpec {
   repeated string requester_i_ds = 4;
   bool read_only = 5;
   bool detached = 6;
+  bool disable_access_time = 7;
+  bool secure = 8;
 }
 
 // MountSpec is the spec for volume mount.
@@ -237,6 +239,8 @@ message VolumeMountRequestSpec {
   string requester = 2;
   bool read_only = 3;
   bool detached = 4;
+  bool disable_access_time = 5;
+  bool secure = 6;
 }
 
 // VolumeMountStatusSpec is the spec for VolumeMountStatus.
@@ -246,6 +250,8 @@ message VolumeMountStatusSpec {
   string target = 3;
   bool read_only = 4;
   bool detached = 5;
+  bool disable_access_time = 6;
+  bool secure = 7;
 }
 
 // VolumeStatusSpec is the spec for VolumeStatus resource.

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
@@ -50,7 +50,7 @@ func GetSystemVolumeTransformers(ctx context.Context,
 // GetStateVolumeTransformer returns the transformer for the STATE volume.
 func GetStateVolumeTransformer(encryptionMeta *runtime.MetaKey, inContainer, isAgent bool) volumeConfigTransformer {
 	return func(cfg configconfig.Config) ([]VolumeResource, error) {
-		var volumeConfigurator func(vc *block.VolumeConfig) error
+		var volumeConfigurator func(*block.VolumeConfig) error
 
 		if inContainer {
 			volumeConfigurator = NewBuilder().

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
@@ -272,7 +272,7 @@ func TestExistingVolumeTransformer(t *testing.T) {
 							Match: cel.MustExpression(cel.ParseBooleanExpression(`volume.partition_label == "MY-DATA"`, celenv.VolumeLocator())),
 						},
 					},
-					MountSpec: blockcfg.MountSpec{
+					MountSpec: blockcfg.ExistingMountSpec{
 						MountReadOnly: pointer.To(false),
 					},
 				},
@@ -314,7 +314,7 @@ func TestExistingVolumeTransformer(t *testing.T) {
 							Match: cel.MustExpression(cel.ParseBooleanExpression(`volume.partition_label == "READONLY-DATA"`, celenv.VolumeLocator())),
 						},
 					},
-					MountSpec: blockcfg.MountSpec{
+					MountSpec: blockcfg.ExistingMountSpec{
 						MountReadOnly: pointer.To(true),
 					},
 				},

--- a/internal/app/machined/pkg/controllers/block/mount_status.go
+++ b/internal/app/machined/pkg/controllers/block/mount_status.go
@@ -91,6 +91,8 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 							vms.TypedSpec().VolumeID = mountStatus.TypedSpec().Spec.VolumeID
 							vms.TypedSpec().ReadOnly = mountStatus.TypedSpec().Spec.ReadOnly
 							vms.TypedSpec().Detached = mountStatus.TypedSpec().Detached
+							vms.TypedSpec().DisableAccessTime = mountStatus.TypedSpec().Spec.DisableAccessTime
+							vms.TypedSpec().Secure = mountStatus.TypedSpec().Spec.Secure
 
 							// This needs to be set through accessor, and is not guaranteed to resolve to a valid root.
 							vms.TypedSpec().SetRoot(mountStatus.TypedSpec().Root())

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1447,6 +1447,11 @@ func MountEphemeralPartition(runtime.Sequence, any) (runtime.TaskExecutionFunc, 
 		mountRequest.TypedSpec().VolumeID = constants.EphemeralPartitionLabel
 		mountRequest.TypedSpec().Requester = "sequencer"
 
+		if cfg := r.Config(); cfg != nil {
+			vol, _ := cfg.Volumes().ByName(constants.EphemeralPartitionLabel)
+			mountRequest.TypedSpec().Secure = vol.Mount().Secure()
+		}
+
 		if err := r.State().V1Alpha2().Resources().Create(ctx, mountRequest); err != nil {
 			return fmt.Errorf("failed to create EPHEMERAL mount request: %w", err)
 		}

--- a/internal/pkg/mount/v3/manager.go
+++ b/internal/pkg/mount/v3/manager.go
@@ -210,13 +210,19 @@ func WithMountAttributes(flags int) ManagerOption {
 	}
 }
 
+// WithDisableAccessTime sets MOUNT_ATTR_NOATIME.
+func WithDisableAccessTime() ManagerOption {
+	return WithMountAttributes(unix.MOUNT_ATTR_NOATIME)
+}
+
+// WithSecure sets MOUNT_ATTR_NOSUID and MOUNT_ATTR_NODEV.
+func WithSecure() ManagerOption {
+	return WithMountAttributes(unix.MOUNT_ATTR_NOSUID | unix.MOUNT_ATTR_NODEV)
+}
+
 // WithReadOnly sets the mount as read only.
 func WithReadOnly() ManagerOption {
-	return ManagerOption{
-		set: func(m *Manager) {
-			m.mountattr |= unix.MOUNT_ATTR_RDONLY
-		},
-	}
+	return WithMountAttributes(unix.MOUNT_ATTR_RDONLY)
 }
 
 // WithDetached sets the mount as detached.

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -949,15 +949,17 @@ func (x *LocatorSpec) GetDiskMatch() *v1alpha1.CheckedExpr {
 
 // MountRequestSpec is the spec for MountRequest.
 type MountRequestSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VolumeId      string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
-	ParentMountId string                 `protobuf:"bytes,2,opt,name=parent_mount_id,json=parentMountId,proto3" json:"parent_mount_id,omitempty"`
-	Requesters    []string               `protobuf:"bytes,3,rep,name=requesters,proto3" json:"requesters,omitempty"`
-	RequesterIDs  []string               `protobuf:"bytes,4,rep,name=requester_i_ds,json=requesterIDs,proto3" json:"requester_i_ds,omitempty"`
-	ReadOnly      bool                   `protobuf:"varint,5,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
-	Detached      bool                   `protobuf:"varint,6,opt,name=detached,proto3" json:"detached,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	VolumeId          string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
+	ParentMountId     string                 `protobuf:"bytes,2,opt,name=parent_mount_id,json=parentMountId,proto3" json:"parent_mount_id,omitempty"`
+	Requesters        []string               `protobuf:"bytes,3,rep,name=requesters,proto3" json:"requesters,omitempty"`
+	RequesterIDs      []string               `protobuf:"bytes,4,rep,name=requester_i_ds,json=requesterIDs,proto3" json:"requester_i_ds,omitempty"`
+	ReadOnly          bool                   `protobuf:"varint,5,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
+	Detached          bool                   `protobuf:"varint,6,opt,name=detached,proto3" json:"detached,omitempty"`
+	DisableAccessTime bool                   `protobuf:"varint,7,opt,name=disable_access_time,json=disableAccessTime,proto3" json:"disable_access_time,omitempty"`
+	Secure            bool                   `protobuf:"varint,8,opt,name=secure,proto3" json:"secure,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *MountRequestSpec) Reset() {
@@ -1028,6 +1030,20 @@ func (x *MountRequestSpec) GetReadOnly() bool {
 func (x *MountRequestSpec) GetDetached() bool {
 	if x != nil {
 		return x.Detached
+	}
+	return false
+}
+
+func (x *MountRequestSpec) GetDisableAccessTime() bool {
+	if x != nil {
+		return x.DisableAccessTime
+	}
+	return false
+}
+
+func (x *MountRequestSpec) GetSecure() bool {
+	if x != nil {
+		return x.Secure
 	}
 	return false
 }
@@ -1926,13 +1942,15 @@ func (x *VolumeConfigSpec) GetSymlink() *SymlinkProvisioningSpec {
 
 // VolumeMountRequestSpec is the spec for VolumeMountRequest.
 type VolumeMountRequestSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VolumeId      string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
-	Requester     string                 `protobuf:"bytes,2,opt,name=requester,proto3" json:"requester,omitempty"`
-	ReadOnly      bool                   `protobuf:"varint,3,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
-	Detached      bool                   `protobuf:"varint,4,opt,name=detached,proto3" json:"detached,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	VolumeId          string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
+	Requester         string                 `protobuf:"bytes,2,opt,name=requester,proto3" json:"requester,omitempty"`
+	ReadOnly          bool                   `protobuf:"varint,3,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
+	Detached          bool                   `protobuf:"varint,4,opt,name=detached,proto3" json:"detached,omitempty"`
+	DisableAccessTime bool                   `protobuf:"varint,5,opt,name=disable_access_time,json=disableAccessTime,proto3" json:"disable_access_time,omitempty"`
+	Secure            bool                   `protobuf:"varint,6,opt,name=secure,proto3" json:"secure,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *VolumeMountRequestSpec) Reset() {
@@ -1993,16 +2011,32 @@ func (x *VolumeMountRequestSpec) GetDetached() bool {
 	return false
 }
 
+func (x *VolumeMountRequestSpec) GetDisableAccessTime() bool {
+	if x != nil {
+		return x.DisableAccessTime
+	}
+	return false
+}
+
+func (x *VolumeMountRequestSpec) GetSecure() bool {
+	if x != nil {
+		return x.Secure
+	}
+	return false
+}
+
 // VolumeMountStatusSpec is the spec for VolumeMountStatus.
 type VolumeMountStatusSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VolumeId      string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
-	Requester     string                 `protobuf:"bytes,2,opt,name=requester,proto3" json:"requester,omitempty"`
-	Target        string                 `protobuf:"bytes,3,opt,name=target,proto3" json:"target,omitempty"`
-	ReadOnly      bool                   `protobuf:"varint,4,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
-	Detached      bool                   `protobuf:"varint,5,opt,name=detached,proto3" json:"detached,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	VolumeId          string                 `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
+	Requester         string                 `protobuf:"bytes,2,opt,name=requester,proto3" json:"requester,omitempty"`
+	Target            string                 `protobuf:"bytes,3,opt,name=target,proto3" json:"target,omitempty"`
+	ReadOnly          bool                   `protobuf:"varint,4,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
+	Detached          bool                   `protobuf:"varint,5,opt,name=detached,proto3" json:"detached,omitempty"`
+	DisableAccessTime bool                   `protobuf:"varint,6,opt,name=disable_access_time,json=disableAccessTime,proto3" json:"disable_access_time,omitempty"`
+	Secure            bool                   `protobuf:"varint,7,opt,name=secure,proto3" json:"secure,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *VolumeMountStatusSpec) Reset() {
@@ -2066,6 +2100,20 @@ func (x *VolumeMountStatusSpec) GetReadOnly() bool {
 func (x *VolumeMountStatusSpec) GetDetached() bool {
 	if x != nil {
 		return x.Detached
+	}
+	return false
+}
+
+func (x *VolumeMountStatusSpec) GetDisableAccessTime() bool {
+	if x != nil {
+		return x.DisableAccessTime
+	}
+	return false
+}
+
+func (x *VolumeMountStatusSpec) GetSecure() bool {
+	if x != nil {
+		return x.Secure
 	}
 	return false
 }
@@ -2501,7 +2549,7 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\vLocatorSpec\x12;\n" +
 	"\x05match\x18\x01 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\x05match\x12D\n" +
 	"\n" +
-	"disk_match\x18\x02 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\tdiskMatch\"\xd6\x01\n" +
+	"disk_match\x18\x02 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\tdiskMatch\"\x9e\x02\n" +
 	"\x10MountRequestSpec\x12\x1b\n" +
 	"\tvolume_id\x18\x01 \x01(\tR\bvolumeId\x12&\n" +
 	"\x0fparent_mount_id\x18\x02 \x01(\tR\rparentMountId\x12\x1e\n" +
@@ -2510,7 +2558,9 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"requesters\x12$\n" +
 	"\x0erequester_i_ds\x18\x04 \x03(\tR\frequesterIDs\x12\x1b\n" +
 	"\tread_only\x18\x05 \x01(\bR\breadOnly\x12\x1a\n" +
-	"\bdetached\x18\x06 \x01(\bR\bdetached\"\x82\x03\n" +
+	"\bdetached\x18\x06 \x01(\bR\bdetached\x12.\n" +
+	"\x13disable_access_time\x18\a \x01(\bR\x11disableAccessTime\x12\x16\n" +
+	"\x06secure\x18\b \x01(\bR\x06secure\"\x82\x03\n" +
 	"\tMountSpec\x12\x1f\n" +
 	"\vtarget_path\x18\x01 \x01(\tR\n" +
 	"targetPath\x12#\n" +
@@ -2592,18 +2642,22 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\n" +
 	"encryption\x18\x06 \x01(\v20.talos.resource.definitions.block.EncryptionSpecR\n" +
 	"encryption\x12S\n" +
-	"\asymlink\x18\a \x01(\v29.talos.resource.definitions.block.SymlinkProvisioningSpecR\asymlink\"\x8c\x01\n" +
+	"\asymlink\x18\a \x01(\v29.talos.resource.definitions.block.SymlinkProvisioningSpecR\asymlink\"\xd4\x01\n" +
 	"\x16VolumeMountRequestSpec\x12\x1b\n" +
 	"\tvolume_id\x18\x01 \x01(\tR\bvolumeId\x12\x1c\n" +
 	"\trequester\x18\x02 \x01(\tR\trequester\x12\x1b\n" +
 	"\tread_only\x18\x03 \x01(\bR\breadOnly\x12\x1a\n" +
-	"\bdetached\x18\x04 \x01(\bR\bdetached\"\xa3\x01\n" +
+	"\bdetached\x18\x04 \x01(\bR\bdetached\x12.\n" +
+	"\x13disable_access_time\x18\x05 \x01(\bR\x11disableAccessTime\x12\x16\n" +
+	"\x06secure\x18\x06 \x01(\bR\x06secure\"\xeb\x01\n" +
 	"\x15VolumeMountStatusSpec\x12\x1b\n" +
 	"\tvolume_id\x18\x01 \x01(\tR\bvolumeId\x12\x1c\n" +
 	"\trequester\x18\x02 \x01(\tR\trequester\x12\x16\n" +
 	"\x06target\x18\x03 \x01(\tR\x06target\x12\x1b\n" +
 	"\tread_only\x18\x04 \x01(\bR\breadOnly\x12\x1a\n" +
-	"\bdetached\x18\x05 \x01(\bR\bdetached\"\x83\n" +
+	"\bdetached\x18\x05 \x01(\bR\bdetached\x12.\n" +
+	"\x13disable_access_time\x18\x06 \x01(\bR\x11disableAccessTime\x12\x16\n" +
+	"\x06secure\x18\a \x01(\bR\x06secure\"\x83\n" +
 	"\n" +
 	"\x10VolumeStatusSpec\x12H\n" +
 	"\x05phase\x18\x01 \x01(\x0e22.talos.resource.definitions.enums.BlockVolumePhaseR\x05phase\x12\x1a\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -937,6 +937,26 @@ func (m *MountRequestSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Secure {
+		i--
+		if m.Secure {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.DisableAccessTime {
+		i--
+		if m.DisableAccessTime {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
 	if m.Detached {
 		i--
 		if m.Detached {
@@ -1874,6 +1894,26 @@ func (m *VolumeMountRequestSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Secure {
+		i--
+		if m.Secure {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.DisableAccessTime {
+		i--
+		if m.DisableAccessTime {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
 	if m.Detached {
 		i--
 		if m.Detached {
@@ -1940,6 +1980,26 @@ func (m *VolumeMountStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Secure {
+		i--
+		if m.Secure {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
+	if m.DisableAccessTime {
+		i--
+		if m.DisableAccessTime {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
 	}
 	if m.Detached {
 		i--
@@ -2685,6 +2745,12 @@ func (m *MountRequestSpec) SizeVT() (n int) {
 	if m.Detached {
 		n += 2
 	}
+	if m.DisableAccessTime {
+		n += 2
+	}
+	if m.Secure {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3039,6 +3105,12 @@ func (m *VolumeMountRequestSpec) SizeVT() (n int) {
 	if m.Detached {
 		n += 2
 	}
+	if m.DisableAccessTime {
+		n += 2
+	}
+	if m.Secure {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3065,6 +3137,12 @@ func (m *VolumeMountStatusSpec) SizeVT() (n int) {
 		n += 2
 	}
 	if m.Detached {
+		n += 2
+	}
+	if m.DisableAccessTime {
+		n += 2
+	}
+	if m.Secure {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -5889,6 +5967,46 @@ func (m *MountRequestSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Detached = bool(v != 0)
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DisableAccessTime", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DisableAccessTime = bool(v != 0)
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Secure", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Secure = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -8274,6 +8392,46 @@ func (m *VolumeMountRequestSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Detached = bool(v != 0)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DisableAccessTime", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DisableAccessTime = bool(v != 0)
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Secure", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Secure = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -8461,6 +8619,46 @@ func (m *VolumeMountStatusSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Detached = bool(v != 0)
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DisableAccessTime", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DisableAccessTime = bool(v != 0)
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Secure", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Secure = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -24,6 +24,7 @@ type VolumeConfig interface {
 	NamedDocument
 	Provisioning() VolumeProvisioningConfig
 	Encryption() EncryptionConfig
+	Mount() VolumeMountConfig
 }
 
 // VolumeProvisioningConfig defines the interface to access volume provisioning configuration.
@@ -91,6 +92,24 @@ func (emptyVolumeConfig) MaxSizeNegative() bool {
 	return false
 }
 
+func (emptyVolumeConfig) Mount() VolumeMountConfig {
+	return emptyVolumeMountConfig{}
+}
+
+type emptyVolumeMountConfig struct{}
+
+func (emptyVolumeMountConfig) DisableAccessTime() bool {
+	return false
+}
+
+func (emptyVolumeMountConfig) Secure() bool {
+	return true
+}
+
+func (emptyVolumeMountConfig) ReadOnly() bool {
+	return false
+}
+
 // UserVolumeConfig defines the interface to access user volume configuration.
 type UserVolumeConfig interface {
 	NamedDocument
@@ -99,6 +118,7 @@ type UserVolumeConfig interface {
 	Provisioning() VolumeProvisioningConfig
 	Filesystem() FilesystemConfig
 	Encryption() EncryptionConfig
+	Mount() UserVolumeMountConfig
 }
 
 // RawVolumeConfig defines the interface to access raw volume configuration.
@@ -114,7 +134,7 @@ type ExistingVolumeConfig interface {
 	NamedDocument
 	ExistingVolumeConfigSignal()
 	VolumeDiscovery() VolumeDiscoveryConfig
-	Mount() VolumeMountConfig
+	Mount() ExistingVolumeMountConfig
 }
 
 // ExternalVolumeConfig defines the interface to access external volume configuration.
@@ -122,7 +142,7 @@ type ExternalVolumeConfig interface {
 	NamedDocument
 	ExternalVolumeConfigSignal()
 	Type() block.FilesystemType
-	Mount() ExternalMountConfig
+	Mount() ExternalVolumeMountConfig
 }
 
 // VolumeDiscoveryConfig defines the interface to discover volumes.
@@ -132,17 +152,29 @@ type VolumeDiscoveryConfig interface {
 
 // VolumeMountConfig defines the interface to access volume mount configuration.
 type VolumeMountConfig interface {
+	Secure() bool
+}
+
+// UserVolumeMountConfig defines the interface to access volume mount configuration.
+type UserVolumeMountConfig interface {
+	VolumeMountConfig
+	DisableAccessTime() bool
+}
+
+// ExistingVolumeMountConfig defines the interface to access volume mount configuration.
+type ExistingVolumeMountConfig interface {
+	UserVolumeMountConfig
 	ReadOnly() bool
 }
 
-// ExternalMountConfig defines the interface to access volume mount configuration.
-type ExternalMountConfig interface {
-	ReadOnly() bool
-	Virtiofs() optional.Optional[ExternalMountConfigSpec]
+// ExternalVolumeMountConfig defines the interface to access volume mount configuration.
+type ExternalVolumeMountConfig interface {
+	ExistingVolumeMountConfig
+	Virtiofs() optional.Optional[ExternalVolumeMountConfigSpec]
 }
 
-// ExternalMountConfigSpec defines the interface to access external mount configuration spec.
-type ExternalMountConfigSpec interface {
+// ExternalVolumeMountConfigSpec defines the interface to access external mount configuration spec.
+type ExternalVolumeMountConfigSpec interface {
 	Source() string
 	Parameters() ([]block.ParameterSpec, error)
 }

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -199,6 +199,34 @@
       "type": "object",
       "description": "EncryptionSpec represents volume encryption settings."
     },
+    "block.ExistingMountSpec": {
+      "properties": {
+        "readOnly": {
+          "type": "boolean",
+          "title": "readOnly",
+          "description": "Mount the volume read-only.\n",
+          "markdownDescription": "Mount the volume read-only.",
+          "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+        },
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExistingMountSpec describes how the volume is mounted."
+    },
     "block.ExistingVolumeConfigV1Alpha1": {
       "properties": {
         "apiVersion": {
@@ -234,7 +262,7 @@
           "x-intellij-html-description": "\u003cp\u003eThe discovery describes how to find a volume.\u003c/p\u003e\n"
         },
         "mount": {
-          "$ref": "#/$defs/block.MountSpec",
+          "$ref": "#/$defs/block.ExistingMountSpec",
           "title": "mount",
           "description": "The mount describes additional mount options.\n",
           "markdownDescription": "The mount describes additional mount options.",
@@ -257,6 +285,20 @@
           "description": "Mount the volume read-only.\n",
           "markdownDescription": "Mount the volume read-only.",
           "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+        },
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
         },
         "virtiofs": {
           "$ref": "#/$defs/block.VirtiofsMountSpec",
@@ -349,12 +391,12 @@
     },
     "block.MountSpec": {
       "properties": {
-        "readOnly": {
+        "secure": {
           "type": "boolean",
-          "title": "readOnly",
-          "description": "Mount the volume read-only.\n",
-          "markdownDescription": "Mount the volume read-only.",
-          "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -496,6 +538,27 @@
       ],
       "description": "SwapVolumeConfig is a disk swap volume configuration document.\\nSwap volume is automatically allocated as a partition on the specified disk\\nand activated as swap, removing a swap volume deactivates swap.\\nThe partition label is automatically generated as `s-\u003cname\u003e`.\\n"
     },
+    "block.UserMountSpec": {
+      "properties": {
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "UserMountSpec describes how the volume is mounted."
+    },
     "block.UserVolumeConfigV1Alpha1": {
       "properties": {
         "apiVersion": {
@@ -554,6 +617,13 @@
           "description": "The encryption describes how the volume is encrypted.\n",
           "markdownDescription": "The encryption describes how the volume is encrypted.",
           "x-intellij-html-description": "\u003cp\u003eThe encryption describes how the volume is encrypted.\u003c/p\u003e\n"
+        },
+        "mount": {
+          "$ref": "#/$defs/block.UserMountSpec",
+          "title": "mount",
+          "description": "The mount describes additional mount options.\n",
+          "markdownDescription": "The mount describes additional mount options.",
+          "x-intellij-html-description": "\u003cp\u003eThe mount describes additional mount options.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -618,6 +688,13 @@
           "description": "The encryption describes how the volume is encrypted.\n",
           "markdownDescription": "The encryption describes how the volume is encrypted.",
           "x-intellij-html-description": "\u003cp\u003eThe encryption describes how the volume is encrypted.\u003c/p\u003e\n"
+        },
+        "mount": {
+          "$ref": "#/$defs/block.MountSpec",
+          "title": "mount",
+          "description": "The mount describes additional mount options.\n",
+          "markdownDescription": "The mount describes additional mount options.",
+          "x-intellij-html-description": "\u003cp\u003eThe mount describes additional mount options.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -313,7 +313,7 @@ func (ExistingVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 			},
 			{
 				Name:        "mount",
-				Type:        "MountSpec",
+				Type:        "ExistingMountSpec",
 				Note:        "",
 				Description: "The mount describes additional mount options.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The mount describes additional mount options." /* encoder.LineComment */, "" /* encoder.FootComment */},
@@ -379,11 +379,11 @@ func (VolumeSelector) Doc() *encoder.Doc {
 	return doc
 }
 
-func (MountSpec) Doc() *encoder.Doc {
+func (ExistingMountSpec) Doc() *encoder.Doc {
 	doc := &encoder.Doc{
-		Type:        "MountSpec",
-		Comments:    [3]string{"" /* encoder.HeadComment */, "MountSpec describes how the volume is mounted." /* encoder.LineComment */, "" /* encoder.FootComment */},
-		Description: "MountSpec describes how the volume is mounted.",
+		Type:        "ExistingMountSpec",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "ExistingMountSpec describes how the volume is mounted." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "ExistingMountSpec describes how the volume is mounted.",
 		AppearsIn: []encoder.Appearance{
 			{
 				TypeName:  "ExistingVolumeConfigV1Alpha1",
@@ -397,6 +397,20 @@ func (MountSpec) Doc() *encoder.Doc {
 				Note:        "",
 				Description: "Mount the volume read-only.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Mount the volume read-only." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "disableAccessTime",
+				Type:        "bool",
+				Note:        "",
+				Description: "If true, disable file access time updates.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "If true, disable file access time updates." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "secure",
+				Type:        "bool",
+				Note:        "",
+				Description: "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Enable secure mount options (nosuid, nodev)." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 		},
 	}
@@ -465,6 +479,20 @@ func (ExternalMountSpec) Doc() *encoder.Doc {
 				Note:        "",
 				Description: "Mount the volume read-only.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Mount the volume read-only." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "disableAccessTime",
+				Type:        "bool",
+				Note:        "",
+				Description: "If true, disable file access time updates.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "If true, disable file access time updates." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "secure",
+				Type:        "bool",
+				Note:        "",
+				Description: "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Enable secure mount options (nosuid, nodev)." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
 				Name:        "virtiofs",
@@ -632,6 +660,13 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Description: "The encryption describes how the volume is encrypted.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The encryption describes how the volume is encrypted." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "mount",
+				Type:        "UserMountSpec",
+				Note:        "",
+				Description: "The mount describes additional mount options.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The mount describes additional mount options." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 
@@ -640,6 +675,38 @@ func (UserVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Disk())
 
 	doc.AddExample("", exampleUserVolumeConfigV1Alpha1Partition())
+
+	return doc
+}
+
+func (UserMountSpec) Doc() *encoder.Doc {
+	doc := &encoder.Doc{
+		Type:        "UserMountSpec",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "UserMountSpec describes how the volume is mounted." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "UserMountSpec describes how the volume is mounted.",
+		AppearsIn: []encoder.Appearance{
+			{
+				TypeName:  "UserVolumeConfigV1Alpha1",
+				FieldName: "mount",
+			},
+		},
+		Fields: []encoder.Doc{
+			{
+				Name:        "disableAccessTime",
+				Type:        "bool",
+				Note:        "",
+				Description: "If true, disable file access time updates.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "If true, disable file access time updates." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "secure",
+				Type:        "bool",
+				Note:        "",
+				Description: "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Enable secure mount options (nosuid, nodev)." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+		},
+	}
 
 	return doc
 }
@@ -711,10 +778,42 @@ func (VolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Description: "The encryption describes how the volume is encrypted.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The encryption describes how the volume is encrypted." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "mount",
+				Type:        "MountSpec",
+				Note:        "",
+				Description: "The mount describes additional mount options.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The mount describes additional mount options." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 
 	doc.AddExample("", exampleVolumeConfigEphemeralV1Alpha1())
+
+	return doc
+}
+
+func (MountSpec) Doc() *encoder.Doc {
+	doc := &encoder.Doc{
+		Type:        "MountSpec",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "MountSpec describes how the volume is mounted." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "MountSpec describes how the volume is mounted.",
+		AppearsIn: []encoder.Appearance{
+			{
+				TypeName:  "VolumeConfigV1Alpha1",
+				FieldName: "mount",
+			},
+		},
+		Fields: []encoder.Doc{
+			{
+				Name:        "secure",
+				Type:        "bool",
+				Note:        "",
+				Description: "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Enable secure mount options (nosuid, nodev)." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+		},
+	}
 
 	return doc
 }
@@ -857,15 +956,17 @@ func GetFileDoc() *encoder.FileDoc {
 			ExistingVolumeConfigV1Alpha1{}.Doc(),
 			VolumeDiscoverySpec{}.Doc(),
 			VolumeSelector{}.Doc(),
-			MountSpec{}.Doc(),
+			ExistingMountSpec{}.Doc(),
 			ExternalVolumeConfigV1Alpha1{}.Doc(),
 			ExternalMountSpec{}.Doc(),
 			VirtiofsMountSpec{}.Doc(),
 			RawVolumeConfigV1Alpha1{}.Doc(),
 			SwapVolumeConfigV1Alpha1{}.Doc(),
 			UserVolumeConfigV1Alpha1{}.Doc(),
+			UserMountSpec{}.Doc(),
 			FilesystemSpec{}.Doc(),
 			VolumeConfigV1Alpha1{}.Doc(),
+			MountSpec{}.Doc(),
 			ProvisioningSpec{}.Doc(),
 			DiskSelector{}.Doc(),
 			ZswapConfigV1Alpha1{}.Doc(),

--- a/pkg/machinery/config/types/block/deep_copy.generated.go
+++ b/pkg/machinery/config/types/block/deep_copy.generated.go
@@ -13,6 +13,14 @@ func (o *ExistingVolumeConfigV1Alpha1) DeepCopy() *ExistingVolumeConfigV1Alpha1 
 		cp.MountSpec.MountReadOnly = new(bool)
 		*cp.MountSpec.MountReadOnly = *o.MountSpec.MountReadOnly
 	}
+	if o.MountSpec.MountDisableAccessTime != nil {
+		cp.MountSpec.MountDisableAccessTime = new(bool)
+		*cp.MountSpec.MountDisableAccessTime = *o.MountSpec.MountDisableAccessTime
+	}
+	if o.MountSpec.MountSecure != nil {
+		cp.MountSpec.MountSecure = new(bool)
+		*cp.MountSpec.MountSecure = *o.MountSpec.MountSecure
+	}
 	return &cp
 }
 
@@ -273,6 +281,14 @@ func (o *UserVolumeConfigV1Alpha1) DeepCopy() *UserVolumeConfigV1Alpha1 {
 		cp.EncryptionSpec.EncryptionPerfOptions = make([]string, len(o.EncryptionSpec.EncryptionPerfOptions))
 		copy(cp.EncryptionSpec.EncryptionPerfOptions, o.EncryptionSpec.EncryptionPerfOptions)
 	}
+	if o.MountSpec.MountDisableAccessTime != nil {
+		cp.MountSpec.MountDisableAccessTime = new(bool)
+		*cp.MountSpec.MountDisableAccessTime = *o.MountSpec.MountDisableAccessTime
+	}
+	if o.MountSpec.MountSecure != nil {
+		cp.MountSpec.MountSecure = new(bool)
+		*cp.MountSpec.MountSecure = *o.MountSpec.MountSecure
+	}
 	return &cp
 }
 
@@ -282,6 +298,14 @@ func (o *ExternalVolumeConfigV1Alpha1) DeepCopy() *ExternalVolumeConfigV1Alpha1 
 	if o.MountSpec.MountReadOnly != nil {
 		cp.MountSpec.MountReadOnly = new(bool)
 		*cp.MountSpec.MountReadOnly = *o.MountSpec.MountReadOnly
+	}
+	if o.MountSpec.MountDisableAccessTime != nil {
+		cp.MountSpec.MountDisableAccessTime = new(bool)
+		*cp.MountSpec.MountDisableAccessTime = *o.MountSpec.MountDisableAccessTime
+	}
+	if o.MountSpec.MountSecure != nil {
+		cp.MountSpec.MountSecure = new(bool)
+		*cp.MountSpec.MountSecure = *o.MountSpec.MountSecure
 	}
 	if o.MountSpec.MountVirtiofs != nil {
 		cp.MountSpec.MountVirtiofs = new(VirtiofsMountSpec)
@@ -370,6 +394,10 @@ func (o *VolumeConfigV1Alpha1) DeepCopy() *VolumeConfigV1Alpha1 {
 	if o.EncryptionSpec.EncryptionPerfOptions != nil {
 		cp.EncryptionSpec.EncryptionPerfOptions = make([]string, len(o.EncryptionSpec.EncryptionPerfOptions))
 		copy(cp.EncryptionSpec.EncryptionPerfOptions, o.EncryptionSpec.EncryptionPerfOptions)
+	}
+	if o.MountSpec.MountSecure != nil {
+		cp.MountSpec.MountSecure = new(bool)
+		*cp.MountSpec.MountSecure = *o.MountSpec.MountSecure
 	}
 	return &cp
 }

--- a/pkg/machinery/config/types/block/external_volume_config.go
+++ b/pkg/machinery/config/types/block/external_volume_config.go
@@ -86,6 +86,14 @@ type ExternalMountSpec struct {
 	//   description: |
 	//     Mount the volume read-only.
 	MountReadOnly *bool `yaml:"readOnly,omitempty"`
+	//   description: |
+	//     If true, disable file access time updates.
+	MountDisableAccessTime *bool `yaml:"disableAccessTime,omitempty"`
+	//   description: |
+	//     Enable secure mount options (nosuid, nodev).
+	//
+	//     Defaults to true for better security.
+	MountSecure *bool `yaml:"secure,omitempty"`
 
 	//   description: |
 	//     Virtiofs mount options.
@@ -190,25 +198,39 @@ func (s *ExternalVolumeConfigV1Alpha1) Type() FilesystemType {
 }
 
 // Mount implements config.ExternalVolumeConfig interface.
-func (s *ExternalVolumeConfigV1Alpha1) Mount() config.ExternalMountConfig {
+func (s *ExternalVolumeConfigV1Alpha1) Mount() config.ExternalVolumeMountConfig {
 	return s.MountSpec
 }
 
-// ReadOnly implements config.VolumeMountConfig interface.
+// ReadOnly implements config.ExternalVolumeMountConfig interface.
 func (s ExternalMountSpec) ReadOnly() bool {
 	return pointer.SafeDeref(s.MountReadOnly)
 }
 
-// Virtiofs implements config.VolumeMountConfig interface.
-func (s ExternalMountSpec) Virtiofs() optional.Optional[config.ExternalMountConfigSpec] {
-	if s.MountVirtiofs == nil {
-		return optional.None[config.ExternalMountConfigSpec]()
-	}
-
-	return optional.Some[config.ExternalMountConfigSpec](*s.MountVirtiofs)
+// DisableAccessTime implements config.ExternalVolumeMountConfig interface.
+func (s ExternalMountSpec) DisableAccessTime() bool {
+	return pointer.SafeDeref(s.MountDisableAccessTime)
 }
 
-// Source implements config.ExternalMountConfigSpec interface.
+// Secure implements config.ExternalVolumeMountConfig interface.
+func (s ExternalMountSpec) Secure() bool {
+	if s.MountSecure == nil {
+		return true
+	}
+
+	return *s.MountSecure
+}
+
+// Virtiofs implements config.VolumeMountConfig interface.
+func (s ExternalMountSpec) Virtiofs() optional.Optional[config.ExternalVolumeMountConfigSpec] {
+	if s.MountVirtiofs == nil {
+		return optional.None[config.ExternalVolumeMountConfigSpec]()
+	}
+
+	return optional.Some[config.ExternalVolumeMountConfigSpec](*s.MountVirtiofs)
+}
+
+// Source implements config.ExternalVolumeMountConfigSpec interface.
 func (s VirtiofsMountSpec) Source() string {
 	return s.VirtiofsTag
 }

--- a/pkg/machinery/config/types/block/volume_config.go
+++ b/pkg/machinery/config/types/block/volume_config.go
@@ -69,6 +69,18 @@ type VolumeConfigV1Alpha1 struct {
 	//   description: |
 	//     The encryption describes how the volume is encrypted.
 	EncryptionSpec EncryptionSpec `yaml:"encryption,omitempty"`
+	//   description: |
+	//     The mount describes additional mount options.
+	MountSpec MountSpec `yaml:"mount,omitempty"`
+}
+
+// MountSpec describes how the volume is mounted.
+type MountSpec struct {
+	//   description: |
+	//     Enable secure mount options (nosuid, nodev).
+	//
+	//     Defaults to true for better security.
+	MountSecure *bool `yaml:"secure,omitempty"`
 }
 
 // ProvisioningSpec describes how the volume is provisioned.
@@ -222,6 +234,11 @@ func (s *VolumeConfigV1Alpha1) Encryption() config.EncryptionConfig {
 	return s.EncryptionSpec
 }
 
+// Mount implements config.VolumeConfig interface.
+func (s *VolumeConfigV1Alpha1) Mount() config.VolumeMountConfig {
+	return s.MountSpec
+}
+
 // Validate the provisioning spec.
 //
 //nolint:gocyclo
@@ -328,4 +345,13 @@ func (p ProvisioningSpec) RelativeMaxSize() optional.Optional[uint64] {
 	}
 
 	return optional.Some(val)
+}
+
+// Secure implements config.VolumeMountConfig interface.
+func (s MountSpec) Secure() bool {
+	if s.MountSecure == nil {
+		return true
+	}
+
+	return *s.MountSecure
 }

--- a/pkg/machinery/resources/block/mount_request.go
+++ b/pkg/machinery/resources/block/mount_request.go
@@ -29,6 +29,9 @@ type MountRequestSpec struct {
 	ReadOnly      bool   `yaml:"readOnly" protobuf:"5"`
 	Detached      bool   `yaml:"detached" protobuf:"6"`
 
+	DisableAccessTime bool `yaml:"disableAccessTime,omitempty" protobuf:"7"`
+	Secure            bool `yaml:"secure,omitempty" protobuf:"8"`
+
 	Requesters   []string `yaml:"requesters" protobuf:"3"`
 	RequesterIDs []string `yaml:"requesterIDs" protobuf:"4"`
 }

--- a/pkg/machinery/resources/block/volume_mount_request.go
+++ b/pkg/machinery/resources/block/volume_mount_request.go
@@ -25,11 +25,11 @@ type VolumeMountRequest = typed.Resource[VolumeMountRequestSpec, VolumeMountRequ
 type VolumeMountRequestSpec struct {
 	VolumeID string `yaml:"volumeID" protobuf:"1"`
 
-	ReadOnly bool `yaml:"readOnly" protobuf:"3"`
-
-	Detached bool `yaml:"detached" protobuf:"4"`
-
-	Requester string `yaml:"requester" protobuf:"2"`
+	Requester         string `yaml:"requester" protobuf:"2"`
+	ReadOnly          bool   `yaml:"readOnly" protobuf:"3"`
+	Detached          bool   `yaml:"detached" protobuf:"4"`
+	DisableAccessTime bool   `yaml:"disableAccessTime" protobuf:"5"`
+	Secure            bool   `yaml:"secure" protobuf:"6"`
 }
 
 // NewVolumeMountRequest initializes a VolumeMountRequest resource.

--- a/pkg/machinery/resources/block/volume_mount_status.go
+++ b/pkg/machinery/resources/block/volume_mount_status.go
@@ -26,9 +26,11 @@ type VolumeMountStatusSpec struct {
 	VolumeID  string `yaml:"volumeID" protobuf:"1"`
 	Requester string `yaml:"requester" protobuf:"2"`
 
-	Target   string `yaml:"target" protobuf:"3"`
-	ReadOnly bool   `yaml:"readOnly" protobuf:"4"`
-	Detached bool   `yaml:"detached" protobuf:"5"`
+	Target            string `yaml:"target" protobuf:"3"`
+	ReadOnly          bool   `yaml:"readOnly" protobuf:"4"`
+	Detached          bool   `yaml:"detached" protobuf:"5"`
+	DisableAccessTime bool   `yaml:"disableAccessTime" protobuf:"6"`
+	Secure            bool   `yaml:"secure" protobuf:"7"`
 
 	root any
 }

--- a/website/content/v1.13/reference/api.md
+++ b/website/content/v1.13/reference/api.md
@@ -5926,6 +5926,8 @@ MountRequestSpec is the spec for MountRequest.
 | requester_i_ds | [string](#string) | repeated |  |
 | read_only | [bool](#bool) |  |  |
 | detached | [bool](#bool) |  |  |
+| disable_access_time | [bool](#bool) |  |  |
+| secure | [bool](#bool) |  |  |
 
 
 
@@ -6168,6 +6170,8 @@ VolumeMountRequestSpec is the spec for VolumeMountRequest.
 | requester | [string](#string) |  |  |
 | read_only | [bool](#bool) |  |  |
 | detached | [bool](#bool) |  |  |
+| disable_access_time | [bool](#bool) |  |  |
+| secure | [bool](#bool) |  |  |
 
 
 
@@ -6187,6 +6191,8 @@ VolumeMountStatusSpec is the spec for VolumeMountStatus.
 | target | [string](#string) |  |  |
 | read_only | [bool](#bool) |  |  |
 | detached | [bool](#bool) |  |  |
+| disable_access_time | [bool](#bool) |  |  |
+| secure | [bool](#bool) |  |  |
 
 
 

--- a/website/content/v1.13/reference/configuration/block/existingvolumeconfig.md
+++ b/website/content/v1.13/reference/configuration/block/existingvolumeconfig.md
@@ -33,7 +33,7 @@ discovery:
 |-------|------|-------------|----------|
 |`name` |string |Name of the volume.<br><br>Name can only contain:<br>lowercase and uppercase ASCII letters, digits, and hyphens.  | |
 |`discovery` |<a href="#ExistingVolumeConfig.discovery">VolumeDiscoverySpec</a> |The discovery describes how to find a volume.  | |
-|`mount` |<a href="#ExistingVolumeConfig.mount">MountSpec</a> |The mount describes additional mount options.  | |
+|`mount` |<a href="#ExistingVolumeConfig.mount">ExistingMountSpec</a> |The mount describes additional mount options.  | |
 
 
 
@@ -76,7 +76,7 @@ match: volume.name == "xfs" && disk.serial == "SERIAL123"
 
 ## mount {#ExistingVolumeConfig.mount}
 
-MountSpec describes how the volume is mounted.
+ExistingMountSpec describes how the volume is mounted.
 
 
 
@@ -84,6 +84,8 @@ MountSpec describes how the volume is mounted.
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`readOnly` |bool |Mount the volume read-only.  | |
+|`disableAccessTime` |bool |If true, disable file access time updates.  | |
+|`secure` |bool |Enable secure mount options (nosuid, nodev).<br><br>Defaults to true for better security.  | |
 
 
 

--- a/website/content/v1.13/reference/configuration/block/externalvolumeconfig.md
+++ b/website/content/v1.13/reference/configuration/block/externalvolumeconfig.md
@@ -49,6 +49,8 @@ ExternalMountSpec describes how the external volume is mounted.
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`readOnly` |bool |Mount the volume read-only.  | |
+|`disableAccessTime` |bool |If true, disable file access time updates.  | |
+|`secure` |bool |Enable secure mount options (nosuid, nodev).<br><br>Defaults to true for better security.  | |
 |`virtiofs` |<a href="#ExternalVolumeConfig.mount.virtiofs">VirtiofsMountSpec</a> |Virtiofs mount options.  | |
 
 

--- a/website/content/v1.13/reference/configuration/block/uservolumeconfig.md
+++ b/website/content/v1.13/reference/configuration/block/uservolumeconfig.md
@@ -159,6 +159,7 @@ encryption:
 |`provisioning` |<a href="#UserVolumeConfig.provisioning">ProvisioningSpec</a> |The provisioning describes how the volume is provisioned.  | |
 |`filesystem` |<a href="#UserVolumeConfig.filesystem">FilesystemSpec</a> |The filesystem describes how the volume is formatted.  | |
 |`encryption` |<a href="#UserVolumeConfig.encryption">EncryptionSpec</a> |The encryption describes how the volume is encrypted.  | |
+|`mount` |<a href="#UserVolumeConfig.mount">UserMountSpec</a> |The mount describes additional mount options.  | |
 
 
 
@@ -379,6 +380,23 @@ EncryptionKeyTPMOptions represents the options for TPM-based key protection.
 
 
 
+
+
+
+
+
+
+## mount {#UserVolumeConfig.mount}
+
+UserMountSpec describes how the volume is mounted.
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`disableAccessTime` |bool |If true, disable file access time updates.  | |
+|`secure` |bool |Enable secure mount options (nosuid, nodev).<br><br>Defaults to true for better security.  | |
 
 
 

--- a/website/content/v1.13/reference/configuration/block/volumeconfig.md
+++ b/website/content/v1.13/reference/configuration/block/volumeconfig.md
@@ -60,6 +60,7 @@ provisioning:
 |`name` |string |Name of the volume.  | |
 |`provisioning` |<a href="#VolumeConfig.provisioning">ProvisioningSpec</a> |The provisioning describes how the volume is provisioned.  | |
 |`encryption` |<a href="#VolumeConfig.encryption">EncryptionSpec</a> |The encryption describes how the volume is encrypted.  | |
+|`mount` |<a href="#VolumeConfig.mount">MountSpec</a> |The mount describes additional mount options.  | |
 
 
 
@@ -263,6 +264,22 @@ EncryptionKeyTPMOptions represents the options for TPM-based key protection.
 
 
 
+
+
+
+
+
+
+## mount {#VolumeConfig.mount}
+
+MountSpec describes how the volume is mounted.
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`secure` |bool |Enable secure mount options (nosuid, nodev).<br><br>Defaults to true for better security.  | |
 
 
 

--- a/website/content/v1.13/schemas/config.schema.json
+++ b/website/content/v1.13/schemas/config.schema.json
@@ -199,6 +199,34 @@
       "type": "object",
       "description": "EncryptionSpec represents volume encryption settings."
     },
+    "block.ExistingMountSpec": {
+      "properties": {
+        "readOnly": {
+          "type": "boolean",
+          "title": "readOnly",
+          "description": "Mount the volume read-only.\n",
+          "markdownDescription": "Mount the volume read-only.",
+          "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+        },
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExistingMountSpec describes how the volume is mounted."
+    },
     "block.ExistingVolumeConfigV1Alpha1": {
       "properties": {
         "apiVersion": {
@@ -234,7 +262,7 @@
           "x-intellij-html-description": "\u003cp\u003eThe discovery describes how to find a volume.\u003c/p\u003e\n"
         },
         "mount": {
-          "$ref": "#/$defs/block.MountSpec",
+          "$ref": "#/$defs/block.ExistingMountSpec",
           "title": "mount",
           "description": "The mount describes additional mount options.\n",
           "markdownDescription": "The mount describes additional mount options.",
@@ -257,6 +285,20 @@
           "description": "Mount the volume read-only.\n",
           "markdownDescription": "Mount the volume read-only.",
           "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+        },
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
         },
         "virtiofs": {
           "$ref": "#/$defs/block.VirtiofsMountSpec",
@@ -349,12 +391,12 @@
     },
     "block.MountSpec": {
       "properties": {
-        "readOnly": {
+        "secure": {
           "type": "boolean",
-          "title": "readOnly",
-          "description": "Mount the volume read-only.\n",
-          "markdownDescription": "Mount the volume read-only.",
-          "x-intellij-html-description": "\u003cp\u003eMount the volume read-only.\u003c/p\u003e\n"
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -496,6 +538,27 @@
       ],
       "description": "SwapVolumeConfig is a disk swap volume configuration document.\\nSwap volume is automatically allocated as a partition on the specified disk\\nand activated as swap, removing a swap volume deactivates swap.\\nThe partition label is automatically generated as `s-\u003cname\u003e`.\\n"
     },
+    "block.UserMountSpec": {
+      "properties": {
+        "disableAccessTime": {
+          "type": "boolean",
+          "title": "disableAccessTime",
+          "description": "If true, disable file access time updates.\n",
+          "markdownDescription": "If true, disable file access time updates.",
+          "x-intellij-html-description": "\u003cp\u003eIf true, disable file access time updates.\u003c/p\u003e\n"
+        },
+        "secure": {
+          "type": "boolean",
+          "title": "secure",
+          "description": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.\n",
+          "markdownDescription": "Enable secure mount options (nosuid, nodev).\n\nDefaults to true for better security.",
+          "x-intellij-html-description": "\u003cp\u003eEnable secure mount options (nosuid, nodev).\u003c/p\u003e\n\n\u003cp\u003eDefaults to true for better security.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "UserMountSpec describes how the volume is mounted."
+    },
     "block.UserVolumeConfigV1Alpha1": {
       "properties": {
         "apiVersion": {
@@ -554,6 +617,13 @@
           "description": "The encryption describes how the volume is encrypted.\n",
           "markdownDescription": "The encryption describes how the volume is encrypted.",
           "x-intellij-html-description": "\u003cp\u003eThe encryption describes how the volume is encrypted.\u003c/p\u003e\n"
+        },
+        "mount": {
+          "$ref": "#/$defs/block.UserMountSpec",
+          "title": "mount",
+          "description": "The mount describes additional mount options.\n",
+          "markdownDescription": "The mount describes additional mount options.",
+          "x-intellij-html-description": "\u003cp\u003eThe mount describes additional mount options.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -618,6 +688,13 @@
           "description": "The encryption describes how the volume is encrypted.\n",
           "markdownDescription": "The encryption describes how the volume is encrypted.",
           "x-intellij-html-description": "\u003cp\u003eThe encryption describes how the volume is encrypted.\u003c/p\u003e\n"
+        },
+        "mount": {
+          "$ref": "#/$defs/block.MountSpec",
+          "title": "mount",
+          "description": "The mount describes additional mount options.\n",
+          "markdownDescription": "The mount describes additional mount options.",
+          "x-intellij-html-description": "\u003cp\u003eThe mount describes additional mount options.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This PR closes https://github.com/siderolabs/talos/issues/12308

## What? (description)

- Add support for adding extra mount options for volumes.

## Why? (reasoning)

- Allowing users more options for mounting volumes , ref : https://man7.org/linux/man-pages/man8/mount.8.html

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
