### PR TITLE
feat: bump kube-network-policy to v1.0.0

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1172,7 +1172,7 @@ const (
 	// KubeNetworkPoliciesVersion is the version of kube-network-policies when network policies are enabled for flannel.
 	//
 	// renovate: datasource=docker depName=registry.k8s.io/networking/kube-network-policies
-	KubeNetworkPoliciesVersion = "v0.9.2"
+	KubeNetworkPoliciesVersion = "v1.0.0"
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -2255,7 +2255,7 @@ talosctl image k8s-bundle [flags]
       --flannel-version semver                 Flannel CNI semantic version (default v0.28.1)
   -h, --help                                   help for k8s-bundle
       --k8s-version semver                     Kubernetes semantic version (default v1.36.0-alpha.1)
-      --kube-network-policies-version semver   kube-network-policies semantic version (default v0.9.2)
+      --kube-network-policies-version semver   kube-network-policies semantic version (default v1.0.0)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
The latest release.
