### PR TITLE
fix: drop aws & azure KMS APIs from the machined build

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
@@ -18,8 +18,8 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot"
 	"github.com/siderolabs/talos/internal/pkg/partition"
-	"github.com/siderolabs/talos/pkg/imager/profile"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/imageropts"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 )
 
@@ -86,14 +86,14 @@ func NewAuto() Bootloader {
 // New returns a new bootloader based on the secureboot flag and architecture.
 func New(bootloader, talosVersion, arch string) (Bootloader, error) {
 	switch bootloader {
-	case profile.BootLoaderKindGrub.String():
+	case imageropts.BootLoaderKindGrub.String():
 		g := grub.NewConfig()
 		g.AddResetOption = quirks.New(talosVersion).SupportsResetGRUBOption()
 
 		return g, nil
-	case profile.BootLoaderKindSDBoot.String():
+	case imageropts.BootLoaderKindSDBoot.String():
 		return sdboot.New(), nil
-	case profile.BootLoaderKindDualBoot.String():
+	case imageropts.BootLoaderKindDualBoot.String():
 		return dual.New(), nil
 	default:
 		return nil, fmt.Errorf("unsupported bootloader %q", bootloader)

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -11,10 +11,10 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/imager/profile"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/imageropts"
 	"github.com/siderolabs/talos/pkg/machinery/meta"
 )
 
@@ -104,7 +104,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 					return false
 				}
 
-				return r.State().Machine().Installed() && val == profile.BootLoaderKindDualBoot.String()
+				return r.State().Machine().Installed() && val == imageropts.BootLoaderKindDualBoot.String()
 			},
 			"cleanupBootloader",
 			CleanupBootloader,


### PR DESCRIPTION
Replace imports of `pkg/imager` which are reachable from machined.

See #12980
