### PR TITLE
fix(machined): don't require DNS when using proxy

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/discovery_service.go
+++ b/internal/app/machined/pkg/controllers/cluster/discovery_service.go
@@ -243,7 +243,7 @@ func (ctrl *DiscoveryServiceController) Run(ctx context.Context, r controller.Ru
 
 			client, err = discoveryclient.NewClient(discoveryclient.Options{
 				Cipher:        cipherBlock,
-				Endpoint:      discoveryConfig.TypedSpec().ServiceEndpoint,
+				Endpoint:      "passthrough:" + discoveryConfig.TypedSpec().ServiceEndpoint,
 				ClusterID:     discoveryConfig.TypedSpec().ServiceClusterID,
 				AffiliateID:   localAffiliateID,
 				TTL:           defaultDiscoveryTTL,


### PR DESCRIPTION
# Pull Request

## What? (description)

As per https://pkg.go.dev/google.golang.org/grpc#WithContextDialer gRPC will perform a DNS lookup on the discovery endpoint even when using a proxy. In an air gapped scenario without DNS but a working http(s) proxy, this breaks discovery. This forces gRPC to pass the endpoint host on to the dialer without doing its own lookup.

## Why? (reasoning)

Without this, Discovery doesn't work if the node is truly airgapped behind a proxy, including no DNS.
Running a dev cluster with ` --airgapped --nameservers 8.8.8.8` simulates this:

```
user: warning: [2026-03-20T12:07:49.969152611Z]: [talos] error serving dns request {"component": "dns-resolve-cache", "error": "read udp 172.20.0.2:58347->8.8.8.8:53: i/o timeout"}
user: warning: [2026-03-20T12:07:49.972176568Z]: [talos] error serving dns request {"component": "dns-resolve-cache", "error": "read udp 172.20.0.2:49019->8.8.8.8:53: i/o timeout"}
user: warning: [2026-03-20T12:07:51.972556435Z]: [talos] error serving dns request {"component": "dns-resolve-cache", "error": "read udp 172.20.0.2:51154->8.8.8.8:53: i/o timeout"}
user: warning: [2026-03-20T12:07:51.975565151Z]: [talos] error serving dns request {"component": "dns-resolve-cache", "error": "read udp 172.20.0.2:35450->8.8.8.8:53: i/o timeout"}
user: warning: [2026-03-20T12:07:51.977993469Z]: [talos] hello failed {"component": "controller-runtime", "controller": "cluster.DiscoveryServiceController", "error": "rpc  error: code = Unavailable desc = dns: A record lookup error: lookup discovery.talos.dev on 127.0.0.53:53: server misbehaving", "endpoint": "discovery.talos.dev:443"}          
```

The failed DNS lookup comes from gRPC as mentioned above. By forcing the `passthrough` "resolver", this lookup is suppressed and the hostname simply sent in the CONNECT`request to the proxy.
Without proxy configuration, it still saves gRPC's DNS lookup and then proceeds as usual.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
  _probably applicable, but no idea how to test this in a meaningful way_
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
  _yes, but getting an unrelated failure with or without this PR_
