### PR TITLE
fix: default value for BondUseCarrier, resolve #12742

### DIFF
--- a/pkg/machinery/config/types/network/bond.go
+++ b/pkg/machinery/config/types/network/bond.go
@@ -429,7 +429,7 @@ func (s *BondConfigV1Alpha1) DownDelay() optional.Optional[uint32] {
 // UseCarrier implements NetworkBondConfig interface.
 func (s *BondConfigV1Alpha1) UseCarrier() optional.Optional[bool] {
 	if s.BondUseCarrier == nil {
-		return optional.None[bool]()
+		return optional.Some(true)
 	}
 
 	return optional.Some(*s.BondUseCarrier)


### PR DESCRIPTION
## Fix bond flapping 
Fix regression introduced in talos v1.12 by changing the default value of `use_carrier` for bond configuration.

fix #12742

