### PR TITLE
fix: handle gateways which are not on-link routes in dhcp4

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -21,10 +20,9 @@ import (
 	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
-	"go4.org/netipx"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
-	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
@@ -306,161 +304,18 @@ func (d *DHCP4) TimeServerSpecs() []network.TimeServerSpecSpec {
 	return d.timeservers
 }
 
-//nolint:gocyclo
 func (d *DHCP4) parseNetworkConfigFromAck(ack *dhcpv4.DHCPv4, useHostname bool) {
+	specs := dhcpparse.ParseDHCP4Ack(ack, d.linkName, d.routeMetric, useHostname)
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	addr, _ := netipx.FromStdIPNet(&net.IPNet{
-		IP:   ack.YourIPAddr,
-		Mask: ack.SubnetMask(),
-	})
-
-	d.addresses = []network.AddressSpecSpec{
-		{
-			Address:     addr,
-			LinkName:    d.linkName,
-			Family:      nethelpers.FamilyInet4,
-			Scope:       nethelpers.ScopeGlobal,
-			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
-			Priority:    d.routeMetric,
-			ConfigLayer: network.ConfigOperator,
-		},
-	}
-
-	mtu, err := dhcpv4.GetUint16(dhcpv4.OptionInterfaceMTU, ack.Options)
-	if err == nil {
-		d.links = []network.LinkSpecSpec{
-			{
-				Name: d.linkName,
-				MTU:  uint32(mtu),
-				Up:   true,
-			},
-		}
-	} else {
-		d.links = nil
-	}
-
-	// rfc3442:
-	//   If the DHCP server returns both a Classless Static Routes option and
-	//   a Router option, the DHCP client MUST ignore the Router option.
-	d.routes = nil
-
-	if len(ack.ClasslessStaticRoute()) > 0 {
-		for _, route := range ack.ClasslessStaticRoute() {
-			gw, _ := netipx.FromStdIP(route.Router)
-			dst, _ := netipx.FromStdIPNet(route.Dest)
-
-			d.routes = append(d.routes, network.RouteSpecSpec{
-				Family:      nethelpers.FamilyInet4,
-				Destination: dst,
-				Source:      addr.Addr(),
-				Gateway:     gw,
-				OutLinkName: d.linkName,
-				Table:       nethelpers.TableMain,
-				Priority:    d.routeMetric,
-				Scope:       nethelpers.ScopeGlobal,
-				Type:        nethelpers.TypeUnicast,
-				Protocol:    nethelpers.ProtocolBoot,
-				ConfigLayer: network.ConfigOperator,
-			})
-		}
-	} else {
-		for _, router := range ack.Router() {
-			gw, _ := netipx.FromStdIP(router)
-
-			d.routes = append(d.routes, network.RouteSpecSpec{
-				Family:      nethelpers.FamilyInet4,
-				Gateway:     gw,
-				Source:      addr.Addr(),
-				OutLinkName: d.linkName,
-				Table:       nethelpers.TableMain,
-				Priority:    d.routeMetric,
-				Scope:       nethelpers.ScopeGlobal,
-				Type:        nethelpers.TypeUnicast,
-				Protocol:    nethelpers.ProtocolBoot,
-				ConfigLayer: network.ConfigOperator,
-			})
-
-			if !addr.Contains(gw) {
-				// Add an interface route for the gateway if it's not in the same network
-				d.routes = append(d.routes, network.RouteSpecSpec{
-					Family:      nethelpers.FamilyInet4,
-					Destination: netip.PrefixFrom(gw, gw.BitLen()),
-					Source:      addr.Addr(),
-					OutLinkName: d.linkName,
-					Table:       nethelpers.TableMain,
-					Priority:    d.routeMetric,
-					Scope:       nethelpers.ScopeLink,
-					Type:        nethelpers.TypeUnicast,
-					Protocol:    nethelpers.ProtocolBoot,
-					ConfigLayer: network.ConfigOperator,
-				})
-			}
-		}
-	}
-
-	for i := range d.routes {
-		d.routes[i].Normalize()
-	}
-
-	if useHostname {
-		d.hostname = nil
-
-		hostname := strings.TrimRight(ack.HostName(), "\x00")
-
-		if hostname != "" {
-			spec := network.HostnameSpecSpec{
-				ConfigLayer: network.ConfigOperator,
-			}
-
-			if err := spec.ParseFQDN(hostname); err == nil {
-				domainName := strings.TrimRight(ack.DomainName(), "\x00")
-
-				if domainName != "" {
-					spec.Domainname = domainName
-				}
-
-				d.hostname = []network.HostnameSpecSpec{
-					spec,
-				}
-			}
-		}
-	}
-
-	if len(ack.DNS()) > 0 {
-		convertIP := func(ip net.IP) netip.Addr {
-			result, _ := netipx.FromStdIP(ip)
-
-			return result
-		}
-
-		d.resolvers = []network.ResolverSpecSpec{
-			{
-				DNSServers:  xslices.Map(ack.DNS(), convertIP),
-				ConfigLayer: network.ConfigOperator,
-			},
-		}
-	} else {
-		d.resolvers = nil
-	}
-
-	if len(ack.NTPServers()) > 0 {
-		convertIP := func(ip net.IP) string {
-			result, _ := netipx.FromStdIP(ip)
-
-			return result.String()
-		}
-
-		d.timeservers = []network.TimeServerSpecSpec{
-			{
-				NTPServers:  xslices.Map(ack.NTPServers(), convertIP),
-				ConfigLayer: network.ConfigOperator,
-			},
-		}
-	} else {
-		d.timeservers = nil
-	}
+	d.addresses = specs.Addresses
+	d.links = specs.Links
+	d.routes = specs.Routes
+	d.hostname = specs.Hostname
+	d.resolvers = specs.Resolvers
+	d.timeservers = specs.TimeServers
 }
 
 func (d *DHCP4) newClient() (*nclient4.Client, error) {

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package dhcpparse converts DHCP packets into network configuration specs.
+//
+// It is split out of the operator package so the parsing logic can be
+// unit-tested through a public surface, without reaching into operator
+// internals.
+package dhcpparse
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/siderolabs/gen/xslices"
+	"go4.org/netipx"
+
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+// DHCP4AckSpecs holds the network configuration parsed out of a DHCPv4 ACK.
+//
+// All slices are nil when the ACK carries no data of that kind, so assigning
+// the whole struct fully replaces previous lease state.
+type DHCP4AckSpecs struct {
+	Addresses   []network.AddressSpecSpec
+	Links       []network.LinkSpecSpec
+	Routes      []network.RouteSpecSpec
+	Hostname    []network.HostnameSpecSpec
+	Resolvers   []network.ResolverSpecSpec
+	TimeServers []network.TimeServerSpecSpec
+}
+
+// ParseDHCP4Ack converts a DHCPv4 ACK packet into network configuration specs.
+//
+// It is a pure function (no I/O, no shared state) — `linkName` and
+// `routeMetric` come from the operator's configuration, and `useHostname`
+// controls whether the ACK's hostname/domain options are honored.
+//
+//nolint:gocyclo
+func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useHostname bool) DHCP4AckSpecs {
+	var specs DHCP4AckSpecs
+
+	addr, _ := netipx.FromStdIPNet(&net.IPNet{
+		IP:   ack.YourIPAddr,
+		Mask: ack.SubnetMask(),
+	})
+
+	specs.Addresses = []network.AddressSpecSpec{
+		{
+			Address:     addr,
+			LinkName:    linkName,
+			Family:      nethelpers.FamilyInet4,
+			Scope:       nethelpers.ScopeGlobal,
+			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			Priority:    routeMetric,
+			ConfigLayer: network.ConfigOperator,
+		},
+	}
+
+	if mtu, err := dhcpv4.GetUint16(dhcpv4.OptionInterfaceMTU, ack.Options); err == nil {
+		specs.Links = []network.LinkSpecSpec{
+			{
+				Name: linkName,
+				MTU:  uint32(mtu),
+				Up:   true,
+			},
+		}
+	}
+
+	// rfc3442:
+	//   If the DHCP server returns both a Classless Static Routes option and
+	//   a Router option, the DHCP client MUST ignore the Router option.
+	if len(ack.ClasslessStaticRoute()) > 0 {
+		// Track gateways for which we've already emitted an on-link route so
+		// we don't add duplicates when several classless routes share a gateway.
+		onLinkGateways := map[netip.Addr]struct{}{}
+
+		for _, route := range ack.ClasslessStaticRoute() {
+			gw, _ := netipx.FromStdIP(route.Router)
+			dst, _ := netipx.FromStdIPNet(route.Dest)
+
+			specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+				Family:      nethelpers.FamilyInet4,
+				Destination: dst,
+				Source:      addr.Addr(),
+				Gateway:     gw,
+				OutLinkName: linkName,
+				Table:       nethelpers.TableMain,
+				Priority:    routeMetric,
+				Scope:       nethelpers.ScopeGlobal,
+				Type:        nethelpers.TypeUnicast,
+				Protocol:    nethelpers.ProtocolBoot,
+				ConfigLayer: network.ConfigOperator,
+			})
+
+			// If the gateway lives outside the lease's subnet, the kernel
+			// can't resolve it as on-link and refuses to install the route.
+			// AWS does this in IPv6-only subnets, handing out a 169.254.x.x/32
+			// lease with classless routes via 169.254.0.1. Add an explicit
+			// on-link route to the gateway so those routes can be installed.
+			if gw.IsValid() && !gw.IsUnspecified() && !addr.Contains(gw) {
+				if _, seen := onLinkGateways[gw]; !seen {
+					onLinkGateways[gw] = struct{}{}
+
+					specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+						Family:      nethelpers.FamilyInet4,
+						Destination: netip.PrefixFrom(gw, gw.BitLen()),
+						Source:      addr.Addr(),
+						OutLinkName: linkName,
+						Table:       nethelpers.TableMain,
+						Priority:    routeMetric,
+						Scope:       nethelpers.ScopeLink,
+						Type:        nethelpers.TypeUnicast,
+						Protocol:    nethelpers.ProtocolBoot,
+						ConfigLayer: network.ConfigOperator,
+					})
+				}
+			}
+		}
+	} else {
+		for _, router := range ack.Router() {
+			gw, _ := netipx.FromStdIP(router)
+
+			specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+				Family:      nethelpers.FamilyInet4,
+				Gateway:     gw,
+				Source:      addr.Addr(),
+				OutLinkName: linkName,
+				Table:       nethelpers.TableMain,
+				Priority:    routeMetric,
+				Scope:       nethelpers.ScopeGlobal,
+				Type:        nethelpers.TypeUnicast,
+				Protocol:    nethelpers.ProtocolBoot,
+				ConfigLayer: network.ConfigOperator,
+			})
+
+			if !addr.Contains(gw) {
+				// Add an interface route for the gateway if it's not in the same network
+				specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+					Family:      nethelpers.FamilyInet4,
+					Destination: netip.PrefixFrom(gw, gw.BitLen()),
+					Source:      addr.Addr(),
+					OutLinkName: linkName,
+					Table:       nethelpers.TableMain,
+					Priority:    routeMetric,
+					Scope:       nethelpers.ScopeLink,
+					Type:        nethelpers.TypeUnicast,
+					Protocol:    nethelpers.ProtocolBoot,
+					ConfigLayer: network.ConfigOperator,
+				})
+			}
+		}
+	}
+
+	for i := range specs.Routes {
+		specs.Routes[i].Normalize()
+	}
+
+	if useHostname {
+		hostname := strings.TrimRight(ack.HostName(), "\x00")
+
+		if hostname != "" {
+			spec := network.HostnameSpecSpec{
+				ConfigLayer: network.ConfigOperator,
+			}
+
+			if err := spec.ParseFQDN(hostname); err == nil {
+				domainName := strings.TrimRight(ack.DomainName(), "\x00")
+
+				if domainName != "" {
+					spec.Domainname = domainName
+				}
+
+				specs.Hostname = []network.HostnameSpecSpec{
+					spec,
+				}
+			}
+		}
+	}
+
+	if len(ack.DNS()) > 0 {
+		convertIP := func(ip net.IP) netip.Addr {
+			result, _ := netipx.FromStdIP(ip)
+
+			return result
+		}
+
+		specs.Resolvers = []network.ResolverSpecSpec{
+			{
+				DNSServers:  xslices.Map(ack.DNS(), convertIP),
+				ConfigLayer: network.ConfigOperator,
+			},
+		}
+	}
+
+	if len(ack.NTPServers()) > 0 {
+		convertIP := func(ip net.IP) string {
+			result, _ := netipx.FromStdIP(ip)
+
+			return result.String()
+		}
+
+		specs.TimeServers = []network.TimeServerSpecSpec{
+			{
+				NTPServers:  xslices.Map(ack.NTPServers(), convertIP),
+				ConfigLayer: network.ConfigOperator,
+			},
+		}
+	}
+
+	return specs
+}

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
@@ -1,0 +1,209 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package dhcpparse_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/siderolabs/gen/xtesting/must"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+)
+
+func TestParseDHCP4Ack(t *testing.T) {
+	const (
+		linkName    = "eth0"
+		routeMetric = uint32(1024)
+	)
+
+	t.Run("basic ACK with router in lease subnet", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Addresses, 1)
+		assert.Equal(t, must.Value(netip.ParsePrefix("10.0.0.5/24"))(t), specs.Addresses[0].Address)
+		assert.Equal(t, linkName, specs.Addresses[0].LinkName)
+		assert.Equal(t, nethelpers.FamilyInet4, specs.Addresses[0].Family)
+		assert.Equal(t, routeMetric, specs.Addresses[0].Priority)
+
+		assert.Empty(t, specs.Links, "no MTU option => no link spec")
+
+		require.Len(t, specs.Routes, 1)
+		assert.Equal(t, must.Value(netip.ParseAddr("10.0.0.1"))(t), specs.Routes[0].Gateway)
+		assert.Equal(t, must.Value(netip.ParseAddr("10.0.0.5"))(t), specs.Routes[0].Source)
+		assert.Equal(t, nethelpers.ScopeGlobal, specs.Routes[0].Scope)
+		assert.Equal(t, linkName, specs.Routes[0].OutLinkName)
+
+		assert.Empty(t, specs.Hostname)
+		assert.Empty(t, specs.Resolvers)
+		assert.Empty(t, specs.TimeServers)
+	})
+
+	t.Run("router outside lease subnet adds on-link route", func(t *testing.T) {
+		// Lease 10.0.0.5/32 with gateway 10.0.0.1: gateway not on-link.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(32, 32)),
+			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Routes, 2)
+		assert.Equal(t, must.Value(netip.ParseAddr("10.0.0.1"))(t), specs.Routes[0].Gateway)
+		assert.Equal(t, nethelpers.ScopeGlobal, specs.Routes[0].Scope)
+
+		assert.Equal(t, must.Value(netip.ParsePrefix("10.0.0.1/32"))(t), specs.Routes[1].Destination)
+		assert.Equal(t, nethelpers.ScopeLink, specs.Routes[1].Scope, "on-link helper route")
+		assert.False(t, specs.Routes[1].Gateway.IsValid(), "on-link route has no gateway")
+	})
+
+	t.Run("classless static routes win over router option", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
+			dhcpv4.WithOption(dhcpv4.OptClasslessStaticRoute(&dhcpv4.Route{
+				Dest:   &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
+				Router: net.IPv4(10, 0, 0, 254),
+			})),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		// Classless routes win, router option ignored — only the classless
+		// route is present (gateway is in the subnet, no helper needed).
+		require.Len(t, specs.Routes, 1)
+		assert.Equal(t, must.Value(netip.ParseAddr("10.0.0.254"))(t), specs.Routes[0].Gateway)
+	})
+
+	t.Run("classless route with gateway outside lease subnet adds on-link route (AWS IPv6-only)", func(t *testing.T) {
+		// AWS IPv6-only handout: 169.254.x.x/32 lease, classless routes via
+		// 169.254.0.1 — without an on-link helper the kernel refuses these
+		// routes with ENETUNREACH.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(169, 254, 251, 148)),
+			dhcpv4.WithNetmask(net.CIDRMask(32, 32)),
+			dhcpv4.WithOption(dhcpv4.OptClasslessStaticRoute(
+				&dhcpv4.Route{
+					Dest:   &net.IPNet{IP: net.IPv4(169, 254, 169, 123), Mask: net.CIDRMask(32, 32)},
+					Router: net.IPv4(169, 254, 0, 1),
+				},
+				&dhcpv4.Route{
+					Dest:   &net.IPNet{IP: net.IPv4(169, 254, 169, 249), Mask: net.CIDRMask(32, 32)},
+					Router: net.IPv4(169, 254, 0, 1),
+				},
+				&dhcpv4.Route{
+					Dest:   &net.IPNet{IP: net.IPv4(169, 254, 169, 254), Mask: net.CIDRMask(31, 32)},
+					Router: net.IPv4(169, 254, 0, 1),
+				},
+			)),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		// 3 classless routes + 1 on-link helper for the shared gateway (deduped).
+		require.Len(t, specs.Routes, 4)
+
+		gw := must.Value(netip.ParseAddr("169.254.0.1"))(t)
+
+		assert.Equal(t, must.Value(netip.ParsePrefix("169.254.169.123/32"))(t), specs.Routes[0].Destination)
+		assert.Equal(t, gw, specs.Routes[0].Gateway)
+		assert.Equal(t, must.Value(netip.ParsePrefix("169.254.0.1/32"))(t), specs.Routes[1].Destination)
+		assert.Equal(t, nethelpers.ScopeLink, specs.Routes[1].Scope)
+		assert.False(t, specs.Routes[1].Gateway.IsValid(), "on-link helper has no gateway")
+
+		assert.Equal(t, must.Value(netip.ParsePrefix("169.254.169.249/32"))(t), specs.Routes[2].Destination)
+		assert.Equal(t, gw, specs.Routes[2].Gateway)
+
+		assert.Equal(t, must.Value(netip.ParsePrefix("169.254.169.254/31"))(t), specs.Routes[3].Destination)
+		assert.Equal(t, gw, specs.Routes[3].Gateway)
+	})
+
+	t.Run("classless route with on-link router (router=0.0.0.0)", func(t *testing.T) {
+		// RFC 3442: router=0.0.0.0 means destination is on-link.
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptClasslessStaticRoute(&dhcpv4.Route{
+				Dest:   &net.IPNet{IP: net.IPv4(192, 168, 1, 0), Mask: net.CIDRMask(24, 32)},
+				Router: net.IPv4(0, 0, 0, 0),
+			})),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		require.Len(t, specs.Routes, 1, "no helper for unspecified gateway")
+		assert.Equal(t, must.Value(netip.ParsePrefix("192.168.1.0/24"))(t), specs.Routes[0].Destination)
+		assert.False(t, specs.Routes[0].Gateway.IsValid(), "Normalize converts 0.0.0.0 to zero value")
+		assert.Equal(t, nethelpers.ScopeLink, specs.Routes[0].Scope, "Normalize sets scope=link for routes with no gateway")
+	})
+
+	t.Run("DNS, NTP, MTU, hostname all parsed", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptDNS(net.IPv4(8, 8, 8, 8), net.IPv4(8, 8, 4, 4))),
+			dhcpv4.WithOption(dhcpv4.OptNTPServers(net.IPv4(169, 254, 169, 123))),
+			dhcpv4.WithOption(dhcpv4.OptHostName("myhost")),
+			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
+			dhcpv4.WithOption(dhcpv4.OptGeneric(dhcpv4.OptionInterfaceMTU, []byte{0x05, 0xdc})), // 1500
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, true)
+
+		require.Len(t, specs.Links, 1)
+		assert.Equal(t, uint32(1500), specs.Links[0].MTU)
+		assert.Equal(t, linkName, specs.Links[0].Name)
+		assert.True(t, specs.Links[0].Up)
+
+		require.Len(t, specs.Resolvers, 1)
+		assert.Equal(
+			t,
+			[]netip.Addr{
+				must.Value(netip.ParseAddr("8.8.8.8"))(t),
+				must.Value(netip.ParseAddr("8.8.4.4"))(t),
+			},
+			specs.Resolvers[0].DNSServers,
+		)
+
+		require.Len(t, specs.TimeServers, 1)
+		assert.Equal(t, []string{"169.254.169.123"}, specs.TimeServers[0].NTPServers)
+
+		require.Len(t, specs.Hostname, 1)
+		assert.Equal(t, "myhost", specs.Hostname[0].Hostname)
+		assert.Equal(t, "example.com", specs.Hostname[0].Domainname)
+	})
+
+	t.Run("useHostname=false ignores hostname even when present", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptHostName("myhost")),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+
+		assert.Empty(t, specs.Hostname)
+	})
+}


### PR DESCRIPTION
If the DHCP server hands out e.g. `/32` address while the gateway is outside of the range, automatically inject onlink route for the gateway to make it reachable.

This was spotted on IPv6-only AWS instance, the issue is harmless, but might fix other scenarios.
