### PR TITLE
fix: improve OpenStack bare metal network configuration reliability

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -12,9 +12,12 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log"
+	"net"
 	"net/netip"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-procfs/procfs"
@@ -48,8 +51,9 @@ func (o *OpenStack) ParseMetadata(
 	extIPs []netip.Addr,
 	metadata *MetadataConfig,
 	st state.State,
-) (*runtime.PlatformNetworkConfig, error) {
+) (*runtime.PlatformNetworkConfig, bool, error) {
 	networkConfig := &runtime.PlatformNetworkConfig{}
+	needsReconcile := false
 
 	if metadata.Hostname != "" {
 		hostnameSpec := network.HostnameSpecSpec{
@@ -57,7 +61,7 @@ func (o *OpenStack) ParseMetadata(
 		}
 
 		if err := hostnameSpec.ParseFQDN(metadata.Hostname); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		networkConfig.Hostnames = append(networkConfig.Hostnames, hostnameSpec)
@@ -72,7 +76,7 @@ func (o *OpenStack) ParseMetadata(
 			if ip, err := netip.ParseAddr(netsvc.Address); err == nil {
 				dnsIPs = append(dnsIPs, ip)
 			} else {
-				return nil, fmt.Errorf("failed to parse dns service ip: %w", err)
+				return nil, false, fmt.Errorf("failed to parse dns service ip: %w", err)
 			}
 		}
 	}
@@ -86,7 +90,7 @@ func (o *OpenStack) ParseMetadata(
 
 	hostInterfaces, err := safe.StateListAll[*network.LinkStatus](ctx, st)
 	if err != nil {
-		return nil, fmt.Errorf("error listing host interfaces: %w", err)
+		return nil, false, fmt.Errorf("error listing host interfaces: %w", err)
 	}
 
 	ifaces := make(map[string]string)
@@ -103,12 +107,12 @@ func (o *OpenStack) ParseMetadata(
 
 		mode, err := nethelpers.BondModeByName(netLink.BondMode)
 		if err != nil {
-			return nil, fmt.Errorf("invalid bond_mode: %w", err)
+			return nil, false, fmt.Errorf("invalid bond_mode: %w", err)
 		}
 
 		hashPolicy, err := nethelpers.BondXmitHashPolicyByName(netLink.BondHashPolicy)
 		if err != nil {
-			return nil, fmt.Errorf("invalid bond_xmit_hash_policy: %w", err)
+			return nil, false, fmt.Errorf("invalid bond_xmit_hash_policy: %w", err)
 		}
 
 		bondName := fmt.Sprintf("bond%d", bondIndex)
@@ -130,6 +134,15 @@ func (o *OpenStack) ParseMetadata(
 				DownDelay:  200,
 				LACPRate:   nethelpers.LACPRateFast,
 			},
+		}
+
+		if netLink.Mac != "" {
+			mac, err := net.ParseMAC(netLink.Mac)
+			if err != nil {
+				return nil, false, fmt.Errorf("invalid bond MAC address %q: %w", netLink.Mac, err)
+			}
+
+			bondLink.HardwareAddress = nethelpers.HardwareAddr(mac)
 		}
 
 		if mode == nethelpers.BondMode8023AD {
@@ -178,11 +191,18 @@ func (o *OpenStack) ParseMetadata(
 		case "phy", "vif", "ovs", "bridge", "tap", "vhostuser", "hw_veb":
 			linkName := ""
 
-			for hostInterface := range hostInterfaces.All() {
-				if strings.EqualFold(hostInterface.TypedSpec().PermanentAddr.String(), netLink.Mac) {
-					linkName = hostInterface.Metadata().ID()
+			if netLink.Mac != "" {
+				for hostInterface := range hostInterfaces.All() {
+					macAddress := hostInterface.TypedSpec().PermanentAddr.String()
+					if macAddress == "" {
+						macAddress = hostInterface.TypedSpec().HardwareAddr.String()
+					}
 
-					break
+					if strings.EqualFold(macAddress, netLink.Mac) {
+						linkName = hostInterface.Metadata().ID()
+
+						break
+					}
 				}
 			}
 
@@ -190,6 +210,8 @@ func (o *OpenStack) ParseMetadata(
 				linkName = fmt.Sprintf("eth%d", idx)
 
 				log.Printf("failed to find interface with MAC %q, using %q", netLink.Mac, linkName)
+
+				needsReconcile = true
 			}
 
 			ifaces[netLink.ID] = linkName
@@ -290,7 +312,7 @@ func (o *OpenStack) ParseMetadata(
 		if ntwrk.Address != "" {
 			ipPrefix, err := address.IPPrefixFrom(ntwrk.Address, ntwrk.Netmask)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse ip address: %w", err)
+				return nil, false, fmt.Errorf("failed to parse ip address: %w", err)
 			}
 
 			family := nethelpers.FamilyInet4
@@ -312,7 +334,7 @@ func (o *OpenStack) ParseMetadata(
 			if ntwrk.Gateway != "" {
 				gw, err := netip.ParseAddr(ntwrk.Gateway)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse gateway ip: %w", err)
+					return nil, false, fmt.Errorf("failed to parse gateway ip: %w", err)
 				}
 
 				priority := uint32(network.DefaultRouteMetric)
@@ -341,12 +363,12 @@ func (o *OpenStack) ParseMetadata(
 		for _, route := range ntwrk.Routes {
 			gw, err := netip.ParseAddr(route.Gateway)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse route gateway: %w", err)
+				return nil, false, fmt.Errorf("failed to parse route gateway: %w", err)
 			}
 
 			dest, err := address.IPPrefixFrom(route.Network, route.Netmask)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse route network: %w", err)
+				return nil, false, fmt.Errorf("failed to parse route network: %w", err)
 			}
 
 			family := nethelpers.FamilyInet4
@@ -386,7 +408,7 @@ func (o *OpenStack) ParseMetadata(
 		ProviderID:   fmt.Sprintf("openstack:///%s", metadata.UUID),
 	}
 
-	return networkConfig, nil
+	return networkConfig, needsReconcile, nil
 }
 
 // Configuration implements the runtime.Platform interface.
@@ -426,7 +448,14 @@ func (o *OpenStack) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
+//
+//nolint:gocyclo
 func (o *OpenStack) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
+	// wait for devices to be ready before proceeding, otherwise we might not find network interfaces by MAC
+	if err := netutils.WaitForDevicesReady(ctx, st); err != nil {
+		return fmt.Errorf("error waiting for devices to be ready: %w", err)
+	}
+
 	networkSource := false
 
 	metadataConfigDl, metadataNetworkConfigDl, _, err := o.configFromCD(ctx, st)
@@ -462,16 +491,36 @@ func (o *OpenStack) NetworkConfiguration(ctx context.Context, st state.State, ch
 		}
 	}
 
-	networkConfig, err := o.ParseMetadata(ctx, &unmarshalledNetworkConfig, extIPs, &meta, st)
-	if err != nil {
-		return err
-	}
+	// do a loop to retry network config remap in case of missing links
+	// on each try, export the configuration as it is, and if the network is reconciled next time, export the reconciled configuration
+	bckoff := backoff.NewExponentialBackOff()
 
-	select {
-	case ch <- networkConfig:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	for {
+		networkConfig, needsReconcile, err := o.ParseMetadata(ctx, &unmarshalledNetworkConfig, extIPs, &meta, st)
+		if err != nil {
+			return err
+		}
 
-	return nil
+		select {
+		case ch <- networkConfig:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		if !needsReconcile {
+			return nil
+		}
+
+		// wait for backoff to retry network config remap
+		nextBackoff := bckoff.NextBackOff()
+		if nextBackoff == backoff.Stop {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(nextBackoff):
+		}
+	}
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
@@ -5,6 +5,7 @@
 package openstack_test
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"net/netip"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -32,47 +34,115 @@ var rawNetwork []byte
 var expectedNetworkConfig string
 
 func TestParseMetadata(t *testing.T) {
-	o := &openstack.OpenStack{}
+	t.Parallel()
 
-	var metadata openstack.MetadataConfig
+	for _, tt := range []struct {
+		name                   string
+		networkJSON            []byte
+		metadataJSON           []byte
+		extIPs                 []netip.Addr
+		setupState             func(t *testing.T, ctx context.Context, st state.State)
+		expectedNeedsReconcile bool
+		expected               string
+		checkResult            func(t *testing.T, cfg *runtime.PlatformNetworkConfig)
+	}{
+		{
+			name:         "full config",
+			networkJSON:  rawNetwork,
+			metadataJSON: rawMetadata,
+			extIPs:       []netip.Addr{netip.MustParseAddr("1.2.3.4")},
+			setupState: func(t *testing.T, ctx context.Context, st state.State) {
+				eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+				eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x30}
+				require.NoError(t, st.Create(ctx, eth0))
 
-	require.NoError(t, json.Unmarshal(rawMetadata, &metadata))
+				eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
+				eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x31}
+				require.NoError(t, st.Create(ctx, eth1))
 
-	var n openstack.NetworkConfig
+				eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
+				eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x33}
+				require.NoError(t, st.Create(ctx, eth2))
 
-	require.NoError(t, json.Unmarshal(rawNetwork, &n))
+				eth3 := network.NewLinkStatus(network.NamespaceName, "eth3")
+				eth3.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf8}
+				require.NoError(t, st.Create(ctx, eth3))
 
-	ctx := t.Context()
+				eth4 := network.NewLinkStatus(network.NamespaceName, "eth4")
+				eth4.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf7}
+				require.NoError(t, st.Create(ctx, eth4))
+			},
+			expected: expectedNetworkConfig,
+		},
+		{
+			name:        "HardwareAddr fallback",
+			networkJSON: []byte(`{"links":[{"id":"iface1","type":"phy","ethernet_mac_address":"aa:bb:cc:dd:ee:ff","mtu":1500}],"networks":[{"id":"net1","link":"iface1","type":"ipv4_dhcp"}]}`),
+			setupState: func(t *testing.T, ctx context.Context, st state.State) {
+				eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+				eth0.TypedSpec().HardwareAddr = nethelpers.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+				require.NoError(t, st.Create(ctx, eth0))
+			},
+			checkResult: func(t *testing.T, cfg *runtime.PlatformNetworkConfig) {
+				require.Len(t, cfg.Links, 1)
+				assert.Equal(t, "eth0", cfg.Links[0].Name)
+			},
+		},
+		{
+			name:        "empty MAC does not match",
+			networkJSON: []byte(`{"links":[{"id":"iface1","type":"phy","ethernet_mac_address":"","mtu":1500}],"networks":[{"id":"net1","link":"iface1","type":"ipv4_dhcp"}]}`),
+			setupState: func(t *testing.T, ctx context.Context, st state.State) {
+				eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+				require.NoError(t, st.Create(ctx, eth0))
+			},
+			expectedNeedsReconcile: true,
+		},
+		{
+			name:        "MAC mismatch triggers reconcile",
+			networkJSON: []byte(`{"links":[{"id":"iface1","type":"phy","ethernet_mac_address":"aa:bb:cc:dd:ee:ff","mtu":1500}],"networks":[{"id":"net1","link":"iface1","type":"ipv4_dhcp"}]}`),
+			setupState: func(t *testing.T, ctx context.Context, st state.State) {
+				eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+				eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+				require.NoError(t, st.Create(ctx, eth0))
+			},
+			expectedNeedsReconcile: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
+			ctx := t.Context()
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
-	eth0.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x30}
-	require.NoError(t, st.Create(ctx, eth0))
+			tt.setupState(t, ctx, st)
 
-	eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
-	eth1.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x31}
-	require.NoError(t, st.Create(ctx, eth1))
+			var (
+				metadata openstack.MetadataConfig
+				n        openstack.NetworkConfig
+			)
 
-	eth2 := network.NewLinkStatus(network.NamespaceName, "eth2")
-	eth2.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0xa4, 0xbf, 0x00, 0x10, 0x20, 0x33}
-	require.NoError(t, st.Create(ctx, eth2))
+			if tt.metadataJSON != nil {
+				require.NoError(t, json.Unmarshal(tt.metadataJSON, &metadata))
+			}
 
-	// Bond slaves
+			require.NoError(t, json.Unmarshal(tt.networkJSON, &n))
 
-	eth3 := network.NewLinkStatus(network.NamespaceName, "eth3")
-	eth3.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf8}
-	require.NoError(t, st.Create(ctx, eth3))
+			o := &openstack.OpenStack{}
 
-	eth4 := network.NewLinkStatus(network.NamespaceName, "eth4")
-	eth4.TypedSpec().PermanentAddr = nethelpers.HardwareAddr{0x4c, 0xd9, 0x8f, 0xb3, 0x34, 0xf7}
-	require.NoError(t, st.Create(ctx, eth4))
+			networkConfig, needsReconcile, err := o.ParseMetadata(ctx, &n, tt.extIPs, &metadata, st)
+			require.NoError(t, err)
 
-	networkConfig, err := o.ParseMetadata(ctx, &n, []netip.Addr{netip.MustParseAddr("1.2.3.4")}, &metadata, st)
-	require.NoError(t, err)
+			assert.Equal(t, tt.expectedNeedsReconcile, needsReconcile)
 
-	marshaled, err := yaml.Marshal(networkConfig)
-	require.NoError(t, err)
+			if tt.expected != "" {
+				marshaled, err := yaml.Marshal(networkConfig)
+				require.NoError(t, err)
 
-	assert.Equal(t, expectedNetworkConfig, string(marshaled))
+				assert.Equal(t, tt.expected, string(marshaled))
+			}
+
+			if tt.checkResult != nil {
+				tt.checkResult(t, networkConfig)
+			}
+		})
+	}
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/testdata/expected.yaml
@@ -36,6 +36,7 @@ links:
       mtu: 1500
       kind: bond
       type: ether
+      hardwareAddr: 4c:d9:8f:b3:34:f7
       bondMaster:
         mode: 802.3ad
         xmitHashPolicy: layer2+3


### PR DESCRIPTION
## Summary

Fixes network configuration issues on OpenStack bare metal (Ironic) servers with bonded interfaces.

Changes:
- Add `WaitForDevicesReady` call before parsing network configuration to ensure network interfaces are available
- Add fallback to `HardwareAddr` when `PermanentAddr` is empty (ethtool may not have populated it yet)
- Add retry loop with exponential backoff when MAC address matching fails
- Remove hardcoded bond parameters (`UpDelay: 200`, `DownDelay: 200`, `LACPRate: fast`) to use kernel defaults matching Ubuntu behavior
- Explicitly set bond interface MAC address from OpenStack metadata to ensure the switch sees the correct MAC

The bond MAC fix addresses a critical issue where Linux assigns the bond the MAC of the first enslaved interface, which may not match the MAC expected by the switch. OpenStack metadata provides the correct MAC via `ethernet_mac_address` field, and we now apply it explicitly.

The retry loop, HardwareAddr fallback and `WaitForDevicesReady` match the pattern used in the NoCloud platform.

## Testing

These changes have been verified in production on our bare metal servers (GCore Bare Metal Cloud) and everything works correctly after the fix.