### PR TITLE
fix: allow to expose a port multiple times in Docker

### DIFF
--- a/pkg/provision/providers/docker/node.go
+++ b/pkg/provision/providers/docker/node.go
@@ -320,12 +320,10 @@ func genPortMap(portList []string, defaultHostIP string) (portMap, error) {
 		}
 
 		portSetRet[natPort] = struct{}{}
-		portMapRet[natPort] = []network.PortBinding{
-			{
-				HostIP:   hostAddr,
-				HostPort: hostPort,
-			},
-		}
+		portMapRet[natPort] = append(portMapRet[natPort], network.PortBinding{
+			HostIP:   hostAddr,
+			HostPort: hostPort,
+		})
 	}
 
 	return portMap{portSetRet, portMapRet}, nil


### PR DESCRIPTION
This change prevents user-specified exposed ports from overriding the
default ones.

This allows one e.g. to export the Kubernetes endpoint both at the
default random port and at a specified host address.

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
