### PR TITLE
feat: add trusted roots generation to stdpatches

### DIFF
--- a/pkg/machinery/config/generate/stdpatches/stdpatches.go
+++ b/pkg/machinery/config/generate/stdpatches/stdpatches.go
@@ -6,6 +6,8 @@
 package stdpatches
 
 import (
+	"fmt"
+
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
@@ -13,6 +15,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 )
 
@@ -33,6 +36,18 @@ func WithStaticHostname(versionContract *config.VersionContract, hostname string
 			},
 		},
 	})
+}
+
+// WithTrustedRoots returns a patch that sets trusted roots in the machine configuration.
+func WithTrustedRoots(versionContract *config.VersionContract, trustedRoots string) ([]byte, error) {
+	if versionContract.MultidocNetworkConfigSupported() {
+		trustedRootsConfig := security.NewTrustedRootsConfigV1Alpha1()
+		trustedRootsConfig.Certificates = trustedRoots
+
+		return patchFromDocument(trustedRootsConfig)
+	}
+
+	return nil, fmt.Errorf("trusted roots patch is not supported for version contract %s", versionContract.String())
 }
 
 func patchFromDocument(doc configconfig.Document) ([]byte, error) {

--- a/pkg/machinery/config/generate/stdpatches/stdpatches_test.go
+++ b/pkg/machinery/config/generate/stdpatches/stdpatches_test.go
@@ -48,6 +48,22 @@ func TestPatches(t *testing.T) {
 				assert.Equal(t, "hostname-1", cfg.NetworkHostnameConfig().Hostname())
 			},
 		},
+		{
+			name: "WithTrustedRoots",
+
+			patch: func(vc *config.VersionContract) ([]byte, error) {
+				return stdpatches.WithTrustedRoots(vc, "trusted-roots-1")
+			},
+
+			versionContracts: []*config.VersionContract{
+				config.TalosVersion1_12,
+			},
+			kubernetesVersion: "1.34.0",
+
+			assertion: func(t *testing.T, cfg config.Config) {
+				assert.Len(t, cfg.TrustedRoots().ExtraTrustedRootCertificates(), 1)
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This PR would add the ability to generate a standardized document for trusted roots. Ran into wanting this with the vsphere provider and I generally feel like we should try to extend the available standard patches here over time.