### PR TITLE
feat: update doc links to docs.siderolabs.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-More information about contributing to Talos can be found in the [Documentation](https://www.talos.dev/latest/learn-more/developing-talos/).
+More information about contributing to Talos can be found in the [Documentation](https://docs.siderolabs.com/talos/latest/build-and-extend-talos/custom-images-and-development/developing-talos).
 
 ## Developer Certificate of Origin
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -303,7 +303,7 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 		}
 
 		if len(extensions) > 0 {
-			warnings = append(warnings, ".machine.install.extensions is deprecated, please see https://www.talos.dev/latest/talos-guides/install/boot-assets/")
+			warnings = append(warnings, ".machine.install.extensions is deprecated, please see https://docs.siderolabs.com/talos/latest/platform-specific-installations/boot-assets")
 		}
 	}
 
@@ -994,7 +994,7 @@ func (c *Config) RuntimeValidate(ctx context.Context, st state.State, mode valid
 		}
 
 		if len(c.MachineConfig.Install().Extensions()) > 0 {
-			warnings = append(warnings, ".machine.install.extensions is deprecated, please see https://www.talos.dev/latest/talos-guides/install/boot-assets/")
+			warnings = append(warnings, ".machine.install.extensions is deprecated, please see https://docs.siderolabs.com/talos/latest/platform-specific-installations/boot-assets")
 		}
 
 		if err := ValidateKubernetesImageTag(c.Machine().Kubelet().Image()); err != nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -277,7 +277,7 @@ func TestValidate(t *testing.T) {
 			},
 			requiresInstall: true,
 			expectedWarnings: []string{
-				".machine.install.extensions is deprecated, please see https://www.talos.dev/latest/talos-guides/install/boot-assets/",
+				".machine.install.extensions is deprecated, please see https://docs.siderolabs.com/talos/latest/platform-specific-installations/boot-assets",
 			},
 		},
 		{

--- a/pkg/machinery/platforms/platforms.go
+++ b/pkg/machinery/platforms/platforms.go
@@ -132,7 +132,7 @@ func MetalPlatform() Platform {
 		Description: "Runs on bare-metal servers",
 
 		Architectures:   []Arch{ArchAmd64, ArchArm64},
-		Documentation:   "/talos-guides/install/bare-metal-platforms/",
+		Documentation:   "/platform-specific-installations/bare-metal-platforms/bootloader",
 		DiskImageSuffix: "raw.zst",
 		BootMethods: []BootMethod{
 			BootMethodISO,
@@ -155,7 +155,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on AWS VMs booted from an AMI",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/aws/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/aws",
 			DiskImageSuffix: "raw.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -168,7 +168,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Google Cloud VMs booted from a disk image",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/gcp/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/gcp",
 			DiskImageSuffix: "raw.tar.gz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -181,7 +181,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Equinix Metal bare-metal servers",
 
 			Architectures: []Arch{ArchAmd64, ArchArm64},
-			Documentation: "/talos-guides/install/bare-metal-platforms/equinix-metal/",
+			Documentation: "/platform-specific-installations/bare-metal-platforms/equinix-metal",
 			BootMethods: []BootMethod{
 				BootMethodPXE,
 			},
@@ -194,7 +194,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Microsoft Azure Linux Virtual Machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/azure/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/azure",
 			DiskImageSuffix: "vhd.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -207,7 +207,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Digital Ocean droplets",
 
 			Architectures:   []Arch{ArchAmd64},
-			Documentation:   "/talos-guides/install/cloud-platforms/digitalocean/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/digitalocean",
 			DiskImageSuffix: "raw.gz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -220,7 +220,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on various hypervisors supporting 'nocloud' metadata (Proxmox, Oxide Computer, etc.)",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/nocloud/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/nocloud",
 			DiskImageSuffix: "raw.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -236,7 +236,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on OpenStack virtual machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/openstack/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/openstack",
 			DiskImageSuffix: "raw.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -251,7 +251,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on VMWare ESXi virtual machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/virtualized-platforms/vmware/",
+			Documentation:   "/platform-specific-installations/virtualized-platforms/vmware",
 			DiskImageSuffix: "ova",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -267,7 +267,7 @@ func CloudPlatforms() []Platform {
 
 			Architectures:   []Arch{ArchAmd64},
 			MinVersion:      semver.MustParse("1.7.0"),
-			Documentation:   "/talos-guides/install/cloud-platforms/akamai/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/akamai",
 			DiskImageSuffix: "raw.gz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -280,7 +280,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Apache CloudStack virtual machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/cloudstack/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/cloudstack",
 			DiskImageSuffix: "raw.gz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -295,7 +295,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Hetzner virtual machines",
 
 			Architectures:   []Arch{ArchAmd64},
-			Documentation:   "/talos-guides/install/cloud-platforms/hetzner/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/hetzner",
 			DiskImageSuffix: "raw.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -308,7 +308,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Oracle Cloud virtual machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/oracle/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/oracle",
 			DiskImageSuffix: "qcow2",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -321,7 +321,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on UpCloud virtual machines",
 
 			Architectures:   []Arch{ArchAmd64},
-			Documentation:   "/talos-guides/install/cloud-platforms/upcloud/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/upcloud",
 			DiskImageSuffix: "raw.xz",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -334,7 +334,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Vultr Cloud Compute virtual machines",
 
 			Architectures: []Arch{ArchAmd64},
-			Documentation: "/talos-guides/install/cloud-platforms/vultr/",
+			Documentation: "/platform-specific-installations/cloud-platforms/vultr",
 			BootMethods: []BootMethod{
 				BootMethodISO,
 				BootMethodPXE,
@@ -348,7 +348,7 @@ func CloudPlatforms() []Platform {
 			Description: "Runs on Exoscale virtual machines",
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
-			Documentation:   "/talos-guides/install/cloud-platforms/exoscale/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/exoscale",
 			DiskImageSuffix: "qcow2",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
@@ -363,7 +363,7 @@ func CloudPlatforms() []Platform {
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
 			DiskImageSuffix: "raw.zst",
-			Documentation:   "/talos-guides/install/virtualized-platforms/opennebula/",
+			Documentation:   "/platform-specific-installations/virtualized-platforms/opennebula",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
 				BootMethodISO,
@@ -378,7 +378,7 @@ func CloudPlatforms() []Platform {
 
 			Architectures:   []Arch{ArchAmd64, ArchArm64},
 			DiskImageSuffix: "raw.zst",
-			Documentation:   "/talos-guides/install/cloud-platforms/scaleway/",
+			Documentation:   "/platform-specific-installations/cloud-platforms/scaleway",
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
 				BootMethodISO,

--- a/pkg/machinery/platforms/sbcs.go
+++ b/pkg/machinery/platforms/sbcs.go
@@ -47,7 +47,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-raspberrypi",
 
 			Label:         "Raspberry Pi Series",
-			Documentation: "/talos-guides/install/single-board-computers/rpi_generic/",
+			Documentation: "/platform-specific-installations/single-board-computers/rpi_generic",
 		},
 		{
 			Name: "revpi_generic",
@@ -66,7 +66,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-allwinner",
 
 			Label:         "Banana Pi M64",
-			Documentation: "/talos-guides/install/single-board-computers/bananapi_m64/",
+			Documentation: "/platform-specific-installations/single-board-computers/bananapi_m64",
 		},
 		{
 			Name: "nanopi_r4s",
@@ -75,7 +75,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Friendlyelec Nano PI R4S",
-			Documentation: "/talos-guides/install/single-board-computers/nanopi_r4s/",
+			Documentation: "/platform-specific-installations/single-board-computers/nanopi_r4s",
 
 			MinVersion: semver.MustParse("1.3.0"),
 		},
@@ -96,7 +96,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-jetson",
 
 			Label:         "Jetson Nano",
-			Documentation: "/talos-guides/install/single-board-computers/jetson_nano/",
+			Documentation: "/platform-specific-installations/single-board-computers/jetson_nano",
 		},
 		{
 			Name: "libretech_all_h3_cc_h5",
@@ -105,7 +105,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-allwinner",
 
 			Label:         "Libre Computer Board ALL-H3-CC",
-			Documentation: "/talos-guides/install/single-board-computers/libretech_all_h3_cc_h5/",
+			Documentation: "/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5",
 		},
 		{
 			Name: "orangepi_r1_plus_lts",
@@ -114,7 +114,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Orange Pi R1 Plus LTS",
-			Documentation: "/talos-guides/install/single-board-computers/orangepi_r1_plus_lts/",
+			Documentation: "/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts",
 
 			MinVersion: semver.MustParse("1.7.0"),
 		},
@@ -125,7 +125,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-allwinner",
 
 			Label:         "Pine64",
-			Documentation: "/talos-guides/install/single-board-computers/pine64/",
+			Documentation: "/platform-specific-installations/single-board-computers/pine64",
 		},
 		{
 			Name: "rock64",
@@ -134,7 +134,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Pine64 Rock64",
-			Documentation: "/talos-guides/install/single-board-computers/rock64/",
+			Documentation: "/platform-specific-installations/single-board-computers/rock64",
 		},
 		{
 			Name: "rock4cplus",
@@ -143,7 +143,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Radxa ROCK 4C Plus",
-			Documentation: "/talos-guides/install/single-board-computers/rock4cplus/",
+			Documentation: "/platform-specific-installations/single-board-computers/rock4cplus",
 
 			MinVersion: semver.MustParse("1.7.0"),
 		},
@@ -153,8 +153,7 @@ func SBCs() []SBC {
 			OverlayName:  "rock4se",
 			OverlayImage: "siderolabs/sbc-rockchip",
 
-			Label:         "Radxa ROCK 4SE",
-			Documentation: "", // missing
+			Label: "Radxa ROCK 4SE",
 
 			MinVersion: semver.MustParse("1.8.0-alpha.1"),
 		},
@@ -165,7 +164,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Radxa ROCK 5A",
-			Documentation: "/talos-guides/install/single-board-computers/rock5b/",
+			Documentation: "/platform-specific-installations/single-board-computers/rock5b",
 
 			MinVersion: semver.MustParse("1.10.0-beta.0"),
 		},
@@ -176,7 +175,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Radxa ROCK 5B",
-			Documentation: "/talos-guides/install/single-board-computers/rock5b/",
+			Documentation: "/platform-specific-installations/single-board-computers/rock5b",
 
 			MinVersion: semver.MustParse("1.9.2"),
 		},
@@ -187,7 +186,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Radxa ROCK PI 4",
-			Documentation: "/talos-guides/install/single-board-computers/rockpi_4/",
+			Documentation: "/platform-specific-installations/single-board-computers/rockpi_4",
 		},
 		{
 			Name: "rockpi_4c",
@@ -196,7 +195,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Radxa ROCK PI 4C",
-			Documentation: "/talos-guides/install/single-board-computers/rockpi_4c/",
+			Documentation: "/platform-specific-installations/single-board-computers/rockpi_4c",
 		},
 		{
 			Name: "helios64",
@@ -204,8 +203,7 @@ func SBCs() []SBC {
 			OverlayName:  "helios64",
 			OverlayImage: "siderolabs/sbc-rockchip",
 
-			Label:         "Kobol Helios64",
-			Documentation: "", // missing
+			Label: "Kobol Helios64",
 
 			MinVersion: semver.MustParse("1.8.0-alpha.2"),
 		},
@@ -216,7 +214,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Turing RK1",
-			Documentation: "/talos-guides/install/single-board-computers/turing_rk1/",
+			Documentation: "/platform-specific-installations/single-board-computers/turing_rk1",
 
 			MinVersion: semver.MustParse("1.9.0-beta.0"),
 		},
@@ -227,7 +225,7 @@ func SBCs() []SBC {
 			OverlayImage: "siderolabs/sbc-rockchip",
 
 			Label:         "Orange Pi 5",
-			Documentation: "/talos-guides/install/single-board-computers/orangepi_5/",
+			Documentation: "/platform-specific-installations/single-board-computers/orangepi_5",
 
 			MinVersion: semver.MustParse("1.9.2"),
 		},


### PR DESCRIPTION
Update various documentation links that are pointing to `www.talos.dev` to the new docs page at `docs.siderolabs.com`.

Related to siderolabs/omni#1956

Factory/Omni will be updated in a follow-up PR.