### PR TITLE
fix: use append instead of prepend in service-account-issuer

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -141,7 +141,9 @@ BREAKING: If you were relying on the resources EtcdConfigs, KubeletConfigs, Cont
     [notes.serviceAccountIssuer]
     title = "Service Account Issuer configuration"
     description = """\
-In API Server, passing extra args with `service-account-issuer` will prepend them before default value.
+In API Server, passing extra args with `service-account-issuer` will append them after default value.
+This allows easy migration, e.g. by changing `.cluster.controlPlane.endpoint` to new value, and keeping the old value in
+`.cluster.apiServer.extraArgs["service-account-issuer"]`.
 """
 
 [make_deps]

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -429,7 +429,7 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"etcd-keyfile":                     argsbuilder.MergeDenied,
 		"kubelet-client-certificate":       argsbuilder.MergeDenied,
 		"kubelet-client-key":               argsbuilder.MergeDenied,
-		"service-account-issuer":           argsbuilder.MergePrepend,
+		"service-account-issuer":           argsbuilder.MergeAppend,
 		"service-account-key-file":         argsbuilder.MergeDenied,
 		"service-account-signing-key-file": argsbuilder.MergeDenied,
 		"tls-cert-file":                    argsbuilder.MergeDenied,


### PR DESCRIPTION
Changing `.cluster.controlPlane.endpoint=$NEW` will cause old tokens to be no longer valid.
We want to ensure that new tokens are issued using the `.cluster.controlPlane.endpoint=$NEW` value,
but all the existing tokens (issued using `.cluster.controlPlane.endpoint=$OLD`) are still accepted.
