### PR TITLE
feat: add --cidr-v6 flag for custom IPv6 prefix in QEMU provisioner

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -381,18 +381,33 @@ func (m *Maker[T]) initCIDRs() error {
 	}
 
 	if !cidr4.Addr().Is4() {
-		return errors.New("IPV4 CIDR expected, got IPV6 CIDR")
+		return errors.New("IPv4 CIDR expected for --cidr, got IPv6 CIDR")
 	}
 
-	// use ULA IPv6 network fd00::/8, add 'TAL' in hex to build /32 network, add IPv4 CIDR to build /64 unique network
-	cidr6, err := netip.ParsePrefix(
-		fmt.Sprintf(
-			"fd74:616c:%02x%02x:%02x%02x::/64",
-			cidr4.Addr().As4()[0], cidr4.Addr().As4()[1], cidr4.Addr().As4()[2], cidr4.Addr().As4()[3],
-		),
-	)
-	if err != nil {
-		return fmt.Errorf("error validating cidr IPv6 block: %w", err)
+	var cidr6 netip.Prefix
+
+	if m.Ops.NetworkCIDRv6 != "" {
+		m.Ops.NetworkIPv6 = true
+
+		cidr6, err = netip.ParsePrefix(m.Ops.NetworkCIDRv6)
+		if err != nil {
+			return fmt.Errorf("error validating cidr-v6 block: %w", err)
+		}
+
+		if !cidr6.Addr().Is6() {
+			return errors.New("IPv6 CIDR expected for --cidr-v6, got IPv4 CIDR")
+		}
+	} else {
+		// use ULA IPv6 network fd00::/8, add 'TAL' in hex to build /32 network, add IPv4 CIDR to build /64 unique network
+		cidr6, err = netip.ParsePrefix(
+			fmt.Sprintf(
+				"fd74:616c:%02x%02x:%02x%02x::/64",
+				cidr4.Addr().As4()[0], cidr4.Addr().As4()[1], cidr4.Addr().As4()[2], cidr4.Addr().As4()[3],
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("error validating cidr IPv6 block: %w", err)
+		}
 	}
 
 	var cidrs []netip.Prefix

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
@@ -149,6 +149,60 @@ func TestCommonMaker_MachineConfig(t *testing.T) {
 	assertConfigDefaultness(t, cOps, m, nil)
 }
 
+func TestCommonMaker_CustomIPv6CIDR(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	cOps.Controlplanes = 1
+	cOps.Workers = 1
+	cOps.NetworkCIDRv6 = "2001:db8:1::/64"
+	cOps.RootOps.ClusterName = "test-custom-v6"
+
+	m := getInitializedTestMaker(t, cOps)
+
+	assert.Equal(t, 2, len(m.Cidrs))
+	assert.Equal(t, "10.5.0.0/24", m.Cidrs[0].String())
+	assert.Equal(t, "2001:db8:1::/64", m.Cidrs[1].String())
+
+	controlplanes := m.ClusterRequest.Nodes.ControlPlaneNodes()
+	workers := m.ClusterRequest.Nodes.WorkerNodes()
+
+	assert.Equal(t, "10.5.0.2", controlplanes[0].IPs[0].String())
+	assert.Equal(t, "2001:db8:1::2", controlplanes[0].IPs[1].String())
+	assert.Equal(t, "10.5.0.3", workers[0].IPs[0].String())
+	assert.Equal(t, "2001:db8:1::3", workers[0].IPs[1].String())
+}
+
+func TestCommonMaker_CustomIPv6CIDR_Invalid(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	cOps.NetworkIPv6 = true
+	cOps.NetworkCIDRv6 = "invalid-cidr"
+	cOps.RootOps.ClusterName = "test-invalid-v6"
+
+	m, err := makers.New(makers.MakerOptions[any]{CommonOps: cOps, Provisioner: testProvisioner{}})
+	require.NoError(t, err)
+
+	m.SetExtraOptionsProvider(&nothingProvider{})
+
+	err = m.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cidr-v6")
+}
+
+func TestCommonMaker_CustomIPv6CIDR_IPv4Passed(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	cOps.NetworkIPv6 = true
+	cOps.NetworkCIDRv6 = "10.5.0.0/24"
+	cOps.RootOps.ClusterName = "test-ipv4-to-v6"
+
+	m, err := makers.New(makers.MakerOptions[any]{CommonOps: cOps, Provisioner: testProvisioner{}})
+	require.NoError(t, err)
+
+	m.SetExtraOptionsProvider(&nothingProvider{})
+
+	err = m.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv6 CIDR expected for --cidr-v6")
+}
+
 // assertConfigDefaultness makes sure the maker-generated machine configs are not different from default talos machine configs.
 func assertConfigDefaultness[ExtraOps any](t *testing.T, cOps clusterops.Common, m makers.Maker[ExtraOps], desiredExtraGenOps []generate.Option, extraPatches ...configpatcher.Patch) {
 	versionContract, err := config.ParseContractFromVersion(version.Tag)

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -82,6 +82,7 @@ type Common struct {
 	WireguardCIDR             string
 	WithUUIDHostnames         bool
 	NetworkIPv6               bool
+	NetworkCIDRv6             string
 	OmniAPIEndpoint           string
 }
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -26,6 +26,7 @@ var (
 	registryMirrorFlagName    = "registry-mirror"
 	networkMTUFlagName        = "mtu"
 	networkCIDRFlagName       = "cidr"
+	networkCIDRv6FlagName     = "cidr-v6"
 	talosVersionFlagName      = "talos-version"
 
 	// Flags that have been renamed in the user-facing commands.

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -172,7 +172,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		addNetworkMTUFlag(common, &cOps.NetworkMTU)
 		addTalosVersionFlag(common, &cOps.TalosVersion, "the desired Talos version to generate config for")
 
-		common.StringVar(&cOps.NetworkCIDR, networkCIDRFlagName, cOps.NetworkCIDR, "CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way)")
+		common.StringVar(&cOps.NetworkCIDR, networkCIDRFlagName, cOps.NetworkCIDR, "IPv4 CIDR of the cluster network")
 		common.StringVar(&cOps.WireguardCIDR, wireguardCIDRFlag, cOps.WireguardCIDR, "CIDR of the wireguard network")
 		common.BoolVar(&cOps.ApplyConfigEnabled, applyConfigEnabledFlag, cOps.ApplyConfigEnabled, "enable apply config when the VM is starting in maintenance mode")
 		common.StringSliceVar(&cOps.RegistryInsecure, registryInsecureFlag, cOps.RegistryInsecure, "list of registry hostnames to skip TLS verification for")
@@ -195,6 +195,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		common.BoolVar(&cOps.SkipK8sNodeReadinessCheck, skipK8sNodeReadinessCheckFlag, cOps.SkipK8sNodeReadinessCheck, "skip k8s node readiness checks")
 		common.BoolVar(&cOps.WithJSONLogs, withJSONLogsFlag, cOps.WithJSONLogs, "enable JSON logs receiver and configure Talos to send logs there")
 		common.BoolVar(&cOps.WithUUIDHostnames, withUUIDHostnamesFlag, cOps.WithUUIDHostnames, "use machine UUIDs as default hostnames")
+		common.StringVar(&cOps.NetworkCIDRv6, networkCIDRv6FlagName, cOps.NetworkCIDRv6, "IPv6 CIDR of the cluster network (optional, enables IPv6, defaults to automatic ULA derivation)")
 		common.BoolVar(&cOps.NetworkIPv6, networkIPv6Flag, cOps.NetworkIPv6, "enable IPv6 network in the cluster")
 
 		return common

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
@@ -33,7 +33,7 @@ func init() {
 	commonFlags := getCommonUserFacingFlags(&cOps)
 	addControlplanesFlag(commonFlags, &cOps.Controlplanes)
 	addTalosVersionFlag(commonFlags, &cOps.TalosVersion, "the desired talos version")
-	commonFlags.StringVar(&cOps.NetworkCIDR, networkCIDRFlagName, "10.5.0.0/24", "CIDR of the cluster network")
+	commonFlags.StringVar(&cOps.NetworkCIDR, networkCIDRFlagName, "10.5.0.0/24", "IPv4 CIDR of the cluster network")
 
 	getQemuFlags := func() *pflag.FlagSet {
 		qemu := pflag.NewFlagSet("qemu", pflag.PanicOnError)


### PR DESCRIPTION
## Summary

- Adds `--cidr-v6` flag to `talosctl cluster create qemu` to specify a custom IPv6 CIDR
- Falls back to ULA derivation (existing behavior) if `--cidr-v6` is not specified
- Enables joining QEMU-provisioned nodes to clusters with public IPv6 addressing

## Changes

- Add `NetworkCIDRv6` field to `Common` options struct in `options.go`
- Add `networkCIDRv6FlagName` constant and flag binding in `cmd.go` / `cmd_qemu.go`
- Modify `initCIDRs()` in `common.go` to use custom IPv6 CIDR when provided

## Example Usage

```bash
talosctl cluster create qemu   --cidr 10.5.0.0/24   --cidr-v6 2a01:e11:2440:2435::/80   --ipv6   --workers 1
```

## Testing

- All existing unit tests pass
- Built talosctl and verified `--help` shows the new flag
- Tested with custom IPv6 CIDR and verified it is used instead of ULA

Closes #12872

## Breaking Changes

None - backward compatible. If `--cidr-v6` is not specified, the existing ULA derivation behavior is used.