### PR TITLE
fix: image gc controller config

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -204,7 +204,7 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			V1Alpha1ServiceManager: system.Services(ctrl.v1alpha1Runtime),
 		},
 		cri.NewImageGCController("containerd", false),
-		cri.NewImageGCController("cri", false),
+		cri.NewImageGCController("cri", true),
 		&cri.RegistriesConfigController{},
 		&cri.SeccompProfileController{},
 		&cri.SeccompProfileFileController{


### PR DESCRIPTION
While refactoring image GC to run on both containerds I messed up controller settings: the CRI image GC should have second argument as 'true', which means it waits for the "expected images" to be populated so that it doesn't GC active kubelet/etcd images.
