### PR TITLE
fix: always set advertised peer URLs

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -528,17 +528,17 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime, spec 
 
 			denyListArgs.Set("initial-cluster", argsbuilder.Value{initialCluster})
 		}
-
-		if !extraArgs.Contains("initial-advertise-peer-urls") {
-			denyListArgs.Set("initial-advertise-peer-urls",
-				argsbuilder.Value{formatEtcdURLs(spec.AdvertisedAddresses, constants.EtcdPeerPort)},
-			)
-		}
 	}
 
 	if !extraArgs.Contains("advertise-client-urls") {
 		denyListArgs.Set("advertise-client-urls",
 			argsbuilder.Value{formatEtcdURLs(spec.AdvertisedAddresses, constants.EtcdClientPort)},
+		)
+	}
+
+	if !extraArgs.Contains("initial-advertise-peer-urls") {
+		denyListArgs.Set("initial-advertise-peer-urls",
+			argsbuilder.Value{formatEtcdURLs(spec.AdvertisedAddresses, constants.EtcdPeerPort)},
 		)
 	}
 


### PR DESCRIPTION
It seems that etcd might derive them incorrectly on IPv6-only system.

This change is confusing, as it sets the `--initial-` prefixed flag even after join, but it seems that on etcd side, the configuration value is used always despite the flag name.

Fixes #12646 (see the issue for more details)
