### PR TITLE
fix: do not pick up a system disk from a loop device

### DIFF
--- a/internal/app/machined/pkg/controllers/block/system_disk.go
+++ b/internal/app/machined/pkg/controllers/block/system_disk.go
@@ -7,6 +7,7 @@ package block
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -68,6 +69,11 @@ func (ctrl *SystemDiskController) Run(ctx context.Context, r controller.Runtime,
 		)
 
 		for volume := range discoveredVolumes.All() {
+			// ignore loop devices, a disk image of Talos might be mounted there, and we don't want to consider it as a candidate for the system disk.
+			if strings.HasPrefix(volume.TypedSpec().Parent, "loop") {
+				continue
+			}
+
 			if volume.TypedSpec().PartitionLabel == constants.MetaPartitionLabel {
 				systemDiskID = volume.TypedSpec().Parent
 				systemDiskPath = volume.TypedSpec().ParentDevPath

--- a/internal/app/machined/pkg/controllers/block/system_disk_test.go
+++ b/internal/app/machined/pkg/controllers/block/system_disk_test.go
@@ -37,11 +37,20 @@ func TestSystemDiskSuite(t *testing.T) {
 func (suite *SystemDiskSuite) TestReconcile() {
 	ctest.AssertNoResource[*block.SystemDisk](suite, block.SystemDiskID)
 
+	discoveredVolumeLoop := block.NewDiscoveredVolume(block.NamespaceName, "loop11p4")
+	discoveredVolumeLoop.TypedSpec().PartitionLabel = constants.MetaPartitionLabel
+	discoveredVolumeLoop.TypedSpec().Parent = "loop11"
+	discoveredVolumeLoop.TypedSpec().ParentDevPath = "/dev/loop11"
+	suite.Create(discoveredVolumeLoop)
+
+	// loop devices should be ignored, so the system disk should not be created.
+	ctest.AssertNoResource[*block.SystemDisk](suite, block.SystemDiskID)
+
 	discoveredVolume := block.NewDiscoveredVolume(block.NamespaceName, "vda4")
 	discoveredVolume.TypedSpec().PartitionLabel = constants.MetaPartitionLabel
 	discoveredVolume.TypedSpec().Parent = "vda"
 	discoveredVolume.TypedSpec().ParentDevPath = "/dev/vda"
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), discoveredVolume))
+	suite.Create(discoveredVolume)
 
 	ctest.AssertResource(suite, block.SystemDiskID, func(r *block.SystemDisk, asrt *assert.Assertions) {
 		asrt.Equal("vda", r.TypedSpec().DiskID)


### PR DESCRIPTION
If someone mounts a Talos disk image over a loop device, it will appear in DiscoveredVolumes correctly, but we should not match it as a system disk. A system disk can't be a loop device.
