### PR TITLE
fix(talosctl): pass --k8s-endpoint flag to rotate-ca kubernetes rotation

### DIFF
--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -150,6 +150,8 @@ func rotateKubernetesCA(ctx context.Context, c *client.Client, encoderOpt encode
 		TalosClient: c,
 		ClusterInfo: clusterInfo,
 
+		KubernetesEndpoint: rotateCACmdFlags.forceEndpoint,
+
 		NewKubernetesCA: newBundle.Certs.K8s,
 
 		EncoderOption: encoderOpt,

--- a/pkg/rotate/pki/kubernetes/kubernetes.go
+++ b/pkg/rotate/pki/kubernetes/kubernetes.go
@@ -42,6 +42,9 @@ type Options struct {
 	// ClusterInfo provides information about cluster topology.
 	ClusterInfo cluster.Info
 
+	// KubernetesEndpoint overrides the default Kubernetes API endpoint.
+	KubernetesEndpoint string
+
 	// NewKubernetesCA is the new CA for Kubernetes API.
 	NewKubernetesCA *x509.PEMEncodedCertificateAndKey
 
@@ -168,6 +171,7 @@ func (r *rotator) fetchClient(ctx context.Context, clientPtr **cluster.Kubernete
 
 	*clientPtr = &cluster.KubernetesClient{
 		ClientProvider: r.talosClientProvider,
+		ForceEndpoint:  r.opts.KubernetesEndpoint,
 	}
 
 	_, err := (*clientPtr).K8sClient(client.WithNode(ctx, firstNode.InternalIP.String()))


### PR DESCRIPTION
## What? (description)

Pass the `--k8s-endpoint` flag value to the Kubernetes client during CA rotation.

The flag was defined in the CLI but never actually used - the value was stored in `rotateCACmdFlags.forceEndpoint` but not passed to `kubernetes.Options`, so the Kubernetes client always used the default endpoint from kubeconfig.

## Why? (reasoning)

When rotating Kubernetes CA on a cluster behind NAT or with a virtual IP that is not directly accessible, users need to specify an alternative endpoint. Without this fix, the `--k8s-endpoint` flag has no effect and the rotation fails trying to connect to the unreachable default endpoint.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)