### PR TITLE
fix: wipe disk by signatures

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/partition.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/partition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/go-blockdevice/v2/partitioning/gpt"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/talos/internal/pkg/partition"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
@@ -101,7 +102,7 @@ func CreatePartition(ctx context.Context, logger *zap.Logger, diskPath string, v
 
 	defer partitionDev.Close() //nolint:errcheck
 
-	if err = partitionDev.FastWipe(); err != nil {
+	if err = partition.WipeWithSignatures(partitionDev, partitionDevName, logger.Sugar().Debugf); err != nil {
 		return CreatePartitionResult{}, xerrors.NewTaggedf[Retryable]("error wiping partition: %w", err)
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1125,7 +1125,11 @@ func ResetSystemDisk(_ runtime.Sequence, data any) (runtime.TaskExecutionFunc, s
 
 				defer dev.Close() //nolint:errcheck
 
-				return dev.FastWipe()
+				if err = partition.WipeWithSignatures(dev, devPath, logger.Printf); err != nil {
+					return err
+				}
+
+				return nil
 			}(systemDiskPath); err != nil {
 				return fmt.Errorf("failed to wipe system disk %s: %w", systemDiskPath, err)
 			}
@@ -1163,7 +1167,11 @@ func ResetUserDisks(_ runtime.Sequence, data any) (runtime.TaskExecutionFunc, st
 
 			logger.Printf("wiping user disk %s", deviceName)
 
-			return dev.FastWipe()
+			if err = partition.WipeWithSignatures(dev, deviceName, logger.Printf); err != nil {
+				return err
+			}
+
+			return nil
 		}
 
 		for _, deviceName := range in.GetUserDisksToWipe() {

--- a/internal/app/maintenance/server.go
+++ b/internal/app/maintenance/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/resources"
 	storaged "github.com/siderolabs/talos/internal/app/storaged"
+	"github.com/siderolabs/talos/internal/pkg/partition"
 	"github.com/siderolabs/talos/pkg/grpc/middleware/authz"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
@@ -252,7 +253,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (*machine.
 
 	defer dev.Close() //nolint:errcheck
 
-	if err = dev.FastWipe(); err != nil {
+	if err = partition.WipeWithSignatures(dev, systemDisk.DevPath, log.Printf); err != nil {
 		return nil, err
 	}
 
@@ -269,8 +270,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (*machine.
 
 			log.Printf("wiping user disk %s", deviceName)
 
-			err = dev.FastWipe()
-			if err != nil {
+			if err = partition.WipeWithSignatures(dev, deviceName, log.Printf); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/integration/api/environment.go
+++ b/internal/integration/api/environment.go
@@ -80,6 +80,7 @@ func (suite *EnvironmentSuite) TestEnvironment() {
 		suite.ctx, node, func(nodeCtx context.Context) error {
 			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, 5*time.Minute,
+		suite.CleanupFailedPods,
 	)
 
 	suite.Require().Eventually(func() bool {
@@ -95,6 +96,7 @@ func (suite *EnvironmentSuite) TestEnvironment() {
 		suite.ctx, node, func(nodeCtx context.Context) error {
 			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, 5*time.Minute,
+		suite.CleanupFailedPods,
 	)
 
 	suite.Require().Eventually(func() bool {

--- a/internal/integration/api/update-hostname.go
+++ b/internal/integration/api/update-hostname.go
@@ -137,31 +137,11 @@ func (suite *UpdateHostnameSuite) TestUpdateHostname() {
 }
 
 func (suite *UpdateHostnameSuite) updateHostname(nodeCtx context.Context, newHostname string) {
-	// [TODO]: this should be dropped once Terraform Provider is updated for Talos 1.12
-	// do a negative patch removing v1alpha1 hostname-related config
-	// In "normal" tests config is generated without hostname v1alpha1 parts,
-	// but when the cluster is generated via Terraform, it uses outdated machinery and
-	// generates config with v1alpha1 hostname parts.
-	v1alpha1Drop := map[string]any{
-		"machine": map[string]any{
-			"network": map[string]any{
-				"hostname": map[string]any{
-					"$patch": "delete",
-				},
-			},
-			"features": map[string]any{
-				"stableHostname": map[string]any{
-					"$patch": "delete",
-				},
-			},
-		},
-	}
-
 	hostnameConfig := network.NewHostnameConfigV1Alpha1()
 	hostnameConfig.ConfigAuto = pointer.To(nethelpers.AutoHostnameKindOff)
 	hostnameConfig.ConfigHostname = newHostname
 
-	suite.PatchMachineConfig(nodeCtx, v1alpha1Drop, hostnameConfig)
+	suite.PatchMachineConfig(nodeCtx, hostnameConfig)
 }
 
 func init() {

--- a/internal/pkg/partition/helpers.go
+++ b/internal/pkg/partition/helpers.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package partition
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/go-blockdevice/v2/blkid"
+	"github.com/siderolabs/go-blockdevice/v2/block"
+)
+
+// WipeWithSignatures wipes the given block device by its signatures (if available)
+// and falls back to fast wipe otherwise.
+//
+// The function assumes that the caller locked properly the block device (or the parent
+// device in case of partitions) before calling it.
+//
+// If non-nil log function is passed, it will be used to log the wipe process.
+func WipeWithSignatures(bd *block.Device, deviceName string, log func(string, ...any)) error {
+	info, err := blkid.Probe(bd.File(), blkid.WithSkipLocking(true))
+	if err == nil && info != nil && len(info.SignatureRanges) > 0 { // probe successful, wipe by signatures
+		if err = bd.FastWipe(xslices.Map(info.SignatureRanges, func(r blkid.SignatureRange) block.Range {
+			return block.Range(r)
+		})...); err != nil {
+			return fmt.Errorf("failed to wipe block device %q: %v", deviceName, err)
+		}
+
+		if log != nil {
+			log("block device %q wiped by ranges: %s",
+				deviceName,
+				strings.Join(
+					xslices.Map(info.SignatureRanges,
+						func(r blkid.SignatureRange) string {
+							return fmt.Sprintf("%d-%d", r.Offset, r.Offset+r.Size)
+						},
+					),
+					", ",
+				),
+			)
+		}
+
+		return nil
+	}
+
+	// probe failed or no signatures found, fast wipe
+	if err = bd.FastWipe(); err != nil {
+		return fmt.Errorf("failed to wipe block device %q: %v", deviceName, err)
+	}
+
+	if log != nil {
+		log("block device %q wiped with fast method", deviceName)
+	}
+
+	return nil
+}

--- a/internal/pkg/partition/wipe.go
+++ b/internal/pkg/partition/wipe.go
@@ -107,7 +107,7 @@ func (v *VolumeWipeTarget) wipeWithParentLocked(log func(string, ...any)) error 
 
 	log("wiping volume %q (%s)", v.GetLabel(), v.devName)
 
-	return bd.FastWipe()
+	return WipeWithSignatures(bd, v.devName, log)
 }
 
 func (v *VolumeWipeTarget) dropWithParentLocked(parentBd *block.Device, log func(string, ...any)) error {


### PR DESCRIPTION
Fixes #12491

In (almost) all places we previously used `FastWipe`, use instead a helper which will try to discover filesystem/partition signatures, and wipe them.

This fixes the issue when a partition re-created in the same place might already hit a scenario when the "old" filesystem is discovered in the same place.
