### PR TITLE
feat: add support for configurable route types

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -332,9 +332,9 @@ func (ctrl *RouteConfigController) processMachineConfig(linkConfigs []cfg.Networ
 			route.OutLinkName = linkConfig.Name()
 			route.ConfigLayer = network.ConfigMachineConfiguration
 
-			route.Type = nethelpers.TypeUnicast
+			route.Type = spec.Type().ValueOr(nethelpers.TypeUnicast)
 
-			if route.Destination.Addr().IsMulticast() {
+			if !spec.Type().IsPresent() && route.Destination.Addr().IsMulticast() {
 				route.Type = nethelpers.TypeMulticast
 			}
 

--- a/pkg/machinery/config/config/network.go
+++ b/pkg/machinery/config/config/network.go
@@ -169,6 +169,7 @@ type NetworkRouteConfig interface {
 	MTU() optional.Optional[uint32]
 	Metric() optional.Optional[uint32]
 	Table() optional.Optional[nethelpers.RoutingTable]
+	Type() optional.Optional[nethelpers.RouteType]
 }
 
 // NetworkLinkAliasConfig defines a network link alias configuration.

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2601,6 +2601,24 @@
           "description": "The routing table to use for the route.\n\nIf not specified, the main routing table will be used.\n",
           "markdownDescription": "The routing table to use for the route.\n\nIf not specified, the main routing table will be used.",
           "x-intellij-html-description": "\u003cp\u003eThe routing table to use for the route.\u003c/p\u003e\n\n\u003cp\u003eIf not specified, the main routing table will be used.\u003c/p\u003e\n"
+        },
+        "type": {
+          "enum": [
+            "local",
+            "broadcast",
+            "unicast",
+            "multicast",
+            "blackhole",
+            "unreachable",
+            "prohibit",
+            "throw",
+            "nat",
+            "xresolve"
+          ],
+          "title": "type",
+          "description": "The route type.\n\nIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.\n",
+          "markdownDescription": "The route type.\n\nIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.",
+          "x-intellij-html-description": "\u003cp\u003eThe route type.\u003c/p\u003e\n\n\u003cp\u003eIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/network/link.go
+++ b/pkg/machinery/config/types/network/link.go
@@ -168,6 +168,23 @@ type RouteConfig struct {
 	//   schema:
 	//     type: string
 	RouteTable nethelpers.RoutingTable `yaml:"table,omitempty"`
+	//   description: |
+	//     The route type.
+	//
+	//     If not specified, the route type will be unicast (or multicast for multicast destinations).
+	//     Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.
+	//   values:
+	//     - "local"
+	//     - "broadcast"
+	//     - "unicast"
+	//     - "multicast"
+	//     - "blackhole"
+	//     - "unreachable"
+	//     - "prohibit"
+	//     - "throw"
+	//     - "nat"
+	//     - "xresolve"
+	RouteType nethelpers.RouteType `yaml:"type,omitempty"`
 }
 
 // NewLinkConfigV1Alpha1 creates a new LinkConfig config document.
@@ -385,4 +402,13 @@ func (r RouteConfig) Table() optional.Optional[nethelpers.RoutingTable] {
 	}
 
 	return optional.Some(r.RouteTable)
+}
+
+// Type implements NetworkRouteConfig interface.
+func (r RouteConfig) Type() optional.Optional[nethelpers.RouteType] {
+	if r.RouteType == nethelpers.TypeUnspec {
+		return optional.None[nethelpers.RouteType]()
+	}
+
+	return optional.Some(r.RouteType)
 }

--- a/pkg/machinery/config/types/network/link_test.go
+++ b/pkg/machinery/config/types/network/link_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 )
 
 //go:embed testdata/linkconfig.yaml
@@ -44,6 +45,7 @@ func TestLinkConfigMarshalStability(t *testing.T) {
 		},
 		{
 			RouteGateway: network.Addr{netip.MustParseAddr("fe80::1")},
+			RouteType:    nethelpers.TypeBlackhole,
 		},
 	}
 	cfg.LinkMulticast = pointer.To(true)
@@ -90,6 +92,7 @@ func TestLinkConfigUnmarshal(t *testing.T) {
 				},
 				{
 					RouteGateway: network.Addr{netip.MustParseAddr("fe80::1")},
+					RouteType:    nethelpers.TypeBlackhole,
 				},
 			},
 			LinkMulticast: pointer.To(true),

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -1248,6 +1248,25 @@ func (RouteConfig) Doc() *encoder.Doc {
 				Description: "The routing table to use for the route.\n\nIf not specified, the main routing table will be used.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The routing table to use for the route." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "type",
+				Type:        "RouteType",
+				Note:        "",
+				Description: "The route type.\n\nIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The route type." /* encoder.LineComment */, "" /* encoder.FootComment */},
+				Values: []string{
+					"local",
+					"broadcast",
+					"unicast",
+					"multicast",
+					"blackhole",
+					"unreachable",
+					"prohibit",
+					"throw",
+					"nat",
+					"xresolve",
+				},
+			},
 		},
 	}
 

--- a/pkg/machinery/config/types/network/testdata/linkconfig.yaml
+++ b/pkg/machinery/config/types/network/testdata/linkconfig.yaml
@@ -11,4 +11,5 @@ routes:
     - destination: 10.3.5.0/24
       gateway: 10.3.5.1
     - gateway: fe80::1
+      type: blackhole
 multicast: true

--- a/website/content/v1.13/reference/configuration/network/bondconfig.md
+++ b/website/content/v1.13/reference/configuration/network/bondconfig.md
@@ -204,6 +204,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/reference/configuration/network/bridgeconfig.md
+++ b/website/content/v1.13/reference/configuration/network/bridgeconfig.md
@@ -130,6 +130,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/reference/configuration/network/dummylinkconfig.md
+++ b/website/content/v1.13/reference/configuration/network/dummylinkconfig.md
@@ -83,6 +83,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/reference/configuration/network/linkconfig.md
+++ b/website/content/v1.13/reference/configuration/network/linkconfig.md
@@ -90,6 +90,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/reference/configuration/network/vlanconfig.md
+++ b/website/content/v1.13/reference/configuration/network/vlanconfig.md
@@ -95,6 +95,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/reference/configuration/network/wireguardconfig.md
+++ b/website/content/v1.13/reference/configuration/network/wireguardconfig.md
@@ -116,6 +116,7 @@ gateway: 10.0.0.1
 |`metric` |uint32 |The optional metric for the route.  | |
 |`mtu` |uint32 |The optional MTU for the route.  | |
 |`table` |RoutingTable |The routing table to use for the route.<br><br>If not specified, the main routing table will be used.  | |
+|`type` |RouteType |The route type.<br><br>If not specified, the route type will be unicast (or multicast for multicast destinations).<br>Common types: unicast, local, broadcast, blackhole, unreachable, prohibit.  |`local`<br />`broadcast`<br />`unicast`<br />`multicast`<br />`blackhole`<br />`unreachable`<br />`prohibit`<br />`throw`<br />`nat`<br />`xresolve`<br /> |
 
 
 

--- a/website/content/v1.13/schemas/config.schema.json
+++ b/website/content/v1.13/schemas/config.schema.json
@@ -2601,6 +2601,24 @@
           "description": "The routing table to use for the route.\n\nIf not specified, the main routing table will be used.\n",
           "markdownDescription": "The routing table to use for the route.\n\nIf not specified, the main routing table will be used.",
           "x-intellij-html-description": "\u003cp\u003eThe routing table to use for the route.\u003c/p\u003e\n\n\u003cp\u003eIf not specified, the main routing table will be used.\u003c/p\u003e\n"
+        },
+        "type": {
+          "enum": [
+            "local",
+            "broadcast",
+            "unicast",
+            "multicast",
+            "blackhole",
+            "unreachable",
+            "prohibit",
+            "throw",
+            "nat",
+            "xresolve"
+          ],
+          "title": "type",
+          "description": "The route type.\n\nIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.\n",
+          "markdownDescription": "The route type.\n\nIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.",
+          "x-intellij-html-description": "\u003cp\u003eThe route type.\u003c/p\u003e\n\n\u003cp\u003eIf not specified, the route type will be unicast (or multicast for multicast destinations).\nCommon types: unicast, local, broadcast, blackhole, unreachable, prohibit.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Adds support for specifying route type in network configuration for Talos 1.12+ document-based configs. This enables creation of blackhole routes and other route types (unreachable, prohibit, etc.) in addition to the default unicast routes.

Key changes:
- Add RouteType field to RouteConfig struct in link.go
- Add Type() method to NetworkRouteConfig interface
- Update RouteConfigController.processMachineConfig to use Type from configuration
- Add unit test TestMachineConfigurationWithRouteType for blackhole and unicast routes
- Generate documentation for new RouteType field

Note: This feature is only available in 1.12+ document-based network configuration. v1alpha1 (pre-1.12) configs continue to default to unicast routes as the cfg.Route interface doesn't support the Type() method.

## Why? (reasoning)

In order to workaround the connectivity check that requires to set a default gateway, we'd like to create a blackhole for default gateway, but it is currently not possible because the route type is not exposed.

see. https://github.com/siderolabs/talos/discussions/12400

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
