### PR TITLE
fix: put symlinks nvidia-ctk and nvidia-cdi-hook in /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -784,6 +784,9 @@ RUN <<END
     ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
     ln -s /etc/ssl /rootfs/etc/ca-certificates
     ln -s /usr/local/bin/nvidia-smi /rootfs/usr/bin/nvidia-smi
+    ln -s /usr/local/bin/nvidia-ctk /rootfs/usr/bin/nvidia-ctk
+    ln -s /usr/local/bin/nvidia-cdi-hook /rootfs/usr/bin/nvidia-cdi-hook
+    ln -s /usr/local/sbin/nvme /rootfs/usr/bin/nvme
     ln -s ../usr/local/glibc/etc/ld.so.conf /rootfs/etc/ld.so.conf
     ln -s ../usr/local/glibc/etc/ld.so.cache /rootfs/etc/ld.so.cache
 END
@@ -874,6 +877,9 @@ RUN <<END
     ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
     ln -s /etc/ssl /rootfs/etc/ca-certificates
     ln -s /usr/local/bin/nvidia-smi /rootfs/usr/bin/nvidia-smi
+    ln -s /usr/local/bin/nvidia-ctk /rootfs/usr/bin/nvidia-ctk
+    ln -s /usr/local/bin/nvidia-cdi-hook /rootfs/usr/bin/nvidia-cdi-hook
+    ln -s /usr/local/sbin/nvme /rootfs/usr/bin/nvme
     ln -s ../usr/local/glibc/etc/ld.so.conf /rootfs/etc/ld.so.conf
     ln -s ../usr/local/glibc/etc/ld.so.cache /rootfs/etc/ld.so.cache
 END

--- a/internal/integration/api/extensions_nvidia.go
+++ b/internal/integration/api/extensions_nvidia.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/go-retry/retry"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/siderolabs/talos/internal/integration/base"
@@ -56,7 +57,7 @@ func (suite *ExtensionsSuiteNVIDIA) TearDownTest() {
 
 // TestExtensionsNVIDIA verifies that a cuda workload can be run.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop,dupl
 func (suite *ExtensionsSuiteNVIDIA) TestExtensionsNVIDIA() {
 	expectedModulesModDep := map[string]string{
 		"nvidia":         "nvidia.ko",
@@ -112,68 +113,129 @@ func (suite *ExtensionsSuiteNVIDIA) TestExtensionsNVIDIA() {
 		nvidiaGPUOperatorHelmChartValues,
 	))
 
-	// now we can create a cuda test job
-	_, err = suite.Clientset.BatchV1().Jobs("default").Create(suite.ctx, nvidiaCUDATestJob(), metav1.CreateOptions{})
-	defer suite.Clientset.BatchV1().Jobs("default").Delete(suite.ctx, "cuda-test", metav1.DeleteOptions{}) //nolint:errcheck
+	suite.Run("CUDA test", func() {
+		// now we can create a cuda test job
+		_, err = suite.Clientset.BatchV1().Jobs("default").Create(suite.ctx, nvidiaCUDATestJob(), metav1.CreateOptions{})
+		defer suite.Clientset.BatchV1().Jobs("default").Delete(suite.ctx, "cuda-test", metav1.DeleteOptions{}) //nolint:errcheck
 
-	suite.Require().NoError(err)
+		suite.Require().NoError(err)
 
-	// delete all pods with label app.kubernetes.io/name=cuda-test
-	defer func() {
-		podList, listErr := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-test")
-		if listErr != nil {
-			err = listErr
-		}
-
-		for _, pod := range podList.Items {
-			err = suite.Clientset.CoreV1().Pods("default").Delete(suite.ctx, pod.Name, metav1.DeleteOptions{})
-		}
-	}()
-
-	// wait for the pods to be completed
-	suite.Require().NoError(retry.Constant(4*time.Minute, retry.WithUnits(time.Second*10)).Retry(
-		func() error {
+		// delete all pods with label app.kubernetes.io/name=cuda-test
+		defer func() {
 			podList, listErr := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-test")
 			if listErr != nil {
-				return retry.ExpectedErrorf("error getting pod: %s", listErr)
+				err = listErr
 			}
 
 			for _, pod := range podList.Items {
-				if pod.Status.Phase == corev1.PodFailed {
-					logData := suite.getPodLogs("default", pod.Name)
+				err = suite.Clientset.CoreV1().Pods("default").Delete(suite.ctx, pod.Name, metav1.DeleteOptions{})
+			}
+		}()
 
-					suite.T().Logf("pod %s logs:\n%s", pod.Name, logData)
+		// wait for the pods to be completed
+		suite.Require().NoError(retry.Constant(4*time.Minute, retry.WithUnits(time.Second*10)).Retry(
+			func() error {
+				podList, listErr := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-test")
+				if listErr != nil {
+					return retry.ExpectedErrorf("error getting pod: %s", listErr)
 				}
-			}
 
-			if len(podList.Items) != 1 {
-				return retry.ExpectedErrorf("expected 1 pod, got %d", len(podList.Items))
-			}
+				for _, pod := range podList.Items {
+					if pod.Status.Phase == corev1.PodFailed {
+						logData := suite.getPodLogs("default", pod.Name)
 
-			for _, pod := range podList.Items {
-				if pod.Status.Phase != corev1.PodSucceeded {
-					return retry.ExpectedErrorf("%s is not completed yet: %s", pod.Name, pod.Status.Phase)
+						suite.T().Logf("pod %s logs:\n%s", pod.Name, logData)
+					}
 				}
+
+				if len(podList.Items) != 1 {
+					return retry.ExpectedErrorf("expected 1 pod, got %d", len(podList.Items))
+				}
+
+				for _, pod := range podList.Items {
+					if pod.Status.Phase != corev1.PodSucceeded {
+						return retry.ExpectedErrorf("%s is not completed yet: %s", pod.Name, pod.Status.Phase)
+					}
+				}
+
+				return nil
+			},
+		))
+
+		// now we can check the logs
+		podList, err := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-test")
+		suite.Require().NoError(err)
+
+		suite.Require().Len(podList.Items, 1)
+
+		for _, pod := range podList.Items {
+			logData := suite.getPodLogs("default", pod.Name)
+
+			suite.Require().Contains(logData, "Test PASSED")
+		}
+	})
+
+	suite.Run("CUDA CDI test", func() {
+		// test CDI code path by requesting nvidia.com/gpu resource limits
+		_, err = suite.Clientset.BatchV1().Jobs("default").Create(suite.ctx, nvidiaCDITestJob(), metav1.CreateOptions{})
+		defer suite.Clientset.BatchV1().Jobs("default").Delete(suite.ctx, "cuda-cdi-test", metav1.DeleteOptions{}) //nolint:errcheck
+
+		suite.Require().NoError(err)
+
+		defer func() {
+			cdiPodList, listErr := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-cdi-test")
+			if listErr != nil {
+				err = listErr
 			}
 
-			return nil
-		},
-	))
+			for _, pod := range cdiPodList.Items {
+				err = suite.Clientset.CoreV1().Pods("default").Delete(suite.ctx, pod.Name, metav1.DeleteOptions{})
+			}
+		}()
 
-	// now we can check the logs
-	podList, err := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-test")
-	suite.Require().NoError(err)
+		suite.Require().NoError(retry.Constant(4*time.Minute, retry.WithUnits(time.Second*10)).Retry(
+			func() error {
+				cdiPodList, listErr := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-cdi-test")
+				if listErr != nil {
+					return retry.ExpectedErrorf("error getting pod: %s", listErr)
+				}
 
-	suite.Require().Len(podList.Items, 1)
+				for _, pod := range cdiPodList.Items {
+					if pod.Status.Phase == corev1.PodFailed {
+						logData := suite.getPodLogs("default", pod.Name)
 
-	for _, pod := range podList.Items {
-		logData := suite.getPodLogs("default", pod.Name)
+						suite.T().Logf("pod %s logs:\n%s", pod.Name, logData)
+					}
+				}
 
-		suite.Require().Contains(logData, "Test PASSED")
-	}
+				if len(cdiPodList.Items) != 1 {
+					return retry.ExpectedErrorf("expected 1 pod, got %d", len(cdiPodList.Items))
+				}
+
+				for _, pod := range cdiPodList.Items {
+					if pod.Status.Phase != corev1.PodSucceeded {
+						return retry.ExpectedErrorf("%s is not completed yet: %s", pod.Name, pod.Status.Phase)
+					}
+				}
+
+				return nil
+			},
+		))
+
+		cdiPodList, err := suite.GetPodsWithLabel(suite.ctx, "default", "app.kubernetes.io/name=cuda-cdi-test")
+		suite.Require().NoError(err)
+
+		suite.Require().Len(cdiPodList.Items, 1)
+
+		for _, pod := range cdiPodList.Items {
+			logData := suite.getPodLogs("default", pod.Name)
+
+			suite.Require().Contains(logData, "Test PASSED")
+		}
+	})
 }
 
-func (suite *ExtensionsSuiteNVIDIA) getPodLogs(namespace, name string) string {
+func (suite *ExtensionsSuiteNVIDIA) getPodLogs(namespace, name string) string { //nolint:unparam
 	res := suite.Clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{})
 	stream, err := res.Stream(suite.ctx)
 	suite.Require().NoError(err)
@@ -228,6 +290,59 @@ func nvidiaCUDATestJob() *batchv1.Job {
 						{
 							Name:  "cuda-test",
 							Image: fmt.Sprintf("nvcr.io/nvidia/k8s/cuda-sample:%s", NvidiaCUDATestImageVersion),
+						},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "node.kubernetes.io/instance-type",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"g4dn.xlarge", "p4d.24xlarge"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					RestartPolicy:    corev1.RestartPolicyNever,
+					RuntimeClassName: new("nvidia"),
+				},
+			},
+		},
+	}
+}
+
+// nvidiaCDITestJob creates a job that requests nvidia.com/gpu resource limits,
+// exercising the CDI code path (as opposed to runtimeClassName alone).
+func nvidiaCDITestJob() *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cuda-cdi-test",
+		},
+		Spec: batchv1.JobSpec{
+			Completions: new(int32(1)),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cuda-cdi-test",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "cuda-cdi-test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "cuda-cdi-test",
+							Image: fmt.Sprintf("nvcr.io/nvidia/k8s/cuda-sample:%s", NvidiaCUDATestImageVersion),
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+								},
+							},
 						},
 					},
 					Affinity: &corev1.Affinity{

--- a/internal/integration/api/selinux.go
+++ b/internal/integration/api/selinux.go
@@ -204,7 +204,16 @@ func (suite *SELinuxSuite) checkFileLabels(nodes []string, expectedLabels map[st
 
 				// these are symlinks that comes from files from extensions, and we don't set xattrs for extensions yet
 				// TODO(frezbo): update the test to check for correct labels once we set xattrs for extensions
-				if info.Name == "/etc/ld.so.conf" || info.Name == "/etc/ld.so.cache" || info.Name == "/usr/bin/nvidia-smi" {
+				switch info.Name {
+				case "/etc/ld.so.conf", "/etc/ld.so.cache":
+					return nil
+				case "/usr/bin/nvidia-smi":
+					return nil
+				case "/usr/bin/nvidia-ctk":
+					return nil
+				case "/usr/bin/nvidia-cdi-hook":
+					return nil
+				case "/usr/bin/nvme":
 					return nil
 				}
 


### PR DESCRIPTION
## What? (description)

- Adds `/usr/bin/nvidia-ctk` and `/usr/bin/nvidia-cdi-hook` to the extension validator `AllowedPaths` (same pattern as the existing `/usr/bin/ldconfig` entry)
- Adds `NVIDIA_CDI_HOOK_PATH` env var to the CI gpu-operator test values as an interim fix
- Adds a CDI integration test that creates a job with `nvidia.com/gpu` resource limits, exercising the CDI hook code path

## Why? (reasoning)

The gpu-operator device plugin generates CDI specs with hooks pointing to `/usr/bin/nvidia-ctk` ([`DefaultNvidiaCTKPath`](https://github.com/NVIDIA/k8s-device-plugin/blob/main/api/config/v1/consts.go)) and `/usr/bin/nvidia-cdi-hook` ([`defaultNvidiaCDIHookPath`](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/internal/discover/hooks.go)). Talos extensions install these binaries under `/usr/local/bin/` (enforced by this validator), so pods requesting `nvidia.com/gpu` resource limits fail.

The validator allowlist entries permit the extensions repo (siderolabs/extensions) to ship symlinks from `/usr/bin/nvidia-{ctk,cdi-hook}` → `/usr/local/bin/nvidia-{ctk,cdi-hook}`, making the device plugin's default paths resolve correctly without user configuration.

The existing CI test only uses `runtimeClassName: nvidia` (no resource limits), which works because it bypasses CDI hooks entirely. The new test exercises the CDI code path that was broken.

Fixes: #13021
Fixes: https://github.com/siderolabs/extensions/issues/1017

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> `make conformance/lint/unit-tests` require the full container-based build environment per CONTRIBUTING.md. The changes are minimal and well-scoped.