### PR TITLE
fix: correctly calculate end ranges for nftables sets

### DIFF
--- a/internal/app/machined/pkg/adapters/network/nftables_rule.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule.go
@@ -93,25 +93,36 @@ func (set NfTablesSet) KeyType() nftables.SetDatatype {
 }
 
 // SetElements returns the set elements.
+//
+//nolint:gocyclo
 func (set NfTablesSet) SetElements() []nftables.SetElement {
 	switch set.Kind {
 	case SetKindIPv4, SetKindIPv6:
 		elements := make([]nftables.SetElement, 0, len(set.Addresses)*2)
 
 		for _, r := range set.Addresses {
-			fromBin, _ := r.From().MarshalBinary()    //nolint:errcheck // doesn't fail
-			toBin, _ := r.To().Next().MarshalBinary() //nolint:errcheck // doesn't fail
+			fromBin, _ := r.From().MarshalBinary() //nolint:errcheck // doesn't fail
 
 			elements = append(elements,
 				nftables.SetElement{
 					Key:         fromBin,
 					IntervalEnd: false,
 				},
-				nftables.SetElement{
+			)
+
+			// r.To().Next() overflows for the max address (255.255.255.255 or ffff:...:ffff),
+			// returning the zero Addr whose MarshalBinary() yields nil.
+			// In that case, omit the interval-end element — nftables treats the absence
+			// of an end boundary as extending to the maximum value.
+			next := r.To().Next()
+			if next.IsValid() {
+				toBin, _ := next.MarshalBinary() //nolint:errcheck // doesn't fail
+
+				elements = append(elements, nftables.SetElement{
 					Key:         toBin,
 					IntervalEnd: true,
-				},
-			)
+				})
+			}
 		}
 
 		return elements
@@ -122,18 +133,25 @@ func (set NfTablesSet) SetElements() []nftables.SetElement {
 
 		for _, p := range ports {
 			from := binaryutil.BigEndian.PutUint16(p[0])
-			to := binaryutil.BigEndian.PutUint16(p[1] + 1)
 
 			elements = append(elements,
 				nftables.SetElement{
 					Key:         from,
 					IntervalEnd: false,
 				},
-				nftables.SetElement{
-					Key:         to,
-					IntervalEnd: true,
-				},
 			)
+
+			// handle overflow of p[1]+1 for the max port 65535, as binaryutil.BigEndian.PutUint16(65536) returns 0
+			if p[1] != 65535 {
+				to := binaryutil.BigEndian.PutUint16(p[1] + 1)
+
+				elements = append(elements,
+					nftables.SetElement{
+						Key:         to,
+						IntervalEnd: true,
+					},
+				)
+			}
 		}
 
 		return elements

--- a/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
+++ b/internal/app/machined/pkg/adapters/network/nftables_rule_test.go
@@ -812,6 +812,55 @@ func TestNftablesSet(t *testing.T) { //nolint:tparallel
 				{Key: []uint8{0x13, 0x8a}, IntervalEnd: true},
 			},
 		},
+		{
+			name: "ports with overflow",
+
+			set: network.NfTablesSet{
+				Kind: network.SetKindPort,
+				Ports: [][2]uint16{
+					{65530, 65535},
+				},
+			},
+
+			expectedKeyType:  nftables.TypeInetService,
+			expectedInterval: true,
+			expectedData: []nftables.SetElement{ // network byte order
+				{Key: []uint8{0xff, 0xfa}, IntervalEnd: false}, // 65530-inf
+			},
+		},
+		{
+			name: "regular ip range",
+
+			set: network.NfTablesSet{
+				Kind: network.SetKindIPv4,
+				Addresses: []netipx.IPRange{
+					netipx.MustParseIPRange("10.0.0.0-10.0.0.255"),
+				},
+			},
+
+			expectedKeyType:  nftables.TypeIPAddr,
+			expectedInterval: true,
+			expectedData: []nftables.SetElement{ // network byte order
+				{Key: []uint8{10, 0, 0, 0}, IntervalEnd: false},
+				{Key: []uint8{10, 0, 1, 0}, IntervalEnd: true},
+			},
+		},
+		{
+			name: "ip range with overflow",
+
+			set: network.NfTablesSet{
+				Kind: network.SetKindIPv4,
+				Addresses: []netipx.IPRange{
+					netipx.MustParseIPRange("10.0.0.0-255.255.255.255"),
+				},
+			},
+
+			expectedKeyType:  nftables.TypeIPAddr,
+			expectedInterval: true,
+			expectedData: []nftables.SetElement{ // network byte order
+				{Key: []uint8{10, 0, 0, 0}, IntervalEnd: false}, // 10.0.0.0-inf
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expectedKeyType, test.set.KeyType())

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
@@ -557,6 +557,50 @@ func (s *NfTablesChainSuite) TestL4MatchAny() {
 }`)
 }
 
+func (s *NfTablesChainSuite) TestL4MatchAnyWithHole() {
+	chain := network.NewNfTablesChain(network.NamespaceName, "test-tcp")
+	chain.TypedSpec().Type = nethelpers.ChainTypeFilter
+	chain.TypedSpec().Hook = nethelpers.ChainHookInput
+	chain.TypedSpec().Priority = nethelpers.ChainPriorityFilter
+	chain.TypedSpec().Policy = nethelpers.VerdictAccept
+	chain.TypedSpec().Rules = []network.NfTablesRule{
+		{
+			MatchSourceAddress: &network.NfTablesAddressMatch{
+				IncludeSubnets: []netip.Prefix{
+					netip.MustParsePrefix("0.0.0.0/0"),
+					netip.MustParsePrefix("::/0"),
+				},
+				ExcludeSubnets: []netip.Prefix{
+					netip.MustParsePrefix("10.1.2.3/32"),
+					netip.MustParsePrefix("fe80::1/128"),
+				},
+			},
+			MatchLayer4: &network.NfTablesLayer4Match{
+				Protocol: nethelpers.ProtocolTCP,
+				MatchDestinationPort: &network.NfTablesPortMatch{
+					Ranges: []network.PortRange{
+						{
+							Lo: 1023,
+							Hi: 1023,
+						},
+					},
+				},
+			},
+			Verdict: new(nethelpers.VerdictAccept),
+		},
+	}
+
+	s.Require().NoError(s.State().Create(s.Ctx(), chain))
+
+	s.checkNftOutput(`table inet talos-test {
+	chain test-tcp {
+		type filter hook input priority filter; policy accept;
+		ip saddr { 0.0.0.0-10.1.2.2, 10.1.2.4-255.255.255.255 } tcp dport { 1023 } accept
+		ip6 saddr { ::-fe80::, fe80::2-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } tcp dport { 1023 } accept
+	}
+}`)
+}
+
 func (s *NfTablesChainSuite) TestICMPTypeMatch() {
 	chain := network.NewNfTablesChain(network.NamespaceName, "test-tcp")
 	chain.TypedSpec().Type = nethelpers.ChainTypeFilter


### PR DESCRIPTION
If the end range reaches "max value", we need to drop it instead of overflowing.

Fixes #12890
