### PR TITLE
test: fix the flakes in tests with trusted roots

### DIFF
--- a/internal/integration/api/trusted-roots.go
+++ b/internal/integration/api/trusted-roots.go
@@ -12,8 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/siderolabs/gen/xslices"
+
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -65,6 +68,14 @@ func (suite *TrustedRootsSuite) TestTrustedRoots() {
 	// build a Talos API context which is tied to the node
 	nodeCtx := client.WithNode(suite.ctx, node)
 
+	// query the current TrustedRoots config to restore it after the test
+	cfg, err := suite.ReadConfigFromNode(nodeCtx)
+	suite.Require().NoError(err)
+
+	originalConfig := xslices.Filter(cfg.Documents(), func(doc config.Document) bool {
+		return doc.Kind() == security.TrustedRootsConfig
+	})
+
 	const name = "test-ca"
 
 	cfgDocument := security.NewTrustedRootsConfigV1Alpha1()
@@ -90,6 +101,11 @@ func (suite *TrustedRootsSuite) TestTrustedRoots() {
 	suite.Require().Eventually(func() bool {
 		return !strings.Contains(suite.readTrustedRoots(nodeCtx), name)
 	}, 5*time.Second, 100*time.Millisecond)
+
+	// restore back trusted roots config if it existed before the test
+	if len(originalConfig) > 0 {
+		suite.PatchMachineConfig(nodeCtx, xslices.Map(originalConfig, func(d config.Document) any { return d })...)
+	}
 }
 
 func init() {


### PR DESCRIPTION
As one of the integration tests was overriding TrustedRoots config, it erased the required settings leading to a random failure (depending on the nodes picked for subsequent tests).

Fixes #13013
