### PR TITLE
fix: typo with rpi_5 profile name

### DIFF
--- a/pkg/machinery/platforms/sbcs.go
+++ b/pkg/machinery/platforms/sbcs.go
@@ -31,9 +31,9 @@ func (s SBC) DiskImagePath(talosVersion string) string {
 func SBCs() []SBC {
 	return []SBC{
 		{
-			Name: "rpi5",
+			Name: "rpi_5",
 
-			OverlayName:  "rpi5",
+			OverlayName:  "rpi_5",
 			OverlayImage: "siderolabs/sbc-raspberrypi",
 
 			Label: "Raspberry Pi 5",


### PR DESCRIPTION
Missing underscore.

```
error enhancing profile from schematic: official overlay {"" "" ""} is not available for Talos version v1.12.3
```

Overlay should be `rpi_5` is `rpi5`.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
