### PR TITLE
feat: resetting a node now requires a confirmation from the user

### DIFF
--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -2983,6 +2983,7 @@ talosctl reset [flags]
       --graceful                                 if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
   -h, --help                                     help for reset
       --insecure                                 reset using the insecure (encrypted with no auth) maintenance service
+  -y, --noconfirm                                if set, do not ask for confirmation
   -n, --nodes strings                            target the specified nodes
       --reboot                                   if true, reboot the node after resetting instead of shutting down
       --siderov1-keys-dir string                 The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
As known for example from `apt install` has a conformation step before executing the task: `Do you want to continue? [Y/n]`.  
I think this style of confirmation would also be a good addition to the `talosclt reset` command.

Maybe this could even be expanded to commands like `talosctl wipe`, `talosctl shutdown`, ...?

<img width="584" height="73" alt="grafik" src="https://github.com/user-attachments/assets/86b41bfd-b0a3-43cd-9438-ed0bfc3c07b4" />


## Why? (reasoning)
I nearly reset a node of my k8s cluster because I thought `talosctl reboot` was auto completed, instead `talosctl reset` was auto completed.  
With this experience and because this command is of a destroying nature I think a confirmation by the user would make `talosctl reset` safer. (:  

It seems this happened also to other users: https://github.com/siderolabs/talos/issues/10133#issuecomment-2771817866, https://github.com/siderolabs/talos/issues/10133#issuecomment-2771826284

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
