### PR TITLE
feat: include hid-generic.ko kernel module in rootfs

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -51,6 +51,7 @@ kernel/drivers/hid/hid-cherry.ko
 kernel/drivers/hid/hid-chicony.ko
 kernel/drivers/hid/hid-cypress.ko
 kernel/drivers/hid/hid-ezkey.ko
+kernel/drivers/hid/hid-generic.ko
 kernel/drivers/hid/hid-gyration.ko
 kernel/drivers/hid/hid-ite.ko
 kernel/drivers/hid/hid-kensington.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -34,6 +34,7 @@ kernel/drivers/hid/hid-cherry.ko
 kernel/drivers/hid/hid-chicony.ko
 kernel/drivers/hid/hid-cypress.ko
 kernel/drivers/hid/hid-ezkey.ko
+kernel/drivers/hid/hid-generic.ko
 kernel/drivers/hid/hid-gyration.ko
 kernel/drivers/hid/hid-ite.ko
 kernel/drivers/hid/hid-kensington.ko


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Add hid-generic kernel module to the talos image.

## Why? (reasoning)

HP iLO 4 virtual keyboard identifies as "BMC Virtual Keyboard" ([03f0:7029](https://linux-hardware.org/?id=usb:03f0-7029)) at "usb-0000:01:00.4-1/input0" and is currently not recognized. On a debian distro, it's loaded with hid-generic. I believe that adding hid-generic module should allow it's detection.

>  hid-generic 0003:03F0:7029.0001: input,hidraw0: USB HID v1.01 Keyboard [BMC Virtual Keyboard ] on usb-0000:01:00.4-1/input0

Relates to #12905 

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
