### PR TITLE
pcap(talosctl): move talosctl pcap example to Example

### DIFF
--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -39,9 +39,8 @@ var pcapCmd = &cobra.Command{
 	Use:     "pcap",
 	Aliases: []string{"tcpdump"},
 	Short:   "Capture the network packets from the node.",
-	Long: `The command launches packet capture on the node and streams back the packets as raw pcap file.
-
-Default behavior is to decode the packets with internal decoder to stdout:
+	Long:    `The command launches packet capture on the node and streams back the packets as raw pcap file.`,
+	Example: `Default behavior is to decode the packets with internal decoder to stdout:
 
     talosctl pcap -i eth0
 

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -2834,6 +2834,13 @@ Capture the network packets from the node.
 
 The command launches packet capture on the node and streams back the packets as raw pcap file.
 
+```
+talosctl pcap [flags]
+```
+
+### Examples
+
+```
 Default behavior is to decode the packets with internal decoder to stdout:
 
     talosctl pcap -i eth0
@@ -2857,9 +2864,6 @@ for e.g. Wireguard tunnels:
 As packet capture is transmitted over the network, it is recommended to filter out the Talos API traffic,
 e.g. by excluding packets with the port 50000.
    
-
-```
-talosctl pcap [flags]
 ```
 
 ### Options


### PR DESCRIPTION
it is before on Long but wrong display on docs website (already use by image cache-create cmd)

