### PR TITLE
fix: use correct dhcp option for unicast dhcp renewal

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -463,15 +463,15 @@ func (d *DHCP4) parseNetworkConfigFromAck(ack *dhcpv4.DHCPv4, useHostname bool) 
 func (d *DHCP4) newClient() (*nclient4.Client, error) {
 	var clientOpts []nclient4.ClientOpt
 
-	// We have an existing lease, target the server with unicast
-	if d.lease != nil && !d.lease.ACK.ServerIPAddr.IsUnspecified() {
+	// We have an existing lease, target the server with unicast.
+	if d.lease != nil && d.lease.ACK.ServerIdentifier() != nil {
 		// RFC 2131, section 4.3.2:
 		//     DHCPREQUEST generated during RENEWING state:
 		//     ... This message will be unicast, so no relay
 		//     agents will be involved in its transmission.
 		clientOpts = append(clientOpts,
 			nclient4.WithServerAddr(&net.UDPAddr{
-				IP:   d.lease.ACK.ServerIPAddr,
+				IP:   d.lease.ACK.ServerIdentifier(),
 				Port: nclient4.ServerPort,
 			}),
 			// WithUnicast must be specified manually, WithServerAddr is not enough
@@ -556,7 +556,7 @@ func (d *DHCP4) requestRenew(ctx context.Context, hostname network.HostnameStatu
 	addresses := d.AddressSpecs()
 
 	switch {
-	case d.lease != nil && !d.lease.ACK.ServerIPAddr.IsUnspecified():
+	case d.lease != nil && d.lease.ACK.ServerIdentifier() != nil:
 		d.logger.Debug("DHCP RENEW", zap.String("link", d.linkName))
 		d.lease, err = client.Renew(ctx, d.lease, mods...)
 	case d.lease != nil && d.lease.Offer != nil:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Talos attempts to do unicast DHCP renewal, if possible.
However, if the DHCP server announces a PXE server in DHCP replies, talos erroneously send packets to this server, instead of the actual DHCP server. Because it falls back to broadcast, this issue did not surface.
On networks where the PXE server has a different IP than the DHCP server (not uncommon in commercial and homelab setups), talos continuously logged this error:

```
[talos] DHCP request/renew failed {"component": "controller-runtime", "controller": "network.OperatorSpecController", "operator": "dhcp4", "error": "got an error while processing the request: no matching response packet received", "link": "enp2s0"} 
```

Use Option 54 (`server-identifier`) as the unicast destination, not `siaddr` (`ServerIPAddr`), which indicates the the PXE `next server` field (RFC 2131 §2) and is not the correct field to use in this context.

The error message itself originates in a library imported for handling DHCP.

## Why? (reasoning)

DHCP is not broken as it falls back to broadcast, but it does not work as expected and produces log spam.

Overly restrictive and unreasonably paranoid firewalls might also cut the network connection, as over the course of the bug talos (whilst already booted) will send unexpected DHCP requests to the PXE server IP of the network.

The log message is also somewhat confusing.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.


---

Feel free to take over and merge this on my behalf.

Reproducer, it's somewhat tricky to set up:
1. deploy dnsmasq or similar. restrict to an isolated interface/network. Make sure it is the only DHCP server on that network.
2. set PXE server DHCP Option to some IP, that is not equal to the IP it listens on
3. set DHCP lease time to something low, like 60 seconds
4. create a talos VM on that same network. Boot the iso, this uses DHCPv4 per default
5. run `tcpdump`, on the network interface look for `arp` and `dhcp` traffic (I used `sudo tcpdump -i virbr-talos-pxe -n -v 'udp dst port 68 or dst port 67 or arp'`) 
7. after a short while, talos will ARP and reach out to the PXE IP defined in step two. As it has already booted and received an IP request via DHCP broadcast, there is no reason for it to do this. This is the bug fixed here.
8. Compare to an iso built from the fixed version, step 7 will not happen anymore and talos will straight send it's DHCP renewal request to the designated DHCP server IP.

I used `libvirt` for this on a bridge interface. `dnsmasq.conf` used:

```
# Interface
interface=virbr-talos-pxe
bind-interfaces

# DNS — forward to a public resolver so Talos can reach NTP etc.
no-resolv
server=8.8.8.8

# DHCP — 60s lease so T1 fires at 30s, short enough for interactive testing
dhcp-range=10.10.2.100,10.10.2.199,60s

# PXE next-server: sets siaddr=10.10.2.50 in every DHCP reply.
# This is the bug trigger: siaddr ≠ server-identifier (10.10.2.1).
dhcp-boot=snp.efi,,10.10.2.50

# Fictitious host entry, surfaces ARP issue in tcpdump
dhcp-host=52:54:00:de:ad:01,fake-pxe,10.10.2.50

dhcp-leasefile=/tmp/dnsmasq-pxe.leases
log-dhcp
```