### PR TITLE
feat(talosctl): add --skip-verify flag to skip TLS certificate verification

### DIFF
--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -98,6 +98,10 @@ var applyConfigCmd = &cobra.Command{
 				return WithClientMaintenance(applyConfigCmdFlags.certFingerprints, f)
 			}
 
+			if GlobalArgs.SkipVerify {
+				return WithClientSkipVerify(f)
+			}
+
 			return WithClient(f)
 		}
 

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -56,6 +56,10 @@ To get a list of all available resource definitions, issue 'talosctl get rd'`,
 			return WithClientMaintenance(nil, getResources(args))
 		}
 
+		if GlobalArgs.SkipVerify {
+			return WithClientSkipVerify(getResources(args))
+		}
+
 		return WithClient(getResources(args))
 	},
 }

--- a/cmd/talosctl/cmd/talos/meta.go
+++ b/cmd/talosctl/cmd/talos/meta.go
@@ -43,6 +43,10 @@ var metaWriteCmd = &cobra.Command{
 			return WithClientMaintenance(nil, fn)
 		}
 
+		if GlobalArgs.SkipVerify {
+			return WithClientSkipVerify(fn)
+		}
+
 		return WithClient(fn)
 	},
 }
@@ -64,6 +68,10 @@ var metaDeleteCmd = &cobra.Command{
 
 		if metaCmdFlags.insecure {
 			return WithClientMaintenance(nil, fn)
+		}
+
+		if GlobalArgs.SkipVerify {
+			return WithClientSkipVerify(fn)
 		}
 
 		return WithClient(fn)

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -113,6 +113,10 @@ var resetCmd = &cobra.Command{
 				return WithClientMaintenance(nil, resetNoWait)
 			}
 
+			if GlobalArgs.SkipVerify {
+				return WithClientSkipVerify(resetNoWait)
+			}
+
 			return WithClient(resetNoWait)
 		}
 

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -52,6 +52,12 @@ func WithClientMaintenance(enforceFingerprints []string, action func(context.Con
 	return GlobalArgs.WithClientMaintenance(enforceFingerprints, action)
 }
 
+// WithClientSkipVerify wraps common code to initialize Talos client with TLS verification disabled
+// but with client certificate authentication preserved.
+func WithClientSkipVerify(action func(context.Context, *client.Client) error) error {
+	return GlobalArgs.WithClientSkipVerify(action)
+}
+
 // Commands is a list of commands published by the package.
 var Commands []*cobra.Command
 
@@ -81,6 +87,7 @@ func addCommand(cmd *cobra.Command) {
 		),
 	)
 	cli.Should(cmd.RegisterFlagCompletionFunc("context", CompleteConfigContext))
+	cmd.PersistentFlags().BoolVar(&GlobalArgs.SkipVerify, "skip-verify", false, "skip TLS certificate verification (keeps client authentication)")
 
 	Commands = append(Commands, cmd)
 }

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -130,6 +130,10 @@ func runUpgradeNoWait(opts []client.UpgradeOption) error {
 		return WithClientMaintenance(nil, upgradeFn)
 	}
 
+	if GlobalArgs.SkipVerify {
+		return WithClientSkipVerify(upgradeFn)
+	}
+
 	return WithClient(upgradeFn)
 }
 

--- a/cmd/talosctl/cmd/talos/version.go
+++ b/cmd/talosctl/cmd/talos/version.go
@@ -54,6 +54,10 @@ var versionCmd = &cobra.Command{
 			return WithClientMaintenance(nil, cmdVersion)
 		}
 
+		if GlobalArgs.SkipVerify {
+			return WithClientSkipVerify(cmdVersion)
+		}
+
 		return WithClient(cmdVersion)
 	},
 }

--- a/cmd/talosctl/cmd/talos/wipe.go
+++ b/cmd/talosctl/cmd/talos/wipe.go
@@ -43,6 +43,10 @@ Use device names as arguments, for example: vda or sda5.`,
 			return WithClientMaintenance(nil, cmdWipe(args))
 		}
 
+		if GlobalArgs.SkipVerify {
+			return WithClientSkipVerify(cmdWipe(args))
+		}
+
 		return WithClient(cmdWipe(args))
 	},
 }

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -8,6 +8,7 @@ package global
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -27,6 +28,7 @@ type Args struct {
 	Nodes           []string
 	Endpoints       []string
 	SideroV1KeysDir string
+	SkipVerify      bool
 }
 
 // NodeList returns the list of nodes to run the command against.
@@ -38,6 +40,11 @@ func (c *Args) NodeList() []string {
 //
 // WithClientNoNodes doesn't set any node information on the request context.
 func (c *Args) WithClientNoNodes(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	// If SkipVerify is set, use WithClientSkipVerify instead
+	if c.SkipVerify {
+		return c.WithClientSkipVerify(action)
+	}
+
 	return cli.WithContext(
 		context.Background(), func(ctx context.Context) error {
 			cfg, err := clientconfig.Open(c.Talosconfig)
@@ -137,6 +144,84 @@ func (c *Args) WithClientMaintenance(enforceFingerprints []string, action func(c
 			defer c.Close()
 
 			return action(ctx, c)
+		},
+	)
+}
+
+// WithClientSkipVerify wraps common code to initialize Talos client with TLS verification disabled
+// but with client certificate authentication preserved.
+// This is useful when connecting to nodes via IP addresses not listed in the server certificate's SANs.
+func (c *Args) WithClientSkipVerify(action func(context.Context, *client.Client) error) error {
+	return cli.WithContext(
+		context.Background(), func(ctx context.Context) error {
+			cfg, err := clientconfig.Open(c.Talosconfig)
+			if err != nil {
+				return fmt.Errorf("failed to open config file %q: %w", c.Talosconfig, err)
+			}
+
+			// Get context name - use override if specified, otherwise use default
+			contextName := c.CmdContext
+			if contextName == "" {
+				contextName = cfg.Context
+			}
+
+			configContext, ok := cfg.Contexts[contextName]
+			if !ok {
+				return fmt.Errorf("context %q not found in config", contextName)
+			}
+
+			// Build TLS config with InsecureSkipVerify but preserve client certificate
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+			}
+
+			// Add client certificate if available
+			if configContext.Crt != "" && configContext.Key != "" {
+				crtBytes, err := base64.StdEncoding.DecodeString(configContext.Crt)
+				if err != nil {
+					return fmt.Errorf("error decoding certificate: %w", err)
+				}
+
+				keyBytes, err := base64.StdEncoding.DecodeString(configContext.Key)
+				if err != nil {
+					return fmt.Errorf("error decoding key: %w", err)
+				}
+
+				cert, err := tls.X509KeyPair(crtBytes, keyBytes)
+				if err != nil {
+					return fmt.Errorf("could not load client key pair: %w", err)
+				}
+
+				tlsConfig.Certificates = []tls.Certificate{cert}
+			}
+
+			opts := []client.OptionFunc{
+				client.WithTLSConfig(tlsConfig),
+				client.WithDefaultGRPCDialOptions(),
+			}
+
+			// Use endpoints from command-line flags or config
+			if len(c.Endpoints) > 0 {
+				opts = append(opts, client.WithEndpoints(c.Endpoints...))
+			} else if len(configContext.Endpoints) > 0 {
+				opts = append(opts, client.WithEndpoints(configContext.Endpoints...))
+			}
+
+			cli, err := client.New(ctx, opts...)
+			if err != nil {
+				return fmt.Errorf("error constructing client: %w", err)
+			}
+			//nolint:errcheck
+			defer cli.Close()
+
+			// Set nodes on context
+			if len(c.Nodes) > 0 {
+				ctx = client.WithNodes(ctx, c.Nodes...)
+			} else if len(configContext.Nodes) > 0 {
+				ctx = client.WithNodes(ctx, configContext.Nodes...)
+			}
+
+			return action(ctx, cli)
 		},
 	)
 }

--- a/pkg/machinery/client/options.go
+++ b/pkg/machinery/client/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	unixSocketPath      string
 	clusterNameOverride string
 	sideroV1KeysDir     string
+	skipVerify          bool
 }
 
 // OptionFunc sets an option for the creation of the Client.
@@ -153,6 +154,17 @@ func WithCluster(cluster string) OptionFunc {
 func WithSideroV1KeysDir(keysDir string) OptionFunc {
 	return func(o *Options) error {
 		o.sideroV1KeysDir = keysDir
+
+		return nil
+	}
+}
+
+// WithSkipVerify disables TLS certificate verification while preserving client authentication.
+// This is useful when connecting to nodes via IP addresses not listed in the server certificate's SANs,
+// or when the server certificate is signed by an unknown CA.
+func WithSkipVerify() OptionFunc {
+	return func(o *Options) error {
+		o.skipVerify = true
 
 		return nil
 	}


### PR DESCRIPTION
## Summary

Add global `--skip-verify` flag that disables TLS server certificate verification while preserving client certificate authentication.

This is useful when connecting to nodes via IP addresses not listed in the server certificate's SANs (e.g., NAT, VPN, port-forwarding scenarios).

### Changes

- Add `SkipVerify` field to `global.Args` struct
- Add `WithClientSkipVerify` method that creates TLS connection with `InsecureSkipVerify: true` but preserves client certificate
- Add `--skip-verify` global flag to all commands
- Update commands that support `--insecure` to also check for `--skip-verify`:
  - `apply-config`
  - `get`
  - `meta write/delete`
  - `reset`
  - `upgrade`
  - `version`
  - `wipe disk`

### Difference from --insecure

- `--insecure`: Uses maintenance mode API without client authentication
- `--skip-verify`: Uses normal authenticated API but skips server certificate verification

## Test plan

- [ ] Run `talosctl get members --skip-verify -n <ip>` against a node with mismatched SAN
- [ ] Run `talosctl apply-config --skip-verify -n <ip> -f config.yaml`
- [ ] Verify client authentication still works (commands fail without valid talosconfig)