### PR TITLE
fix: unset rlimits for extension services

### DIFF
--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -131,6 +132,13 @@ func (svc *Extension) getOCIOptions(envVars []string, mounts []specs.Mount) []oc
 		oci.WithCapabilities(capability.AllGrantableCapabilities()),
 		oci.WithAllDevicesAllowed,
 		oci.WithEnv(envVars),
+		func(_ context.Context, _ oci.Client, _ *containers.Container, spec *oci.Spec) error {
+			// clear the rlimits, allow to inherit from machined -> containerd
+			// (see https://github.com/containerd/cri/issues/515)
+			spec.Process.Rlimits = nil
+
+			return nil
+		},
 	}
 
 	if !svc.Spec.Container.Security.WriteableRootfs {


### PR DESCRIPTION
See https://github.com/siderolabs/talos/discussions/13012

The containerd's default OCI spec sets NOFILE rlimit to 1024, unset it to simply let machined defaults take over.
