### PR TITLE
fix: stop building talosctl debug on Windows

### DIFF
--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build !windows
+
 package talos
 
 import (


### PR DESCRIPTION
This command is very specific to terminal operations which don't exist or might not work well enough on Windows.

Windows users will have better luck with WSL and Linux talosctl.
