### PR TITLE
fix: panic in hardware.SystemInfoController

### DIFF
--- a/internal/app/machined/pkg/controllers/hardware/system.go
+++ b/internal/app/machined/pkg/controllers/hardware/system.go
@@ -90,8 +90,6 @@ func (ctrl *SystemInfoController) Run(ctx context.Context, r controller.Runtime,
 		case <-r.EventCh():
 		}
 
-		r.StartTrackingOutputs()
-
 		_, err := safe.ReaderGetByID[*runtime.MetaLoaded](ctx, r, runtime.MetaLoadedID)
 		if err != nil {
 			if state.IsNotFoundError(err) {
@@ -111,6 +109,8 @@ func (ctrl *SystemInfoController) Run(ctx context.Context, r controller.Runtime,
 
 			ctrl.SMBIOS = s
 		}
+
+		r.StartTrackingOutputs()
 
 		if err := ctrl.reconcileSystemInformation(ctx, r, logger); err != nil {
 			return err


### PR DESCRIPTION
The panic:

```
2026/03/16 13:39:56 172.20.0.3: {"component":"controller-runtime","controller":"hardware.SystemInfoController","error":"controller \"hardware.SystemInfoController\" panicked: output tracking already enabled\n\ngoroutine 613 [running]:\nruntime/debug.Stack()\n\t/go/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/rruntime.(*Adapter).runOnce.func2()\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/internal/rruntime/run.go:67 +0x4c\npanic({0x2a43dc0?, 0x350ff30?})\n\t/go/src/runtime/panic.go:860 +0x13a\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/rruntime.(*Adapter).StartTrackingOutputs(0x38246abe1c98?)\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/internal/rruntime/output_tracker.go:25 +0x94\ngithub.com/siderolabs/talos/internal/app/machined/pkg/controllers/hardware.(*SystemInfoController).Run(0x38246a3fe280, {0x3549b50, 0x38246a96dbd0}, {0x358b070, 0x38246adaf0e0}, 0x38246adba000)\n\t/src/internal/app/machined/pkg/controllers/hardware/system.go:93 +0x127\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/rruntime.(*Adapter).runOnce(0x38246adaf0e0, {0x3549b50, 0x38246a96dbd0}, 0x38246adba000)\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/internal/rruntime/run.go:73 +0xfa\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/rruntime.(*Adapter).Run(0x38246adaf0e0, {0x3549b50, 0x38246a96dbd0})\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/internal/rruntime/run.go:25 +0x16b\ngithub.com/cosi-project/runtime/pkg/controller/runtime.(*Runtime).Run.func1.2()\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/runtime.go:201 +0x2e\ngithub.com/cosi-project/runtime/pkg/controller/runtime.(*Runtime).Run.func1.goFunc.3()\n\t/.cache/mod/github.com/cosi-project/runtime@v1.14.0/pkg/controller/runtime/runtime.go:473 +0x13\ngolang.org/x/sync/errgroup.(*Group).Go.func1()\n\t/.cache/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x50\ncreated by golang.org/x/sync/errgroup.(*Group).Go in goroutine 146\n\t/.cache/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x95\n","msg":"2026-03-16T09:39:56.457Z \u001b[31mERROR\u001b[0m controller failed","talos-level":"info","talos-service":"controller-runtime","talos-time":"2026-03-16T09:39:56.718594712Z"}
```

This more of a cosmetic issue, but still - move tracking outputs below the `continue` statement, otherwise it might be called twice in a single run.
