### PR TITLE
fix: update path handling on talosctl cgroups

### DIFF
--- a/cmd/talosctl/cmd/talos/cgroupsprinter/presets.go
+++ b/cmd/talosctl/cmd/talos/cgroupsprinter/presets.go
@@ -7,6 +7,7 @@ package cgroupsprinter
 import (
 	"embed"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -37,7 +38,8 @@ func GetPresetNames() []string {
 
 // GetPreset returns the preset by name.
 func GetPreset(name string) Schema {
-	f, err := presetsFS.Open(filepath.Join("presets", name+".yaml"))
+	// embed.FS always uses / as separator, even on Windows, we need OS-agnostic path joining here
+	f, err := presetsFS.Open(path.Join("presets", name+".yaml"))
 	if err != nil {
 		panic(err) // should not fail
 	}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

A small fix for [bug](https://github.com/siderolabs/talos/issues/12836) in talosctl that solves breakage of `talosctl cgroups --preset=<preset>` .

## Why? (reasoning)

The call to filepath.join in current code causes breakage when using talosctl on windows due to wrong slash introduced into the embed path.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
