### PR TITLE
feat: add customHeaders support to cluster.network.cni

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -394,11 +394,14 @@ func NewControlPlaneExtraManifestsController() *ControlPlaneExtraManifestsContro
 
 				spec := k8s.ExtraManifestsConfigSpec{}
 
+				cniHeaders := cfgProvider.Cluster().Network().CNI().CustomHeaders()
+
 				for _, url := range cfgProvider.Cluster().Network().CNI().URLs() {
 					spec.ExtraManifests = append(spec.ExtraManifests, k8s.ExtraManifest{
-						Name:     url,
-						URL:      url,
-						Priority: "05", // push CNI to the top
+						Name:         url,
+						URL:          url,
+						Priority:     "05", // push CNI to the top
+						ExtraHeaders: cniHeaders,
 					})
 				}
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
@@ -923,6 +923,65 @@ func (suite *K8sControlPlaneSuite) TestReconcileKubeProxyModeLegacy() {
 	)
 }
 
+func (suite *K8sControlPlaneSuite) TestReconcileCNICustomHeaders() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(
+		container.NewV1Alpha1(
+			&v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							URL: u,
+						},
+					},
+					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
+						CNI: &v1alpha1.CNIConfig{
+							CNIName: "custom",
+							CNIUrls: []string{
+								"https://raw.githubusercontent.com/example/cni/main/cni.yaml",
+								"https://raw.githubusercontent.com/example/cni/main/cni-rbac.yaml",
+							},
+							CNICustomHeaders: map[string]string{
+								"Authorization": "Bearer token123",
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+
+	suite.setupMachine(cfg)
+
+	rtestutils.AssertResources(suite.Ctx(), suite.T(), suite.State(), []resource.ID{k8s.ExtraManifestsConfigID},
+		func(extraManifests *k8s.ExtraManifestsConfig, assert *assert.Assertions) {
+			assert.Equal(
+				&k8s.ExtraManifestsConfigSpec{
+					ExtraManifests: []k8s.ExtraManifest{
+						{
+							Name:         "https://raw.githubusercontent.com/example/cni/main/cni.yaml",
+							URL:          "https://raw.githubusercontent.com/example/cni/main/cni.yaml",
+							Priority:     "05",
+							ExtraHeaders: map[string]string{"Authorization": "Bearer token123"},
+						},
+						{
+							Name:         "https://raw.githubusercontent.com/example/cni/main/cni-rbac.yaml",
+							URL:          "https://raw.githubusercontent.com/example/cni/main/cni-rbac.yaml",
+							Priority:     "05",
+							ExtraHeaders: map[string]string{"Authorization": "Bearer token123"},
+						},
+					},
+				}, extraManifests.TypedSpec())
+		},
+	)
+}
+
 func TestK8sControlPlaneSuite(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/machinery/config/config/cluster.go
+++ b/pkg/machinery/config/config/cluster.go
@@ -65,6 +65,7 @@ type ClusterNetwork interface {
 type CNI interface {
 	Name() string
 	URLs() []string
+	CustomHeaders() map[string]string
 	Flannel() FlannelCNI
 }
 

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -4009,6 +4009,18 @@
           "markdownDescription": "URLs containing manifests to apply for the CNI.\nShould be present for \"custom\", must be empty for \"flannel\" and \"none\".",
           "x-intellij-html-description": "\u003cp\u003eURLs containing manifests to apply for the CNI.\nShould be present for \u0026ldquo;custom\u0026rdquo;, must be empty for \u0026ldquo;flannel\u0026rdquo; and \u0026ldquo;none\u0026rdquo;.\u003c/p\u003e\n"
         },
+        "customHeaders": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "title": "customHeaders",
+          "description": "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.\n",
+          "markdownDescription": "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.",
+          "x-intellij-html-description": "\u003cp\u003eA map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.\u003c/p\u003e\n"
+        },
         "flannel": {
           "$ref": "#/$defs/v1alpha1.FlannelCNIConfig",
           "title": "flannel",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
@@ -20,6 +20,11 @@ func (c *CNIConfig) URLs() []string {
 	return c.CNIUrls
 }
 
+// CustomHeaders implements the config.CNI interface.
+func (c *CNIConfig) CustomHeaders() map[string]string {
+	return c.CNICustomHeaders
+}
+
 // Flannel implements the config.CNI interface.
 func (c *CNIConfig) Flannel() config.FlannelCNI {
 	return c.CNIFlannel

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1555,6 +1555,16 @@ type CNIConfig struct {
 	//     Should be present for "custom", must be empty for "flannel" and "none".
 	CNIUrls []string `yaml:"urls,omitempty"`
 	//   description: |
+	//     A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+	//     This is useful for authenticated CNI manifest downloads.
+	//   examples:
+	//     - value: >
+	//         map[string]string{
+	//           "Authorization": "Bearer token123",
+	//           "X-Custom-Header": "value",
+	//         }
+	CNICustomHeaders map[string]string `yaml:"customHeaders,omitempty"`
+	//   description: |
 	//		Flannel configuration options.
 	CNIFlannel *FlannelCNIConfig `yaml:"flannel,omitempty"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1628,6 +1628,13 @@ func (CNIConfig) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "URLs containing manifests to apply for the CNI." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
+				Name:        "customHeaders",
+				Type:        "map[string]string",
+				Note:        "",
+				Description: "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "flannel",
 				Type:        "FlannelCNIConfig",
 				Note:        "",
@@ -1638,6 +1645,11 @@ func (CNIConfig) Doc() *encoder.Doc {
 	}
 
 	doc.AddExample("", clusterCustomCNIExample())
+
+	doc.Fields[2].AddExample("", map[string]string{
+		"Authorization":   "Bearer token123",
+		"X-Custom-Header": "value",
+	})
 
 	return doc
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -470,9 +470,19 @@ func ValidateCNI(cni config.CNI) ([]string, error) {
 			result = multierror.Append(result, err)
 		}
 
+		if len(cni.CustomHeaders()) != 0 {
+			err := fmt.Errorf(`"customHeaders" field should be empty for %q CNI`, cni.Name())
+			result = multierror.Append(result, err)
+		}
+
 	case constants.NoneCNI:
 		if len(cni.URLs()) != 0 {
 			err := fmt.Errorf(`"urls" field should be empty for %q CNI`, cni.Name())
+			result = multierror.Append(result, err)
+		}
+
+		if len(cni.CustomHeaders()) != 0 {
+			err := fmt.Errorf(`"customHeaders" field should be empty for %q CNI`, cni.Name())
 			result = multierror.Append(result, err)
 		}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -2209,6 +2209,38 @@ func TestValidateCNI(t *testing.T) {
 			},
 			expectedError: "1 error occurred:\n\t* \"flannelKubeNetworkPoliciesEnabled\" should not be enabled for \"none\" CNI\n\n",
 		},
+		{
+			name: "CustomHeaders",
+			config: &v1alpha1.CNIConfig{
+				CNIName: constants.CustomCNI,
+				CNIUrls: []string{
+					"https://host.test/quick-install.yaml",
+				},
+				CNICustomHeaders: map[string]string{
+					"Authorization": "Bearer token123",
+				},
+			},
+		},
+		{
+			name: "FlannelCustomHeaders",
+			config: &v1alpha1.CNIConfig{
+				CNIName: constants.FlannelCNI,
+				CNICustomHeaders: map[string]string{
+					"Authorization": "Bearer token123",
+				},
+			},
+			expectedError: "1 error occurred:\n\t* \"customHeaders\" field should be empty for \"flannel\" CNI\n\n",
+		},
+		{
+			name: "NoneCustomHeaders",
+			config: &v1alpha1.CNIConfig{
+				CNIName: constants.NoneCNI,
+				CNICustomHeaders: map[string]string{
+					"Authorization": "Bearer token123",
+				},
+			},
+			expectedError: "1 error occurred:\n\t* \"customHeaders\" field should be empty for \"none\" CNI\n\n",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -226,6 +226,13 @@ func (in *CNIConfig) DeepCopyInto(out *CNIConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CNICustomHeaders != nil {
+		in, out := &in.CNICustomHeaders, &out.CNICustomHeaders
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.CNIFlannel != nil {
 		in, out := &in.CNIFlannel, &out.CNIFlannel
 		*out = new(FlannelCNIConfig)

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -973,6 +973,11 @@ cluster:
         # The CNI used.
         cni:
             name: flannel # Name of CNI to use.
+
+            # # A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+            # customHeaders:
+            #     Authorization: Bearer token123
+            #     X-Custom-Header: value
         dnsDomain: cluster.local # The domain used by Kubernetes DNS.
         # The pod subnet CIDR.
         podSubnets:
@@ -998,6 +1003,11 @@ network:
     # The CNI used.
     cni:
         name: flannel # Name of CNI to use.
+
+        # # A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+        # customHeaders:
+        #     Authorization: Bearer token123
+        #     X-Custom-Header: value
     dnsDomain: cluster.local # The domain used by Kubernetes DNS.
     # The pod subnet CIDR.
     podSubnets:
@@ -1267,6 +1277,11 @@ cluster:
         # The CNI used.
         cni:
             name: flannel # Name of CNI to use.
+
+            # # A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+            # customHeaders:
+            #     Authorization: Bearer token123
+            #     X-Custom-Header: value
         dnsDomain: cluster.local # The domain used by Kubernetes DNS.
         # The pod subnet CIDR.
         podSubnets:
@@ -1285,6 +1300,11 @@ cni:
     # URLs containing manifests to apply for the CNI.
     urls:
         - https://docs.projectcalico.org/archive/v3.20/manifests/canal.yaml
+
+    # # A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+    # customHeaders:
+    #     Authorization: Bearer token123
+    #     X-Custom-Header: value
 {{< /highlight >}}</details> | |
 |`dnsDomain` |string |The domain used by Kubernetes DNS.<br>The default is `cluster.local` <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 dnsDomain: cluster.local
@@ -1315,6 +1335,11 @@ cluster:
             # URLs containing manifests to apply for the CNI.
             urls:
                 - https://docs.projectcalico.org/archive/v3.20/manifests/canal.yaml
+
+            # # A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.
+            # customHeaders:
+            #     Authorization: Bearer token123
+            #     X-Custom-Header: value
 {{< /highlight >}}
 
 
@@ -1322,6 +1347,11 @@ cluster:
 |-------|------|-------------|----------|
 |`name` |string |Name of CNI to use.  |`flannel`<br />`custom`<br />`none`<br /> |
 |`urls` |[]string |URLs containing manifests to apply for the CNI.<br>Should be present for "custom", must be empty for "flannel" and "none".  | |
+|`customHeaders` |map[string]string |A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.<br>This is useful for authenticated CNI manifest downloads. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+customHeaders:
+    Authorization: Bearer token123
+    X-Custom-Header: value
+{{< /highlight >}}</details> | |
 |`flannel` |<a href="#Config.cluster.network.cni.flannel">FlannelCNIConfig</a> |description: |<br>Flannel configuration options.<br>  | |
 
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -4009,6 +4009,18 @@
           "markdownDescription": "URLs containing manifests to apply for the CNI.\nShould be present for \"custom\", must be empty for \"flannel\" and \"none\".",
           "x-intellij-html-description": "\u003cp\u003eURLs containing manifests to apply for the CNI.\nShould be present for \u0026ldquo;custom\u0026rdquo;, must be empty for \u0026ldquo;flannel\u0026rdquo; and \u0026ldquo;none\u0026rdquo;.\u003c/p\u003e\n"
         },
+        "customHeaders": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "title": "customHeaders",
+          "description": "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.\n",
+          "markdownDescription": "A map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.",
+          "x-intellij-html-description": "\u003cp\u003eA map of key-value pairs that will be added as HTTP headers while fetching CNI URLs.\nThis is useful for authenticated CNI manifest downloads.\u003c/p\u003e\n"
+        },
         "flannel": {
           "$ref": "#/$defs/v1alpha1.FlannelCNIConfig",
           "title": "flannel",


### PR DESCRIPTION
## What? (description)

Add a `customHeaders` field to `CNIConfig` (`cluster.network.cni`) that allows specifying arbitrary HTTP headers to be sent when fetching CNI manifest URLs.

The new field is a `map[string]string` and is only valid when `cni.name` is `custom`. It is rejected by validation for `flannel` and `none` CNI types.

## Why? (reasoning)

Some CNI manifests are hosted behind authenticated endpoints — private registries, internal artifact servers, or GitHub repos requiring a bearer token. Without this field there is no way to fetch such manifests during cluster bootstrap, forcing users to mirror manifests to a public location.

The headers are forwarded to `ExtraManifest.ExtraHeaders` for every CNI URL, so the existing manifest-fetching path handles them without any new download logic.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)