### PR TITLE
fix(machined): fix hostname sanitization and FQDN splitting for OpenNebula

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/hostname_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/hostname_test.go
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package opennebula_test
+
+import (
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula"
+)
+
+// minimalContext returns the minimum context bytes needed to exercise hostname
+// parsing without triggering ETH* processing.
+func minimalContext(vars string) []byte {
+	return []byte("ETH0_MAC = \"02:00:c0:a8:01:5c\"\nETH0_IP = \"10.0.0.1\"\nETH0_MASK = \"255.255.255.0\"\n" + vars)
+}
+
+func TestSanitizeHostname(t *testing.T) {
+	t.Parallel()
+
+	o := &opennebula.OpenNebula{}
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	for _, tc := range []struct {
+		name           string
+		nameVar        string
+		wantHostname   string
+		wantDomainname string
+	}{
+		{
+			name:           "clean hostname passes through unchanged",
+			nameVar:        "myhost",
+			wantHostname:   "myhost",
+			wantDomainname: "",
+		},
+		{
+			name:           "FQDN is split on first dot",
+			nameVar:        "myhost.example.com",
+			wantHostname:   "myhost",
+			wantDomainname: "example.com",
+		},
+		{
+			name:           "invalid chars replaced with hyphen",
+			nameVar:        "my_host",
+			wantHostname:   "my-host",
+			wantDomainname: "",
+		},
+		{
+			name:           "leading and trailing hyphens stripped",
+			nameVar:        "-myhost-",
+			wantHostname:   "myhost",
+			wantDomainname: "",
+		},
+		{
+			name:           "per-label hyphen trimming",
+			nameVar:        "my-.host",
+			wantHostname:   "my",
+			wantDomainname: "host",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := minimalContext("NAME = \"" + tc.nameVar + "\"")
+
+			networkConfig, err := o.ParseMetadata(st, ctx)
+			require.NoError(t, err)
+			require.Len(t, networkConfig.Hostnames, 1)
+
+			assert.Equal(t, tc.wantHostname, networkConfig.Hostnames[0].Hostname)
+			assert.Equal(t, tc.wantDomainname, networkConfig.Hostnames[0].Domainname)
+		})
+	}
+
+	t.Run("empty string produces no hostname entry", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := minimalContext("NAME = \"\"")
+
+		networkConfig, err := o.ParseMetadata(st, ctx)
+		require.NoError(t, err)
+		assert.Empty(t, networkConfig.Hostnames)
+	})
+}
+
+func TestParseMetadataHostname(t *testing.T) {
+	t.Parallel()
+
+	o := &opennebula.OpenNebula{}
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	for _, tc := range []struct {
+		name           string
+		vars           string
+		wantHostname   string
+		wantDomainname string
+	}{
+		{
+			name:           "HOSTNAME takes priority",
+			vars:           "HOSTNAME = \"fromhostname\"\nSET_HOSTNAME = \"fromsethostname\"\nNAME = \"fromname\"",
+			wantHostname:   "fromhostname",
+			wantDomainname: "",
+		},
+		{
+			name:           "falls back to SET_HOSTNAME when HOSTNAME is empty",
+			vars:           "SET_HOSTNAME = \"fromsethostname\"\nNAME = \"fromname\"",
+			wantHostname:   "fromsethostname",
+			wantDomainname: "",
+		},
+		{
+			name:           "falls back to NAME when both HOSTNAME and SET_HOSTNAME are empty",
+			vars:           "NAME = \"fromname\"",
+			wantHostname:   "fromname",
+			wantDomainname: "",
+		},
+		{
+			name:           "DNS_HOSTNAME=YES is not used as Domainname",
+			vars:           "NAME = \"myhost\"\nDNS_HOSTNAME = \"YES\"",
+			wantHostname:   "myhost",
+			wantDomainname: "",
+		},
+		{
+			name:           "FQDN in NAME is split into Hostname and Domainname",
+			vars:           "NAME = \"myhost.example.com\"",
+			wantHostname:   "myhost",
+			wantDomainname: "example.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := minimalContext(tc.vars)
+
+			networkConfig, err := o.ParseMetadata(st, ctx)
+			require.NoError(t, err)
+			require.Len(t, networkConfig.Hostnames, 1)
+
+			assert.Equal(t, tc.wantHostname, networkConfig.Hostnames[0].Hostname)
+			assert.Equal(t, tc.wantDomainname, networkConfig.Hostnames[0].Domainname)
+		})
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/opennebula/opennebula.go
@@ -36,6 +36,39 @@ func (o *OpenNebula) Name() string {
 	return "opennebula"
 }
 
+// sanitizeHostname replaces characters invalid in DNS labels with hyphens,
+// strips leading/trailing hyphens from the whole string and from each label.
+// This mirrors the reference sanitization in one-apps/context-linux:
+//
+//	sed -e 's/[^-a-zA-Z0-9\.]/-/g' -e 's/^-*//g' -e 's/-*$//g'
+//
+// Talos is intentionally stricter: it also trims hyphens per-label so every
+// label is RFC-1123-valid (no label may start or end with a hyphen).
+func sanitizeHostname(raw string) string {
+	var b strings.Builder
+
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+
+	s := strings.Trim(b.String(), "-")
+
+	labels := strings.Split(s, ".")
+	for i, l := range labels {
+		labels[i] = strings.Trim(l, "-")
+	}
+
+	return strings.Join(labels, ".")
+}
+
 // ParseMetadata converts opennebula metadata to platform network config.
 //
 //nolint:gocyclo
@@ -49,6 +82,9 @@ func (o *OpenNebula) ParseMetadata(st state.State, oneContextPlain []byte) (*run
 	}
 
 	// Create HostnameSpecSpec entry
+	// HOSTNAME is checked first (deviation from the reference which tries
+	// SET_HOSTNAME before HOSTNAME) to preserve backward compatibility with
+	// existing Talos deployments that rely on the OpenNebula-injected FQDN.
 	hostnameValue := oneContext["HOSTNAME"]
 	if hostnameValue == "" {
 		hostnameValue = oneContext["SET_HOSTNAME"]
@@ -56,6 +92,8 @@ func (o *OpenNebula) ParseMetadata(st state.State, oneContextPlain []byte) (*run
 			hostnameValue = oneContext["NAME"]
 		}
 	}
+
+	hostnameValue = sanitizeHostname(hostnameValue)
 
 	// Iterate through parsed environment variables looking for ETHn_MAC keys.
 	// The presence of ETHn_MAC is the sole trigger for interface configuration,
@@ -180,19 +218,22 @@ func (o *OpenNebula) ParseMetadata(st state.State, oneContextPlain []byte) (*run
 			}
 		}
 	}
-	// Create HostnameSpecSpec entry
-	networkConfig.Hostnames = append(networkConfig.Hostnames,
-		network.HostnameSpecSpec{
-			Hostname:    hostnameValue,
-			Domainname:  oneContext["DNS_HOSTNAME"],
-			ConfigLayer: network.ConfigPlatform,
-		},
-	)
 
-	// Create Metadata entry
+	hostnameSpec := network.HostnameSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+	}
+
+	if hostnameValue != "" {
+		if err := hostnameSpec.ParseFQDN(hostnameValue); err != nil {
+			return nil, fmt.Errorf("failed to parse hostname: %w", err)
+		}
+
+		networkConfig.Hostnames = append(networkConfig.Hostnames, hostnameSpec)
+	}
+
 	networkConfig.Metadata = &runtimeres.PlatformMetadataSpec{
 		Platform:   o.Name(),
-		Hostname:   hostnameValue,
+		Hostname:   hostnameSpec.Hostname,
 		InstanceID: oneContext["VMID"],
 	}
 


### PR DESCRIPTION
## What? (description)

Three hostname bugs are fixed in the OpenNebula platform implementation:

1. **`DNS_HOSTNAME` misused as `Domainname`**: `DNS_HOSTNAME` is a boolean flag (`YES`/`NO`) that tells the OpenNebula daemon to perform a reverse DNS lookup for the hostname. It is not a domain name string. Using it as `Domainname` produced invalid FQDNs like `myhost.YES`.

2. **No FQDN splitting**: if the hostname source contained a dot (e.g. `NAME = "myhost.example.com"`), the full string was used as `Hostname` instead of splitting on the first dot.

3. **No sanitization**: invalid characters (spaces, underscores, etc.) were passed through unchanged, potentially producing hostnames that fail validation.

The fix adds `sanitizeHostname()` which replaces non-`[a-zA-Z0-9.-]` characters with hyphens, strips leading/trailing hyphens from the whole string and from each DNS label (stricter than the reference `sed` command, to guarantee RFC-1123-valid labels), then delegates to `ParseFQDN()` — consistent with how all other Talos platform implementations parse hostnames.

The variable priority order `HOSTNAME` > `SET_HOSTNAME` > `NAME` is preserved as a backward-compatible deviation from the reference (which tries `SET_HOSTNAME` first).

## Why? (reasoning)

Matches the sanitization behavior of the reference `one-apps/context-linux` (`net-15-hostname`) and produces valid hostnames for Talos. The `DNS_HOSTNAME` bug could silently inject `"YES"` or `"NO"` as a domain name suffix on any deployment that sets it.

## ⚠ Breaking change note

`Domainname` no longer reads from `DNS_HOSTNAME`. Any deployment that inadvertently relied on `Domainname` containing `"YES"` or `"NO"` will see the domain name cleared to `""`. Since that value was semantically wrong, this is a bug fix.

## Acceptance

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)