### PR TITLE
fix: wrong slot of encryption key was logged

### DIFF
--- a/internal/pkg/encryption/encryption.go
+++ b/internal/pkg/encryption/encryption.go
@@ -250,7 +250,7 @@ func (h *Handler) syncKeys(ctx context.Context, logger *zap.Logger, path string,
 
 				failedSyncs = append(failedSyncs, fmt.Sprintf("error removing key slot %s: %s", slot, err))
 			} else {
-				logger.Info("removed encryption key", zap.Int("slot", k.Slot))
+				logger.Info("removed encryption key", zap.Int("slot", int(s)))
 			}
 		}
 	}


### PR DESCRIPTION
During removal of encryption key, we logged slot of current key instead of the removed key.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
