### PR TITLE
fix: reset the ticker when the KubeSpan is disabled/enabled

### DIFF
--- a/internal/app/machined/pkg/controllers/kubespan/manager.go
+++ b/internal/app/machined/pkg/controllers/kubespan/manager.go
@@ -119,6 +119,12 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 		ticker  *time.Ticker
 	)
 
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+
 	if ctrl.WireguardClientFactory == nil {
 		ctrl.WireguardClientFactory = func() (WireguardClient, error) {
 			return wgctrl.New()
@@ -156,6 +162,7 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 		if cfg == nil || !cfg.TypedSpec().Enabled {
 			if ticker != nil {
 				ticker.Stop()
+				ticker = nil
 
 				tickerC = nil
 			}


### PR DESCRIPTION
Fixes #13226

The issue was that that the ticker was stopped, but never set to `nil`, so that it was never re-created when the KubeSpan is enabled back again.
