### PR TITLE
chore: rename internal `talosctl debug air-gapped`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/debug/debug.go
+++ b/cmd/talosctl/cmd/mgmt/debug/debug.go
@@ -11,7 +11,7 @@ import (
 
 // Cmd represents the debug command.
 var Cmd = &cobra.Command{
-	Use:    "debug",
+	Use:    "debug-tool",
 	Short:  "A collection of commands to facilitate debugging of Talos.",
 	Hidden: true,
 	Long:   ``,

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -275,7 +275,7 @@ case "${WITH_AIRGAPPED:-false}" in
     QEMU_FLAGS+=("--image-cache-tls-key-file=${TMP}/image-cache-tls.key")
     ;;
   http-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 > /tmp/airgapped.log 2>&1 &
+    "${TALOSCTL}" debug-tool air-gapped --advertised-address 172.20.1.1 > /tmp/airgapped.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
     mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"
@@ -283,7 +283,7 @@ case "${WITH_AIRGAPPED:-false}" in
     QEMU_FLAGS+=("--config-patch=@${TMP}/air-gapped-patch.yaml")
     ;;
   secure-http-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --use-secure-proxy > /tmp/airgapped-secure.log 2>&1 &
+    "${TALOSCTL}" debug-tool air-gapped --advertised-address 172.20.1.1 --use-secure-proxy > /tmp/airgapped-secure.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
     mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"
@@ -291,7 +291,7 @@ case "${WITH_AIRGAPPED:-false}" in
     QEMU_FLAGS+=("--config-patch=@${TMP}/air-gapped-patch.yaml")
     ;;
   https-reverse-proxy)
-    "${TALOSCTL}" debug air-gapped --advertised-address 172.20.1.1 --inject-http-proxy=false --https-reverse-proxy-target=https://registry.dev.siderolabs.io > /tmp/airgapped-reverse-proxy.log 2>&1 &
+    "${TALOSCTL}" debug-tool air-gapped --advertised-address 172.20.1.1 --inject-http-proxy=false --https-reverse-proxy-target=https://registry.dev.siderolabs.io > /tmp/airgapped-reverse-proxy.log 2>&1 &
     sleep 5 # wait for the air-gapped server to start
     cat air-gapped-patch.yaml
     mv air-gapped-patch.yaml "${TMP}/air-gapped-patch.yaml"


### PR DESCRIPTION
This command was always hidden, rename it to `debug-tool` to free up the `talosctl debug` for #12392 
