### PR TITLE
fix: boot with GRUB

### DIFF
--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -250,10 +250,9 @@ func (q Quirks) XFSMkfsConfig() string {
 	// if the version doesn't parse, we assume it's latest Talos
 	// update when we have a new LTS config
 	case version == nil:
-		return "/usr/share/xfsprogs/mkfs/lts_6.18.conf"
+		// [TODO]: lts_6.18.config doesn't work with GRUB, it doesn't recognize the xfs filesystem.
+		return "/usr/share/xfsprogs/mkfs/lts_6.12.conf"
 	// add new version once we have a new LTS config
-	case version.GTE(semver.MustParse("1.13.0")):
-		return "/usr/share/xfsprogs/mkfs/lts_6.18.conf"
 	case version.GTE(semver.MustParse("1.10.0")):
 		return "/usr/share/xfsprogs/mkfs/lts_6.12.conf"
 	case version.GTE(semver.MustParse("1.8.0")) && version.LT(semver.MustParse("1.10.0")):

--- a/pkg/machinery/imager/quirks/quirks_test.go
+++ b/pkg/machinery/imager/quirks/quirks_test.go
@@ -169,10 +169,10 @@ func TestXFSMkfsConfigFile(t *testing.T) {
 		},
 		{
 			version:  "1.13.0",
-			expected: "/usr/share/xfsprogs/mkfs/lts_6.18.conf",
+			expected: "/usr/share/xfsprogs/mkfs/lts_6.12.conf",
 		},
 		{
-			expected: "/usr/share/xfsprogs/mkfs/lts_6.18.conf",
+			expected: "/usr/share/xfsprogs/mkfs/lts_6.12.conf",
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {


### PR DESCRIPTION
The problem is that xfs with 6.18 LTS settings is not supported by GRUB yet. It might be supported with newly released 2.14 though.
