### PR TITLE
feat: add host-namespace debug profile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,6 +92,7 @@ linters:
                 - "internal/app/dashboard/main.go"
                 - "internal/app/debug/container_streams.go"
                 - "internal/app/debug/debug.go"
+                - "internal/app/debug/hostns.go"
                 - "internal/app/lifecycle/container.go"
                 - "internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go"
                 - "internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go"

--- a/api/machine/debug.proto
+++ b/api/machine/debug.proto
@@ -33,6 +33,9 @@ message DebugContainerRunRequestSpec {
   enum Profile {
     PROFILE_UNSPECIFIED = 0;
     PROFILE_PRIVILEGED = 1;
+    // PROFILE_HOST_NS forks the host mount namespace, overlays image tools at /nix,
+    // and runs the shell directly on the host rootfs without nsenter.
+    PROFILE_HOST_NS = 2;
   }
 
   Profile profile = 5;

--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -8,6 +8,7 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
@@ -36,12 +38,16 @@ func init() {
 	debugCmd.Flags().StringSliceVar(&debugCmdFlags.args, "args", nil, "arguments to pass to the container")
 	debugCmd.Flags().StringVar(&debugCmdFlags.namespace, "namespace", "inmem", "namespace to use: `system` (CRI containerd) or `inmem` for in-memory containerd instance")
 
+	// The --host-ns flag and its examples are only registered in debug builds
+	// (sidero.debug). The server-side PROFILE_HOST_NS API is always available.
+	registerDebugHostNsFlag(debugCmd)
+
 	addCommand(debugCmd)
 }
 
 // debugCmd represents the debug command.
 var debugCmd = &cobra.Command{
-	Use:   "debug <image-tar-path|image ref> [args]",
+	Use:   "debug [<image-tar-path|image ref>]",
 	Short: "Run a debug container from an image archive or reference",
 	Example: `  # Run a debug container from a local tar archive (image will be loaded into Talos from the archive)
     talosctl debug ./debug-tools.tar --args /bin/sh
@@ -49,7 +55,7 @@ var debugCmd = &cobra.Command{
   # Run a debug container from an image reference (Talos will pull the image if not present)
     talosctl debug docker.io/library/alpine:latest --args /bin/sh`,
 
-	Args: cobra.ExactArgs(1),
+	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -72,8 +78,22 @@ var debugCmd = &cobra.Command{
 			return err
 		}
 
+		// Determine the image reference. A positional argument (tar path or image
+		// ref) always wins; otherwise host-ns falls back to the default Nix tools
+		// image, while the privileged profile requires an explicit image.
+		var imageRef string
+
+		switch {
+		case len(args) > 0:
+			imageRef = args[0]
+		case debugHostNsEnabled():
+			imageRef = constants.DebugHostNsImage
+		default:
+			return errors.New("an image tar path or reference is required")
+		}
+
 		// verify if we are sending a tarball or pulling an image
-		_, err = os.Stat(args[0])
+		_, err = os.Stat(imageRef)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to stat image argument: %w", err)
 		}
@@ -81,12 +101,12 @@ var debugCmd = &cobra.Command{
 		var imgName string
 
 		if err == nil {
-			imgName, err = imageImportInternal(ctx, c, ctrdInstance, node, args[0], rep)
+			imgName, err = imageImportInternal(ctx, c, ctrdInstance, node, imageRef, rep)
 			if err != nil {
 				return fmt.Errorf("failed to import image: %w", err)
 			}
 		} else {
-			pullResult, err := imagePullInternal(ctx, clientFactory, ctrdInstance, args[0], rep)
+			pullResult, err := imagePullInternal(ctx, clientFactory, ctrdInstance, imageRef, rep)
 			if err != nil {
 				return fmt.Errorf("failed to pull image: %w", err)
 			}
@@ -113,7 +133,12 @@ var debugCmd = &cobra.Command{
 			return fmt.Errorf("failed to create debug container stream: %w", err)
 		}
 
-		return runContainer(ctx, rep, runStream, imgName, debugCmdFlags.args, ctrdInstance)
+		profile := machine.DebugContainerRunRequestSpec_PROFILE_PRIVILEGED
+		if debugHostNsEnabled() {
+			profile = machine.DebugContainerRunRequestSpec_PROFILE_HOST_NS
+		}
+
+		return runContainer(ctx, rep, runStream, imgName, debugCmdFlags.args, ctrdInstance, profile)
 	},
 }
 
@@ -125,6 +150,7 @@ func runContainer(
 	imageName string,
 	args []string,
 	ctrdInstance *common.ContainerdInstance,
+	profile machine.DebugContainerRunRequestSpec_Profile,
 ) error { //nolint:gocyclo,cyclop
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -137,7 +163,7 @@ func runContainer(
 				Containerd: ctrdInstance,
 				ImageName:  imageName,
 				Args:       args,
-				Profile:    machine.DebugContainerRunRequestSpec_PROFILE_PRIVILEGED,
+				Profile:    profile,
 				Tty:        isTTY,
 			},
 		},

--- a/cmd/talosctl/cmd/talos/debug_hostns.go
+++ b/cmd/talosctl/cmd/talos/debug_hostns.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !windows && sidero.debug
+
+package talos
+
+import "github.com/spf13/cobra"
+
+// debugHostNs holds the value of the --host-ns flag, registered only in debug builds.
+var debugHostNs bool
+
+// registerDebugHostNsFlag registers the --host-ns flag and appends its usage examples.
+// It is only compiled into debug (sidero.debug) builds; release builds get the no-op stub.
+func registerDebugHostNsFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&debugHostNs, "host-ns", false,
+		"run in the host mount namespace with image tools overlaid: run host binaries (zpool, etcdctl, …) directly without nsenter")
+
+	cmd.Example += `
+
+  # Run in the host mount namespace: host binaries (zpool, etcdctl, …) work directly,
+  # Nix tools from nixos/nix are available on PATH — no nsenter needed
+    talosctl debug --host-ns
+
+  # Same, but pull a custom image for tools instead of the default nixos/nix
+    talosctl debug --host-ns ghcr.io/myorg/my-tools:latest`
+}
+
+// debugHostNsEnabled reports whether the debug session should run in the host
+// mount namespace (PROFILE_HOST_NS).
+func debugHostNsEnabled() bool {
+	return debugHostNs
+}

--- a/cmd/talosctl/cmd/talos/debug_hostns_stub.go
+++ b/cmd/talosctl/cmd/talos/debug_hostns_stub.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !windows && !sidero.debug
+
+package talos
+
+import "github.com/spf13/cobra"
+
+// registerDebugHostNsFlag is a no-op in release builds: the --host-ns flag is
+// only available in debug (sidero.debug) builds. The server-side PROFILE_HOST_NS
+// API is unaffected and remains available.
+func registerDebugHostNsFlag(*cobra.Command) {}
+
+// debugHostNsEnabled always reports false in release builds.
+func debugHostNsEnabled() bool {
+	return false
+}

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -731,6 +731,7 @@ var imageIntegrationCmd = &cobra.Command{
 			"registry.k8s.io/kube-apiserver:v1.27.0",
 			"registry.k8s.io/kube-apiserver:v1.27.1",
 			"docker.io/library/alpine:3.23",
+			constants.DebugHostNsImage,
 			"docker.io/library/nginx:latest",
 			imageIntegrationCmdFlags.registryAndUser + "/installer:" +
 				imageIntegrationCmdFlags.installerTag,

--- a/internal/app/debug/container_streams.go
+++ b/internal/app/debug/container_streams.go
@@ -202,6 +202,140 @@ func (g *grpcStdioStreamer) processMessage(ctx context.Context, task containerda
 	return nil
 }
 
+// hostNsControl carries out-of-band control messages from the gRPC recv loop
+// to the locked goroutine that owns the child process and pty master.
+type hostNsControl struct {
+	signal int32
+	resize *machine.DebugContainerTerminalResize
+}
+
+// streamHostNs is the streaming coordinator for PROFILE_HOST_NS sessions.
+// Unlike stream(), it does not need a containerd Task. Signals and resize events
+// are forwarded to the child via controlC; stdin/stdout travel through pipes as usual.
+func (g *grpcStdioStreamer) streamHostNs(ctx context.Context, exitC <-chan int, controlC chan<- hostNsControl) error { //nolint:gocyclo,cyclop
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sendLoopCh, recvLoopCh := make(chan error, 1), make(chan error, 1)
+
+	go func(errCh chan<- error) {
+		errCh <- panicsafe.RunErr(g.sendLoop)
+	}(sendLoopCh)
+
+	go func(errCh chan<- error) {
+		errCh <- panicsafe.RunErr(func() error {
+			return g.recvLoopHostNs(controlC)
+		})
+	}(recvLoopCh)
+
+	for {
+		select {
+		case code := <-exitC:
+			g.stdoutW.Close() //nolint:errcheck
+			g.stdinW.Close()  //nolint:errcheck
+
+			cancel()
+
+			if sendLoopCh != nil {
+				<-sendLoopCh
+			}
+
+			if err := g.srv.Send(&machine.DebugContainerRunResponse{
+				Resp: &machine.DebugContainerRunResponse_ExitCode{
+					ExitCode: int32(code),
+				},
+			}); err != nil {
+				return fmt.Errorf("host-ns: send exit code: %w", err)
+			}
+
+			if recvLoopCh != nil {
+				<-recvLoopCh
+			}
+
+			return nil
+
+		case sendErr := <-sendLoopCh:
+			if sendErr == nil {
+				sendLoopCh = nil
+
+				continue
+			}
+
+			g.stdinW.Close() //nolint:errcheck
+
+			return fmt.Errorf("host-ns: send loop: %w", sendErr)
+
+		case recvErr := <-recvLoopCh:
+			if recvErr == nil {
+				recvLoopCh = nil
+
+				continue
+			}
+
+			g.stdoutW.Close() //nolint:errcheck
+
+			return fmt.Errorf("host-ns: recv loop: %w", recvErr)
+
+		case <-ctx.Done():
+			g.stdoutW.Close() //nolint:errcheck
+			g.stdinW.Close()  //nolint:errcheck
+
+			if recvLoopCh != nil {
+				<-recvLoopCh
+			}
+
+			if sendLoopCh != nil {
+				<-sendLoopCh
+			}
+
+			return ctx.Err()
+		}
+	}
+}
+
+// recvLoopHostNs reads gRPC messages, forwarding stdin bytes to the child pipe
+// and routing signals/resize events to the control loop via controlC.
+// Sends to controlC are non-blocking: if the child has already exited the
+// control loop goroutine will have stopped reading, and we drop rather than hang.
+func (g *grpcStdioStreamer) recvLoopHostNs(controlC chan<- hostNsControl) error { //nolint:gocyclo
+	defer g.stdinW.Close() //nolint:errcheck
+
+	for {
+		msg, err := g.srv.Recv()
+		if err != nil {
+			if status.Code(err) != codes.Canceled && err != io.EOF {
+				return fmt.Errorf("host-ns recv: %w", err)
+			}
+
+			return nil
+		}
+
+		switch msg.Request.(type) {
+		case *machine.DebugContainerRunRequest_StdinData:
+			if data := msg.GetStdinData(); len(data) > 0 {
+				if _, writeErr := g.stdinW.Write(data); writeErr != nil {
+					return fmt.Errorf("host-ns stdin write: %w", writeErr)
+				}
+			}
+
+		case *machine.DebugContainerRunRequest_Signal:
+			select {
+			case controlC <- hostNsControl{signal: msg.GetSignal()}:
+			default:
+			}
+
+		case *machine.DebugContainerRunRequest_TermResize:
+			select {
+			case controlC <- hostNsControl{resize: msg.GetTermResize()}:
+			default:
+			}
+
+		default:
+			log.Printf("host-ns: unknown request type %T", msg.Request)
+		}
+	}
+}
+
 func (g *grpcStdioStreamer) sendLoop() error {
 	defer g.stdoutW.Close() //nolint:errcheck
 

--- a/internal/app/debug/debug.go
+++ b/internal/app/debug/debug.go
@@ -51,7 +51,9 @@ func (s *Service) ContainerRun(srv grpc.BidiStreamingServer[machine.DebugContain
 		return status.Errorf(codes.InvalidArgument, "expected debug container spec")
 	}
 
-	if spec.GetProfile() != machine.DebugContainerRunRequestSpec_PROFILE_PRIVILEGED {
+	switch spec.GetProfile() { //nolint:exhaustive
+	case machine.DebugContainerRunRequestSpec_PROFILE_PRIVILEGED, machine.DebugContainerRunRequestSpec_PROFILE_HOST_NS:
+	default:
 		return status.Errorf(codes.InvalidArgument, "unsupported debug container profile: %s", spec.GetProfile())
 	}
 
@@ -113,23 +115,28 @@ func (s *Service) ContainerRun(srv grpc.BidiStreamingServer[machine.DebugContain
 		cg.Delete() //nolint: errcheck
 	}()
 
+	// 4a. PROFILE_HOST_NS: namespace fork + overlay, no containerd task.
+	// Pass cgroupPath so the child is placed in the per-session cgroup rather than
+	// inheriting machined's /init cgroup with oom_score_adj=0.
+	if spec.GetProfile() == machine.DebugContainerRunRequestSpec_PROFILE_HOST_NS {
+		return runHostNsContainer(ctx, detachedContext, c8dClient, img, spec, srv, containerID, cgroupPath)
+	}
+
+	// 4b. PROFILE_PRIVILEGED: standard containerd container.
 	ctr, err := createDebugContainer(ctx, c8dClient, containerID, img, spec, cgroupPath)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("debug container: container %s created", ctr.ID())
+	log.Printf("debug: container %s created", ctr.ID())
 
 	defer func() {
 		cleanupErr := ctr.Delete(detachedContext, client.WithSnapshotCleanup)
 		if cleanupErr != nil {
-			log.Printf("debug container: failed to delete container %s: %s", ctr.ID(), cleanupErr.Error())
+			log.Printf("debug: failed to delete container %s: %s", ctr.ID(), cleanupErr.Error())
 		}
-
-		log.Printf("debug container: container %s deleted", ctr.ID())
 	}()
 
-	// 4. run and attach to the debug container
 	return runAndAttachContainer(ctx, detachedContext, spec, srv, ctr)
 }
 

--- a/internal/app/debug/hostns.go
+++ b/internal/app/debug/hostns.go
@@ -1,0 +1,446 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
+	ocispec "github.com/opencontainers/image-spec/identity"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+
+	"github.com/siderolabs/talos/internal/pkg/hostns"
+	"github.com/siderolabs/talos/internal/pkg/lookpath"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// runHostNsContainer handles PROFILE_HOST_NS: it builds a debug root in the HOST mount
+// namespace — host / as an overlay lower with a disk-backed upper, the image's /nix
+// overlaid in, and the live host mounts bound in — then execs the requested command
+// chrooted into that root. Because it runs in the host mount namespace (no fork), host
+// binaries work at their native paths and tools that manage host mounts (zpool, mount)
+// affect the host; the overlay's scratch mounts are removed on teardown.
+func runHostNsContainer( //nolint:gocyclo
+	ctx context.Context,
+	detachedCtx context.Context,
+	client *containerd.Client,
+	img containerd.Image,
+	spec *machine.DebugContainerRunRequestSpec,
+	srv grpc.BidiStreamingServer[machine.DebugContainerRunRequest, machine.DebugContainerRunResponse],
+	containerID string,
+	cgroupPath string,
+) error {
+	// Derive a cancelable context. When streamHostNs returns — client disconnect,
+	// transport error, or child exit — we cancel it so the control loop kills the
+	// child process group, then wait for the launch goroutine before teardown runs.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// 1. Writable snapshot of the image (Prepare, not View): the read-only /nix source.
+	// The default in-memory ("inmem") debug containerd roots on tmpfs, so session writes
+	// (including new /nix store paths) are captured in disk-backed overlay uppers under
+	// varBase instead. Removed by the deferred Remove below.
+	snapshotKey := containerID + "-hostns-rw"
+
+	diffIDs, err := img.RootFS(ctx)
+	if err != nil {
+		return fmt.Errorf("host-ns: get image rootfs: %w", err)
+	}
+
+	chainID := ocispec.ChainID(diffIDs).String()
+
+	snapshotMounts, err := client.SnapshotService("").Prepare(ctx, snapshotKey, chainID)
+	if err != nil {
+		return fmt.Errorf("host-ns: prepare writable snapshot: %w", err)
+	}
+
+	defer func() {
+		if rmErr := client.SnapshotService("").Remove(detachedCtx, snapshotKey); rmErr != nil && !errdefs.IsNotFound(rmErr) {
+			log.Printf("host-ns: failed to remove snapshot %s: %v", snapshotKey, rmErr)
+		}
+	}()
+
+	// 2. Per-session work dir on the EPHEMERAL /var disk. It holds both the image/merged
+	// mount points and the overlay upper/work layers — everything under one directory,
+	// on disk (not /run, which is tmpfs/RAM; the overlay writes, including the nix store,
+	// must be disk-backed).
+	workDir := filepath.Join(constants.DebugHostNsWorkdirBase, containerID)
+	if err = os.MkdirAll(workDir, 0o700); err != nil {
+		return fmt.Errorf("host-ns: create work dir: %w", err)
+	}
+
+	defer os.RemoveAll(workDir) //nolint:errcheck
+
+	// 3. Build the debug root in the host mount namespace; teardown removes only our
+	// scratch mounts, leaving host mounts (and anything the session created) intact.
+	merged, teardown, err := hostns.Setup(snapshotMounts, workDir, workDir)
+	if err != nil {
+		return fmt.Errorf("host-ns: setup root: %w", err)
+	}
+
+	defer teardown() //nolint:errcheck
+
+	// 4. Seed /etc files the squashfs lower doesn't carry.
+	seedEtcFiles(merged)
+
+	// 5. gRPC I/O streams.
+	grpcStreamer, stdinR, stdoutW := newGrpcStreamWriter(srv)
+
+	// 6. Command + args: with explicit args, args[0] is the executable (resolved
+	// against PATH in launchInHostNs); otherwise default to the Nix bash.
+	const defaultShell = "/nix/var/nix/profiles/default/bin/bash"
+
+	var (
+		shell   string
+		cmdArgs []string
+	)
+
+	if args := spec.GetArgs(); len(args) > 0 {
+		shell = args[0]
+		cmdArgs = args
+	} else {
+		shell = defaultShell
+		cmdArgs = []string{defaultShell}
+	}
+
+	// 7. Env: Nix profile on PATH (per-user profile first so nix-env installs win),
+	// plus caller-supplied overrides.
+	env := []string{
+		"PATH=/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt",
+		"TERM=xterm-256color",
+		"HOME=/root",
+	}
+
+	for k, v := range spec.GetEnv() {
+		env = append(env, k+"="+v)
+	}
+
+	// 8. Per-session cgroup dir as an fd: SysProcAttr.CgroupFD places the child into
+	// the cgroup atomically at fork, avoiding a post-fork cgroup.procs write race.
+	cgroupFd, err := os.Open(filepath.Join("/sys/fs/cgroup", cgroupPath))
+	if err != nil {
+		return fmt.Errorf("host-ns: open cgroup dir %s: %w", cgroupPath, err)
+	}
+
+	// 9. Control channel: carries signals and pty-resize events from the gRPC recv
+	// loop into the goroutine that owns the child. Buffered so recv never blocks.
+	controlC := make(chan hostNsControl, 16)
+
+	exitC := make(chan int, 1)
+	launchDone := make(chan struct{})
+
+	go func() {
+		defer close(launchDone)
+
+		code, launchErr := launchInHostNs(ctx, merged, shell, cmdArgs, env, stdinR, stdoutW, spec.GetTty(), cgroupFd, controlC)
+		cgroupFd.Close() //nolint:errcheck
+
+		if launchErr != nil {
+			log.Printf("host-ns: launch error: %v", launchErr)
+
+			// Surface the failure to the client: it flows through the stdout pipe →
+			// sendLoop → talosctl, so the user sees the cause, not a bare exit code.
+			fmt.Fprintf(stdoutW, "host-ns: launch failed: %v\r\n", launchErr) //nolint:errcheck
+		}
+
+		// Close the stdout pipe so the send loop drains and the streaming coordinator
+		// receives EOF before we send the exit code.
+		grpcStreamer.stdoutW.Close() //nolint:errcheck
+
+		exitC <- code
+	}()
+
+	streamErr := grpcStreamer.streamHostNs(ctx, exitC, controlC)
+
+	// Kill the child process group (no-op if already exited), then wait for the launch
+	// goroutine before the deferred teardown/cleanup runs.
+	cancel()
+	<-launchDone
+
+	return streamErr
+}
+
+// seedEtcFiles writes into the overlay's /etc the files the raw squashfs lower does
+// not carry: the host's live resolv.conf (otherwise DNS is broken), and a nix.conf so
+// the package manager works without the nixbld build-users group or a sandbox.
+func seedEtcFiles(merged string) {
+	if hostResolv, readErr := os.ReadFile("/etc/resolv.conf"); readErr == nil && len(hostResolv) > 0 {
+		resolvDst := filepath.Join(merged, "etc", "resolv.conf")
+
+		if mkErr := os.MkdirAll(filepath.Dir(resolvDst), 0o755); mkErr == nil {
+			os.WriteFile(resolvDst, hostResolv, 0o644) //nolint:errcheck
+		}
+	}
+
+	nixConfDst := filepath.Join(merged, "etc", "nix", "nix.conf")
+	if mkErr := os.MkdirAll(filepath.Dir(nixConfDst), 0o755); mkErr == nil {
+		os.WriteFile(nixConfDst, []byte( //nolint:errcheck
+			"build-users-group =\n"+
+				"sandbox = false\n"+
+				"experimental-features = nix-command flakes\n",
+		), 0o644)
+	}
+}
+
+// launchInHostNs execs the requested command chrooted into the prepared root (merged),
+// wiring stdio (or a pty) and placing the child in the debug cgroup. Mount setup lives
+// in package hostns; this only starts and supervises the child.
+func launchInHostNs(
+	ctx context.Context,
+	merged string,
+	shell string,
+	args []string,
+	env []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	tty bool,
+	cgroupFd *os.File,
+	controlC <-chan hostNsControl,
+) (exitCode int, err error) {
+	// Resolve the executable against PATH within the root: execve does not search PATH
+	// for a bare command name (e.g. "zpool"), and we cannot LookPath in machined's
+	// namespace (no /nix there). lookpath.InRoot resolves inside merged (RESOLVE_IN_ROOT),
+	// handling host binaries and Nix profile symlinks alike.
+	execPath, err := lookpath.InRoot(merged, shell, env)
+	if err != nil {
+		return 1, err
+	}
+
+	// Open the pty before the child chroots, while /dev/ptmx is reachable; the fds
+	// remain valid across the chroot.
+	var ptyMaster, ptySlave *os.File
+
+	if tty {
+		ptyMaster, ptySlave, err = openPty()
+		if err != nil {
+			return 1, fmt.Errorf("open pty: %w", err)
+		}
+	}
+
+	// The chroot into merged is applied in the CHILD via SysProcAttr.Chroot — never in
+	// this process, whose root must stay untouched.
+	cmd := &exec.Cmd{
+		Path: execPath,
+		Args: args,
+		Env:  env,
+		Dir:  "/",
+	}
+
+	if tty {
+		return runWithOpenPty(ctx, cmd, merged, ptyMaster, ptySlave, stdin, stdout, cgroupFd, controlC)
+	}
+
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stdout
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Chroot:      merged,
+		Setsid:      true,
+		UseCgroupFD: true,
+		CgroupFD:    int(cgroupFd.Fd()),
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		return 1, fmt.Errorf("start shell: %w", startErr)
+	}
+
+	setDebugOOMScore(cmd.Process.Pid)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go runControlLoop(ctx, done, controlC, cmd.Process.Pid, nil)
+
+	if waitErr := cmd.Wait(); waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+
+		return 1, waitErr
+	}
+
+	return 0, nil
+}
+
+// runControlLoop handles out-of-band control messages for a running host-ns child:
+//   - Signal: delivered to the child's process group so the shell and its
+//     children all receive it (e.g., Ctrl-C kills the foreground pipeline).
+//   - TermResize: applies TIOCSWINSZ on the pty master so the child's terminal
+//     geometry stays in sync with the user's window.
+//
+// It also owns the child's lifetime relative to the stream: if ctx is canceled
+// (client disconnect or transport error) it SIGKILLs the whole process group so
+// the shell and its children don't leak as orphans.
+//
+// Exits when done is closed or ctx is canceled.
+func runControlLoop(ctx context.Context, done <-chan struct{}, controlC <-chan hostNsControl, pid int, ptyMaster *os.File) {
+	for {
+		select {
+		case <-done:
+			return
+
+		case <-ctx.Done():
+			// Negative pid targets the process group (the child is a session
+			// leader via Setsid), so pipelines and subshells die with the shell.
+			syscall.Kill(-pid, syscall.SIGKILL) //nolint:errcheck
+
+			return
+
+		case ctrl := <-controlC:
+			if ctrl.signal != 0 {
+				// Negative pid targets the entire process group, ensuring that
+				// child processes of the shell (pipelines, subshells) also receive
+				// the signal rather than only the shell itself.
+				syscall.Kill(-pid, syscall.Signal(ctrl.signal)) //nolint:errcheck
+			}
+
+			if ctrl.resize != nil && ptyMaster != nil {
+				unix.IoctlSetWinsize(int(ptyMaster.Fd()), unix.TIOCSWINSZ, &unix.Winsize{ //nolint:errcheck
+					Row: uint16(ctrl.resize.Height),
+					Col: uint16(ctrl.resize.Width),
+				})
+			}
+		}
+	}
+}
+
+// setDebugOOMScore marks the given pid as more expendable than system services
+// so that OOM kills target debug sessions before daemons. /proc is bind-mounted
+// from the host so this write is valid inside the chroot.
+func setDebugOOMScore(pid int) {
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	if err := os.WriteFile(path, []byte("500"), 0o644); err != nil {
+		log.Printf("host-ns: set oom_score_adj for pid %d: %v", pid, err)
+	}
+}
+
+// runWithOpenPty starts cmd attached to already-opened pty fds and relays I/O
+// between the pty master and the provided stdin/stdout streams.
+// Both ptyMaster and ptySlave must have been opened before any chroot call.
+func runWithOpenPty(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	chrootDir string,
+	ptyMaster, ptySlave *os.File,
+	stdin io.Reader,
+	stdout io.Writer,
+	cgroupFd *os.File,
+	controlC <-chan hostNsControl,
+) (int, error) {
+	defer ptyMaster.Close() //nolint:errcheck
+
+	cmd.Stdin = ptySlave
+	cmd.Stdout = ptySlave
+	cmd.Stderr = ptySlave
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Chroot:      chrootDir,
+		Setsid:      true,
+		Setctty:     true,
+		Ctty:        0, // fd 0 in the child (ptySlave as Stdin) is the controlling terminal
+		UseCgroupFD: true,
+		CgroupFD:    int(cgroupFd.Fd()),
+	}
+
+	if err := cmd.Start(); err != nil {
+		ptySlave.Close() //nolint:errcheck
+
+		return 1, fmt.Errorf("start shell (tty): %w", err)
+	}
+
+	ptySlave.Close() //nolint:errcheck
+
+	setDebugOOMScore(cmd.Process.Pid)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go runControlLoop(ctx, done, controlC, cmd.Process.Pid, ptyMaster)
+
+	// Relay pty master → gRPC stdout.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := ptyMaster.Read(buf)
+			if n > 0 {
+				stdout.Write(buf[:n]) //nolint:errcheck
+			}
+
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	// Relay gRPC stdin → pty master.
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := stdin.Read(buf)
+			if n > 0 {
+				ptyMaster.Write(buf[:n]) //nolint:errcheck
+			}
+
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	if waitErr := cmd.Wait(); waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+
+		return 1, waitErr
+	}
+
+	return 0, nil
+}
+
+// openPty opens a new pseudo-terminal pair using Linux's /dev/ptmx.
+// Returns (master, slave) file handles.
+func openPty() (*os.File, *os.File, error) {
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open /dev/ptmx: %w", err)
+	}
+
+	// Unlock the slave pty. TIOCSPTLCK expects a pointer to int, not an inline value.
+	if err = unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		master.Close() //nolint:errcheck
+
+		return nil, nil, fmt.Errorf("unlock pty slave: %w", err)
+	}
+
+	// Get the slave pty index (TIOCGPTN) and construct its path.
+	n, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		master.Close() //nolint:errcheck
+
+		return nil, nil, fmt.Errorf("get pty number: %w", err)
+	}
+
+	slaveName := fmt.Sprintf("/dev/pts/%d", n)
+
+	slave, err := os.OpenFile(slaveName, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		master.Close() //nolint:errcheck
+
+		return nil, nil, fmt.Errorf("open slave pty %s: %w", slaveName, err)
+	}
+
+	return master, slave, nil
+}

--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
@@ -320,14 +321,14 @@ func (suite *ExtensionsSuiteQEMU) TestExtensionsZFS() {
 
 	suite.Require().NotEmpty(userDisks, "expected at least one user disks to be available")
 
-	stdout, exitCode, err := suite.ExecInHostMountNS(suite.ctx, node,
+	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node,
 		"zpool", "create", "-m", "/var/tank", "tank", userDisks[0],
 	)
 	suite.Require().NoError(err)
 	suite.Require().EqualValues(0, exitCode, "zpool create failed: %s", stdout)
 	suite.Require().Equal("", stdout)
 
-	stdout, exitCode, err = suite.ExecInHostMountNS(suite.ctx, node,
+	stdout, exitCode, err = suite.RunDebugContainer(suite.ctx, node,
 		"zfs", "create", "-V", "1gb", "tank/vol",
 	)
 	suite.Require().NoError(err)
@@ -335,12 +336,20 @@ func (suite *ExtensionsSuiteQEMU) TestExtensionsZFS() {
 	suite.Require().Equal("", stdout)
 
 	defer func() {
-		if _, _, err := suite.ExecInHostMountNS(suite.ctx, node, "zfs", "destroy", "tank/vol"); err != nil {
+		if _, _, err := suite.RunDebugContainer(suite.ctx, node, "zfs", "destroy", "tank/vol"); err != nil {
 			suite.T().Logf("failed to remove zfs dataset tank/vol: %v", err)
 		}
 
-		if _, _, err := suite.ExecInHostMountNS(suite.ctx, node, "zpool", "destroy", "tank"); err != nil {
+		if _, _, err := suite.RunDebugContainer(suite.ctx, node, "zpool", "destroy", "tank"); err != nil {
 			suite.T().Logf("failed to remove zpool tank: %v", err)
+		}
+
+		// Wipe the disk so no zfs label lingers (otherwise the pool is re-discovered
+		// as a volume after the test).
+		if err := suite.Client.BlockDeviceWipe(client.WithNode(suite.ctx, node), &storage.BlockDeviceWipeRequest{
+			Devices: []*storage.BlockDeviceWipeDescriptor{{Device: filepath.Base(userDisks[0])}},
+		}); err != nil {
+			suite.T().Logf("failed to wipe disk %s: %v", userDisks[0], err)
 		}
 	}()
 
@@ -403,7 +412,7 @@ func (suite *ExtensionsSuiteQEMU) checkZFSPoolMounted(t *assert.CollectT, node s
 func (suite *ExtensionsSuiteQEMU) TestExtensionsUtilLinuxTools() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 
-	stdout, exitCode, err := suite.ExecInHostMountNS(suite.ctx, node,
+	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node,
 		"/usr/local/sbin/fstrim", "--version",
 	)
 	suite.Require().NoError(err)

--- a/internal/integration/api/wipe.go
+++ b/internal/integration/api/wipe.go
@@ -129,7 +129,7 @@ func (suite *WipeSuite) TestWipeFilesystem() {
 
 	userDisk := userDisks[0]
 
-	stdout, exitCode, err := suite.ExecInHostMountNS(suite.ctx, node, "mkfs.xfs", userDisk)
+	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node, "mkfs.xfs", userDisk)
 	suite.Require().NoError(err)
 	suite.Require().EqualValues(0, exitCode, "mkfs.xfs failed: %s", stdout)
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -719,6 +719,10 @@ func (apiSuite *APISuite) DumpLogs(ctx context.Context, node string, service, pa
 			apiSuite.T().Logf("%s (%s): %s", node, service, scanner.Text())
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		apiSuite.T().Logf("error reading logs from %s (%s): %v", node, service, err)
+	}
 }
 
 // ReadFile reads file from the node.

--- a/internal/integration/base/debug_exec.go
+++ b/internal/integration/base/debug_exec.go
@@ -16,24 +16,16 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
-
-// DebugContainerImage is the default image used for one-shot privileged debug containers.
-const DebugContainerImage = "docker.io/library/alpine:3.23"
 
 // RunDebugContainer pulls the image (if needed) and runs a one-shot privileged debug container
 // on the node via the DebugService, returning the combined stdout/stderr output and the exit code.
-//
-// The debug container runs in the host PID/IPC/network namespaces, fully privileged, with the host
-// root filesystem bind-mounted at /host, but it does not join the host mount namespace. To run host
-// binaries (e.g. those installed by system extensions, which live in the host root and mount
-// namespace), use ExecInHostMountNS which wraps the command with nsenter.
-//
 // Note: in non-TTY mode the server multiplexes stdout and stderr into a single stream, so the
 // returned output contains both.
 //
 //nolint:gocyclo
-func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node, image string, args ...string) (string, int32, error) {
+func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, args ...string) (string, int32, error) {
 	nodeCtx := client.WithNode(ctx, node)
 
 	containerd := &common.ContainerdInstance{
@@ -44,10 +36,10 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node, image str
 	// pull the image into the system namespace first
 	rcv, err := apiSuite.Client.ImageClient.Pull(nodeCtx, &machineapi.ImageServicePullRequest{
 		Containerd: containerd,
-		ImageRef:   image,
+		ImageRef:   constants.DebugHostNsImage,
 	})
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to pull image %q: %w", image, err)
+		return "", 0, fmt.Errorf("failed to pull image %q: %w", constants.DebugHostNsImage, err)
 	}
 
 	var pulledImage string
@@ -59,7 +51,7 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node, image str
 				break
 			}
 
-			return "", 0, fmt.Errorf("failed to pull image %q: %w", image, err)
+			return "", 0, fmt.Errorf("failed to pull image %q: %w", constants.DebugHostNsImage, err)
 		}
 
 		pulledImage = msg.GetName()
@@ -76,7 +68,7 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node, image str
 				Containerd: containerd,
 				ImageName:  pulledImage,
 				Args:       args,
-				Profile:    machineapi.DebugContainerRunRequestSpec_PROFILE_PRIVILEGED,
+				Profile:    machineapi.DebugContainerRunRequestSpec_PROFILE_HOST_NS,
 			},
 		},
 	}); err != nil {
@@ -120,15 +112,4 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node, image str
 	}
 
 	return out.String(), exitCode, nil
-}
-
-// ExecInHostMountNS runs a command in the host mount namespace via a one-shot privileged debug
-// container, returning the combined stdout/stderr output and the exit code.
-//
-// The command is executed via `nsenter --mount=/proc/1/ns/mnt --` so that host binaries installed
-// by system extensions (which live in the host root filesystem and mount namespace) are reachable.
-func (apiSuite *APISuite) ExecInHostMountNS(ctx context.Context, node string, command ...string) (string, int32, error) {
-	args := append([]string{"nsenter", "--mount=/proc/1/ns/mnt", "--"}, command...)
-
-	return apiSuite.RunDebugContainer(ctx, node, DebugContainerImage, args...)
 }

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -669,6 +669,10 @@ func (k8sSuite *K8sSuite) LogPodLogs(ctx context.Context, namespace, podName str
 	for scanner.Scan() {
 		k8sSuite.T().Logf("%s/%s: %s", namespace, podName, scanner.Text())
 	}
+
+	if err := scanner.Err(); err != nil {
+		k8sSuite.T().Logf("failed to read pod logs: %s", err)
+	}
 }
 
 // HelmInstall installs the Helm chart with the given namespace, repository, version, release name, chart name and values.

--- a/internal/pkg/hostns/hostns.go
+++ b/internal/pkg/hostns/hostns.go
@@ -1,0 +1,190 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package hostns builds the PROFILE_HOST_NS debug root in the host mount namespace.
+//
+// It does NOT fork the mount namespace: the debug session runs in the host's mount
+// namespace so tools that manage host mounts (zpool, mount, umount) actually affect
+// the host. The Nix toolset is layered in via an overlay whose scratch mounts live
+// under a per-session directory and are removed on teardown, so the only lasting
+// footprint is what the session deliberately creates on the host.
+package hostns
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"golang.org/x/sys/unix"
+
+	mountv3 "github.com/siderolabs/talos/internal/pkg/mount/v3"
+)
+
+// HostBinds are the live host mounts bind-mounted into the debug root so tools can
+// reach the running node: devices, kernel filesystems, runtime sockets (/run,
+// /system) and data (/var). They are recursively bind-mounted and made shared, so a
+// mount a session creates under them (e.g. `zpool create -m /var/tank`) propagates to
+// the host, and unmounts propagate back — the session manages host mounts as if it
+// were in the host namespace (which it is). Flags (nodev, nosuid, noexec) are inherited
+// from the already-compliant host mounts.
+//
+// /var is bound even though the session's own scratch (merged, image, overlay uppers)
+// lives under it: Setup marks those scratch mounts MS_UNBINDABLE, so the recursive /var
+// bind skips them and cannot nest merged into itself.
+var HostBinds = []string{"dev", "proc", "sys", "run", "system", "var"}
+
+// Setup builds the debug chroot root in the CURRENT (host) mount namespace:
+//   - the image snapshot mounted read-only at baseDir/image (via fsopen, so the many-
+//     layer overlay does not go through containerd's mount.All, whose CLONE_FS worker
+//     would mount it in a way that escapes cleanup);
+//   - an overlay root (lower=/ plus a disk-backed upper under varBase) at baseDir/merged;
+//   - the image's /nix overlaid at merged/nix (disk-backed upper);
+//   - HostBinds recursively bind-mounted and shared into merged.
+//
+// It returns the merged root (for the child to chroot into) and a teardown func.
+// Teardown makes merged's subtree private and then recursively unmounts merged, so it
+// removes ONLY our scratch mounts: the host's own mounts, and anything the session
+// propagated to the host (e.g. a created zfs pool), are left intact.
+func Setup(snapshotMounts []mount.Mount, baseDir, varBase string) (merged string, teardown func() error, err error) { //nolint:gocyclo
+	imageDir := filepath.Join(baseDir, "image")
+	merged = filepath.Join(baseDir, "merged")
+	mergedMounted := false
+
+	// cleanup removes only our scratch mounts: it severs propagation first so tearing
+	// down our overlay does not ripple onto the host's mounts, or onto anything a
+	// session propagated up (e.g. /var/tank of a freshly created pool). merged (and its
+	// /nix overlay + host binds) is unmounted first, then the sibling image mount it
+	// layered on. Held in a local so the error-path rollback below never sees the nil
+	// teardown that an error `return` leaves in the named result.
+	cleanup := func() error {
+		if mergedMounted {
+			if privateErr := unix.Mount("", merged, "", unix.MS_PRIVATE|unix.MS_REC, ""); privateErr != nil {
+				return fmt.Errorf("make merged root private: %w", privateErr)
+			}
+		}
+
+		return errors.Join(
+			mount.UnmountRecursive(merged, unix.MNT_DETACH),
+			mount.UnmountRecursive(imageDir, unix.MNT_DETACH),
+		)
+	}
+
+	// Roll back any partial setup on error.
+	defer func() {
+		if err != nil {
+			cleanup() //nolint:errcheck
+		}
+	}()
+
+	if err = os.MkdirAll(imageDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("mkdir image dir: %w", err)
+	}
+
+	if err = mountImageSnapshot(snapshotMounts, imageDir); err != nil {
+		return "", nil, fmt.Errorf("mount image snapshot: %w", err)
+	}
+
+	// Overlay root: host / as lower, disk-backed upper/work under varBase (mountv3
+	// creates the target and the upper/work dirs). The upper lets the session create
+	// /nix, /etc/nix, etc. without touching Talos's immutable squashfs, on disk.
+	if _, err = mountv3.NewOverlayWithBasePath([]string{"/"}, merged, varBase, nil).Mount(); err != nil {
+		return "", nil, fmt.Errorf("mount overlay root: %w", err)
+	}
+
+	mergedMounted = true
+
+	// Overlay the image /nix at merged/nix, disk-backed upper, so new nix store paths
+	// from `nix profile install` land on disk (the inmem containerd root is tmpfs).
+	nixSrc := filepath.Join(imageDir, "nix")
+	nixDst := filepath.Join(merged, "nix")
+
+	if _, err = mountv3.NewOverlayWithBasePath([]string{nixSrc}, nixDst, varBase, nil).Mount(); err != nil {
+		return "", nil, fmt.Errorf("mount /nix overlay: %w", err)
+	}
+
+	// merged and image live under /var (baseDir), which is recursively bound into
+	// merged/var below. Mark them MS_UNBINDABLE *now* — after the /nix overlay, which
+	// clones imageDir/nix as its lower (unbindable would block that) — so the recursive
+	// /var bind skips them instead of re-including merged and nesting it into itself (an
+	// exploding mount recursion). Unbindable blocks being a bind *source* only; the host
+	// binds below still mount *under* merged fine.
+	for _, m := range []string{imageDir, merged} {
+		if err = unix.Mount("", m, "", unix.MS_UNBINDABLE, ""); err != nil {
+			return "", nil, fmt.Errorf("make %s unbindable: %w", m, err)
+		}
+	}
+
+	// Bind the live host mounts in, shared. The overlay lowerdir=/ only exposes the
+	// squashfs mount-point directories, not the live devtmpfs/procfs/tmpfs/EPHEMERAL
+	// mounts, so bind them in explicitly. Shared propagation makes host mount
+	// management work both ways (see HostBinds).
+	for _, dir := range HostBinds {
+		src := "/" + dir
+
+		// Skip a bind whose source the host doesn't have. On Talos all of HostBinds
+		// exist; this keeps the setup robust (and testable off-Talos) rather than
+		// hard-failing the whole session over one missing path.
+		if _, statErr := os.Stat(src); statErr != nil {
+			continue
+		}
+
+		dst := filepath.Join(merged, dir)
+
+		if err = os.MkdirAll(dst, 0o755); err != nil {
+			return "", nil, fmt.Errorf("mkdir %s: %w", dst, err)
+		}
+
+		if err = unix.Mount(src, dst, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			return "", nil, fmt.Errorf("bind-mount %s: %w", src, err)
+		}
+
+		if err = unix.Mount("", dst, "", unix.MS_SHARED|unix.MS_REC, ""); err != nil {
+			return "", nil, fmt.Errorf("make %s shared: %w", dst, err)
+		}
+	}
+
+	return merged, cleanup, nil
+}
+
+// mountImageSnapshot mounts the containerd image snapshot read-only at target using
+// fsopen (mountv3) for the overlay case, rather than containerd's mount.All whose
+// many-layer path mounts from a CLONE_FS-only worker. We only read the image (the
+// /nix overlay layered on top supplies the writable layer), so read-only suffices.
+func mountImageSnapshot(mounts []mount.Mount, target string) error {
+	if len(mounts) == 1 && mounts[0].Type == "overlay" {
+		var (
+			lowers []string
+			upper  string
+		)
+
+		for _, o := range mounts[0].Options {
+			switch {
+			case strings.HasPrefix(o, "lowerdir="):
+				lowers = strings.Split(strings.TrimPrefix(o, "lowerdir="), ":")
+			case strings.HasPrefix(o, "upperdir="):
+				upper = strings.TrimPrefix(o, "upperdir=")
+			}
+		}
+
+		// overlay lowerdir is ordered top-to-bottom; the writable upper (if any) sits
+		// above all lowers, so it becomes the highest read-only layer.
+		dirs := lowers
+		if upper != "" {
+			dirs = append([]string{upper}, lowers...)
+		}
+
+		if _, err := mountv3.NewReadOnlyOverlay(dirs, target, nil).Mount(); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Single-layer snapshots come back as a bind mount; mount.All handles those
+	// inline (no lowerdir compaction, no worker goroutine).
+	return mount.All(mounts, target)
+}

--- a/internal/pkg/hostns/hostns_test.go
+++ b/internal/pkg/hostns/hostns_test.go
@@ -1,0 +1,197 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package hostns_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/siderolabs/talos/internal/pkg/hostns"
+)
+
+// TestSetupTeardownNoLeak exercises the full mount setup and, crucially, verifies the
+// teardown removes every scratch mount without disturbing the host's own mounts.
+//
+// It runs inside a fresh private mount namespace so the test's mounts — and any
+// teardown bug — cannot leak into the CI host. LockOSThread is intentionally never
+// unlocked: the Go runtime terminates the (namespace-tainted) thread when the test
+// goroutine exits, so other tests keep the original namespace.
+func TestSetupTeardownNoLeak(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for mount operations")
+	}
+
+	runtime.LockOSThread()
+
+	require.NoError(t, unix.Unshare(unix.CLONE_NEWNS))
+	require.NoError(t, unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""))
+
+	// Setup recursively bind-mounts /sys into the debug root and makes that bind
+	// shared. Keep the source shared too, matching Talos, so an unsafe teardown of
+	// the bind propagates back and unmounts the host source.
+	require.NoError(t, unix.Mount("", "/sys", "", unix.MS_REC|unix.MS_SHARED, ""))
+
+	tmp := t.TempDir()
+
+	// Fake image snapshot: overlayfs needs at least two lower layers (a real Nix image
+	// has ~70). The top layer carries /nix/bin/tool.
+	imgUpperLayer := filepath.Join(tmp, "img1")
+	imgLowerLayer := filepath.Join(tmp, "img0")
+	require.NoError(t, os.MkdirAll(filepath.Join(imgUpperLayer, "nix", "bin"), 0o755))
+	require.NoError(t, os.MkdirAll(imgLowerLayer, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(imgUpperLayer, "nix", "bin", "tool"), []byte("x"), 0o755))
+
+	snap := []mount.Mount{{Type: "overlay", Source: "overlay", Options: []string{"lowerdir=" + imgUpperLayer + ":" + imgLowerLayer}}}
+
+	baseDir := filepath.Join(tmp, "base")
+	varBase := filepath.Join(tmp, "var")
+
+	baseline := len(mountTargets(t))
+
+	merged, teardown, err := hostns.Setup(snap, baseDir, varBase)
+	require.NoError(t, err)
+
+	torndown := false
+
+	t.Cleanup(func() {
+		if !torndown {
+			_ = teardown() //nolint:errcheck
+		}
+	})
+
+	// The image /nix is overlaid into the merged root and reachable.
+	_, err = os.Stat(filepath.Join(merged, "nix", "bin", "tool"))
+	assert.NoError(t, err, "image /nix overlaid into merged")
+
+	// The overlay root and every host bind are mounted.
+	assert.True(t, isMounted(t, merged), "overlay root mounted")
+
+	// merged must be unbindable so the recursive /var bind can't re-include it (which
+	// would nest merged into itself — an exploding mount recursion).
+	assert.True(t, isUnbindable(t, merged), "overlay root is unbindable")
+
+	for _, dir := range hostns.HostBinds {
+		if _, statErr := os.Stat("/" + dir); statErr != nil {
+			continue // host lacks this dir (e.g. /system off-Talos); Setup skips it
+		}
+
+		assert.True(t, isMounted(t, filepath.Join(merged, dir)), "%s bound into merged", dir)
+	}
+
+	// A session creates a scratch mount inside the chroot root.
+	require.NoError(t, os.MkdirAll(filepath.Join(merged, "mnt", "x"), 0o755))
+	require.NoError(t, unix.Mount("sess", filepath.Join(merged, "mnt", "x"), "tmpfs", 0, ""))
+
+	// Teardown must remove ALL our mounts and leave the host's mounts intact.
+	require.NoError(t, teardown())
+
+	torndown = true
+
+	assert.Zero(t, countUnder(t, baseDir), "no scratch mounts remain under baseDir")
+	assert.True(t, isMounted(t, "/proc"), "host /proc survived teardown")
+	assert.True(t, isMounted(t, "/sys"), "host /sys survived teardown")
+	assert.Equal(t, baseline, len(mountTargets(t)), "mount table returned to baseline — nothing leaked")
+}
+
+// TestSetupRollbackOnError verifies a failed Setup leaves no mounts behind.
+func TestSetupRollbackOnError(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for mount operations")
+	}
+
+	runtime.LockOSThread()
+
+	require.NoError(t, unix.Unshare(unix.CLONE_NEWNS))
+	require.NoError(t, unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""))
+
+	tmp := t.TempDir()
+	baseDir := filepath.Join(tmp, "base")
+	varBase := filepath.Join(tmp, "var")
+
+	baseline := len(mountTargets(t))
+
+	// A snapshot whose lower dir does not exist makes the image overlay mount fail.
+	snap := []mount.Mount{{Type: "overlay", Source: "overlay", Options: []string{"lowerdir=" + filepath.Join(tmp, "does-not-exist")}}}
+
+	_, _, err := hostns.Setup(snap, baseDir, varBase)
+	require.Error(t, err)
+
+	assert.Equal(t, baseline, len(mountTargets(t)), "failed Setup left no mounts behind")
+}
+
+func mountTargets(t *testing.T) []string {
+	t.Helper()
+
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	require.NoError(t, err)
+
+	var targets []string
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		if fields := strings.Fields(line); len(fields) >= 5 {
+			targets = append(targets, fields[4]) // field 5: mount point
+		}
+	}
+
+	return targets
+}
+
+func isMounted(t *testing.T, target string) bool {
+	t.Helper()
+
+	return slices.Contains(mountTargets(t), target)
+}
+
+// isUnbindable reports whether the mount at target carries the "unbindable"
+// propagation type (per /proc/self/mountinfo optional fields).
+func isUnbindable(t *testing.T, target string) bool {
+	t.Helper()
+
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	require.NoError(t, err)
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 7 || fields[4] != target {
+			continue
+		}
+
+		// Optional propagation fields run from index 6 up to the "-" separator.
+		for _, f := range fields[6:] {
+			if f == "-" {
+				break
+			}
+
+			if f == "unbindable" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func countUnder(t *testing.T, prefix string) int {
+	t.Helper()
+
+	n := 0
+
+	for _, m := range mountTargets(t) {
+		if strings.HasPrefix(m, prefix) {
+			n++
+		}
+	}
+
+	return n
+}

--- a/internal/pkg/lookpath/lookpath.go
+++ b/internal/pkg/lookpath/lookpath.go
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package lookpath resolves executables by PATH within a root directory, following
+// symlinks confined to that root via openat2(RESOLVE_IN_ROOT).
+package lookpath
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// InRoot resolves name to a path that can be exec'd after chrooting into root.
+//
+// A name containing a slash is returned unchanged (treated as an explicit path).
+// Otherwise the PATH entry from env is searched, and each candidate is resolved under
+// root with RESOLVE_IN_ROOT: absolute symlink targets (e.g. Nix profile links pointing
+// into /nix/store, which may live on a sub-mount of root) are interpreted relative to
+// root, and resolution can never escape it. The returned path is the PATH-relative
+// candidate, valid once the caller chroots into root. Returns an error if name is not
+// found as an executable file.
+func InRoot(root, name string, env []string) (string, error) {
+	if strings.Contains(name, "/") {
+		return name, nil
+	}
+
+	var pathEnv string
+
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, "PATH="); ok {
+			pathEnv = v
+		}
+	}
+
+	rootFD, err := unix.Open(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return "", fmt.Errorf("open root %q: %w", root, err)
+	}
+
+	defer unix.Close(rootFD) //nolint:errcheck
+
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+
+		candidate := filepath.Join(dir, name)
+
+		if executableInRoot(rootFD, candidate) {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("executable %q not found in $PATH", name)
+}
+
+// executableInRoot reports whether candidate resolves, confined to rootFD, to a
+// regular executable file.
+func executableInRoot(rootFD int, candidate string) bool {
+	fd, err := unix.Openat2(rootFD, strings.TrimPrefix(candidate, "/"), &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+	})
+	if err != nil {
+		return false
+	}
+
+	defer unix.Close(fd) //nolint:errcheck
+
+	var st unix.Stat_t
+	if unix.Fstat(fd, &st) != nil {
+		return false
+	}
+
+	return st.Mode&unix.S_IFMT == unix.S_IFREG && st.Mode&0o111 != 0
+}

--- a/internal/pkg/lookpath/lookpath_test.go
+++ b/internal/pkg/lookpath/lookpath_test.go
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package lookpath_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/siderolabs/talos/internal/pkg/lookpath"
+)
+
+func TestInRoot(t *testing.T) {
+	root := t.TempDir()
+
+	requireOpenat2InRoot(t, root)
+
+	// Layout under root:
+	//   store/tool             real executable
+	//   store/data             regular, non-executable file
+	//   sbin/other             real executable (in the second PATH dir)
+	//   bin/tool   -> /store/tool     absolute symlink (must resolve relative to root)
+	//   bin/rel    -> ../store/tool   relative symlink
+	//   bin/notexec-> /store/data     absolute symlink to a non-exec file
+	//   bin/escape -> /etc/passwd     absolute symlink; resolves to root/etc/passwd (absent)
+	for _, dir := range []string{"bin", "sbin", "store"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, dir), 0o755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "store", "tool"), []byte("x"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "store", "data"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sbin", "other"), []byte("x"), 0o755))
+	require.NoError(t, os.Symlink("/store/tool", filepath.Join(root, "bin", "tool")))
+	require.NoError(t, os.Symlink("../store/tool", filepath.Join(root, "bin", "rel")))
+	require.NoError(t, os.Symlink("/store/data", filepath.Join(root, "bin", "notexec")))
+	require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(root, "bin", "escape")))
+
+	env := []string{"HOME=/root", "PATH=/bin:/sbin"}
+
+	for _, tt := range []struct {
+		name    string
+		cmd     string
+		want    string
+		wantErr bool
+	}{
+		{name: "absolute symlink resolves within root", cmd: "tool", want: "/bin/tool"},
+		{name: "relative symlink", cmd: "rel", want: "/bin/rel"},
+		{name: "found in second PATH dir", cmd: "other", want: "/sbin/other"},
+		{name: "explicit absolute path returned as-is", cmd: "/usr/bin/env", want: "/usr/bin/env"},
+		{name: "explicit relative path returned as-is", cmd: "./x", want: "./x"},
+		{name: "escape stays confined to root", cmd: "escape", wantErr: true},
+		{name: "non-executable not returned", cmd: "notexec", wantErr: true},
+		{name: "missing not found", cmd: "nope", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := lookpath.InRoot(root, tt.cmd, env)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInRootEmptyPath(t *testing.T) {
+	root := t.TempDir()
+
+	requireOpenat2InRoot(t, root)
+
+	_, err := lookpath.InRoot(root, "anything", []string{"HOME=/root"})
+	assert.Error(t, err)
+}
+
+// requireOpenat2InRoot skips the test if the kernel lacks openat2/RESOLVE_IN_ROOT.
+func requireOpenat2InRoot(t *testing.T, root string) {
+	t.Helper()
+
+	fd, err := unix.Open(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	require.NoError(t, err)
+
+	defer unix.Close(fd) //nolint:errcheck
+
+	if _, err := unix.Openat2(fd, ".", &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_IN_ROOT,
+	}); errors.Is(err, unix.ENOSYS) {
+		t.Skip("openat2(RESOLVE_IN_ROOT) not supported by this kernel")
+	} else {
+		require.NoError(t, err)
+	}
+}

--- a/pkg/machinery/api/machine/debug.pb.go
+++ b/pkg/machinery/api/machine/debug.pb.go
@@ -29,6 +29,9 @@ type DebugContainerRunRequestSpec_Profile int32
 const (
 	DebugContainerRunRequestSpec_PROFILE_UNSPECIFIED DebugContainerRunRequestSpec_Profile = 0
 	DebugContainerRunRequestSpec_PROFILE_PRIVILEGED  DebugContainerRunRequestSpec_Profile = 1
+	// PROFILE_HOST_NS forks the host mount namespace, overlays image tools at /nix,
+	// and runs the shell directly on the host rootfs without nsenter.
+	DebugContainerRunRequestSpec_PROFILE_HOST_NS DebugContainerRunRequestSpec_Profile = 2
 )
 
 // Enum value maps for DebugContainerRunRequestSpec_Profile.
@@ -36,10 +39,12 @@ var (
 	DebugContainerRunRequestSpec_Profile_name = map[int32]string{
 		0: "PROFILE_UNSPECIFIED",
 		1: "PROFILE_PRIVILEGED",
+		2: "PROFILE_HOST_NS",
 	}
 	DebugContainerRunRequestSpec_Profile_value = map[string]int32{
 		"PROFILE_UNSPECIFIED": 0,
 		"PROFILE_PRIVILEGED":  1,
+		"PROFILE_HOST_NS":     2,
 	}
 )
 
@@ -416,7 +421,7 @@ const file_machine_debug_proto_rawDesc = "" +
 	"\x06signal\x18\x03 \x01(\x05H\x00R\x06signal\x12H\n" +
 	"\vterm_resize\x18\x04 \x01(\v2%.machine.DebugContainerTerminalResizeH\x00R\n" +
 	"termResizeB\t\n" +
-	"\arequest\"\x9e\x03\n" +
+	"\arequest\"\xb3\x03\n" +
 	"\x1cDebugContainerRunRequestSpec\x12:\n" +
 	"\n" +
 	"containerd\x18\x01 \x01(\v2\x1a.common.ContainerdInstanceR\n" +
@@ -429,10 +434,11 @@ const file_machine_debug_proto_rawDesc = "" +
 	"\x03tty\x18\x06 \x01(\bR\x03tty\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\":\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
 	"\aProfile\x12\x17\n" +
 	"\x13PROFILE_UNSPECIFIED\x10\x00\x12\x16\n" +
-	"\x12PROFILE_PRIVILEGED\x10\x01\"L\n" +
+	"\x12PROFILE_PRIVILEGED\x10\x01\x12\x13\n" +
+	"\x0fPROFILE_HOST_NS\x10\x02\"L\n" +
 	"\x1cDebugContainerTerminalResize\x12\x14\n" +
 	"\x05width\x18\x01 \x01(\x05R\x05width\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\x05R\x06height\"e\n" +

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -769,6 +769,18 @@ const (
 	// CgroupSystemDebug is the cgroup name for debug processes.
 	CgroupSystemDebug = CgroupSystem + "/debug"
 
+	// DebugHostNsImage is the default image used for PROFILE_HOST_NS debug sessions.
+	// It provides a Nix environment whose store paths are self-contained and do not
+	// conflict with the Talos host's library paths when bind-mounted into the forked
+	// mount namespace.
+	DebugHostNsImage = "docker.io/nixos/nix:latest"
+
+	// DebugHostNsWorkdirBase is the disk-backed base directory for PROFILE_HOST_NS
+	// overlay upper/work layers. It lives on the EPHEMERAL partition (/var) so that
+	// writes to the session root (nix eval cache, /tmp, /etc) and the /nix store do
+	// not pin RAM in a tmpfs — the default in-memory debug containerd roots on tmpfs.
+	DebugHostNsWorkdirBase = "/var/system/debug"
+
 	// SelinuxLabelMachined is the SELinux label for machined.
 	SelinuxLabelMachined = "system_u:system_r:init_t:s0"
 

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -1248,6 +1248,7 @@ InspectService provides auxiliary API to inspect OS internals.
 | ---- | ------ | ----------- |
 | PROFILE_UNSPECIFIED | 0 |  |
 | PROFILE_PRIVILEGED | 1 |  |
+| PROFILE_HOST_NS | 2 | PROFILE_HOST_NS forks the host mount namespace, overlays image tools at /nix, and runs the shell directly on the host rootfs without nsenter. |
 
 
  <!-- end enums -->

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -1400,7 +1400,7 @@ talosctl dashboard [flags]
 Run a debug container from an image archive or reference
 
 ```
-talosctl debug <image-tar-path|image ref> [args] [flags]
+talosctl debug [<image-tar-path|image ref>] [flags]
 ```
 
 ### Examples


### PR DESCRIPTION
Add a PROFILE_HOST_NS debug profile that runs `talosctl debug` in a fork of
the host mount namespace instead of a containerd task. The session gets an
overlay root (host `/` as lower + disk-backed upper) with a Nix tools image's
`/nix` overlaid in, so host binaries (zpool, mkfs.xfs, …) run at their native
paths without nsenter while Nix-provided tools are on PATH.
The `talosctl debug --host-ns` flag is gated behind the `sidero.debug` build
tag (WITH_DEBUG=true); the machine API profile is always available.