### PR TITLE
feat: enable restarting precreated qemu cluster

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/start.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/start.go
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers"
+)
+
+// startCmd represents the cluster start command.
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Starts a stopped local Talos Kubernetes cluster",
+	Long: `Starts a local Talos Kubernetes cluster that was previously created but is now stopped.
+This is useful when the development container is restarted and the VM processes are no longer running.
+The cluster state (disks, configs) must still exist from a previous 'cluster create' command.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cli.WithContext(context.Background(), start)
+	},
+}
+
+func start(ctx context.Context) error {
+	state, err := provision.ReadState(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster state: %w", err)
+	}
+
+	provisioner, err := providers.Factory(ctx, state.ProvisionerName)
+	if err != nil {
+		return err
+	}
+
+	defer provisioner.Close() //nolint:errcheck
+
+	cluster, err := provisioner.Reflect(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+	if err != nil {
+		return err
+	}
+
+	return provisioner.Start(
+		ctx,
+		cluster,
+		provision.WithLogWriter(os.Stdout),
+	)
+}
+
+func init() {
+	AddProvisionerFlag(startCmd)
+	cli.Should(startCmd.Flags().MarkDeprecated(ProvisionerFlagName, "the provisioner is inferred automatically"))
+
+	Cmd.AddCommand(startCmd)
+}

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -130,6 +130,11 @@ func (p *provisioner) UserDiskName(index int) string {
 	return ""
 }
 
+// Start is not supported for docker provisioner.
+func (p *provisioner) Start(ctx context.Context, cluster provision.Cluster, opts ...provision.Option) error {
+	return fmt.Errorf("start is not supported for docker provisioner")
+}
+
 // GetFirstInterface returns first network interface name.
 func (p *provisioner) GetFirstInterface() v1alpha1.IfaceSelector {
 	return v1alpha1.IfaceByName(p.GetFirstInterfaceName())

--- a/pkg/provision/providers/qemu/start.go
+++ b/pkg/provision/providers/qemu/start.go
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers/vm"
+)
+
+// Start restarts an existing cluster that was previously created but is now stopped.
+// This recreates the network bridge and restarts all helper services and VM nodes.
+func (p *provisioner) Start(ctx context.Context, cluster provision.Cluster, opts ...provision.Option) error {
+	options := provision.DefaultOptions()
+
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return err
+		}
+	}
+
+	state, ok := cluster.(*provision.State)
+	if !ok {
+		return fmt.Errorf("cluster is not a *provision.State")
+	}
+
+	fmt.Fprintln(options.LogWriter, "recreating network bridge", state.BridgeName)
+
+	if err := p.RecreateNetwork(ctx, state, options); err != nil {
+		return fmt.Errorf("error recreating network: %w", err)
+	}
+
+	fmt.Fprintln(options.LogWriter, "starting load balancer")
+
+	if err := p.StartLoadBalancer(state); err != nil {
+		return fmt.Errorf("error starting loadbalancer: %w", err)
+	}
+
+	fmt.Fprintln(options.LogWriter, "starting dnsd")
+
+	if err := p.StartDNSd(state); err != nil {
+		return fmt.Errorf("error starting dnsd: %w", err)
+	}
+
+	fmt.Fprintln(options.LogWriter, "starting nodes")
+
+	if err := p.startNodes(ctx, state, &options); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(options.LogWriter, "starting dhcpd")
+
+	if err := p.StartDHCPd(state); err != nil {
+		return fmt.Errorf("error starting dhcpd: %w", err)
+	}
+
+	return nil
+}
+
+// startNodes starts all nodes from saved state.
+func (p *provisioner) startNodes(ctx context.Context, state *provision.State, options *provision.Options) error {
+	errCh := make(chan error)
+	nodes := state.ClusterInfo.Nodes
+
+	for _, node := range nodes {
+		go func(node provision.NodeInfo) {
+			errCh <- p.startNode(ctx, state, node, options)
+		}(node)
+	}
+
+	var multiErr *multierror.Error
+
+	for range nodes {
+		multiErr = multierror.Append(multiErr, <-errCh)
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+// startNode starts a single node from saved state.
+func (p *provisioner) startNode(_ context.Context, state *provision.State, node provision.NodeInfo, options *provision.Options) error {
+	pidPath := state.GetRelativePath(fmt.Sprintf("%s.pid", node.Name))
+
+	// Check if already running
+	if vm.IsProcessRunning(pidPath) {
+		fmt.Fprintf(options.LogWriter, "node %s already running\n", node.Name)
+
+		return nil
+	}
+
+	// Read the saved launch config
+	configPath := state.GetRelativePath(fmt.Sprintf("%s.config", node.Name))
+
+	configFile, err := os.Open(configPath)
+	if err != nil {
+		return fmt.Errorf("error opening config file for %s: %w", node.Name, err)
+	}
+
+	defer configFile.Close() //nolint:errcheck
+
+	// Verify the config is valid JSON
+	var launchConfig LaunchConfig
+	if err := json.NewDecoder(configFile).Decode(&launchConfig); err != nil {
+		return fmt.Errorf("error decoding config file for %s: %w", node.Name, err)
+	}
+
+	// Seek back to beginning for stdin
+	if _, err := configFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("error seeking config file for %s: %w", node.Name, err)
+	}
+
+	logFile, err := os.OpenFile(state.GetRelativePath(fmt.Sprintf("%s.log", node.Name)), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return fmt.Errorf("error opening log file for %s: %w", node.Name, err)
+	}
+
+	defer logFile.Close() //nolint:errcheck
+
+	fmt.Fprintf(options.LogWriter, "starting node %s\n", node.Name)
+
+	cmd := exec.Command(state.SelfExecutable, "qemu-launch") //nolint:noctx // runs in background
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = configFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // daemonize
+	}
+
+	if err = cmd.Start(); err != nil {
+		return fmt.Errorf("error starting node %s: %w", node.Name, err)
+	}
+
+	if err = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing PID file for %s: %w", node.Name, err)
+	}
+
+	return nil
+}

--- a/pkg/provision/providers/vm/dhcpd_darwin.go
+++ b/pkg/provision/providers/vm/dhcpd_darwin.go
@@ -23,6 +23,12 @@ import (
 // starts the talos DHCP server and then starts the apple bootp server again, which is configured such
 // that it detects existing dhcp servers on interfaces and doesn't interfare with them.
 func (p *Provisioner) CreateDHCPd(ctx context.Context, state *provision.State, clusterReq provision.ClusterRequest) error {
+	state.DHCPdConfig = &provision.DHCPdConfig{
+		GatewayAddrs:   clusterReq.Network.GatewayAddrs,
+		IPXEBootScript: clusterReq.IPXEBootScript,
+	}
+	state.SelfExecutable = clusterReq.SelfExecutable
+
 	err := waitForInterface(ctx, state.BridgeName)
 	if err != nil {
 		return err
@@ -35,7 +41,7 @@ func (p *Provisioner) CreateDHCPd(ctx context.Context, state *provision.State, c
 		return fmt.Errorf("failed to stop native dhcp server: %w", err)
 	}
 
-	err = p.startDHCPd(state, clusterReq)
+	err = p.StartDHCPd(state)
 	if err != nil {
 		return err
 	}

--- a/pkg/provision/providers/vm/dhcpd_linux.go
+++ b/pkg/provision/providers/vm/dhcpd_linux.go
@@ -12,5 +12,11 @@ import (
 
 // CreateDHCPd creates a DHCP server.
 func (p *Provisioner) CreateDHCPd(ctx context.Context, state *provision.State, clusterReq provision.ClusterRequest) error {
-	return p.startDHCPd(state, clusterReq)
+	state.DHCPdConfig = &provision.DHCPdConfig{
+		GatewayAddrs:   clusterReq.Network.GatewayAddrs,
+		IPXEBootScript: clusterReq.IPXEBootScript,
+	}
+	state.SelfExecutable = clusterReq.SelfExecutable
+
+	return p.StartDHCPd(state)
 }

--- a/pkg/provision/providers/vm/dnsd.go
+++ b/pkg/provision/providers/vm/dnsd.go
@@ -68,7 +68,12 @@ const (
 
 // CreateDNSd creates the DNSd server.
 func (p *Provisioner) CreateDNSd(state *State, clusterReq provision.ClusterRequest) error {
-	return p.startDNSd(state, clusterReq)
+	state.DNSdConfig = &provision.DNSdConfig{
+		GatewayAddrs: clusterReq.Network.GatewayAddrs,
+	}
+	state.SelfExecutable = clusterReq.SelfExecutable
+
+	return p.StartDNSd(state)
 }
 
 // DestroyDNSd destoys DNSd server.

--- a/pkg/provision/providers/vm/dnsd_darwin.go
+++ b/pkg/provision/providers/vm/dnsd_darwin.go
@@ -4,14 +4,11 @@
 
 package vm
 
-import (
-	"github.com/siderolabs/talos/pkg/provision"
-)
-
-func (p *Provisioner) startDNSd(_ *State, _ provision.ClusterRequest) error {
+func (p *Provisioner) stopDNSd(_ *State) error {
 	return nil
 }
 
-func (p *Provisioner) stopDNSd(_ *State) error {
+// StartDNSd on darwin is a no-op since DNSd is not used.
+func (p *Provisioner) StartDNSd(_ *State) error {
 	return nil
 }

--- a/pkg/provision/providers/vm/loadbalancer_darwin.go
+++ b/pkg/provision/providers/vm/loadbalancer_darwin.go
@@ -6,9 +6,9 @@ package vm
 
 import "net/netip"
 
-// getLbBindIP returns the 0.0.0.0 address to bind to all interfaces on macos.
+// GetLbBindIP returns the 0.0.0.0 address to bind to all interfaces on macos.
 // The bridge interface address is not used as the bridge is not yet created at this stage.
 // Multiple loadbalancers can be assigned via different ports.
-func getLbBindIP(_ netip.Addr) string {
+func GetLbBindIP(_ netip.Addr) string {
 	return "0.0.0.0"
 }

--- a/pkg/provision/providers/vm/loadbalancer_linux.go
+++ b/pkg/provision/providers/vm/loadbalancer_linux.go
@@ -6,7 +6,7 @@ package vm
 
 import "net/netip"
 
-// getLbBindIP returns the gateway address to bind the loadbalancer to the bridge interface.
-func getLbBindIP(gateway netip.Addr) string {
+// GetLbBindIP returns the gateway address to bind the loadbalancer to the bridge interface.
+func GetLbBindIP(gateway netip.Addr) string {
 	return gateway.String()
 }

--- a/pkg/provision/providers/vm/network_darwin.go
+++ b/pkg/provision/providers/vm/network_darwin.go
@@ -6,6 +6,7 @@ package vm
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/siderolabs/gen/xslices"
@@ -36,4 +37,9 @@ func (p *Provisioner) CreateNetwork(ctx context.Context, state *provision.State,
 // DestroyNetwork does nothing on darwin as the network is automatically cleaned up by qemu when the final machine of a cidr block is killed.
 func (p *Provisioner) DestroyNetwork(state *provision.State) error {
 	return nil
+}
+
+// RecreateNetwork on darwin is not supported as cluster restart requires QEMU.
+func (p *Provisioner) RecreateNetwork(ctx context.Context, state *provision.State, options provision.Options) error {
+	return fmt.Errorf("cluster restart is not supported on darwin; darwin uses vmnet which persists across restarts")
 }

--- a/pkg/provision/providers/vm/start.go
+++ b/pkg/provision/providers/vm/start.go
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// IsProcessRunning checks if a process is running by reading its PID from a file
+// and sending signal 0 to verify it's alive.
+func IsProcessRunning(pidPath string) bool {
+	pidFile, err := os.Open(pidPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false
+		}
+
+		return false
+	}
+
+	defer pidFile.Close() //nolint:errcheck
+
+	var pid int
+
+	if _, err = fmt.Fscanf(pidFile, "%d", &pid); err != nil {
+		return false
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	// Signal 0 doesn't send any signal but checks if the process exists
+	err = proc.Signal(syscall.Signal(0))
+
+	return err == nil
+}

--- a/pkg/provision/providers/vm/start_test.go
+++ b/pkg/provision/providers/vm/start_test.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/provision/providers/vm"
+)
+
+func TestIsProcessRunning(t *testing.T) {
+	t.Run("non-existent pid file", func(t *testing.T) {
+		assert.False(t, vm.IsProcessRunning("/nonexistent/path/to/pid"))
+	})
+
+	t.Run("invalid pid in file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pidPath := filepath.Join(tmpDir, "test.pid")
+
+		err := os.WriteFile(pidPath, []byte("not-a-number"), 0o644)
+		assert.NoError(t, err)
+
+		assert.False(t, vm.IsProcessRunning(pidPath))
+	})
+
+	t.Run("non-existent process", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pidPath := filepath.Join(tmpDir, "test.pid")
+
+		// Use a very high PID that's unlikely to exist
+		err := os.WriteFile(pidPath, []byte("999999999"), 0o644)
+		assert.NoError(t, err)
+
+		assert.False(t, vm.IsProcessRunning(pidPath))
+	})
+
+	t.Run("running process", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pidPath := filepath.Join(tmpDir, "test.pid")
+
+		// Use current process PID
+		err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o644)
+		assert.NoError(t, err)
+
+		assert.True(t, vm.IsProcessRunning(pidPath))
+	})
+}

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -19,6 +19,7 @@ import (
 //nolint:interfacebloat
 type Provisioner interface {
 	Create(context.Context, ClusterRequest, ...Option) (Cluster, error)
+	Start(context.Context, Cluster, ...Option) error
 	Destroy(context.Context, Cluster, ...Option) error
 
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -43,6 +43,7 @@ type NetworkInfo struct {
 	GatewayAddrs      []netip.Addr
 	MTU               int
 	NoMasqueradeCIDRs []netip.Prefix
+	IPMasquerade      bool
 }
 
 // NodeInfo describes a node.

--- a/pkg/provision/state.go
+++ b/pkg/provision/state.go
@@ -9,12 +9,31 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/netip"
 	"os"
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
 	yaml "go.yaml.in/yaml/v4"
 )
+
+// LoadBalancerConfig holds configuration for restarting the load balancer.
+type LoadBalancerConfig struct {
+	BindAddress string
+	Upstreams   []string
+	Ports       []int
+}
+
+// DHCPdConfig holds configuration for restarting the DHCP server.
+type DHCPdConfig struct {
+	GatewayAddrs   []netip.Addr
+	IPXEBootScript string
+}
+
+// DNSdConfig holds configuration for restarting the DNS server.
+type DNSdConfig struct {
+	GatewayAddrs []netip.Addr
+}
 
 // StateFileName is the name of the yaml state file.
 const StateFileName = "state.yaml"
@@ -27,6 +46,15 @@ type State struct {
 	ClusterInfo ClusterInfo
 
 	VMCNIConfig *libcni.NetworkConfigList
+
+	// SelfExecutable is the path to the talosctl binary used to launch helper services.
+	SelfExecutable string
+
+	// Helper service configurations for restart support.
+	LoadBalancerConfig *LoadBalancerConfig
+	DHCPdConfig        *DHCPdConfig
+	DNSdConfig         *DNSdConfig
+	CNIConfig          *CNIConfig
 
 	statePath string
 }

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -600,6 +600,37 @@ talosctl cluster show [flags]
 
 * [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
 
+## talosctl cluster start
+
+Starts a stopped local Talos Kubernetes cluster
+
+### Synopsis
+
+Starts a local Talos Kubernetes cluster that was previously created but is now stopped.
+This is useful when the development container is restarted and the VM processes are no longer running.
+The cluster state (disks, configs) must still exist from a previous 'cluster create' command.
+
+```
+talosctl cluster start [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
+```
+
+### SEE ALSO
+
+* [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
+
 ## talosctl cluster
 
 A collection of commands for managing local docker-based or QEMU-based clusters
@@ -618,6 +649,7 @@ A collection of commands for managing local docker-based or QEMU-based clusters
 * [talosctl cluster create](#talosctl-cluster-create)	 - Create a local Talos cluster.
 * [talosctl cluster destroy](#talosctl-cluster-destroy)	 - Destroys a local Talos kubernetes cluster
 * [talosctl cluster show](#talosctl-cluster-show)	 - Shows info about a local provisioned kubernetes cluster
+* [talosctl cluster start](#talosctl-cluster-start)	 - Starts a stopped local Talos Kubernetes cluster
 
 ## talosctl completion
 


### PR DESCRIPTION
This is useful when using talosctl created clusters as development clusters where rapid iteration is required.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Adds a `calosctl cluster start` command to start existing clusters that were shut down (for example by system restart).

## Why? (reasoning)
Talos takes ~5 minutes to do an install and fresh start whereas just restaring it takes ~2 minutes to get ready. My use case involves using talos on a host I need to restart often making slow starts waste high amounts of developer time. I'd still want to use Talos instead of K3s but the boot speed is the main problem. This addresses 50% of that.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
