### PR TITLE
fix: unseal with "slow" TPM

### DIFF
--- a/internal/pkg/encryption/encryption.go
+++ b/internal/pkg/encryption/encryption.go
@@ -26,7 +26,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
-const keyHandlerTimeout = time.Second * 10
+const keyHandlerTimeout = time.Second * 20
 
 // Helpers provides helper methods for encryption handling.
 type Helpers struct {

--- a/pkg/machinery/resources/hardware/pcr_status.go
+++ b/pkg/machinery/resources/hardware/pcr_status.go
@@ -75,7 +75,9 @@ func LockPCRStatus(st FinalizerState, pcr int, finalizerName string) func(contex
 
 		fnErr := fn()
 
-		if err := st.RemoveFinalizer(ctx, pcrStatus.Metadata(), finalizerName); err != nil {
+		// detach context deadline/cancellation from the finalizer removal,
+		// as we want to make sure it is removed even if the context is canceled or times out
+		if err := st.RemoveFinalizer(context.WithoutCancel(ctx), pcrStatus.Metadata(), finalizerName); err != nil {
 			fnErr = errors.Join(fnErr, fmt.Errorf("failed to unlock PCR %d: %w", pcr, err))
 		}
 


### PR DESCRIPTION
Fixes #13056

The TPM unseal operation doesn't respect the context, and we had 10 second timeout for the whole key unlock operation.

So there might a case when a "slow" TPM unseal runs for more than 10 seconds, and by the time TPM unseal is down, context timeout already passed, so a somewhat wrong messahe pops in, as the rate limiter is configured with any limit, but it fails due to the fact that the context got canceled (but it would have failed later anyways doing the actual resource operation).
