### PR TITLE
fix: hold user volumes root mountpoint

### DIFF
--- a/internal/app/machined/pkg/controllers/block/volume_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config_test.go
@@ -82,6 +82,9 @@ func TestVolumeConfigSuite(t *testing.T) {
 }
 
 func (suite *VolumeConfigSuite) TestReconcileDefaults() {
+	// user volume mount point should be hold mounted all the time to prevent cascading unmounts on kubelet restart
+	ctest.AssertResource(suite, constants.UserVolumeMountPoint, func(*block.VolumeMountRequest, *assert.Assertions) {})
+
 	// no machine config, default config which only searches for
 	ctest.AssertResource(suite, constants.MetaPartitionLabel, func(r *block.VolumeConfig, asrt *assert.Assertions) {
 		asrt.Empty(r.TypedSpec().Provisioning)


### PR DESCRIPTION
This is a regression introduced in #12122 and #12141.

Without this, only `kubelet` holds `/var/mnt`, so on kubelet restart, Talos tries to unmount it, cascading into unmount of all user volumes, which shouldn't be the case.

Fixes #12797
