### PR TITLE
feat: run depmod with verification on rootfs build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -648,6 +648,7 @@ FROM tools AS depmod-amd64
 WORKDIR /staging
 COPY hack/modules-amd64.txt .
 COPY --from=pkg-kernel-amd64 /usr/lib/modules usr/lib/modules
+COPY --from=pkg-kernel-amd64 /boot/System.map /staging
 RUN <<EOF
 set -euo pipefail
 
@@ -655,7 +656,17 @@ KERNEL_VERSION=$(ls usr/lib/modules)
 
 xargs -a modules-amd64.txt -I {} install -D usr/lib/modules/${KERNEL_VERSION}/{} /build/usr/lib/modules/${KERNEL_VERSION}/{}
 
-depmod -b /build/usr ${KERNEL_VERSION}
+# check if the output of the command is empty, as depmod doesn't fail and just prints a warning
+DEPMOD_OUTPUT=$(depmod -b /build/usr -F /staging/System.map --errsyms -w ${KERNEL_VERSION} 2>&1)
+
+if [ -n "${DEPMOD_OUTPUT}" ]; then
+    echo "depmod output is not empty, indicating a potential issue:"
+    echo "${DEPMOD_OUTPUT}"
+    exit 1
+else
+    echo "depmod completed successfully with no warnings."
+fi
+
 EOF
 
 FROM scratch AS modules-amd64
@@ -665,6 +676,7 @@ FROM tools AS depmod-arm64
 WORKDIR /staging
 COPY hack/modules-arm64.txt .
 COPY --from=pkg-kernel-arm64 /usr/lib/modules usr/lib/modules
+COPY --from=pkg-kernel-arm64 /boot/System.map /staging
 RUN <<EOF
 set -euo pipefail
 
@@ -672,7 +684,17 @@ KERNEL_VERSION=$(ls usr/lib/modules)
 
 xargs -a modules-arm64.txt -I {} install -D usr/lib/modules/${KERNEL_VERSION}/{} /build/usr/lib/modules/${KERNEL_VERSION}/{}
 
-depmod -b /build/usr ${KERNEL_VERSION}
+# check if the output of the command is empty, as depmod doesn't fail and just prints a warning
+DEPMOD_OUTPUT=$(depmod -b /build/usr -F /staging/System.map --errsyms -w ${KERNEL_VERSION} 2>&1)
+
+if [ -n "${DEPMOD_OUTPUT}" ]; then
+    echo "depmod output is not empty, indicating a potential issue:"
+    echo "${DEPMOD_OUTPUT}"
+    exit 1
+else
+    echo "depmod completed successfully with no warnings."
+fi
+
 EOF
 
 FROM scratch AS modules-arm64

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ EMBED_TARGET ?= embed
 TOOLS_PREFIX ?= ghcr.io/siderolabs/tools
 TOOLS ?= v1.14.0-alpha.0-6-g44ad18c
 PKGS_PREFIX ?= ghcr.io/siderolabs
-PKGS ?= v1.14.0-alpha.0-26-gc77f985
+PKGS ?= v1.14.0-alpha.0-27-gadeaafc
 GENERATE_VEX_PREFIX ?= ghcr.io/siderolabs/generate-vex
 GENERATE_VEX ?= latest
 

--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -32,6 +32,7 @@ kernel/drivers/edac/i82975x_edac.ko
 kernel/drivers/edac/ie31200_edac.ko
 kernel/drivers/edac/igen6_edac.ko
 kernel/drivers/edac/sb_edac.ko
+kernel/drivers/edac/skx_edac_common.ko
 kernel/drivers/edac/skx_edac.ko
 kernel/drivers/edac/x38_edac.ko
 kernel/drivers/gpu/drm/display/drm_display_helper.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -154,6 +154,7 @@ kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-renesas-gbeth.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-rk.ko
+kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-sun55i.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-sunxi.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-tegra.ko
@@ -162,6 +163,7 @@ kernel/drivers/net/ethernet/stmicro/stmmac/stmmac-platform.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/stmmac.ko
 kernel/drivers/net/mdio.ko
 kernel/drivers/net/pcs/pcs_xpcs.ko
+kernel/drivers/net/pcs/pcs-rzn1-miic.ko
 kernel/drivers/net/phy/dp83867.ko
 kernel/drivers/net/usb/r8152.ko
 kernel/drivers/net/vmxnet3/vmxnet3.ko

--- a/pkg/machinery/gendata/data/pkgs
+++ b/pkg/machinery/gendata/data/pkgs
@@ -1,1 +1,1 @@
-v1.14.0-alpha.0-26-gc77f985
+v1.14.0-alpha.0-27-gadeaafc


### PR DESCRIPTION
Verify that the set of modules in the rootfs with the kernel combined
doesn't have any unresolved symbols.

Uses https://github.com/siderolabs/pkgs/pull/1530