### PR TITLE
fix: patch with delete for LinkConfigs

### DIFF
--- a/pkg/machinery/config/configpatcher/testdata/patchlink/base.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchlink/base.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth0
+addresses:
+  - address: 10.0.42.136/24
+routes:
+  - gateway: 10.0.42.1

--- a/pkg/machinery/config/configpatcher/testdata/patchlink/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchlink/expected.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth0
+addresses:
+    - address: 10.0.42.137/24
+routes:
+    - gateway: 10.0.42.1

--- a/pkg/machinery/config/configpatcher/testdata/patchlink/patch.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchlink/patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth0
+addresses:
+  - address: 10.0.42.136/24
+    $patch: delete
+  - address: 10.0.42.137/24


### PR DESCRIPTION
There were two issues which prevented this patch from working:

* `CommonLinkConfig` is an embedded struct, so we need to make selector descend into embedded structs properly
* The previous `reflect.Value.String()` doesn't handle correctly complex values (like `netip.Prefix`) which have a custom `fmt.Stringer`

See https://github.com/siderolabs/talos/discussions/12848#discussioncomment-15910003
