### PR TITLE
feat: add explicit service account support to Talos client

### DIFF
--- a/pkg/machinery/client/connection.go
+++ b/pkg/machinery/client/connection.go
@@ -92,10 +92,11 @@ func (c *Client) getConn(opts ...grpc.DialOption) (*grpcConnectionWrapper, error
 		}
 
 		authInterceptor := interceptor.New(interceptor.Options{
-			UserKeyProvider: getKeyProvider(c.options.sideroV1KeysDir),
-			ContextName:     contextName,
-			Identity:        sideroV1.Identity,
-			ClientName:      "Talos",
+			UserKeyProvider:      getKeyProvider(c.options.sideroV1KeysDir),
+			ContextName:          contextName,
+			Identity:             sideroV1.Identity,
+			ClientName:           "Talos",
+			ServiceAccountBase64: c.options.serviceAccountBase64,
 		})
 
 		dialOpts = append(dialOpts,

--- a/pkg/machinery/client/options.go
+++ b/pkg/machinery/client/options.go
@@ -29,9 +29,10 @@ type Options struct {
 	contextOverride    string
 	contextOverrideSet bool
 
-	unixSocketPath      string
-	clusterNameOverride string
-	sideroV1KeysDir     string
+	unixSocketPath       string
+	clusterNameOverride  string
+	sideroV1KeysDir      string
+	serviceAccountBase64 string
 }
 
 // OptionFunc sets an option for the creation of the Client.
@@ -153,6 +154,17 @@ func WithCluster(cluster string) OptionFunc {
 func WithSideroV1KeysDir(keysDir string) OptionFunc {
 	return func(o *Options) error {
 		o.sideroV1KeysDir = keysDir
+
+		return nil
+	}
+}
+
+// WithServiceAccount sets the base64-encoded service account key for authentication.
+//
+// When set, the service account key takes priority over SIDERO_SERVICE_ACCOUNT_KEY and OMNI_SERVICE_ACCOUNT_KEY environment variables.
+func WithServiceAccount(serviceAccountBase64 string) OptionFunc {
+	return func(o *Options) error {
+		o.serviceAccountBase64 = serviceAccountBase64
 
 		return nil
 	}


### PR DESCRIPTION
Add a new functional option for setting the service account key to be used by the Talos client. It already respected the env vars SIDERO_SERVICE_ACCOUNT_KEY and OMNI_SERVICE_ACCOUNT_KEY through the go-api-signature library, but did not provide any way to pass them explicitly.
