### PR TITLE
fix: marshal of FailOverMac property

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected-2bonds.yaml
@@ -65,7 +65,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200
@@ -91,7 +91,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/equinixmetal/testdata/expected.yaml
@@ -48,7 +48,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1-pnap.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v1-pnap.yaml
@@ -42,7 +42,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         resendIgmp: 1
         lpInterval: 1

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2-serverscom.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2-serverscom.yaml
@@ -59,7 +59,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200
@@ -85,7 +85,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/nocloud/testdata/expected-v2.yaml
@@ -74,7 +74,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -43,7 +43,7 @@ links:
         arpValidate: none
         arpAllTargets: any
         primaryReselect: always
-        failOverMac: 0
+        failOverMac: none
         miimon: 100
         updelay: 200
         downdelay: 200

--- a/pkg/machinery/config/types/network/bond_test.go
+++ b/pkg/machinery/config/types/network/bond_test.go
@@ -30,6 +30,7 @@ func TestBondConfigMarshalStability(t *testing.T) {
 	cfg.BondLinks = []string{"eth0", "eth1"}
 	cfg.BondMode = pointer.To(nethelpers.BondMode8023AD)
 	cfg.BondXmitHashPolicy = pointer.To(nethelpers.BondXmitPolicyLayer34)
+	cfg.BondFailOverMAC = pointer.To(nethelpers.FailOverMACFollow)
 	cfg.BondLACPRate = pointer.To(nethelpers.LACPRateSlow)
 	cfg.BondMIIMon = pointer.To(uint32(100))
 	cfg.BondUpDelay = pointer.To(uint32(200))
@@ -70,6 +71,7 @@ func TestBondConfigUnmarshal(t *testing.T) {
 		BondLinks:           []string{"eth0", "eth1"},
 		BondMode:            pointer.To(nethelpers.BondMode8023AD),
 		BondXmitHashPolicy:  pointer.To(nethelpers.BondXmitPolicyLayer34),
+		BondFailOverMAC:     pointer.To(nethelpers.FailOverMACFollow),
 		BondLACPRate:        pointer.To(nethelpers.LACPRateSlow),
 		BondMIIMon:          pointer.To(uint32(100)),
 		BondUpDelay:         pointer.To(uint32(200)),

--- a/pkg/machinery/config/types/network/testdata/bondconfig.yaml
+++ b/pkg/machinery/config/types/network/testdata/bondconfig.yaml
@@ -10,6 +10,7 @@ updelay: 200
 downdelay: 200
 xmitHashPolicy: layer3+4
 lacpRate: slow
+failOverMac: follow
 adActorSysPrio: 65535
 resendIGMP: 1
 packetsPerSlave: 1

--- a/pkg/machinery/nethelpers/failovermac_test.go
+++ b/pkg/machinery/nethelpers/failovermac_test.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nethelpers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+)
+
+func TestFailOverMACUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		input    string
+		expected nethelpers.FailOverMAC
+	}{
+		{
+			input:    "none",
+			expected: nethelpers.FailOverMACNone,
+		},
+		{
+			input:    "active",
+			expected: nethelpers.FailOverMACActive,
+		},
+		{
+			input:    "follow",
+			expected: nethelpers.FailOverMACFollow,
+		},
+		{
+			input:    "",
+			expected: nethelpers.FailOverMACNone,
+		},
+		{
+			input:    "0",
+			expected: nethelpers.FailOverMACNone,
+		},
+		{
+			input:    "1",
+			expected: nethelpers.FailOverMACActive,
+		},
+		{
+			input:    "2",
+			expected: nethelpers.FailOverMACFollow,
+		},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+
+			var f nethelpers.FailOverMAC
+
+			err := f.UnmarshalText([]byte(test.input))
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, f)
+		})
+	}
+}

--- a/pkg/machinery/resources/network/link_spec_test.go
+++ b/pkg/machinery/resources/network/link_spec_test.go
@@ -105,7 +105,7 @@ bondMaster:
     arpAllTargets: any
     primary: 3
     primaryReselect: better
-    failOverMac: 2
+    failOverMac: follow
     adSelect: count
     miimon: 33
     updelay: 100

--- a/pkg/machinery/resources/network/link_status_test.go
+++ b/pkg/machinery/resources/network/link_status_test.go
@@ -144,7 +144,7 @@ bondMaster:
     arpAllTargets: any
     primary: 3
     primaryReselect: better
-    failOverMac: 2
+    failOverMac: follow
     adSelect: count
     miimon: 33
     updelay: 100


### PR DESCRIPTION
This value for some historical reason (I guess treating empty string as 'none') doesn't use standard enumer's methods.

So we shipped it in Talos 1.12 without proper encoding/decoding in YAML config documents (it was actually converted to int).

Fix encoding, but keep backwards compatibility for integer values just in case someone already started relying on it.

Fixes #12625
