### PR TITLE
fix: validate missing apiVersion in config document decoder

### DIFF
--- a/pkg/machinery/config/configloader/internal/decoder/decoder.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder.go
@@ -21,6 +21,9 @@ import (
 // ErrMissingKind indicates that the manifest is missing a kind.
 var ErrMissingKind = errors.New("missing kind")
 
+// ErrMissingAPIVersion indicates that the manifest is missing an apiVersion.
+var ErrMissingAPIVersion = errors.New("missing apiVersion")
+
 const (
 	// ManifestAPIVersionKey is the string indicating a manifest's version.
 	ManifestAPIVersionKey = "apiVersion"
@@ -176,6 +179,8 @@ func decode(manifest *yaml.Node) (target config.Document, err error) {
 		target, err = registry.New("v1alpha1", "")
 	case kind == "":
 		err = ErrMissingKind
+	case version == "":
+		err = ErrMissingAPIVersion
 	default:
 		target, err = registry.New(kind, version)
 	}

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -322,7 +322,15 @@ config:
           - content: MONITOR ${upsmonHost} 1 remote pass foo
             mountPath: /usr/local/etc/nut/upsmon.conf
 `),
-			expectedErr: "error decoding document /ExtensionServiceConfig/ (line 2): \"ExtensionServiceConfig\" \"\": not registered",
+			expectedErr: "error decoding document /ExtensionServiceConfig/ (line 2): missing apiVersion",
+		},
+		{
+			name: "missing apiVersion",
+			source: []byte(`---
+kind: mock
+test: true
+`),
+			expectedErr: "error decoding document /mock/ (line 2): missing apiVersion",
 		},
 	}
 


### PR DESCRIPTION
## Summary
Adds an `ErrMissingAPIVersion` validation check in the config document decoder, parallel to the existing `ErrMissingKind`.
## Problem
When applying a config patch with a typo in the `apiVersion` key (e.g. `apiVerstion: v1alpha1` instead of `apiVersion: v1alpha1`), the decoder fails to extract the version and falls through to `registry.New(kind, "")`. This produces a misleading error:
"ExtensionServiceConfig" "": not registered
This suggests the document type doesn't exist, when the actual problem is a missing/misspelled `apiVersion` field. This is especially confusing because the decoder already validates `kind` with `ErrMissingKind` but has no equivalent check for `apiVersion`.
## Fix
Added a `case version == "":` branch in the `decode()` switch statement in `pkg/machinery/config/configloader/internal/decoder/decoder.go`, between the existing `kind == ""` check and the `default` registry lookup. The error now clearly reads:
error decoding document /ExtensionServiceConfig/ (line 2): missing apiVersion
## Changes
- `pkg/machinery/config/configloader/internal/decoder/decoder.go` — added `ErrMissingAPIVersion` sentinel error and validation case
- `pkg/machinery/config/configloader/internal/decoder/decoder_test.go` — updated existing misspelled apiVersion test expectation, added new test for completely absent apiVersion
## Motivation
Spent two days ripping my hair out trying to figure out why i could not push a tailscale config patch to my nodes, thrown off by the "ExtensionServiceConfig not registered" message and overlooking a typo in my patch file. 
The typo in question: "apiVerstion" instead of "apiVersion"...