### PR TITLE
test: fix a flake in the manifest sync test

### DIFF
--- a/internal/integration/k8s/manifests.go
+++ b/internal/integration/k8s/manifests.go
@@ -16,6 +16,8 @@ import (
 	"go.yaml.in/yaml/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/cluster/kubernetes"
@@ -122,7 +124,8 @@ func (suite *ManifestsSuite) TestSync() {
 
 	// 3. Assert that kube-proxy has the extra arg
 	pods, err := suite.Clientset.CoreV1().Pods("kube-system").List(suite.ctx, metav1.ListOptions{
-		LabelSelector: "k8s-app=kube-proxy",
+		LabelSelector: labels.Set{"k8s-app": "kube-proxy"}.String(),
+		FieldSelector: fields.OneTermEqualSelector("status.phase", "Running").String(),
 	})
 	suite.Require().NoError(err)
 	suite.Require().NotEmpty(pods.Items)
@@ -130,7 +133,7 @@ func (suite *ManifestsSuite) TestSync() {
 	for _, pod := range pods.Items {
 		suite.Require().NotEmpty(pod.Spec.Containers)
 
-		suite.Assert().Contains(pod.Spec.Containers[0].Command, "--nodeport-addresses=0.0.0.0/0")
+		suite.Assert().Contains(pod.Spec.Containers[0].Command, "--nodeport-addresses=0.0.0.0/0", "pod is %#+v", pod)
 	}
 
 	// 4. Disable kube-proxy


### PR DESCRIPTION
A sample failure:

```
manifests.go:133:
        	Error Trace:	/src/internal/integration/k8s/manifests.go:133
        	Error:      	[]string{"/usr/local/bin/kube-proxy", "--cluster-cidr=10.244.0.0/16", "--conntrack-max-per-core=0", "--hostname-override=$(NODE_NAME)", "--kubeconfig=/etc/kubernetes/kubeconfig", "--proxy-mode=nftables"} does not contain "--nodeport-addresses=0.0.0.0/0"
        	Test:       	TestIntegration/k8s.ManifestsSuite/TestSync
    manifests.go:137: disabling kube-proxy
```

My running theory is that `List()` picks up a stale pod, so trying to filter it out and log it in full if we hit it.
