### PR TITLE
revert: changes for automatic merging 'service-account-issuer'

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -156,14 +156,6 @@ This includes fields such as `.cluster.apiServer.extraArgs`.
 BREAKING: If you were relying on the resources EtcdConfigs, KubeletConfigs, ControllerManagerConfigs, SchedulerConfigs or APIServerConfigs, the protobuf format has changed from `map<string,string>` to `map<string,message>`.
 """
 
-    [notes.serviceAccountIssuer]
-        title = "Service Account Issuer configuration"
-        description = """\
-In API Server, passing extra args with `service-account-issuer` will append them after default value.
-This allows easy migration, e.g. by changing `.cluster.controlPlane.endpoint` to new value, and keeping the old value in
-`.cluster.apiServer.extraArgs["service-account-issuer"]`.
-"""
-
     [notes.negativeMaxVolumeSize]
     title = "Negative Max Volume Size"
     description = """\
@@ -305,6 +297,7 @@ for more details on how to configure NVIDIA GPU support in Talos.
         description = """\
 Talos now supports routing rules via the new `RoutingRuleConfig` machine config document.
 """
+
 
 [make_deps]
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -429,7 +429,7 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"etcd-keyfile":                     argsbuilder.MergeDenied,
 		"kubelet-client-certificate":       argsbuilder.MergeDenied,
 		"kubelet-client-key":               argsbuilder.MergeDenied,
-		"service-account-issuer":           argsbuilder.MergeAppend,
+		"service-account-issuer":           argsbuilder.MergePrepend,
 		"service-account-key-file":         argsbuilder.MergeDenied,
 		"service-account-signing-key-file": argsbuilder.MergeDenied,
 		"tls-cert-file":                    argsbuilder.MergeDenied,

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -429,7 +429,6 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"etcd-keyfile":                     argsbuilder.MergeDenied,
 		"kubelet-client-certificate":       argsbuilder.MergeDenied,
 		"kubelet-client-key":               argsbuilder.MergeDenied,
-		"service-account-issuer":           argsbuilder.MergePrepend,
 		"service-account-key-file":         argsbuilder.MergeDenied,
 		"service-account-signing-key-file": argsbuilder.MergeDenied,
 		"tls-cert-file":                    argsbuilder.MergeDenied,

--- a/pkg/argsbuilder/argsbuilder_args.go
+++ b/pkg/argsbuilder/argsbuilder_args.go
@@ -53,18 +53,6 @@ func (a Args) Merge(args Args, setters ...MergeOption) error {
 		case MergeOverwrite:
 			a[key] = slices.Clone(val)
 
-		case MergeAppend:
-			existing := make([]string, 0, len(val)+len(a[key]))
-			existing = append(existing, a[key]...)
-			existing = append(existing, val...)
-			a[key] = existing
-
-		case MergePrepend:
-			existing := make([]string, 0, len(val)+len(a[key]))
-			existing = append(existing, val...)
-			existing = append(existing, a[key]...)
-			a[key] = existing
-
 		case MergeAdditive:
 			// 1. Join the existing []string slice into one string so we can Split it.
 			//    This handles cases where a[key] might be ["a", "b"] or ["a,b"].

--- a/pkg/argsbuilder/argsbuilder_interface.go
+++ b/pkg/argsbuilder/argsbuilder_interface.go
@@ -14,10 +14,6 @@ const (
 	MergeAdditive
 	// MergeDenied fail merge if another object has the arg defined.
 	MergeDenied
-	// MergePrepend prepends new values before existing ones.
-	MergePrepend
-	// MergeAppend appends new values after existing ones.
-	MergeAppend
 )
 
 // MergePolicies merge policy map.

--- a/pkg/argsbuilder/argsbuilder_test.go
+++ b/pkg/argsbuilder/argsbuilder_test.go
@@ -23,10 +23,9 @@ func (suite *ArgsbuilderSuite) TestMergeAdditive() {
 	}
 
 	suite.Require().NoError(
-		args.Merge(
-			argsbuilder.Args{
-				"param": {"value2, value10"},
-			},
+		args.Merge(argsbuilder.Args{
+			"param": {"value2, value10"},
+		},
 			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
 				"param": argsbuilder.MergeAdditive,
 			}),
@@ -72,72 +71,6 @@ func (suite *ArgsbuilderSuite) TestMergeOverwrite() {
 
 	suite.Require().Equal([]string{"value10", "value11"}, args["param"])
 	suite.Assert().Equal([]string{"--param=value10", "--param=value11"}, args.Args())
-}
-
-//nolint:dupl
-func (suite *ArgsbuilderSuite) TestMergePrepend() {
-	args := argsbuilder.Args{
-		"param": {"value1"},
-	}
-
-	suite.Require().NoError(
-		args.Merge(argsbuilder.Args{
-			"param": {"value2", "value3"},
-		},
-			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
-				"param": argsbuilder.MergePrepend,
-			}),
-		),
-	)
-
-	suite.Require().Equal([]string{"value2", "value3", "value1"}, args["param"])
-	suite.Assert().Equal([]string{"--param=value2", "--param=value3", "--param=value1"}, args.Args())
-
-	suite.Require().NoError(
-		args.Merge(argsbuilder.Args{
-			"param": {"value4"},
-		},
-			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
-				"param": argsbuilder.MergePrepend,
-			}),
-		),
-	)
-
-	suite.Require().Equal([]string{"value4", "value2", "value3", "value1"}, args["param"])
-	suite.Assert().Equal([]string{"--param=value4", "--param=value2", "--param=value3", "--param=value1"}, args.Args())
-}
-
-//nolint:dupl
-func (suite *ArgsbuilderSuite) TestMergeAppend() {
-	args := argsbuilder.Args{
-		"param": {"value1"},
-	}
-
-	suite.Require().NoError(
-		args.Merge(argsbuilder.Args{
-			"param": {"value2", "value3"},
-		},
-			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
-				"param": argsbuilder.MergeAppend,
-			}),
-		),
-	)
-
-	suite.Require().Equal([]string{"value1", "value2", "value3"}, args["param"])
-	suite.Assert().Equal([]string{"--param=value1", "--param=value2", "--param=value3"}, args.Args())
-
-	suite.Require().NoError(
-		args.Merge(argsbuilder.Args{
-			"param": {"value4"},
-		},
-			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
-				"param": argsbuilder.MergeAppend,
-			}),
-		),
-	)
-
-	suite.Require().Equal([]string{"value1", "value2", "value3", "value4"}, args["param"])
-	suite.Assert().Equal([]string{"--param=value1", "--param=value2", "--param=value3", "--param=value4"}, args.Args())
 }
 
 func (suite *ArgsbuilderSuite) TestMergeDenied() {


### PR DESCRIPTION
https://github.com/siderolabs/talos/pull/13215

This reverts commits:
- d1954278a1ba3470b2e5ccae90762078c18d69e9.
- 01a3678913de0fa4d309a361428c117d24ce0d1e.

Fixes #13210 