### PR TITLE
fix: implement merger for PercentageSize

### DIFF
--- a/pkg/machinery/config/types/block/percentage_size.go
+++ b/pkg/machinery/config/types/block/percentage_size.go
@@ -93,3 +93,16 @@ func (ps PercentageSize) IsZero() bool {
 func (ps PercentageSize) IsNegative() bool {
 	return ps.negative
 }
+
+// Merge implements merger interface.
+func (ps *PercentageSize) Merge(other any) error {
+	otherPS, ok := other.(PercentageSize)
+	if !ok {
+		return fmt.Errorf("cannot merge %T with %T", ps, other)
+	}
+
+	ps.raw = otherPS.raw
+	ps.value = otherPS.value
+
+	return nil
+}


### PR DESCRIPTION
Fixing issue when PercentageSize is used and instead of calling Merge it was trying to merge individual unexported fields.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>

Blocks #12585 