### PR TITLE
test: allow more tests to run in FIPS strict mode

### DIFF
--- a/internal/app/machined/pkg/adapters/kubespan/identity.go
+++ b/internal/app/machined/pkg/adapters/kubespan/identity.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/mdlayher/netx/eui64"
 	"github.com/siderolabs/gen/value"
+	"go.uber.org/zap"
 	"go4.org/netipx"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
+	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/kubespan"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -33,14 +35,25 @@ type identity struct {
 }
 
 // GenerateKey generates new Wireguard key.
-func (a identity) GenerateKey() error {
-	key, err := wgtypes.GeneratePrivateKey()
+func (a identity) GenerateKey(logger *zap.Logger) error {
+	var (
+		key wgtypes.Key
+		err error
+	)
+
+	fipsmode.SkipEnforcement(logger, "kubespan.GenerateKey", func() {
+		key, err = wgtypes.GeneratePrivateKey()
+	})
+
 	if err != nil {
 		return err
 	}
 
 	a.IdentitySpec.PrivateKey = key.String()
-	a.IdentitySpec.PublicKey = key.PublicKey().String()
+
+	fipsmode.SkipEnforcement(logger, "kubespan.GenerateKey", func() {
+		a.IdentitySpec.PublicKey = key.PublicKey().String()
+	})
 
 	return nil
 }

--- a/internal/app/machined/pkg/adapters/kubespan/identity_test.go
+++ b/internal/app/machined/pkg/adapters/kubespan/identity_test.go
@@ -10,20 +10,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	kubespanadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/kubespan"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/kubespan"
 )
 
 func TestIdentityGenerateKey(t *testing.T) {
-	if fipsmode.Strict() {
-		t.Skip("skipping test in strict FIPS mode")
-	}
-
 	var spec kubespan.IdentitySpec
 
-	assert.NoError(t, kubespanadapter.IdentitySpec(&spec).GenerateKey())
+	assert.NoError(t, kubespanadapter.IdentitySpec(&spec).GenerateKey(zap.NewNop()))
 }
 
 func TestIdentityUpdateAddress(t *testing.T) {

--- a/internal/app/machined/pkg/adapters/network/wireguard_spec_test.go
+++ b/internal/app/machined/pkg/adapters/network/wireguard_spec_test.go
@@ -5,6 +5,7 @@
 package network_test
 
 import (
+	"crypto/fips140"
 	"net"
 	"net/netip"
 	"testing"
@@ -15,278 +16,271 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
 func TestWireguardSpecDecode(t *testing.T) {
-	if fipsmode.Strict() {
-		t.Skip("skipping test in strict FIPS mode")
-	}
+	fips140.WithoutEnforcement(func() {
+		priv, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	priv, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		pub1, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	pub1, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		pub2, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	pub2, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		var spec network.WireguardSpec
 
-	var spec network.WireguardSpec
-
-	// decode in spec mode
-	networkadapter.WireguardSpec(&spec).Decode(&wgtypes.Device{
-		PrivateKey:   priv,
-		ListenPort:   30000,
-		FirewallMark: 1,
-		Peers: []wgtypes.Peer{
-			{
-				PublicKey:    pub1.PublicKey(),
-				PresharedKey: priv,
-				Endpoint: &net.UDPAddr{
-					IP:   net.ParseIP("10.2.0.3"),
-					Port: 20000,
+		// decode in spec mode
+		networkadapter.WireguardSpec(&spec).Decode(&wgtypes.Device{
+			PrivateKey:   priv,
+			ListenPort:   30000,
+			FirewallMark: 1,
+			Peers: []wgtypes.Peer{
+				{
+					PublicKey:    pub1.PublicKey(),
+					PresharedKey: priv,
+					Endpoint: &net.UDPAddr{
+						IP:   net.ParseIP("10.2.0.3"),
+						Port: 20000,
+					},
+					AllowedIPs: []net.IPNet{
+						{
+							IP:   net.ParseIP("172.24.0.0"),
+							Mask: net.IPv4Mask(255, 255, 0, 0),
+						},
+					},
 				},
-				AllowedIPs: []net.IPNet{
-					{
-						IP:   net.ParseIP("172.24.0.0"),
-						Mask: net.IPv4Mask(255, 255, 0, 0),
+				{
+					PublicKey: pub2.PublicKey(),
+					AllowedIPs: []net.IPNet{
+						{
+							IP:   net.ParseIP("172.25.0.0"),
+							Mask: net.IPv4Mask(255, 255, 255, 0),
+						},
 					},
 				},
 			},
-			{
-				PublicKey: pub2.PublicKey(),
-				AllowedIPs: []net.IPNet{
-					{
-						IP:   net.ParseIP("172.25.0.0"),
-						Mask: net.IPv4Mask(255, 255, 255, 0),
+		}, false)
+
+		expected := network.WireguardSpec{
+			PrivateKey:   priv.String(),
+			ListenPort:   30000,
+			FirewallMark: 1,
+			Peers: []network.WireguardPeer{
+				{
+					PublicKey:    pub1.PublicKey().String(),
+					PresharedKey: priv.String(),
+					Endpoint:     "10.2.0.3:20000",
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.24.0.0/16"),
+					},
+				},
+				{
+					PublicKey: pub2.PublicKey().String(),
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.25.0.0/24"),
 					},
 				},
 			},
-		},
-	}, false)
+		}
 
-	expected := network.WireguardSpec{
-		PrivateKey:   priv.String(),
-		ListenPort:   30000,
-		FirewallMark: 1,
-		Peers: []network.WireguardPeer{
-			{
-				PublicKey:    pub1.PublicKey().String(),
-				PresharedKey: priv.String(),
-				Endpoint:     "10.2.0.3:20000",
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.24.0.0/16"),
-				},
-			},
-			{
-				PublicKey: pub2.PublicKey().String(),
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.25.0.0/24"),
-				},
-			},
-		},
-	}
+		assert.Equal(t, expected, spec)
+		assert.True(t, expected.Equal(&spec))
 
-	assert.Equal(t, expected, spec)
-	assert.True(t, expected.Equal(&spec))
+		// zeroed out listen port is still acceptable on the right side
+		spec.ListenPort = 0
+		assert.True(t, expected.Equal(&spec))
 
-	// zeroed out listen port is still acceptable on the right side
-	spec.ListenPort = 0
-	assert.True(t, expected.Equal(&spec))
+		// ... but not on the left side
+		expected.ListenPort = 0
+		spec.ListenPort = 30000
+		assert.False(t, expected.Equal(&spec))
 
-	// ... but not on the left side
-	expected.ListenPort = 0
-	spec.ListenPort = 30000
-	assert.False(t, expected.Equal(&spec))
+		var zeroSpec network.WireguardSpec
 
-	var zeroSpec network.WireguardSpec
-
-	assert.False(t, zeroSpec.Equal(&spec))
+		assert.False(t, zeroSpec.Equal(&spec))
+	})
 }
 
 func TestWireguardSpecDecodeStatus(t *testing.T) {
-	if fipsmode.Strict() {
-		t.Skip("skipping test in strict FIPS mode")
-	}
+	fips140.WithoutEnforcement(func() {
+		priv, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	priv, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		var spec network.WireguardSpec
 
-	var spec network.WireguardSpec
+		// decode in status mode
+		networkadapter.WireguardSpec(&spec).Decode(&wgtypes.Device{
+			PrivateKey:   priv,
+			PublicKey:    priv.PublicKey(),
+			ListenPort:   30000,
+			FirewallMark: 1,
+		}, true)
 
-	// decode in status mode
-	networkadapter.WireguardSpec(&spec).Decode(&wgtypes.Device{
-		PrivateKey:   priv,
-		PublicKey:    priv.PublicKey(),
-		ListenPort:   30000,
-		FirewallMark: 1,
-	}, true)
+		expected := network.WireguardSpec{
+			PublicKey:    priv.PublicKey().String(),
+			ListenPort:   30000,
+			FirewallMark: 1,
+			Peers:        []network.WireguardPeer{},
+		}
 
-	expected := network.WireguardSpec{
-		PublicKey:    priv.PublicKey().String(),
-		ListenPort:   30000,
-		FirewallMark: 1,
-		Peers:        []network.WireguardPeer{},
-	}
-
-	assert.Equal(t, expected, spec)
+		assert.Equal(t, expected, spec)
+	})
 }
 
 func TestWireguardSpecEncode(t *testing.T) {
-	if fipsmode.Strict() {
-		t.Skip("skipping test in strict FIPS mode")
-	}
+	fips140.WithoutEnforcement(func() {
+		priv, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	priv, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		pub1, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	pub1, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		pub2, err := wgtypes.GeneratePrivateKey()
+		require.NoError(t, err)
 
-	pub2, err := wgtypes.GeneratePrivateKey()
-	require.NoError(t, err)
+		// make sure pub1 < pub2
+		if pub1.PublicKey().String() > pub2.PublicKey().String() {
+			pub1, pub2 = pub2, pub1
+		}
 
-	// make sure pub1 < pub2
-	if pub1.PublicKey().String() > pub2.PublicKey().String() {
-		pub1, pub2 = pub2, pub1
-	}
-
-	specV1 := network.WireguardSpec{
-		PrivateKey:   priv.String(),
-		ListenPort:   30000,
-		FirewallMark: 1,
-		Peers: []network.WireguardPeer{
-			{
-				PublicKey: pub1.PublicKey().String(),
-				Endpoint:  "10.2.0.3:20000",
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.24.0.0/16"),
+		specV1 := network.WireguardSpec{
+			PrivateKey:   priv.String(),
+			ListenPort:   30000,
+			FirewallMark: 1,
+			Peers: []network.WireguardPeer{
+				{
+					PublicKey: pub1.PublicKey().String(),
+					Endpoint:  "10.2.0.3:20000",
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.24.0.0/16"),
+					},
 				},
-			},
-			{
-				PublicKey: pub2.PublicKey().String(),
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.25.0.0/24"),
-				},
-			},
-		},
-	}
-
-	specV1.Sort()
-
-	var zero network.WireguardSpec
-
-	networkadapter.WireguardSpec(&zero).Decode(&wgtypes.Device{}, false)
-	zero.Sort()
-
-	// from zero (empty) config to config with two peers
-	delta, err := networkadapter.WireguardSpec(&specV1).Encode(&zero)
-	require.NoError(t, err)
-
-	assert.Equal(t, &wgtypes.Config{
-		PrivateKey:   &priv,
-		ListenPort:   new(30000),
-		FirewallMark: new(1),
-		Peers: []wgtypes.PeerConfig{
-			{
-				PublicKey: pub1.PublicKey(),
-				Endpoint: &net.UDPAddr{
-					IP:   net.ParseIP("10.2.0.3"),
-					Port: 20000,
-				},
-				PersistentKeepaliveInterval: new(time.Duration(0)),
-				ReplaceAllowedIPs:           true,
-				AllowedIPs: []net.IPNet{
-					{
-						IP:   net.ParseIP("172.24.0.0").To4(),
-						Mask: net.IPv4Mask(255, 255, 0, 0),
+				{
+					PublicKey: pub2.PublicKey().String(),
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.25.0.0/24"),
 					},
 				},
 			},
-			{
-				PublicKey:                   pub2.PublicKey(),
-				PersistentKeepaliveInterval: new(time.Duration(0)),
-				ReplaceAllowedIPs:           true,
-				AllowedIPs: []net.IPNet{
-					{
-						IP:   net.ParseIP("172.25.0.0").To4(),
-						Mask: net.IPv4Mask(255, 255, 255, 0),
+		}
+
+		specV1.Sort()
+
+		var zero network.WireguardSpec
+
+		networkadapter.WireguardSpec(&zero).Decode(&wgtypes.Device{}, false)
+		zero.Sort()
+
+		// from zero (empty) config to config with two peers
+		delta, err := networkadapter.WireguardSpec(&specV1).Encode(&zero)
+		require.NoError(t, err)
+
+		assert.Equal(t, &wgtypes.Config{
+			PrivateKey:   &priv,
+			ListenPort:   new(30000),
+			FirewallMark: new(1),
+			Peers: []wgtypes.PeerConfig{
+				{
+					PublicKey: pub1.PublicKey(),
+					Endpoint: &net.UDPAddr{
+						IP:   net.ParseIP("10.2.0.3"),
+						Port: 20000,
+					},
+					PersistentKeepaliveInterval: new(time.Duration(0)),
+					ReplaceAllowedIPs:           true,
+					AllowedIPs: []net.IPNet{
+						{
+							IP:   net.ParseIP("172.24.0.0").To4(),
+							Mask: net.IPv4Mask(255, 255, 0, 0),
+						},
+					},
+				},
+				{
+					PublicKey:                   pub2.PublicKey(),
+					PersistentKeepaliveInterval: new(time.Duration(0)),
+					ReplaceAllowedIPs:           true,
+					AllowedIPs: []net.IPNet{
+						{
+							IP:   net.ParseIP("172.25.0.0").To4(),
+							Mask: net.IPv4Mask(255, 255, 255, 0),
+						},
 					},
 				},
 			},
-		},
-	}, delta)
+		}, delta)
 
-	// noop
-	delta, err = networkadapter.WireguardSpec(&specV1).Encode(&specV1)
-	require.NoError(t, err)
+		// noop
+		delta, err = networkadapter.WireguardSpec(&specV1).Encode(&specV1)
+		require.NoError(t, err)
 
-	assert.Equal(t, &wgtypes.Config{}, delta)
+		assert.Equal(t, &wgtypes.Config{}, delta)
 
-	// delete peer2
-	specV2 := network.WireguardSpec{
-		PrivateKey:   priv.String(),
-		ListenPort:   30000,
-		FirewallMark: 1,
-		Peers: []network.WireguardPeer{
-			{
-				PublicKey: pub1.PublicKey().String(),
-				Endpoint:  "10.2.0.3:20000",
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.24.0.0/16"),
-				},
-			},
-		},
-	}
-
-	delta, err = networkadapter.WireguardSpec(&specV2).Encode(&specV1)
-	require.NoError(t, err)
-
-	assert.Equal(t, &wgtypes.Config{
-		Peers: []wgtypes.PeerConfig{
-			{
-				PublicKey: pub2.PublicKey(),
-				Remove:    true,
-			},
-		},
-	}, delta)
-
-	// update peer1, firewallMark
-	specV3 := network.WireguardSpec{
-		PrivateKey:   priv.String(),
-		ListenPort:   30000,
-		FirewallMark: 2,
-		Peers: []network.WireguardPeer{
-			{
-				PublicKey:    pub1.PublicKey().String(),
-				PresharedKey: priv.String(),
-				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("172.24.0.0/16"),
-				},
-			},
-		},
-	}
-
-	delta, err = networkadapter.WireguardSpec(&specV3).Encode(&specV2)
-	require.NoError(t, err)
-
-	assert.Equal(t, &wgtypes.Config{
-		FirewallMark: new(2),
-		Peers: []wgtypes.PeerConfig{
-			{
-				PublicKey:                   pub1.PublicKey(),
-				PresharedKey:                &priv,
-				PersistentKeepaliveInterval: new(time.Duration(0)),
-				ReplaceAllowedIPs:           true,
-				AllowedIPs: []net.IPNet{
-					{
-						IP:   net.ParseIP("172.24.0.0").To4(),
-						Mask: net.IPv4Mask(255, 255, 0, 0),
+		// delete peer2
+		specV2 := network.WireguardSpec{
+			PrivateKey:   priv.String(),
+			ListenPort:   30000,
+			FirewallMark: 1,
+			Peers: []network.WireguardPeer{
+				{
+					PublicKey: pub1.PublicKey().String(),
+					Endpoint:  "10.2.0.3:20000",
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.24.0.0/16"),
 					},
 				},
 			},
-		},
-	}, delta)
+		}
+
+		delta, err = networkadapter.WireguardSpec(&specV2).Encode(&specV1)
+		require.NoError(t, err)
+
+		assert.Equal(t, &wgtypes.Config{
+			Peers: []wgtypes.PeerConfig{
+				{
+					PublicKey: pub2.PublicKey(),
+					Remove:    true,
+				},
+			},
+		}, delta)
+
+		// update peer1, firewallMark
+		specV3 := network.WireguardSpec{
+			PrivateKey:   priv.String(),
+			ListenPort:   30000,
+			FirewallMark: 2,
+			Peers: []network.WireguardPeer{
+				{
+					PublicKey:    pub1.PublicKey().String(),
+					PresharedKey: priv.String(),
+					AllowedIPs: []netip.Prefix{
+						netip.MustParsePrefix("172.24.0.0/16"),
+					},
+				},
+			},
+		}
+
+		delta, err = networkadapter.WireguardSpec(&specV3).Encode(&specV2)
+		require.NoError(t, err)
+
+		assert.Equal(t, &wgtypes.Config{
+			FirewallMark: new(2),
+			Peers: []wgtypes.PeerConfig{
+				{
+					PublicKey:                   pub1.PublicKey(),
+					PresharedKey:                &priv,
+					PersistentKeepaliveInterval: new(time.Duration(0)),
+					ReplaceAllowedIPs:           true,
+					AllowedIPs: []net.IPNet{
+						{
+							IP:   net.ParseIP("172.24.0.0").To4(),
+							Mask: net.IPv4Mask(255, 255, 0, 0),
+						},
+					},
+				},
+			},
+		}, delta)
+	})
 }

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 
 	clusteradapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/cluster"
 	kubespanadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/kubespan"
 	clusterctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/cluster"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -59,16 +59,12 @@ func (suite *LocalAffiliateSuite) TestGeneration() {
 		asrt.Equal(cluster.KubeSpanAffiliateSpec{}, spec.KubeSpan)
 	})
 
-	if fipsmode.Strict() {
-		suite.T().Skip("skipping test in strict FIPS mode (Wireguard/KubeSpan)")
-	}
-
 	// enable kubespan
 	mac, err := net.ParseMAC("ea:71:1b:b2:cc:ee")
 	suite.Require().NoError(err)
 
 	ksIdentity := kubespan.NewIdentity(kubespan.NamespaceName, kubespan.LocalIdentity)
-	suite.Require().NoError(kubespanadapter.IdentitySpec(ksIdentity.TypedSpec()).GenerateKey())
+	suite.Require().NoError(kubespanadapter.IdentitySpec(ksIdentity.TypedSpec()).GenerateKey(zap.NewNop()))
 	suite.Require().NoError(kubespanadapter.IdentitySpec(ksIdentity.TypedSpec()).UpdateAddress("8XuV9TZHW08DOk3bVxQjH9ih_TBKjnh-j44tsCLSBzo=", mac))
 	suite.Require().NoError(suite.state.Create(suite.ctx, ksIdentity))
 

--- a/internal/app/machined/pkg/controllers/kubespan/identity.go
+++ b/internal/app/machined/pkg/controllers/kubespan/identity.go
@@ -21,7 +21,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/automaton/blockautomaton"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/kubespan"
@@ -106,10 +105,6 @@ func (ctrl *IdentityController) Run(ctx context.Context, r controller.Runtime, l
 		alreadyHasIdentity := err == nil
 
 		if cfg != nil && firstMAC != nil && cfg.TypedSpec().Enabled {
-			if fipsmode.Strict() {
-				return fmt.Errorf("KubeSpan is not supported in strict FIPS mode")
-			}
-
 			if ctrl.stateMachine == nil && !alreadyHasIdentity {
 				ctrl.stateMachine = blockautomaton.NewVolumeMounter(
 					ctrl.Name(),
@@ -150,7 +145,7 @@ func (ctrl *IdentityController) establishIdentity(
 			var localIdentity kubespan.IdentitySpec
 
 			if err := controllers.LoadOrNewFromFile(root, constants.KubeSpanIdentityFilename, &localIdentity, func(v *kubespan.IdentitySpec) error {
-				return kubespanadapter.IdentitySpec(v).GenerateKey()
+				return kubespanadapter.IdentitySpec(v).GenerateKey(logger)
 			}); err != nil {
 				return fmt.Errorf("error caching kubespan identity: %w", err)
 			}

--- a/internal/app/machined/pkg/controllers/kubespan/identity_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/identity_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	kubespanctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/kubespan"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -134,10 +133,6 @@ publicKey: Oak2fBEWngBhwslBxDVgnRNHXs88OAp4kjroSX0uqUE=
 
 func TestIdentitySuite(t *testing.T) {
 	t.Parallel()
-
-	if fipsmode.Strict() {
-		t.Skip("skipping test in FIPS mode")
-	}
 
 	if os.Geteuid() != 0 {
 		t.Skip("skipping test that requires root privileges")

--- a/internal/app/machined/pkg/controllers/kubespan/manager_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/manager_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	kubespanadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/kubespan"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	kubespanctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/kubespan"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/kubespan"
@@ -71,10 +71,6 @@ func (mock *mockWireguardClient) Close() error {
 
 //nolint:dupl
 func (suite *ManagerSuite) TestReconcile() {
-	if fipsmode.Strict() {
-		suite.T().Skip("skipping test in strict FIPS mode")
-	}
-
 	cfg := kubespan.NewConfig(config.NamespaceName, kubespan.ConfigID)
 	cfg.TypedSpec().Enabled = true
 	cfg.TypedSpec().SharedSecret = "TPbGXrYlvuXgAl8dERpwjlA5tnEMoihPDPxlovcLtVg="
@@ -85,7 +81,7 @@ func (suite *ManagerSuite) TestReconcile() {
 	suite.Require().NoError(err)
 
 	localIdentity := kubespan.NewIdentity(kubespan.NamespaceName, kubespan.LocalIdentity)
-	suite.Require().NoError(kubespanadapter.IdentitySpec(localIdentity.TypedSpec()).GenerateKey())
+	suite.Require().NoError(kubespanadapter.IdentitySpec(localIdentity.TypedSpec()).GenerateKey(zap.NewNop()))
 	suite.Require().NoError(
 		kubespanadapter.IdentitySpec(localIdentity.TypedSpec()).UpdateAddress(
 			"v16UCWpO2iOm82n6F8dGCJ41ZXXBvDrjRDs2su7C_zs=",

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -6,6 +6,7 @@
 package network_test
 
 import (
+	"crypto/fips140"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -22,7 +23,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	networkcfg "github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -640,20 +640,26 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyleVRF() {
 }
 
 func (suite *LinkConfigSuite) TestMachineConfigurationNewStyleNotFIPS() {
-	if fipsmode.Strict() {
-		suite.T().Skip("skipping test in strict FIPS mode")
-	}
-
 	suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.LinkConfigController{}))
 
-	privKey, err := wgtypes.GeneratePrivateKey()
-	suite.Require().NoError(err)
+	var (
+		privKey, pskKey, peerKey wgtypes.Key
+		peerKeyPub               wgtypes.Key
+		err                      error
+	)
 
-	pskKey, err := wgtypes.GenerateKey()
-	suite.Require().NoError(err)
+	fips140.WithoutEnforcement(func() {
+		privKey, err = wgtypes.GeneratePrivateKey()
+		suite.Require().NoError(err)
 
-	peerKey, err := wgtypes.GenerateKey()
-	suite.Require().NoError(err)
+		pskKey, err = wgtypes.GenerateKey()
+		suite.Require().NoError(err)
+
+		peerKey, err = wgtypes.GenerateKey()
+		suite.Require().NoError(err)
+
+		peerKeyPub = peerKey.PublicKey()
+	})
 
 	wc1 := networkcfg.NewWireguardConfigV1Alpha1("wg0")
 	wc1.LinkUp = new(true)
@@ -661,7 +667,7 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyleNotFIPS() {
 	wc1.WireguardListenPort = 12345
 	wc1.WireguardPeers = []networkcfg.WireguardPeer{
 		{
-			WireguardPublicKey:    peerKey.PublicKey().String(),
+			WireguardPublicKey:    peerKeyPub.String(),
 			WireguardPresharedKey: pskKey.String(),
 			WireguardAllowedIPs:   []networkcfg.Prefix{{Prefix: netip.MustParsePrefix("10.0.0.0/24")}},
 		},
@@ -690,7 +696,7 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyleNotFIPS() {
 					FirewallMark: 0,
 					Peers: []network.WireguardPeer{
 						{
-							PublicKey:    peerKey.PublicKey().String(),
+							PublicKey:    peerKeyPub.String(),
 							PresharedKey: pskKey.String(),
 							AllowedIPs: []netip.Prefix{
 								netip.MustParsePrefix("10.0.0.0/24"),

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -6,6 +6,7 @@
 package network_test
 
 import (
+	"crypto/fips140"
 	"fmt"
 	"math/rand/v2"
 	"net"
@@ -28,7 +29,6 @@ import (
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -776,18 +776,30 @@ func (suite *LinkSpecSuite) TestVRF() {
 
 //nolint:gocyclo
 func (suite *LinkSpecSuite) TestWireguard() {
-	if fipsmode.Strict() {
-		suite.T().Skip("skipping test in strict FIPS mode")
-	}
+	var (
+		priv, priv2, pub1, pub2             wgtypes.Key
+		privPub, priv2Pub, pub1Pub, pub2Pub wgtypes.Key
+		err                                 error
+	)
 
-	priv, err := wgtypes.GeneratePrivateKey()
-	suite.Require().NoError(err)
+	fips140.WithoutEnforcement(func() {
+		priv, err = wgtypes.GeneratePrivateKey()
+		suite.Require().NoError(err)
 
-	pub1, err := wgtypes.GeneratePrivateKey()
-	suite.Require().NoError(err)
+		pub1, err = wgtypes.GeneratePrivateKey()
+		suite.Require().NoError(err)
 
-	pub2, err := wgtypes.GeneratePrivateKey()
-	suite.Require().NoError(err)
+		pub2, err = wgtypes.GeneratePrivateKey()
+		suite.Require().NoError(err)
+
+		priv2, err = wgtypes.GeneratePrivateKey()
+		suite.Require().NoError(err)
+
+		privPub = priv.PublicKey()
+		pub1Pub = pub1.PublicKey()
+		pub2Pub = pub2.PublicKey()
+		priv2Pub = priv2.PublicKey()
+	})
 
 	wgInterface := suite.uniqueDummyInterface()
 
@@ -803,14 +815,14 @@ func (suite *LinkSpecSuite) TestWireguard() {
 			FirewallMark: 1,
 			Peers: []network.WireguardPeer{
 				{
-					PublicKey: pub1.PublicKey().String(),
+					PublicKey: pub1Pub.String(),
 					Endpoint:  "10.2.0.3:20000",
 					AllowedIPs: []netip.Prefix{
 						netip.MustParsePrefix("172.24.0.0/16"),
 					},
 				},
 				{
-					PublicKey: pub2.PublicKey().String(),
+					PublicKey: pub2Pub.String(),
 					AllowedIPs: []netip.Prefix{
 						netip.MustParsePrefix("172.25.0.0/24"),
 					},
@@ -827,14 +839,11 @@ func (suite *LinkSpecSuite) TestWireguard() {
 	ctest.AssertResource(suite, wgInterface, func(r *network.LinkStatus, asrt *assert.Assertions) {
 		asrt.Equal("wireguard", r.TypedSpec().Kind)
 		asrt.Contains([]nethelpers.OperationalState{nethelpers.OperStateUp, nethelpers.OperStateUnknown}, r.TypedSpec().OperationalState)
-		asrt.Equal(priv.PublicKey().String(), r.TypedSpec().Wireguard.PublicKey)
+		asrt.Equal(privPub.String(), r.TypedSpec().Wireguard.PublicKey)
 		asrt.Len(r.TypedSpec().Wireguard.Peers, 2)
 	})
 
 	// attempt to change wireguard private key
-	priv2, err := wgtypes.GeneratePrivateKey()
-	suite.Require().NoError(err)
-
 	ctest.UpdateWithConflicts(suite, wg, func(r *network.LinkSpec) error {
 		r.TypedSpec().Wireguard.PrivateKey = priv2.String()
 
@@ -842,7 +851,7 @@ func (suite *LinkSpecSuite) TestWireguard() {
 	})
 
 	ctest.AssertResource(suite, wgInterface, func(r *network.LinkStatus, asrt *assert.Assertions) {
-		asrt.Equal(priv2.PublicKey().String(), r.TypedSpec().Wireguard.PublicKey)
+		asrt.Equal(priv2Pub.String(), r.TypedSpec().Wireguard.PublicKey)
 	})
 
 	// teardown the links

--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -81,12 +81,6 @@ func (ctrl *ManagerController) Outputs() []controller.Output {
 //
 //nolint:gocyclo,cyclop
 func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
-	if fipsmode.Strict() {
-		logger.Warn("SideroLink is not supported in strict FIPS mode")
-
-		return nil
-	}
-
 	// initially, wait for the network address status to be ready
 	if err := networkutils.WaitForNetworkReady(ctx, r,
 		func(status *network.StatusSpec) bool {
@@ -133,7 +127,10 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 	if bytes.Equal(ctrl.nodeKey[:], zeroKey[:]) {
 		var err error
 
-		ctrl.nodeKey, err = wgtypes.GeneratePrivateKey()
+		fipsmode.SkipEnforcement(logger, "siderolink.GenerateKey", func() {
+			ctrl.nodeKey, err = wgtypes.GeneratePrivateKey()
+		})
+
 		if err != nil {
 			return fmt.Errorf("error generating Wireguard key: %w", err)
 		}
@@ -392,10 +389,16 @@ func (ctrl *ManagerController) provision(ctx context.Context, r controller.Runti
 			wgOverGRPC = new(true)
 		}
 
+		var publicKeyString string
+
+		fipsmode.SkipEnforcement(logger, "siderolink.GenerateKey", func() {
+			publicKeyString = ctrl.nodeKey.PublicKey().String()
+		})
+
 		sideroLinkClient := pb.NewProvisionServiceClient(conn)
 		request := &pb.ProvisionRequest{
 			NodeUuid:          nodeUUID,
-			NodePublicKey:     ctrl.nodeKey.PublicKey().String(),
+			NodePublicKey:     publicKeyString,
 			NodeUniqueToken:   new(uniqTokenRes.TypedSpec().Token),
 			TalosVersion:      new(version.Tag),
 			WireguardOverGrpc: wgOverGRPC,

--- a/internal/app/machined/pkg/controllers/siderolink/manager_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	siderolinkctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/fipsmode"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
@@ -33,10 +32,6 @@ import (
 
 func TestManagerSuite(t *testing.T) {
 	t.Parallel()
-
-	if fipsmode.Strict() {
-		t.Skip("skipping test in strict FIPS mode")
-	}
 
 	suite.Run(t, &ManagerSuite{})
 }

--- a/pkg/machinery/fipsmode/fipsmode.go
+++ b/pkg/machinery/fipsmode/fipsmode.go
@@ -9,6 +9,8 @@ import (
 	"crypto/fips140"
 	"crypto/sha1"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Enabled checks if the system is running in FIPS mode.
@@ -31,3 +33,12 @@ var Strict = sync.OnceValue(func() bool {
 
 	return strict
 })
+
+// SkipEnforcement executes the given function without FIPS enforcement.
+func SkipEnforcement(logger *zap.Logger, functionName string, f func()) {
+	if Strict() {
+		logger.Warn("skipping FIPS enforcement for the given function (because strict FIPS mode is enabled)", zap.String("function", functionName))
+	}
+
+	fips140.WithoutEnforcement(f)
+}


### PR DESCRIPTION
Remove the skip statements/rework the code to allow FIPS builds to do Wireguard by wrapping Wireguard operations into `fips140.WithoutEnforcement` blocks.

Using Wireguard (or not using it) is still a user's choice, but this allows tests to run in strict mode.

There might be more fixes required for FIPS strict, right now being blocked by Go issue with X25119 which is going to be backported to Go 1.26.3.
