### PR TITLE
fix: do not publish fatal event on expected sequence termination

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/machine_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status.go
@@ -422,8 +422,10 @@ func (ctrl *MachineStatusController) watchEvents() {
 						newStage = runtime.MachineStageRebooting
 					}
 				case machineapi.SequenceEvent_NOOP:
-					if event.Error != nil && event.Error.Code == common.Code_FATAL {
-						// fatal errors lead to reboot
+					shuttingDown := currentSequence == v1alpha1runtime.SequenceShutdown.String()
+
+					// fatal errors lead to reboot, but do not set the stage to rebooting if we are shutting down
+					if event.Error != nil && event.Error.Code == common.Code_FATAL && !shuttingDown {
 						newStage = runtime.MachineStageRebooting
 					}
 				case machineapi.SequenceEvent_STOP:

--- a/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -17,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	runtimectrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/runtime"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -156,4 +158,46 @@ func (suite *MachineStatusSuite) TestReconcile() {
 	}
 
 	suite.assertMachineStatus(runtime.MachineStageRebooting, true, nil)
+
+	// Start a shutdown sequence. The shutdown task returns a RebootError at the end, which the
+	// sequencer publishes as a NOOP event with Code_FATAL. The stage should stay at "shutting down"
+	// throughout, not flip to "rebooting".
+	suite.eventCh <- v1alpha1runtime.EventInfo{
+		Event: v1alpha1runtime.Event{
+			Payload: &machineapi.SequenceEvent{
+				Sequence: v1alpha1runtime.SequenceShutdown.String(),
+				Action:   machineapi.SequenceEvent_START,
+			},
+		},
+	}
+
+	suite.assertMachineStatus(runtime.MachineStageShuttingDown, true, nil)
+
+	suite.eventCh <- v1alpha1runtime.EventInfo{
+		Event: v1alpha1runtime.Event{
+			Payload: &machineapi.SequenceEvent{
+				Sequence: v1alpha1runtime.SequenceShutdown.String(),
+				Action:   machineapi.SequenceEvent_NOOP,
+				Error: &common.Error{
+					Code:    common.Code_FATAL,
+					Message: "sequence failed: unix.Reboot(4321fedc)",
+				},
+			},
+		},
+	}
+
+	// Poll over a short window to verify the stage never flips to "rebooting" or any other stage after the NOOP event.
+	suite.Require().Never(
+		func() bool {
+			status, err := safe.StateGetByID[*runtime.MachineStatus](suite.Ctx(), suite.State(), runtime.MachineStatusID)
+			suite.NoError(err, "status should exist")
+
+			return status.TypedSpec().Stage != runtime.MachineStageShuttingDown
+		},
+		500*time.Millisecond,
+		50*time.Millisecond,
+		"machine stage should not flip to rebooting during shutdown sequence",
+	)
+
+	suite.assertMachineStatus(runtime.MachineStageShuttingDown, true, nil)
 }


### PR DESCRIPTION
Sequences that intentionally terminate the machine (reboot, shutdown, upgrade, etc.) return a reboot signal to the sequencer when they complete. This was being treated as a sequence failure and published as a fatal event, which downstream consumers (including the machine stage tracking) interpreted as the machine entering reboot, even when it was actually shutting down.

The reboot signal is now recognized as expected termination and no longer emitted as a fatal event.
