### PR TITLE
fix: skip empty documents on config decoding

### DIFF
--- a/internal/app/machined/pkg/controllers/config/acquire_test.go
+++ b/internal/app/machined/pkg/controllers/config/acquire_test.go
@@ -349,10 +349,15 @@ func (suite *AcquireSuite) TestFromDiskFailure() {
 	ev := suite.platformEvent.getEvents()[0]
 	suite.Assert().Equal(platform.EventTypeFailure, ev.Type)
 	suite.Assert().Equal("Error loading and validating Talos machine config.", ev.Message)
-	suite.Assert().Equal("failed to load \"config.yaml\" from STATE: unknown keys found during decoding:\naaaversion: v1alpha1 # Indicates the schema used to decode the contents.\n", ev.Error.Error())
+	suite.Assert().Equal(
+		"failed to load \"config.yaml\" from STATE: error decoding document /v1alpha1/ (line 1): unknown keys found during decoding:\n"+
+			"aaaversion: v1alpha1 # Indicates the schema used to decode the contents.\n",
+		ev.Error.Error(),
+	)
 
 	suite.Assert().Equal(&machineapi.ConfigLoadErrorEvent{
-		Error: "failed to load \"config.yaml\" from STATE: unknown keys found during decoding:\naaaversion: v1alpha1 # Indicates the schema used to decode the contents.\n",
+		Error: "failed to load \"config.yaml\" from STATE: error decoding document /v1alpha1/ (line 1): unknown keys found during decoding:\n" +
+			"aaaversion: v1alpha1 # Indicates the schema used to decode the contents.\n",
 	}, suite.eventPublisher.getEvents()[0])
 }
 

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -129,13 +129,29 @@ test: true
 			expectedErr: "",
 		},
 		{
+			name: "empty docs",
+			source: []byte(`---
+kind: mock
+apiVersion: v1alpha1
+test: true
+---
+---
+`),
+			expected: []config.Document{
+				&Mock{
+					Test: true,
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "missing kind",
 			source: []byte(`---
 apiVersion: v1alpha2
 test: true
 `),
 			expected:    nil,
-			expectedErr: "missing kind",
+			expectedErr: "error decoding document v1alpha2/v1alpha1/ (line 2): missing kind",
 		},
 		{
 			name: "empty kind",
@@ -145,7 +161,7 @@ apiVersion: v1alpha2
 test: true
 `),
 			expected:    nil,
-			expectedErr: "missing kind",
+			expectedErr: "error decoding document v1alpha2/v1alpha1/ (line 2): missing kind",
 		},
 		{
 			name: "tab instead of spaces",
@@ -167,7 +183,7 @@ test: true
 extra: fail
 `),
 			expected:    nil,
-			expectedErr: "unknown keys found during decoding:\nextra: fail\n",
+			expectedErr: "error decoding document v1alpha1/mock/ (line 2): unknown keys found during decoding:\nextra: fail\n",
 		},
 		{
 			name: "extra fields in map",
@@ -180,7 +196,7 @@ map:
     extra: me
 `),
 			expected:    nil,
-			expectedErr: "unknown keys found during decoding:\nmap:\n    first:\n        extra: me\n",
+			expectedErr: "error decoding document v1alpha2/mock/ (line 2): unknown keys found during decoding:\nmap:\n    first:\n        extra: me\n",
 		},
 		{
 			name: "extra fields in slice",
@@ -194,7 +210,7 @@ slice:
     fields: here
 `),
 			expected:    nil,
-			expectedErr: "unknown keys found during decoding:\nslice:\n    - fields: here\n      more: extra\n      not: working\n",
+			expectedErr: "error decoding document v1alpha2/mock/ (line 2): unknown keys found during decoding:\nslice:\n    - fields: here\n      more: extra\n      not: working\n",
 		},
 		{
 			name: "extra zero fields in map",
@@ -207,7 +223,7 @@ map:
       b: {}
 `),
 			expected:    nil,
-			expectedErr: "unknown keys found during decoding:\nmap:\n    second:\n        a:\n            b: {}\n",
+			expectedErr: "error decoding document v1alpha2/mock/ (line 2): unknown keys found during decoding:\nmap:\n    second:\n        a:\n            b: {}\n",
 		},
 		{
 			name: "valid nested",
@@ -306,7 +322,7 @@ config:
           - content: MONITOR ${upsmonHost} 1 remote pass foo
             mountPath: /usr/local/etc/nut/upsmon.conf
 `),
-			expectedErr: "\"ExtensionServiceConfig\" \"\": not registered",
+			expectedErr: "error decoding document /ExtensionServiceConfig/ (line 2): \"ExtensionServiceConfig\" \"\": not registered",
 		},
 	}
 


### PR DESCRIPTION
Fixes #12649

The cryptic error was coming from our code, as it never worked if the decoded node is not mapping node.

Also annotate errors with line numbers (or document kinds) to make understanding the problem better, specifically for multi-doc and long configs.
