### PR TITLE
fix: introduce pull attempt stall detection for image pull 

### DIFF
--- a/internal/pkg/containers/image/resolver.go
+++ b/internal/pkg/containers/image/resolver.go
@@ -5,18 +5,22 @@
 package image
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/siderolabs/gen/xslices"
 
+	"github.com/siderolabs/talos/internal/pkg/containers/image/stallguard"
 	"github.com/siderolabs/talos/pkg/httpdefaults"
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cri"
@@ -199,7 +203,32 @@ func PrepareAuth(auth config.RegistryAuthConfig, host, expectedHost string) (str
 	return "", "", fmt.Errorf("invalid auth config for %q", host)
 }
 
+// PullConnIdleTimeout is the maximum time a pull connection is allowed to make
+// no progress (read no bytes) before it is considered stalled and aborted.
+//
+// This guards against connections which are silently black-holed (e.g. after a
+// network reconfiguration) and would otherwise hang until the global pull
+// timeout. It does not penalize slow-but-progressing pulls, as the deadline is
+// reset on every successful read.
+const PullConnIdleTimeout = 90 * time.Second
+
 // newTransport creates HTTP transport with default settings.
 func newTransport() *http.Transport {
-	return httpdefaults.PatchTransport(cleanhttp.DefaultTransport())
+	transport := httpdefaults.PatchTransport(cleanhttp.DefaultTransport())
+
+	baseDialContext := transport.DialContext
+	if baseDialContext == nil {
+		baseDialContext = (&net.Dialer{}).DialContext
+	}
+
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := baseDialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+
+		return stallguard.NewConn(conn, PullConnIdleTimeout), nil
+	}
+
+	return transport
 }

--- a/internal/pkg/containers/image/stallguard/stallguard.go
+++ b/internal/pkg/containers/image/stallguard/stallguard.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package stallguard provides a net.Conn wrapper which aborts reads that make
+// no progress for a configurable idle timeout.
+package stallguard
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// Conn wraps a net.Conn and aborts reads which make no progress for idleTimeout.
+//
+// The read deadline is armed before every Read and reset on each successful
+// read, so a connection trips the deadline only when no bytes flow at all for
+// the full idleTimeout window. Slow-but-progressing reads are not penalized.
+//
+// This guards against connections which are silently black-holed (e.g. after a
+// network reconfiguration) and would otherwise hang indefinitely.
+//
+// Deadlines set by the caller via SetReadDeadline/SetDeadline are honored: the
+// effective read deadline is the earlier of the caller-set deadline and the
+// stall guard's idle deadline, so the guard never relaxes a shorter timeout the
+// caller asked for.
+type Conn struct {
+	net.Conn
+
+	idleTimeout time.Duration
+
+	mu               sync.Mutex
+	externalDeadline time.Time // caller-set read deadline; zero means none
+}
+
+// NewConn wraps conn so that reads which make no progress for idleTimeout fail
+// with an i/o timeout error.
+func NewConn(conn net.Conn, idleTimeout time.Duration) *Conn {
+	return &Conn{
+		Conn:        conn,
+		idleTimeout: idleTimeout,
+	}
+}
+
+// Read implements io.Reader, arming a read deadline before delegating to the
+// underlying connection.
+func (c *Conn) Read(b []byte) (int, error) {
+	idleDeadline := time.Now().Add(c.idleTimeout)
+
+	c.mu.Lock()
+	external := c.externalDeadline
+	c.mu.Unlock()
+
+	deadline := idleDeadline
+	if !external.IsZero() && external.Before(idleDeadline) {
+		deadline = external
+	}
+
+	if err := c.Conn.SetReadDeadline(deadline); err != nil {
+		return 0, err
+	}
+
+	return c.Conn.Read(b)
+}
+
+// SetReadDeadline records the caller-set read deadline and applies it to the
+// underlying connection, so an in-flight Read is unblocked immediately.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.externalDeadline = t
+	c.mu.Unlock()
+
+	return c.Conn.SetReadDeadline(t)
+}
+
+// SetDeadline records the caller-set read deadline (SetDeadline sets both read
+// and write deadlines) and applies it to the underlying connection.
+func (c *Conn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.externalDeadline = t
+	c.mu.Unlock()
+
+	return c.Conn.SetDeadline(t)
+}

--- a/internal/pkg/containers/image/stallguard/stallguard_test.go
+++ b/internal/pkg/containers/image/stallguard/stallguard_test.go
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package stallguard_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/stallguard"
+)
+
+func TestConnReadStalls(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+		assert.NoError(t, server.Close())
+	})
+
+	conn := stallguard.NewConn(client, 50*time.Millisecond)
+
+	// nothing is ever written to the server side, so the read should trip the
+	// idle deadline rather than blocking forever.
+	_, err := conn.Read(make([]byte, 16))
+
+	var netErr net.Error
+
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout(), "expected a timeout error, got %v", err)
+}
+
+func TestConnReadProgressResetsDeadline(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+		assert.NoError(t, server.Close())
+	})
+
+	const (
+		idleTimeout = 100 * time.Millisecond
+		interval    = idleTimeout / 5
+		writes      = 10
+	)
+
+	conn := stallguard.NewConn(client, idleTimeout)
+
+	errCh := make(chan error, 1)
+
+	// trickle bytes at an interval well below idleTimeout: each successful read
+	// resets the deadline, so the total transfer (interval*writes) outlasts a
+	// single idle window without ever tripping it.
+	go func() {
+		for range writes {
+			time.Sleep(interval)
+
+			if _, err := server.Write([]byte{0}); err != nil {
+				errCh <- err
+
+				return
+			}
+		}
+
+		errCh <- nil
+	}()
+
+	buf := make([]byte, 1)
+
+	for range writes {
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+	}
+
+	require.NoError(t, <-errCh)
+}
+
+func TestConnHonorsShorterExternalDeadline(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+		assert.NoError(t, server.Close())
+	})
+
+	// idle timeout is large; the caller sets a much shorter read deadline, which
+	// must win so the guard does not relax a stricter timeout the caller asked
+	// for.
+	conn := stallguard.NewConn(client, time.Hour)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+
+	start := time.Now()
+
+	_, err := conn.Read(make([]byte, 16))
+
+	var netErr net.Error
+
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout(), "expected a timeout error, got %v", err)
+	assert.Less(t, time.Since(start), time.Minute, "read should honor the shorter caller deadline, not the idle timeout")
+}

--- a/internal/pkg/install/pull.go
+++ b/internal/pkg/install/pull.go
@@ -42,7 +42,6 @@ func PullAndValidateInstallerImage(ctx context.Context, resources state.State, r
 	img, err := image.Pull(
 		containerdctx, registryBuilder, resources, client, ref,
 		image.WithSkipIfAlreadyPulled(),
-		image.WithMaxNotFoundRetries(1),
 		image.WithProgressReporter(console.NewProgressReporter),
 	)
 	if err != nil {


### PR DESCRIPTION
Also unlock not found (404) retries for installer image pulls.
