### PR TITLE
fix: add metal-agent mode to runtime capabilities

### DIFF
--- a/internal/app/machined/pkg/runtime/mode.go
+++ b/internal/app/machined/pkg/runtime/mode.go
@@ -92,11 +92,13 @@ func (m Mode) capabilities() uint64 {
 	all := ^uint64(0)
 
 	return [...]uint64{
-		// metal
+		// cloud
 		all,
 		// container
 		all ^ uint64(Reboot|Shutdown|Upgrade|Rollback|MetaKV),
-		// cloud
+		// metal
+		all,
+		// metal-agent
 		all,
 	}[m]
 }


### PR DESCRIPTION
The runtime capabilities lookup did not include an entry for the metal-agent mode, causing an index out of range panic when any capability check was performed in that mode. This broke MetaWrite calls from Omni to machines running in metal-agent mode through the new unified apid, preventing them from appearing as pending machines.

Also fix the incorrect comments on the existing entries to match the actual iota order.
