### PR TITLE
fix: use network config from config-drive even when user_data is missing

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
@@ -10,6 +10,9 @@ import "errors"
 // ErrNoConfigSource indicates that the platform does not have a configured source for the configuration.
 var ErrNoConfigSource = errors.New("no configuration source")
 
+// ErrNoUserData indicates that config drive was found but user_data is missing.
+var ErrNoUserData = errors.New("no user_data in config drive")
+
 // ErrNoHostname indicates that the meta server does not have a instance hostname.
 var ErrNoHostname = errors.New("failed to fetch hostname from metadata service")
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
@@ -148,7 +148,7 @@ func (o *OpenStack) configFromCD(ctx context.Context, r state.State) (metaConfig
 	}
 
 	if machineConfig == nil {
-		err = errors.ErrNoConfigSource
+		err = errors.ErrNoUserData
 	}
 
 	return metaConfig, networkConfig, machineConfig, err


### PR DESCRIPTION
When OpenStack config-drive contains `meta_data.json` and `network_data.json` but `no user_data`, the `NetworkConfiguration` method was incorrectly falling back to network metadata service. This happened because `configFromCD` returns `ErrNoConfigSource` when `user_data` is missing, causing the already-read metadata and network config to be discarded.

This fix checks if metadata was successfully read from config-drive before falling back to network, allowing network configuration to be applied even when user_data is not provided (e.g., in OpenStack Ironic bare metal setups where machine config is applied later via talosctl).