### PR TITLE
feat: add support for negative max size

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -169,6 +169,7 @@ message PartitionSpec {
   string label = 4;
   string type_uuid = 5;
   uint64 relative_max_size = 6;
+  bool negative_max_size = 7;
 }
 
 // ProvisioningSpec is the spec for volume provisioning.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -146,6 +146,15 @@ This allows easy migration, e.g. by changing `.cluster.controlPlane.endpoint` to
 `.cluster.apiServer.extraArgs["service-account-issuer"]`.
 """
 
+    [notes.negativeMaxVolumeSize]
+    title = "Negative Max Volume Size"
+    description = """\
+Negative max size represents the amount of space to be left free on the device, rather than the size the volume should consume.
+For example:
+    * a max size of "-10GiB" means the volume can grow to the available space minus 10GiB.
+    * a max size of "-25%" means the volume can grow to the available space minus 25%.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/partition.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/partition.go
@@ -65,7 +65,11 @@ func CreatePartition(ctx context.Context, logger *zap.Logger, diskPath string, v
 	available := pt.LargestContiguousAllocatable()
 
 	size := volumeCfg.TypedSpec().Provisioning.PartitionSpec.MinSize
-	maxSize := volumeCfg.TypedSpec().Provisioning.PartitionSpec.ResolveMaxSize(available)
+
+	maxSize, err := volumeCfg.TypedSpec().Provisioning.PartitionSpec.ResolveMaxSize(available)
+	if err != nil {
+		return CreatePartitionResult{}, fmt.Errorf("error resolving max size: %w", err)
+	}
 
 	if available < size {
 		// should never happen

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
@@ -116,6 +116,7 @@ func GetEphemeralVolumeTransformer(inContainer bool) volumeConfigTransformer {
 							MinSize:         extraVolumeConfig.Provisioning().MinSize().ValueOr(quirks.New("").PartitionSizes().EphemeralMinSize()),
 							MaxSize:         extraVolumeConfig.Provisioning().MaxSize().ValueOrZero(),
 							RelativeMaxSize: extraVolumeConfig.Provisioning().RelativeMaxSize().ValueOrZero(),
+							NegativeMaxSize: extraVolumeConfig.Provisioning().MaxSizeNegative(),
 							Grow:            extraVolumeConfig.Provisioning().Grow().ValueOr(true),
 							Label:           constants.EphemeralPartitionLabel,
 							TypeUUID:        partition.LinuxFilesystemData,

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
@@ -105,6 +105,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 						MinSize:         cmp.Or(userVolumeConfig.Provisioning().MinSize().ValueOrZero(), MinUserVolumeSize),
 						MaxSize:         userVolumeConfig.Provisioning().MaxSize().ValueOrZero(),
 						RelativeMaxSize: userVolumeConfig.Provisioning().RelativeMaxSize().ValueOrZero(),
+						NegativeMaxSize: userVolumeConfig.Provisioning().MaxSizeNegative(),
 						Grow:            userVolumeConfig.Provisioning().Grow().ValueOrZero(),
 						Label:           volumeID,
 						TypeUUID:        partition.LinuxFilesystemData,
@@ -317,6 +318,7 @@ func SwapVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 					PartitionSpec: block.PartitionSpec{
 						MaxSize:         cmp.Or(swapVolumeConfig.Provisioning().MaxSize().ValueOrZero(), MinUserVolumeSize),
 						RelativeMaxSize: swapVolumeConfig.Provisioning().RelativeMaxSize().ValueOrZero(),
+						NegativeMaxSize: swapVolumeConfig.Provisioning().MaxSizeNegative(),
 						Grow:            swapVolumeConfig.Provisioning().Grow().ValueOrZero(),
 						Label:           volumeID,
 						TypeUUID:        partition.LinkSwap,

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -1328,6 +1328,7 @@ type PartitionSpec struct {
 	Label           string                 `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
 	TypeUuid        string                 `protobuf:"bytes,5,opt,name=type_uuid,json=typeUuid,proto3" json:"type_uuid,omitempty"`
 	RelativeMaxSize uint64                 `protobuf:"varint,6,opt,name=relative_max_size,json=relativeMaxSize,proto3" json:"relative_max_size,omitempty"`
+	NegativeMaxSize bool                   `protobuf:"varint,7,opt,name=negative_max_size,json=negativeMaxSize,proto3" json:"negative_max_size,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1402,6 +1403,13 @@ func (x *PartitionSpec) GetRelativeMaxSize() uint64 {
 		return x.RelativeMaxSize
 	}
 	return 0
+}
+
+func (x *PartitionSpec) GetNegativeMaxSize() bool {
+	if x != nil {
+		return x.NegativeMaxSize
+	}
+	return false
 }
 
 // ProvisioningSpec is the spec for volume provisioning.
@@ -2534,14 +2542,15 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\x04type\x18\x01 \x01(\x0e26.talos.resource.definitions.enums.BlockFSParameterTypeR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
 	"\x06string\x18\x03 \x01(\tR\x06string\x12\x16\n" +
-	"\x06binary\x18\x05 \x01(\fR\x06binary\"\xb8\x01\n" +
+	"\x06binary\x18\x05 \x01(\fR\x06binary\"\xe4\x01\n" +
 	"\rPartitionSpec\x12\x19\n" +
 	"\bmin_size\x18\x01 \x01(\x04R\aminSize\x12\x19\n" +
 	"\bmax_size\x18\x02 \x01(\x04R\amaxSize\x12\x12\n" +
 	"\x04grow\x18\x03 \x01(\bR\x04grow\x12\x14\n" +
 	"\x05label\x18\x04 \x01(\tR\x05label\x12\x1b\n" +
 	"\ttype_uuid\x18\x05 \x01(\tR\btypeUuid\x12*\n" +
-	"\x11relative_max_size\x18\x06 \x01(\x04R\x0frelativeMaxSize\"\xae\x02\n" +
+	"\x11relative_max_size\x18\x06 \x01(\x04R\x0frelativeMaxSize\x12*\n" +
+	"\x11negative_max_size\x18\a \x01(\bR\x0fnegativeMaxSize\"\xae\x02\n" +
 	"\x10ProvisioningSpec\x12S\n" +
 	"\rdisk_selector\x18\x01 \x01(\v2..talos.resource.definitions.block.DiskSelectorR\fdiskSelector\x12V\n" +
 	"\x0epartition_spec\x18\x02 \x01(\v2/.talos.resource.definitions.block.PartitionSpecR\rpartitionSpec\x12\x12\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -1286,6 +1286,16 @@ func (m *PartitionSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.NegativeMaxSize {
+		i--
+		if m.NegativeMaxSize {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
 	if m.RelativeMaxSize != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RelativeMaxSize))
 		i--
@@ -2813,6 +2823,9 @@ func (m *PartitionSpec) SizeVT() (n int) {
 	}
 	if m.RelativeMaxSize != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.RelativeMaxSize))
+	}
+	if m.NegativeMaxSize {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6795,6 +6808,26 @@ func (m *PartitionSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NegativeMaxSize", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NegativeMaxSize = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -33,6 +33,7 @@ type VolumeProvisioningConfig interface {
 	MinSize() optional.Optional[uint64]
 	MaxSize() optional.Optional[uint64]
 	RelativeMaxSize() optional.Optional[uint64]
+	MaxSizeNegative() bool
 }
 
 // WrapVolumesConfigList wraps a list of VolumeConfig providing access by name.
@@ -82,12 +83,12 @@ func (emptyVolumeConfig) MaxSize() optional.Optional[uint64] {
 	return optional.None[uint64]()
 }
 
-func (emptyVolumeConfig) RelativeMinSize() optional.Optional[uint64] {
+func (emptyVolumeConfig) RelativeMaxSize() optional.Optional[uint64] {
 	return optional.None[uint64]()
 }
 
-func (emptyVolumeConfig) RelativeMaxSize() optional.Optional[uint64] {
-	return optional.None[uint64]()
+func (emptyVolumeConfig) MaxSizeNegative() bool {
+	return false
 }
 
 // UserVolumeConfig defines the interface to access user volume configuration.

--- a/pkg/machinery/config/types/block/size.go
+++ b/pkg/machinery/config/types/block/size.go
@@ -115,3 +115,16 @@ func (s Size) IsZero() bool {
 func (s Size) IsRelative() bool {
 	return (s.PercentageSize != nil && !s.PercentageSize.IsZero())
 }
+
+// IsNegative returns true if the value is negative.
+func (s Size) IsNegative() bool {
+	if s.ByteSize != nil {
+		return s.ByteSize.IsNegative()
+	}
+
+	if s.PercentageSize != nil {
+		return s.PercentageSize.IsNegative()
+	}
+
+	return false
+}

--- a/pkg/machinery/config/types/block/size_test.go
+++ b/pkg/machinery/config/types/block/size_test.go
@@ -18,8 +18,9 @@ func TestSizeUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
-		in   string
-		want uint64
+		in       string
+		want     uint64
+		negative bool
 	}{
 		{in: "", want: 0},
 		{in: "100%", want: 100},
@@ -30,6 +31,14 @@ func TestSizeUnmarshal(t *testing.T) {
 		{in: "2.5GB", want: 2500000000},
 		{in: "2.5G", want: 2500000000},
 		{in: "1MiB", want: 1048576},
+		{in: "-100%", want: 100, negative: true},
+		{in: "-33.4%", want: 33, negative: true},
+		{in: "-33.4124%", want: 33, negative: true},
+		{in: "-1048576", want: 1048576, negative: true},
+		{in: "-2.5GiB", want: 2684354560, negative: true},
+		{in: "-2.5GB", want: 2500000000, negative: true},
+		{in: "-2.5G", want: 2500000000, negative: true},
+		{in: "-1MiB", want: 1048576, negative: true},
 	} {
 		t.Run(test.in, func(t *testing.T) {
 			t.Parallel()
@@ -44,12 +53,14 @@ func TestSizeUnmarshal(t *testing.T) {
 				val, ok := s.RelativeValue()
 				assert.True(t, ok)
 				assert.Equal(t, test.want, val)
+				assert.Equal(t, test.negative, s.IsNegative())
 			} else {
 				assert.Equal(t, test.want, s.Value())
 
 				val, ok := s.RelativeValue()
 				assert.False(t, ok)
 				assert.Zero(t, val)
+				assert.Equal(t, test.negative, s.IsNegative())
 			}
 
 			out, err := s.MarshalText()

--- a/pkg/machinery/config/types/block/testdata/volumeconfig_negativemaxsize.yaml
+++ b/pkg/machinery/config/types/block/testdata/volumeconfig_negativemaxsize.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+provisioning:
+    minSize: 10GiB
+    maxSize: -10GiB

--- a/pkg/machinery/config/types/block/volume_config_test.go
+++ b/pkg/machinery/config/types/block/volume_config_test.go
@@ -66,6 +66,19 @@ func TestVolumeConfigMarshalUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:     "negative max size",
+			filename: "volumeconfig_negativemaxsize.yaml",
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("-10GiB")
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+
+				return c
+			},
+		},
+		{
 			name:     "state",
 			filename: "volumeconfig_state.yaml",
 			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
@@ -172,6 +185,21 @@ func TestVolumeConfigValidate(t *testing.T) {
 			expectedErrors: "min size is greater than max size",
 		},
 		{
+			name: "min size negative",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("-10GiB")
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("10GiB")
+
+				return c
+			},
+
+			expectedErrors: "min size cannot be negative",
+		},
+		{
 			name: "state provisioning config",
 
 			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
@@ -252,6 +280,34 @@ func TestVolumeConfigValidate(t *testing.T) {
 
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("2.5TiB")
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+
+				return c
+			},
+		},
+		{
+			name: "valid negative",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("-2GiB")
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+
+				return c
+			},
+		},
+		{
+			name: "valid percentage",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("90%")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
 
 				return c

--- a/pkg/machinery/resources/block/volume_config_test.go
+++ b/pkg/machinery/resources/block/volume_config_test.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package block_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+func TestPartitionSpec_ResolveMaxSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		ps        *block.PartitionSpec
+		available uint64
+		want      uint64
+		err       string
+	}{
+		{
+			name: "absolute max size",
+			ps: &block.PartitionSpec{
+				MaxSize: 50,
+			},
+			available: 100,
+			want:      50,
+		},
+		{
+			name: "relative max size",
+			ps: &block.PartitionSpec{
+				RelativeMaxSize: 50,
+			},
+			available: 100,
+			want:      50,
+		},
+		{
+			name: "negative absolute max size",
+			ps: &block.PartitionSpec{
+				MaxSize:         20,
+				NegativeMaxSize: true,
+			},
+			available: 100,
+			want:      80,
+		},
+		{
+			name: "negative relative max size",
+			ps: &block.PartitionSpec{
+				RelativeMaxSize: 25,
+				NegativeMaxSize: true,
+			},
+			available: 200,
+			want:      150,
+		},
+		{
+			name:      "zero sizes",
+			ps:        &block.PartitionSpec{},
+			available: 100,
+			want:      0,
+		},
+		{
+			name: "negative absolute max size > available",
+			ps: &block.PartitionSpec{
+				MaxSize:         2500,
+				NegativeMaxSize: true,
+			},
+			available: 200,
+			err:       "partition size cannot be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := tt.ps.ResolveMaxSize(tt.available)
+			assert.Equal(t, tt.want, actual)
+
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/website/content/v1.13/reference/api.md
+++ b/website/content/v1.13/reference/api.md
@@ -5784,6 +5784,7 @@ PartitionSpec is the spec for volume partitioning.
 | label | [string](#string) |  |  |
 | type_uuid | [string](#string) |  |  |
 | relative_max_size | [uint64](#uint64) |  |  |
+| negative_max_size | [bool](#bool) |  |  |
 
 
 


### PR DESCRIPTION
Add support for negative max size values in volume configuration. Negative max size represents the amount of space to be left free on the device, rather than the size the volume should consume. For example, a max size of "-10GiB" means the volume can grow to the device size minus 10GiB.

Closes #12405

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
