### PR TITLE
fix: unmount pseudo-late recursively

### DIFF
--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -327,7 +327,7 @@ func (suite *EtcFileConfigSuite) ExtraTearDown() {
 		if suite.etcRoot.FSType() == "os" {
 			suite.Require().NoError(os.Remove(suite.podResolvConfPath))
 		} else {
-			suite.Require().NoError(mount.SafeUnmount(context.Background(), nil, suite.podResolvConfPath))
+			suite.Require().NoError(mount.SafeUnmount(context.Background(), nil, suite.podResolvConfPath, false))
 		}
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -754,7 +754,7 @@ func UnmountPodMounts(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 			if strings.HasPrefix(mountpoint, constants.EphemeralMountPoint+"/") {
 				logger.Printf("unmounting %s\n", mountpoint)
 
-				if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint); err != nil {
+				if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint, false); err != nil {
 					if errors.Is(err, syscall.EINVAL) {
 						log.Printf("ignoring unmount error %s: %v", mountpoint, err)
 					} else {
@@ -811,7 +811,7 @@ func UnmountSystemDiskBindMounts(runtime.Sequence, any) (runtime.TaskExecutionFu
 
 			logger.Printf("unmounting %s\n", mountpoint)
 
-			if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint); err != nil {
+			if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint, false); err != nil {
 				if errors.Is(err, syscall.EINVAL) {
 					log.Printf("ignoring unmount error %s: %v", mountpoint, err)
 				} else {

--- a/internal/pkg/mount/v3/all.go
+++ b/internal/pkg/mount/v3/all.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -120,4 +121,29 @@ func readMountInfo() ([]mountInfo, error) {
 	}
 
 	return mounts, scanner.Err()
+}
+
+func getSubmounts(target string) ([]string, error) {
+	mounts, err := readMountInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	var submounts []string
+
+	for _, mnt := range mounts {
+		if mnt.MountPoint == target {
+			continue
+		}
+
+		if strings.HasPrefix(mnt.MountPoint, target+"/") {
+			submounts = append(submounts, mnt.MountPoint)
+		}
+	}
+
+	sort.Slice(submounts, func(i, j int) bool {
+		return len(submounts[i]) > len(submounts[j])
+	})
+
+	return submounts, nil
 }

--- a/internal/pkg/mount/v3/helpers.go
+++ b/internal/pkg/mount/v3/helpers.go
@@ -55,6 +55,7 @@ func NewReadOnlyOverlay(sources []string, target string, printer func(string, ..
 	}
 
 	options = append(options,
+		WithPrinter(printer),
 		WithTarget(target),
 		WithReadOnly(),
 		WithFsopen("overlay", fsOptions...),
@@ -173,6 +174,7 @@ func Pseudo(printer func(string, ...any)) Managers {
 	return gather(
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/dev"),
 			WithKeepOpenAfterMount(),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID),
@@ -183,6 +185,7 @@ func Pseudo(printer func(string, ...any)) Managers {
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/proc"),
 			WithKeepOpenAfterMount(),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV),
@@ -190,6 +193,7 @@ func Pseudo(printer func(string, ...any)) Managers {
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys"),
 			WithKeepOpenAfterMount(),
 			WithFsopen("sysfs"),
@@ -202,6 +206,7 @@ func PseudoLate(printer func(string, ...any)) Managers {
 	return gather(
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/run"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_RELATIME),
 			WithSelinuxLabel(constants.RunSelinuxLabel),
@@ -212,8 +217,10 @@ func PseudoLate(printer func(string, ...any)) Managers {
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/system"),
 			WithSelinuxLabel(constants.SystemSelinuxLabel),
+			WithRecursiveUnmount(),
 			WithFsopen(
 				"tmpfs",
 				fsopen.WithStringParameter("mode", "0755"),
@@ -221,6 +228,7 @@ func PseudoLate(printer func(string, ...any)) Managers {
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/tmp"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV),
 			WithFsopen(
@@ -237,12 +245,14 @@ func PseudoSub(printer func(string, ...any)) Managers {
 	return gather(
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/dev/shm"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV|unix.MOUNT_ATTR_RELATIME),
 			WithFsopen("tmpfs"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/dev/pts"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC),
 			WithFsopen(
@@ -254,47 +264,55 @@ func PseudoSub(printer func(string, ...any)) Managers {
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NODEV),
 			WithTarget("/dev/hugepages"),
 			WithFsopen("hugetlbfs"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys/fs/bpf"),
 			WithFsopen("bpf"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys/kernel/security"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV|unix.MOUNT_ATTR_RELATIME),
 			WithFsopen("securityfs"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys/kernel/tracing"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV),
 			WithFsopen("tracefs"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys/kernel/config"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV|unix.MOUNT_ATTR_RELATIME),
 			WithFsopen("configfs"),
 		),
 		newManager(
 			always,
+			WithPrinter(printer),
 			WithTarget("/sys/kernel/debug"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV|unix.MOUNT_ATTR_RELATIME),
 			WithFsopen("debugfs"),
 		),
 		newManager(
 			selinux.IsEnabled,
+			WithPrinter(printer),
 			WithTarget("/sys/fs/selinux"),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_RELATIME),
 			WithFsopen("selinuxfs"),
 		),
 		newManager(
 			hasEFIVars,
+			WithPrinter(printer),
 			WithTarget(constants.EFIVarsMountPoint),
 			WithMountAttributes(unix.MOUNT_ATTR_NOSUID|unix.MOUNT_ATTR_NOEXEC|unix.MOUNT_ATTR_NODEV|unix.MOUNT_ATTR_RELATIME|unix.MOUNT_ATTR_RDONLY),
 			WithFsopen("efivarfs"),

--- a/internal/pkg/mount/v3/manager.go
+++ b/internal/pkg/mount/v3/manager.go
@@ -31,6 +31,7 @@ type Manager struct {
 	mountattr             int
 	extraDirs             []string
 	extraUnmountCallbacks []func(m *Manager)
+	recursiveUnmount      bool
 
 	point *Point
 }
@@ -109,7 +110,8 @@ func (m *Manager) Unmount() error {
 	}
 
 	opts := UnmountOptions{
-		Printer: printer,
+		Printer:   printer,
+		Recursive: m.recursiveUnmount,
 	}
 
 	for _, cb := range m.extraUnmountCallbacks {
@@ -250,6 +252,15 @@ func WithExtraUnmountCallbacks(callbacks ...func(m *Manager)) ManagerOption {
 	return ManagerOption{
 		set: func(m *Manager) {
 			m.extraUnmountCallbacks = append(m.extraUnmountCallbacks, callbacks...)
+		},
+	}
+}
+
+// WithRecursiveUnmount enables recursive unmounting of all child mounts before unmounting the target.
+func WithRecursiveUnmount() ManagerOption {
+	return ManagerOption{
+		set: func(m *Manager) {
+			m.recursiveUnmount = true
 		},
 	}
 }

--- a/internal/pkg/mount/v3/point.go
+++ b/internal/pkg/mount/v3/point.go
@@ -123,7 +123,8 @@ func (p *Point) Share() error {
 
 // UnmountOptions represents options for unmounting a mount point.
 type UnmountOptions struct {
-	Printer func(string, ...any)
+	Printer   func(string, ...any)
+	Recursive bool
 }
 
 // Release closes the file descriptor of the underlying mount point.
@@ -146,7 +147,7 @@ func (p *Point) Unmount(opts UnmountOptions) error {
 	}
 
 	return p.retry(func() error {
-		return SafeUnmount(context.Background(), opts.Printer, p.target)
+		return SafeUnmount(context.Background(), opts.Printer, p.target, opts.Recursive)
 	}, true)
 }
 

--- a/internal/pkg/mount/v3/unmount.go
+++ b/internal/pkg/mount/v3/unmount.go
@@ -71,7 +71,8 @@ unmountLoop:
 // SafeUnmount unmounts the target path, first without force, then with force if the first attempt fails.
 //
 // It makes sure that unmounting has a finite operation timeout.
-func SafeUnmount(ctx context.Context, printer func(string, ...any), target string) error {
+// If recursive is true, it will first unmount all child mounts under target.
+func SafeUnmount(ctx context.Context, printer func(string, ...any), target string, recursive bool) error {
 	const (
 		unmountTimeout      = 90 * time.Second
 		unmountForceTimeout = 10 * time.Second
@@ -81,19 +82,60 @@ func SafeUnmount(ctx context.Context, printer func(string, ...any), target strin
 		printer = discard
 	}
 
+	if recursive {
+		submounts, err := getSubmounts(target)
+		if err != nil {
+			printer("failed to get submounts for %s: %v", target, err)
+		} else {
+			for _, submount := range submounts {
+				printer("recursively unmounting submount %s", submount)
+
+				if err := safeUnmountSingle(ctx, printer, submount, unmountTimeout); err != nil {
+					printer("failed to unmount submount %s: %v", submount, err)
+				}
+			}
+		}
+	}
+
 	ok, err := unmountLoop(ctx, printer, target, 0, unmountTimeout, "")
 
 	if ok {
 		return err
 	}
 
+	logSubmounts(printer, target)
+
 	printer("unmounting %s with force", target)
 
-	ok, err = unmountLoop(ctx, printer, target, unix.MNT_FORCE, unmountTimeout, " with force flag")
+	ok, err = unmountLoop(ctx, printer, target, unix.MNT_FORCE, unmountForceTimeout, " with force flag")
 
 	if ok {
 		return err
 	}
 
+	logSubmounts(printer, target)
+
 	return fmt.Errorf("unmounting %s with force flag timed out", target)
+}
+
+func safeUnmountSingle(ctx context.Context, printer func(string, ...any), target string, timeout time.Duration) error {
+	ok, err := unmountLoop(ctx, printer, target, 0, timeout, "")
+	if ok {
+		return err
+	}
+
+	return nil
+}
+
+func logSubmounts(printer func(string, ...any), target string) {
+	submounts, err := getSubmounts(target)
+	if err != nil {
+		printer("failed to get submounts for %s: %v", target, err)
+
+		return
+	}
+
+	if len(submounts) > 0 {
+		printer("submounts on %s: %v", target, submounts)
+	}
 }


### PR DESCRIPTION
Pseudo late mount points (`/system`, `/run` and `/system`) were consistently failing to unmount.
While reaching this unmount sequence, we should already have unmounted any children.
However, if those are not unmounted, we should log what are we unmounting and unmount them recursively.

```log
[  188.361988] [talos] recursively unmounting submount /system/libexec/trustd/trustd {"component": "early-startup"}
[  188.374844] [talos] recursively unmounting submount /system/resolved/resolv.conf {"component": "early-startup"}
[  188.382318] [talos] recursively unmounting submount /system/libexec/apid/apid {"component": "early-startup"}
```

Fixes #12974

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
