### PR TITLE
test: add image verification for factory.talos.dev

### DIFF
--- a/hack/test/patches/image-verification.yaml
+++ b/hack/test/patches/image-verification.yaml
@@ -11,3 +11,7 @@ rules:
       keyless:
         issuer: https://accounts.google.com
         subjectRegex: '(@siderolabs\.com$|^releasemgr-svc@talos-production\.iam\.gserviceaccount\.com$)'
+    - image: factory.talos.dev/*
+      keyless:
+        issuer: https://accounts.google.com
+        subject: image-factory-signing@talos-production.iam.gserviceaccount.com


### PR DESCRIPTION
This modifies a test patch, it will not have much effect in the CI (as it doesn't pull from factory.talos.dev), but good for local testing.
