### PR TITLE
feat(images): default to factory installer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,6 +287,7 @@ ARG NAME
 ARG SHA
 ARG USERNAME
 ARG REGISTRY
+ARG FACTORY
 ARG TAG
 ARG ARTIFACTS
 ARG PKGS
@@ -296,6 +297,7 @@ RUN mkdir -p pkg/machinery/gendata/data && \
     echo -n ${SHA} > pkg/machinery/gendata/data/sha && \
     echo -n ${USERNAME} > pkg/machinery/gendata/data/username && \
     echo -n ${REGISTRY} > pkg/machinery/gendata/data/registry && \
+    echo -n ${FACTORY} > pkg/machinery/gendata/data/factory && \
     echo -n ${PKGS} > pkg/machinery/gendata/data/pkgs && \
     echo -n ${TOOLS} > pkg/machinery/gendata/data/tools && \
     echo -n ${TAG} > pkg/machinery/gendata/data/tag && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REGISTRY ?= ghcr.io
+FACTORY ?= factory.talos.dev
 USERNAME ?= siderolabs
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]\*)
@@ -242,6 +243,7 @@ COMMON_ARGS += --build-arg=PKG_ZSTD=$(PKG_ZSTD)
 COMMON_ARGS += --build-arg=PKGS_PREFIX=$(PKGS_PREFIX)
 COMMON_ARGS += --build-arg=PKGS=$(PKGS)
 COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
+COMMON_ARGS += --build-arg=FACTORY=$(FACTORY)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 COMMON_ARGS += --build-arg=TAG=$(TAG)

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -206,7 +206,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 
 		qemu.BoolVar(&qOps.PreallocateDisks, preallocateDisksFlag, true, "whether disk space should be preallocated")
 		qemu.StringSliceVar(&qOps.ClusterUserVolumes, clusterUserVolumesFlag, qOps.ClusterUserVolumes, "list of user volumes to create for each VM in format: <name1>:<size1>:<name2>:<size2>")
-		qemu.StringVar(&qOps.NodeInstallImage, nodeInstallImageFlag, helpers.DefaultImage(images.DefaultInstallerImageRepository), "the installer image to use")
+		qemu.StringVar(&qOps.NodeInstallImage, nodeInstallImageFlag, helpers.DefaultImage(images.InstallerImageRepository("metal")), "the installer image to use")
 		qemu.StringVar(&qOps.NodeVmlinuzPath, nodeVmlinuzPathFlag, helpers.ArtifactPath(constants.KernelAssetWithArch), "the compressed kernel image to use")
 		qemu.StringVar(&qOps.NodeISOPath, nodeISOPathFlag, qOps.NodeISOPath, "the ISO path to use for the initial boot")
 		qemu.StringVar(&qOps.NodeUSBPath, nodeUSBPathFlag, qOps.NodeUSBPath, "the USB stick image path to use for the initial boot")

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -428,7 +428,7 @@ func init() {
 	genConfigCmd := NewConfigCmd("config")
 
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.installDisk, "install-disk", "/dev/sda", "the disk to install to")
-	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.installImage, "install-image", helpers.DefaultImage(images.DefaultInstallerImageRepository), "the image used to perform an installation")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.installImage, "install-image", helpers.DefaultImage(images.InstallerImageRepository("metal")), "the image used to perform an installation")
 	genConfigCmd.Flags().StringSliceVar(&genConfigCmdFlags.additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.configVersion, "version", "v1alpha1", "the desired machine config version to generate")

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -344,7 +344,7 @@ func upgradeGetActorID(ctx context.Context, c *client.Client, opts []client.Upgr
 
 func init() {
 	upgradeCmd.Flags().StringVarP(&upgradeCmdFlags.upgradeImage, "image", "i",
-		fmt.Sprintf("%s/%s/installer:%s", images.Registry, images.Username, version.Trim(version.Tag)),
+		fmt.Sprintf("%s:%s", images.InstallerImageRepository("metal"), version.Trim(version.Tag)),
 		"the container image to use for performing the install")
 	upgradeCmd.Flags().StringVar(&upgradeCmdFlags.namespace, "namespace", "system",
 		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance",

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -41,6 +41,11 @@ Talos now runs etcd and kube-apiserver with a minimum TLS version of 1.3, improv
 Custom settings for cipher suites have been removed, as they are ignored when TLS 1.3 is used, which simplifies configuration and ensures the use of modern, secure defaults.
 """
 
+    [notes.defaultInstaller]
+        title = "Default Installer Image"
+        description = """\
+The default installer image has been updated to use the Image Factory.
+"""
 
 [make_deps]
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1505,7 +1505,7 @@ func Install(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 		case !r.State().Machine().Installed():
 			installerImage := r.Config().Machine().Install().Image()
 			if installerImage == "" {
-				installerImage = images.DefaultInstallerImage
+				installerImage = images.InstallerImage("metal")
 			}
 
 			logger.Printf("waiting for the image cache")

--- a/internal/integration/provision/k8s_compatibility.go
+++ b/internal/integration/provision/k8s_compatibility.go
@@ -153,7 +153,7 @@ func (suite *K8sCompatibilitySuite) TestAllVersions() {
 		SourceInstallerImage: fmt.Sprintf(
 			"%s/%s:%s",
 			DefaultSettings.TargetInstallImageRegistry,
-			images.DefaultInstallerImageName,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 			DefaultSettings.CurrentVersion,
 		),
 		SourceVersion:    DefaultSettings.CurrentVersion,

--- a/internal/integration/provision/maintenance_basic.go
+++ b/internal/integration/provision/maintenance_basic.go
@@ -67,7 +67,7 @@ func (suite *MaintenanceBasicSuite) TestAPI() {
 		SourceInstallerImage: fmt.Sprintf(
 			"%s/%s:%s",
 			DefaultSettings.TargetInstallImageRegistry,
-			images.DefaultInstallerImageName,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 			DefaultSettings.CurrentVersion,
 		),
 		SourceVersion:    DefaultSettings.CurrentVersion,

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -62,7 +62,7 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 	sourceInstallerImage := fmt.Sprintf(
 		"%s/%s:%s",
 		DefaultSettings.TargetInstallImageRegistry,
-		images.DefaultInstallerImageName,
+		images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 		DefaultSettings.CurrentVersion,
 	)
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -108,7 +108,7 @@ func upgradeStableToCurrent() upgradeSpec {
 		TargetInstallerImage: fmt.Sprintf(
 			"%s/%s:%s",
 			DefaultSettings.TargetInstallImageRegistry,
-			images.DefaultInstallerImageName,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 			DefaultSettings.CurrentVersion,
 		),
 		TargetVersion:    DefaultSettings.CurrentVersion,
@@ -126,7 +126,7 @@ func upgradeCurrentToCurrent() upgradeSpec {
 	installerImage := fmt.Sprintf(
 		"%s/%s:%s",
 		DefaultSettings.TargetInstallImageRegistry,
-		images.DefaultInstallerImageName,
+		images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 		DefaultSettings.CurrentVersion,
 	)
 
@@ -155,7 +155,7 @@ func upgradeCurrentToCurrentBios() upgradeSpec {
 	installerImage := fmt.Sprintf(
 		"%s/%s:%s",
 		DefaultSettings.TargetInstallImageRegistry,
-		images.DefaultInstallerImageName,
+		images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 		DefaultSettings.CurrentVersion,
 	)
 
@@ -194,7 +194,7 @@ func upgradeStableToCurrentPreserveStage() upgradeSpec {
 		TargetInstallerImage: fmt.Sprintf(
 			"%s/%s:%s",
 			DefaultSettings.TargetInstallImageRegistry,
-			images.DefaultInstallerImageName,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 			DefaultSettings.CurrentVersion,
 		),
 		TargetVersion:    DefaultSettings.CurrentVersion,
@@ -210,7 +210,7 @@ func upgradeCurrentToCurrentNewCmdline() upgradeSpec {
 	installerImage := fmt.Sprintf(
 		"%s/%s:%s",
 		DefaultSettings.TargetInstallImageRegistry,
-		images.DefaultInstallerImageName,
+		images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 		DefaultSettings.CurrentVersion,
 	)
 
@@ -241,7 +241,7 @@ func upgradeCurrentToCurrentEnforcing() upgradeSpec {
 	installerImage := fmt.Sprintf(
 		"%s/%s:%s",
 		DefaultSettings.TargetInstallImageRegistry,
-		images.DefaultInstallerImageName,
+		images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
 		DefaultSettings.CurrentVersion,
 	)
 

--- a/pkg/imager/profile/input.go
+++ b/pkg/imager/profile/input.go
@@ -189,10 +189,10 @@ func (i *Input) FillDefaults(arch, version string, secureboot bool) {
 	}
 
 	if i.BaseInstaller == zeroContainerAsset {
-		i.BaseInstaller.ImageRef = fmt.Sprintf("%s:%s", images.DefaultInstallerImageRepository, version)
+		i.BaseInstaller.ImageRef = fmt.Sprintf("%s:%s", images.DefaultInstallerImageRepository, version) //nolint:staticcheck // required as a <1.11.0 fallback
 
 		if quirks.New(version).SupportsUnifiedInstaller() {
-			i.BaseInstaller.ImageRef = fmt.Sprintf("%s-base:%s", images.DefaultInstallerImageRepository, version)
+			i.BaseInstaller.ImageRef = fmt.Sprintf("%s:%s", images.DefaultInstallerBaseImageRepository, version)
 		}
 	}
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -17,16 +17,27 @@ var (
 	// Registry is the default registry.
 	Registry = gendata.ImagesRegistry
 
+	// Factory is the default factory for images.
+	Factory = gendata.ImageFactory
+
+	// DefaultInstallerImageSchematic is the default (empty) image schematic for the installer.
+	DefaultInstallerImageSchematic = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
 	// DefaultInstallerImageName is the default container image name for
 	// the installer.
+	//
+	// Deprecated: This image is only used for legacy installer for Talos <1.11.0 and during tests.
 	DefaultInstallerImageName = Username + "/installer"
 
 	// DefaultInstallerImageRepository is the default container repository for
 	// the installer.
+	//
+	// Deprecated: This image is only used for legacy installer for Talos <1.11.0 and during tests.
 	DefaultInstallerImageRepository = Registry + "/" + DefaultInstallerImageName
 
-	// DefaultInstallerImage is the default installer image.
-	DefaultInstallerImage = DefaultInstallerImageRepository + ":" + version.Tag
+	// DefaultInstallerBaseImageRepository is the default container repository for
+	// installer-base image.
+	DefaultInstallerBaseImageRepository = Registry + "/" + Username + "/installer-base"
 
 	// DefaultTalosImageName is the default container image name for
 	// the talos image.
@@ -38,10 +49,6 @@ var (
 
 	// DefaultTalosImage is the default talos image.
 	DefaultTalosImage = DefaultTalosImageRepository + ":" + version.Tag
-
-	// DefaultInstallerBaseImageRepository is the default container repository for
-	// installer-base image.
-	DefaultInstallerBaseImageRepository = Registry + "/" + Username + "/installer-base"
 
 	// DefaultImagerImageRepository is the default container repository for
 	// imager image.
@@ -67,3 +74,13 @@ var (
 	// extensions manifest.
 	DefaultExtensionsManifestRepository = Registry + "/" + DefaultExtensionsManifestName
 )
+
+// InstallerImageRepository returns the default container repository for the installer for the given platform.
+func InstallerImageRepository(platform string) string {
+	return Factory + "/" + platform + "-installer/" + DefaultInstallerImageSchematic
+}
+
+// InstallerImage returns the default installer image for the given platform.
+func InstallerImage(platform string) string {
+	return InstallerImageRepository(platform) + ":" + version.Tag
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -900,7 +900,7 @@ type InstallConfig struct {
 	//     Image reference for each Talos release can be found on
 	//     [GitHub releases page](https://github.com/siderolabs/talos/releases).
 	//   examples:
-	//     - value: '"ghcr.io/siderolabs/installer:latest"'
+	//     - value: '"factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest"'
 	InstallImage string `yaml:"image,omitempty"`
 	// docgen:nodoc
 	//

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -945,7 +945,7 @@ func (InstallConfig) Doc() *encoder.Doc {
 	doc.Fields[0].AddExample("", "/dev/sda")
 	doc.Fields[0].AddExample("", "/dev/nvme0")
 	doc.Fields[1].AddExample("", machineInstallDiskSelectorExample())
-	doc.Fields[3].AddExample("", "ghcr.io/siderolabs/installer:latest")
+	doc.Fields[3].AddExample("", "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest")
 
 	return doc
 }

--- a/pkg/machinery/gendata/data/factory
+++ b/pkg/machinery/gendata/data/factory
@@ -1,0 +1,1 @@
+factory.talos.dev

--- a/pkg/machinery/gendata/gendata.go
+++ b/pkg/machinery/gendata/gendata.go
@@ -29,6 +29,9 @@ var (
 	// ImagesRegistry declares variable used by images package.
 	//go:embed data/registry
 	ImagesRegistry string
+	// ImageFactory declares variable used by images package.
+	//go:embed data/factory
+	ImageFactory string
 	// ArtifactsPath declares variable used by helpers package.
 	//go:embed data/artifacts
 	ArtifactsPath string

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -171,7 +171,7 @@ talosctl cluster create dev [flags]
       --image-cache-tls-key-file string          path to image cache TLS key
       --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
       --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
-      --install-image string                     the installer image to use (default "ghcr.io/siderolabs/installer:latest")
+      --install-image string                     the installer image to use (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest")
       --ipv4                                     enable IPv4 network in the cluster (default true)
       --ipv6                                     enable IPv6 network in the cluster
       --ipxe-boot-script string                  iPXE boot script (URL) to use
@@ -386,7 +386,7 @@ talosctl cluster create dev [flags]
       --image-cache-tls-key-file string          path to image cache TLS key
       --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
       --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
-      --install-image string                     the installer image to use (default "ghcr.io/siderolabs/installer:latest")
+      --install-image string                     the installer image to use (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest")
       --ipv4                                     enable IPv4 network in the cluster (default true)
       --ipv6                                     enable IPv6 network in the cluster
       --ipxe-boot-script string                  iPXE boot script (URL) to use
@@ -1878,7 +1878,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
-      --install-image string                     the image used to perform an installation (default "ghcr.io/siderolabs/installer:latest")
+      --install-image string                     the image used to perform an installation (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest")
       --kubernetes-version string                desired kubernetes version to run (default "1.36.0")
   -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
   -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
@@ -3454,7 +3454,7 @@ talosctl upgrade [flags]
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for upgrade
-  -i, --image string               the container image to use for performing the install (default "ghcr.io/siderolabs/installer:v1.13.0-alpha.2")
+  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.13.0-alpha.2")
       --legacy                     force use of legacy upgrade method
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
   -n, --nodes strings              target the specified nodes

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -559,7 +559,7 @@ diskSelector:
     # busPath: /pci0000:00/*
 {{< /highlight >}}</details> | |
 |`image` |string |Allows for supplying the image used to perform the installation.<br>Image reference for each Talos release can be found on<br>[GitHub releases page](https://github.com/siderolabs/talos/releases). <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-image: ghcr.io/siderolabs/installer:latest
+image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest
 {{< /highlight >}}</details> | |
 |`wipe` |bool |Indicates if the installation disk should be wiped at installation time.<br>Defaults to `true`.  |`true`<br />`yes`<br />`false`<br />`no`<br /> |
 |`legacyBIOSSupport` |bool |Indicates if MBR partition should be marked as bootable (active).<br>Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.  | |


### PR DESCRIPTION
Defaults to installer image from factory.talos.dev. Default images now
use schematic hash naming (metal-installer/<hash>) instead of
registry-based naming.

Fixes https://github.com/siderolabs/talos/issues/13138

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
