### PR TITLE
fix(machined): clear stale bond ARP/NS targets on decode

### DIFF
--- a/internal/app/machined/pkg/adapters/network/bond_master_spec.go
+++ b/internal/app/machined/pkg/adapters/network/bond_master_spec.go
@@ -183,6 +183,7 @@ func (a bondMaster) Encode() ([]byte, error) {
 //
 //nolint:gocyclo,cyclop
 func (a bondMaster) Decode(data []byte) error {
+	*a.BondMasterSpec = network.BondMasterSpec{}
 	bond := a.BondMasterSpec
 
 	decoder, err := netlink.NewAttributeDecoder(data)

--- a/internal/app/machined/pkg/adapters/network/bond_master_spec_test.go
+++ b/internal/app/machined/pkg/adapters/network/bond_master_spec_test.go
@@ -5,6 +5,7 @@
 package network_test
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,4 +31,32 @@ func TestBondMasterSpec(t *testing.T) {
 	require.NoError(t, networkadapter.BondMasterSpec(&decodedSpec).Decode(b))
 
 	require.Equal(t, spec, decodedSpec)
+}
+
+func TestBondMasterSpecDecodeClearsTargets(t *testing.T) {
+	initial := network.BondMasterSpec{
+		Mode:         nethelpers.BondModeActiveBackup,
+		ARPIPTargets: []netip.Addr{netip.MustParseAddr("198.51.100.254")},
+		NSIP6Targets: []netip.Addr{netip.MustParseAddr("fd00::1")},
+	}
+
+	initialEncoded, err := networkadapter.BondMasterSpec(&initial).Encode()
+	require.NoError(t, err)
+
+	cleared := network.BondMasterSpec{
+		Mode: nethelpers.BondModeActiveBackup,
+	}
+
+	clearedEncoded, err := networkadapter.BondMasterSpec(&cleared).Encode()
+	require.NoError(t, err)
+
+	var decodedSpec network.BondMasterSpec
+
+	require.NoError(t, networkadapter.BondMasterSpec(&decodedSpec).Decode(initialEncoded))
+	require.Equal(t, initial.ARPIPTargets, decodedSpec.ARPIPTargets)
+	require.Equal(t, initial.NSIP6Targets, decodedSpec.NSIP6Targets)
+
+	require.NoError(t, networkadapter.BondMasterSpec(&decodedSpec).Decode(clearedEncoded))
+	require.Empty(t, decodedSpec.ARPIPTargets)
+	require.Empty(t, decodedSpec.NSIP6Targets)
 }


### PR DESCRIPTION

# Pull Request

## What? (description)
Reset ARPIPTargets and NSIP6Targets at the start of BondMasterSpec.Decode.

## Why? (reasoning)
Without this, repeated decode calls on the same struct can retain old target entries after config removes them, which makes linkspec of the bond interface drift from current bond configuration.

Add a regression test that decodes a payload with targets, then decodes a payload without target attributes into the same struct and asserts both slices are empty.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [X] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
