### PR TITLE
fix(talosctl): pass --k8s-endpoint flag to rotate-ca kubernetes rotation

### DIFF
--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -150,6 +150,8 @@ func rotateKubernetesCA(ctx context.Context, c *client.Client, encoderOpt encode
 		TalosClient: c,
 		ClusterInfo: clusterInfo,
 
+		KubernetesEndpoint: rotateCACmdFlags.forceEndpoint,
+
 		NewKubernetesCA: newBundle.Certs.K8s,
 
 		EncoderOption: encoderOpt,

--- a/pkg/rotate/pki/kubernetes/kubernetes.go
+++ b/pkg/rotate/pki/kubernetes/kubernetes.go
@@ -42,6 +42,9 @@ type Options struct {
 	// ClusterInfo provides information about cluster topology.
 	ClusterInfo cluster.Info
 
+	// KubernetesEndpoint overrides the default Kubernetes API endpoint.
+	KubernetesEndpoint string
+
 	// NewKubernetesCA is the new CA for Kubernetes API.
 	NewKubernetesCA *x509.PEMEncodedCertificateAndKey
 
@@ -168,6 +171,7 @@ func (r *rotator) fetchClient(ctx context.Context, clientPtr **cluster.Kubernete
 
 	*clientPtr = &cluster.KubernetesClient{
 		ClientProvider: r.talosClientProvider,
+		ForceEndpoint:  r.opts.KubernetesEndpoint,
 	}
 
 	_, err := (*clientPtr).K8sClient(client.WithNode(ctx, firstNode.InternalIP.String()))


### PR DESCRIPTION
The --k8s-endpoint flag was defined but never used in the rotate-ca command. This fix passes the flag value through to the Kubernetes client, allowing users to override the default Kubernetes API endpoint during CA rotation.

Forked from #12644 