### PR TITLE
feat: add quirk for talosctl factory downloads

### DIFF
--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -324,3 +324,15 @@ func (q Quirks) ProcMemOverrideNever() bool {
 
 	return q.v.GTE(minTalosVersionProcMemOverrideNever)
 }
+
+var minTalosVersionFactoryTalosctlDownload = semver.MustParse("1.11.0-alpha.3")
+
+// SupportsFactoryTalosctlDownload returns true if the Talos version supports downloading talosctl from image factory.
+func (q Quirks) SupportsFactoryTalosctlDownload() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minTalosVersionFactoryTalosctlDownload)
+}


### PR DESCRIPTION
Add a SupportsFactoryTalosctlDownload quirk to mark the minimum version that supports talosctl downloads from factory

See:
- https://github.com/siderolabs/image-factory/pull/431#discussion_r3137080655
