### PR TITLE
fix: panic in configpatcher when the whole section is missing

### DIFF
--- a/pkg/machinery/config/configloader/internal/decoder/selector.go
+++ b/pkg/machinery/config/configloader/internal/decoder/selector.go
@@ -141,6 +141,10 @@ func deleteForPath(val reflect.Value, path []string, key, value string) error {
 	}
 
 	if val.Kind() == reflect.Pointer || val.Kind() == reflect.Interface {
+		if val.IsNil() {
+			return ErrLookupFailed
+		}
+
 		return deleteForPath(val.Elem(), path, key, value)
 	}
 

--- a/pkg/machinery/config/configpatcher/testdata/patchdeletemissing/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchdeletemissing/config.yaml
@@ -1,0 +1,2 @@
+version: v1alpha1
+machine: {}

--- a/pkg/machinery/config/configpatcher/testdata/patchdeletemissing/strategic1.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchdeletemissing/strategic1.yaml
@@ -1,0 +1,4 @@
+machine:
+  network:
+    hostname:
+      $patch: delete


### PR DESCRIPTION
Reproducer can be found in testdata, but tl;dr it tries to traverse via `*T` where `T` is a nested struct, and the pointer value is nil.

It was seen in the tests with Talos 1.13+ which drops `.machine.network` completely by default.
