### PR TITLE
feat(ci): add aws arm64 pipelines

### DIFF
--- a/.github/workflows/artifacts-cron-cron.yaml
+++ b/.github/workflows/artifacts-cron-cron.yaml
@@ -1,14 +1,14 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
+# Generated on 2026-04-14T14:11:05Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 3 * * *
-name: integration-qemu-encrypted-vip-cron
+    - cron: 0 3 * * *
+name: artifacts-cron-cron
 jobs:
   default:
     runs-on:
@@ -51,57 +51,66 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
-      - name: Download artifacts
-        if: github.event_name != 'schedule'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
-        with:
-          name: talos-artifacts
-          path: _out
-      - name: Fix artifact permissions
-        if: github.event_name != 'schedule'
+      - name: external-artifacts
         run: |
-          xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: Download artifacts
-        if: github.event_name == 'schedule'
-        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
-        with:
-          event: schedule
-          if_no_artifact_found: fail
-          name: talos-artifacts-cron
-          path: _out
-          workflow: artifacts-cron-cron.yaml
-          workflow_conclusion: success
-      - name: Fix artifact permissions
-        if: github.event_name == 'schedule'
+          make external-artifacts
+      - name: generate
         run: |
-          xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: verify-commit-sha
-        if: github.event_name == 'schedule'
+          make generate
+      - name: uki-certs
+        env:
+          PLATFORM: linux/amd64
         run: |
-          make verify-commit-sha
-      - name: ci-temp-release-tag
-        run: |
-          make ci-temp-release-tag
-      - name: e2e-qemu
+          make uki-certs
+      - name: build
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
-          QEMU_EXTRA_DISKS: "4"
-          QEMU_EXTRA_DISKS_DRIVERS: virtiofs,ide,nvme
-          QEMU_EXTRA_DISKS_SIZE: "10240"
-          QEMU_EXTRA_DISKS_TAGS: disk0
-          WITH_CONFIG_PATCH: '@hack/test/patches/image-verification.yaml'
-          WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
-          WITH_DISK_ENCRYPTION: "true"
-          WITH_KUBESPAN: "true"
-          WITH_VIRTUAL_IP: "true"
+          PLATFORM: linux/amd64,linux/arm64
+          PUSH: "true"
         run: |
-          sudo -E make e2e-qemu
+          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
+      - name: talosctl-cni-bundle
+        run: |
+          make talosctl-cni-bundle
+      - name: iso
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make iso secureboot-iso
+      - name: images-essential
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make images-essential
+      - name: images-essential-enforcing
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
+          PLATFORM: linux/amd64,linux/arm64
+          PUSH: "true"
+          TAG_SUFFIX_OUT: -enforcing
+        run: |
+          make images-essential
+      - name: image-aws
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
+      - name: save-commit-sha
+        run: |
+          make save-commit-sha
+      - name: Generate executable list
+        run: |
+          find _out -type f -executable > _out/executable-artifacts
       - name: save artifacts
-        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # version: v7.0.0
         with:
-          name: talos-logs-integration-qemu-encrypted-vip
-          path: |-
-            /tmp/logs-*.tar.gz
-            /tmp/support-*.zip
-          retention-days: "5"
+          name: talos-artifacts-cron
+          path: |
+            _out
+          retention-days: "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -616,22 +616,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: integration-images-list
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -749,36 +754,29 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: image-aws
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           PLATFORM: linux/amd64,linux/arm64
@@ -788,6 +786,136 @@ jobs:
         env:
           E2E_AWS_TARGET: default
           IMAGE_REGISTRY: registry.dev.siderolabs.io
+        run: |
+          make e2e-aws-prepare
+      - name: checkout contrib
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+        with:
+          path: _out/contrib
+          ref: main
+          repository: siderolabs/contrib
+      - name: setup tf
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # version: v4.0.0
+        with:
+          terraform_wrapper: "false"
+      - name: tf apply
+        env:
+          TF_E2E_ACTION: apply
+          TF_E2E_TEST_TYPE: aws
+          TF_SCRIPT_DIR: _out/contrib
+        run: |
+          make e2e-cloud-tf
+      - name: e2e-aws
+        run: |
+          make e2e-aws
+      - name: tf destroy
+        if: always()
+        env:
+          TF_E2E_ACTION: destroy
+          TF_E2E_REFRESH_ON_DESTROY: "false"
+          TF_E2E_TEST_TYPE: aws
+          TF_SCRIPT_DIR: _out/contrib
+        run: |
+          make e2e-cloud-tf
+  integration-aws-arm64:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: generic
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/aws') || contains(fromJSON(needs.default.outputs.labels), 'integration/aws-arm64') || contains(fromJSON(needs.default.outputs.labels), 'integration/release-gate')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: Download artifacts
+        if: github.event_name != 'schedule'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          name: talos-artifacts
+          path: _out
+      - name: Fix artifact permissions
+        if: github.event_name != 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
+      - name: e2e-aws-prepare
+        env:
+          E2E_AWS_TARGET: default
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          TARGET_ARCH: arm64
         run: |
           make e2e-aws-prepare
       - name: checkout contrib
@@ -885,38 +1013,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -933,6 +1050,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nonfree-kmod-nvidia-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-lts
@@ -1038,34 +1162,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1082,6 +1199,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nonfree-kmod-nvidia-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-lts
@@ -1188,38 +1312,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1236,6 +1349,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nonfree-kmod-nvidia-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-production
@@ -1341,34 +1461,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1385,6 +1498,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nonfree-kmod-nvidia-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-production
@@ -1491,38 +1611,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1539,6 +1648,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nvidia-open-gpu-kernel-modules-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-lts
@@ -1644,34 +1760,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1688,6 +1797,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nvidia-open-gpu-kernel-modules-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-lts
@@ -1794,38 +1910,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1842,6 +1947,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nvidia-open-gpu-kernel-modules-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-production
@@ -1947,34 +2059,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -1991,6 +2096,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nvidia-open-gpu-kernel-modules-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-production
@@ -2091,22 +2203,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-cilium
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-cilium
@@ -2215,18 +2332,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2296,22 +2422,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: conformance-qemu
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-conformance-qemu
@@ -2391,29 +2522,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -2422,6 +2532,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: conformance-qemu
         env:
           EXTRA_TEST_ARGS: -talos.enforcing
@@ -2593,26 +2724,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -2724,35 +2856,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: image-gcp
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2851,28 +2975,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: image-cache
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2971,28 +3094,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: factory-1.11-iso
         env:
           FACTORY_BOOT_METHOD: iso
@@ -3143,22 +3265,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -3225,22 +3352,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: image-metal-uki
         if: github.event_name == 'schedule'
         env:
@@ -3362,22 +3494,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-no-cluster-discovery
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-no-cluster-discovery
@@ -3483,29 +3620,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -3514,6 +3630,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-no-cluster-discovery
         env:
           EXTRA_TEST_ARGS: -talos.enforcing
@@ -3631,42 +3768,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-        run: |
-          make iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-bios
         env:
           EXTRA_TEST_ARGS: -talos.verifyukibooted=false
@@ -3795,22 +3917,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-network-chaos
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-network-chaos
@@ -3904,29 +4031,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -3935,6 +4041,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-network-chaos
         env:
           EXTRA_TEST_ARGS: -talos.enforcing
@@ -4037,22 +4164,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-siderolink
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-siderolink
@@ -4165,29 +4297,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -4196,6 +4307,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-siderolink
         env:
           EXTRA_TEST_ARGS: -talos.enforcing
@@ -4320,36 +4452,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare
@@ -4428,22 +4551,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: installer-enforcing
         if: github.event_name == 'schedule'
         env:
@@ -4532,29 +4660,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-        run: |
-          make iso
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: installer
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -4641,22 +4767,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare
@@ -4735,22 +4866,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -4833,26 +4969,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -4970,22 +5107,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu-csi-openebs
         env:
           EXTRA_TEST_ARGS: -talos.csi=openebs
@@ -5077,22 +5219,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu-csi-rook-ceph
         env:
           EXTRA_TEST_ARGS: -talos.csi=rook-ceph
@@ -5183,22 +5330,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -5282,29 +5434,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -5313,6 +5444,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-qemu
         env:
           EXTRA_TEST_ARGS: -talos.enforcing
@@ -5397,22 +5549,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: build-race
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -5506,8 +5663,25 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
       - name: reproducibility-test
@@ -5575,44 +5749,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
-      - name: secureboot-iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make secureboot-iso
       - name: integration-trusted-boot
         env:
           EXTRA_TEST_ARGS: -talos.trustedboot
@@ -5692,29 +5849,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -5723,6 +5859,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-airgapped-cron.yaml
+++ b/.github/workflows/integration-airgapped-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: integration-images-list
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-aws-arm64-cron.yaml
+++ b/.github/workflows/integration-aws-arm64-cron.yaml
@@ -1,18 +1,18 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 "on":
   schedule:
-    - cron: 30 6 * * *
-name: integration-extensions-cron
+    - cron: 30 7 * * *
+name: integration-aws-arm64-cron
 jobs:
   default:
     runs-on:
-      group: large
+      group: generic
     steps:
       - name: gather-system-info
         id: system-info
@@ -51,6 +51,12 @@ jobs:
           driver: remote
           endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
         timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: Download artifacts
         if: github.event_name != 'schedule'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
@@ -82,48 +88,46 @@ jobs:
       - name: ci-temp-release-tag
         run: |
           make ci-temp-release-tag
-      - name: checkout extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
+      - name: e2e-aws-prepare
+        env:
+          E2E_AWS_TARGET: default
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          TARGET_ARCH: arm64
+        run: |
+          make e2e-aws-prepare
+      - name: checkout contrib
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
-          path: _out/extensions
+          path: _out/contrib
           ref: main
-          repository: siderolabs/extensions
-      - name: unshallow-extensions
-        run: |
-          git -C _out/extensions fetch --prune --unshallow
-      - name: set variables
-        run: |
-          cat _out/talos-metadata >> "$GITHUB_ENV"
-      - name: build extensions
-        env:
-          PLATFORM: linux/amd64
-          PUSH: "true"
-          REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make all extensions-metadata -C _out/extensions
-      - name: installer extensions
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-        run: |
-          make installer-with-extensions
-      - name: e2e-extensions
-        env:
-          EXTRA_TEST_ARGS: -talos.extensions.qemu
-          GITHUB_STEP_NAME: ${{ github.job}}-e2e-extensions
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          QEMU_EXTRA_DISKS: "3"
-          QEMU_MEMORY_WORKERS: "4096"
-          QEMU_WORKERS: "1"
-          SHORT_INTEGRATION_TEST: "yes"
-          WITH_CONFIG_PATCH_WORKER: '@_out/installer-extensions-patch.yaml:@hack/test/patches/extensions.yaml:@hack/test/patches/dm-raid-module.yaml'
-        run: |
-          sudo -E make e2e-qemu
-      - name: save artifacts
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # version: v7.0.0
+          repository: siderolabs/contrib
+      - name: setup tf
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # version: v4.0.0
         with:
-          name: talos-logs-integration-extensions
-          path: |-
-            /tmp/logs-*.tar.gz
-            /tmp/support-*.zip
-          retention-days: "5"
+          terraform_wrapper: "false"
+      - name: tf apply
+        env:
+          TF_E2E_ACTION: apply
+          TF_E2E_TEST_TYPE: aws
+          TF_SCRIPT_DIR: _out/contrib
+        run: |
+          make e2e-cloud-tf
+      - name: e2e-aws
+        run: |
+          make e2e-aws
+      - name: tf destroy
+        if: always()
+        env:
+          TF_E2E_ACTION: destroy
+          TF_E2E_REFRESH_ON_DESTROY: "false"
+          TF_E2E_TEST_TYPE: aws
+          TF_SCRIPT_DIR: _out/contrib
+        run: |
+          make e2e-cloud-tf

--- a/.github/workflows/integration-aws-cron.yaml
+++ b/.github/workflows/integration-aws-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,36 +67,29 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: image-aws
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           PLATFORM: linux/amd64,linux/arm64

--- a/.github/workflows/integration-aws-nvidia-nonfree-lts-arm64-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-lts-arm64-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,34 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -111,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nonfree-kmod-nvidia-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-lts

--- a/.github/workflows/integration-aws-nvidia-nonfree-lts-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-lts-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,38 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -115,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nonfree-kmod-nvidia-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-lts

--- a/.github/workflows/integration-aws-nvidia-nonfree-production-arm64-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-production-arm64-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,34 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -111,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nonfree-kmod-nvidia-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-production

--- a/.github/workflows/integration-aws-nvidia-nonfree-production-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-nonfree-production-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,38 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -115,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nonfree-kmod-nvidia-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-nonfree-production

--- a/.github/workflows/integration-aws-nvidia-oss-lts-arm64-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-lts-arm64-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-08T12:37:05Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,34 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -111,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nvidia-open-gpu-kernel-modules-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-lts

--- a/.github/workflows/integration-aws-nvidia-oss-lts-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-lts-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,38 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -115,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-lts nvidia-open-gpu-kernel-modules-lts extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-lts

--- a/.github/workflows/integration-aws-nvidia-oss-production-arm64-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-production-arm64-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,34 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-          PUSH: "true"
-        run: |
-          make installer-base imager _out/integration-test-linux-amd64
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -111,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nvidia-open-gpu-kernel-modules-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-production

--- a/.github/workflows/integration-aws-nvidia-oss-production-cron.yaml
+++ b/.github/workflows/integration-aws-nvidia-oss-production-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,38 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: image-aws
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make image-aws
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:
@@ -115,6 +104,13 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
         run: |
           make nvidia-container-toolkit-production nvidia-open-gpu-kernel-modules-production extensions-metadata -C _out/extensions
+      - name: image-aws
+        if: github.event_name != 'schedule'
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-aws
       - name: e2e-aws-prepare
         env:
           E2E_AWS_TARGET: nvidia-oss-production

--- a/.github/workflows/integration-cilium-cron.yaml
+++ b/.github/workflows/integration-cilium-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-cilium
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-cilium

--- a/.github/workflows/integration-conformance-cron.yaml
+++ b/.github/workflows/integration-conformance-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: conformance-qemu
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-conformance-qemu

--- a/.github/workflows/integration-conformance-enforcing-cron.yaml
+++ b/.github/workflows/integration-conformance-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: conformance-qemu
         env:
           EXTRA_TEST_ARGS: -talos.enforcing

--- a/.github/workflows/integration-gcp-cron.yaml
+++ b/.github/workflows/integration-gcp-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -67,35 +67,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: image-gcp
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-image-cache-cron.yaml
+++ b/.github/workflows/integration-image-cache-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,28 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: image-cache
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-image-factory-cron.yaml
+++ b/.github/workflows/integration-image-factory-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,28 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: factory-1.11-iso
         env:
           FACTORY_BOOT_METHOD: iso

--- a/.github/workflows/integration-images-cron.yaml
+++ b/.github/workflows/integration-images-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-misc-0-cron.yaml
+++ b/.github/workflows/integration-misc-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: image-metal-uki
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-misc-1-cron.yaml
+++ b/.github/workflows/integration-misc-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-no-cluster-discovery
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-no-cluster-discovery

--- a/.github/workflows/integration-misc-1-enforcing-cron.yaml
+++ b/.github/workflows/integration-misc-1-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-no-cluster-discovery
         env:
           EXTRA_TEST_ARGS: -talos.enforcing

--- a/.github/workflows/integration-misc-2-cron.yaml
+++ b/.github/workflows/integration-misc-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,42 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-        run: |
-          make iso
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: e2e-bios
         env:
           EXTRA_TEST_ARGS: -talos.verifyukibooted=false

--- a/.github/workflows/integration-misc-3-cron.yaml
+++ b/.github/workflows/integration-misc-3-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-network-chaos
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-network-chaos

--- a/.github/workflows/integration-misc-3-enforcing-cron.yaml
+++ b/.github/workflows/integration-misc-3-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-network-chaos
         env:
           EXTRA_TEST_ARGS: -talos.enforcing

--- a/.github/workflows/integration-misc-4-cron.yaml
+++ b/.github/workflows/integration-misc-4-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-siderolink
         env:
           GITHUB_STEP_NAME: ${{ github.job}}-e2e-siderolink

--- a/.github/workflows/integration-misc-4-enforcing-cron.yaml
+++ b/.github/workflows/integration-misc-4-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-siderolink
         env:
           EXTRA_TEST_ARGS: -talos.enforcing

--- a/.github/workflows/integration-provision-0-cron.yaml
+++ b/.github/workflows/integration-provision-0-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,36 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare

--- a/.github/workflows/integration-provision-1-cron.yaml
+++ b/.github/workflows/integration-provision-1-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: installer-enforcing
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/integration-provision-2-cron.yaml
+++ b/.github/workflows/integration-provision-2-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-        run: |
-          make iso
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: installer
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-provision-3-cron.yaml
+++ b/.github/workflows/integration-provision-3-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: provision-tests-prepare
         run: |
           make provision-tests-prepare

--- a/.github/workflows/integration-qemu-cron.yaml
+++ b/.github/workflows/integration-qemu-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-longhorn-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,26 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: generate
-        if: github.event_name == 'schedule'
-        run: |
-          make generate
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: checkout extensions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
         with:

--- a/.github/workflows/integration-qemu-csi-openebs-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-openebs-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu-csi-openebs
         env:
           EXTRA_TEST_ARGS: -talos.csi=openebs

--- a/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
+++ b/.github/workflows/integration-qemu-csi-rook-ceph-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: e2e-qemu-csi-rook-ceph
         env:
           EXTRA_TEST_ARGS: -talos.csi=rook-ceph

--- a/.github/workflows/integration-qemu-enforcing-cron.yaml
+++ b/.github/workflows/integration-qemu-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: e2e-qemu
         env:
           EXTRA_TEST_ARGS: -talos.enforcing

--- a/.github/workflows/integration-qemu-race-cron.yaml
+++ b/.github/workflows/integration-qemu-race-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,22 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: build-race
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io

--- a/.github/workflows/integration-reproducibility-test-cron.yaml
+++ b/.github/workflows/integration-reproducibility-test-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,8 +61,25 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
       - name: reproducibility-test

--- a/.github/workflows/integration-trusted-boot-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T16:51:40Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,44 +61,27 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
       - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
         run: |
           make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
-      - name: images-essential
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make images-essential
-      - name: secureboot-iso
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
-          PLATFORM: linux/amd64,linux/arm64
-        run: |
-          make secureboot-iso
       - name: integration-trusted-boot
         env:
           EXTRA_TEST_ARGS: -talos.trustedboot

--- a/.github/workflows/integration-trusted-boot-enforcing-cron.yaml
+++ b/.github/workflows/integration-trusted-boot-enforcing-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-09T14:38:32Z by kres b6d29bf.
+# Generated on 2026-04-14T18:15:42Z by kres b6d29bf-dirty.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -61,29 +61,8 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           xargs -a _out/executable-artifacts -I {} chmod +x {}
-      - name: ci-temp-release-tag
-        if: github.event_name != 'schedule'
-        run: |
-          make ci-temp-release-tag
-      - name: uki-certs
-        if: github.event_name == 'schedule'
-        env:
-          PLATFORM: linux/amd64
-        run: |
-          make uki-certs
-      - name: build
-        if: github.event_name == 'schedule'
-        env:
-          IMAGE_REGISTRY: registry.dev.siderolabs.io
-          PLATFORM: linux/amd64,linux/arm64
-          PUSH: "true"
-        run: |
-          make talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-      - name: talosctl-cni-bundle
-        if: github.event_name == 'schedule'
-        run: |
-          make talosctl-cni-bundle
       - name: images-essential-enforcing
+        if: github.event_name != 'schedule'
         env:
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           IMAGER_ARGS: --extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1
@@ -92,6 +71,27 @@ jobs:
           TAG_SUFFIX_OUT: -enforcing
         run: |
           make images-essential
+      - name: Download artifacts
+        if: github.event_name == 'schedule'
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # version: v20
+        with:
+          event: schedule
+          if_no_artifact_found: fail
+          name: talos-artifacts-cron
+          path: _out
+          workflow: artifacts-cron-cron.yaml
+          workflow_conclusion: success
+      - name: Fix artifact permissions
+        if: github.event_name == 'schedule'
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: verify-commit-sha
+        if: github.event_name == 'schedule'
+        run: |
+          make verify-commit-sha
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
       - name: secureboot-iso
         if: github.event_name == 'schedule'
         env:

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,12 +1,13 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T10:50:34Z by kres b6d29bf.
 
 "on":
   workflow_run:
     workflows:
       - default
       - grype-scan-cron
+      - artifacts-cron-cron
       - integration-qemu-cron
       - integration-qemu-enforcing-cron
       - integration-embedded-cron
@@ -39,6 +40,7 @@
       - integration-image-cache-cron
       - integration-image-factory-cron
       - integration-aws-cron
+      - integration-aws-arm64-cron
       - integration-aws-nvidia-oss-lts-cron
       - integration-aws-nvidia-oss-lts-arm64-cron
       - integration-aws-nvidia-oss-production-cron

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,12 +1,13 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-11T06:20:55Z by kres b6d29bf.
+# Generated on 2026-04-14T10:50:34Z by kres b6d29bf.
 
 "on":
   workflow_run:
     workflows:
       - default
       - grype-scan-cron
+      - artifacts-cron-cron
       - integration-qemu-cron
       - integration-qemu-enforcing-cron
       - integration-embedded-cron
@@ -39,6 +40,7 @@
       - integration-image-cache-cron
       - integration-image-factory-cron
       - integration-aws-cron
+      - integration-aws-arm64-cron
       - integration-aws-nvidia-oss-lts-cron
       - integration-aws-nvidia-oss-lts-arm64-cron
       - integration-aws-nvidia-oss-production-cron

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -88,11 +88,15 @@ spec:
     - integration-image-cache
     - integration-image-factory
     - integration-aws
+    - integration-aws-arm64
     - integration-aws-nvidia-oss-lts
     - integration-aws-nvidia-oss-lts-arm64
     - integration-aws-nvidia-oss-production
+    - integration-aws-nvidia-oss-production-arm64
     - integration-aws-nvidia-nonfree-lts
+    - integration-aws-nvidia-nonfree-lts-arm64
     - integration-aws-nvidia-nonfree-production
+    - integration-aws-nvidia-nonfree-production-arm64
     - integration-gcp
 ---
 kind: common.GHWorkflow
@@ -377,6 +381,56 @@ spec:
             artifactPath: /tmp/logs-*.tar.gz
             additionalArtifacts:
               - "/tmp/support-*.zip"
+    - name: artifacts-cron
+      buildxOptions:
+        enabled: true
+      runnerGroup: large
+      crons:
+        - '0 3 * * *'
+      cronOnly: true
+      steps:
+        - name: external-artifacts
+        - name: generate
+        - name: uki-certs
+          environment:
+            PLATFORM: linux/amd64
+        - name: build
+          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+            PUSH: true
+        - name: talosctl-cni-bundle
+        - name: iso
+          command: iso secureboot-iso
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: images-essential
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: images-essential-enforcing
+          command: images-essential
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1"
+            TAG_SUFFIX_OUT: -enforcing
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+            PUSH: true
+        - name: image-aws
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: save-commit-sha
+        - name: save-artifacts
+          artifactStep:
+            type: upload
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+            retentionDays: 1
     - name: integration-qemu
       buildxOptions:
         enabled: true
@@ -396,20 +450,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-qemu
           withSudo: true
           environment:
@@ -451,26 +504,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -478,6 +514,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: e2e-qemu
           withSudo: true
           environment:
@@ -568,20 +617,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: conformance-qemu
           command: e2e-qemu
           withSudo: true
@@ -620,26 +668,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -647,6 +678,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: conformance-qemu
           command: e2e-qemu
           withSudo: true
@@ -688,39 +732,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: secureboot-iso
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: integration-trusted-boot
           command: e2e-qemu
           withSudo: true
@@ -759,26 +783,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -786,6 +793,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: secureboot-iso
           conditions:
             - only-on-schedule
@@ -834,32 +854,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: provision-tests-prepare
         - name: provision-tests-track-0
           withSudo: true
@@ -896,20 +903,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: installer-enforcing
           conditions:
             - only-on-schedule
@@ -956,26 +962,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: iso
-          conditions:
-            - only-on-schedule
-          environment:
-            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: installer
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -1018,20 +1017,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: provision-tests-prepare
         - name: provision-tests-track-3
           withSudo: true
@@ -1068,20 +1066,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: integration-images-list
           command: integration-images-list
           environment:
@@ -1153,20 +1150,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: image-metal-uki # needed for e2e-uki-4k
           conditions:
             - only-on-schedule
@@ -1248,20 +1244,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-no-cluster-discovery
           command: e2e-qemu
           withSudo: true
@@ -1328,26 +1323,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -1355,6 +1333,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: e2e-no-cluster-discovery
           command: e2e-qemu
           withSudo: true
@@ -1433,38 +1424,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: iso # needed for e2e-bios-iso
-          conditions:
-            - only-on-schedule
-          command: iso
-          environment:
-            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-bios
           command: e2e-qemu
           withSudo: true
@@ -1554,20 +1526,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-network-chaos
           command: e2e-qemu
           withSudo: true
@@ -1621,26 +1592,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -1648,6 +1602,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: e2e-network-chaos
           command: e2e-qemu
           withSudo: true
@@ -1711,20 +1678,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-siderolink
           command: e2e-qemu
           withSudo: true
@@ -1798,26 +1764,9 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: images-essential-enforcing
           conditions:
             - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: uki-certs
-          environment:
-            PLATFORM: linux/amd64
-          conditions:
-            - only-on-schedule
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential-enforcing
           command: images-essential
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -1825,6 +1774,19 @@ spec:
             TAG_SUFFIX_OUT: -enforcing
             IMAGE_REGISTRY: registry.dev.siderolabs.io
             PUSH: true
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: e2e-siderolink
           command: e2e-qemu
           withSudo: true
@@ -1909,23 +1871,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -1991,20 +1949,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-cilium
           command: e2e-qemu
           withSudo: true
@@ -2067,20 +2024,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-qemu
           withSudo: true
           environment:
@@ -2123,20 +2079,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: build-race
           command: initramfs installer-base imager installer
           environment:
@@ -2190,20 +2145,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-qemu-csi-rook-ceph
           command: e2e-qemu
           withSudo: true
@@ -2256,23 +2210,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -2349,20 +2299,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: e2e-qemu-csi-openebs
           command: e2e-qemu
           withSudo: true
@@ -2414,20 +2363,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: images
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -2451,9 +2399,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
+        - name: download-artifacts-cron
           conditions:
-            - not-on-schedule
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: reproducibility-test
           environment:
             IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2474,17 +2432,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
-        - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: build
+        - name: download-artifacts-cron
           conditions:
             - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
         - name: images
           environment:
             PLATFORM: linux/amd64,linux/arm64
@@ -2509,25 +2469,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: image-cache
           command: cache-create
           environment:
@@ -2584,25 +2538,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
         - name: factory-1.11-iso
           command: e2e-image-factory
           withSudo: true
@@ -2714,32 +2662,22 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
+        - name: image-aws
           conditions:
             - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-        - name: image-aws
           environment:
             PLATFORM: linux/amd64,linux/arm64
             IMAGE_REGISTRY: registry.dev.siderolabs.io
@@ -2747,6 +2685,74 @@ spec:
           environment:
             E2E_AWS_TARGET: default
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: checkout contrib
+          checkoutStep:
+            repository: siderolabs/contrib
+            ref: main
+            path: _out/contrib
+        - name: setup tf
+          terraformStep: true
+        - name: tf apply
+          command: e2e-cloud-tf
+          environment:
+            TF_SCRIPT_DIR: _out/contrib
+            TF_E2E_TEST_TYPE: aws
+            TF_E2E_ACTION: apply
+        - name: e2e-aws
+        - name: tf destroy
+          command: e2e-cloud-tf
+          conditions:
+            - always
+          environment:
+            TF_SCRIPT_DIR: _out/contrib
+            TF_E2E_TEST_TYPE: aws
+            TF_E2E_ACTION: destroy
+            TF_E2E_REFRESH_ON_DESTROY: false
+    - name: integration-aws-arm64
+      buildxOptions:
+        enabled: true
+      sops: true
+      depends:
+        - default
+      runnerGroup: generic # we can use generic here since the tests run against a remote talos cluster
+      crons:
+        - '30 7 * * *'
+      triggerLabels:
+        - integration/aws
+        - integration/aws-arm64
+        - integration/release-gate
+      steps:
+        - name: download-artifacts
+          conditions:
+            - not-on-schedule
+          artifactStep:
+            type: download
+            artifactName: talos-artifacts
+            artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
+        - name: ci-temp-release-tag
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: e2e-aws-prepare
+          environment:
+            E2E_AWS_TARGET: default
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
+            TARGET_ARCH: arm64
         - name: checkout contrib
           checkoutStep:
             repository: siderolabs/contrib
@@ -2791,32 +2797,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: image-aws
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -2834,6 +2827,12 @@ spec:
             PLATFORM: linux/amd64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -2887,29 +2886,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: installer-base imager _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: image-aws
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -2927,6 +2916,12 @@ spec:
             PLATFORM: linux/arm64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -2981,32 +2976,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: image-aws
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3024,6 +3006,12 @@ spec:
             PLATFORM: linux/amd64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3077,29 +3065,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: installer-base imager _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: image-aws
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3117,6 +3095,12 @@ spec:
             PLATFORM: linux/arm64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3171,32 +3155,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: image-aws
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3214,6 +3185,12 @@ spec:
             PLATFORM: linux/amd64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3267,29 +3244,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: installer-base imager _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: image-aws
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3307,6 +3274,12 @@ spec:
             PLATFORM: linux/arm64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3361,32 +3334,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: image-aws
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3404,6 +3364,12 @@ spec:
             PLATFORM: linux/amd64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3457,29 +3423,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: generate
-          conditions:
-            - only-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: installer-base imager _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: image-aws
-          environment:
-            PLATFORM: linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: checkout extensions
           checkoutStep:
             repository: siderolabs/extensions
@@ -3497,6 +3453,12 @@ spec:
             PLATFORM: linux/arm64
             PUSH: true
             REGISTRY: registry.dev.siderolabs.io
+        - name: image-aws
+          conditions:
+            - not-on-schedule
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: e2e-aws-prepare
           environment:
             EXTENSIONS_METADATA_FILE: _out/extensions/_out/extensions-metadata
@@ -3550,31 +3512,19 @@ spec:
             type: download
             artifactName: talos-artifacts
             artifactPath: _out
+        - name: download-artifacts-cron
+          conditions:
+            - only-on-schedule
+          artifactStep:
+            type: workflow-download
+            workflowName: artifacts-cron-cron.yaml
+            workflowEvent: schedule
+            artifactName: talos-artifacts-cron
+            artifactPath: _out
+        - name: verify-commit-sha
+          conditions:
+            - only-on-schedule
         - name: ci-temp-release-tag
-          conditions:
-            - not-on-schedule
-        - name: uki-certs
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64
-        - name: build
-          conditions:
-            - only-on-schedule
-          command: talosctl-linux-amd64 kernel sd-boot sd-stub initramfs installer-base imager talos _out/integration-test-linux-amd64
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
-            PUSH: true
-        - name: talosctl-cni-bundle
-          conditions:
-            - only-on-schedule
-        - name: images-essential
-          conditions:
-            - only-on-schedule
-          environment:
-            PLATFORM: linux/amd64,linux/arm64
-            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: image-gcp
           environment:
             PLATFORM: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -750,3 +750,15 @@ ci-temp-release-tag: ## Generates a temporary release tag for CI run.
 		echo "TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
 		echo "ABBREV_TAG=$(CI_RELEASE_TAG)" >> "$${GITHUB_ENV}"; \
 	fi
+
+.PHONY: save-commit-sha
+save-commit-sha: $(ARTIFACTS) ## Saves the commit SHA to a file in the artifacts directory.
+	@echo "$(SHA)" > $(ARTIFACTS)/commit_sha.txt
+
+.PHONY: verify-commit-sha
+verify-commit-sha: ## Verifies that the commit SHA in the artifacts directory matches the current commit SHA.
+	@read sha < $(ARTIFACTS)/commit_sha.txt && \
+	if [ "$$sha" != "$(SHA)" ]; then \
+		echo "Commit SHA mismatch: expected $$sha, got $(SHA)"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
feat(ci): add aws arm64 pipelines

Add aws arm64 pipeline

This also splits building artifacts into it's own cron job,
so that we don't build in each step and overwrite the installer image
when multiple crons are running in parallel.

This should also save some time for crons not having to rebuild every single time.

Signed-off-by: Noel Georgi <git@frezbo.dev>