### PR TITLE
feat: add --platform=all support to image cache-create

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -1017,7 +1017,8 @@ func init() {
 	imageCacheCreateCmd.PersistentFlags().StringVar(&imageCacheCreateCmdFlags.imageLayerCachePath, "image-layer-cache-path", "", "directory to save the image layer cache")
 	imageCacheCreateCmd.PersistentFlags().Var(imageCacheCreateCmdFlags.layout, "layout",
 		"Specifies the cache layout format: \"oci\" for an OCI image layout directory, or \"flat\" for a registry-like flat file structure")
-	imageCacheCreateCmd.PersistentFlags().StringSliceVar(&imageCacheCreateCmdFlags.platform, "platform", []string{"linux/amd64"}, "platform to use for the cache")
+	imageCacheCreateCmd.PersistentFlags().StringSliceVar(&imageCacheCreateCmdFlags.platform, "platform", []string{"linux/amd64"},
+		"platform(s) to cache (e.g. linux/amd64,linux/arm64), or \"all\" to cache every platform in the image index")
 	imageCacheCreateCmd.PersistentFlags().StringSliceVar(&imageCacheCreateCmdFlags.images, "images", nil, "images to cache")
 	imageCacheCreateCmd.MarkPersistentFlagRequired("images") //nolint:errcheck
 	imageCacheCreateCmd.PersistentFlags().BoolVar(&imageCacheCreateCmdFlags.insecure, "insecure", false, "allow insecure registries")

--- a/pkg/imager/cache/cache.go
+++ b/pkg/imager/cache/cache.go
@@ -81,67 +81,59 @@ func Generate(images []string, platforms []string, insecure bool, imageLayerCach
 		return fmt.Errorf("must specify at least one platform")
 	}
 
-	for _, platform := range platforms {
-		v1Platform, err := v1.ParsePlatform(platform)
-		if err != nil {
-			return fmt.Errorf("parsing platform: %w", err)
-		}
+	allPlatforms := len(platforms) == 1 && platforms[0] == "all"
 
-		if err := os.MkdirAll(filepath.Join(tmpDir, blobsDir), 0o755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(filepath.Join(tmpDir, blobsDir), 0o755); err != nil {
+		return err
+	}
 
-		var nameOptions []name.Option
+	var nameOptions []name.Option
 
-		keychain := authn.NewMultiKeychain(
-			authn.DefaultKeychain,
-			github.Keychain,
-			google.Keychain,
-		)
+	keychain := authn.NewMultiKeychain(
+		authn.DefaultKeychain,
+		github.Keychain,
+		google.Keychain,
+	)
 
-		craneOpts := []crane.Option{
-			crane.WithAuthFromKeychain(keychain),
-		}
+	craneOpts := []crane.Option{
+		crane.WithAuthFromKeychain(keychain),
+	}
 
+	sigRemoteOpts := []remote.Option{
+		remote.WithAuthFromKeychain(keychain),
+	}
+
+	if insecure {
+		craneOpts = append(craneOpts, crane.Insecure)
+		nameOptions = append(nameOptions, name.Insecure)
+	}
+
+	if allPlatforms {
 		remoteOpts := []remote.Option{
 			remote.WithAuthFromKeychain(keychain),
-			remote.WithPlatform(*v1Platform),
 		}
 
-		// sigRemoteOpts is used for fetching cosign signatures - no platform resolution
-		// since signatures are platform-independent and may be stored as OCI image indexes.
-		sigRemoteOpts := []remote.Option{
-			remote.WithAuthFromKeychain(keychain),
+		if err := retryImages(images, func(src string) error {
+			return processImageAllPlatforms(src, tmpDir, imageLayerCachePath, nameOptions, craneOpts, remoteOpts, sigRemoteOpts, withCosignSignatures)
+		}); err != nil {
+			return err
 		}
-
-		if insecure {
-			craneOpts = append(craneOpts, crane.Insecure)
-			nameOptions = append(nameOptions, name.Insecure)
-		}
-
-		for _, src := range images {
-			r := retry.Exponential(
-				30*time.Minute,
-				retry.WithUnits(time.Second),
-				retry.WithJitter(time.Second),
-				retry.WithErrorLogging(true),
-			)
-
-			err := r.Retry(func() error {
-				if err := processImage(src, tmpDir, imageLayerCachePath, nameOptions, craneOpts, remoteOpts, sigRemoteOpts, withCosignSignatures); err != nil {
-					switch {
-					case errors.Is(err, new(name.ErrBadName)):
-						return err
-
-					default:
-						return retry.ExpectedError(err)
-					}
-				}
-
-				return nil
-			})
+	} else {
+		for _, platform := range platforms {
+			v1Platform, err := v1.ParsePlatform(platform)
 			if err != nil {
-				return fmt.Errorf("failed to prcess image: %w", err)
+				return fmt.Errorf("parsing platform: %w", err)
+			}
+
+			remoteOpts := []remote.Option{
+				remote.WithAuthFromKeychain(keychain),
+				remote.WithPlatform(*v1Platform),
+			}
+
+			if err := retryImages(images, func(src string) error {
+				return processImage(src, tmpDir, imageLayerCachePath, platform, nameOptions, craneOpts, remoteOpts, sigRemoteOpts, withCosignSignatures)
+			}); err != nil {
+				return err
 			}
 		}
 	}
@@ -179,7 +171,12 @@ func Generate(images []string, platforms []string, insecure bool, imageLayerCach
 		return fmt.Errorf("creating layout: %w", err)
 	}
 
-	imagePlatform, err := v1.ParsePlatform(platforms[0])
+	outerPlatformStr := "linux/amd64"
+	if !allPlatforms {
+		outerPlatformStr = platforms[0]
+	}
+
+	imagePlatform, err := v1.ParsePlatform(outerPlatformStr)
 	if err != nil {
 		return fmt.Errorf("parsing platform: %w", err)
 	}
@@ -264,16 +261,45 @@ func copyDir(src, dest string) error {
 	})
 }
 
+func retryImages(images []string, fn func(src string) error) error {
+	for _, src := range images {
+		r := retry.Exponential(
+			30*time.Minute,
+			retry.WithUnits(time.Second),
+			retry.WithJitter(time.Second),
+			retry.WithErrorLogging(true),
+		)
+
+		if err := r.Retry(func() error {
+			if err := fn(src); err != nil {
+				switch {
+				case errors.Is(err, new(name.ErrBadName)):
+					return err
+
+				default:
+					return retry.ExpectedError(err)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to process image: %w", err)
+		}
+	}
+
+	return nil
+}
+
 //nolint:gocyclo,cyclop
 func processImage(
-	src, tmpDir, imageLayerCachePath string,
+	src, tmpDir, imageLayerCachePath, platform string,
 	nameOptions []name.Option,
 	craneOpts []crane.Option,
 	remoteOpts []remote.Option,
 	sigRemoteOpts []remote.Option,
 	withCosignSignatures bool,
 ) error {
-	fmt.Fprintf(os.Stderr, "fetching image %q\n", src)
+	fmt.Fprintf(os.Stderr, "fetching image %q (%s)\n", src, platform)
 
 	ref, err := name.ParseReference(src, nameOptions...)
 	if err != nil {
@@ -342,41 +368,71 @@ func processImage(
 		img = cache.Image(img, cache.NewFilesystemCache(imageLayerCachePath))
 	}
 
-	layers, err := img.Layers()
+	return cacheImage(img, digestDir, tmpDir)
+}
+
+//nolint:gocyclo
+func processImageAllPlatforms(
+	src, tmpDir, imageLayerCachePath string,
+	nameOptions []name.Option,
+	craneOpts []crane.Option,
+	remoteOpts []remote.Option,
+	sigRemoteOpts []remote.Option,
+	withCosignSignatures bool,
+) error {
+	ref, err := name.ParseReference(src, nameOptions...)
 	if err != nil {
-		return fmt.Errorf("getting image layers: %w", err)
+		return fmt.Errorf("parsing reference %q: %w", src, err)
 	}
 
-	config, err := img.RawConfigFile()
+	rmt, err := remote.Get(ref, remoteOpts...)
 	if err != nil {
-		return fmt.Errorf("getting image config: %w", err)
+		return fmt.Errorf("fetching %q: %w", src, err)
 	}
 
-	platformManifest, err := img.RawManifest()
+	if rmt.MediaType != types.OCIImageIndex && rmt.MediaType != types.DockerManifestList {
+		return processImage(src, tmpDir, imageLayerCachePath, "linux/amd64", nameOptions, craneOpts,
+			append(remoteOpts, remote.WithPlatform(v1.Platform{OS: "linux", Architecture: "amd64"})),
+			sigRemoteOpts, withCosignSignatures)
+	}
+
+	idx, err := rmt.ImageIndex()
 	if err != nil {
-		return fmt.Errorf("getting image platform manifest: %w", err)
+		return fmt.Errorf("getting image index %q: %w", src, err)
 	}
 
-	h := sha256.New()
-	if _, err := h.Write(platformManifest); err != nil {
-		return fmt.Errorf("platform manifest hash: %w", err)
+	idxManifest, err := idx.IndexManifest()
+	if err != nil {
+		return fmt.Errorf("getting index manifest %q: %w", src, err)
 	}
 
-	if err := os.WriteFile(filepath.Join(digestDir, fmt.Sprintf("sha256-%x", h.Sum(nil))), platformManifest, 0o644); err != nil {
+	digestDir := filepath.Join(tmpDir, manifestsDir, rewriteRegistry(ref.Context().RegistryStr(), src), filepath.FromSlash(ref.Context().RepositoryStr()), "digest")
+	if err := os.MkdirAll(digestDir, 0o755); err != nil {
 		return err
 	}
 
-	configHash, err := img.ConfigName()
-	if err != nil {
-		return fmt.Errorf("getting image config hash: %w", err)
-	}
+	first := true
 
-	if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, strings.ReplaceAll(configHash.String(), "sha256:", "sha256-")), config, 0o644); err != nil {
-		return err
-	}
+	for _, desc := range idxManifest.Manifests {
+		if desc.Platform != nil && desc.Platform.OS != "unknown" {
+			platRemoteOpts := append(append([]remote.Option{}, remoteOpts...), remote.WithPlatform(*desc.Platform))
+			platformLabel := desc.Platform.OS + "/" + desc.Platform.Architecture
 
-	for _, layer := range layers {
-		if err = processLayer(layer, tmpDir); err != nil {
+			if err := processImage(src, tmpDir, imageLayerCachePath, platformLabel, nameOptions, craneOpts, platRemoteOpts, sigRemoteOpts, first && withCosignSignatures); err != nil {
+				return err
+			}
+
+			first = false
+
+			continue
+		}
+
+		childImg, err := idx.Image(desc.Digest)
+		if err != nil {
+			return fmt.Errorf("getting attestation image %s: %w", desc.Digest, err)
+		}
+
+		if err := cacheImage(childImg, digestDir, tmpDir); err != nil {
 			return err
 		}
 	}
@@ -449,7 +505,6 @@ func processCosignSignature(
 
 		switch sigRmt.MediaType { //nolint:exhaustive
 		case types.OCIImageIndex, types.DockerManifestList:
-			// Signature is an OCI image index - process each child manifest.
 			idx, err := sigRmt.ImageIndex()
 			if err != nil {
 				return fmt.Errorf("getting cosign image index: %w", err)
@@ -466,79 +521,65 @@ func processCosignSignature(
 					return fmt.Errorf("getting cosign child image %s: %w", descriptor.Digest, err)
 				}
 
-				childManifest, err := childImg.RawManifest()
-				if err != nil {
-					return fmt.Errorf("getting cosign child manifest: %w", err)
-				}
-
-				childDigest, err := childImg.Digest()
-				if err != nil {
-					return fmt.Errorf("getting cosign child digest: %w", err)
-				}
-
-				if err := os.WriteFile(filepath.Join(digestDir, strings.ReplaceAll(childDigest.String(), "sha256:", "sha256-")), childManifest, 0o644); err != nil {
+				if err := cacheImage(childImg, digestDir, tmpDir); err != nil {
 					return err
-				}
-
-				config, err := childImg.RawConfigFile()
-				if err != nil {
-					return fmt.Errorf("getting cosign child config: %w", err)
-				}
-
-				configHash, err := childImg.ConfigName()
-				if err != nil {
-					return fmt.Errorf("getting cosign child config hash: %w", err)
-				}
-
-				if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, strings.ReplaceAll(configHash.String(), "sha256:", "sha256-")), config, 0o644); err != nil {
-					return err
-				}
-
-				layers, err := childImg.Layers()
-				if err != nil {
-					return fmt.Errorf("getting cosign child layers: %w", err)
-				}
-
-				for _, layer := range layers {
-					if err = processLayer(layer, tmpDir); err != nil {
-						return err
-					}
 				}
 			}
 		default:
-			// Signature is a single image manifest.
 			img, err := sigRmt.Image()
 			if err != nil {
 				return fmt.Errorf("getting cosign image: %w", err)
 			}
 
-			config, err := img.RawConfigFile()
-			if err != nil {
-				return fmt.Errorf("getting cosign config: %w", err)
-			}
-
-			configHash, err := img.ConfigName()
-			if err != nil {
-				return fmt.Errorf("getting cosign config hash: %w", err)
-			}
-
-			if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, strings.ReplaceAll(configHash.String(), "sha256:", "sha256-")), config, 0o644); err != nil {
+			if err := cacheImage(img, digestDir, tmpDir); err != nil {
 				return err
-			}
-
-			layers, err := img.Layers()
-			if err != nil {
-				return fmt.Errorf("getting cosign layers: %w", err)
-			}
-
-			for _, layer := range layers {
-				if err = processLayer(layer, tmpDir); err != nil {
-					return err
-				}
 			}
 		}
 
 		return nil
+	}
+
+	return nil
+}
+
+func cacheImage(img v1.Image, digestDir, tmpDir string) error {
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return fmt.Errorf("getting image manifest: %w", err)
+	}
+
+	h := sha256.New()
+	if _, err := h.Write(manifest); err != nil {
+		return fmt.Errorf("hashing manifest: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(digestDir, fmt.Sprintf("sha256-%x", h.Sum(nil))), manifest, 0o644); err != nil {
+		return err
+	}
+
+	config, err := img.RawConfigFile()
+	if err != nil {
+		return fmt.Errorf("getting image config: %w", err)
+	}
+
+	configHash, err := img.ConfigName()
+	if err != nil {
+		return fmt.Errorf("getting image config hash: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, blobsDir, strings.ReplaceAll(configHash.String(), "sha256:", "sha256-")), config, 0o644); err != nil {
+		return err
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("getting image layers: %w", err)
+	}
+
+	for _, layer := range layers {
+		if err := processLayer(layer, tmpDir); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -2182,7 +2182,7 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
       --images strings                  images to cache
       --insecure                        allow insecure registries
       --layout string                   Specifies the cache layout format: "oci" for an OCI image layout directory, or "flat" for a registry-like flat file structure (default "oci")
-      --platform strings                platform to use for the cache (default [linux/amd64])
+      --platform strings                platform(s) to cache (e.g. linux/amd64,linux/arm64), or "all" to cache every platform in the image index (default [linux/amd64])
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Add support for caching all platforms in a multi-platform image index by passing --platform=all to the images cache-create command.

When all is specified, the index manifest is fetched without platform resolution, and each platform-specific image is downloaded individually. Attestation manifests (unknown/unknown) are included.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Currently we only support downloading for a specific platform. This will not work for a airgapped environment since we need all platforms.

## Why? (reasoning)
But adding `all` we can create a image cache with for all platforms

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

## Tests
```
cat images.txt | ./talosctl-dirty images cache-create \
      --force \
      --layout flat \
      --image-layer-cache-path ./layer-cache \
      --image-cache-path ./image-cache-dirty \
      --images=- --platform all
fetching image "ghcr.io/siderolabs/installer:v1.12.5" (linux/amd64)
fetching cosign signature "ghcr.io/siderolabs/installer:sha256-8954c1a28ff95a24a014cae1e42fc93b2c9dd779cd695597e82b9a418e9fa8fe.sig"
> layer "sha256:ce08a4cd135c38da6a5125c7fea8d5d513de4227b0429cf4c5f8fcfdf4d9b03e" (size 244 B)...
> layer "sha256:899efe77ae8a698d59f791d731390cf8f185c572a93d2998e128f44c09c92675" (size 25 MB)...
> layer "sha256:a7456aed8bb30e9dbfe565fad673e8f9d6f3bd35bb275786abdb3d638c8940ed" (size 99 MB)...
fetching image "ghcr.io/siderolabs/installer:v1.12.5" (linux/arm64)
> layer "sha256:ff1fdfc0bcb1b6d9f381d0ef2968b8ffd748f16cd02587360fc2600631153e40" (size 23 MB)...
> layer "sha256:e364261a437a8171f09de7ca8b5cf85f0b5f2d0b4ee18d5a3216c0962d6812fa" (size 90 MB)...
fetching image "ghcr.io/siderolabs/installer-base:v1.12.5" (linux/amd64)
fetching cosign signature "ghcr.io/siderolabs/installer-base:sha256-e24bd67beadd8faee27904c71011d5cdc30e894256be7c87ab808dff4da3bb9d.sig"
> layer "sha256:53a2f3732513a0683097b3442c954adc3ee49352102fdd88fbe8828e3b426d04" (size 249 B)...
fetching image "ghcr.io/siderolabs/installer-base:v1.12.5" (linux/arm64)
> layer "sha256:8c1cd95335e91b7ed1dc7a02a9642c3a6facade1b1b5a1501322b7779aa03aad" (size 3.3 kB)...
> layer "sha256:bf980e1afc1923dba3cd2995026b2e37c9596fd40343ecb9adfc8ccb5e3fef92" (size 3.3 kB)...
```

> See `make help` for a description of the available targets.
