### PR TITLE
fix: drop unused type from ExternalVolume schema

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -341,8 +341,7 @@
         },
         "filesystemType": {
           "enum": [
-            "virtiofs",
-            "nfs"
+            "virtiofs"
           ],
           "title": "filesystemType",
           "description": "Filesystem type.\n",

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -443,7 +443,6 @@ func (ExternalVolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Filesystem type." /* encoder.LineComment */, "" /* encoder.FootComment */},
 				Values: []string{
 					"virtiofs",
-					"nfs",
 				},
 			},
 			{

--- a/pkg/machinery/config/types/block/external_volume_config.go
+++ b/pkg/machinery/config/types/block/external_volume_config.go
@@ -72,7 +72,6 @@ type ExternalVolumeConfigV1Alpha1 struct {
 	//     Filesystem type.
 	//   values:
 	//     - virtiofs
-	//     - nfs
 	//  schema:
 	//    type: string
 	FilesystemType FilesystemType `yaml:"filesystemType"`
@@ -235,7 +234,7 @@ func (s VirtiofsMountSpec) Source() string {
 	return s.VirtiofsTag
 }
 
-// Parameters implements config.NFSMountConfig interface.
+// Parameters implements config.ExternalVolumeMountConfigSpec interface.
 func (s VirtiofsMountSpec) Parameters() ([]block.ParameterSpec, error) {
 	return nil, nil
 }

--- a/website/content/v1.13/reference/configuration/block/externalvolumeconfig.md
+++ b/website/content/v1.13/reference/configuration/block/externalvolumeconfig.md
@@ -33,7 +33,7 @@ mount:
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
 |`name` |string |Name of the mount.<br><br>Name might be between 1 and 34 characters long and can only contain:<br>lowercase and uppercase ASCII letters, digits, and hyphens.  | |
-|`filesystemType` |FilesystemType |Filesystem type.  |`virtiofs`<br />`nfs`<br /> |
+|`filesystemType` |FilesystemType |Filesystem type.  |`virtiofs`<br /> |
 |`mount` |<a href="#ExternalVolumeConfig.mount">ExternalMountSpec</a> |The mount describes additional mount options.  | |
 
 

--- a/website/content/v1.13/schemas/config.schema.json
+++ b/website/content/v1.13/schemas/config.schema.json
@@ -341,8 +341,7 @@
         },
         "filesystemType": {
           "enum": [
-            "virtiofs",
-            "nfs"
+            "virtiofs"
           ],
           "title": "filesystemType",
           "description": "Filesystem type.\n",


### PR DESCRIPTION
ExternalVolume has type=nfs defined in the Schema. It is currently
unused and unimplemented, and will fail to provision. Remove it
from the schema, validation and docs, to not confuse the users.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
