### PR TITLE
feat: add VLAN support to OpenStack platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/metadata.go
@@ -52,6 +52,9 @@ type NetworkConfig struct {
 		BondLinks      []string `json:"bond_links,omitempty"`
 		BondMIIMon     uint32   `json:"bond_miimon,string,omitempty"`
 		BondHashPolicy string   `json:"bond_xmit_hash_policy,omitempty"`
+		VlanID         uint16   `json:"vlan_id,omitempty"`
+		VlanLink       string   `json:"vlan_link,omitempty"`
+		VlanMac        string   `json:"vlan_mac_address,omitempty"`
 	} `json:"links"`
 	Networks []struct {
 		ID      string `json:"id,omitempty"`

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -94,6 +94,17 @@ links:
       masterName: bond0
       slaveIndex: 1
       layer: platform
+    - name: bond0.100
+      logical: true
+      up: true
+      mtu: 1400
+      kind: vlan
+      type: ether
+      parentName: bond0
+      vlan:
+        vlanID: 100
+        vlanProtocol: 802.1q
+      layer: platform
 routes:
     - family: inet6
       dst: ""
@@ -190,6 +201,13 @@ operators:
       requireUp: true
       dhcp6:
         routeMetric: 2048
+        skipHostnameRequest: true
+      layer: platform
+    - operator: dhcp4
+      linkName: bond0.100
+      requireUp: true
+      dhcp4:
+        routeMetric: 1024
         skipHostnameRequest: true
       layer: platform
 externalIPs:

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/network.json
@@ -43,6 +43,15 @@
             "id": "83f59825-bf2d-4ea7-98be-edc772fe82de",
             "type": "phy",
             "ethernet_mac_address": "4c:d9:8f:b3:34:f7"
+        },
+        {
+            "id": "vlan-interface-001",
+            "vif_id": "acf55ef1-9a79-4c59-bec7-1ebf01a9a918",
+            "type": "vlan",
+            "mtu": 1400,
+            "vlan_mac_address": null,
+            "vlan_link": "tap7819ff08-20",
+            "vlan_id": 100
         }
     ],
     "networks": [
@@ -138,6 +147,12 @@
                     "address": "8.8.4.4"
                 }
             ]
+        },
+        {
+            "id": "vlan-network",
+            "type": "ipv4_dhcp",
+            "link": "vlan-interface-001",
+            "network_id": "5ee412a7-13c5-4306-ad4d-85c06241e5f4"
         }
     ],
     "services": [


### PR DESCRIPTION
This adds support for VLAN interfaces in OpenStack network_data.json. VLANs are configured with type "vlan" and reference a parent link via "vlan_link" field. The VLAN ID is specified in "vlan_id" field.

Example network_data.json entry:
```json
{
    "type": "vlan",
    "vlan_link": "tap7819ff08-20",
    "vlan_id": 100
}
```

This enables Talos to automatically configure VLAN interfaces when booting on OpenStack/Ironic bare metal with VLAN-based network topology.