### PR TITLE
feat: allow glibc ld files in etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -761,8 +761,6 @@ RUN <<END
     ln -s /usr/local/bin/nvidia-ctk /rootfs/usr/bin/nvidia-ctk
     ln -s /usr/local/bin/nvidia-cdi-hook /rootfs/usr/bin/nvidia-cdi-hook
     ln -s /usr/local/sbin/nvme /rootfs/usr/bin/nvme
-    ln -s ../usr/local/glibc/etc/ld.so.conf /rootfs/etc/ld.so.conf
-    ln -s ../usr/local/glibc/etc/ld.so.cache /rootfs/etc/ld.so.cache
 END
 
 FROM build AS rootfs-base-arm64
@@ -851,8 +849,6 @@ RUN <<END
     ln -s /usr/local/bin/nvidia-ctk /rootfs/usr/bin/nvidia-ctk
     ln -s /usr/local/bin/nvidia-cdi-hook /rootfs/usr/bin/nvidia-cdi-hook
     ln -s /usr/local/sbin/nvme /rootfs/usr/bin/nvme
-    ln -s ../usr/local/glibc/etc/ld.so.conf /rootfs/etc/ld.so.conf
-    ln -s ../usr/local/glibc/etc/ld.so.cache /rootfs/etc/ld.so.cache
 END
 
 FROM build-go AS build-sbom

--- a/pkg/machinery/extensions/extensions.go
+++ b/pkg/machinery/extensions/extensions.go
@@ -19,6 +19,8 @@ var AllowedPaths = []string{
 	"/usr/lib/ld-linux-aarch64.so.1",
 	// /sbin/ldconfig is required by the nvidia container toolkit.
 	"/usr/bin/ldconfig",
+	"/etc/ld.so.conf",
+	"/etc/ld.so.cache",
 	"/usr/lib/udev/rules.d",
 	"/usr/local",
 	// glvnd, egl and vulkan are needed for OpenGL/Vulkan.


### PR DESCRIPTION
Allow both /etc/ld.so.conf and /etc/ld.so.cache files in /etc since tools expect these to be standard.

See: https://github.com/siderolabs/extensions/pull/1031

Replaces changes for Dockerfile from #12909