### PR TITLE
fix: add os:meta:writer role to the dashboard

### DIFF
--- a/internal/app/dashboard/main.go
+++ b/internal/app/dashboard/main.go
@@ -40,7 +40,7 @@ func dashboardMain() error {
 	startup.LimitMaxProcs(constants.DashboardMaxProcs)
 
 	md := metadata.Pairs()
-	authz.SetMetadata(md, role.MakeSet(role.Reader))
+	authz.SetMetadata(md, role.MakeSet(role.Reader, role.MetaWriter))
 
 	ctx, cancel := sigtermAwareContext(context.Background())
 	defer cancel()

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -89,8 +89,8 @@ var rules = map[string]role.Set{
 	"/machine.MachineService/Logs":                        role.MakeSet(role.Admin, role.Operator, role.Reader),
 	"/machine.MachineService/LogsContainers":              role.MakeSet(role.Admin, role.Operator, role.Reader),
 	"/machine.MachineService/Memory":                      role.MakeSet(role.Admin, role.Operator, role.Reader),
-	"/machine.MachineService/MetaWrite":                   role.MakeSet(role.Admin),
-	"/machine.MachineService/MetaDelete":                  role.MakeSet(role.Admin),
+	"/machine.MachineService/MetaWrite":                   role.MakeSet(role.Admin, role.MetaWriter),
+	"/machine.MachineService/MetaDelete":                  role.MakeSet(role.Admin, role.MetaWriter),
 	"/machine.MachineService/Mounts":                      role.MakeSet(role.Admin, role.Operator, role.Reader),
 	"/machine.MachineService/NetworkDeviceStats":          role.MakeSet(role.Admin, role.Operator, role.Reader),
 	"/machine.MachineService/Netstat":                     role.MakeSet(role.Admin, role.Operator, role.Reader),
@@ -171,7 +171,7 @@ func (s *machinedService) Main(ctx context.Context, _ runtime.Runtime, logWriter
 			{
 				// internal dashboard
 				Pattern:      "dashboard",
-				AllowedRoles: role.MakeSet(role.Reader),
+				AllowedRoles: role.MakeSet(role.Reader, role.MetaWriter),
 			},
 			{
 				// installer access during installation/upgrade

--- a/pkg/machinery/role/role.go
+++ b/pkg/machinery/role/role.go
@@ -35,6 +35,9 @@ const (
 	// ImageVerifier defines Talos role that allows verifying images.
 	ImageVerifier = Role(Prefix + "image:verifier")
 
+	// MetaWriter defines Talos role that allows mutating META values (write and delete).
+	MetaWriter = Role(Prefix + "meta:writer")
+
 	// Impersonator defines Talos role for impersonating another user (and their role).
 	// Used internally, but may also be granted to the user.
 	Impersonator = Role(Prefix + "impersonator")
@@ -47,7 +50,7 @@ type Set struct {
 
 var (
 	// All roles that can be granted to users.
-	All = MakeSet(Admin, Operator, Reader, EtcdBackup, ImageVerifier, Impersonator)
+	All = MakeSet(Admin, Operator, Reader, EtcdBackup, ImageVerifier, MetaWriter, Impersonator)
 
 	// Zero is an empty set of roles.
 	Zero = MakeSet()


### PR DESCRIPTION
When dashboard runs within Talos, it previously used `os:admin` role which allows anything.

With changes in 1.13, I dropped the role to `os:reader`, which is a way tighter scope from the security perspective, but it broke network config tab - it tries to write to META, which is not allowed under `os:reader` role, so this change fixes the dashboard, but still keeps the RBAC tight.
