### PR TITLE
feat: allow dashboard mouse support

### DIFF
--- a/internal/pkg/dashboard/components/footer.go
+++ b/internal/pkg/dashboard/components/footer.go
@@ -14,6 +14,14 @@ import (
 	"github.com/siderolabs/gen/maps"
 )
 
+// hitRegion represents a clickable region in the footer.
+type hitRegion struct {
+	startX int
+	endX   int
+	node   string // non-empty if this is a node region
+	screen string // non-empty if this is a screen region
+}
+
 // Footer represents the top bar with host info.
 type Footer struct {
 	tview.TextView
@@ -25,9 +33,18 @@ type Footer struct {
 
 	selectedScreen string
 	paused         bool
+
+	hitRegions []hitRegion
+
+	// NodeClick is called when a node label is clicked. May be nil.
+	NodeClick func(node string)
+	// ScreenClick is called when a screen label is clicked. May be nil.
+	ScreenClick func(screen string)
 }
 
 // NewFooter initializes Footer.
+//
+//nolint:gocyclo
 func NewFooter(screenKeyToName map[string]string, nodes []string) *Footer {
 	var initialScreen string
 	for _, name := range screenKeyToName {
@@ -62,6 +79,30 @@ func NewFooter(screenKeyToName map[string]string, nodes []string) *Footer {
 		return x, y, width, height
 	})
 
+	widget.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		if action != tview.MouseLeftClick {
+			return action, event
+		}
+
+		mx, _ := event.Position()
+		wx, _, _, _ := widget.GetRect()
+		clickX := mx - wx
+
+		for _, region := range widget.hitRegions {
+			if clickX >= region.startX && clickX < region.endX {
+				if region.node != "" && widget.NodeClick != nil {
+					widget.NodeClick(region.node)
+				} else if region.screen != "" && widget.ScreenClick != nil {
+					widget.ScreenClick(region.screen)
+				}
+
+				break
+			}
+		}
+
+		return action, event
+	})
+
 	widget.refresh()
 
 	return widget
@@ -88,52 +129,87 @@ func (widget *Footer) SetPaused(paused bool) {
 	widget.refresh()
 }
 
+// refresh rebuilds the footer text and updates hit regions for mouse click detection.
+//
+// The footer format is: [node1 | node2 | node3] --- [F1: Screen1] --- [Screen2] --- ...
+// where the selected node/screen is highlighted in red.
+// Hit regions track the x-offset ranges of each node and screen label.
 func (widget *Footer) refresh() {
-	widget.SetText(fmt.Sprintf(
-		"[%s] --- %s",
-		widget.nodesText(),
-		widget.screensText(),
-	))
-}
+	var sb strings.Builder
 
-func (widget *Footer) nodesText() string {
-	nodesCopy := make([]string, 0, len(widget.nodes))
+	x := 0
+	widget.hitRegions = widget.hitRegions[:0]
 
-	for _, node := range widget.nodes {
-		if node == widget.selectedNode {
-			name := node
-			if name == "" {
-				name = "(local)"
-			}
+	// write appends s to the text and advances x by the visible character width.
+	write := func(s string, visibleWidth int) {
+		sb.WriteString(s)
 
-			nodesCopy = append(nodesCopy, fmt.Sprintf("[red]%s[-]", name))
-		} else {
-			nodesCopy = append(nodesCopy, node)
-		}
+		x += visibleWidth
 	}
 
-	return strings.Join(nodesCopy, " | ")
-}
+	// Opening bracket wrapping the nodes section.
+	write("[", 1)
 
-func (widget *Footer) screensText() string {
+	for i, node := range widget.nodes {
+		if i > 0 {
+			write(" | ", 3)
+		}
+
+		displayName := node
+		if displayName == "" {
+			displayName = "(local)"
+		}
+
+		startX := x
+		nameLen := len([]rune(displayName))
+
+		if node == widget.selectedNode {
+			write(fmt.Sprintf("[red]%s[-]", displayName), nameLen)
+		} else {
+			write(displayName, nameLen)
+		}
+
+		widget.hitRegions = append(widget.hitRegions, hitRegion{
+			startX: startX,
+			endX:   x,
+			node:   node,
+		})
+	}
+
+	// Closing bracket and separator between nodes and screens.
+	write("] --- ", 6)
+
 	screenKeys := maps.Keys(widget.screenKeyToName)
 	slices.Sort(screenKeys)
 
-	screenTexts := make([]string, 0, len(widget.screenKeyToName))
-
-	for _, screenKey := range screenKeys {
-		screen := widget.screenKeyToName[screenKey]
-
-		if screen == widget.selectedScreen {
-			screenTexts = append(screenTexts, fmt.Sprintf("[[red]%s[-]]", screen))
-		} else {
-			screenTexts = append(screenTexts, fmt.Sprintf("[%s: %s]", screenKey, screen))
+	for i, screenKey := range screenKeys {
+		if i > 0 {
+			write(" --- ", 5)
 		}
+
+		screenName := widget.screenKeyToName[screenKey]
+		startX := x
+
+		if screenName == widget.selectedScreen {
+			// [[red]ScreenName[-]] renders as [ScreenName] (the [[ is an escaped [).
+			write(fmt.Sprintf("[[red]%s[-]]", screenName), len([]rune(screenName))+2)
+		} else {
+			// [F1: ScreenName] is not a tview color tag and renders literally.
+			write(fmt.Sprintf("[%s: %s]", screenKey, screenName), len(screenKey)+len([]rune(screenName))+4)
+		}
+
+		widget.hitRegions = append(widget.hitRegions, hitRegion{
+			startX: startX,
+			endX:   x,
+			screen: screenName,
+		})
 	}
 
 	if widget.paused {
-		screenTexts = append(screenTexts, "[[yellow]PAUSED[-]]")
+		// [[yellow]PAUSED[-]] renders as [PAUSED] — no click region needed.
+		write(" --- ", 5)
+		write("[[yellow]PAUSED[-]]", 8)
 	}
 
-	return strings.Join(screenTexts, " --- ")
+	widget.SetText(sb.String())
 }

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -164,6 +164,7 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 
 	dashboard.pages = tview.NewPages().AddPage(pageMain, dashboard.mainGrid, true, true)
 
+	dashboard.app.EnableMouse(true)
 	dashboard.app.SetRoot(dashboard.pages, true).SetFocus(dashboard.pages)
 
 	header := components.NewHeader()
@@ -182,6 +183,25 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 	})
 
 	dashboard.footer = components.NewFooter(screenKeyToName, nodes)
+
+	dashboard.footer.NodeClick = func(node string) {
+		allowNodeNavigation := dashboard.selectedScreenConfig != nil && dashboard.selectedScreenConfig.allowNodeNavigation
+		if !allowNodeNavigation {
+			return
+		}
+
+		for i, n := range dashboard.nodes {
+			if n == node {
+				dashboard.selectNodeByIndex(i)
+
+				break
+			}
+		}
+	}
+
+	dashboard.footer.ScreenClick = func(screenName string) {
+		dashboard.selectScreen(Screen(screenName))
+	}
 
 	dashboard.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		config, screenOk := screenConfigByKeyCode[event.Key()]


### PR DESCRIPTION
Allow mouse input, this already works in Table component (process list).

We have a custom footer, which is not a set of buttons, so instead add a custom handler, so that nodes & screens in the footer are clickable now.

No change for the way it looks.
