### PR TITLE
fix: stop pulling wrong platform for images

### DIFF
--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -195,7 +195,7 @@ func Pull(
 		containerdRemoteOpts := []containerd.RemoteOpt{
 			containerd.WithPullUnpack,
 			containerd.WithChildLabelMap(images.ChildGCLabelsFilterLayers),
-			containerd.WithPlatformMatcher(platforms.OnlyStrict(platforms.DefaultSpec())),
+			containerd.WithPlatformMatcher(platforms.Default()),
 			containerd.WithResolver(resolver),
 		}
 


### PR DESCRIPTION
Attempt to fix intermittent issue with images being pulled with the wrong platform for multi-platform images.

The Claude did the analysis, and I think the root cause is that the `DefaultSpec()` we used causes the match to include `variant` which is e.g. `v8` for arm64, while if the image doesn't declare the exact variant, it might skip filtering and pick up the first layer which is amd64.

It is still not clear why exactly it is intermittent this way.

But this change aligns it more closely with the way containerd pulls, so should be good to go.
