### PR TITLE
fix: use node podCIDRs for kubespan advertiseKubernetesNetworks

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -218,6 +218,7 @@ message NodeStatusSpec {
   bool unschedulable = 3;
   map<string, string> labels = 4;
   map<string, string> annotations = 5;
+  repeated common.NetIPPrefix pod_cid_rs = 6;
 }
 
 // NodeTaintSpecSpec represents a label that's attached to a Talos node.

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -1780,6 +1780,7 @@ type NodeStatusSpec struct {
 	Unschedulable bool                   `protobuf:"varint,3,opt,name=unschedulable,proto3" json:"unschedulable,omitempty"`
 	Labels        map[string]string      `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Annotations   map[string]string      `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	PodCidRs      []*common.NetIPPrefix  `protobuf:"bytes,6,rep,name=pod_cid_rs,json=podCidRs,proto3" json:"pod_cid_rs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1845,6 +1846,13 @@ func (x *NodeStatusSpec) GetLabels() map[string]string {
 func (x *NodeStatusSpec) GetAnnotations() map[string]string {
 	if x != nil {
 		return x.Annotations
+	}
+	return nil
+}
+
+func (x *NodeStatusSpec) GetPodCidRs() []*common.NetIPPrefix {
+	if x != nil {
+		return x.PodCidRs
 	}
 	return nil
 }
@@ -2509,14 +2517,16 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\taddresses\x18\x01 \x03(\v2\r.common.NetIPR\taddresses\";\n" +
 	"\x11NodeLabelSpecSpec\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\xa3\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\xd6\x03\n" +
 	"\x0eNodeStatusSpec\x12\x1a\n" +
 	"\bnodename\x18\x01 \x01(\tR\bnodename\x12\x1d\n" +
 	"\n" +
 	"node_ready\x18\x02 \x01(\bR\tnodeReady\x12$\n" +
 	"\runschedulable\x18\x03 \x01(\bR\runschedulable\x12R\n" +
 	"\x06labels\x18\x04 \x03(\v2:.talos.resource.definitions.k8s.NodeStatusSpec.LabelsEntryR\x06labels\x12a\n" +
-	"\vannotations\x18\x05 \x03(\v2?.talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntryR\vannotations\x1a9\n" +
+	"\vannotations\x18\x05 \x03(\v2?.talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntryR\vannotations\x121\n" +
+	"\n" +
+	"pod_cid_rs\x18\x06 \x03(\v2\x13.common.NetIPPrefixR\bpodCidRs\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
@@ -2634,6 +2644,7 @@ var file_resource_definitions_k8s_k8s_proto_goTypes = []any{
 	(*structpb.Struct)(nil),              // 48: google.protobuf.Struct
 	(*common.NetIP)(nil),                 // 49: common.NetIP
 	(*proto.Mount)(nil),                  // 50: talos.resource.definitions.proto.Mount
+	(*common.NetIPPrefix)(nil),           // 51: common.NetIPPrefix
 }
 var file_resource_definitions_k8s_k8s_proto_depIdxs = []int32{
 	36, // 0: talos.resource.definitions.k8s.APIServerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.APIServerConfigSpec.ExtraArgsEntry
@@ -2665,25 +2676,26 @@ var file_resource_definitions_k8s_k8s_proto_depIdxs = []int32{
 	49, // 26: talos.resource.definitions.k8s.NodeIPSpec.addresses:type_name -> common.NetIP
 	42, // 27: talos.resource.definitions.k8s.NodeStatusSpec.labels:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.LabelsEntry
 	43, // 28: talos.resource.definitions.k8s.NodeStatusSpec.annotations:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntry
-	44, // 29: talos.resource.definitions.k8s.Resources.requests:type_name -> talos.resource.definitions.k8s.Resources.RequestsEntry
-	45, // 30: talos.resource.definitions.k8s.Resources.limits:type_name -> talos.resource.definitions.k8s.Resources.LimitsEntry
-	46, // 31: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry
-	13, // 32: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
-	47, // 33: talos.resource.definitions.k8s.SchedulerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.EnvironmentVariablesEntry
-	29, // 34: talos.resource.definitions.k8s.SchedulerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
-	48, // 35: talos.resource.definitions.k8s.SchedulerConfigSpec.config:type_name -> google.protobuf.Struct
-	48, // 36: talos.resource.definitions.k8s.SingleManifest.object:type_name -> google.protobuf.Struct
-	48, // 37: talos.resource.definitions.k8s.StaticPodSpec.pod:type_name -> google.protobuf.Struct
-	48, // 38: talos.resource.definitions.k8s.StaticPodStatusSpec.pod_status:type_name -> google.protobuf.Struct
-	3,  // 39: talos.resource.definitions.k8s.APIServerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 40: talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 41: talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 42: talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	43, // [43:43] is the sub-list for method output_type
-	43, // [43:43] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	51, // 29: talos.resource.definitions.k8s.NodeStatusSpec.pod_cid_rs:type_name -> common.NetIPPrefix
+	44, // 30: talos.resource.definitions.k8s.Resources.requests:type_name -> talos.resource.definitions.k8s.Resources.RequestsEntry
+	45, // 31: talos.resource.definitions.k8s.Resources.limits:type_name -> talos.resource.definitions.k8s.Resources.LimitsEntry
+	46, // 32: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry
+	13, // 33: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
+	47, // 34: talos.resource.definitions.k8s.SchedulerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.EnvironmentVariablesEntry
+	29, // 35: talos.resource.definitions.k8s.SchedulerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
+	48, // 36: talos.resource.definitions.k8s.SchedulerConfigSpec.config:type_name -> google.protobuf.Struct
+	48, // 37: talos.resource.definitions.k8s.SingleManifest.object:type_name -> google.protobuf.Struct
+	48, // 38: talos.resource.definitions.k8s.StaticPodSpec.pod:type_name -> google.protobuf.Struct
+	48, // 39: talos.resource.definitions.k8s.StaticPodStatusSpec.pod_status:type_name -> google.protobuf.Struct
+	3,  // 40: talos.resource.definitions.k8s.APIServerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 41: talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 42: talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 43: talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	44, // [44:44] is the sub-list for method output_type
+	44, // [44:44] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_resource_definitions_k8s_k8s_proto_init() }

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -1888,6 +1888,30 @@ func (m *NodeStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PodCidRs) > 0 {
+		for iNdEx := len(m.PodCidRs) - 1; iNdEx >= 0; iNdEx-- {
+			if vtmsg, ok := interface{}(m.PodCidRs[iNdEx]).(interface {
+				MarshalToSizedBufferVT([]byte) (int, error)
+			}); ok {
+				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			} else {
+				encoded, err := proto.Marshal(m.PodCidRs[iNdEx])
+				if err != nil {
+					return 0, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			}
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if len(m.Annotations) > 0 {
 		for k := range m.Annotations {
 			v := m.Annotations[k]
@@ -3259,6 +3283,18 @@ func (m *NodeStatusSpec) SizeVT() (n int) {
 			_ = v
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.PodCidRs) > 0 {
+		for _, e := range m.PodCidRs {
+			if size, ok := interface{}(e).(interface {
+				SizeVT() int
+			}); ok {
+				l = size.SizeVT()
+			} else {
+				l = proto.Size(e)
+			}
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -8724,6 +8760,48 @@ func (m *NodeStatusSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodCidRs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PodCidRs = append(m.PodCidRs, &common.NetIPPrefix{})
+			if unmarshal, ok := interface{}(m.PodCidRs[len(m.PodCidRs)-1]).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.PodCidRs[len(m.PodCidRs)-1]); err != nil {
+					return err
+				}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/resources/k8s/deep_copy.generated.go
+++ b/pkg/machinery/resources/k8s/deep_copy.generated.go
@@ -424,6 +424,10 @@ func (o NodeStatusSpec) DeepCopy() NodeStatusSpec {
 			cp.Annotations[k2] = v2
 		}
 	}
+	if o.PodCIDRs != nil {
+		cp.PodCIDRs = make([]netip.Prefix, len(o.PodCIDRs))
+		copy(cp.PodCIDRs, o.PodCIDRs)
+	}
 	return cp
 }
 

--- a/pkg/machinery/resources/k8s/node_status.go
+++ b/pkg/machinery/resources/k8s/node_status.go
@@ -5,6 +5,8 @@
 package k8s
 
 import (
+	"net/netip"
+
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
@@ -28,6 +30,7 @@ type NodeStatusSpec struct {
 	Unschedulable bool              `yaml:"unschedulable" protobuf:"3"`
 	Labels        map[string]string `yaml:"labels" protobuf:"4"`
 	Annotations   map[string]string `yaml:"annotations" protobuf:"5"`
+	PodCIDRs      []netip.Prefix    `yaml:"podCIDRs" protobuf:"6"`
 }
 
 // NewNodeStatus initializes a NodeStatus resource.

--- a/website/content/v1.13/reference/api.md
+++ b/website/content/v1.13/reference/api.md
@@ -7398,6 +7398,7 @@ NodeStatusSpec describes Kubernetes NodeStatus.
 | unschedulable | [bool](#bool) |  |  |
 | labels | [NodeStatusSpec.LabelsEntry](#talos.resource.definitions.k8s.NodeStatusSpec.LabelsEntry) | repeated |  |
 | annotations | [NodeStatusSpec.AnnotationsEntry](#talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntry) | repeated |  |
+| pod_cid_rs | [common.NetIPPrefix](#common.NetIPPrefix) | repeated |  |
 
 
 


### PR DESCRIPTION


# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This changes the way kubespan gets the podCIDR to advertise when `advertiseKubernetesNetworks` is enabled. Before, it used the interface address, but some CNIs (such as Cilium in NativeRouting) only set a single /32 IP to a single interface (`cilium_host` in cilium's case). This adds the `v1.Node`'s `.spec.podCIDRs` array to the `k8s.NodeStatus` object and uses this to advertise the kubernetes network.


## Why? (reasoning)

https://github.com/siderolabs/talos/issues/9043#issuecomment-3748835327


## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
