### PR TITLE
fix: ignore volumes in wave calculation without provisioning

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
@@ -10,6 +10,7 @@ import (
 	"math"
 
 	"github.com/siderolabs/gen/optional"
+	"github.com/siderolabs/gen/value"
 
 	"github.com/siderolabs/talos/internal/pkg/encryption"
 	blockpb "github.com/siderolabs/talos/pkg/machinery/api/resource/definitions/block"
@@ -18,7 +19,12 @@ import (
 
 // CompareVolumeConfigs compares two volume configs in the proposed order of provisioning.
 func CompareVolumeConfigs(a, b *block.VolumeConfig) int {
-	// first, sort by wave, smaller wave first
+	// first, sort volumes without provisioning instructions first, as they don't block provisioning of other volumes
+	if c := cmpBool(!value.IsZero(a.TypedSpec().Provisioning), !value.IsZero(b.TypedSpec().Provisioning)); c != 0 {
+		return c
+	}
+
+	// second, sort by wave, smaller wave first
 	if c := cmp.Compare(a.TypedSpec().Provisioning.Wave, b.TypedSpec().Provisioning.Wave); c != 0 {
 		return c
 	}

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes_test.go
@@ -25,6 +25,18 @@ func TestCompareVolumeConfigs(t *testing.T) {
 		expected int
 	}{
 		{
+			name: "no provisioning instructions",
+
+			a: &block.VolumeConfigSpec{},
+			b: &block.VolumeConfigSpec{
+				Provisioning: block.ProvisioningSpec{
+					Wave: block.WaveSystemDisk,
+				},
+			},
+
+			expected: -1,
+		},
+		{
 			name: "different wave",
 
 			a: &block.VolumeConfigSpec{
@@ -35,6 +47,9 @@ func TestCompareVolumeConfigs(t *testing.T) {
 			b: &block.VolumeConfigSpec{
 				Provisioning: block.ProvisioningSpec{
 					Wave: block.WaveUserVolumes,
+					FilesystemSpec: block.FilesystemSpec{
+						Type: block.FilesystemTypeEXT4,
+					},
 				},
 			},
 


### PR DESCRIPTION
The waves are used in the volume manager to order provisioning of volumes on disk (allocating a partition, etc.), so that system volumes are done first, and only then user volumes are allocated.

The wave calculation logic had a bug though with volumes which don't have provisioning instructions (they can be only located), e.g. the `IMAGECACHE-ISO` volume which is only located, but never provisioned.

Such volume (if the ISO is missing) will always stay in `missing` status, which is fine, but it shouldn't block the provisioning of the next waves.

Moreover, if `.provisioning` is not set, reading wave from it doesn't make sense, as it will always be zero (unset).

Also sort the volume configs accordingly, volumes without provisioning instructions should be always processed first, they don't block others.
