### PR TITLE
fix: return failed precondition on upgrade when not installed

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -503,6 +503,10 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 		return nil, err
 	}
 
+	if !s.Controller.Runtime().State().Machine().Installed() {
+		return nil, status.Errorf(codes.FailedPrecondition, "Talos is not installed")
+	}
+
 	log.Printf("upgrade request received: staged %v, force %v, reboot mode %v", in.GetStage(), in.GetForce(), in.GetRebootMode().String())
 
 	log.Printf("validating %q", in.GetImage())


### PR DESCRIPTION
This check was in maintenance Upgrade API for Talos <= 1.12, so keep it in the "normal" API as well.

It always makes sense - the upgrade would fail if Talos is not installed, but that failure in legacy Upgrade API is async and not reported properly back.
