### PR TITLE
fix(network): skip reserved routing rule priorities

### DIFF
--- a/internal/app/machined/pkg/controllers/network/routing_rule_config.go
+++ b/internal/app/machined/pkg/controllers/network/routing_rule_config.go
@@ -17,10 +17,18 @@ import (
 	"go.uber.org/zap"
 
 	cfg "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
+
+var reservedConfigRulePriorities = map[uint32]struct{}{
+	constants.LinuxReservedRulePriorityLocal:   {},
+	constants.KubeSpanDefaultRulePriority:      {},
+	constants.LinuxReservedRulePriorityMain:    {},
+	constants.LinuxReservedRulePriorityDefault: {},
+}
 
 // RoutingRuleConfigController manages network.RoutingRuleSpec based on machine configuration.
 type RoutingRuleConfigController struct{}
@@ -72,6 +80,7 @@ func (ctrl *RoutingRuleConfigController) Run(ctx context.Context, r controller.R
 
 		if machineConfig != nil {
 			rules := ctrl.processConfig(
+				logger,
 				machineConfig.Config().NetworkRoutingRuleConfigs(),
 			)
 
@@ -109,12 +118,24 @@ func (ctrl *RoutingRuleConfigController) apply(ctx context.Context, r controller
 }
 
 func (ctrl *RoutingRuleConfigController) processConfig(
+	logger *zap.Logger,
 	ruleConfigs []cfg.NetworkRoutingRuleConfig,
 ) []network.RoutingRuleSpecSpec {
 	rules := make([]network.RoutingRuleSpecSpec, 0, len(ruleConfigs))
 
 	for _, ruleCfg := range ruleConfigs {
 		var rule network.RoutingRuleSpecSpec
+
+		priority := ruleCfg.Priority()
+
+		if _, reserved := reservedConfigRulePriorities[priority]; reserved {
+			logger.Warn(
+				"skipping routing rule at reserved priority",
+				zap.Uint32("priority", priority),
+			)
+
+			continue
+		}
 
 		src := ruleCfg.Src().ValueOrZero()
 		dst := ruleCfg.Dst().ValueOrZero()
@@ -126,7 +147,7 @@ func (ctrl *RoutingRuleConfigController) processConfig(
 		rule.FwMark = ruleCfg.FwMark()
 		rule.FwMask = ruleCfg.FwMask()
 		rule.ConfigLayer = network.ConfigMachineConfiguration
-		rule.Priority = ruleCfg.Priority()
+		rule.Priority = priority
 
 		rule.Table = ruleCfg.Table()
 

--- a/internal/app/machined/pkg/controllers/network/routing_rule_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/routing_rule_config_test.go
@@ -145,6 +145,43 @@ func (suite *RoutingRuleConfigSuite) TestMachineConfigurationWithFwMark() {
 	)
 }
 
+// TestReservedPrioritySkipped verifies that user configs at kernel-reserved
+// priorities never produce a RoutingRuleSpec, so the spec controller can
+// never tear down (and thus delete) kernel-managed rules at those priorities.
+func (suite *RoutingRuleConfigSuite) TestReservedPrioritySkipped() {
+	suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.RoutingRuleConfigController{}))
+
+	// Validation rejects these priorities at apply time, but processConfig
+	// must also defensively skip them to protect against any path that
+	// bypasses validation.
+	reserved := networkcfg.NewRoutingRuleConfigV1Alpha1(0)
+	reserved.RuleTable = nethelpers.RoutingTable(100)
+	reserved.RuleSrc = networkcfg.Prefix{Prefix: netip.MustParsePrefix("10.0.0.0/8")}
+	reserved.RuleAction = nethelpers.RoutingRuleActionUnicast
+
+	allowed := networkcfg.NewRoutingRuleConfigV1Alpha1(2000)
+	allowed.RuleTable = nethelpers.RoutingTable(100)
+	allowed.RuleAction = nethelpers.RoutingRuleActionUnicast
+
+	ctr, err := container.New(reserved, allowed)
+	suite.Require().NoError(err)
+
+	suite.Create(config.NewMachineConfig(ctr))
+
+	ctest.AssertResources(
+		suite,
+		[]string{
+			"configuration/inet4/02000",
+			"configuration/inet6/02000",
+		},
+		func(*network.RoutingRuleSpec, *assert.Assertions) {},
+		rtestutils.WithNamespace(network.ConfigNamespaceName),
+	)
+
+	ctest.AssertNoResource[*network.RoutingRuleSpec](suite, "configuration/inet4/00000")
+	ctest.AssertNoResource[*network.RoutingRuleSpec](suite, "configuration/inet6/00000")
+}
+
 func TestRoutingRuleConfigSuite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/machined/pkg/controllers/network/routing_rule_spec.go
+++ b/internal/app/machined/pkg/controllers/network/routing_rule_spec.go
@@ -22,9 +22,17 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/watch"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
+
+// reservedRulePriorities are kernel-managed routing rule priorities Talos must never touch.
+var reservedRulePriorities = map[uint32]struct{}{
+	constants.LinuxReservedRulePriorityLocal:   {},
+	constants.LinuxReservedRulePriorityMain:    {},
+	constants.LinuxReservedRulePriorityDefault: {},
+}
 
 // RoutingRuleSpecController applies network.RoutingRuleSpec to the kernel.
 type RoutingRuleSpecController struct{}
@@ -55,7 +63,8 @@ func (ctrl *RoutingRuleSpecController) Outputs() []controller.Output {
 //nolint:gocyclo
 func (ctrl *RoutingRuleSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	// watch link changes as some routes might need to be re-applied if the link appears
-	watcher, err := watch.NewRtNetlink(watch.NewDefaultRateLimitedTrigger(ctx, r), unix.RTMGRP_IPV4_RULE)
+	watcher, err := watch.NewRtNetlink(watch.NewDefaultRateLimitedTrigger(ctx, r), unix.RTMGRP_IPV4_RULE,
+		unix.RTNLGRP_IPV4_RULE, unix.RTNLGRP_IPV6_RULE)
 	if err != nil {
 		return err
 	}
@@ -126,6 +135,24 @@ func (ctrl *RoutingRuleSpecController) syncRule(
 	rule *network.RoutingRuleSpec,
 ) error {
 	spec := rule.TypedSpec()
+
+	if _, reserved := reservedRulePriorities[spec.Priority]; reserved {
+		// Never operate on rules at kernel-reserved priorities, even if a spec slipped through.
+		// Still drop the finalizer on tearing-down so the resource can be destroyed.
+		if rule.Metadata().Phase() == resource.PhaseTearingDown {
+			if err := r.RemoveFinalizer(ctx, rule.Metadata(), ctrl.Name()); err != nil {
+				return fmt.Errorf("error removing finalizer: %w", err)
+			}
+		}
+
+		logger.Warn(
+			"skipping routing rule at reserved priority",
+			zap.Uint32("priority", spec.Priority),
+			zap.Stringer("family", spec.Family),
+		)
+
+		return nil
+	}
 
 	switch rule.Metadata().Phase() {
 	case resource.PhaseTearingDown:
@@ -300,6 +327,13 @@ func (ctrl *RoutingRuleSpecController) matchesPrefix(existingIP *net.IP, existin
 }
 
 func (ctrl *RoutingRuleSpecController) matchesRuleKey(existing *rtnetlink.RuleMessage, spec *network.RoutingRuleSpecSpec) bool {
+	// Only operate on rules Talos owns (RTPROT_STATIC).
+	// Kernel-installed rules (local/main/default at reserved priorities) carry RTPROT_KERNEL,
+	// other agents (Cilium, etc.) carry their own protocol markers; never touch those.
+	if pointer.SafeDeref(existing.Attributes.Protocol) != unix.RTPROT_STATIC {
+		return false
+	}
+
 	if pointer.SafeDeref(existing.Attributes.Priority) != spec.Priority {
 		return false
 	}

--- a/internal/app/machined/pkg/controllers/network/routing_rule_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/routing_rule_spec_test.go
@@ -440,6 +440,142 @@ func (suite *RoutingRuleSpecSuite) TestDstPrefix() {
 	)
 }
 
+// TestForeignRulePreserved verifies the controller never deletes rules it
+// did not install (rules with a Protocol other than RTPROT_STATIC), even
+// when their priority+family collides with a Talos-managed spec.
+func (suite *RoutingRuleSpecSuite) TestForeignRulePreserved() {
+	priority := uint32(31100)
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	// Pre-install a foreign rule at the same priority+family with a
+	// non-Talos protocol marker (RTPROT_BOOT). The controller's match
+	// logic must ignore this rule and not delete it.
+	srcIP := net.ParseIP("10.88.0.0").To4()
+	foreignProto := uint8(unix.RTPROT_BOOT)
+	foreignTable := uint32(200)
+	foreignPriority := priority
+
+	foreignMsg := &rtnetlink.RuleMessage{
+		Family:    uint8(nethelpers.FamilyInet4),
+		Table:     uint8(200),
+		Action:    unix.FR_ACT_TO_TBL,
+		SrcLength: 16,
+		Attributes: &rtnetlink.RuleAttributes{
+			Priority: &foreignPriority,
+			Table:    &foreignTable,
+			Src:      &srcIP,
+			Protocol: &foreignProto,
+		},
+	}
+
+	suite.Require().NoError(conn.Rule.Add(foreignMsg))
+
+	defer func() {
+		_ = conn.Rule.Delete(foreignMsg) //nolint:errcheck
+	}()
+
+	// Create a Talos-owned spec at the same priority+family but a different src.
+	// Without the protocol gate the spec controller would key-match the foreign
+	// rule on (priority, family) and delete it.
+	rule := network.NewRoutingRuleSpec(network.NamespaceName, "foreign-collision-rule")
+	*rule.TypedSpec() = network.RoutingRuleSpecSpec{
+		Family:      nethelpers.FamilyInet4,
+		Src:         netip.MustParsePrefix("10.77.0.0/16"),
+		Table:       nethelpers.RoutingTable(100),
+		Priority:    priority,
+		Action:      nethelpers.RoutingRuleActionUnicast,
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+
+	suite.Create(rule)
+
+	// Talos-owned rule must appear.
+	suite.Assert().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				return suite.assertRule(
+					nethelpers.FamilyInet4,
+					netip.MustParsePrefix("10.77.0.0/16"),
+					netip.Prefix{},
+					priority,
+					func(rtnetlink.RuleMessage) error { return nil },
+				)
+			},
+		),
+	)
+
+	// Foreign rule must still be present.
+	rules, err := conn.Rule.List()
+	suite.Require().NoError(err)
+
+	var foreignFound bool
+
+	for _, r := range rules {
+		if r.Family != uint8(nethelpers.FamilyInet4) {
+			continue
+		}
+
+		if pointer.SafeDeref(r.Attributes.Priority) != priority {
+			continue
+		}
+
+		if pointer.SafeDeref(r.Attributes.Protocol) != unix.RTPROT_BOOT {
+			continue
+		}
+
+		foreignFound = true
+
+		break
+	}
+
+	suite.Assert().True(foreignFound, "foreign rule was deleted by the spec controller")
+
+	// Tear the Talos-owned rule down — foreign rule must still survive.
+	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), rule.Metadata()))
+
+	suite.Assert().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				return suite.assertNoRule(
+					nethelpers.FamilyInet4,
+					netip.MustParsePrefix("10.77.0.0/16"),
+					netip.Prefix{},
+					priority,
+				)
+			},
+		),
+	)
+
+	rules, err = conn.Rule.List()
+	suite.Require().NoError(err)
+
+	foreignFound = false
+
+	for _, r := range rules {
+		if r.Family != uint8(nethelpers.FamilyInet4) {
+			continue
+		}
+
+		if pointer.SafeDeref(r.Attributes.Priority) != priority {
+			continue
+		}
+
+		if pointer.SafeDeref(r.Attributes.Protocol) != unix.RTPROT_BOOT {
+			continue
+		}
+
+		foreignFound = true
+
+		break
+	}
+
+	suite.Assert().True(foreignFound, "foreign rule was deleted during teardown of Talos-owned rule")
+}
+
 func TestRoutingRuleSpecSuite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/api/network-config.go
+++ b/internal/integration/api/network-config.go
@@ -749,6 +749,41 @@ func (suite *NetworkConfigSuite) routingRuleTestCtx() (context.Context, context.
 	return context.WithTimeout(context.Background(), 2*time.Minute)
 }
 
+// kernelDefaultRoutingRules lists the rule IDs the kernel auto-installs in every
+// network namespace. These must remain present at all times - Talos must never
+// delete rules it did not create.
+var kernelDefaultRoutingRules = []struct {
+	id       string
+	priority uint32
+	table    nethelpers.RoutingTable
+}{
+	{"inet4/00000", 0, nethelpers.RoutingTable(255)},     // local
+	{"inet4/32766", 32766, nethelpers.RoutingTable(254)}, // main
+	{"inet4/32767", 32767, nethelpers.RoutingTable(253)}, // default
+	{"inet6/00000", 0, nethelpers.RoutingTable(255)},     // local
+	{"inet6/32766", 32766, nethelpers.RoutingTable(254)}, // main
+}
+
+// assertKernelDefaultRoutingRulesPresent asserts that the kernel-installed
+// default routing rules (priorities 0/32766/32767, both families) are still
+// present in RoutingRuleStatus. Every routing-rule integration test calls
+// this both before applying its config and after teardown.
+func (suite *NetworkConfigSuite) assertKernelDefaultRoutingRulesPresent(nodeCtx context.Context) {
+	suite.T().Helper()
+
+	for _, expected := range kernelDefaultRoutingRules {
+		rtestutils.AssertResource(
+			nodeCtx, suite.T(), suite.Client.COSI, expected.id,
+			func(rule *networkres.RoutingRuleStatus, asrt *assert.Assertions) {
+				asrt.Equal(expected.table, rule.TypedSpec().Table,
+					"kernel-default rule %s missing or table changed", expected.id)
+				asrt.Equal(expected.priority, rule.TypedSpec().Priority,
+					"kernel-default rule %s priority changed", expected.id)
+			},
+		)
+	}
+}
+
 // TestRoutingRuleBasic tests creation of a routing rule with a numeric table ID.
 //
 //nolint:dupl
@@ -760,6 +795,8 @@ func (suite *NetworkConfigSuite) TestRoutingRuleBasic() {
 	nodeCtx := client.WithNode(ctx, node)
 
 	suite.T().Logf("testing routing rule (basic) on node %q", node)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 
 	const rulePriority uint32 = 1000
 
@@ -781,9 +818,13 @@ func (suite *NetworkConfigSuite) TestRoutingRuleBasic() {
 		},
 	)
 
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
+
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.RoutingRuleKind, strconv.FormatUint(uint64(rulePriority), 10))
 
 	rtestutils.AssertNoResource[*networkres.RoutingRuleStatus](nodeCtx, suite.T(), suite.Client.COSI, ruleStatusID)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 }
 
 // TestRoutingRuleIPv6 tests creation of an IPv6 routing rule.
@@ -797,6 +838,8 @@ func (suite *NetworkConfigSuite) TestRoutingRuleIPv6() {
 	nodeCtx := client.WithNode(ctx, node)
 
 	suite.T().Logf("testing routing rule (IPv6) on node %q", node)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 
 	const rulePriority uint32 = 3000
 
@@ -818,9 +861,13 @@ func (suite *NetworkConfigSuite) TestRoutingRuleIPv6() {
 		},
 	)
 
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
+
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.RoutingRuleKind, strconv.FormatUint(uint64(rulePriority), 10))
 
 	rtestutils.AssertNoResource[*networkres.RoutingRuleStatus](nodeCtx, suite.T(), suite.Client.COSI, ruleStatusID)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 }
 
 // TestRoutingRuleSrcAndDst tests creation of a routing rule with both source and destination prefixes.
@@ -832,6 +879,8 @@ func (suite *NetworkConfigSuite) TestRoutingRuleSrcAndDst() {
 	nodeCtx := client.WithNode(ctx, node)
 
 	suite.T().Logf("testing routing rule (src+dst) on node %q", node)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 
 	const rulePriority uint32 = 4000
 
@@ -855,9 +904,13 @@ func (suite *NetworkConfigSuite) TestRoutingRuleSrcAndDst() {
 		},
 	)
 
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
+
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.RoutingRuleKind, strconv.FormatUint(uint64(rulePriority), 10))
 
 	rtestutils.AssertNoResource[*networkres.RoutingRuleStatus](nodeCtx, suite.T(), suite.Client.COSI, ruleStatusID)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 }
 
 // TestRoutingRuleBlackholeAction tests creation of a routing rule with blackhole action.
@@ -869,6 +922,8 @@ func (suite *NetworkConfigSuite) TestRoutingRuleBlackholeAction() {
 	nodeCtx := client.WithNode(ctx, node)
 
 	suite.T().Logf("testing routing rule (blackhole action) on node %q", node)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 
 	const rulePriority uint32 = 5000
 
@@ -890,9 +945,13 @@ func (suite *NetworkConfigSuite) TestRoutingRuleBlackholeAction() {
 		},
 	)
 
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
+
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.RoutingRuleKind, strconv.FormatUint(uint64(rulePriority), 10))
 
 	rtestutils.AssertNoResource[*networkres.RoutingRuleStatus](nodeCtx, suite.T(), suite.Client.COSI, ruleStatusID)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 }
 
 // TestRoutingRuleFwMark tests creation of a routing rule with firewall mark matching.
@@ -904,6 +963,8 @@ func (suite *NetworkConfigSuite) TestRoutingRuleFwMark() {
 	nodeCtx := client.WithNode(ctx, node)
 
 	suite.T().Logf("testing routing rule (fwmark) on node %q", node)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 
 	const rulePriority uint32 = 6000
 
@@ -928,9 +989,13 @@ func (suite *NetworkConfigSuite) TestRoutingRuleFwMark() {
 		},
 	)
 
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
+
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.RoutingRuleKind, strconv.FormatUint(uint64(rulePriority), 10))
 
 	rtestutils.AssertNoResource[*networkres.RoutingRuleStatus](nodeCtx, suite.T(), suite.Client.COSI, ruleStatusID)
+
+	suite.assertKernelDefaultRoutingRulesPresent(nodeCtx)
 }
 
 func init() {

--- a/tools/structprotogen/consts/consts.go
+++ b/tools/structprotogen/consts/consts.go
@@ -251,7 +251,8 @@ func (b *ConstBlocks) FormatProtoFile(w io.Writer) error {
 			}
 
 			if i == 0 && constant.Value != "0" {
-				fmt.Fprintf(w,
+				fmt.Fprintf(
+					w,
 					"  %s_%s_UNSPECIFIED = 0;\n",
 					strings.ToUpper(block.TypePkg),
 					strings.ToUpper(block.TypeName),


### PR DESCRIPTION
Prevent config controller from generating specs for rules at kernel-reserved
priorities (local, main, default), stopping the spec controller from ever
tearing them down. Add protocol check (RTPROT_STATIC only) to ensure Talos
only manages its own rules, never touching kernel or third-party agent rules.

Part of #13257

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
