### PR TITLE
blockutils: open the filesystem as read-only

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/blockutils/blockutils.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/blockutils/blockutils.go
@@ -154,6 +154,7 @@ func ReadFromVolume(ctx context.Context, r state.State, labels []string, cb func
 		mount.WithFsopen(
 			volumeStatus.TypedSpec().Filesystem.String(),
 			fsopen.WithSource(volumeStatus.TypedSpec().MountLocation),
+			fsopen.WithBoolParameter("ro"),
 		),
 		mount.WithDetached(),
 	)


### PR DESCRIPTION
Updated `ReadFromVolume` to open the filesystem it's attempting to read from as read-only. This allows `vfat` cloud init volumes to be successfully read by Talos Linux. This change was made here and not in `pkg/xfs/fsopen/fsopen_linux.go` so that it only applies to volumes that are being read for cloud init configuration, not all volumes.

Fixes https://github.com/siderolabs/talos/issues/12647.