### PR TITLE
fix: allow static hosts in `/etc/hosts` without hostname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/siderolabs/go-circular v0.2.3
 	github.com/siderolabs/go-cmd v0.1.3
 	github.com/siderolabs/go-copy v0.1.0
-	github.com/siderolabs/go-debug v0.6.1
+	github.com/siderolabs/go-debug v0.6.2
 	github.com/siderolabs/go-kmsg v0.1.4
 	github.com/siderolabs/go-kubeconfig v0.1.1
 	github.com/siderolabs/go-kubernetes v0.2.32

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/siderolabs/go-cmd v0.1.3 h1:JrgZwqhJQeoec3QRON0LK+fv+0y7d0DyY7zsfkO6c
 github.com/siderolabs/go-cmd v0.1.3/go.mod h1:bg7HY4mRNu4zKebAgUevSwuYNtcvPMJfuhLRkVKHZ0k=
 github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
 github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
-github.com/siderolabs/go-debug v0.6.1 h1:LAkM2ADz+naL3PA6Mv0SzyXYx7aCxYlKdO2dSiZmhRc=
-github.com/siderolabs/go-debug v0.6.1/go.mod h1:qKGKnrkHXdgj+gPaGujFs3L/hc87FXYTp1/l6kN/1s0=
+github.com/siderolabs/go-debug v0.6.2 h1:zWWMTcrYDVyiNTotSxEVg++hj9mb2ctuTNVnOeCWtO8=
+github.com/siderolabs/go-debug v0.6.2/go.mod h1:tcHnBjzOfEC/Stfc+cpP8J9Y6y5Pp89XNBN0n3dsWD4=
 github.com/siderolabs/go-kmsg v0.1.4 h1:RLAa90O9bWuhA3pXPAYAdrI+kzcqTshZASRA5yso/mo=
 github.com/siderolabs/go-kmsg v0.1.4/go.mod h1:BLkt2N2DHT0wsFMz32lMw6vNEZL90c8ZnBjpIUoBb/M=
 github.com/siderolabs/go-kubeconfig v0.1.1 h1:tZlgpelj/OqrcHVUwISPN0NRgObcflpH9WtE41mtQZ0=

--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -5,15 +5,11 @@
 package network_test
 
 import (
-	"context"
 	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -139,42 +135,4 @@ func TestAddressMergeSuite(t *testing.T) {
 			},
 		},
 	})
-}
-
-func assertResources[R rtestutils.ResourceWithRD](
-	ctx context.Context,
-	t *testing.T,
-	state state.State,
-	requiredIDs []string,
-	check func(R, *assert.Assertions),
-	opts ...rtestutils.Option,
-) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	rtestutils.AssertResources(
-		ctx,
-		t,
-		state,
-		xslices.Map(requiredIDs, func(id string) resource.ID { return id }),
-		check,
-		opts...,
-	)
-}
-
-func assertNoResource[R rtestutils.ResourceWithRD](
-	ctx context.Context,
-	t *testing.T,
-	state state.State,
-	id string,
-) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	rtestutils.AssertNoResource[R](
-		ctx,
-		t,
-		state,
-		id,
-	)
 }


### PR DESCRIPTION
Allow static hosts to be populated even if the hostname is not populated yet.

This allows to use `ExtraHostConfig` before the hostname is established.

Fixes #12792

While I'm at it, refactor the unit-tests to use modern ctest.DefaultSuite.
