### PR TITLE
feat: support conditional start of IPv6 dns servers

### DIFF
--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -259,6 +259,7 @@ message HostDNSConfigSpec {
   repeated common.NetIPPort listen_addresses = 2;
   common.NetIP service_host_dns_address = 3;
   bool resolve_member_names = 4;
+  common.NetIP service_host_dns_address_v6 = 5;
 }
 
 // HostnameSpecSpec describes node hostname.

--- a/internal/app/machined/pkg/controllers/network/address_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -118,6 +119,40 @@ func (suite *AddressSpecSuite) TestLoopback() {
 	// torn down address should be removed immediately
 	suite.Assert().EventuallyWithT(func(collect *assert.CollectT) {
 		assertNoLinkAddress(assert.New(collect), "lo", "127.11.0.1/32")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	suite.Destroy(loopback)
+}
+
+func (suite *AddressSpecSuite) TestIPV6ULA() {
+	loopback := network.NewAddressSpec(network.NamespaceName, "lo/"+constants.HostDNSAddressV6+"/128")
+	*loopback.TypedSpec() = network.AddressSpecSpec{
+		Address:     netip.MustParsePrefix(constants.HostDNSAddressV6 + "/128"),
+		LinkName:    "lo",
+		Family:      nethelpers.FamilyInet6,
+		Scope:       nethelpers.ScopeGlobal,
+		ConfigLayer: network.ConfigDefault,
+		Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+	}
+
+	for _, res := range []resource.Resource{loopback} {
+		suite.Create(res)
+	}
+
+	suite.Assert().EventuallyWithT(func(collect *assert.CollectT) {
+		assertLinkAddress(assert.New(collect), "lo", constants.HostDNSAddressV6+"/128")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// teardown the address
+	_, err := suite.State().Teardown(suite.Ctx(), loopback.Metadata())
+	suite.Require().NoError(err)
+
+	_, err = suite.State().WatchFor(suite.Ctx(), loopback.Metadata(), state.WithFinalizerEmpty())
+	suite.Require().NoError(err)
+
+	// torn down address should be removed immediately
+	suite.Assert().EventuallyWithT(func(collect *assert.CollectT) {
+		assertNoLinkAddress(assert.New(collect), "lo", constants.HostDNSAddressV6+"/128")
 	}, 3*time.Second, 10*time.Millisecond)
 
 	suite.Destroy(loopback)

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache.go
@@ -117,7 +117,7 @@ func (ctrl *DNSResolveCacheController) run(ctx context.Context, r controller.Run
 	}
 
 	pairs := allAddressPairs(cfg.TypedSpec().ListenAddresses)
-	forwardKubeDNSToHost := cfg.TypedSpec().ServiceHostDNSAddress.IsValid()
+	forwardKubeDNSToHost := cfg.TypedSpec().ServiceHostDNSAddress.IsValid() || cfg.TypedSpec().ServiceHostDNSAddressV6.IsValid()
 
 	for runCfg, runErr := range ctrl.manager.RunAll(pairs, forwardKubeDNSToHost) {
 		switch {

--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
@@ -286,6 +286,7 @@ func getDynamicPort(t *testing.T) string {
 func makeAddrs(port string) []netip.AddrPort {
 	return []netip.AddrPort{
 		netip.MustParseAddrPort("127.0.0.53:" + port),
+		netip.MustParseAddrPort("[::1]:" + port),
 	}
 }
 

--- a/internal/app/machined/pkg/controllers/network/etcfile.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile.go
@@ -165,7 +165,7 @@ func (ctrl *EtcFileController) Run(ctx context.Context, r controller.Runtime, lo
 
 		if resolverStatus != nil && hostDNSCfg != nil {
 			dnsServers := xslices.FilterInPlace(
-				[]netip.Addr{hostDNSCfg.TypedSpec().ServiceHostDNSAddress},
+				[]netip.Addr{hostDNSCfg.TypedSpec().ServiceHostDNSAddress, hostDNSCfg.TypedSpec().ServiceHostDNSAddressV6},
 				netip.Addr.IsValid,
 			)
 

--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -121,8 +121,10 @@ func (suite *EtcFileConfigSuite) ExtraSetup() {
 	suite.hostDNSConfig.TypedSpec().ListenAddresses = []netip.AddrPort{
 		netip.MustParseAddrPort("127.0.0.53:53"),
 		netip.MustParseAddrPort("169.254.116.108:53"),
+		netip.MustParseAddrPort("[fd54:616c:6f73::204f:5320:444e:531]:53"),
 	}
 	suite.hostDNSConfig.TypedSpec().ServiceHostDNSAddress = netip.MustParseAddr("169.254.116.108")
+	suite.hostDNSConfig.TypedSpec().ServiceHostDNSAddressV6 = netip.MustParseAddr("fd54:616c:6f73::204f:5320:444e:531")
 }
 
 type etcFileContents struct {
@@ -212,7 +214,7 @@ func (suite *EtcFileConfigSuite) TestComplete() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n10.0.0.1    a b\n10.0.0.2    c d\n", //nolint:lll
 			resolvConf:       "nameserver 127.0.0.53\n\nsearch foo.example.com\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n\nsearch foo.example.com\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n\nsearch foo.example.com\n",
 		},
 	)
 }
@@ -225,7 +227,7 @@ func (suite *EtcFileConfigSuite) TestExtraHostsNoHostname() {
 		etcFileContents{
 			hosts:            "127.0.0.1 localhost\n::1       localhost ip6-localhost ip6-loopback\nff02::1   ip6-allnodes\nff02::2   ip6-allrouters\n10.0.0.1  a b\n10.0.0.2  c d\n",
 			resolvConf:       "nameserver 127.0.0.53\n\nsearch foo.example.com\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n\nsearch foo.example.com\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n\nsearch foo.example.com\n",
 		},
 	)
 }
@@ -238,7 +240,7 @@ func (suite *EtcFileConfigSuite) TestNoExtraHosts() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n\nsearch foo.example.com\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n\nsearch foo.example.com\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n\nsearch foo.example.com\n",
 		},
 	)
 }
@@ -261,7 +263,7 @@ func (suite *EtcFileConfigSuite) TestNoSearchDomainLegacy() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n",
 		},
 	)
 }
@@ -282,7 +284,7 @@ func (suite *EtcFileConfigSuite) TestNoSearchDomainNewStyle() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo.example.com foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n",
 		},
 	)
 }
@@ -295,7 +297,7 @@ func (suite *EtcFileConfigSuite) TestNoDomainname() {
 		etcFileContents{
 			hosts:            "127.0.0.1   localhost\n33.11.22.44 foo\n::1         localhost ip6-localhost ip6-loopback\nff02::1     ip6-allnodes\nff02::2     ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n",
 		},
 	)
 }
@@ -306,7 +308,7 @@ func (suite *EtcFileConfigSuite) TestOnlyResolvers() {
 		etcFileContents{
 			hosts:            "127.0.0.1 localhost\n::1       localhost ip6-localhost ip6-loopback\nff02::1   ip6-allnodes\nff02::2   ip6-allrouters\n",
 			resolvConf:       "nameserver 127.0.0.53\n",
-			resolvGlobalConf: "nameserver 169.254.116.108\n",
+			resolvGlobalConf: "nameserver 169.254.116.108\nnameserver fd54:616c:6f73:0:204f:5320:444e:531\n",
 		},
 	)
 }

--- a/internal/app/machined/pkg/controllers/network/hostdns_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config.go
@@ -94,6 +94,7 @@ func (ctrl *HostDNSConfigController) Run(ctx context.Context, r controller.Runti
 			}
 
 			res.TypedSpec().ServiceHostDNSAddress = netip.Addr{}
+			res.TypedSpec().ServiceHostDNSAddressV6 = netip.Addr{}
 
 			if hostDNSConfig == nil {
 				res.TypedSpec().Enabled = false
@@ -123,6 +124,17 @@ func (ctrl *HostDNSConfigController) Run(ctx context.Context, r controller.Runti
 
 				res.TypedSpec().ListenAddresses = append(res.TypedSpec().ListenAddresses, netip.AddrPortFrom(parsed, 53))
 				res.TypedSpec().ServiceHostDNSAddress = parsed
+			}
+
+			if slices.ContainsFunc(
+				podCIDRs,
+				func(cidr string) bool { return netip.MustParsePrefix(cidr).Addr().Is6() },
+			) {
+				parsed := netip.MustParseAddr(constants.HostDNSAddressV6)
+				newServiceAddrs = append(newServiceAddrs, parsed)
+
+				res.TypedSpec().ListenAddresses = append(res.TypedSpec().ListenAddresses, netip.AddrPortFrom(parsed, 53))
+				res.TypedSpec().ServiceHostDNSAddressV6 = parsed
 			}
 
 			return nil

--- a/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
@@ -119,6 +119,7 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv4() {
 	suite.Create(cfg)
 
 	hostDNSAddr := netip.MustParseAddr(constants.HostDNSAddress)
+	hostDNSAddrV6 := netip.MustParseAddr(constants.HostDNSAddressV6)
 
 	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
 		asrt.True(r.TypedSpec().Enabled)
@@ -126,29 +127,40 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv4() {
 			[]netip.AddrPort{
 				netip.MustParseAddrPort("127.0.0.53:53"),
 				netip.AddrPortFrom(hostDNSAddr, 53),
+				netip.AddrPortFrom(hostDNSAddrV6, 53),
 			},
 			r.TypedSpec().ListenAddresses,
 		)
 		asrt.Equal(hostDNSAddr, r.TypedSpec().ServiceHostDNSAddress)
+		asrt.Equal(hostDNSAddrV6, r.TypedSpec().ServiceHostDNSAddressV6)
 	})
 
-	addrPrefix := netip.PrefixFrom(hostDNSAddr, hostDNSAddr.BitLen())
+	for _, addrPrefix := range []netip.Prefix{
+		netip.PrefixFrom(hostDNSAddr, hostDNSAddr.BitLen()),
+		netip.PrefixFrom(hostDNSAddrV6, hostDNSAddrV6.BitLen()),
+	} {
+		ctest.AssertResource(
+			suite,
+			network.LayeredID(network.ConfigOperator, network.AddressID("lo", addrPrefix)),
+			func(r *network.AddressSpec, asrt *assert.Assertions) {
+				spec := r.TypedSpec()
 
-	ctest.AssertResource(
-		suite,
-		network.LayeredID(network.ConfigOperator, network.AddressID("lo", addrPrefix)),
-		func(r *network.AddressSpec, asrt *assert.Assertions) {
-			spec := r.TypedSpec()
+				if addrPrefix.Addr().Is6() {
+					asrt.Equal(nethelpers.FamilyInet6, spec.Family)
+					asrt.Equal(nethelpers.ScopeGlobal, spec.Scope)
+				} else {
+					asrt.Equal(nethelpers.FamilyInet4, spec.Family)
+					asrt.Equal(nethelpers.ScopeHost, spec.Scope)
+				}
 
-			asrt.Equal(addrPrefix, spec.Address)
-			asrt.Equal("lo", spec.LinkName)
-			asrt.Equal(nethelpers.FamilyInet4, spec.Family)
-			asrt.Equal(nethelpers.ScopeHost, spec.Scope)
-			asrt.Equal(nethelpers.AddressFlags(nethelpers.AddressPermanent), spec.Flags)
-			asrt.Equal(network.ConfigOperator, spec.ConfigLayer)
-		},
-		rtestutils.WithNamespace(network.ConfigNamespaceName),
-	)
+				asrt.Equal(addrPrefix, spec.Address)
+				asrt.Equal("lo", spec.LinkName)
+				asrt.Equal(nethelpers.AddressFlags(nethelpers.AddressPermanent), spec.Flags)
+				asrt.Equal(network.ConfigOperator, spec.ConfigLayer)
+			},
+			rtestutils.WithNamespace(network.ConfigNamespaceName),
+		)
+	}
 }
 
 func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv6Only() {
@@ -184,10 +196,14 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv6Only() {
 	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
 		asrt.True(r.TypedSpec().Enabled)
 		asrt.Equal(
-			[]netip.AddrPort{netip.MustParseAddrPort("127.0.0.53:53")},
+			[]netip.AddrPort{
+				netip.MustParseAddrPort("127.0.0.53:53"),
+				netip.MustParseAddrPort("[" + constants.HostDNSAddressV6 + "]:53"),
+			},
 			r.TypedSpec().ListenAddresses,
 		)
 		asrt.Equal(netip.Addr{}, r.TypedSpec().ServiceHostDNSAddress)
+		asrt.Equal(netip.MustParseAddr(constants.HostDNSAddressV6), r.TypedSpec().ServiceHostDNSAddressV6)
 	})
 
 	ctest.AssertNoResource[*network.AddressSpec](

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
 
+	cfg "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -210,8 +211,6 @@ func (ctrl *NfTablesChainConfigController) buildIngressChain(cfg *config.Machine
 
 			if hostDNSConfig := cfg.Config().NetworkHostDNSConfig(); hostDNSConfig != nil {
 				if hostDNSConfig.ForwardKubeDNSToHost() {
-					hostDNSIP := netip.MustParseAddr(constants.HostDNSAddress)
-
 					// allow traffic to host DNS
 					for _, protocol := range []nethelpers.Protocol{nethelpers.ProtocolUDP, nethelpers.ProtocolTCP} {
 						spec.Rules = append(
@@ -227,7 +226,7 @@ func (ctrl *NfTablesChainConfigController) buildIngressChain(cfg *config.Machine
 									),
 								},
 								MatchDestinationAddress: &network.NfTablesAddressMatch{
-									IncludeSubnets: []netip.Prefix{netip.PrefixFrom(hostDNSIP, hostDNSIP.BitLen())},
+									IncludeSubnets: hostDNSSubnets(cfg.Config().Cluster().Network()),
 								},
 								MatchLayer4: &network.NfTablesLayer4Match{
 									Protocol: protocol,
@@ -433,3 +432,20 @@ func (ctrl *NfTablesChainConfigController) buildPreroutingChain(cfg *config.Mach
 		return nil
 	}
 }
+
+func hostDNSSubnets(clusterNetwork cfg.ClusterNetwork) []netip.Prefix {
+	result := []netip.Addr{hostDNSIPv4}
+
+	for _, podCIDR := range clusterNetwork.PodCIDRs() {
+		if netip.MustParsePrefix(podCIDR).Addr().Is6() {
+			result = append(result, hostDNSIPv6)
+		}
+	}
+
+	return xslices.Map(result, func(a netip.Addr) netip.Prefix { return netip.PrefixFrom(a, a.BitLen()) })
+}
+
+var (
+	hostDNSIPv4 = netip.MustParseAddr(constants.HostDNSAddress)
+	hostDNSIPv6 = netip.MustParseAddr(constants.HostDNSAddressV6)
+)

--- a/internal/pkg/dns/dns_test.go
+++ b/internal/pkg/dns/dns_test.go
@@ -82,7 +82,7 @@ func TestDNS(t *testing.T) {
 		},
 	}
 
-	for _, dnsAddr := range []string{"127.0.0.1:10700"} {
+	for _, dnsAddr := range []string{"127.0.0.1:10700", "[::1]:10700"} {
 		for _, test := range tests {
 			t.Run(dnsAddr+"/"+test.name, func(t *testing.T) {
 				stop := newManager(t, test.nameservers...)
@@ -123,6 +123,14 @@ func TestDNSEmptyDestinations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dnssrv.RcodeServerFailure, r.Rcode, r)
 
+	r, err = dnssrv.Exchange(createQuery("google.com"), "[::1]:10700")
+	require.NoError(t, err)
+	require.Equal(t, dnssrv.RcodeServerFailure, r.Rcode, r)
+
+	r, err = dnssrv.Exchange(createQuery("google.com"), "[::1]:10700")
+	require.NoError(t, err)
+	require.Equal(t, dnssrv.RcodeServerFailure, r.Rcode, r)
+
 	stop()
 }
 
@@ -142,6 +150,8 @@ func Test_ServeBackground(t *testing.T) {
 	for _, err := range m.RunAll(slices.Values([]dns.AddressPair{
 		{Network: "udp", Addr: netip.MustParseAddrPort("127.0.0.1:10700")},
 		{Network: "udp", Addr: netip.MustParseAddrPort("127.0.0.1:10701")},
+		{Network: "udp", Addr: netip.MustParseAddrPort("[::1]:10700")},
+		{Network: "udp", Addr: netip.MustParseAddrPort("[::1]:10701")},
 	}), false) {
 		require.NoError(t, err)
 	}
@@ -189,6 +199,9 @@ func newManager(t *testing.T, nameservers ...string) func() {
 		{Network: "udp", Addr: netip.MustParseAddrPort("127.0.0.1:10700")},
 		{Network: "udp", Addr: netip.MustParseAddrPort("127.0.0.1:10701")},
 		{Network: "tcp", Addr: netip.MustParseAddrPort("127.0.0.1:10700")},
+		{Network: "udp", Addr: netip.MustParseAddrPort("[::1]:10700")},
+		{Network: "tcp", Addr: netip.MustParseAddrPort("[::1]:10700")},
+		{Network: "udp", Addr: netip.MustParseAddrPort("[::1]:10700")},
 	}), false) {
 		if err != nil && strings.Contains(err.Error(), "failed to set TCP_FASTOPEN") {
 			continue
@@ -200,6 +213,8 @@ func newManager(t *testing.T, nameservers ...string) func() {
 	for _, err := range m.RunAll(slices.Values([]dns.AddressPair{
 		{Network: "udp", Addr: netip.MustParseAddrPort("127.0.0.1:10700")},
 		{Network: "tcp", Addr: netip.MustParseAddrPort("127.0.0.1:10700")},
+		{Network: "udp", Addr: netip.MustParseAddrPort("[::1]:10700")},
+		{Network: "tcp", Addr: netip.MustParseAddrPort("[::1]:10700")},
 	}), false) {
 		if err != nil && strings.Contains(err.Error(), "failed to set TCP_FASTOPEN") {
 			continue

--- a/pkg/machinery/api/resource/definitions/network/network.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network.pb.go
@@ -1765,13 +1765,14 @@ func (x *HardwareAddrSpec) GetHardwareAddr() []byte {
 
 // HostDNSConfigSpec describes host DNS config.
 type HostDNSConfigSpec struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
-	Enabled               bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	ListenAddresses       []*common.NetIPPort    `protobuf:"bytes,2,rep,name=listen_addresses,json=listenAddresses,proto3" json:"listen_addresses,omitempty"`
-	ServiceHostDnsAddress *common.NetIP          `protobuf:"bytes,3,opt,name=service_host_dns_address,json=serviceHostDnsAddress,proto3" json:"service_host_dns_address,omitempty"`
-	ResolveMemberNames    bool                   `protobuf:"varint,4,opt,name=resolve_member_names,json=resolveMemberNames,proto3" json:"resolve_member_names,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	Enabled                 bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	ListenAddresses         []*common.NetIPPort    `protobuf:"bytes,2,rep,name=listen_addresses,json=listenAddresses,proto3" json:"listen_addresses,omitempty"`
+	ServiceHostDnsAddress   *common.NetIP          `protobuf:"bytes,3,opt,name=service_host_dns_address,json=serviceHostDnsAddress,proto3" json:"service_host_dns_address,omitempty"`
+	ResolveMemberNames      bool                   `protobuf:"varint,4,opt,name=resolve_member_names,json=resolveMemberNames,proto3" json:"resolve_member_names,omitempty"`
+	ServiceHostDnsAddressV6 *common.NetIP          `protobuf:"bytes,5,opt,name=service_host_dns_address_v6,json=serviceHostDnsAddressV6,proto3" json:"service_host_dns_address_v6,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *HostDNSConfigSpec) Reset() {
@@ -1830,6 +1831,13 @@ func (x *HostDNSConfigSpec) GetResolveMemberNames() bool {
 		return x.ResolveMemberNames
 	}
 	return false
+}
+
+func (x *HostDNSConfigSpec) GetServiceHostDnsAddressV6() *common.NetIP {
+	if x != nil {
+		return x.ServiceHostDnsAddressV6
+	}
+	return nil
 }
 
 // HostnameSpecSpec describes node hostname.
@@ -5363,12 +5371,13 @@ const file_resource_definitions_network_network_proto_rawDesc = "" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"K\n" +
 	"\x10HardwareAddrSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
-	"\rhardware_addr\x18\x02 \x01(\fR\fhardwareAddr\"\xe5\x01\n" +
+	"\rhardware_addr\x18\x02 \x01(\fR\fhardwareAddr\"\xb2\x02\n" +
 	"\x11HostDNSConfigSpec\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12<\n" +
 	"\x10listen_addresses\x18\x02 \x03(\v2\x11.common.NetIPPortR\x0flistenAddresses\x12F\n" +
 	"\x18service_host_dns_address\x18\x03 \x01(\v2\r.common.NetIPR\x15serviceHostDnsAddress\x120\n" +
-	"\x14resolve_member_names\x18\x04 \x01(\bR\x12resolveMemberNames\"\xa7\x01\n" +
+	"\x14resolve_member_names\x18\x04 \x01(\bR\x12resolveMemberNames\x12K\n" +
+	"\x1bservice_host_dns_address_v6\x18\x05 \x01(\v2\r.common.NetIPR\x17serviceHostDnsAddressV6\"\xa7\x01\n" +
 	"\x10HostnameSpecSpec\x12\x1a\n" +
 	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1e\n" +
 	"\n" +
@@ -5829,121 +5838,122 @@ var file_resource_definitions_network_network_proto_depIdxs = []int32{
 	85,  // 38: talos.resource.definitions.network.HTTPProbeSpec.timeout:type_name -> google.protobuf.Duration
 	86,  // 39: talos.resource.definitions.network.HostDNSConfigSpec.listen_addresses:type_name -> common.NetIPPort
 	70,  // 40: talos.resource.definitions.network.HostDNSConfigSpec.service_host_dns_address:type_name -> common.NetIP
-	69,  // 41: talos.resource.definitions.network.HostnameSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	87,  // 42: talos.resource.definitions.network.LinkSpecSpec.type:type_name -> talos.resource.definitions.enums.NethelpersLinkType
-	3,   // 43: talos.resource.definitions.network.LinkSpecSpec.bond_slave:type_name -> talos.resource.definitions.network.BondSlave
-	5,   // 44: talos.resource.definitions.network.LinkSpecSpec.bridge_slave:type_name -> talos.resource.definitions.network.BridgeSlave
-	60,  // 45: talos.resource.definitions.network.LinkSpecSpec.vlan:type_name -> talos.resource.definitions.network.VLANSpec
-	2,   // 46: talos.resource.definitions.network.LinkSpecSpec.bond_master:type_name -> talos.resource.definitions.network.BondMasterSpec
-	4,   // 47: talos.resource.definitions.network.LinkSpecSpec.bridge_master:type_name -> talos.resource.definitions.network.BridgeMasterSpec
-	64,  // 48: talos.resource.definitions.network.LinkSpecSpec.wireguard:type_name -> talos.resource.definitions.network.WireguardSpec
-	69,  // 49: talos.resource.definitions.network.LinkSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	61,  // 50: talos.resource.definitions.network.LinkSpecSpec.vrf_master:type_name -> talos.resource.definitions.network.VRFMasterSpec
-	62,  // 51: talos.resource.definitions.network.LinkSpecSpec.vrf_slave:type_name -> talos.resource.definitions.network.VRFSlave
-	87,  // 52: talos.resource.definitions.network.LinkStatusSpec.type:type_name -> talos.resource.definitions.enums.NethelpersLinkType
-	88,  // 53: talos.resource.definitions.network.LinkStatusSpec.operational_state:type_name -> talos.resource.definitions.enums.NethelpersOperationalState
-	82,  // 54: talos.resource.definitions.network.LinkStatusSpec.port:type_name -> talos.resource.definitions.enums.NethelpersPort
-	83,  // 55: talos.resource.definitions.network.LinkStatusSpec.duplex:type_name -> talos.resource.definitions.enums.NethelpersDuplex
-	60,  // 56: talos.resource.definitions.network.LinkStatusSpec.vlan:type_name -> talos.resource.definitions.network.VLANSpec
-	4,   // 57: talos.resource.definitions.network.LinkStatusSpec.bridge_master:type_name -> talos.resource.definitions.network.BridgeMasterSpec
-	2,   // 58: talos.resource.definitions.network.LinkStatusSpec.bond_master:type_name -> talos.resource.definitions.network.BondMasterSpec
-	64,  // 59: talos.resource.definitions.network.LinkStatusSpec.wireguard:type_name -> talos.resource.definitions.network.WireguardSpec
-	61,  // 60: talos.resource.definitions.network.LinkStatusSpec.vrf_master:type_name -> talos.resource.definitions.network.VRFMasterSpec
-	66,  // 61: talos.resource.definitions.network.NfTablesAddressMatch.include_subnets:type_name -> common.NetIPPrefix
-	66,  // 62: talos.resource.definitions.network.NfTablesAddressMatch.exclude_subnets:type_name -> common.NetIPPrefix
-	89,  // 63: talos.resource.definitions.network.NfTablesChainSpec.hook:type_name -> talos.resource.definitions.enums.NethelpersNfTablesChainHook
-	90,  // 64: talos.resource.definitions.network.NfTablesChainSpec.priority:type_name -> talos.resource.definitions.enums.NethelpersNfTablesChainPriority
-	37,  // 65: talos.resource.definitions.network.NfTablesChainSpec.rules:type_name -> talos.resource.definitions.network.NfTablesRule
-	91,  // 66: talos.resource.definitions.network.NfTablesChainSpec.policy:type_name -> talos.resource.definitions.enums.NethelpersNfTablesVerdict
-	92,  // 67: talos.resource.definitions.network.NfTablesConntrackStateMatch.states:type_name -> talos.resource.definitions.enums.NethelpersConntrackState
-	93,  // 68: talos.resource.definitions.network.NfTablesICMPTypeMatch.types:type_name -> talos.resource.definitions.enums.NethelpersICMPType
-	94,  // 69: talos.resource.definitions.network.NfTablesIfNameMatch.operator:type_name -> talos.resource.definitions.enums.NethelpersMatchOperator
-	95,  // 70: talos.resource.definitions.network.NfTablesLayer4Match.protocol:type_name -> talos.resource.definitions.enums.NethelpersProtocol
-	36,  // 71: talos.resource.definitions.network.NfTablesLayer4Match.match_source_port:type_name -> talos.resource.definitions.network.NfTablesPortMatch
-	36,  // 72: talos.resource.definitions.network.NfTablesLayer4Match.match_destination_port:type_name -> talos.resource.definitions.network.NfTablesPortMatch
-	31,  // 73: talos.resource.definitions.network.NfTablesLayer4Match.match_icmp_type:type_name -> talos.resource.definitions.network.NfTablesICMPTypeMatch
-	43,  // 74: talos.resource.definitions.network.NfTablesPortMatch.ranges:type_name -> talos.resource.definitions.network.PortRange
-	32,  // 75: talos.resource.definitions.network.NfTablesRule.match_o_if_name:type_name -> talos.resource.definitions.network.NfTablesIfNameMatch
-	91,  // 76: talos.resource.definitions.network.NfTablesRule.verdict:type_name -> talos.resource.definitions.enums.NethelpersNfTablesVerdict
-	35,  // 77: talos.resource.definitions.network.NfTablesRule.match_mark:type_name -> talos.resource.definitions.network.NfTablesMark
-	35,  // 78: talos.resource.definitions.network.NfTablesRule.set_mark:type_name -> talos.resource.definitions.network.NfTablesMark
-	27,  // 79: talos.resource.definitions.network.NfTablesRule.match_source_address:type_name -> talos.resource.definitions.network.NfTablesAddressMatch
-	27,  // 80: talos.resource.definitions.network.NfTablesRule.match_destination_address:type_name -> talos.resource.definitions.network.NfTablesAddressMatch
-	33,  // 81: talos.resource.definitions.network.NfTablesRule.match_layer4:type_name -> talos.resource.definitions.network.NfTablesLayer4Match
-	32,  // 82: talos.resource.definitions.network.NfTablesRule.match_i_if_name:type_name -> talos.resource.definitions.network.NfTablesIfNameMatch
-	29,  // 83: talos.resource.definitions.network.NfTablesRule.clamp_mss:type_name -> talos.resource.definitions.network.NfTablesClampMSS
-	34,  // 84: talos.resource.definitions.network.NfTablesRule.match_limit:type_name -> talos.resource.definitions.network.NfTablesLimitMatch
-	30,  // 85: talos.resource.definitions.network.NfTablesRule.match_conntrack_state:type_name -> talos.resource.definitions.network.NfTablesConntrackStateMatch
-	66,  // 86: talos.resource.definitions.network.NodeAddressFilterSpec.include_subnets:type_name -> common.NetIPPrefix
-	66,  // 87: talos.resource.definitions.network.NodeAddressFilterSpec.exclude_subnets:type_name -> common.NetIPPrefix
-	96,  // 88: talos.resource.definitions.network.NodeAddressSortAlgorithmSpec.algorithm:type_name -> talos.resource.definitions.enums.NethelpersAddressSortAlgorithm
-	66,  // 89: talos.resource.definitions.network.NodeAddressSpec.addresses:type_name -> common.NetIPPrefix
-	96,  // 90: talos.resource.definitions.network.NodeAddressSpec.sort_algorithm:type_name -> talos.resource.definitions.enums.NethelpersAddressSortAlgorithm
-	97,  // 91: talos.resource.definitions.network.OperatorSpecSpec.operator:type_name -> talos.resource.definitions.enums.NetworkOperator
-	8,   // 92: talos.resource.definitions.network.OperatorSpecSpec.dhcp4:type_name -> talos.resource.definitions.network.DHCP4OperatorSpec
-	9,   // 93: talos.resource.definitions.network.OperatorSpecSpec.dhcp6:type_name -> talos.resource.definitions.network.DHCP6OperatorSpec
-	59,  // 94: talos.resource.definitions.network.OperatorSpecSpec.vip:type_name -> talos.resource.definitions.network.VIPOperatorSpec
-	69,  // 95: talos.resource.definitions.network.OperatorSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	0,   // 96: talos.resource.definitions.network.PlatformConfigSpec.addresses:type_name -> talos.resource.definitions.network.AddressSpecSpec
-	25,  // 97: talos.resource.definitions.network.PlatformConfigSpec.links:type_name -> talos.resource.definitions.network.LinkSpecSpec
-	48,  // 98: talos.resource.definitions.network.PlatformConfigSpec.routes:type_name -> talos.resource.definitions.network.RouteSpecSpec
-	21,  // 99: talos.resource.definitions.network.PlatformConfigSpec.hostnames:type_name -> talos.resource.definitions.network.HostnameSpecSpec
-	46,  // 100: talos.resource.definitions.network.PlatformConfigSpec.resolvers:type_name -> talos.resource.definitions.network.ResolverSpecSpec
-	55,  // 101: talos.resource.definitions.network.PlatformConfigSpec.time_servers:type_name -> talos.resource.definitions.network.TimeServerSpecSpec
-	41,  // 102: talos.resource.definitions.network.PlatformConfigSpec.operators:type_name -> talos.resource.definitions.network.OperatorSpecSpec
-	70,  // 103: talos.resource.definitions.network.PlatformConfigSpec.external_ips:type_name -> common.NetIP
-	44,  // 104: talos.resource.definitions.network.PlatformConfigSpec.probes:type_name -> talos.resource.definitions.network.ProbeSpecSpec
-	98,  // 105: talos.resource.definitions.network.PlatformConfigSpec.metadata:type_name -> talos.resource.definitions.runtime.PlatformMetadataSpec
-	85,  // 106: talos.resource.definitions.network.ProbeSpecSpec.interval:type_name -> google.protobuf.Duration
-	54,  // 107: talos.resource.definitions.network.ProbeSpecSpec.tcp:type_name -> talos.resource.definitions.network.TCPProbeSpec
-	69,  // 108: talos.resource.definitions.network.ProbeSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	18,  // 109: talos.resource.definitions.network.ProbeSpecSpec.http:type_name -> talos.resource.definitions.network.HTTPProbeSpec
-	70,  // 110: talos.resource.definitions.network.ResolverSpecSpec.dns_servers:type_name -> common.NetIP
-	69,  // 111: talos.resource.definitions.network.ResolverSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	70,  // 112: talos.resource.definitions.network.ResolverStatusSpec.dns_servers:type_name -> common.NetIP
-	67,  // 113: talos.resource.definitions.network.RouteSpecSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
-	66,  // 114: talos.resource.definitions.network.RouteSpecSpec.destination:type_name -> common.NetIPPrefix
-	70,  // 115: talos.resource.definitions.network.RouteSpecSpec.source:type_name -> common.NetIP
-	70,  // 116: talos.resource.definitions.network.RouteSpecSpec.gateway:type_name -> common.NetIP
-	99,  // 117: talos.resource.definitions.network.RouteSpecSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
-	68,  // 118: talos.resource.definitions.network.RouteSpecSpec.scope:type_name -> talos.resource.definitions.enums.NethelpersScope
-	100, // 119: talos.resource.definitions.network.RouteSpecSpec.type:type_name -> talos.resource.definitions.enums.NethelpersRouteType
-	101, // 120: talos.resource.definitions.network.RouteSpecSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersRouteProtocol
-	69,  // 121: talos.resource.definitions.network.RouteSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	67,  // 122: talos.resource.definitions.network.RouteStatusSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
-	66,  // 123: talos.resource.definitions.network.RouteStatusSpec.destination:type_name -> common.NetIPPrefix
-	70,  // 124: talos.resource.definitions.network.RouteStatusSpec.source:type_name -> common.NetIP
-	70,  // 125: talos.resource.definitions.network.RouteStatusSpec.gateway:type_name -> common.NetIP
-	99,  // 126: talos.resource.definitions.network.RouteStatusSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
-	68,  // 127: talos.resource.definitions.network.RouteStatusSpec.scope:type_name -> talos.resource.definitions.enums.NethelpersScope
-	100, // 128: talos.resource.definitions.network.RouteStatusSpec.type:type_name -> talos.resource.definitions.enums.NethelpersRouteType
-	101, // 129: talos.resource.definitions.network.RouteStatusSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersRouteProtocol
-	67,  // 130: talos.resource.definitions.network.RoutingRuleSpecSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
-	66,  // 131: talos.resource.definitions.network.RoutingRuleSpecSpec.src:type_name -> common.NetIPPrefix
-	66,  // 132: talos.resource.definitions.network.RoutingRuleSpecSpec.dst:type_name -> common.NetIPPrefix
-	99,  // 133: talos.resource.definitions.network.RoutingRuleSpecSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
-	102, // 134: talos.resource.definitions.network.RoutingRuleSpecSpec.action:type_name -> talos.resource.definitions.enums.NethelpersRoutingRuleAction
-	69,  // 135: talos.resource.definitions.network.RoutingRuleSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	67,  // 136: talos.resource.definitions.network.RoutingRuleStatusSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
-	66,  // 137: talos.resource.definitions.network.RoutingRuleStatusSpec.src:type_name -> common.NetIPPrefix
-	66,  // 138: talos.resource.definitions.network.RoutingRuleStatusSpec.dst:type_name -> common.NetIPPrefix
-	99,  // 139: talos.resource.definitions.network.RoutingRuleStatusSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
-	102, // 140: talos.resource.definitions.network.RoutingRuleStatusSpec.action:type_name -> talos.resource.definitions.enums.NethelpersRoutingRuleAction
-	85,  // 141: talos.resource.definitions.network.TCPProbeSpec.timeout:type_name -> google.protobuf.Duration
-	69,  // 142: talos.resource.definitions.network.TimeServerSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
-	70,  // 143: talos.resource.definitions.network.VIPOperatorSpec.ip:type_name -> common.NetIP
-	57,  // 144: talos.resource.definitions.network.VIPOperatorSpec.equinix_metal:type_name -> talos.resource.definitions.network.VIPEquinixMetalSpec
-	58,  // 145: talos.resource.definitions.network.VIPOperatorSpec.h_cloud:type_name -> talos.resource.definitions.network.VIPHCloudSpec
-	103, // 146: talos.resource.definitions.network.VLANSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersVLANProtocol
-	99,  // 147: talos.resource.definitions.network.VRFMasterSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
-	85,  // 148: talos.resource.definitions.network.WireguardPeer.persistent_keepalive_interval:type_name -> google.protobuf.Duration
-	66,  // 149: talos.resource.definitions.network.WireguardPeer.allowed_ips:type_name -> common.NetIPPrefix
-	63,  // 150: talos.resource.definitions.network.WireguardSpec.peers:type_name -> talos.resource.definitions.network.WireguardPeer
-	151, // [151:151] is the sub-list for method output_type
-	151, // [151:151] is the sub-list for method input_type
-	151, // [151:151] is the sub-list for extension type_name
-	151, // [151:151] is the sub-list for extension extendee
-	0,   // [0:151] is the sub-list for field type_name
+	70,  // 41: talos.resource.definitions.network.HostDNSConfigSpec.service_host_dns_address_v6:type_name -> common.NetIP
+	69,  // 42: talos.resource.definitions.network.HostnameSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	87,  // 43: talos.resource.definitions.network.LinkSpecSpec.type:type_name -> talos.resource.definitions.enums.NethelpersLinkType
+	3,   // 44: talos.resource.definitions.network.LinkSpecSpec.bond_slave:type_name -> talos.resource.definitions.network.BondSlave
+	5,   // 45: talos.resource.definitions.network.LinkSpecSpec.bridge_slave:type_name -> talos.resource.definitions.network.BridgeSlave
+	60,  // 46: talos.resource.definitions.network.LinkSpecSpec.vlan:type_name -> talos.resource.definitions.network.VLANSpec
+	2,   // 47: talos.resource.definitions.network.LinkSpecSpec.bond_master:type_name -> talos.resource.definitions.network.BondMasterSpec
+	4,   // 48: talos.resource.definitions.network.LinkSpecSpec.bridge_master:type_name -> talos.resource.definitions.network.BridgeMasterSpec
+	64,  // 49: talos.resource.definitions.network.LinkSpecSpec.wireguard:type_name -> talos.resource.definitions.network.WireguardSpec
+	69,  // 50: talos.resource.definitions.network.LinkSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	61,  // 51: talos.resource.definitions.network.LinkSpecSpec.vrf_master:type_name -> talos.resource.definitions.network.VRFMasterSpec
+	62,  // 52: talos.resource.definitions.network.LinkSpecSpec.vrf_slave:type_name -> talos.resource.definitions.network.VRFSlave
+	87,  // 53: talos.resource.definitions.network.LinkStatusSpec.type:type_name -> talos.resource.definitions.enums.NethelpersLinkType
+	88,  // 54: talos.resource.definitions.network.LinkStatusSpec.operational_state:type_name -> talos.resource.definitions.enums.NethelpersOperationalState
+	82,  // 55: talos.resource.definitions.network.LinkStatusSpec.port:type_name -> talos.resource.definitions.enums.NethelpersPort
+	83,  // 56: talos.resource.definitions.network.LinkStatusSpec.duplex:type_name -> talos.resource.definitions.enums.NethelpersDuplex
+	60,  // 57: talos.resource.definitions.network.LinkStatusSpec.vlan:type_name -> talos.resource.definitions.network.VLANSpec
+	4,   // 58: talos.resource.definitions.network.LinkStatusSpec.bridge_master:type_name -> talos.resource.definitions.network.BridgeMasterSpec
+	2,   // 59: talos.resource.definitions.network.LinkStatusSpec.bond_master:type_name -> talos.resource.definitions.network.BondMasterSpec
+	64,  // 60: talos.resource.definitions.network.LinkStatusSpec.wireguard:type_name -> talos.resource.definitions.network.WireguardSpec
+	61,  // 61: talos.resource.definitions.network.LinkStatusSpec.vrf_master:type_name -> talos.resource.definitions.network.VRFMasterSpec
+	66,  // 62: talos.resource.definitions.network.NfTablesAddressMatch.include_subnets:type_name -> common.NetIPPrefix
+	66,  // 63: talos.resource.definitions.network.NfTablesAddressMatch.exclude_subnets:type_name -> common.NetIPPrefix
+	89,  // 64: talos.resource.definitions.network.NfTablesChainSpec.hook:type_name -> talos.resource.definitions.enums.NethelpersNfTablesChainHook
+	90,  // 65: talos.resource.definitions.network.NfTablesChainSpec.priority:type_name -> talos.resource.definitions.enums.NethelpersNfTablesChainPriority
+	37,  // 66: talos.resource.definitions.network.NfTablesChainSpec.rules:type_name -> talos.resource.definitions.network.NfTablesRule
+	91,  // 67: talos.resource.definitions.network.NfTablesChainSpec.policy:type_name -> talos.resource.definitions.enums.NethelpersNfTablesVerdict
+	92,  // 68: talos.resource.definitions.network.NfTablesConntrackStateMatch.states:type_name -> talos.resource.definitions.enums.NethelpersConntrackState
+	93,  // 69: talos.resource.definitions.network.NfTablesICMPTypeMatch.types:type_name -> talos.resource.definitions.enums.NethelpersICMPType
+	94,  // 70: talos.resource.definitions.network.NfTablesIfNameMatch.operator:type_name -> talos.resource.definitions.enums.NethelpersMatchOperator
+	95,  // 71: talos.resource.definitions.network.NfTablesLayer4Match.protocol:type_name -> talos.resource.definitions.enums.NethelpersProtocol
+	36,  // 72: talos.resource.definitions.network.NfTablesLayer4Match.match_source_port:type_name -> talos.resource.definitions.network.NfTablesPortMatch
+	36,  // 73: talos.resource.definitions.network.NfTablesLayer4Match.match_destination_port:type_name -> talos.resource.definitions.network.NfTablesPortMatch
+	31,  // 74: talos.resource.definitions.network.NfTablesLayer4Match.match_icmp_type:type_name -> talos.resource.definitions.network.NfTablesICMPTypeMatch
+	43,  // 75: talos.resource.definitions.network.NfTablesPortMatch.ranges:type_name -> talos.resource.definitions.network.PortRange
+	32,  // 76: talos.resource.definitions.network.NfTablesRule.match_o_if_name:type_name -> talos.resource.definitions.network.NfTablesIfNameMatch
+	91,  // 77: talos.resource.definitions.network.NfTablesRule.verdict:type_name -> talos.resource.definitions.enums.NethelpersNfTablesVerdict
+	35,  // 78: talos.resource.definitions.network.NfTablesRule.match_mark:type_name -> talos.resource.definitions.network.NfTablesMark
+	35,  // 79: talos.resource.definitions.network.NfTablesRule.set_mark:type_name -> talos.resource.definitions.network.NfTablesMark
+	27,  // 80: talos.resource.definitions.network.NfTablesRule.match_source_address:type_name -> talos.resource.definitions.network.NfTablesAddressMatch
+	27,  // 81: talos.resource.definitions.network.NfTablesRule.match_destination_address:type_name -> talos.resource.definitions.network.NfTablesAddressMatch
+	33,  // 82: talos.resource.definitions.network.NfTablesRule.match_layer4:type_name -> talos.resource.definitions.network.NfTablesLayer4Match
+	32,  // 83: talos.resource.definitions.network.NfTablesRule.match_i_if_name:type_name -> talos.resource.definitions.network.NfTablesIfNameMatch
+	29,  // 84: talos.resource.definitions.network.NfTablesRule.clamp_mss:type_name -> talos.resource.definitions.network.NfTablesClampMSS
+	34,  // 85: talos.resource.definitions.network.NfTablesRule.match_limit:type_name -> talos.resource.definitions.network.NfTablesLimitMatch
+	30,  // 86: talos.resource.definitions.network.NfTablesRule.match_conntrack_state:type_name -> talos.resource.definitions.network.NfTablesConntrackStateMatch
+	66,  // 87: talos.resource.definitions.network.NodeAddressFilterSpec.include_subnets:type_name -> common.NetIPPrefix
+	66,  // 88: talos.resource.definitions.network.NodeAddressFilterSpec.exclude_subnets:type_name -> common.NetIPPrefix
+	96,  // 89: talos.resource.definitions.network.NodeAddressSortAlgorithmSpec.algorithm:type_name -> talos.resource.definitions.enums.NethelpersAddressSortAlgorithm
+	66,  // 90: talos.resource.definitions.network.NodeAddressSpec.addresses:type_name -> common.NetIPPrefix
+	96,  // 91: talos.resource.definitions.network.NodeAddressSpec.sort_algorithm:type_name -> talos.resource.definitions.enums.NethelpersAddressSortAlgorithm
+	97,  // 92: talos.resource.definitions.network.OperatorSpecSpec.operator:type_name -> talos.resource.definitions.enums.NetworkOperator
+	8,   // 93: talos.resource.definitions.network.OperatorSpecSpec.dhcp4:type_name -> talos.resource.definitions.network.DHCP4OperatorSpec
+	9,   // 94: talos.resource.definitions.network.OperatorSpecSpec.dhcp6:type_name -> talos.resource.definitions.network.DHCP6OperatorSpec
+	59,  // 95: talos.resource.definitions.network.OperatorSpecSpec.vip:type_name -> talos.resource.definitions.network.VIPOperatorSpec
+	69,  // 96: talos.resource.definitions.network.OperatorSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	0,   // 97: talos.resource.definitions.network.PlatformConfigSpec.addresses:type_name -> talos.resource.definitions.network.AddressSpecSpec
+	25,  // 98: talos.resource.definitions.network.PlatformConfigSpec.links:type_name -> talos.resource.definitions.network.LinkSpecSpec
+	48,  // 99: talos.resource.definitions.network.PlatformConfigSpec.routes:type_name -> talos.resource.definitions.network.RouteSpecSpec
+	21,  // 100: talos.resource.definitions.network.PlatformConfigSpec.hostnames:type_name -> talos.resource.definitions.network.HostnameSpecSpec
+	46,  // 101: talos.resource.definitions.network.PlatformConfigSpec.resolvers:type_name -> talos.resource.definitions.network.ResolverSpecSpec
+	55,  // 102: talos.resource.definitions.network.PlatformConfigSpec.time_servers:type_name -> talos.resource.definitions.network.TimeServerSpecSpec
+	41,  // 103: talos.resource.definitions.network.PlatformConfigSpec.operators:type_name -> talos.resource.definitions.network.OperatorSpecSpec
+	70,  // 104: talos.resource.definitions.network.PlatformConfigSpec.external_ips:type_name -> common.NetIP
+	44,  // 105: talos.resource.definitions.network.PlatformConfigSpec.probes:type_name -> talos.resource.definitions.network.ProbeSpecSpec
+	98,  // 106: talos.resource.definitions.network.PlatformConfigSpec.metadata:type_name -> talos.resource.definitions.runtime.PlatformMetadataSpec
+	85,  // 107: talos.resource.definitions.network.ProbeSpecSpec.interval:type_name -> google.protobuf.Duration
+	54,  // 108: talos.resource.definitions.network.ProbeSpecSpec.tcp:type_name -> talos.resource.definitions.network.TCPProbeSpec
+	69,  // 109: talos.resource.definitions.network.ProbeSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	18,  // 110: talos.resource.definitions.network.ProbeSpecSpec.http:type_name -> talos.resource.definitions.network.HTTPProbeSpec
+	70,  // 111: talos.resource.definitions.network.ResolverSpecSpec.dns_servers:type_name -> common.NetIP
+	69,  // 112: talos.resource.definitions.network.ResolverSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	70,  // 113: talos.resource.definitions.network.ResolverStatusSpec.dns_servers:type_name -> common.NetIP
+	67,  // 114: talos.resource.definitions.network.RouteSpecSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
+	66,  // 115: talos.resource.definitions.network.RouteSpecSpec.destination:type_name -> common.NetIPPrefix
+	70,  // 116: talos.resource.definitions.network.RouteSpecSpec.source:type_name -> common.NetIP
+	70,  // 117: talos.resource.definitions.network.RouteSpecSpec.gateway:type_name -> common.NetIP
+	99,  // 118: talos.resource.definitions.network.RouteSpecSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
+	68,  // 119: talos.resource.definitions.network.RouteSpecSpec.scope:type_name -> talos.resource.definitions.enums.NethelpersScope
+	100, // 120: talos.resource.definitions.network.RouteSpecSpec.type:type_name -> talos.resource.definitions.enums.NethelpersRouteType
+	101, // 121: talos.resource.definitions.network.RouteSpecSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersRouteProtocol
+	69,  // 122: talos.resource.definitions.network.RouteSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	67,  // 123: talos.resource.definitions.network.RouteStatusSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
+	66,  // 124: talos.resource.definitions.network.RouteStatusSpec.destination:type_name -> common.NetIPPrefix
+	70,  // 125: talos.resource.definitions.network.RouteStatusSpec.source:type_name -> common.NetIP
+	70,  // 126: talos.resource.definitions.network.RouteStatusSpec.gateway:type_name -> common.NetIP
+	99,  // 127: talos.resource.definitions.network.RouteStatusSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
+	68,  // 128: talos.resource.definitions.network.RouteStatusSpec.scope:type_name -> talos.resource.definitions.enums.NethelpersScope
+	100, // 129: talos.resource.definitions.network.RouteStatusSpec.type:type_name -> talos.resource.definitions.enums.NethelpersRouteType
+	101, // 130: talos.resource.definitions.network.RouteStatusSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersRouteProtocol
+	67,  // 131: talos.resource.definitions.network.RoutingRuleSpecSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
+	66,  // 132: talos.resource.definitions.network.RoutingRuleSpecSpec.src:type_name -> common.NetIPPrefix
+	66,  // 133: talos.resource.definitions.network.RoutingRuleSpecSpec.dst:type_name -> common.NetIPPrefix
+	99,  // 134: talos.resource.definitions.network.RoutingRuleSpecSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
+	102, // 135: talos.resource.definitions.network.RoutingRuleSpecSpec.action:type_name -> talos.resource.definitions.enums.NethelpersRoutingRuleAction
+	69,  // 136: talos.resource.definitions.network.RoutingRuleSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	67,  // 137: talos.resource.definitions.network.RoutingRuleStatusSpec.family:type_name -> talos.resource.definitions.enums.NethelpersFamily
+	66,  // 138: talos.resource.definitions.network.RoutingRuleStatusSpec.src:type_name -> common.NetIPPrefix
+	66,  // 139: talos.resource.definitions.network.RoutingRuleStatusSpec.dst:type_name -> common.NetIPPrefix
+	99,  // 140: talos.resource.definitions.network.RoutingRuleStatusSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
+	102, // 141: talos.resource.definitions.network.RoutingRuleStatusSpec.action:type_name -> talos.resource.definitions.enums.NethelpersRoutingRuleAction
+	85,  // 142: talos.resource.definitions.network.TCPProbeSpec.timeout:type_name -> google.protobuf.Duration
+	69,  // 143: talos.resource.definitions.network.TimeServerSpecSpec.config_layer:type_name -> talos.resource.definitions.enums.NetworkConfigLayer
+	70,  // 144: talos.resource.definitions.network.VIPOperatorSpec.ip:type_name -> common.NetIP
+	57,  // 145: talos.resource.definitions.network.VIPOperatorSpec.equinix_metal:type_name -> talos.resource.definitions.network.VIPEquinixMetalSpec
+	58,  // 146: talos.resource.definitions.network.VIPOperatorSpec.h_cloud:type_name -> talos.resource.definitions.network.VIPHCloudSpec
+	103, // 147: talos.resource.definitions.network.VLANSpec.protocol:type_name -> talos.resource.definitions.enums.NethelpersVLANProtocol
+	99,  // 148: talos.resource.definitions.network.VRFMasterSpec.table:type_name -> talos.resource.definitions.enums.NethelpersRoutingTable
+	85,  // 149: talos.resource.definitions.network.WireguardPeer.persistent_keepalive_interval:type_name -> google.protobuf.Duration
+	66,  // 150: talos.resource.definitions.network.WireguardPeer.allowed_ips:type_name -> common.NetIPPrefix
+	63,  // 151: talos.resource.definitions.network.WireguardSpec.peers:type_name -> talos.resource.definitions.network.WireguardPeer
+	152, // [152:152] is the sub-list for method output_type
+	152, // [152:152] is the sub-list for method input_type
+	152, // [152:152] is the sub-list for extension type_name
+	152, // [152:152] is the sub-list for extension extendee
+	0,   // [0:152] is the sub-list for field type_name
 }
 
 func init() { file_resource_definitions_network_network_proto_init() }

--- a/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
@@ -1683,6 +1683,28 @@ func (m *HostDNSConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.ServiceHostDnsAddressV6 != nil {
+		if vtmsg, ok := interface{}(m.ServiceHostDnsAddressV6).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.ServiceHostDnsAddressV6)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.ResolveMemberNames {
 		i--
 		if m.ResolveMemberNames {
@@ -5857,6 +5879,16 @@ func (m *HostDNSConfigSpec) SizeVT() (n int) {
 	}
 	if m.ResolveMemberNames {
 		n += 2
+	}
+	if m.ServiceHostDnsAddressV6 != nil {
+		if size, ok := interface{}(m.ServiceHostDnsAddressV6).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.ServiceHostDnsAddressV6)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -11431,6 +11463,50 @@ func (m *HostDNSConfigSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.ResolveMemberNames = bool(v != 0)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceHostDnsAddressV6", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ServiceHostDnsAddressV6 == nil {
+				m.ServiceHostDnsAddressV6 = &common.NetIP{}
+			}
+			if unmarshal, ok := interface{}(m.ServiceHostDnsAddressV6).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.ServiceHostDnsAddressV6); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1243,6 +1243,11 @@ const (
 	// Note: 116 = 't' and 108 = 'l' in ASCII.
 	HostDNSAddress = "169.254.116.108"
 
+	// HostDNSAddressV6 is the address of the host DNS server in IPv6 network.
+	//
+	// Note: fd54:616c:6f73::204f:5320:444e:53 is "Talos OS DNS".
+	HostDNSAddressV6 = "fd54:616c:6f73::204f:5320:444e:531"
+
 	// MetalAgentModeFlagPath is the path to the file indicating if the node is running in Metal Agent mode.
 	MetalAgentModeFlagPath = "/usr/local/etc/is-metal-agent"
 

--- a/pkg/machinery/resources/network/hostdns_config.go
+++ b/pkg/machinery/resources/network/hostdns_config.go
@@ -28,10 +28,11 @@ const HostDNSConfigID resource.ID = "config"
 //
 //gotagsrewrite:gen
 type HostDNSConfigSpec struct {
-	Enabled               bool             `yaml:"enabled" protobuf:"1"`
-	ListenAddresses       []netip.AddrPort `yaml:"listenAddresses,omitempty" protobuf:"2"`
-	ServiceHostDNSAddress netip.Addr       `yaml:"serviceHostDNSAddress,omitempty" protobuf:"3"`
-	ResolveMemberNames    bool             `yaml:"resolveMemberNames,omitempty" protobuf:"4"`
+	Enabled                 bool             `yaml:"enabled" protobuf:"1"`
+	ListenAddresses         []netip.AddrPort `yaml:"listenAddresses,omitempty" protobuf:"2"`
+	ServiceHostDNSAddress   netip.Addr       `yaml:"serviceHostDNSAddress,omitempty" protobuf:"3"`
+	ResolveMemberNames      bool             `yaml:"resolveMemberNames,omitempty" protobuf:"4"`
+	ServiceHostDNSAddressV6 netip.Addr       `yaml:"serviceHostDNSAddressV6,omitempty" protobuf:"5"`
 }
 
 // NewHostDNSConfig initializes a HostDNSConfig resource.

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -9434,6 +9434,7 @@ HostDNSConfigSpec describes host DNS config.
 | listen_addresses | [common.NetIPPort](#common.NetIPPort) | repeated |  |
 | service_host_dns_address | [common.NetIP](#common.NetIP) |  |  |
 | resolve_member_names | [bool](#bool) |  |  |
+| service_host_dns_address_v6 | [common.NetIP](#common.NetIP) |  |  |
 
 
 


### PR DESCRIPTION
This PR does those things:
- Raise IPv6 listener on link-local address for dns (both TCP and UDP).
- Update kubelet's `resolv.conf` IPv4/IPv6 endpoints.

Closes #9384

Link: https://github.com/siderolabs/talos/pull/9596
Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>
