### PR TITLE
feat: auto-enroll SecureBoot keys for disk images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-05-01T15:48:11Z by kres 1762ab2.
+# Generated on 2026-05-05T17:21:59Z by kres 1762ab2.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -4800,6 +4800,94 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # version: v7.0.1
         with:
           name: talos-logs-integration-trusted-boot-default
+          path: |-
+            /tmp/logs-*.tar.gz
+            /tmp/support-*.zip
+          retention-days: "5"
+  integration-trusted-boot-disk-image:
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      packages: write
+      pull-requests: read
+    runs-on:
+      group: large
+    if: contains(fromJSON(needs.default.outputs.labels || '[]'), 'integration/trusted-boot-disk-image') || contains(fromJSON(needs.default.outputs.labels || '[]'), 'integration/trusted-boot') || contains(fromJSON(needs.default.outputs.labels || '[]'), 'integration/release-gate')
+    needs:
+      - default
+      - integration-build-enforcing
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          name: talos-enforcing-artifacts
+          path: _out
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
+      - name: image-secureboot-metal
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-secureboot-metal
+      - name: integration-trusted-boot
+        env:
+          EXTRA_TEST_ARGS: -talos.trustedboot
+          GITHUB_STEP_NAME: ${{ github.job}}-integration-trusted-boot-disk-image
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          VIA_MAINTENANCE_MODE: "true"
+          WITH_CONFIG_PATCH: '@hack/test/patches/image-verification.yaml'
+          WITH_TRUSTED_BOOT_DISK_IMAGE: "true"
+        run: |
+          sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # version: v7.0.1
+        with:
+          name: talos-logs-integration-trusted-boot-disk-image
           path: |-
             /tmp/logs-*.tar.gz
             /tmp/support-*.zip

--- a/.github/workflows/integration-trusted-boot-triggered.yaml
+++ b/.github/workflows/integration-trusted-boot-triggered.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-27T17:59:00Z by kres e4dc583.
+# Generated on 2026-05-05T17:21:59Z by kres 1762ab2.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -26,13 +26,19 @@ jobs:
           - extraTestArgs: -talos.trustedboot
             variant: default
             withConfigPatch: '@hack/test/patches/image-verification.yaml'
+            withTrustedBootISO: "true"
+          - extraTestArgs: -talos.trustedboot
+            variant: disk-image
+            withConfigPatch: '@hack/test/patches/image-verification.yaml'
+            withTrustedBootDiskImage: "true"
           - extraTestArgs: -talos.trustedboot -talos.enforcing
             tagSuffixIn: -enforcing
             variant: enforcing
             withConfigPatch: '@hack/test/patches/image-verification.yaml'
             withEnforcing: "true"
+            withTrustedBootISO: "true"
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
     steps:
       - name: gather-system-info
         id: system-info
@@ -92,6 +98,14 @@ jobs:
           PLATFORM: linux/amd64,linux/arm64
         run: |
           make secureboot-iso
+      - name: image-secureboot-metal
+        if: ${{ matrix.withTrustedBootDiskImage }}
+        env:
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          IMAGER_ARGS: --extra-kernel-arg=console=ttyS0
+          PLATFORM: linux/amd64,linux/arm64
+        run: |
+          make image-secureboot-metal
       - name: integration-trusted-boot
         env:
           EXTRA_TEST_ARGS: ${{ matrix.extraTestArgs }}
@@ -101,7 +115,8 @@ jobs:
           VIA_MAINTENANCE_MODE: "true"
           WITH_CONFIG_PATCH: ${{ matrix.withConfigPatch }}
           WITH_ENFORCING: ${{ matrix.withEnforcing }}
-          WITH_TRUSTED_BOOT_ISO: "true"
+          WITH_TRUSTED_BOOT_DISK_IMAGE: ${{ matrix.withTrustedBootDiskImage }}
+          WITH_TRUSTED_BOOT_ISO: ${{ matrix.withTrustedBootISO }}
         run: |
           sudo -E make e2e-qemu
       - name: save artifacts

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -619,15 +619,21 @@ spec:
         - integration/trusted-boot
         - integration/release-gate
       matrix:
-        maxParallel: 2
+        maxParallel: 3
         labelKeys: [variant]
         include:
           - variant: default
             withConfigPatch: "@hack/test/patches/image-verification.yaml"
+            withTrustedBootISO: "true"
             extraTestArgs: "-talos.trustedboot"
+          - variant: disk-image
+            withConfigPatch: "@hack/test/patches/image-verification.yaml"
+            extraTestArgs: "-talos.trustedboot"
+            withTrustedBootDiskImage: "true"
           - variant: enforcing
             withConfigPatch: "@hack/test/patches/image-verification.yaml"
             tagSuffixIn: -enforcing
+            withTrustedBootISO: "true"
             withEnforcing: "true"
             extraTestArgs: "-talos.trustedboot -talos.enforcing"
       steps:
@@ -644,13 +650,21 @@ spec:
             PLATFORM: linux/amd64,linux/arm64
             IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0 --extra-kernel-arg=enforcing=1"
             IMAGE_REGISTRY: registry.dev.siderolabs.io
+        - name: image-secureboot-metal
+          conditions:
+            - matrix.withTrustedBootDiskImage
+          environment:
+            PLATFORM: linux/amd64,linux/arm64
+            IMAGER_ARGS: "--extra-kernel-arg=console=ttyS0"
+            IMAGE_REGISTRY: registry.dev.siderolabs.io
         - name: integration-trusted-boot
           command: e2e-qemu
           withSudo: true
           environment:
             GITHUB_STEP_NAME: ${{ github.job}}-integration-trusted-boot-${{ matrix.variant }}
             VIA_MAINTENANCE_MODE: true
-            WITH_TRUSTED_BOOT_ISO: true
+            WITH_TRUSTED_BOOT_ISO: ${{ matrix.withTrustedBootISO }}
+            WITH_TRUSTED_BOOT_DISK_IMAGE: ${{ matrix.withTrustedBootDiskImage }}
             WITH_CONFIG_PATCH: ${{ matrix.withConfigPatch }}
             TAG_SUFFIX_IN: ${{ matrix.tagSuffixIn }}
             WITH_ENFORCING: ${{ matrix.withEnforcing }}

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -74,6 +74,16 @@ type Options struct {
 	BootAssets          bootloaderoptions.BootAssets
 	Printf              func(string, ...any)
 	MountPrefix         string
+
+	// SecureBoot key auto-enrollment (image creation mode only).
+	//
+	// When SecureBootEnrollKeys is non-empty, the bootloader installer writes
+	// loader/keys/auto/{PK,KEK,db}.auth on the ESP and renders loader.conf with
+	// secure-boot-enroll set to this value.
+	SecureBootEnrollKeys string
+	PlatformKeyPath      string
+	KeyExchangeKeyPath   string
+	SignatureKeyPath     string
 }
 
 // Mode is the install mode.
@@ -517,6 +527,11 @@ func (i *Installer) generateBootloaderOptions(ctx context.Context, mode Mode, in
 		Printf:            i.options.Printf,
 		MountPrefix:       i.options.MountPrefix,
 		BlkidInfo:         info,
+
+		SecureBootEnrollKeys: i.options.SecureBootEnrollKeys,
+		PlatformKeyPath:      i.options.PlatformKeyPath,
+		KeyExchangeKeyPath:   i.options.KeyExchangeKeyPath,
+		SignatureKeyPath:     i.options.SignatureKeyPath,
 
 		ExtraInstallStep: func() error {
 			if i.options.OverlayInstaller != nil {

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -179,6 +179,15 @@ case "${WITH_TRUSTED_BOOT_ISO:-false}" in
     ;;
 esac
 
+case "${WITH_TRUSTED_BOOT_DISK_IMAGE:-false}" in
+  false)
+    ;;
+  *)
+    INSTALLER_IMAGE=${INSTALLER_IMAGE}-amd64-secureboot
+    QEMU_FLAGS+=("--disk-image-path=_out/metal-amd64-secureboot.raw.zst" "--with-tpm2" "--encrypt-ephemeral" "--encrypt-state" "--encrypt-user-volumes" "--disk-encryption-key-types=tpm")
+    ;;
+esac
+
 case "${WITH_TPM1_2:-false}" in
   false)
     ;;

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options/options.go
@@ -43,6 +43,16 @@ type InstallOptions struct {
 
 	// Optional: blkid probe result.
 	BlkidInfo *blkid.Info
+
+	// SecureBoot key auto-enrollment (image mode only).
+	//
+	// When SecureBootEnrollKeys is non-empty, the sd-boot installer writes
+	// loader/keys/auto/{PK,KEK,db}.auth on the ESP using the provided key
+	// paths and renders loader.conf with this secure-boot-enroll mode.
+	SecureBootEnrollKeys string
+	PlatformKeyPath      string
+	KeyExchangeKeyPath   string
+	SignatureKeyPath     string
 }
 
 // InstallResult is the result of the installation.

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/export_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/export_test.go
@@ -8,4 +8,5 @@ package sdboot
 var (
 	FindMatchingUKIFile = findMatchingUKIFile
 	GenerateNextUKIName = generateNextUKIName
+	GenerateAssets      = (*Config).generateAssets
 )

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/generate_assets_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/generate_assets_test.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sdboot_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/options"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func TestGenerateAssets(t *testing.T) {
+	t.Parallel()
+
+	const (
+		baseLoaderConf = "# systemd-boot configuration\n\ntimeout 10\n"
+		ukiContents    = "fake-uki"
+		sdBootContents = "fake-sd-boot"
+		pkContents     = "fake-pk-auth"
+		kekContents    = "fake-kek-auth"
+		dbContents     = "fake-db-auth"
+		ukiFileName    = "Talos-1.13.0.efi"
+	)
+
+	for _, tc := range []struct {
+		name           string
+		enrollKeys     string
+		expectedConf   string
+		expectKeysAuto bool
+	}{
+		{
+			name:           "no_enrollment",
+			enrollKeys:     "",
+			expectedConf:   baseLoaderConf,
+			expectKeysAuto: false,
+		},
+		{
+			name:           "if_safe",
+			enrollKeys:     "if-safe",
+			expectedConf:   baseLoaderConf + "\nsecure-boot-enroll if-safe\n",
+			expectKeysAuto: true,
+		},
+		{
+			name:           "force",
+			enrollKeys:     "force",
+			expectedConf:   baseLoaderConf + "\nsecure-boot-enroll force\n",
+			expectKeysAuto: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mountPrefix := t.TempDir()
+			srcDir := t.TempDir()
+
+			ukiPath := filepath.Join(srcDir, "uki.efi")
+			sdBootPath := filepath.Join(srcDir, "systemd-bootx64.efi")
+			pkPath := filepath.Join(srcDir, "PK.auth")
+			kekPath := filepath.Join(srcDir, "KEK.auth")
+			dbPath := filepath.Join(srcDir, "db.auth")
+
+			require.NoError(t, os.WriteFile(ukiPath, []byte(ukiContents), 0o644))
+			require.NoError(t, os.WriteFile(sdBootPath, []byte(sdBootContents), 0o644))
+			require.NoError(t, os.WriteFile(pkPath, []byte(pkContents), 0o644))
+			require.NoError(t, os.WriteFile(kekPath, []byte(kekContents), 0o644))
+			require.NoError(t, os.WriteFile(dbPath, []byte(dbContents), 0o644))
+
+			opts := options.InstallOptions{
+				Arch:        "amd64",
+				MountPrefix: mountPrefix,
+				BootAssets: options.BootAssets{
+					UKIPath:    ukiPath,
+					SDBootPath: sdBootPath,
+				},
+				SecureBootEnrollKeys: tc.enrollKeys,
+				PlatformKeyPath:      pkPath,
+				KeyExchangeKeyPath:   kekPath,
+				SignatureKeyPath:     dbPath,
+				Printf:               func(string, ...any) {},
+			}
+
+			require.NoError(t, sdboot.GenerateAssets(&sdboot.Config{}, opts, ukiFileName))
+
+			loaderDir := filepath.Join(mountPrefix, constants.EFIMountPoint, "loader")
+
+			confBytes, err := os.ReadFile(filepath.Join(loaderDir, "loader.conf"))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedConf, string(confBytes))
+
+			keysDir := filepath.Join(loaderDir, "keys", "auto")
+
+			if tc.expectKeysAuto {
+				for filename, expectedContent := range map[string]string{
+					constants.PlatformKeyAsset:    pkContents,
+					constants.KeyExchangeKeyAsset: kekContents,
+					constants.SignatureKeyAsset:   dbContents,
+				} {
+					got, err := os.ReadFile(filepath.Join(keysDir, filename))
+					require.NoError(t, err, "reading %s", filename)
+					require.Equal(t, expectedContent, string(got), "content of %s", filename)
+				}
+			} else {
+				_, err := os.Stat(keysDir)
+				require.True(t, os.IsNotExist(err), "loader/keys/auto should not exist when no enrollment keys configured")
+			}
+
+			// UKI is copied to EFI/Linux/<ukiFileName>
+			gotUKI, err := os.ReadFile(filepath.Join(mountPrefix, constants.EFIMountPoint, "EFI", "Linux", ukiFileName))
+			require.NoError(t, err)
+			require.Equal(t, ukiContents, string(gotUKI))
+
+			// sd-boot is copied to EFI/boot/BOOTX64.efi (amd64)
+			gotSDBoot, err := os.ReadFile(filepath.Join(mountPrefix, constants.EFIMountPoint, "EFI", "boot", "BOOTX64.efi"))
+			require.NoError(t, err)
+			require.Equal(t, sdBootContents, string(gotSDBoot))
+		})
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
@@ -439,11 +439,33 @@ func (c *Config) setup(opts options.InstallOptions, ukiFileName string) (*option
 }
 
 func (c *Config) generateAssets(opts options.InstallOptions, ukiFileName string) error {
-	if err := os.MkdirAll(filepath.Join(opts.MountPrefix, constants.EFIMountPoint, "loader"), 0o755); err != nil {
+	loaderDir := filepath.Join(opts.MountPrefix, constants.EFIMountPoint, "loader")
+
+	if err := os.MkdirAll(loaderDir, 0o755); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.MountPrefix, constants.EFIMountPoint, "loader", "loader.conf"), LoaderConfBytes, 0o644); err != nil {
+	loaderConf := LoaderConfBytes
+
+	if opts.SecureBootEnrollKeys != "" {
+		loaderConf = slices.Concat(loaderConf, []byte("\nsecure-boot-enroll "+opts.SecureBootEnrollKeys+"\n"))
+
+		keysDir := filepath.Join(loaderDir, "keys", "auto")
+		if err := os.MkdirAll(keysDir, 0o755); err != nil {
+			return err
+		}
+
+		if err := utils.CopyFiles(
+			opts.Printf,
+			utils.SourceDestination(opts.PlatformKeyPath, filepath.Join(keysDir, constants.PlatformKeyAsset)),
+			utils.SourceDestination(opts.KeyExchangeKeyPath, filepath.Join(keysDir, constants.KeyExchangeKeyAsset)),
+			utils.SourceDestination(opts.SignatureKeyPath, filepath.Join(keysDir, constants.SignatureKeyAsset)),
+		); err != nil {
+			return err
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(loaderDir, "loader.conf"), loaderConf, 0o644); err != nil {
 		return err
 	}
 

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -142,42 +142,11 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		if i.prof.Input.SecureBoot.PlatformKeyPath == "" {
 			report.Report(reporter.Update{Message: "generating SecureBoot database...", Status: reporter.StatusRunning})
+		}
 
-			// generate the database automatically from provided values
-			enrolledPEM := pem.EncodeToMemory(&pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: signer.Certificate().Raw,
-			})
-
-			var entries []database.Entry
-
-			entries, err = database.Generate(enrolledPEM, signer, database.IncludeWellKnownCertificates(i.prof.Input.SecureBoot.IncludeWellKnownCerts))
-			if err != nil {
-				return fmt.Errorf("failed to generate database: %w", err)
-			}
-
-			for _, entry := range entries {
-				entryPath := filepath.Join(i.tempDir, entry.Name)
-
-				if err = os.WriteFile(entryPath, entry.Contents, 0o600); err != nil {
-					return err
-				}
-
-				switch entry.Name {
-				case constants.PlatformKeyAsset:
-					options.PlatformKeyPath = entryPath
-				case constants.KeyExchangeKeyAsset:
-					options.KeyExchangeKeyPath = entryPath
-				case constants.SignatureKeyAsset:
-					options.SignatureKeyPath = entryPath
-				default:
-					return fmt.Errorf("unknown database entry: %s", entry.Name)
-				}
-			}
-		} else {
-			options.PlatformKeyPath = i.prof.Input.SecureBoot.PlatformKeyPath
-			options.KeyExchangeKeyPath = i.prof.Input.SecureBoot.KeyExchangeKeyPath
-			options.SignatureKeyPath = i.prof.Input.SecureBoot.SignatureKeyPath
+		options.PlatformKeyPath, options.KeyExchangeKeyPath, options.SignatureKeyPath, err = i.prepareEnrollmentDBs(signer)
+		if err != nil {
+			return err
 		}
 
 		generator, err = options.CreateUEFI(ctx, printf)
@@ -306,6 +275,71 @@ func (i *Imager) outImage(ctx context.Context, path string, report *reporter.Rep
 	return nil
 }
 
+// prepareEnrollmentDBs returns paths to PK, KEK and db .auth files for SecureBoot
+// key auto-enrollment. If the profile supplies pre-built DBs via
+// Input.SecureBoot.PlatformKeyPath (etc.), those paths are returned as-is.
+// Otherwise, the databases are generated from the signer and written to i.tempDir.
+//
+//nolint:gocyclo
+func (i *Imager) prepareEnrollmentDBs(signer pesign.CertificateSigner) (pkPath, kekPath, dbPath string, err error) {
+	pkPath = i.prof.Input.SecureBoot.PlatformKeyPath
+	kekPath = i.prof.Input.SecureBoot.KeyExchangeKeyPath
+	dbPath = i.prof.Input.SecureBoot.SignatureKeyPath
+
+	if pkPath != "" || kekPath != "" || dbPath != "" {
+		var missing []string
+
+		if pkPath == "" {
+			missing = append(missing, "Input.SecureBoot.PlatformKeyPath")
+		}
+
+		if kekPath == "" {
+			missing = append(missing, "Input.SecureBoot.KeyExchangeKeyPath")
+		}
+
+		if dbPath == "" {
+			missing = append(missing, "Input.SecureBoot.SignatureKeyPath")
+		}
+
+		if len(missing) > 0 {
+			return "", "", "", fmt.Errorf("partial SecureBoot pre-built database configuration: missing %s", strings.Join(missing, ", "))
+		}
+
+		return pkPath, kekPath, dbPath, nil
+	}
+
+	enrolledPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: signer.Certificate().Raw,
+	})
+
+	entries, err := database.Generate(enrolledPEM, signer, database.IncludeWellKnownCertificates(i.prof.Input.SecureBoot.IncludeWellKnownCerts))
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to generate database: %w", err)
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(i.tempDir, entry.Name)
+
+		if err := os.WriteFile(entryPath, entry.Contents, 0o600); err != nil {
+			return "", "", "", err
+		}
+
+		switch entry.Name {
+		case constants.PlatformKeyAsset:
+			pkPath = entryPath
+		case constants.KeyExchangeKeyAsset:
+			kekPath = entryPath
+		case constants.SignatureKeyAsset:
+			dbPath = entryPath
+		default:
+			return "", "", "", fmt.Errorf("unknown database entry: %s", entry.Name)
+		}
+	}
+
+	return pkPath, kekPath, dbPath, nil
+}
+
 //nolint:gocyclo
 func (i *Imager) buildImage(ctx context.Context, path string, printf func(string, ...any)) error {
 	var zeroContainerAsset profile.ContainerAsset
@@ -349,6 +383,23 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 		opts.OverlayInstaller = i.overlayInstaller
 		opts.ExtraOptions = i.prof.Overlay.ExtraOptions
 		opts.OverlayExtractedDir = i.tempDir
+	}
+
+	if i.prof.SecureBootEnabled() && i.prof.Output.ImageOptions.SDBootEnrollKeys != profile.SDBootEnrollKeysOff {
+		signer, err := i.prof.Input.SecureBoot.SecureBootSigner.GetSigner(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get SecureBoot signer: %w", err)
+		}
+
+		pk, kek, db, err := i.prepareEnrollmentDBs(signer)
+		if err != nil {
+			return err
+		}
+
+		opts.SecureBootEnrollKeys = i.prof.Output.ImageOptions.SDBootEnrollKeys.String()
+		opts.PlatformKeyPath = pk
+		opts.KeyExchangeKeyPath = kek
+		opts.SignatureKeyPath = db
 	}
 
 	if i.prof.Input.ImageCache != zeroContainerAsset {

--- a/pkg/imager/profile/default.go
+++ b/pkg/imager/profile/default.go
@@ -147,6 +147,18 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	"secureboot-cloudstack": {
+		Platform:   "cloudstack",
+		SecureBoot: new(true),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatZSTD,
+			ImageOptions: &ImageOptions{
+				DiskSize:   DefaultRAWDiskSize,
+				DiskFormat: DiskFormatRaw,
+			},
+		},
+	},
 	"digital-ocean": {
 		Platform:   "digital-ocean",
 		SecureBoot: new(false),
@@ -208,6 +220,18 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	"secureboot-nocloud": {
+		Platform:   "nocloud",
+		SecureBoot: new(true),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatZSTD,
+			ImageOptions: &ImageOptions{
+				DiskSize:   MinRAWDiskSize,
+				DiskFormat: DiskFormatRaw,
+			},
+		},
+	},
 	"opennebula": {
 		Platform:   "opennebula",
 		SecureBoot: new(false),
@@ -220,9 +244,33 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	"secureboot-opennebula": {
+		Platform:   "opennebula",
+		SecureBoot: new(true),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatZSTD,
+			ImageOptions: &ImageOptions{
+				DiskSize:   MinRAWDiskSize,
+				DiskFormat: DiskFormatRaw,
+			},
+		},
+	},
 	"openstack": {
 		Platform:   "openstack",
 		SecureBoot: new(false),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatZSTD,
+			ImageOptions: &ImageOptions{
+				DiskSize:   MinRAWDiskSize,
+				DiskFormat: DiskFormatRaw,
+			},
+		},
+	},
+	"secureboot-openstack": {
+		Platform:   "openstack",
+		SecureBoot: new(true),
 		Output: Output{
 			Kind:      OutKindImage,
 			OutFormat: OutFormatZSTD,
@@ -272,6 +320,18 @@ var Default = map[string]Profile{
 	"vmware": {
 		Platform:   "vmware",
 		SecureBoot: new(false),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatRaw,
+			ImageOptions: &ImageOptions{
+				DiskSize:   DefaultRAWDiskSize,
+				DiskFormat: DiskFormatOVA,
+			},
+		},
+	},
+	"secureboot-vmware": {
+		Platform:   "vmware",
+		SecureBoot: new(true),
 		Output: Output{
 			Kind:      OutKindImage,
 			OutFormat: OutFormatRaw,

--- a/pkg/imager/profile/output.go
+++ b/pkg/imager/profile/output.go
@@ -45,6 +45,10 @@ type ImageOptions struct {
 	// Bootloader is the bootloader to use for the disk image.
 	// If not set, it defaults to dual-boot.
 	Bootloader BootloaderKind `yaml:"bootloader,omitempty"`
+	// SDBootEnrollKeys is a value in loader.conf secure-boot-enroll: off, manual, if-safe, force.
+	//
+	// If not set, it defaults to if-safe. Only used when SecureBoot is enabled.
+	SDBootEnrollKeys SDBootEnrollKeys `yaml:"sdBootEnrollKeys,omitempty"`
 }
 
 // ISOOptions describes options for the 'iso' output.

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-amd64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: cloudstack
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-cloudstack-arm64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: cloudstack
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-amd64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: nocloud
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-nocloud-arm64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: nocloud
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-amd64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: opennebula
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-opennebula-arm64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: opennebula
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-amd64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: openstack
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 2355101696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-openstack-arm64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: openstack
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-amd64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: amd64
+platform: vmware
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.10.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.11.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.12.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.13.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.14.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw

--- a/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-vmware-arm64-1.9.0.yaml
@@ -1,0 +1,28 @@
+arch: arm64
+platform: vmware
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: ova
+    bootloader: sd-boot
+  outFormat: raw


### PR DESCRIPTION
## What? (description)

Add automatic SecureBoot key enrollment for disk-image builds targeting private-cloud / self-managed platforms.

- New `SDBootEnrollKeys` field in `profile.ImageOptions` (zero value = `if-safe`).
- `prepareEnrollmentDBs` refactors the previously inline PK/KEK/db generation from `outISO` into a shared helper used by both ISO and disk-image paths.
- When enrollment is enabled, `sdboot.generateAssets` writes PK/KEK/db `.auth` files to `loader/keys/auto/` on the ESP and appends `secure-boot-enroll if-safe` to `loader.conf`, causing systemd-boot to enroll keys on first boot when UEFI firmware is in Setup Mode.
- `if-safe` is silently skipped on bare hardware (requires hypervisor detection), so keys stay inert on metal and enroll on VMs.

New profiles added: `secureboot-cloudstack`, `secureboot-nocloud`, `secureboot-opennebula`, `secureboot-openstack`, `secureboot-vmware`. Managed clouds (AWS, Azure, GCP, …) ship vendor PK/KEK and are deliberately excluded. `secureboot-metal` also gains `if-safe` enrollment via the refactoring — no-op on real hardware, enrolls in a VM.

Also fixes `e2e-qemu.sh` to pass `--talosconfig` explicitly to `cluster create` / `config node`, fixing "failed to determine endpoints" in `WITH_TRUSTED_BOOT_DISK_IMAGE=true` runs.

## Why? (reasoning)

Private-cloud VMs (OpenNebula, VMware, OpenStack, etc.) start with empty UEFI NVRAM — there is no pre-installed vendor PK/KEK. Without auto-enrollment the Talos SecureBoot disk images boot, but Secure Boot remains unenforced. This change closes that gap: a user deploying a `secureboot-opennebula` image gets Secure Boot enforced from the second boot onward without any manual UEFI configuration.

## Acceptance

- [x] you linked an issue (if applicable) — N/A
- [x] you included tests (if applicable) — unit test for `sdboot.generateAssets` (no-enrollment / if-safe / force), plus golden fixtures for all new profiles (v1.9–v1.14, amd64+arm64)
- [x] you ran conformance (`make conformance`) — all checks pass; GPG Identity fails locally only (key not in conform's keyring), passes in CI
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`) — `go test ./internal/.../sdboot/...` and `go test ./pkg/imager/profile/...` pass