### PR TITLE
docs: rename security-insights.yml to lowercase for LFX detection

### DIFF
--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,7 +1,7 @@
 header:
-  schema-version: 2.1.0
-  last-updated: '2026-03-26'
-  last-reviewed: '2026-03-26'
+  schema-version: 2.2.0
+  last-updated: '2026-04-22'
+  last-reviewed: '2026-04-22'
   url: https://github.com/siderolabs/talos
   comment: >
     Security Insights for Talos Linux. This file satisfies OSPS Baseline QA-04.01


### PR DESCRIPTION
## What? (description)

Renames `SECURITY-INSIGHTS.yml` → `security-insights.yml` and bumps `schema-version` from `2.1.0` to `2.2.0` (current, released 2026-01-31).

Closes #13189.

## Why? (reasoning)

The previous issue (#13045) landed the file with an uppercase name. The [OSSF Security Insights spec](https://github.com/ossf/security-insights) and its reference implementation at [ossf/si-tooling](https://github.com/ossf/si-tooling/blob/main/v2/si/security_insights.go) require the lowercase form. LFX Insights scans case-sensitively, so the file was never detected — OSPS-QA-04.01 continues to fail on the [dashboard](https://insights.linuxfoundation.org/project/siderolabs-talos/repository/siderolabs_talos/security) with "Insights does not contain a list of repositories", and the Quality score remains at 60%.

Validated against the v2.2.0 `#SecurityInsights` CUE schema with `cue vet` — passes cleanly.

## Acceptance

- [x] you linked an issue (if applicable) — #13189
- [ ] you included tests (if applicable) — N/A (metadata file)
- [ ] you ran conformance (`make conformance`) — N/A for a single YAML rename
- [ ] you formatted your code (`make fmt`) — N/A
- [ ] you linted your code (`make lint`) — N/A
- [ ] you generated documentation (`make docs`) — N/A
- [ ] you ran unit-tests (`make unit-tests`) — N/A

> Validated with `cue vet -d '#SecurityInsights' spec/schema.cue security-insights.yml` against `ossf/security-insights@v2.2.0`.