### PR TITLE
feat: include hid-multitouch.ko kernel module in rootfs

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -58,6 +58,7 @@ kernel/drivers/hid/hid-lg-g15.ko
 kernel/drivers/hid/hid-logitech.ko
 kernel/drivers/hid/hid-microsoft.ko
 kernel/drivers/hid/hid-monterey.ko
+kernel/drivers/hid/hid-multitouch.ko
 kernel/drivers/hid/hid-petalynx.ko
 kernel/drivers/hid/hid-pl.ko
 kernel/drivers/hid/hid-samsung.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -41,6 +41,7 @@ kernel/drivers/hid/hid-lg-g15.ko
 kernel/drivers/hid/hid-logitech.ko
 kernel/drivers/hid/hid-microsoft.ko
 kernel/drivers/hid/hid-monterey.ko
+kernel/drivers/hid/hid-multitouch.ko
 kernel/drivers/hid/hid-petalynx.ko
 kernel/drivers/hid/hid-pl.ko
 kernel/drivers/hid/hid-samsung.ko


### PR DESCRIPTION
# Pull Request

## What? (description)
Add hid-multitouch.ko kernel module to hack/modules-*.txt for it to be included in default rootfs.
Was added to kernel build in pkgs/kernel [here](https://github.com/siderolabs/pkgs/pull/1466).

## Why? (reasoning)
Enables passing multi-touch touchscreens to containers as input devices.

## Acceptance
Built metal image and tested on amd64 device with multi-touch capable display attached via USB (& DisplayPort). Talos boots & kernel module loads automatically.
