### PR TITLE
fix: allow blockdevice wipe in maintenance mode

### DIFF
--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -119,8 +119,12 @@ var rules = map[string]role.Set{
 	"/cosi.resource.State/Update":  role.MakeSet(role.Admin),
 	"/cosi.resource.State/Watch":   role.MakeSet(role.Admin, role.Operator, role.Reader),
 
-	"/storage.StorageService/Disks":           role.MakeSet(role.Admin, role.Operator, role.Reader),
-	"/storage.StorageService/BlockDeviceWipe": role.MakeSet(role.Admin),
+	"/storage.StorageService/Disks": role.MakeSet(role.Admin, role.Operator, role.Reader),
+	"/storage.StorageService/BlockDeviceWipe": role.MakeSet(
+		role.Admin,
+		// for maintenance only, verified in the handler
+		role.Reader,
+	),
 
 	"/time.TimeService/Time":      role.MakeSet(role.Admin, role.Operator, role.Reader),
 	"/time.TimeService/TimeCheck": role.MakeSet(role.Admin, role.Operator, role.Reader),

--- a/internal/app/storaged/server.go
+++ b/internal/app/storaged/server.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/pkg/partition"
+	"github.com/siderolabs/talos/pkg/grpc/middleware/authz"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
 // Server implements storage.StorageService.
@@ -34,8 +36,7 @@ import (
 type Server struct {
 	storage.UnimplementedStorageServiceServer
 
-	Controller      runtime.Controller
-	MaintenanceMode bool
+	Controller runtime.Controller
 }
 
 // Disks implements storage.StorageService.
@@ -99,10 +100,14 @@ func (s *Server) Disks(ctx context.Context, in *emptypb.Empty) (reply *storage.D
 //
 // It allows to wipe unused block devices, for blockdevices in use (volumes), use a different method.
 func (s *Server) BlockDeviceWipe(ctx context.Context, req *storage.BlockDeviceWipeRequest) (*storage.BlockDeviceWipeResponse, error) {
-	// the storage server is included both into machined and maintenance service
-	// in apid/machined mode, the normal authz checks are used before reaching this method
-	// in maintenance mode, we allow this method to be accessible, as it only allows to wipe block devices
-	//
+	// this API is allowed for reader role only in maintenance mode.
+	roles := authz.GetRoles(ctx)
+	inMaintenance := !s.Controller.Runtime().ConfigCompleteForBoot()
+
+	if !inMaintenance && !roles.Includes(role.Admin) {
+		return nil, authz.ErrNotAuthorized
+	}
+
 	// validate the list of devices
 	for _, deviceRequest := range req.GetDevices() {
 		if err := s.validateDeviceForWipe(ctx, deviceRequest.GetDevice(), deviceRequest.GetSkipVolumeCheck(), deviceRequest.GetSkipSecondaryCheck()); err != nil {

--- a/internal/integration/provision/maintenance_basic.go
+++ b/internal/integration/provision/maintenance_basic.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -151,6 +152,16 @@ func (suite *MaintenanceBasicSuite) TestAPI() {
 
 			suite.Require().NoError(err)
 		}
+
+		// block device wipe should be allowed in maintenance mode
+		suite.Require().NoError(maintenanceClient.BlockDeviceWipe(suite.ctx, &storage.BlockDeviceWipeRequest{
+			Devices: []*storage.BlockDeviceWipeDescriptor{
+				{
+					Device: "vda",
+					Method: storage.BlockDeviceWipeDescriptor_FAST,
+				},
+			},
+		}))
 	})
 
 	suite.Run("test all APIs in maintenance mode", func() {

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -33,7 +33,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/meta"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
 
 // MaintenanceSideroLinkSuite ...
@@ -190,49 +192,6 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		}, time.Minute, time.Second, "machines should listen on SideroLink IPs")
 	})
 
-	suite.Run("reboot one machine", func() {
-		maintenanceClient := sideroLinkMaintenanceClients[0]
-		insecureMaintenanceClient := maintenanceClients[0]
-
-		currentBootID := suite.readBootID(maintenanceClient)
-
-		suite.Require().NoError(maintenanceClient.Reboot(suite.ctx))
-
-		// after the reboot the machine should lose SideroLink config, so we expect it to come back up on regular IP
-		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
-			asrt := assert.New(collect)
-
-			version, err := insecureMaintenanceClient.Version(suite.ctx)
-			if !asrt.NoError(err) {
-				return
-			}
-
-			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
-		}, time.Minute, time.Second, "version API should be available after reboot")
-
-		// apply back SideroLink config
-		_, err := insecureMaintenanceClient.ApplyConfiguration(suite.ctx, &machine.ApplyConfigurationRequest{
-			Data: maintenanceConfig,
-		})
-		suite.Require().NoError(err)
-
-		// wait for the machine to come back on SideroLink IP
-		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
-			asrt := assert.New(collect)
-
-			version, err := maintenanceClient.Version(suite.ctx)
-			if !asrt.NoError(err) {
-				return
-			}
-
-			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
-		}, time.Minute, time.Second, "API should listen on SideroLink IP after reboot")
-
-		// check that boot ID has changed after reboot
-		newBootID := suite.readBootID(maintenanceClient)
-		suite.Assert().NotEqual(currentBootID, newBootID, "boot ID should change after reboot")
-	})
-
 	suite.Run("wipe the disk", func() {
 		// we can wipe the disk, as SideroLink client has admin permissions
 		for _, maintenanceClient := range sideroLinkMaintenanceClients {
@@ -359,6 +318,68 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 				},
 			)
 		}
+	})
+
+	suite.Run("write META value", func() {
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+
+		suite.Require().NoError(maintenanceClient.MetaWrite(suite.ctx, meta.UserReserved1, []byte("provision")))
+	})
+
+	suite.Run("reboot one machine", func() {
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+		insecureMaintenanceClient := maintenanceClients[0]
+
+		currentBootID := suite.readBootID(maintenanceClient)
+
+		suite.Require().NoError(maintenanceClient.Reboot(suite.ctx))
+
+		// after the reboot the machine should lose SideroLink config, so we expect it to come back up on regular IP
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			version, err := insecureMaintenanceClient.Version(suite.ctx)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
+		}, time.Minute, time.Second, "version API should be available after reboot")
+
+		// apply back SideroLink config
+		_, err := insecureMaintenanceClient.ApplyConfiguration(suite.ctx, &machine.ApplyConfigurationRequest{
+			Data: maintenanceConfig,
+		})
+		suite.Require().NoError(err)
+
+		// wait for the machine to come back on SideroLink IP
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			version, err := maintenanceClient.Version(suite.ctx)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
+		}, time.Minute, time.Second, "API should listen on SideroLink IP after reboot")
+
+		// check that boot ID has changed after reboot
+		newBootID := suite.readBootID(maintenanceClient)
+		suite.Assert().NotEqual(currentBootID, newBootID, "boot ID should change after reboot")
+	})
+
+	suite.Run("read back META value", func() {
+		ctx, cancel := context.WithTimeout(suite.ctx, 15*time.Second)
+		defer cancel()
+
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+
+		rtestutils.AssertResource(ctx, suite.T(), maintenanceClient.COSI, runtime.MetaKeyTagToID(meta.UserReserved1),
+			func(metaValue *runtime.MetaKey, asrt *assert.Assertions) {
+				asrt.Equal("provision", metaValue.TypedSpec().Value)
+			},
+		)
 	})
 
 	suite.Run("apply config and have a cluster", func() {


### PR DESCRIPTION
This is a regression compared to Talos 1.12: allow blockdevice wipe in maintenance mode (with `os:reader` role).

Also improve the test for maintenance via SideroLink - add a test on install, META write and reboot preserving META value.
