### PR TITLE
fix: ignore image digest when doing upgrade-k8s

### DIFF
--- a/pkg/cluster/kubernetes/detect.go
+++ b/pkg/cluster/kubernetes/detect.go
@@ -48,12 +48,14 @@ func DetectLowestVersion(ctx context.Context, cluster UpgradeProvider, options U
 				continue
 			}
 
-			idx := strings.LastIndex(container.Image, ":")
-			if idx == -1 {
+			image, _, _ := strings.Cut(container.Image, "@")
+
+			_, imageTag, ok := strings.Cut(image, ":")
+			if !ok {
 				continue
 			}
 
-			v, err := semver.ParseTolerant(strings.TrimLeft(container.Image[idx+1:], "v"))
+			v, err := semver.ParseTolerant(strings.TrimLeft(imageTag, "v"))
 			if err != nil {
 				options.Log("failed to parse %s container version %s", app, err)
 

--- a/pkg/cluster/kubernetes/kubelet.go
+++ b/pkg/cluster/kubernetes/kubelet.go
@@ -191,6 +191,8 @@ func upgradeKubeletPatcher(
 		}
 
 		oldImage := kubeletSpec.TypedSpec().Image
+		oldImage, _, _ = strings.Cut(oldImage, "@") // ignore digest if present
+
 		oldSuffix := extractKubeletVersionSuffix(oldImage)
 		newVersion := options.Path.ToVersion() + oldSuffix
 

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -392,6 +392,7 @@ func upgradeStaticPodPatcher(options UpgradeOptions, service string, configResou
 		}
 
 		logUpdate := func(oldImage string) {
+			oldImage, _, _ = strings.Cut(oldImage, "@") // ignore digest if present
 			_, version, _ := strings.Cut(oldImage, ":")
 
 			if version == "" {

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -6,6 +6,7 @@ package images
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
@@ -115,6 +116,8 @@ func ListWithOptions(config config.Config, opts VersionsListOptions) Versions {
 }
 
 func mustParseTag(s string) name.Tag {
+	s, _, _ = strings.Cut(s, "@") // ignore digest if present
+
 	r, err := name.ParseReference(s)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The `talosctl upgrade-k8s` doesn't support pinning to image digests, but it should ignore any image digests if they already exist in the machine configuration.


