### PR TITLE
feat: implement correct config patching for extraArgs fields

### DIFF
--- a/pkg/machinery/config/configpatcher/testdata/apply/config.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/config.yaml
@@ -5,3 +5,8 @@ machine:
     interfaces:
       - interface: eth0
         dhcp: true
+cluster:
+  proxy:
+    extraArgs:
+       metrics-bind-address: $(POD_IP):10249
+       foo: bar

--- a/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/expected.yaml
@@ -23,4 +23,8 @@ machine:
                     - 10.3.4.7
                   routes: []
                   vlanId: 101
-cluster: null
+cluster:
+    controlPlane: null
+    proxy:
+        extraArgs:
+            metrics-bind-address: $(POD_IP):10249

--- a/pkg/machinery/config/configpatcher/testdata/apply/expected_manifests.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/expected_manifests.yaml
@@ -10,6 +10,10 @@ machine:
               dhcp: true
 cluster:
     controlPlane: null
+    proxy:
+        extraArgs:
+            foo: bar
+            metrics-bind-address: $(POD_IP):10249
     inlineManifests:
         - name: cilium
           contents: |

--- a/pkg/machinery/config/configpatcher/testdata/apply/strategic3.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/apply/strategic3.yaml
@@ -7,3 +7,9 @@ machine:
             addresses: [10.3.4.6]
           - vlanId: 101
             addresses: [10.3.4.7]
+cluster:
+  proxy:
+    extraArgs:
+       metrics-bind-address: $(POD_IP):10249
+       foo:
+         $patch: delete

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -21,6 +21,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -67,6 +68,26 @@ func (a Args) ToMap() map[string][]string {
 	}
 
 	return result
+}
+
+// Merge with another Args.
+func (a *Args) Merge(other any) error {
+	otherArgs, ok := other.(Args)
+	if !ok {
+		return fmt.Errorf("cannot merge Args with %T", other)
+	}
+
+	if len(otherArgs) == 0 {
+		return nil
+	}
+
+	if *a == nil {
+		*a = make(Args)
+	}
+
+	maps.Copy(*a, otherArgs)
+
+	return nil
 }
 
 // ArgValue represents a value for an argument, which can be either a single string or a list of strings.


### PR DESCRIPTION
Since the type was changed to the custom one, merging code can't handle it correctly, so add an explicit merge method.

```
merge field v1alpha1.Config.ClusterConfig: merge field v1alpha1.ClusterConfig.ProxyConfig: merge field v1alpha1.ProxyConfig.ExtraArgsConfig: merge map key v1alpha1.Args[metrics-bind-address]: merge field v1alpha1.ArgValue.strValue: merge not possible, left $(POD_IP):10249 is not settable
```
