### PR TITLE
fix: preserve DHCP DNS servers and apply DHCP search domains

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -71,6 +71,12 @@ List of changes:
 - `.cluster.secretboxEncryptionSecret` field was removed from the v1alpha1 config, and full etcd encryption configuration is available with `KubeEtcdEncryptionConfig`.
 """
 
+    [notes.dhcpsearchdomains]
+        title = "DHCP Search Domains"
+        description = """\
+DHCPv4 search domains are now applied to the resolver configuration.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -350,7 +350,6 @@ func (d *DHCP4) requestRenew(ctx context.Context, hostname network.HostnameStatu
 	opts := []dhcpv4.OptionCode{
 		dhcpv4.OptionClasslessStaticRoute,
 		dhcpv4.OptionDomainNameServer,
-		// TODO(twelho): This is unused until network.ResolverSpec supports search domains
 		dhcpv4.OptionDNSDomainSearchList,
 		dhcpv4.OptionNTPServers,
 	}

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
@@ -12,6 +12,7 @@ package dhcpparse
 import (
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -183,7 +184,9 @@ func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useH
 		}
 	}
 
-	if len(ack.DNS()) > 0 {
+	searchDomains := dhcpSearchDomains(ack)
+
+	if len(ack.DNS()) > 0 || len(searchDomains) > 0 {
 		convertIP := func(ip net.IP) netip.Addr {
 			result, _ := netipx.FromStdIP(ip)
 
@@ -192,8 +195,9 @@ func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useH
 
 		specs.Resolvers = []network.ResolverSpecSpec{
 			{
-				DNSServers:  xslices.Map(ack.DNS(), convertIP),
-				ConfigLayer: network.ConfigOperator,
+				DNSServers:    xslices.Map(ack.DNS(), convertIP),
+				SearchDomains: searchDomains,
+				ConfigLayer:   network.ConfigOperator,
 			},
 		}
 	}
@@ -214,4 +218,18 @@ func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useH
 	}
 
 	return specs
+}
+
+func dhcpSearchDomains(ack *dhcpv4.DHCPv4) []string {
+	var searchDomains []string
+
+	if labels := ack.DomainSearch(); labels != nil {
+		searchDomains = append(searchDomains, labels.Labels...)
+	}
+
+	if domainName := strings.TrimRight(ack.DomainName(), "\x00"); domainName != "" && !slices.Contains(searchDomains, domainName) {
+		searchDomains = append(searchDomains, domainName)
+	}
+
+	return searchDomains
 }

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
@@ -185,6 +185,8 @@ func TestParseDHCP4Ack(t *testing.T) {
 			},
 			specs.Resolvers[0].DNSServers,
 		)
+		assert.Equal(t, []string{"example.com"}, specs.Resolvers[0].SearchDomains,
+			"DomainName feeds the search list when DomainSearch is absent")
 
 		require.Len(t, specs.TimeServers, 1)
 		assert.Equal(t, []string{"169.254.169.123"}, specs.TimeServers[0].NTPServers)
@@ -192,6 +194,86 @@ func TestParseDHCP4Ack(t *testing.T) {
 		require.Len(t, specs.Hostname, 1)
 		assert.Equal(t, "myhost", specs.Hostname[0].Hostname)
 		assert.Equal(t, "example.com", specs.Hostname[0].Domainname)
+	})
+
+	t.Run("search domains from DomainSearch option", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptDNS(net.IPv4(8, 8, 8, 8))),
+			dhcpv4.WithDomainSearchList("corp.example.com", "example.com"),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Equal(t, []string{"corp.example.com", "example.com"}, specs.Resolvers[0].SearchDomains)
+	})
+
+	t.Run("DomainName appended to DomainSearch when not already present", func(t *testing.T) {
+		// Both options present, DomainName not in DomainSearch → appended.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithDomainSearchList("corp.example.com"),
+			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Equal(t, []string{"corp.example.com", "example.com"}, specs.Resolvers[0].SearchDomains)
+	})
+
+	t.Run("DomainName not duplicated when already in DomainSearch", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithDomainSearchList("example.com", "corp.example.com"),
+			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Equal(t, []string{"example.com", "corp.example.com"}, specs.Resolvers[0].SearchDomains)
+	})
+
+	t.Run("search domains alone still emit a resolver spec", func(t *testing.T) {
+		// No DNS servers, just a DomainName — the resolver spec must still
+		// be emitted so the search list reaches resolv.conf.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Empty(t, specs.Resolvers[0].DNSServers)
+		assert.Equal(t, []string{"example.com"}, specs.Resolvers[0].SearchDomains)
+	})
+
+	t.Run("blank/null-padded DomainName does not become a search domain", func(t *testing.T) {
+		// Some DHCP servers null-pad the DomainName option; after trimming
+		// it should be treated as absent.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptDNS(net.IPv4(8, 8, 8, 8))),
+			dhcpv4.WithOption(dhcpv4.OptGeneric(dhcpv4.OptionDomainName, []byte("\x00\x00"))),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Empty(t, specs.Resolvers[0].SearchDomains)
 	})
 
 	t.Run("useHostname=false ignores hostname even when present", func(t *testing.T) {

--- a/internal/app/machined/pkg/controllers/network/resolver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge.go
@@ -38,15 +38,24 @@ func NewResolverMergeController() controller.Controller {
 			for res := range list.All() {
 				spec := res.TypedSpec()
 
-				final.SearchDomains = slices.Insert(final.SearchDomains, 0, spec.SearchDomains...)
+				domainPos := 0
+
+				for _, domain := range spec.SearchDomains {
+					if !slices.Contains(final.SearchDomains, domain) {
+						final.SearchDomains = slices.Insert(final.SearchDomains, domainPos, domain)
+						domainPos++
+					}
+				}
 
 				switch spec.ConfigLayer { //nolint:exhaustive
 				case final.ConfigLayer:
 					// simply append server lists on the same layer
 					final.DNSServers = append(final.DNSServers, spec.DNSServers...)
 				case network.ConfigMachineConfiguration:
-					// machine configuration layer overrides any previous layers completely
-					final.DNSServers = slices.Clone(spec.DNSServers)
+					// machine configuration overrides previous layers, but only when DNS servers are set
+					if len(spec.DNSServers) > 0 {
+						final.DNSServers = slices.Clone(spec.DNSServers)
+					}
 				default:
 					// otherwise, do a smart merge across IPv4/IPv6
 					mergeDNSServers(&final.DNSServers, spec.DNSServers)

--- a/internal/app/machined/pkg/controllers/network/resolver_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge_test.go
@@ -117,6 +117,43 @@ func (suite *ResolverMergeSuite) TestMergeIPv46() {
 	)
 }
 
+func (suite *ResolverMergeSuite) TestMergeSearchDomainsOnlyConfig() {
+	def := network.NewResolverSpec(network.ConfigNamespaceName, "default/resolvers")
+	*def.TypedSpec() = network.ResolverSpecSpec{
+		DNSServers: []netip.Addr{
+			netip.MustParseAddr(constants.DefaultPrimaryResolver),
+			netip.MustParseAddr(constants.DefaultSecondaryResolver),
+		},
+		ConfigLayer: network.ConfigDefault,
+	}
+
+	dhcp := network.NewResolverSpec(network.ConfigNamespaceName, "dhcp/eth0")
+	*dhcp.TypedSpec() = network.ResolverSpecSpec{
+		DNSServers:    []netip.Addr{netip.MustParseAddr("192.168.131.1")},
+		SearchDomains: []string{"somewhere.com", "home.lab"},
+		ConfigLayer:   network.ConfigOperator,
+	}
+
+	cfg := network.NewResolverSpec(network.ConfigNamespaceName, "configuration/resolvers")
+	*cfg.TypedSpec() = network.ResolverSpecSpec{
+		SearchDomains: []string{"home.lab", "another.lab"},
+		ConfigLayer:   network.ConfigMachineConfiguration,
+	}
+
+	for _, res := range []resource.Resource{def, dhcp, cfg} {
+		suite.Create(res)
+	}
+
+	suite.assertResolvers(
+		[]string{
+			"resolvers",
+		}, func(r *network.ResolverSpec, asrt *assert.Assertions) {
+			asrt.Equal([]netip.Addr{netip.MustParseAddr("192.168.131.1")}, r.TypedSpec().DNSServers)
+			asrt.Equal([]string{"another.lab", "somewhere.com", "home.lab"}, r.TypedSpec().SearchDomains)
+		},
+	)
+}
+
 func (suite *ResolverMergeSuite) TestMergeIPv6OnlyConfig() {
 	def := network.NewResolverSpec(network.ConfigNamespaceName, "default/resolvers")
 	*def.TypedSpec() = network.ResolverSpecSpec{


### PR DESCRIPTION
# Pull Request


## What? (description)

Fixes two DNS resolver issues introduced in v1.13.0:

  - A `ResolverConfig` that sets only `searchDomains` (without `nameservers`) no longer clears DNS servers obtained from earlier layers (DHCP, platform, cmdline). The merge controller now only overrides `DNSServers` for the machine configuration layer
  when servers are actually provided.
  - DHCPv4 search domains are now propagated to the resolver spec and end up in `/etc/resolv.conf`.

fixes #13270

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
