### PR TITLE
feat: add client-side Kubernetes node drain to reboot and upgrade commands

### DIFF
--- a/cmd/talosctl/cmd/talos/drain.go
+++ b/cmd/talosctl/cmd/talos/drain.go
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	drainpkg "github.com/siderolabs/talos/cmd/talosctl/cmd/talos/drain"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/kubeclient"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+// nodeUpdate carries a progress update from a per-node goroutine to the
+// aggregator goroutine that owns the ProgressWriter + Reporter.
+type nodeUpdate struct {
+	node   string
+	update reporter.Update
+}
+
+// drainNodes runs Phase 1: resolves the Kubernetes node name for each Talos node
+// and performs cordon + drain on all of them in parallel.
+//
+// It returns a map of talosIP -> k8sNodeName for use in the uncordon phase.
+// The context must NOT have "nodes" metadata set (use WithClientAndNodes).
+func drainNodes(ctx context.Context, c *client.Client, nodes []string, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
+	// Fetch kubeconfig once - it is cluster-global, not node-specific.
+	clientset, err := kubeclient.FromTalosClient(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Kubernetes client for drain: %w", err)
+	}
+
+	// Channel for per-node progress updates -> single aggregator goroutine.
+	updateCh := make(chan nodeUpdate)
+
+	// k8sNames collects Talos IP -> K8s node name mappings produced by each goroutine.
+	// Each goroutine writes to its own slot, so no mutex is needed.
+	k8sNames := make(map[string]string, len(nodes))
+
+	var eg errgroup.Group
+
+	// Aggregator goroutine: reads from updateCh, updates ProgressWriter, prints.
+	// It exits when updateCh is closed (after all workers finish).
+	aggregatorDone := make(chan struct{})
+
+	go func() {
+		defer close(aggregatorDone)
+
+		var w drainpkg.ProgressWriter
+
+		for upd := range updateCh {
+			w.UpdateNode(upd.node, upd.update.Message, upd.update.Status)
+			w.PrintProgress(rep)
+		}
+	}()
+
+	// Launch a goroutine per node.
+	for _, node := range nodes {
+		eg.Go(func() error {
+			// Use client.WithNode for single-node COSI routing (avoids one-to-many proxy error).
+			nodeCtx := client.WithNode(ctx, node)
+
+			k8sNodeName, resolveErr := nodedrain.GetKubernetesNodeName(nodeCtx, c)
+			if resolveErr != nil {
+				return fmt.Errorf("error resolving Kubernetes node name for %s: %w", node, resolveErr)
+			}
+
+			k8sNames[node] = k8sNodeName
+
+			// reportFn sends progress through the channel to the aggregator.
+			reportFn := func(upd reporter.Update) {
+				updateCh <- nodeUpdate{node: k8sNodeName, update: upd}
+			}
+
+			return nodedrain.CordonAndDrain(ctx, clientset, k8sNodeName, nodedrain.Options{
+				DrainTimeout: drainTimeout,
+			}, reportFn)
+		})
+	}
+
+	err = eg.Wait()
+
+	close(updateCh)
+
+	<-aggregatorDone
+
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sNames, nil
+}
+
+// uncordonNodes runs Phase 3: waits for each Kubernetes node to become Ready,
+// then uncordons all of them in parallel.
+//
+// nodeNames maps talosIP -> k8sNodeName (produced by drainNodes).
+// The context must NOT have "nodes" metadata set (use WithClientAndNodes).
+func uncordonNodes(ctx context.Context, c *client.Client, nodeNames map[string]string, timeout time.Duration, rep *reporter.Reporter) error {
+	// Fetch a fresh kubeconfig (the previous connection may be stale after reboot).
+	// The context has no "nodes" metadata (called from WithClientAndNodes), so the
+	// request routes to the endpoint which is a control-plane node by convention.
+	clientset, err := kubeclient.FromTalosClient(ctx, c)
+	if err != nil {
+		return fmt.Errorf("error creating Kubernetes client for uncordon: %w", err)
+	}
+
+	updateCh := make(chan nodeUpdate)
+
+	var eg errgroup.Group
+
+	aggregatorDone := make(chan struct{})
+
+	go func() {
+		defer close(aggregatorDone)
+
+		var w drainpkg.ProgressWriter
+
+		for upd := range updateCh {
+			w.UpdateNode(upd.node, upd.update.Message, upd.update.Status)
+			w.PrintProgress(rep)
+		}
+	}()
+
+	for talosIP, k8sNodeName := range nodeNames {
+		_ = talosIP // only k8sNodeName is needed for K8s API calls
+
+		eg.Go(func() error {
+			reportFn := func(upd reporter.Update) {
+				updateCh <- nodeUpdate{node: k8sNodeName, update: upd}
+			}
+
+			reportFn(reporter.Update{
+				Message: fmt.Sprintf("%s: waiting for node to become Ready", k8sNodeName),
+				Status:  reporter.StatusRunning,
+			})
+
+			if waitErr := nodedrain.WaitForNodeReady(ctx, clientset, k8sNodeName, timeout); waitErr != nil {
+				return fmt.Errorf("error waiting for node %q to become Ready: %w", k8sNodeName, waitErr)
+			}
+
+			return nodedrain.Uncordon(ctx, clientset, k8sNodeName, reportFn)
+		})
+	}
+
+	err = eg.Wait()
+
+	close(updateCh)
+
+	<-aggregatorDone
+
+	return err
+}

--- a/cmd/talosctl/cmd/talos/drain/drain.go
+++ b/cmd/talosctl/cmd/talos/drain/drain.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package drain implements Kubernetes node drain progress reporting.
+package drain
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+// ProgressWriter writes drain progress updates to a reporter.
+//
+// It is NOT thread-safe on its own. Callers must ensure that UpdateNode and
+// PrintProgress are called from a single goroutine (e.g. via a channel-based
+// aggregator, matching the action tracker pattern).
+type ProgressWriter struct {
+	// nodeStates keeps track of the current drain state per node.
+	nodeStates map[string]nodeState
+}
+
+// UpdateNode updates the drain progress for a given node.
+func (w *ProgressWriter) UpdateNode(node, message string, status reporter.Status) {
+	if w.nodeStates == nil {
+		w.nodeStates = make(map[string]nodeState)
+	}
+
+	w.nodeStates[node] = nodeState{
+		message: message,
+		status:  status,
+	}
+}
+
+// PrintProgress prints the current drain progress for all nodes to the reporter.
+func (w *ProgressWriter) PrintProgress(rep *reporter.Reporter) {
+	nodes := slices.Collect(maps.Keys(w.nodeStates))
+	sort.Strings(nodes)
+
+	sb := strings.Builder{}
+
+	for _, node := range nodes {
+		state := w.nodeStates[node]
+		fmt.Fprintf(&sb, "%s\n", state.message)
+	}
+
+	// Compute the combined status: error > running > succeeded.
+	combined := reporter.StatusSucceeded
+
+	for _, state := range w.nodeStates {
+		if state.status == reporter.StatusError {
+			combined = reporter.StatusError
+
+			break
+		}
+
+		if state.status == reporter.StatusRunning {
+			combined = reporter.StatusRunning
+		}
+	}
+
+	rep.Report(reporter.Update{
+		Message: sb.String(),
+		Status:  combined,
+	})
+}
+
+type nodeState struct {
+	message string
+	status  reporter.Status
+}

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -8,20 +8,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
+	"github.com/siderolabs/talos/pkg/flags"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
-var rebootCmdFlags struct {
+var rebootCmdFlags = struct {
 	trackableActionCmdFlags
 
-	mode string
+	progress     flags.PflagExtended[reporter.OutputMode]
+	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
+	drain        bool
+	drainTimeout time.Duration
+}{
+	rebootMode: flags.ProtoEnum(machine.RebootRequest_DEFAULT, machine.RebootRequest_Mode_value, machine.RebootRequest_Mode_name),
+	progress:   reporter.NewOutputModeFlag(),
 }
 
 // rebootCmd represents the reboot command.
@@ -35,21 +45,46 @@ var rebootCmd = &cobra.Command{
 			rebootCmdFlags.wait = true
 		}
 
-		var opts []client.RebootMode
-
-		switch rebootCmdFlags.mode {
-		// skips kexec and reboots with power cycle
-		case "powercycle":
-			opts = append(opts, client.WithPowerCycle)
-		case "force":
-			opts = append(opts, client.WithForce)
-		case "default":
-		default:
-			return fmt.Errorf("invalid reboot mode: %q", rebootCmdFlags.mode)
+		if rebootCmdFlags.drain {
+			rebootCmdFlags.wait = true
 		}
 
-		return rebootInternal(rebootCmdFlags.debug, rebootCmdFlags.debug, rebootCmdFlags.timeout, nil, opts...)
+		opts := []client.RebootMode{
+			client.WithRebootMode(rebootCmdFlags.rebootMode.Value()),
+		}
+
+		return rebootRun(opts)
 	},
+}
+
+func rebootRun(opts []client.RebootMode) error {
+	rep := reporter.New(
+		reporter.WithOutputMode(rebootCmdFlags.progress.Value()),
+	)
+
+	if !rebootCmdFlags.drain {
+		return rebootInternal(rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
+	}
+
+	var nodeNames map[string]string
+
+	if err := WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+		var drainErr error
+
+		nodeNames, drainErr = drainNodes(ctx, c, nodes, rebootCmdFlags.drainTimeout, rep)
+
+		return drainErr
+	}); err != nil {
+		return err
+	}
+
+	if err := rebootInternal(rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...); err != nil {
+		return err
+	}
+
+	return WithClientAndNodes(func(ctx context.Context, c *client.Client, _ []string) error {
+		return uncordonNodes(ctx, c, nodeNames, rebootCmdFlags.timeout, rep)
+	})
 }
 
 func rebootInternal(wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
@@ -94,7 +129,16 @@ func rebootGetActorID(opts ...client.RebootMode) func(ctx context.Context, c *cl
 }
 
 func init() {
-	rebootCmd.Flags().StringVarP(&rebootCmdFlags.mode, "mode", "m", "default", "select the reboot mode: \"default\", \"powercycle\" (skips kexec), \"force\" (skips graceful teardown)")
+	rebootCmd.Flags().Var(rebootCmdFlags.progress, "progress", fmt.Sprintf("output mode for upgrade progress. Values: %v", rebootCmdFlags.progress.Options()))
+	rebootCmd.Flags().VarP(rebootCmdFlags.rebootMode, "mode", "m",
+		fmt.Sprintf(
+			"select the reboot mode during upgrade. Mode %q bypasses kexec. Values: %v",
+			strings.ToLower(machine.UpgradeRequest_POWERCYCLE.String()),
+			rebootCmdFlags.rebootMode.Options(),
+		),
+	)
+	rebootCmd.Flags().BoolVar(&rebootCmdFlags.drain, "drain", false, "drain the Kubernetes node before rebooting (cordon + evict pods)")
+	rebootCmd.Flags().DurationVar(&rebootCmdFlags.drainTimeout, "drain-timeout", nodedrain.DefaultDrainTimeout, "timeout for draining the Kubernetes node")
 	rebootCmdFlags.addTrackActionFlags(rebootCmd)
 	addCommand(rebootCmd)
 }

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -23,6 +23,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/multiplex"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/images"
@@ -40,6 +41,9 @@ var upgradeCmdFlags = struct {
 	upgradeImage string
 	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
 	progress     flags.PflagExtended[reporter.OutputMode]
+
+	drain        bool
+	drainTimeout time.Duration
 
 	legacy   bool
 	force    bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
@@ -62,6 +66,10 @@ var upgradeCmd = &cobra.Command{
 			upgradeCmdFlags.wait = true
 		}
 
+		if upgradeCmdFlags.drain {
+			upgradeCmdFlags.wait = true
+		}
+
 		if upgradeCmdFlags.wait && upgradeCmdFlags.insecure {
 			return errors.New("cannot use --wait and --insecure together")
 		}
@@ -78,6 +86,8 @@ var talosUpgradeAPIVersionRange = semver.MustParseRange(">1.13.0-alpha.2 <2.0.0"
 
 // upgradeViaLifecycleService tries the new LifecycleService.Upgrade streaming API.
 // If the server returns codes.Unimplemented, it falls back to the legacy MachineService.Upgrade.
+//
+//nolint:gocyclo
 func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []string) error {
 	if upgradeCmdFlags.debug {
 		upgradeCmdFlags.wait = true
@@ -128,9 +138,25 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		return fmt.Errorf("error during upgrade: %w", err)
 	}
 
+	var nodeNames map[string]string
+
+	if upgradeCmdFlags.drain {
+		nodeNames, err = drainNodes(ctx, c, nodes, upgradeCmdFlags.drainTimeout, rep)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = rebootInternal(upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
 	if err != nil {
 		return fmt.Errorf("error during upgrade: %w", err)
+	}
+
+	// Phase 3: uncordon.
+	if upgradeCmdFlags.drain && len(nodeNames) > 0 {
+		if err := uncordonNodes(ctx, c, nodeNames, upgradeCmdFlags.timeout, rep); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -326,6 +352,8 @@ func init() {
 		),
 	)
 	upgradeCmd.Flags().Var(upgradeCmdFlags.progress, "progress", fmt.Sprintf("output mode for upgrade progress. Values: %v", upgradeCmdFlags.progress.Options()))
+	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.drain, "drain", true, "drain the Kubernetes node before rebooting (cordon + evict pods)")
+	upgradeCmd.Flags().DurationVar(&upgradeCmdFlags.drainTimeout, "drain-timeout", nodedrain.DefaultDrainTimeout, "timeout for draining the Kubernetes node")
 
 	// Mark legacy-only flags as deprecated. These are only used when falling back
 	// to the legacy MachineService.Upgrade unary API for older Talos versions.

--- a/cmd/talosctl/pkg/talos/kubeclient/kubeclient.go
+++ b/cmd/talosctl/pkg/talos/kubeclient/kubeclient.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package kubeclient provides a reusable way to create a Kubernetes clientset
+// from the admin kubeconfig fetched via the Talos API, without writing to the filesystem.
+package kubeclient
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+)
+
+// FromTalosClient fetches the admin kubeconfig from the Talos API and returns
+// a Kubernetes clientset. The kubeconfig is held entirely in memory.
+func FromTalosClient(ctx context.Context, c *client.Client) (kubernetes.Interface, error) {
+	kubeconfigBytes, err := c.Kubeconfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching kubeconfig from Talos API: %w", err)
+	}
+
+	config, err := clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubeconfig: %w", err)
+	}
+
+	restConfig, err := config.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error building REST config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Kubernetes clientset: %w", err)
+	}
+
+	return clientset, nil
+}

--- a/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
+++ b/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
@@ -1,0 +1,199 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package nodedrain provides reusable Kubernetes node drain, cordon, and uncordon
+// operations for use by talosctl commands (upgrade, reboot).
+package nodedrain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/drain"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+const (
+	// DefaultDrainTimeout is the default maximum time to wait for the node to be drained.
+	DefaultDrainTimeout = 5 * time.Minute
+
+	// nodeReadyPollInterval is how often to poll for node readiness.
+	nodeReadyPollInterval = 5 * time.Second
+)
+
+// ReportFunc is a callback for reporting drain progress updates.
+// It decouples drain operations from the reporter, allowing callers to route
+// updates through a channel (for multi-node aggregation) or directly to a reporter.
+type ReportFunc func(reporter.Update)
+
+// Options configures the drain behavior.
+type Options struct {
+	// DrainTimeout is the maximum time to wait for pod evictions to complete.
+	DrainTimeout time.Duration
+}
+
+// GetKubernetesNodeName resolves the Kubernetes node name from a Talos node
+// by reading the Nodename COSI resource.
+//
+// The context must target a single node (via client.WithNode) because COSI
+// State/Get does not support one-to-many proxying.
+func GetKubernetesNodeName(ctx context.Context, c *client.Client) (string, error) {
+	nodenameRes, err := safe.StateGet[*k8s.Nodename](
+		ctx,
+		c.COSI,
+		resource.NewMetadata(k8s.NamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined),
+	)
+	if err != nil {
+		return "", fmt.Errorf("error getting Kubernetes node name from Talos API: %w", err)
+	}
+
+	return nodenameRes.TypedSpec().Nodename, nil
+}
+
+// CordonAndDrain cordons the Kubernetes node (marks it unschedulable) and evicts
+// all pods. It uses the kubectl drain library for proper PDB handling, eviction
+// API support, and pod filtering.
+func CordonAndDrain(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts Options, report ReportFunc) error {
+	timeout := opts.DrainTimeout
+	if timeout == 0 {
+		timeout = DefaultDrainTimeout
+	}
+
+	drainCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	node, err := clientset.CoreV1().Nodes().Get(drainCtx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting node %q: %w", nodeName, err)
+	}
+
+	// Set up the drain helper with sensible defaults covering 90% of cases.
+	drainer := &drain.Helper{
+		Ctx:                 drainCtx,
+		Client:              clientset,
+		Force:               true, // handle unmanaged pods
+		GracePeriodSeconds:  -1,   // use pod's own terminationGracePeriodSeconds
+		IgnoreAllDaemonSets: true, // DaemonSet pods are re-created by the DS controller
+		DeleteEmptyDirData:  true, // node is rebooting, local data is lost anyway
+		Timeout:             timeout,
+		Out:                 io.Discard,
+		ErrOut:              io.Discard,
+		OnPodDeletionOrEvictionStarted: func(pod *corev1.Pod, usingEviction bool) {
+			action := "deleting"
+			if usingEviction {
+				action = "evicting"
+			}
+
+			report(reporter.Update{
+				Message: fmt.Sprintf("%s: %s pod %s/%s", nodeName, action, pod.Namespace, pod.Name),
+				Status:  reporter.StatusRunning,
+			})
+		},
+		OnPodDeletionOrEvictionFinished: func(pod *corev1.Pod, usingEviction bool, err error) {
+			if err != nil {
+				report(reporter.Update{
+					Message: fmt.Sprintf("%s: failed to evict pod %s/%s: %v", nodeName, pod.Namespace, pod.Name, err),
+					Status:  reporter.StatusError,
+				})
+
+				return
+			}
+
+			report(reporter.Update{
+				Message: fmt.Sprintf("%s: evicted pod %s/%s", nodeName, pod.Namespace, pod.Name),
+				Status:  reporter.StatusRunning,
+			})
+		},
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: cordoning node", nodeName),
+		Status:  reporter.StatusRunning,
+	})
+
+	if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {
+		return fmt.Errorf("error cordoning node %q: %w", nodeName, err)
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: node cordoned", nodeName),
+		Status:  reporter.StatusRunning,
+	})
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: draining node", nodeName),
+		Status:  reporter.StatusRunning,
+	})
+
+	if err := drain.RunNodeDrain(drainer, nodeName); err != nil {
+		return fmt.Errorf("error draining node %q: %w", nodeName, err)
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: node drained", nodeName),
+		Status:  reporter.StatusSucceeded,
+	})
+
+	return nil
+}
+
+// WaitForNodeReady polls the Kubernetes API until the node reports a Ready condition
+// with status True.
+func WaitForNodeReady(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, nodeReadyPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			// Transient errors are expected while the node is rebooting.
+			return false, nil //nolint:nilerr
+		}
+
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady {
+				return cond.Status == corev1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+// Uncordon marks the Kubernetes node as schedulable again.
+func Uncordon(ctx context.Context, clientset kubernetes.Interface, nodeName string, report ReportFunc) error {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting node %q for uncordon: %w", nodeName, err)
+	}
+
+	drainer := &drain.Helper{
+		Ctx:    ctx,
+		Client: clientset,
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: uncordoning node", nodeName),
+		Status:  reporter.StatusRunning,
+	})
+
+	if err := drain.RunCordonOrUncordon(drainer, node, false); err != nil {
+		return fmt.Errorf("error uncordoning node %q: %w", nodeName, err)
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: node uncordoned", nodeName),
+		Status:  reporter.StatusSucceeded,
+	})
+
+	return nil
+}

--- a/internal/integration/cli/reboot.go
+++ b/internal/integration/cli/reboot.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -71,6 +72,157 @@ func (suite *RebootSuite) TestReboot() {
 	suite.T().Logf("running the cluster health check")
 
 	// run the health check to make sure cluster is fully healthy after a node reboot
+	args := []string{"--server=false"}
+
+	if suite.K8sEndpoint != "" {
+		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])
+	}
+
+	suite.RunCLI(append([]string{"health"}, args...),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
+}
+
+// TestRebootWithDrain tests that rebooting a node with --drain performs the full
+// drain lifecycle: cordon, drain, reboot, wait for Ready, uncordon.
+func (suite *RebootSuite) TestRebootWithDrain() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	workerNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	suite.T().Logf("rebooting node %s with --drain via the CLI", workerNode)
+
+	suite.RunCLI([]string{
+		"reboot",
+		"-n", workerNode,
+		"--drain",
+		"--drain-timeout", "5m",
+		"--debug",
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrMatchFunc(func(stderr string) error {
+			if strings.Contains(stderr, "method is not supported") {
+				suite.T().Skip("reboot is not supported")
+			}
+
+			var merr *multierror.Error
+
+			// Drain lifecycle messages use the Kubernetes node name (not Talos IP).
+			// We match with \S+ since the exact node name is not known in advance.
+			drainMessages := []string{
+				`\S+: cordoning node`,
+				`\S+: node cordoned`,
+				`\S+: draining node`,
+				`\S+: node drained`,
+				`\S+: waiting for node to become Ready`,
+				`\S+: uncordoning node`,
+				`\S+: node uncordoned`,
+			}
+
+			for _, pattern := range drainMessages {
+				re, reErr := regexp.Compile(pattern)
+				if reErr != nil {
+					merr = multierror.Append(merr, fmt.Errorf("invalid pattern %q: %w", pattern, reErr))
+
+					continue
+				}
+
+				if !re.MatchString(stderr) {
+					merr = multierror.Append(merr, fmt.Errorf("drain message not found in stderr: %q", pattern))
+				}
+			}
+
+			// Action tracker messages use the Talos node IP (quoted).
+			if !strings.Contains(stderr, fmt.Sprintf("%q: events check condition met", workerNode)) {
+				merr = multierror.Append(merr, fmt.Errorf("events check condition not met on %v", workerNode))
+			}
+
+			if !strings.Contains(stderr, fmt.Sprintf("%q: post check passed", workerNode)) {
+				merr = multierror.Append(merr, fmt.Errorf("post check not passed on %v", workerNode))
+			}
+
+			return merr.ErrorOrNil()
+		}))
+
+	suite.T().Logf("running the cluster health check")
+
+	args := []string{"--server=false"}
+
+	if suite.K8sEndpoint != "" {
+		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])
+	}
+
+	suite.RunCLI(append([]string{"health"}, args...),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
+}
+
+// TestRebootWithDrainForcesWait tests that --drain forces --wait=true even when
+// --wait=false is explicitly passed, so the drain lifecycle still completes.
+func (suite *RebootSuite) TestRebootWithDrainForcesWait() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	workerNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	suite.T().Logf("rebooting node %s with --drain --wait=false via the CLI", workerNode)
+
+	suite.RunCLI([]string{
+		"reboot",
+		"-n", workerNode,
+		"--drain",
+		"--wait=false",
+		"--debug",
+	},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrMatchFunc(func(stderr string) error {
+			if strings.Contains(stderr, "method is not supported") {
+				suite.T().Skip("reboot is not supported")
+			}
+
+			var merr *multierror.Error
+
+			// Since --drain forces --wait=true, the full lifecycle should appear.
+			drainMessages := []string{
+				`\S+: cordoning node`,
+				`\S+: node drained`,
+				`\S+: node uncordoned`,
+			}
+
+			for _, pattern := range drainMessages {
+				re, reErr := regexp.Compile(pattern)
+				if reErr != nil {
+					merr = multierror.Append(merr, fmt.Errorf("invalid pattern %q: %w", pattern, reErr))
+
+					continue
+				}
+
+				if !re.MatchString(stderr) {
+					merr = multierror.Append(merr, fmt.Errorf("drain message not found in stderr: %q", pattern))
+				}
+			}
+
+			// Action tracker messages should still appear since --drain overrides --wait.
+			if !strings.Contains(stderr, fmt.Sprintf("%q: events check condition met", workerNode)) {
+				merr = multierror.Append(merr, fmt.Errorf("events check condition not met on %v", workerNode))
+			}
+
+			if !strings.Contains(stderr, fmt.Sprintf("%q: post check passed", workerNode)) {
+				merr = multierror.Append(merr, fmt.Errorf("post check not passed on %v", workerNode))
+			}
+
+			return merr.ErrorOrNil()
+		}))
+
+	suite.T().Logf("running the cluster health check")
+
 	args := []string{"--server=false"}
 
 	if suite.K8sEndpoint != "" {

--- a/website/content/v1.13/reference/cli.md
+++ b/website/content/v1.13/reference/cli.md
@@ -3135,10 +3135,13 @@ talosctl reboot [flags]
   -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
       --context string             Context to be used in command
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
+      --drain                      drain the Kubernetes node before rebooting (cordon + evict pods)
+      --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for reboot
-  -m, --mode string                select the reboot mode: "default", "powercycle" (skips kexec), "force" (skips graceful teardown) (default "default")
+  -m, --mode string                select the reboot mode during upgrade. Mode "powercycle" bypasses kexec. Values: [default force powercycle] (default "default")
   -n, --nodes strings              target the specified nodes
+      --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")
       --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
       --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
       --timeout duration           time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
@@ -3445,6 +3448,8 @@ talosctl upgrade [flags]
   -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
       --context string             Context to be used in command
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
+      --drain                      drain the Kubernetes node before rebooting (cordon + evict pods) (default true)
+      --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for upgrade
   -i, --image string               the container image to use for performing the install (default "ghcr.io/siderolabs/installer:v1.13.0-alpha.2")


### PR DESCRIPTION
Add --drain and --drain-timeout flags to `talosctl reboot` (default off)
and `talosctl upgrade` (default on) that cordon and drain the Kubernetes
node before rebooting, then wait for Ready and uncordon after it comes
back. When --drain is enabled, --wait is forced to true.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
