### PR TITLE
chore(ci): nvidia update helm values

### DIFF
--- a/internal/integration/api/testdata/nvidia-gpu-operator.yaml
+++ b/internal/integration/api/testdata/nvidia-gpu-operator.yaml
@@ -3,4 +3,4 @@ driver:
 toolkit:
   enabled: false
 hostPaths:
-  driverInstallDir: /usr/local/lib
+  driverInstallDir: /usr/local


### PR DESCRIPTION
See #13159, newer GPU operator v26.3.1 has better detection.