### PR TITLE
chore: drop debug shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@
 ARG TOOLS=scratch
 ARG PKGS=scratch
 ARG INSTALLER_ARCH=scratch
-ARG DEBUG_TOOLS_SOURCE=scratch
 
 ARG PKGS_PREFIX=scratch
 ARG TOOLS_PREFIX=scratch
@@ -68,8 +67,6 @@ ARG PKG_XFSPROGS=scratch
 ARG PKG_XZ=scratch
 ARG PKG_ZLIB=scratch
 ARG PKG_ZSTD=scratch
-
-ARG DEBUG_TOOLS_SOURCE=scratch
 
 ARG EMBED_TARGET=embed
 
@@ -225,26 +222,6 @@ FROM ${PKG_ZSTD} AS pkg-zstd
 
 FROM --platform=amd64 ${TOOLS_PREFIX}:${TOOLS} AS tools-amd64
 FROM --platform=arm64 ${TOOLS_PREFIX}:${TOOLS} AS tools-arm64
-
-FROM scratch AS pkg-debug-tools-scratch-amd64
-FROM scratch AS pkg-debug-tools-scratch-arm64
-
-FROM scratch AS pkg-debug-tools-bash-minimal-amd64
-COPY --from=tools-amd64 /usr/bin/bash /bin/bash
-COPY --from=tools-amd64 /usr/lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-COPY --from=tools-amd64 /usr/bin/cat /bin/cat
-COPY --from=tools-amd64 /usr/bin/ls /bin/ls
-COPY --from=tools-amd64 /usr/bin/tee /bin/tee
-
-FROM scratch AS pkg-debug-tools-bash-minimal-arm64
-COPY --from=tools-arm64 /usr/bin/bash /bin/bash
-COPY --from=tools-arm64 /usr/lib/ld-musl-aarch64.so.1 /lib/ld-musl-aarch64.so.1
-COPY --from=tools-arm64 /usr/bin/cat /bin/cat
-COPY --from=tools-arm64 /usr/bin/ls /bin/ls
-COPY --from=tools-arm64 /usr/bin/tee /bin/tee
-
-FROM pkg-debug-tools-${DEBUG_TOOLS_SOURCE}-amd64 AS pkg-debug-tools-amd64
-FROM pkg-debug-tools-${DEBUG_TOOLS_SOURCE}-arm64 AS pkg-debug-tools-arm64
 
 # Strip CNI package.
 
@@ -744,9 +721,6 @@ COPY --link --from=pkg-kmod-amd64 usr/share/spdx/kmod.spdx.json /rootfs/usr/shar
 COPY --link --from=modules-amd64 /usr/lib/modules /rootfs/usr/lib/modules
 COPY --link --from=machined-build-amd64 /machined /rootfs/usr/bin/init
 
-# this is a no-op as it copies from a scratch image when WITH_DEBUG_SHELL is not set
-COPY --link --from=pkg-debug-tools-amd64 * /rootfs/
-
 RUN <<END
     # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
     ln /rootfs/usr/bin/init /rootfs/usr/bin/poweroff
@@ -836,9 +810,6 @@ COPY --link --from=pkg-kmod-arm64 /usr/bin/kmod /rootfs/usr/bin/modprobe
 COPY --link --from=pkg-kmod-arm64 /usr/share/spdx/kmod.spdx.json /rootfs/usr/share/spdx/kmod.spdx.json
 COPY --link --from=modules-arm64 /usr/lib/modules /rootfs/usr/lib/modules
 COPY --link --from=machined-build-arm64 /machined /rootfs/usr/bin/init
-
-# this is a no-op as it copies from a scratch image when WITH_DEBUG_SHELL is not set
-COPY --link --from=pkg-debug-tools-arm64 * /rootfs/
 
 RUN <<END
     # the orderly_poweroff call by the kernel will call '/sbin/poweroff'

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ CI_RELEASE_TAG := $(shell git log --oneline --format=%B -n 1 HEAD^2 -- 2>/dev/nu
 
 ARTIFACTS := _out
 
-DEBUG_TOOLS_SOURCE := scratch
 EMBED_TARGET ?= embed
 
 TOOLS_PREFIX ?= ghcr.io/siderolabs/tools
@@ -152,11 +151,6 @@ else
 GO_LDFLAGS += -s -w
 endif
 
-ifneq (, $(filter $(WITH_DEBUG_SHELL), t true TRUE y yes 1))
-# bash-minimal is a Dockerfile target that copies over the bash from siderolabs tools
-DEBUG_TOOLS_SOURCE := bash-minimal
-endif
-
 GO_BUILDFLAGS_TALOSCTL := $(GO_BUILDFLAGS) -tags "$(GO_BUILDTAGS_TALOSCTL)"
 GO_BUILDFLAGS += -tags "$(GO_BUILDTAGS)"
 
@@ -174,7 +168,6 @@ COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=ABBREV_TAG=$(ABBREV_TAG)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=CGO_ENABLED=$(CGO_ENABLED)
-COMMON_ARGS += --build-arg=DEBUG_TOOLS_SOURCE=$(DEBUG_TOOLS_SOURCE)
 COMMON_ARGS += --build-arg=EMBED_TARGET=$(EMBED_TARGET)
 COMMON_ARGS += --build-arg=GO_BUILDFLAGS_TALOSCTL="$(GO_BUILDFLAGS_TALOSCTL)"
 COMMON_ARGS += --build-arg=GO_BUILDFLAGS="$(GO_BUILDFLAGS)"

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -181,7 +181,6 @@ func (m *Qemu) AddExtraProvisionOpts() error {
 		provision.WithUEFI(m.EOps.UefiEnabled),
 		provision.WithTPM1_2(m.EOps.Tpm1_2Enabled),
 		provision.WithTPM2(m.EOps.Tpm2Enabled),
-		provision.WithDebugShell(m.EOps.DebugShellEnabled),
 		provision.WithIOMMU(m.EOps.WithIOMMU),
 		provision.WithExtraUEFISearchPaths(m.EOps.ExtraUEFISearchPaths),
 		provision.WithTargetArch(m.EOps.TargetArch),

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -138,7 +138,6 @@ type Qemu struct {
 	DiskEncryptionKeyTypes    []string
 	WithFirewall              string
 	WithSiderolinkAgent       flags.Agent
-	DebugShellEnabled         bool
 	WithIOMMU                 bool
 	ConfigInjectionMethod     string
 	Airgapped                 bool

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -55,7 +55,6 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		firewallFlag                  = "with-firewall"
 		tpmEnabledFlag                = "with-tpm1_2"
 		tpm2EnabledFlag               = "with-tpm2"
-		withDebugShellFlag            = "with-debug-shell"
 		withIOMMUFlag                 = "with-iommu"
 		talosconfigFlag               = "talosconfig"
 		applyConfigEnabledFlag        = "with-apply-config"
@@ -221,9 +220,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		qemu.BoolVar(&qOps.UefiEnabled, uefiEnabledFlag, qOps.UefiEnabled, "enable UEFI on x86_64 architecture")
 		qemu.BoolVar(&qOps.Tpm1_2Enabled, tpmEnabledFlag, qOps.Tpm1_2Enabled, "enable TPM 1.2 emulation support using swtpm")
 		qemu.BoolVar(&qOps.Tpm2Enabled, tpm2EnabledFlag, qOps.Tpm2Enabled, "enable TPM 2.0 emulation support using swtpm")
-		qemu.BoolVar(&qOps.DebugShellEnabled, withDebugShellFlag, qOps.DebugShellEnabled, "drop talos into a maintenance shell on boot, this is for advanced debugging for developers only")
 		qemu.BoolVar(&qOps.WithIOMMU, withIOMMUFlag, qOps.WithIOMMU, "enable IOMMU support, this also add a new PCI root port and an interface attached to it")
-		qemu.MarkHidden("with-debug-shell") //nolint:errcheck
 		qemu.StringSliceVar(&qOps.ExtraUEFISearchPaths, extraUEFISearchPathsFlag, qOps.ExtraUEFISearchPaths, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 		qemu.StringSliceVar(&qOps.NetworkNoMasqueradeCIDRs, networkNoMasqueradeCIDRsFlag, qOps.NetworkNoMasqueradeCIDRs, "list of CIDRs to exclude from NAT")
 		qemu.StringSliceVar(&qOps.Nameservers, nameserversFlag, qOps.Nameservers, "list of nameservers to use")

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/siderolabs/go-kubeconfig"
@@ -57,21 +56,6 @@ func createDevCluster(ctx context.Context, cOps clusterops.Common, qOps clustero
 	cluster, err := provisioner.Create(ctx, clusterConfigs.ClusterRequest, clusterConfigs.ProvisionOptions...)
 	if err != nil {
 		return err
-	}
-
-	if qOps.DebugShellEnabled {
-		fmt.Println("You can now connect to debug shell on any node using these commands:")
-
-		for _, node := range clusterConfigs.ClusterRequest.Nodes {
-			talosDir, err := clientconfig.GetTalosDirectory()
-			if err != nil {
-				return err
-			}
-
-			fmt.Printf("socat - UNIX-CONNECT:%s\n", filepath.Join(talosDir, "clusters", cOps.RootOps.ClusterName, node.Name+".serial"))
-		}
-
-		return nil
 	}
 
 	// Create and save the talosctl configuration file.

--- a/internal/pkg/mount/switchroot/switchroot.go
+++ b/internal/pkg/mount/switchroot/switchroot.go
@@ -106,14 +106,6 @@ func Switch(prefix string, mountpoints mount.Managers) (err error) {
 		}
 	}
 
-	if val := procfs.ProcCmdline().Get("talos.debugshell"); val != nil {
-		if err = unix.Exec("/bin/bash", []string{"/bin/bash"}, envv); err != nil {
-			return fmt.Errorf("error executing /bin/bash: %w", err)
-		}
-
-		return nil
-	}
-
 	if err = unix.Exec("/sbin/init", []string{"/sbin/init"}, envv); err != nil {
 		return fmt.Errorf("error executing /sbin/init: %w", err)
 	}

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -88,15 +88,6 @@ func WithTPM2(enabled bool) Option {
 	}
 }
 
-// WithDebugShell drops into debug shell in initramfs.
-func WithDebugShell(enabled bool) Option {
-	return func(o *Options) error {
-		o.WithDebugShell = enabled
-
-		return nil
-	}
-}
-
 // WithIOMMU enables or disables IOMMU.
 func WithIOMMU(enabled bool) Option {
 	return func(o *Options) error {
@@ -225,8 +216,6 @@ type Options struct {
 	TPM1_2Enabled bool
 	// Enable TPM 2.0 emulation using swtpm.
 	TPM2Enabled bool
-	// Enable debug shell in the bootloader.
-	WithDebugShell bool
 	// Enable IOMMU for VMs and add a new PCI root controller and network interface.
 	IOMMUEnabled bool
 	// Configure additional search paths to look for UEFI firmware.

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -55,7 +55,6 @@ type LaunchConfig struct {
 	NodeUUID                  uuid.UUID
 	BadRTC                    bool
 	ArchitectureData          Arch
-	WithDebugShell            bool
 	IOMMUEnabled              bool
 	SkipInjectingExtraCmdline bool
 
@@ -139,14 +138,6 @@ func launchVM(config *LaunchConfig) error {
 		"-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0",
 		"-device", "i6300esb,id=watchdog0",
 		"-watchdog-action", "pause",
-	}
-
-	if config.WithDebugShell {
-		args = append(
-			args,
-			"-serial",
-			fmt.Sprintf("unix:%s/%s.serial,server,nowait", config.StatePath, config.Network.Hostname),
-		)
 	}
 
 	var (

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -95,10 +95,6 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 		}
 	}
 
-	if opts.WithDebugShell {
-		cmdline.Append("talos.debugshell", "")
-	}
-
 	var (
 		nodeConfig   string
 		extraISOPath string
@@ -186,7 +182,6 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 		TFTPServer:                nodeReq.TFTPServer,
 		IPXEBootFileName:          nodeReq.IPXEBootFilename,
 		APIBindAddress:            apiBind,
-		WithDebugShell:            opts.WithDebugShell,
 		IOMMUEnabled:              opts.IOMMUEnabled,
 		Network:                   getLaunchNetworkConfig(state, clusterReq, nodeReq),
 


### PR DESCRIPTION
Now that talos has native `talosctl debug` `WITH_DEBUG_SHELL` seems not needed.