### PR TITLE
fix: reduce memory dashboard usage

### DIFF
--- a/internal/app/dashboard/debug.go
+++ b/internal/app/dashboard/debug.go
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package dashboard
+
+import (
+	"context"
+	"log"
+
+	"github.com/siderolabs/go-debug"
+)
+
+func runDebugServer(ctx context.Context) {
+	const debugAddr = ":9984"
+
+	debugLogFunc := func(msg string) {
+		log.Print(msg)
+	}
+
+	if err := debug.ListenAndServe(ctx, debugAddr, debugLogFunc); err != nil {
+		log.Fatalf("failed to start debug server: %s", err)
+	}
+}

--- a/internal/app/dashboard/main.go
+++ b/internal/app/dashboard/main.go
@@ -39,11 +39,13 @@ func Main() {
 func dashboardMain() error {
 	startup.LimitMaxProcs(constants.DashboardMaxProcs)
 
-	md := metadata.Pairs()
-	authz.SetMetadata(md, role.MakeSet(role.Reader, role.MetaWriter))
-
 	ctx, cancel := sigtermAwareContext(context.Background())
 	defer cancel()
+
+	go runDebugServer(ctx)
+
+	md := metadata.Pairs()
+	authz.SetMetadata(md, role.MakeSet(role.Reader, role.MetaWriter))
 
 	ctx = metadata.NewOutgoingContext(ctx, md)
 

--- a/internal/pkg/dashboard/apidata/diff.go
+++ b/internal/pkg/dashboard/apidata/diff.go
@@ -73,13 +73,11 @@ func diskStatDiff(old, next *machine.DiskStat) *machine.DiskStat {
 	}
 }
 
-func procDiff(old, next *machine.ProcessInfo) *machine.ProcessInfo {
+func procDiff(old, next *machine.ProcessInfo) float64 {
 	if old == nil || next == nil {
-		return &machine.ProcessInfo{}
+		return 0
 	}
 
 	// TODO: support wraparound
-	return &machine.ProcessInfo{
-		CpuTime: next.CpuTime - old.CpuTime,
-	}
+	return next.CpuTime - old.CpuTime
 }

--- a/internal/pkg/dashboard/apidata/node.go
+++ b/internal/pkg/dashboard/apidata/node.go
@@ -27,7 +27,9 @@ type Node struct {
 	SystemStatDiff  *machine.SystemStat
 	NetDevStatsDiff *machine.NetworkDeviceStats
 	DiskStatsDiff   *machine.DiskStats
-	ProcsDiff       map[int32]*machine.ProcessInfo
+	// ProcsDiff maps pid to the CPU-time delta (float64) for that interval.
+	// Using float64 avoids allocating a ProcessInfo struct per process per tick.
+	ProcsDiff map[int32]float64
 
 	// Time-series data.
 	Series map[string][]float64
@@ -116,44 +118,20 @@ func (node *Node) ProcsCreated() uint64 {
 
 // UpdateSeries builds time-series data based on previous iteration data.
 func (node *Node) UpdateSeries(old *Node) {
-	node.Series = make(map[string][]float64)
+	node.Series = make(map[string][]float64, 8)
 
 	for _, graphInfo := range []struct {
 		name string
 		f    func() float64
 	}{
-		{
-			"mem",
-			node.MemUsage,
-		},
-		{
-			"user",
-			func() float64 { return node.CPUUsageByName("user") },
-		},
-		{
-			"system",
-			func() float64 { return node.CPUUsageByName("system") },
-		},
-		{
-			"loadavg",
-			func() float64 { return node.LoadAvg.GetLoad1() },
-		},
-		{
-			"netrxbytes",
-			func() float64 { return float64(node.NetDevStatsDiff.GetTotal().GetRxBytes()) },
-		},
-		{
-			"nettxbytes",
-			func() float64 { return float64(node.NetDevStatsDiff.GetTotal().GetTxBytes()) },
-		},
-		{
-			"diskrdsectors",
-			func() float64 { return float64(node.DiskStatsDiff.GetTotal().GetReadSectors()) },
-		},
-		{
-			"diskwrsectors",
-			func() float64 { return float64(node.DiskStatsDiff.GetTotal().GetWriteSectors()) },
-		},
+		{"mem", node.MemUsage},
+		{"user", func() float64 { return node.CPUUsageByName("user") }},
+		{"system", func() float64 { return node.CPUUsageByName("system") }},
+		{"loadavg", func() float64 { return node.LoadAvg.GetLoad1() }},
+		{"netrxbytes", func() float64 { return float64(node.NetDevStatsDiff.GetTotal().GetRxBytes()) }},
+		{"nettxbytes", func() float64 { return float64(node.NetDevStatsDiff.GetTotal().GetTxBytes()) }},
+		{"diskrdsectors", func() float64 { return float64(node.DiskStatsDiff.GetTotal().GetReadSectors()) }},
+		{"diskwrsectors", func() float64 { return float64(node.DiskStatsDiff.GetTotal().GetWriteSectors()) }},
 	} {
 		oldSeries := old.Series[graphInfo.name]
 
@@ -163,11 +141,6 @@ func (node *Node) UpdateSeries(old *Node) {
 		}
 
 		node.Series[graphInfo.name] = append(oldSeries[off:], graphInfo.f())
-
-		// TODO: bug with plot widget
-		for len(node.Series[graphInfo.name]) < 2 {
-			node.Series[graphInfo.name] = append([]float64{0.0}, node.Series[graphInfo.name]...)
-		}
 	}
 }
 
@@ -201,7 +174,7 @@ func (node *Node) UpdateDiff(old *Node) {
 			return proc.Pid, proc
 		})
 
-		node.ProcsDiff = xslices.ToMap(node.Processes.GetProcesses(), func(proc *machine.ProcessInfo) (int32, *machine.ProcessInfo) {
+		node.ProcsDiff = xslices.ToMap(node.Processes.GetProcesses(), func(proc *machine.ProcessInfo) (int32, float64) {
 			return proc.Pid, procDiff(index[proc.Pid], proc)
 		})
 	}

--- a/internal/pkg/dashboard/components/graphs.go
+++ b/internal/pkg/dashboard/components/graphs.go
@@ -18,15 +18,17 @@ import (
 type BaseGraph struct {
 	tview.Primitive
 
-	plot   *tvxwidgets.Plot
-	labels []string
+	plot     *tvxwidgets.Plot
+	labels   []string
+	plotData [][]float64 // pre-allocated; outer slice reused every update
 }
 
 // NewBaseGraph initializes BaseGraph.
 func NewBaseGraph(title string, labels []string) *BaseGraph {
 	widget := &BaseGraph{
-		plot:   tvxwidgets.NewPlot(),
-		labels: labels,
+		plot:     tvxwidgets.NewPlot(),
+		labels:   labels,
+		plotData: make([][]float64, len(labels)),
 	}
 
 	root := tview.NewFrame(widget.plot).
@@ -52,30 +54,26 @@ func (widget *BaseGraph) OnAPIDataChange(node string, data *apidata.Data) {
 	nodeData := data.Nodes[node]
 
 	if nodeData == nil {
-		plotData := make([][]float64, len(widget.labels))
-
 		for i := range widget.labels {
-			plotData[i] = []float64{0}
+			widget.plotData[i] = []float64{0}
 		}
 
-		widget.plot.SetData(plotData)
+		widget.plot.SetData(widget.plotData)
 
 		return
 	}
 
 	_, _, width, _ := widget.plot.GetPlotRect() //nolint:dogsled
 
-	plotData := make([][]float64, len(widget.labels))
-
 	for i, name := range widget.labels {
 		series := nodeData.Series[name]
 
 		maxPoints := min(width, len(series))
 
-		plotData[i] = slices.Clone(series[len(series)-maxPoints:])
+		widget.plotData[i] = slices.Clone(series[len(series)-maxPoints:])
 	}
 
-	widget.plot.SetData(plotData)
+	widget.plot.SetData(widget.plotData)
 }
 
 // NewCPUGraph creates CPU usage graph.

--- a/internal/pkg/dashboard/components/tables.go
+++ b/internal/pkg/dashboard/components/tables.go
@@ -23,8 +23,13 @@ import (
 type ProcessTable struct {
 	*tview.Table
 
-	lastNode string
+	lastNode     string
+	dataCells    [][processTableCols]*tview.TableCell
+	lastRowCount int
 }
+
+// processTableCols is the number of columns in the ProcessTable.
+const processTableCols = 9
 
 // NewProcessTable initializes ProcessTable.
 func NewProcessTable() *ProcessTable {
@@ -38,7 +43,22 @@ func NewProcessTable() *ProcessTable {
 	widget.SetBorderPadding(0, 0, 1, 0)
 	widget.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse))
 
-	widget.clear()
+	// Header cells are created once and never replaced.
+	widget.SetCell(0, 0, &tview.TableCell{Text: "[::b]PID", Align: tview.AlignRight, MaxWidth: pidWidth, NotSelectable: true})
+	widget.SetCell(0, 1, &tview.TableCell{Text: "[::b]S", Align: tview.AlignCenter, MaxWidth: stateWidth, NotSelectable: true})
+	widget.SetCell(0, 2, &tview.TableCell{Text: "[::b]CPU%", Align: tview.AlignRight, MaxWidth: cpuWidth, NotSelectable: true})
+	widget.SetCell(0, 3, &tview.TableCell{Text: "[::b]MEM%", Align: tview.AlignRight, MaxWidth: memWidth, NotSelectable: true})
+	widget.SetCell(0, 4, &tview.TableCell{Text: "[::b]VIRT", Align: tview.AlignRight, MaxWidth: virtWidth, NotSelectable: true})
+	widget.SetCell(0, 5, &tview.TableCell{Text: "[::b]RES", Align: tview.AlignRight, MaxWidth: resWidth, NotSelectable: true})
+	widget.SetCell(0, 6, &tview.TableCell{Text: "[::b]TIME+", Align: tview.AlignRight, MaxWidth: timeWidth, NotSelectable: true})
+	widget.SetCell(0, 7, &tview.TableCell{Text: "[::b]THR", Align: tview.AlignRight, MaxWidth: threadsWidth, NotSelectable: true})
+	widget.SetCell(0, 8, &tview.TableCell{Text: "[::b]COMMAND", Align: tview.AlignLeft, NotSelectable: true, Expansion: 1})
+
+	// Pre-allocate the noData placeholder in row 1.
+	widget.ensureDataRows(1)
+	widget.dataCells[0][0].Text = noData
+	widget.dataCells[0][0].Align = tview.AlignCenter
+	widget.lastRowCount = 0 // 0 means noData is displayed
 
 	return widget
 }
@@ -55,80 +75,55 @@ const (
 	threadsWidth = 4
 )
 
-func (widget *ProcessTable) clear() {
-	widget.Clear()
+// ensureDataRows grows the dataCells pool to hold at least n rows,
+// calling SetCell for any newly allocated cells.
+func (widget *ProcessTable) ensureDataRows(n int) {
+	for len(widget.dataCells) < n {
+		row := len(widget.dataCells)
 
-	widget.SetCell(0, 0, &tview.TableCell{
-		Text:          "[::b]PID",
-		Align:         tview.AlignRight,
-		MaxWidth:      pidWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 1, &tview.TableCell{
-		Text:          "[::b]S",
-		Align:         tview.AlignCenter,
-		MaxWidth:      stateWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 2, &tview.TableCell{
-		Text:          "[::b]CPU%",
-		Align:         tview.AlignRight,
-		MaxWidth:      cpuWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 3, &tview.TableCell{
-		Text:          "[::b]MEM%",
-		Align:         tview.AlignRight,
-		MaxWidth:      memWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 4, &tview.TableCell{
-		Text:          "[::b]VIRT",
-		Align:         tview.AlignRight,
-		MaxWidth:      virtWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 5, &tview.TableCell{
-		Text:          "[::b]RES",
-		Align:         tview.AlignRight,
-		MaxWidth:      resWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 6, &tview.TableCell{
-		Text:          "[::b]TIME+",
-		Align:         tview.AlignRight,
-		MaxWidth:      timeWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 7, &tview.TableCell{
-		Text:          "[::b]THR",
-		Align:         tview.AlignRight,
-		MaxWidth:      threadsWidth,
-		NotSelectable: true,
-	})
-	widget.SetCell(0, 8, &tview.TableCell{
-		Text:          "[::b]COMMAND",
-		Align:         tview.AlignLeft,
-		NotSelectable: true,
-		Expansion:     1,
-	})
+		var cells [processTableCols]*tview.TableCell
 
-	widget.SetCell(1, 0, &tview.TableCell{
-		Text:          noData,
-		Align:         tview.AlignCenter,
-		NotSelectable: true,
-	})
+		cells[0] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: pidWidth}
+		cells[1] = &tview.TableCell{Align: tview.AlignCenter, MaxWidth: stateWidth}
+		cells[2] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: cpuWidth}
+		cells[3] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: memWidth}
+		cells[4] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: virtWidth}
+		cells[5] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: resWidth}
+		cells[6] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: timeWidth}
+		cells[7] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: threadsWidth}
+		cells[8] = &tview.TableCell{Align: tview.AlignLeft, Expansion: 1}
+
+		widget.dataCells = append(widget.dataCells, cells)
+
+		for col, cell := range cells {
+			widget.SetCell(row+1, col, cell) // +1 because row 0 is the header
+		}
+	}
 }
 
 // OnAPIDataChange implements the APIDataListener interface.
 //
 //nolint:gocyclo
 func (widget *ProcessTable) OnAPIDataChange(node string, data *apidata.Data) {
-	widget.clear()
-
 	nodeData := data.Nodes[node]
 
-	if nodeData == nil {
+	if nodeData == nil || nodeData.Processes == nil {
+		// Show noData in first data row; blank any previously filled rows.
+		widget.ensureDataRows(1)
+		widget.dataCells[0][0].Text = noData
+		widget.dataCells[0][0].Align = tview.AlignCenter
+
+		for j := 1; j < processTableCols; j++ {
+			widget.dataCells[0][j].Text = ""
+		}
+
+		for i := 1; i < widget.lastRowCount; i++ {
+			for col := range widget.dataCells[i] {
+				widget.dataCells[i][col].Text = ""
+			}
+		}
+
+		widget.lastRowCount = 0
 		widget.Select(1, 0)
 
 		return
@@ -144,22 +139,18 @@ func (widget *ProcessTable) OnAPIDataChange(node string, data *apidata.Data) {
 		totalWeightedCPU = 1
 	}
 
-	// All downstream logic relies on nodeData.Processes to be not nil
-	// Putting a check here to reduce cyclomatic complexity
-	if nodeData.Processes == nil {
-		return
-	}
-
 	if nodeData.ProcsDiff != nil {
 		sort.Slice(nodeData.Processes.Processes, func(i, j int) bool {
-			proc1 := nodeData.Processes.Processes[i]
-			proc2 := nodeData.Processes.Processes[j]
-
-			return nodeData.ProcsDiff[proc1.Pid].CpuTime > nodeData.ProcsDiff[proc2.Pid].CpuTime
+			return nodeData.ProcsDiff[nodeData.Processes.Processes[i].Pid] > nodeData.ProcsDiff[nodeData.Processes.Processes[j].Pid]
 		})
 	}
 
+	numProcs := len(nodeData.Processes.Processes)
+	widget.ensureDataRows(numProcs)
+
 	for idx, proc := range nodeData.Processes.Processes {
+		cells := widget.dataCells[idx]
+
 		var args string
 
 		switch {
@@ -180,62 +171,30 @@ func (widget *ProcessTable) OnAPIDataChange(node string, data *apidata.Data) {
 			return r
 		}, args)
 
-		widget.SetCell(idx+1, 0, &tview.TableCell{
-			Text:     strconv.FormatInt(int64(proc.GetPid()), 10),
-			Align:    tview.AlignRight,
-			MaxWidth: pidWidth,
-		})
-
-		widget.SetCell(idx+1, 1, &tview.TableCell{
-			Text:     proc.State,
-			Align:    tview.AlignCenter,
-			MaxWidth: stateWidth,
-		})
-
-		widget.SetCell(idx+1, 2, &tview.TableCell{
-			Text:     fmt.Sprintf("%.1f", nodeData.ProcsDiff[proc.Pid].GetCpuTime()/totalWeightedCPU*100.0),
-			Align:    tview.AlignRight,
-			MaxWidth: cpuWidth,
-		})
-
-		widget.SetCell(idx+1, 3, &tview.TableCell{
-			Text:     fmt.Sprintf("%.1f", float64(proc.ResidentMemory)/float64(totalMem)*100.0),
-			Align:    tview.AlignRight,
-			MaxWidth: memWidth,
-		})
-
-		widget.SetCell(idx+1, 4, &tview.TableCell{
-			Text:     humanize.Bytes(proc.VirtualMemory),
-			Align:    tview.AlignRight,
-			MaxWidth: virtWidth,
-		})
-
-		widget.SetCell(idx+1, 5, &tview.TableCell{
-			Text:     humanize.Bytes(proc.ResidentMemory),
-			Align:    tview.AlignRight,
-			MaxWidth: resWidth,
-		})
-
-		widget.SetCell(idx+1, 6, &tview.TableCell{
-			Text:     (time.Duration(proc.CpuTime) * time.Second).String(),
-			Align:    tview.AlignRight,
-			MaxWidth: timeWidth,
-		})
-
-		widget.SetCell(idx+1, 7, &tview.TableCell{
-			Text:     strconv.FormatInt(int64(proc.Threads), 10),
-			Align:    tview.AlignRight,
-			MaxWidth: threadsWidth,
-		})
-
-		widget.SetCell(idx+1, 8, &tview.TableCell{
-			Text:  args,
-			Align: tview.AlignLeft,
-		})
+		// Restore normal alignment for the first cell (may have been used for noData).
+		cells[0].Align = tview.AlignRight
+		cells[0].Text = strconv.FormatInt(int64(proc.GetPid()), 10)
+		cells[1].Text = proc.State
+		cells[2].Text = fmt.Sprintf("%.1f", nodeData.ProcsDiff[proc.Pid]/totalWeightedCPU*100.0)
+		cells[3].Text = fmt.Sprintf("%.1f", float64(proc.ResidentMemory)/float64(totalMem)*100.0)
+		cells[4].Text = humanize.Bytes(proc.VirtualMemory)
+		cells[5].Text = humanize.Bytes(proc.ResidentMemory)
+		cells[6].Text = (time.Duration(proc.CpuTime) * time.Second).String()
+		cells[7].Text = strconv.FormatInt(int64(proc.Threads), 10)
+		cells[8].Text = args
 	}
 
+	// Blank rows that are no longer needed.
+	for i := numProcs; i < widget.lastRowCount; i++ {
+		for col := range widget.dataCells[i] {
+			widget.dataCells[i][col].Text = ""
+		}
+	}
+
+	widget.lastRowCount = numProcs
+
 	selectedRow, _ := widget.GetSelection()
-	if selectedRow > len(nodeData.Processes.Processes)+1 || widget.lastNode != node {
+	if selectedRow > numProcs+1 || widget.lastNode != node {
 		widget.Select(1, 0)
 	}
 

--- a/internal/pkg/dashboard/components/tables_test.go
+++ b/internal/pkg/dashboard/components/tables_test.go
@@ -21,14 +21,14 @@ func TestUpdate(t *testing.T) {
 				Processes: &machine.Process{
 					Processes: []*machine.ProcessInfo{},
 				},
-				ProcsDiff: map[int32]*machine.ProcessInfo{
-					1: {},
+				ProcsDiff: map[int32]float64{
+					1: 0,
 				},
 				Series: map[string][]float64{},
 			},
 			"node2": {
-				ProcsDiff: map[int32]*machine.ProcessInfo{
-					1: {},
+				ProcsDiff: map[int32]float64{
+					1: 0,
 				},
 			},
 		},

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -427,8 +427,6 @@ func (d *Dashboard) startDataHandler(ctx context.Context) func() error {
 		d.logDataSource.Start(ctx)
 		defer d.logDataSource.Stop() //nolint:errcheck
 
-		lastLogTime := time.Now()
-
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 
@@ -437,28 +435,37 @@ func (d *Dashboard) startDataHandler(ctx context.Context) func() error {
 			case <-ctx.Done():
 				return ctx.Err()
 			case nodeLog := <-d.logDataSource.LogCh:
-				if time.Since(lastLogTime) < 50*time.Millisecond {
-					d.app.QueueUpdate(func() {
-						d.processLog(nodeLog.Node, nodeLog.Log, nodeLog.Error)
-					})
-				} else {
-					d.app.QueueUpdateDraw(func() {
-						d.processLog(nodeLog.Node, nodeLog.Log, nodeLog.Error)
-					})
+				// Drain any additional log lines that are immediately available,
+				// so a burst of logs produces one closure instead of one per line.
+				logs := []logdata.Data{nodeLog}
+
+			drainLogs:
+				for {
+					select {
+					case nl := <-d.logDataSource.LogCh:
+						logs = append(logs, nl)
+					default:
+						break drainLogs
+					}
 				}
 
-				lastLogTime = time.Now()
+				d.app.QueueUpdate(func() {
+					for _, l := range logs {
+						d.processLog(l.Node, l.Log, l.Error)
+					}
+				})
 			case d.data = <-dataCh:
-				d.app.QueueUpdateDraw(func() {
+				d.app.QueueUpdate(func() {
 					if !d.paused {
 						d.processAPIData()
 					}
 				})
 			case nodeResource := <-d.resourceDataSource.NodeResourceCh:
-				d.app.QueueUpdateDraw(func() {
+				d.app.QueueUpdate(func() {
 					d.processNodeResource(nodeResource)
 				})
 			case <-ticker.C:
+				// Only the ticker triggers a full redraw, capping redraws at 2 fps.
 				d.app.QueueUpdateDraw(func() {
 					if !d.paused {
 						d.processTick()

--- a/internal/pkg/dashboard/logdata/logdata.go
+++ b/internal/pkg/dashboard/logdata/logdata.go
@@ -45,12 +45,17 @@ type Source struct {
 	LogCh chan Data
 }
 
+// logChBuffer is the capacity of LogCh. A generous buffer lets the sender
+// continue during UI-update bursts while the drain loop in the dashboard
+// handler batches the queued lines into a single QueueUpdate closure.
+const logChBuffer = 256
+
 // NewSource initializes and returns Source data source.
 func NewSource(client *client.Client, resolver resolver.Resolver) *Source {
 	return &Source{
 		client:   client,
 		resolver: resolver,
-		LogCh:    make(chan Data),
+		LogCh:    make(chan Data, logChBuffer),
 	}
 }
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -867,7 +867,7 @@ const (
 	CgroupKubeletMillicores = 1000
 
 	// CgroupDashboardMaxMemory is the hard memory limit for the dashboard process.
-	CgroupDashboardMaxMemory = 196 * 1024 * 1024
+	CgroupDashboardMaxMemory = 128 * 1024 * 1024
 
 	// CgroupDashboardMillicores is the CPU weight for the dashboard process.
 	CgroupDashboardMillicores = 200


### PR DESCRIPTION
Many small changes, memory reduction measured to be aroun -20MiB.

Reduce cgroup memory limit.

Changes:

* limit updates to 2fps
* batch log updates
* reuse/maps slices to reduce allocations
