### PR TITLE
feat: improve talos upgrade command

### DIFF
--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -106,7 +106,8 @@ var debugCmd = &cobra.Command{
 				return fmt.Errorf("failed to import image: %w", err)
 			}
 		} else {
-			pullResult, err := imagePullInternal(ctx, clientFactory, ctrdInstance, imageRef, rep)
+
+			pullResult, err := imagePullInternal(ctx, clientFactory, ctrdInstance, uniformImageRefs(clientFactory.Nodes(), args[0]), rep)
 			if err != nil {
 				return fmt.Errorf("failed to pull image: %w", err)
 			}

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -247,16 +248,43 @@ func imagePull(ctx context.Context, imageRef string) error {
 		return err
 	}
 
-	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, imageRef, rep)
+	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, uniformImageRefs(clientFactory.Nodes(), imageRef), rep)
 
 	return err
 }
 
+// nodeFromContext extracts the target node from the outgoing gRPC metadata set by client.WithNode.
+func nodeFromContext(ctx context.Context) string {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return ""
+	}
+
+	if v := md.Get("node"); len(v) > 0 {
+		return v[0]
+	}
+
+	return ""
+}
+
+// uniformImageRefs maps every targeted node to the same image reference, for callers which pull or
+// install a single image across all nodes (as opposed to the per-node images resolved by upgrade).
+func uniformImageRefs(nodes []string, imageRef string) map[string]string {
+	refs := make(map[string]string, len(nodes))
+
+	for _, node := range nodes {
+		refs[node] = imageRef
+	}
+
+	return refs
+}
+
+// imagePullInternal pulls a per-node image reference (keyed by node) into each node's container runtime.
 func imagePullInternal(
 	ctx context.Context,
 	clientFactory *global.ClientFactory,
 	containerdInstance *common.ContainerdInstance,
-	imageRef string,
+	imageRefs map[string]string,
 	rep *reporter.Reporter,
 ) (map[string]string, error) {
 	streamCtx, cancel := context.WithCancel(ctx)
@@ -267,7 +295,7 @@ func imagePullInternal(
 		func(ctx context.Context, c *client.Client) (grpc.ServerStreamingClient[machine.ImageServicePullResponse], error) {
 			return c.ImageClient.Pull(ctx, &machine.ImageServicePullRequest{
 				Containerd: containerdInstance,
-				ImageRef:   imageRef,
+				ImageRef:   imageRefs[nodeFromContext(ctx)],
 			})
 		},
 	)
@@ -285,7 +313,7 @@ func imagePullInternal(
 				cancel()
 
 				// fallback to legacy API for older Talos
-				return nil, imagePullLegacy(ctx, imageRef)
+				return nil, imagePullLegacy(ctx, imageRefs[resp.Node])
 			}
 
 			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -38,6 +39,12 @@ var upgradeCmdFlags = struct {
 	trackableActionCmdFlags
 	imageCmdFlagsType
 
+	factory      string
+	schematic    string
+	talosVersion string
+	secureBoot   bool
+	platform     string
+
 	upgradeImage string
 	noReboot     bool
 	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
@@ -45,6 +52,10 @@ var upgradeCmdFlags = struct {
 
 	drain        bool
 	drainTimeout time.Duration
+
+	secureBootChanged     bool
+	factoryChanged        bool
+	componentFlagsChanged bool
 
 	legacy   bool
 	force    bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
@@ -68,6 +79,17 @@ var upgradeCmd = &cobra.Command{
 
 		if upgradeCmdFlags.drain {
 			upgradeCmdFlags.wait = true
+		}
+
+		upgradeCmdFlags.secureBootChanged = cmd.Flags().Changed("secure-boot")
+		upgradeCmdFlags.factoryChanged = cmd.Flags().Changed("factory")
+
+		for _, name := range []string{"factory", "schematic", "talos-version", "secure-boot", "platform"} {
+			if cmd.Flags().Changed(name) {
+				upgradeCmdFlags.componentFlagsChanged = true
+
+				break
+			}
 		}
 
 		return upgradeRun(cmd.Context())
@@ -96,14 +118,21 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 		upgradeCmdFlags.wait = true
 	}
 
+
 	if upgradeCmdFlags.noReboot {
 		upgradeCmdFlags.drain = false
+	}
+
+	imageRefs, err := resolveUpgradeImages(ctx, clientFactory)
+	
+	if err != nil {
+		return err
 	}
 
 	if upgradeCmdFlags.legacy {
 		cli.Warning("Forcing use of legacy upgrade method. This flag is deprecated and will be removed in Talos 1.18.")
 
-		return upgradeLegacy(ctx, clientFactory)
+		return upgradeLegacy(ctx, clientFactory, imageRefs)
 	}
 
 	opts := []client.RebootMode{
@@ -126,18 +155,18 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 				Message: "New upgrade API is not available, falling back to legacy",
 			})
 
-			return upgradeLegacy(ctx, clientFactory)
+			return upgradeLegacy(ctx, clientFactory, imageRefs)
 		}
 
 		return fmt.Errorf("error checking Talos version compatibility: %w", err)
 	}
 
-	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, upgradeCmdFlags.upgradeImage, rep)
+	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, imageRefs, rep)
 	if err != nil {
 		return fmt.Errorf("error pulling upgrade image: %w", err)
 	}
 
-	_, err = upgradeInternal(ctx, clientFactory, containerdInstance, upgradeCmdFlags.upgradeImage, rep)
+	_, err = upgradeInternal(ctx, clientFactory, containerdInstance, imageRefs, rep)
 	if err != nil {
 		return fmt.Errorf("error during upgrade: %w", err)
 	}
@@ -173,7 +202,109 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 	return nil
 }
 
-func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, containerdInstance *common.ContainerdInstance, imageRef string, rep *reporter.Reporter) (map[string]int32, error) {
+// resolveUpgradeImages resolves the installer image reference for each targeted node.
+func resolveUpgradeImages(ctx context.Context, clientFactory *global.ClientFactory) (map[string]string, error) {
+	nodes := clientFactory.Nodes()
+
+	// If --image is set, ignore the component flags and use this for upgrading every node (legacy behavior).
+	if upgradeCmdFlags.upgradeImage != "" {
+		if upgradeCmdFlags.componentFlagsChanged {
+			cli.Warning("--image is set, ignoring component flags (--factory, --schematic, --talos-version, --secure-boot, --platform)")
+		}
+
+		return uniformImageRefs(nodes, upgradeCmdFlags.upgradeImage), nil
+	}
+
+	// If every derived component is set explicitly, no per-node state is needed: the image is uniform.
+	if upgradeCmdFlags.schematic != "" && upgradeCmdFlags.platform != "" &&
+		upgradeCmdFlags.secureBootChanged && upgradeCmdFlags.factoryChanged && upgradeCmdFlags.talosVersion != ""{
+		imageRef := buildUpgradeImage(&helpers.MachineContext{})
+
+		fmt.Printf("upgrade image: %s\n", imageRef)
+
+		return uniformImageRefs(nodes, imageRef), nil
+	}
+
+	// Otherwise, each node's machine state must be read to fill in any components not set explicitly.
+	imageRefs := make(map[string]string, len(nodes))
+
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+
+	for _, node := range nodes {
+		wg.Go(func() {
+			machineCtx := &helpers.MachineContext{}
+
+			queryCtx, c, err := clientFactory.BuildClient(ctx, node)
+			if err != nil {
+				cli.Warning("node %s: error building client to read machine state, using the default installer image: %v", node, err)
+			} else if machineCtx, err = helpers.QueryMachineContext(queryCtx, c); err != nil {
+				cli.Warning("node %s: error reading machine state, using the default installer image: %v", node, err)
+
+				machineCtx = &helpers.MachineContext{}
+			}
+
+			imageRef := buildUpgradeImage(machineCtx)
+
+			mu.Lock()
+			imageRefs[node] = imageRef
+			fmt.Printf("%s: upgrade image: %s\n", node, imageRef)
+			mu.Unlock()
+		})
+	}
+
+	wg.Wait()
+
+	return imageRefs, nil
+}
+
+// buildUpgradeImage builds the installer image reference for a single node, taking each component
+// from the explicit flag when set and otherwise from the node's machine state, with the built-in
+// defaults as the final fallback.
+func buildUpgradeImage(machineCtx *helpers.MachineContext) string {
+	targetVersion := upgradeCmdFlags.talosVersion
+	if targetVersion == "" {
+		targetVersion = version.Tag
+	}
+
+	schematic := upgradeCmdFlags.schematic
+	if schematic == "" {
+		schematic = machineCtx.Schematic
+	}
+
+	if schematic == "" {
+        schematic = images.DefaultInstallerImageSchematic
+    }
+
+	platform := upgradeCmdFlags.platform
+	if platform == "" {
+		platform = machineCtx.Platform
+	}
+
+	if platform == "" {
+		platform = "metal"
+	}
+
+	secureBoot := upgradeCmdFlags.secureBoot
+	if !upgradeCmdFlags.secureBootChanged {
+		secureBoot = machineCtx.SecureBoot
+	}
+
+	factory := upgradeCmdFlags.factory
+	if !upgradeCmdFlags.factoryChanged {
+		factory = machineCtx.FactoryHost
+	}
+
+	if factory == "" {
+		factory = images.Factory
+	}
+
+	return helpers.BuildImageFactoryURL(factory, schematic, targetVersion, platform, secureBoot)
+}
+
+func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, containerdInstance *common.ContainerdInstance, imageRefs map[string]string, rep *reporter.Reporter) (map[string]int32, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -190,7 +321,7 @@ func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, c
 			return c.LifecycleClient.Upgrade(ctx, &machine.LifecycleServiceUpgradeRequest{
 				Containerd: containerdInstance,
 				Source: &machine.InstallArtifactsSource{
-					ImageName: imageRef,
+					ImageName: imageRefs[nodeFromContext(ctx)],
 				},
 			})
 		},
@@ -246,7 +377,7 @@ func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, c
 // upgradeLegacy dispatches to the legacy upgrade path, respecting --wait.
 //
 // Note: remove me in Talos 1.18.
-func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory) error {
+func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, imageRefs map[string]string) error {
 	rebootModeStr := strings.ToUpper(upgradeCmdFlags.rebootMode.String())
 
 	rebootMode, ok := machine.UpgradeRequest_RebootMode_value[rebootModeStr]
@@ -254,8 +385,7 @@ func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory) err
 		return fmt.Errorf("invalid reboot mode: %s", upgradeCmdFlags.rebootMode)
 	}
 
-	opts := []client.UpgradeOption{
-		client.WithUpgradeImage(upgradeCmdFlags.upgradeImage),
+	baseOpts := []client.UpgradeOption{
 		client.WithUpgradeRebootMode(machine.UpgradeRequest_RebootMode(rebootMode)),
 		client.WithUpgradePreserve(upgradeCmdFlags.preserve),
 		client.WithUpgradeStage(upgradeCmdFlags.stage),
@@ -263,14 +393,14 @@ func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory) err
 	}
 
 	if !upgradeCmdFlags.wait {
-		return runUpgradeLegacyNoWaitWithOpts(ctx, opts)
+		return runUpgradeLegacyNoWaitWithOpts(ctx, baseOpts, imageRefs)
 	}
 
 	return action.NewTracker(
 		clientFactory,
 		action.MachineReadyEventFn,
 		func(ctx context.Context, c *client.Client) (string, error) {
-			return upgradeGetActorID(ctx, c, opts)
+			return upgradeGetActorID(ctx, c, baseOpts, imageRefs)
 		},
 		action.WithPostCheck(action.BootIDChangedPostCheckFn),
 		action.WithDebug(upgradeCmdFlags.debug),
@@ -278,10 +408,22 @@ func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory) err
 	).Run(ctx)
 }
 
+// legacyUpgradeOptsForNode returns the upgrade options for a single node, appending that node's
+// resolved installer image (recovered from the node-scoped context) to the shared base options.
+//
+// Note: remove me in Talos 1.18.
+func legacyUpgradeOptsForNode(ctx context.Context, baseOpts []client.UpgradeOption, imageRefs map[string]string) []client.UpgradeOption {
+	opts := make([]client.UpgradeOption, 0, len(baseOpts)+1)
+	opts = append(opts, baseOpts...)
+	opts = append(opts, client.WithUpgradeImage(imageRefs[nodeFromContext(ctx)]))
+
+	return opts
+}
+
 // runUpgradeLegacyNoWaitWithOpts runs the legacy upgrade without waiting.
 //
 // Note: remove me in Talos 1.18.
-func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOption) error {
+func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, baseOpts []client.UpgradeOption, imageRefs map[string]string) error {
 	clientFactory, err := NewClientFactory(ctx, &upgradeCmdFlags)
 	if err != nil {
 		return err
@@ -289,13 +431,13 @@ func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOp
 
 	defer clientFactory.Close() //nolint:errcheck
 
-	return doUpgradeLegacy(ctx, clientFactory, opts)
+	return doUpgradeLegacy(ctx, clientFactory, baseOpts, imageRefs)
 }
 
 // doUpgradeLegacy performs the legacy MachineService.Upgrade call across all nodes.
 //
 // Note: remove me in Talos 1.18.
-func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, opts []client.UpgradeOption) error {
+func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, baseOpts []client.UpgradeOption, imageRefs map[string]string) error {
 	if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
 		return err
 	}
@@ -303,6 +445,8 @@ func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, o
 	responseChan := multiplex.UnaryViaFactory(
 		ctx, clientFactory,
 		func(ctx context.Context, c *client.Client) (*machine.UpgradeResponse, error) {
+			opts := legacyUpgradeOptsForNode(ctx, baseOpts, imageRefs)
+
 			// TODO: See if we can validate version and prevent starting upgrades to an unknown version
 			resp, err := c.UpgradeWithOptions(ctx, opts...) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.18
 			if err != nil {
@@ -341,7 +485,9 @@ func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, o
 // upgradeGetActorID is used by the legacy action tracker path.
 //
 // Note: remove me in Talos 1.18.
-func upgradeGetActorID(ctx context.Context, c *client.Client, opts []client.UpgradeOption) (string, error) {
+func upgradeGetActorID(ctx context.Context, c *client.Client, baseOpts []client.UpgradeOption, imageRefs map[string]string) (string, error) {
+	opts := legacyUpgradeOptsForNode(ctx, baseOpts, imageRefs)
+
 	resp, err := c.UpgradeWithOptions(ctx, opts...) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.18
 	if err != nil {
 		return "", err
@@ -355,9 +501,22 @@ func upgradeGetActorID(ctx context.Context, c *client.Client, opts []client.Upgr
 }
 
 func init() {
-	upgradeCmd.Flags().StringVarP(&upgradeCmdFlags.upgradeImage, "image", "i",
-		fmt.Sprintf("%s:%s", images.InstallerImageRepository("metal"), version.Trim(version.Tag)),
-		"the container image to use for performing the install")
+	upgradeCmd.Flags().StringVar(&upgradeCmdFlags.factory, "factory", "",
+		"Image Factory host to use for the installer image (defaults to the machine's factory, then factory.talos.dev)")
+	upgradeCmd.Flags().StringVar(&upgradeCmdFlags.schematic, "schematic", "",
+		"Image Factory schematic ID to use for the installer image (defaults to the machine's current schematic)")
+	upgradeCmd.Flags().StringVar(&upgradeCmdFlags.talosVersion, "talos-version", "",
+		fmt.Sprintf("Talos version to upgrade to (defaults to talosctl version %s)", version.Tag))
+	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.secureBoot, "secure-boot", false,
+		"use the SecureBoot installer image (defaults to the machine's current SecureBoot state)")
+	upgradeCmd.Flags().StringVar(&upgradeCmdFlags.platform, "platform", "",
+		"platform to use for the installer image (defaults to the machine's platform)")
+
+	// --image overrides the component flags; hidden as a legacy way to specify the installer image.
+	upgradeCmd.Flags().StringVarP(&upgradeCmdFlags.upgradeImage, "image", "i", "",
+		"the container image to use for performing the install (overrides the component flags)")
+	upgradeCmd.Flags().MarkHidden("image") //nolint:errcheck
+
 	upgradeCmd.Flags().StringVar(
 		&upgradeCmdFlags.namespace, "namespace", "system",
 		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance",

--- a/cmd/talosctl/pkg/talos/helpers/image_factory.go
+++ b/cmd/talosctl/pkg/talos/helpers/image_factory.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildImageFactoryURL builds an installer image reference of the form
+// <factory>/<platform>-installer[-secureboot]/<schematic ID>:<version>.
+func BuildImageFactoryURL(factory, schematic, version, platform string, secureBoot bool) string {
+	installerType := platform + "-installer"
+	if secureBoot {
+		installerType += "-secureboot"
+	}
+
+	return fmt.Sprintf("%s/%s/%s:v%s", factory, installerType, schematic, strings.TrimPrefix(version, "v"))
+}

--- a/cmd/talosctl/pkg/talos/helpers/machine_context.go
+++ b/cmd/talosctl/pkg/talos/helpers/machine_context.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+// MachineContext is the machine state relevant to building an installer image reference.
+type MachineContext struct {
+	Schematic   string
+	FactoryHost string
+	Platform    string
+	SecureBoot  bool
+}
+
+// QueryMachineContext reads the machine state of the node set in ctx.
+//
+// Only runtime resources are consulted, never the machine configuration.
+func QueryMachineContext(ctx context.Context, c *client.Client) (*MachineContext, error) {
+	machineCtx := &MachineContext{}
+
+	platformMetadata, err := safe.StateGetByID[*runtimeres.PlatformMetadata](ctx, c.COSI, runtimeres.PlatformMetadataID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get platform metadata: %w", err)
+	}
+
+	machineCtx.Platform = platformMetadata.TypedSpec().Platform
+
+	securityState, err := safe.StateGetByID[*runtimeres.SecurityState](ctx, c.COSI, runtimeres.SecurityStateID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get security state: %w", err)
+	}
+
+	machineCtx.SecureBoot = securityState.TypedSpec().SecureBoot
+
+	// The ImageFactorySchematic resource is surfaced by the runtime controller only when the
+	// machine was installed from an Image Factory image, so its absence is not an error.
+	schematic, err := safe.StateGetByID[*runtimeres.ImageFactorySchematic](ctx, c.COSI, runtimeres.ImageFactorySchematicID)
+	if err != nil {
+		if state.IsNotFoundError(err) || status.Code(err) == codes.PermissionDenied {
+			return machineCtx, nil
+		}
+
+		return nil, fmt.Errorf("failed to get image factory schematic: %w", err)
+	}
+
+	machineCtx.Schematic = schematic.TypedSpec().SchematicID
+	machineCtx.FactoryHost = factoryHostFromAPIURL(schematic.TypedSpec().APIURL)
+
+	return machineCtx, nil
+}
+
+// factoryHostFromAPIURL extracts the host from the schematic's API URL so it can be
+// used as the registry host component of a container image reference.
+//
+// e.g. "https://factory.talos.dev" -> "factory.talos.dev"
+func factoryHostFromAPIURL(apiURL string) string {
+    if u, err := url.Parse(apiURL); err == nil && u.Host != "" {
+        return u.Host
+    }
+    
+    return strings.TrimSuffix(apiURL, "/")
+}


### PR DESCRIPTION
# Pull Request
Resolves https://github.com/siderolabs/talos/issues/12152

## What? (description)

- Remove default `--image` parameter, keep as legacy
- Add other parameters like `--factory, --platform,--secureBoot,--schematic`

## Why? (reasoning)

- Prevents node-bricking by replacing dangerous default `--image` with component-based flags that create image url from machine state / specified requirements and validate secure-boot/platform transitions.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

Trying this out on a test node:
```
jinx@jinx:~/siderolabs/talos$ _out/talosctl-linux-amd64 get extensions --nodes 10.5.0.3
WARNING: 10.5.0.3: server version 1.12.0 is older than client version 1.13.0-alpha.0-29-g8e9718be0-dirty
NODE   NAMESPACE   TYPE   ID   VERSION   NAME   VERSION
$ _out/talosctl-linux-amd64 upgrade --nodes 10.5.0.3 \
  --version v1.12.1 \
  --schematic 08ec3d667c94cc858ff2542dc0ae11055004cc6d8338a3d682ea208e7e736be7 

Upgrade Warnings:
  Adding schematic: 08ec3d667c94cc858ff2542dc0ae11055004cc6d8338a3d682ea208e7e736be7


Upgrade Plan:
Version:    v1.12.0 → v1.12.1
Schematic:  08ec3d667c94cc858ff2542dc0ae11055004cc6d8338a3d682ea208e7e736be7 (CHANGED)
SecureBoot: false (unchanged)
Platform:   metal (unchanged)
Factory:    factory.talos.dev
Image:      factory.talos.dev/metal-installer/08ec3d667c94cc858ff2542dc0ae11055004cc6d8338a3d682ea208e7e736be7:v1.12.1

WARNING: 10.5.0.3: server version 1.12.0 is older than client version 1.13.0-alpha.0-29-g8e9718be0-dirty
watching nodes: [10.5.0.3]
    * 10.5.0.3: post check passed
```
Post upgrade check extensions & upgraded version
```
$ _out/talosctl-linux-amd64 get extensions --nodes 10.5.0.3
WARNING: 10.5.0.3: server version 1.12.1 is older than client version 1.13.0-alpha.0-29-g8e9718be0-dirty
NODE       NAMESPACE   TYPE              ID            VERSION   NAME              VERSION
10.5.0.3   runtime     ExtensionStatus   0             1         amazon-ena        2.16.0-v1.12.1
10.5.0.3   runtime     ExtensionStatus   1             1         binfmt-misc       v1.12.1
10.5.0.3   runtime     ExtensionStatus   2             1         bnx2-bnx2x        20251125
10.5.0.3   runtime     ExtensionStatus   3             1         chelsio-drivers   v1.12.1
10.5.0.3   runtime     ExtensionStatus   4             1         schematic         08ec3d667c94cc858ff2542dc0ae11055004cc6d8338a3d682ea208e7e736be7
10.5.0.3   runtime     ExtensionStatus   modules.dep   1         modules.dep       6.18.2-talos
jinx@jinx:~/siderolabs/talos$ _out/talosctl-linux-amd64 --nodes 10.5.0.3 version
Client:
	Tag:         v1.13.0-alpha.0-29-g8e9718be0-dirty
	SHA:         8e9718be-dirty
	Built:       
	Go version:  go1.25.5
	OS/Arch:     linux/amd64
Server:
	NODE:        10.5.0.3
	Tag:         v1.12.1
	SHA:         7ea2ef7c
	Built:       
	Go version:  go1.25.5
	OS/Arch:     linux/amd64
	Enabled:     RBAC
```