### PR TITLE
fix: upgrade API in maintenance mode (legacy)

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -495,6 +495,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 	}
 
 	actorID := uuid.New().String()
+	inMaintenance := !s.Controller.Runtime().ConfigCompleteForBoot()
 
 	ctx = context.WithValue(ctx, runtime.ActorIDCtxKey{}, actorID)
 
@@ -515,7 +516,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 		return nil, fmt.Errorf("error validating installer image %q: %w", in.GetImage(), err)
 	}
 
-	if s.Controller.Runtime().Config().Machine().Type() != machinetype.TypeWorker && !in.GetForce() {
+	if !inMaintenance && s.Controller.Runtime().Config().Machine().Type() != machinetype.TypeWorker && !in.GetForce() {
 		etcdClient, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create etcd client: %w", err)
@@ -537,7 +538,16 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 
 	runCtx := context.WithValue(context.Background(), runtime.ActorIDCtxKey{}, actorID)
 
-	if in.GetStage() {
+	switch {
+	case inMaintenance:
+		go func() {
+			if err := s.Controller.Run(runCtx, runtime.SequenceMaintenanceUpgrade, in); err != nil {
+				if !runtime.IsRebootError(err) {
+					log.Println("upgrade failed:", err)
+				}
+			}
+		}()
+	case in.GetStage():
 		if ok, err := s.Controller.Runtime().State().Machine().Meta().SetTag(ctx, meta.StagedUpgradeImageRef, in.GetImage()); !ok || err != nil {
 			return nil, fmt.Errorf("error adding staged upgrade image ref tag: %w", err)
 		}
@@ -569,7 +579,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 				}
 			}
 		}()
-	} else {
+	default:
 		go func() {
 			if err := s.Controller.Run(runCtx, runtime.SequenceUpgrade, in); err != nil {
 				if !runtime.IsRebootError(err) {

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -382,6 +382,50 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		)
 	})
 
+	suite.Run("upgrade using legacy API", func() {
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+		insecureMaintenanceClient := maintenanceClients[0]
+
+		currentBootID := suite.readBootID(maintenanceClient)
+
+		_, err := maintenanceClient.Upgrade(suite.ctx, sourceInstallerImage, false, false) //nolint:staticcheck // legacy API test
+		suite.Require().NoError(err)
+
+		// after the reboot the machine should lose SideroLink config, so we expect it to come back up on regular IP
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			version, err := insecureMaintenanceClient.Version(suite.ctx)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
+		}, time.Minute, time.Second, "version API should be available after reboot")
+
+		// apply back SideroLink config
+		_, err = insecureMaintenanceClient.ApplyConfiguration(suite.ctx, &machine.ApplyConfigurationRequest{
+			Data: maintenanceConfig,
+		})
+		suite.Require().NoError(err)
+
+		// wait for the machine to come back on SideroLink IP
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			version, err := maintenanceClient.Version(suite.ctx)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
+		}, time.Minute, time.Second, "API should listen on SideroLink IP after reboot")
+
+		// check that boot ID has changed after reboot
+		newBootID := suite.readBootID(maintenanceClient)
+		suite.Assert().NotEqual(currentBootID, newBootID, "boot ID should change after reboot")
+	})
+
 	suite.Run("apply config and have a cluster", func() {
 		// drop .machine.install, as the machine is already installed
 		patchRemoveInstall := map[string]any{


### PR DESCRIPTION
Add an integration test and fix legacy upgrade API in maintenance mode.

There were several assumptions which do not hold true in maintenance as we have no machine configuration.
