### PR TITLE
fix: always grow disks

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
@@ -75,6 +75,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 					},
 					PartitionSpec: block.PartitionSpec{
 						TypeUUID: partition.LinuxFilesystemData,
+						Grow:     true,
 					},
 					FilesystemSpec: block.FilesystemSpec{
 						Type: userVolumeConfig.Filesystem().Type(),


### PR DESCRIPTION
Previously, there was no way to grow virtual disks attached to VMs,
even though resizing them was possible (e.g. through hypervisor changing
the size of disk). This forces the UserVolume of type=disk to always
grow to full size of the disk.

Fixes #12991

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
