### PR TITLE
fix: use non-sensitive resource for health check precondition

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -79,6 +79,7 @@ message BootstrapManifestsConfigSpec {
   string flannel_kube_service_port = 18;
   bool flannel_kube_network_policies_enabled = 19;
   string flannel_kube_network_policies_image = 20;
+  string cni_name = 21;
 }
 
 // ConfigStatusSpec describes status of rendered secrets.

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -362,6 +362,8 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					FlannelKubeNetworkPoliciesImage:   images.KubeNetworkPolicies.String(),
 
 					TalosAPIServiceEnabled: cfgProvider.Machine().Features().KubernetesTalosAPIAccess().Enabled(),
+
+					CNIName: cfgProvider.Cluster().Network().CNI().Name(),
 				}
 
 				return nil

--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -9,12 +9,11 @@ import (
 	"slices"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 
 	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
-	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 )
 
 // DefaultClusterChecks returns a set of default Talos cluster readiness checks.
@@ -90,12 +89,12 @@ func cniDisabledStatus(ctx context.Context, cluster ClusterInfo) (bool, error) {
 		return false, err
 	}
 
-	mc, err := safe.ReaderGet[*config.MachineConfig](ctx, cli.COSI, resource.NewMetadata(config.NamespaceName, config.MachineConfigType, config.ActiveID, resource.VersionUndefined))
+	bmc, err := safe.ReaderGetByID[*k8s.BootstrapManifestsConfig](ctx, cli.COSI, k8s.BootstrapManifestsConfigID)
 	if err != nil {
 		return false, err
 	}
 
-	return mc.Config().Cluster().Network().CNI().Name() == "none", nil
+	return bmc.TypedSpec().CNIName == "none", nil
 }
 
 // K8sComponentsReadinessChecks returns a set of K8s cluster readiness checks which are specific to the k8s components

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -475,6 +475,7 @@ type BootstrapManifestsConfigSpec struct {
 	FlannelKubeServicePort            string                 `protobuf:"bytes,18,opt,name=flannel_kube_service_port,json=flannelKubeServicePort,proto3" json:"flannel_kube_service_port,omitempty"`
 	FlannelKubeNetworkPoliciesEnabled bool                   `protobuf:"varint,19,opt,name=flannel_kube_network_policies_enabled,json=flannelKubeNetworkPoliciesEnabled,proto3" json:"flannel_kube_network_policies_enabled,omitempty"`
 	FlannelKubeNetworkPoliciesImage   string                 `protobuf:"bytes,20,opt,name=flannel_kube_network_policies_image,json=flannelKubeNetworkPoliciesImage,proto3" json:"flannel_kube_network_policies_image,omitempty"`
+	CniName                           string                 `protobuf:"bytes,21,opt,name=cni_name,json=cniName,proto3" json:"cni_name,omitempty"`
 	unknownFields                     protoimpl.UnknownFields
 	sizeCache                         protoimpl.SizeCache
 }
@@ -638,6 +639,13 @@ func (x *BootstrapManifestsConfigSpec) GetFlannelKubeNetworkPoliciesEnabled() bo
 func (x *BootstrapManifestsConfigSpec) GetFlannelKubeNetworkPoliciesImage() string {
 	if x != nil {
 		return x.FlannelKubeNetworkPoliciesImage
+	}
+	return ""
+}
+
+func (x *BootstrapManifestsConfigSpec) GetCniName() string {
+	if x != nil {
+		return x.CniName
 	}
 	return ""
 }
@@ -2414,7 +2422,7 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\awebhook\x18\x03 \x01(\v2\x17.google.protobuf.StructR\awebhook\"\x85\x01\n" +
 	"\x17AuthorizationConfigSpec\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12T\n" +
-	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\x8d\a\n" +
+	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xa8\a\n" +
 	"\x1cBootstrapManifestsConfigSpec\x12\x16\n" +
 	"\x06server\x18\x01 \x01(\tR\x06server\x12%\n" +
 	"\x0ecluster_domain\x18\x02 \x01(\tR\rclusterDomain\x12\x1c\n" +
@@ -2438,7 +2446,8 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\x19flannel_kube_service_host\x18\x11 \x01(\tR\x16flannelKubeServiceHost\x129\n" +
 	"\x19flannel_kube_service_port\x18\x12 \x01(\tR\x16flannelKubeServicePort\x12P\n" +
 	"%flannel_kube_network_policies_enabled\x18\x13 \x01(\bR!flannelKubeNetworkPoliciesEnabled\x12L\n" +
-	"#flannel_kube_network_policies_image\x18\x14 \x01(\tR\x1fflannelKubeNetworkPoliciesImage\"B\n" +
+	"#flannel_kube_network_policies_image\x18\x14 \x01(\tR\x1fflannelKubeNetworkPoliciesImage\x12\x19\n" +
+	"\bcni_name\x18\x15 \x01(\tR\acniName\"B\n" +
 	"\x10ConfigStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\"\xfd\x05\n" +

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -491,6 +491,15 @@ func (m *BootstrapManifestsConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CniName) > 0 {
+		i -= len(m.CniName)
+		copy(dAtA[i:], m.CniName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CniName)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xaa
+	}
 	if len(m.FlannelKubeNetworkPoliciesImage) > 0 {
 		i -= len(m.FlannelKubeNetworkPoliciesImage)
 		copy(dAtA[i:], m.FlannelKubeNetworkPoliciesImage)
@@ -2782,6 +2791,10 @@ func (m *BootstrapManifestsConfigSpec) SizeVT() (n int) {
 		n += 3
 	}
 	l = len(m.FlannelKubeNetworkPoliciesImage)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CniName)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -5317,6 +5330,38 @@ func (m *BootstrapManifestsConfigSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.FlannelKubeNetworkPoliciesImage = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 21:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CniName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CniName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/resources/k8s/manifests_config.go
+++ b/pkg/machinery/resources/k8s/manifests_config.go
@@ -53,6 +53,8 @@ type BootstrapManifestsConfigSpec struct {
 	PodSecurityPolicyEnabled bool `yaml:"podSecurityPolicyEnabled" protobuf:"14"`
 
 	TalosAPIServiceEnabled bool `yaml:"talosAPIServiceEnabled" protobuf:"15"`
+
+	CNIName string `yaml:"cniName" protobuf:"21"`
 }
 
 // NewBootstrapManifestsConfig returns new BootstrapManifestsConfig resource.

--- a/website/content/v1.13/reference/api.md
+++ b/website/content/v1.13/reference/api.md
@@ -7594,6 +7594,7 @@ BootstrapManifestsConfigSpec is configuration for bootstrap manifests.
 | flannel_kube_service_port | [string](#string) |  |  |
 | flannel_kube_network_policies_enabled | [bool](#bool) |  |  |
 | flannel_kube_network_policies_image | [string](#string) |  |  |
+| cni_name | [string](#string) |  |  |
 
 
 


### PR DESCRIPTION
A fixup for #12896

The health check might be running as a reduced privilege role client, so don't pull the machine config, but instead read a field from a non-sensitive resource.

As this field doesn't exist in older versions of Talos, the check should still run by default (as it will be empty).
