### PR TITLE
fix: make OOM controller more precise by considering separate cgroup PSI

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
@@ -114,12 +114,189 @@ func TestPopulatePsiToCtx(t *testing.T) {
 		expectErr string
 		expect    map[string]any
 	}{
+		//nolint:dupl
 		{
 			name:      "empty",
 			dir:       "./testdata/empty",
-			expectErr: "cannot read memory pressure: error opening cgroupfs file open testdata/empty/memory.pressure: no such file or directory",
-			expect:    map[string]any{},
+			expectErr: "",
+			expect: map[string]any{
+				"memory_full_avg10":    0.0,
+				"memory_full_avg300":   0.0,
+				"memory_full_avg60":    0.0,
+				"memory_full_total":    0.0,
+				"memory_some_avg10":    0.0,
+				"memory_some_avg300":   0.0,
+				"memory_some_avg60":    0.0,
+				"memory_some_total":    0.0,
+				"d_memory_full_avg10":  0.0,
+				"d_memory_full_avg300": 0.0,
+				"d_memory_full_avg60":  0.0,
+				"d_memory_full_total":  0.0,
+				"d_memory_some_avg10":  0.0,
+				"d_memory_some_avg300": 0.0,
+				"d_memory_some_avg60":  0.0,
+				"d_memory_some_total":  0.0,
+
+				"qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+			},
 		},
+		//nolint:dupl
 		{
 			name:      "false",
 			dir:       "./testdata/trigger-false",
@@ -141,8 +318,167 @@ func TestPopulatePsiToCtx(t *testing.T) {
 				"d_memory_some_avg300": 0.0,
 				"d_memory_some_avg60":  0.0,
 				"d_memory_some_total":  0.0,
+
+				"qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 2.82,
+					int(runtime.QoSCgroupClassSystem):     5.64,
+				},
+				"qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 5.95,
+					int(runtime.QoSCgroupClassSystem):     11.9,
+				},
+				"qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.97,
+					int(runtime.QoSCgroupClassSystem):     3.94,
+				},
+				"qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.217234e+07,
+					int(runtime.QoSCgroupClassSystem):     2.434468e+07,
+				},
+				"qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 2.4,
+					int(runtime.QoSCgroupClassSystem):     4.8,
+				},
+				"qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 5.16,
+					int(runtime.QoSCgroupClassSystem):     10.32,
+				},
+				"qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.71,
+					int(runtime.QoSCgroupClassSystem):     3.42,
+				},
+				"qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.0654831e+07,
+					int(runtime.QoSCgroupClassSystem):     1.0654937e+07,
+				},
+				"d_qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
 			},
 		},
+		// //nolint:dupl
 		{
 			name:      "true",
 			dir:       "./testdata/trigger-true",
@@ -164,6 +500,164 @@ func TestPopulatePsiToCtx(t *testing.T) {
 				"d_memory_some_avg300": 0.0,
 				"d_memory_some_avg60":  0.0,
 				"d_memory_some_total":  0.0,
+
+				"qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 17.06,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 17.06,
+					int(runtime.QoSCgroupClassSystem):     34.12,
+				},
+				"qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 8.04,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 8.04,
+					int(runtime.QoSCgroupClassSystem):     16.08,
+				},
+				"qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 2.1,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 2.1,
+					int(runtime.QoSCgroupClassSystem):     4.2,
+				},
+				"qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 1.217234e+07,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.217234e+07,
+					int(runtime.QoSCgroupClassSystem):     2.434468e+07,
+				},
+				"qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 14.54,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 14.54,
+					int(runtime.QoSCgroupClassSystem):     29.08,
+				},
+				"qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 6.97,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 6.97,
+					int(runtime.QoSCgroupClassSystem):     13.94,
+				},
+				"qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 1.82,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.82,
+					int(runtime.QoSCgroupClassSystem):     3.64,
+				},
+				"qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 1.0654831e+07,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 1.0654831e+07,
+					int(runtime.QoSCgroupClassSystem):     2.1309662e+07,
+				},
+				"d_qos_memory_some_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_some_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg10": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg60": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_avg300": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_full_total": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_current": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_peak": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+
+				"qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
+				"d_qos_memory_max": map[int]float64{
+					int(runtime.QoSCgroupClassBesteffort): 0.0,
+					int(runtime.QoSCgroupClassBurstable):  0.0,
+					int(runtime.QoSCgroupClassGuaranteed): 0.0,
+					int(runtime.QoSCgroupClassPodruntime): 0.0,
+					int(runtime.QoSCgroupClassSystem):     0.0,
+				},
 			},
 		},
 	} {
@@ -172,7 +666,7 @@ func TestPopulatePsiToCtx(t *testing.T) {
 
 			ctx := map[string]any{}
 
-			err := oom.PopulatePsiToCtx(test.dir, ctx, make(map[string]float64), 0)
+			err := oom.PopulatePsiToCtx(test.dir, ctx, make(map[string]float64), 500*time.Millisecond)
 
 			if test.expectErr == "" {
 				require.NoError(t, err)
@@ -208,7 +702,7 @@ func TestEvaluateTrigger(t *testing.T) {
 			},
 			triggerExpr: triggerExpr1,
 			expect:      false,
-			expectErr:   "cannot read memory pressure: error opening cgroupfs file open testdata/empty/memory.pressure: no such file or directory",
+			expectErr:   "",
 		},
 		{
 			name: "cgroup-false",
@@ -236,9 +730,12 @@ func TestEvaluateTrigger(t *testing.T) {
 			ctx: map[string]any{
 				"time_since_trigger": 300 * time.Millisecond,
 			},
-			triggerExpr: triggerExpr1,
-			expect:      false,
-			expectErr:   "",
+			triggerExpr: cel.MustExpression(cel.ParseBooleanExpression(
+				`memory_full_avg10 > 12.0 && time_since_trigger > duration("500ms")`,
+				celenv.OOMTrigger(),
+			)),
+			expect:    false,
+			expectErr: "",
 		},
 		{
 			name: "cgroup-true-hot-overridden",
@@ -253,6 +750,17 @@ func TestEvaluateTrigger(t *testing.T) {
 			expect:    true,
 			expectErr: "",
 		},
+		{
+			name: "test multiply_qos",
+			ctx:  map[string]any{},
+			dir:  "./testdata/trigger-true",
+			triggerExpr: cel.MustExpression(cel.ParseBooleanExpression(
+				// 5 * 1 + 2 * -1 + 0 * 3 == 3
+				`multiply_qos_vectors({Besteffort: 5.0, Burstable: 2.0, Guaranteed: 0.0, System: 1.0}, {Besteffort: 1.0, Burstable: -1.0, Guaranteed: 3.0}) == 3.0`,
+				celenv.OOMTrigger(),
+			)),
+			expect: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -266,7 +774,9 @@ func TestEvaluateTrigger(t *testing.T) {
 				"memory_some_avg300": 0,
 				"memory_some_avg60":  0,
 				"memory_some_total":  0,
-			}, 0)
+
+				"init/memory_full_total": 0,
+			}, 500*time.Millisecond)
 
 			if test.expectErr == "" {
 				require.NoError(t, err)

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/init/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/init/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=2.82 avg60=5.95 avg300=1.97 total=12172340
+full avg10=2.40 avg60=5.16 avg300=1.71 total=106

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/podruntime/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/podruntime/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=2.82 avg60=5.95 avg300=1.97 total=12172340
+full avg10=2.40 avg60=5.16 avg300=1.71 total=10654831

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/system/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-false/system/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=2.82 avg60=5.95 avg300=1.97 total=12172340
+full avg10=2.40 avg60=5.16 avg300=1.71 total=10654831

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/init/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/init/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=17.06 avg60=8.04 avg300=2.10 total=12172340
+full avg10=14.54 avg60=6.97 avg300=1.82 total=10654831

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/kubepods/besteffort/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/kubepods/besteffort/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=17.06 avg60=8.04 avg300=2.10 total=12172340
+full avg10=14.54 avg60=6.97 avg300=1.82 total=10654831

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/podruntime/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/podruntime/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=17.06 avg60=8.04 avg300=2.10 total=12172340
+full avg10=14.54 avg60=6.97 avg300=1.82 total=10654831

--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/system/memory.pressure
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/testdata/trigger-true/system/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=17.06 avg60=8.04 avg300=2.10 total=12172340
+full avg10=14.54 avg60=6.97 avg300=1.82 total=10654831

--- a/pkg/machinery/config/types/runtime/testdata/oom.yaml
+++ b/pkg/machinery/config/types/runtime/testdata/oom.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1alpha1
 kind: OOMConfig
-triggerExpression: memory_full_avg10 > 12.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("500ms")
+triggerExpression: |-
+    multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 ||
+    memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))'
 sampleInterval: 100ms

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1282,12 +1282,16 @@ const (
 	ContainerMarkerFilePath = "/usr/etc/in-container"
 
 	// DefaultOOMTriggerExpression is the default CEL expression used to determine whether to trigger OOM.
-	DefaultOOMTriggerExpression = `memory_full_avg10 > 12.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("500ms")`
+	DefaultOOMTriggerExpression = `(multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0) ||
+		(memory_full_avg10 > 75.0 && time_since_trigger > duration("10s"))`
 
 	// DefaultOOMCgroupRankingExpression is the default CEL expression used to rank cgroups for OOM killer.
 	DefaultOOMCgroupRankingExpression = `memory_max.hasValue() ? 0.0 :
 		{Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] *
 		   double(memory_current.orValue(0u))`
+
+	// OOMActionLogKeep is the number of OOM action log entries to keep in memory.
+	OOMActionLogKeep = 50
 
 	// SDStubCmdlineExtraOEMVar is the name of the SMBIOS OEM variable that can be used to pass extra kernel command line parameters to systemd-stub.
 	SDStubCmdlineExtraOEMVar = "io.systemd.stub.kernel-cmdline-extra"

--- a/website/content/v1.13/reference/configuration/runtime/oomconfig.md
+++ b/website/content/v1.13/reference/configuration/runtime/oomconfig.md
@@ -16,7 +16,9 @@ title: OOMConfig
 {{< highlight yaml >}}
 apiVersion: v1alpha1
 kind: OOMConfig
-triggerExpression: memory_full_avg10 > 12.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("500ms") # This expression defines when to trigger OOM action.
+triggerExpression: |- # This expression defines when to trigger OOM action.
+    multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 ||
+    memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))' # This expression defines how to rank cgroups for OOM handler.
 sampleInterval: 100ms # How often should the trigger expression be evaluated.
 {{< /highlight >}}


### PR DESCRIPTION
This should reduce false triggers due to high IO activity and similar
events increasing global memory PSI despite free memory being available.

Fixes: #12526

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
