### PR TITLE
refactor: talosctl - propagate cmd context throughout, properly terminate on SIGINT

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -57,174 +57,174 @@ var rootCmd = &cobra.Command{
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithContext(context.Background(), func(ctx context.Context) error {
-			report := reporter.New()
-			report.Report(reporter.Update{
-				Message: "assembling the finalized profile...",
-				Status:  reporter.StatusRunning,
-			})
+		ctx := cmd.Context()
 
-			baseProfile := args[0]
+		report := reporter.New()
+		report.Report(reporter.Update{
+			Message: "assembling the finalized profile...",
+			Status:  reporter.StatusRunning,
+		})
 
-			var prof profile.Profile
+		baseProfile := args[0]
 
-			if baseProfile == "-" {
-				if err := yaml.NewDecoder(os.Stdin).Decode(&prof); err != nil {
-					return err
-				}
-			} else {
-				prof = profile.Profile{
-					BaseProfileName: baseProfile,
-					Arch:            cmdFlags.Arch,
-					Platform:        cmdFlags.Platform,
-					Customization: profile.CustomizationProfile{
-						ExtraKernelArgs: cmdFlags.ExtraKernelArgs,
-						MetaContents:    cmdFlags.MetaValues.GetMetaValues(),
-					},
-				}
+		var prof profile.Profile
 
-				extraOverlayOptions := overlay.ExtraOptions{}
+		if baseProfile == "-" {
+			if err := yaml.NewDecoder(os.Stdin).Decode(&prof); err != nil {
+				return err
+			}
+		} else {
+			prof = profile.Profile{
+				BaseProfileName: baseProfile,
+				Arch:            cmdFlags.Arch,
+				Platform:        cmdFlags.Platform,
+				Customization: profile.CustomizationProfile{
+					ExtraKernelArgs: cmdFlags.ExtraKernelArgs,
+					MetaContents:    cmdFlags.MetaValues.GetMetaValues(),
+				},
+			}
 
-				for _, option := range cmdFlags.OverlayOptions {
-					if strings.HasPrefix(option, "@") {
-						data, err := os.ReadFile(option[1:])
-						if err != nil {
-							return err
-						}
+			extraOverlayOptions := overlay.ExtraOptions{}
 
-						decoder := yaml.NewDecoder(bytes.NewReader(data))
-						decoder.KnownFields(true)
-
-						if err := decoder.Decode(&extraOverlayOptions); err != nil {
-							return err
-						}
-
-						continue
-					}
-
-					k, v, _ := strings.Cut(option, "=")
-
-					if strings.HasPrefix(v, "@") {
-						data, err := os.ReadFile(v[1:])
-						if err != nil {
-							return err
-						}
-
-						v = string(data)
-					}
-
-					extraOverlayOptions[k] = v
-				}
-
-				if cmdFlags.OverlayName != "" || cmdFlags.OverlayImage != "" {
-					prof.Overlay = &profile.OverlayOptions{
-						Name: cmdFlags.OverlayName,
-						Image: profile.ContainerAsset{
-							ImageRef: cmdFlags.OverlayImage,
-						},
-						ExtraOptions: extraOverlayOptions,
-					}
-
-					prof.Input.OverlayInstaller.ImageRef = cmdFlags.OverlayImage
-				}
-
-				prof.Input.SystemExtensions = xslices.Map(
-					cmdFlags.SystemExtensionImages,
-					func(imageRef string) profile.ContainerAsset {
-						return profile.ContainerAsset{
-							ImageRef:      imageRef,
-							ForceInsecure: cmdFlags.Insecure,
-						}
-					},
-				)
-
-				if cmdFlags.OutputKind != "" {
-					outKind, err := profile.OutputKindString(cmdFlags.OutputKind)
+			for _, option := range cmdFlags.OverlayOptions {
+				if strings.HasPrefix(option, "@") {
+					data, err := os.ReadFile(option[1:])
 					if err != nil {
 						return err
 					}
 
-					prof.Output.Kind = outKind
-				}
+					decoder := yaml.NewDecoder(bytes.NewReader(data))
+					decoder.KnownFields(true)
 
-				if cmdFlags.BaseInstallerImage != "" {
-					prof.Input.BaseInstaller = profile.ContainerAsset{
-						ImageRef: cmdFlags.BaseInstallerImage,
-					}
-				}
-
-				if cmdFlags.ImageCache != "" {
-					parseOpts := []name.Option{name.StrictValidation}
-
-					if cmdFlags.Insecure {
-						parseOpts = append(parseOpts, name.Insecure)
+					if err := decoder.Decode(&extraOverlayOptions); err != nil {
+						return err
 					}
 
-					if _, err := name.ParseReference(cmdFlags.ImageCache, parseOpts...); err == nil {
-						prof.Input.ImageCache = profile.ContainerAsset{
-							ImageRef: cmdFlags.ImageCache,
-						}
-					} else {
-						prof.Input.ImageCache = profile.ContainerAsset{
-							OCIPath: cmdFlags.ImageCache,
-						}
-					}
+					continue
 				}
+
+				k, v, _ := strings.Cut(option, "=")
+
+				if strings.HasPrefix(v, "@") {
+					data, err := os.ReadFile(v[1:])
+					if err != nil {
+						return err
+					}
+
+					v = string(data)
+				}
+
+				extraOverlayOptions[k] = v
+			}
+
+			if cmdFlags.OverlayName != "" || cmdFlags.OverlayImage != "" {
+				prof.Overlay = &profile.OverlayOptions{
+					Name: cmdFlags.OverlayName,
+					Image: profile.ContainerAsset{
+						ImageRef: cmdFlags.OverlayImage,
+					},
+					ExtraOptions: extraOverlayOptions,
+				}
+
+				prof.Input.OverlayInstaller.ImageRef = cmdFlags.OverlayImage
+			}
+
+			prof.Input.SystemExtensions = xslices.Map(
+				cmdFlags.SystemExtensionImages,
+				func(imageRef string) profile.ContainerAsset {
+					return profile.ContainerAsset{
+						ImageRef:      imageRef,
+						ForceInsecure: cmdFlags.Insecure,
+					}
+				},
+			)
+
+			if cmdFlags.OutputKind != "" {
+				outKind, err := profile.OutputKindString(cmdFlags.OutputKind)
+				if err != nil {
+					return err
+				}
+
+				prof.Output.Kind = outKind
+			}
+
+			if cmdFlags.BaseInstallerImage != "" {
+				prof.Input.BaseInstaller = profile.ContainerAsset{
+					ImageRef: cmdFlags.BaseInstallerImage,
+				}
+			}
+
+			if cmdFlags.ImageCache != "" {
+				parseOpts := []name.Option{name.StrictValidation}
 
 				if cmdFlags.Insecure {
-					prof.Input.BaseInstaller.ForceInsecure = cmdFlags.Insecure
-					prof.Input.ImageCache.ForceInsecure = cmdFlags.Insecure
+					parseOpts = append(parseOpts, name.Insecure)
 				}
 
-				if cmdFlags.SecurebootIncludeWellKnownCerts {
-					if prof.Input.SecureBoot == nil {
-						prof.Input.SecureBoot = &profile.SecureBootAssets{}
+				if _, err := name.ParseReference(cmdFlags.ImageCache, parseOpts...); err == nil {
+					prof.Input.ImageCache = profile.ContainerAsset{
+						ImageRef: cmdFlags.ImageCache,
 					}
-
-					prof.Input.SecureBoot.IncludeWellKnownCerts = true
-				}
-
-				if cmdFlags.EmbeddedConfigPath != "" {
-					data, err := os.ReadFile(cmdFlags.EmbeddedConfigPath)
-					if err != nil {
-						return fmt.Errorf("error reading embedded config file: %w", err)
+				} else {
+					prof.Input.ImageCache = profile.ContainerAsset{
+						OCIPath: cmdFlags.ImageCache,
 					}
-
-					prof.Customization.EmbeddedMachineConfiguration = string(data)
 				}
 			}
 
-			if err := os.MkdirAll(cmdFlags.OutputPath, 0o755); err != nil {
-				return err
+			if cmdFlags.Insecure {
+				prof.Input.BaseInstaller.ForceInsecure = cmdFlags.Insecure
+				prof.Input.ImageCache.ForceInsecure = cmdFlags.Insecure
 			}
 
-			imager, err := imager.New(prof)
-			if err != nil {
-				return err
+			if cmdFlags.SecurebootIncludeWellKnownCerts {
+				if prof.Input.SecureBoot == nil {
+					prof.Input.SecureBoot = &profile.SecureBootAssets{}
+				}
+
+				prof.Input.SecureBoot.IncludeWellKnownCerts = true
 			}
 
-			if _, err = imager.Execute(ctx, cmdFlags.OutputPath, report); err != nil {
-				report.Report(reporter.Update{
-					Message: err.Error(),
-					Status:  reporter.StatusError,
-				})
+			if cmdFlags.EmbeddedConfigPath != "" {
+				data, err := os.ReadFile(cmdFlags.EmbeddedConfigPath)
+				if err != nil {
+					return fmt.Errorf("error reading embedded config file: %w", err)
+				}
 
-				return err
+				prof.Customization.EmbeddedMachineConfiguration = string(data)
 			}
+		}
 
-			if cmdFlags.TarToStdout {
-				return archiver.TarGz(ctx, cmdFlags.OutputPath, os.Stdout)
-			}
+		if err := os.MkdirAll(cmdFlags.OutputPath, 0o755); err != nil {
+			return err
+		}
 
-			return nil
-		})
+		imager, err := imager.New(prof)
+		if err != nil {
+			return err
+		}
+
+		if _, err = imager.Execute(ctx, cmdFlags.OutputPath, report); err != nil {
+			report.Report(reporter.Update{
+				Message: err.Error(),
+				Status:  reporter.StatusError,
+			})
+
+			return err
+		}
+
+		if cmdFlags.TarToStdout {
+			return archiver.TarGz(ctx, cmdFlags.OutputPath, os.Stdout)
+		}
+
+		return nil
 	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if _, err := cli.WithContextC(context.Background(), rootCmd.ExecuteContextC); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -5,7 +5,6 @@
 package create
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"slices"
@@ -268,55 +267,53 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		Short: "Creates a local QEMU-based cluster for Talos development.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cli.WithContext(context.Background(), func(ctx context.Context) error {
-				if cmdName == "create" {
-					cli.Warning("the developer oriented 'cluster create' command has been moved to 'cluster create dev'")
+			if cmdName == "create" {
+				cli.Warning("the developer oriented 'cluster create' command has been moved to 'cluster create dev'")
+			}
+
+			if err := validateQemuFlags(cmd.Flags(), unImplementedFlagsDarwin); err != nil {
+				return err
+			}
+
+			var disks strings.Builder
+			fmt.Fprintf(&disks, "virtio:%d", legacyOps.clusterDiskSize)
+
+			for i := range legacyOps.extraDisks {
+				driver := "ide"
+				tag := ""
+				serial := ""
+
+				// ide driver is not supported on arm64
+				if qOps.TargetArch == "arm64" {
+					driver = "virtio"
 				}
 
-				if err := validateQemuFlags(cmd.Flags(), unImplementedFlagsDarwin); err != nil {
-					return err
+				if i < len(legacyOps.extraDisksDrivers) {
+					driver = legacyOps.extraDisksDrivers[i]
 				}
 
-				var disks strings.Builder
-				fmt.Fprintf(&disks, "virtio:%d", legacyOps.clusterDiskSize)
-
-				for i := range legacyOps.extraDisks {
-					driver := "ide"
-					tag := ""
-					serial := ""
-
-					// ide driver is not supported on arm64
-					if qOps.TargetArch == "arm64" {
-						driver = "virtio"
+				if i < len(legacyOps.extraDisksTags) {
+					if legacyOps.extraDisksTags[i] != "" {
+						tag = fmt.Sprintf(":tag=%s", legacyOps.extraDisksTags[i])
 					}
-
-					if i < len(legacyOps.extraDisksDrivers) {
-						driver = legacyOps.extraDisksDrivers[i]
-					}
-
-					if i < len(legacyOps.extraDisksTags) {
-						if legacyOps.extraDisksTags[i] != "" {
-							tag = fmt.Sprintf(":tag=%s", legacyOps.extraDisksTags[i])
-						}
-					}
-
-					if i < len(legacyOps.extraDisksSerials) {
-						if legacyOps.extraDisksSerials[i] != "" {
-							serial = fmt.Sprintf(":serial=%s", legacyOps.extraDisksSerials[i])
-						}
-					}
-
-					fmt.Fprintf(&disks, ",%s:%d%s%s", driver, legacyOps.extraDiskSize, tag, serial)
 				}
 
-				qOps.Disks = flags.Disks{}
-
-				if err := qOps.Disks.Set(disks.String()); err != nil {
-					return err
+				if i < len(legacyOps.extraDisksSerials) {
+					if legacyOps.extraDisksSerials[i] != "" {
+						serial = fmt.Sprintf(":serial=%s", legacyOps.extraDisksSerials[i])
+					}
 				}
 
-				return createDevCluster(ctx, cOps, qOps)
-			})
+				fmt.Fprintf(&disks, ",%s:%d%s%s", driver, legacyOps.extraDiskSize, tag, serial)
+			}
+
+			qOps.Disks = flags.Disks{}
+
+			if err := qOps.Disks.Set(disks.String()); err != nil {
+				return err
+			}
+
+			return createDevCluster(cmd.Context(), cOps, qOps)
 		},
 	}
 	createCmd.Flags().IntVar(&legacyOps.clusterDiskSize, clusterDiskSizeFlag, 6*1024, "default limit on disk size in MB (each VM)")

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
@@ -5,8 +5,6 @@
 package create
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -50,29 +48,27 @@ func init() {
 		Short: "Create a local Docker based kubernetes cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cli.WithContext(context.Background(), func(ctx context.Context) error {
-				provisioner, err := providers.Factory(ctx, providers.DockerProviderName)
-				if err != nil {
-					return err
-				}
+			provisioner, err := providers.Factory(cmd.Context(), providers.DockerProviderName)
+			if err != nil {
+				return err
+			}
 
-				clusterConfigs, err := getDockerClusterRequest(cOps, dOps, provisioner)
-				if err != nil {
-					return err
-				}
+			clusterConfigs, err := getDockerClusterRequest(cOps, dOps, provisioner)
+			if err != nil {
+				return err
+			}
 
-				cluster, err := provisioner.Create(ctx, clusterConfigs.ClusterRequest, clusterConfigs.ProvisionOptions...)
-				if err != nil {
-					return err
-				}
+			cluster, err := provisioner.Create(cmd.Context(), clusterConfigs.ClusterRequest, clusterConfigs.ProvisionOptions...)
+			if err != nil {
+				return err
+			}
 
-				err = postCreate(ctx, cOps, cluster, clusterConfigs)
-				if err != nil {
-					return err
-				}
+			err = postCreate(cmd.Context(), cOps, cluster, clusterConfigs)
+			if err != nil {
+				return err
+			}
 
-				return clustercmd.ShowCluster(cluster)
-			})
+			return clustercmd.ShowCluster(cluster)
 		},
 	}
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
@@ -5,7 +5,6 @@
 package create
 
 import (
-	"context"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,7 +13,6 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/constants"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/preset"
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/provision/providers"
 )
 
@@ -67,14 +65,12 @@ func init() {
 		Long:  cmdDescription.String(),
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cli.WithContext(context.Background(), func(ctx context.Context) error {
-				provisioner, err := providers.Factory(ctx, providers.QemuProviderName)
-				if err != nil {
-					return err
-				}
+			provisioner, err := providers.Factory(cmd.Context(), providers.QemuProviderName)
+			if err != nil {
+				return err
+			}
 
-				return createQemuCluster(ctx, qOps, cOps, presetOptions, provisioner)
-			})
+			return createQemuCluster(cmd.Context(), qOps, cOps, presetOptions, provisioner)
 		},
 	}
 

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -27,7 +27,7 @@ var destroyCmd = &cobra.Command{
 	Short: "Destroys a local Talos kubernetes cluster",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithContext(context.Background(), destroy)
+		return destroy(cmd.Context())
 	},
 }
 

--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -18,7 +18,6 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/providers"
 )
@@ -30,7 +29,7 @@ var showCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithContext(context.Background(), show)
+		return show(cmd.Context())
 	},
 }
 

--- a/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
+++ b/cmd/talosctl/cmd/mgmt/debug/air-gapped.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime"
@@ -53,27 +52,23 @@ var airgappedCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithContext(
-			context.Background(), func(ctx context.Context) error {
-				caPEM, certPEM, keyPEM, err := helpers.GenerateSelfSignedCert([]net.IP{airgappedFlags.advertisedAddress}, nil)
-				if err != nil {
-					return nil
-				}
+		caPEM, certPEM, keyPEM, err := helpers.GenerateSelfSignedCert([]net.IP{airgappedFlags.advertisedAddress}, nil)
+		if err != nil {
+			return nil
+		}
 
-				if err = generateConfigPatch(caPEM); err != nil {
-					return err
-				}
+		if err = generateConfigPatch(caPEM); err != nil {
+			return err
+		}
 
-				eg, ctx := errgroup.WithContext(ctx)
+		eg, ctx := errgroup.WithContext(cmd.Context())
 
-				eg.Go(func() error { return runHTTPServer(ctx, certPEM, keyPEM) })
-				eg.Go(func() error { return runHTTPProxy(ctx) })
-				eg.Go(func() error { return runHTTPSProxy(ctx, certPEM, keyPEM) })
-				eg.Go(func() error { return runHTTPSReverseProxy(ctx, certPEM, keyPEM) })
+		eg.Go(func() error { return runHTTPServer(ctx, certPEM, keyPEM) })
+		eg.Go(func() error { return runHTTPProxy(ctx) })
+		eg.Go(func() error { return runHTTPSProxy(ctx, certPEM, keyPEM) })
+		eg.Go(func() error { return runHTTPSReverseProxy(ctx, certPEM, keyPEM) })
 
-				return eg.Wait()
-			},
-		)
+		return eg.Wait()
 	},
 }
 

--- a/cmd/talosctl/cmd/mgmt/dhcpd_launch.go
+++ b/cmd/talosctl/cmd/mgmt/dhcpd_launch.go
@@ -35,15 +35,15 @@ var dhcpdLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ips := xslices.Map(slices.Collect(strings.SplitSeq(dhcpdLaunchCmdFlags.addr, ",")), net.ParseIP)
 
-		var eg errgroup.Group
+		eg, ctx := errgroup.WithContext(cmd.Context())
 
 		eg.Go(func() error {
-			return vm.DHCPd(dhcpdLaunchCmdFlags.ifName, ips, dhcpdLaunchCmdFlags.statePath)
+			return vm.DHCPd(ctx, dhcpdLaunchCmdFlags.ifName, ips, dhcpdLaunchCmdFlags.statePath)
 		})
 
 		if dhcpdLaunchCmdFlags.ipxeNextHandler != "" {
 			eg.Go(func() error {
-				return vm.TFTPd(ips, dhcpdLaunchCmdFlags.ipxeNextHandler)
+				return vm.TFTPd(ctx, ips, dhcpdLaunchCmdFlags.ipxeNextHandler)
 			})
 		}
 

--- a/cmd/talosctl/cmd/mgmt/dnsd_launch.go
+++ b/cmd/talosctl/cmd/mgmt/dnsd_launch.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
@@ -33,13 +32,7 @@ var dnsdLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ips := xslices.Map(slices.Collect(strings.SplitSeq(dnsdLaunchCmdFlags.addr, ",")), net.ParseIP)
 
-		var eg errgroup.Group
-
-		eg.Go(func() error {
-			return vm.DNSd(ips, dnsdLaunchCmdFlags.resolvConf)
-		})
-
-		return eg.Wait()
+		return vm.DNSd(cmd.Context(), ips, dnsdLaunchCmdFlags.resolvConf)
 	},
 }
 

--- a/cmd/talosctl/cmd/mgmt/gen/secureboot.go
+++ b/cmd/talosctl/cmd/mgmt/gen/secureboot.go
@@ -75,6 +75,7 @@ var genSecurebootDatabaseCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return generateSecureBootDatabase(
+			cmd.Context(),
 			genSecurebootCmdFlags.outputDirectory,
 			genSecurebootDatabaseCmdFlags.enrolledCertificatePath,
 			genSecurebootDatabaseCmdFlags.signingKeyPath,
@@ -142,13 +143,13 @@ func saveAsDER(file string, pem []byte) error {
 // generateSecureBootDatabase generates a UEFI database to enroll the signing certificate.
 //
 // ref: https://blog.hansenpartnership.com/the-meaning-of-all-the-uefi-keys/
-func generateSecureBootDatabase(path, enrolledCertificatePath, signingKeyPath, signingCertificatePath string, includeWellKnownCerts bool) error {
+func generateSecureBootDatabase(ctx context.Context, path, enrolledCertificatePath, signingKeyPath, signingCertificatePath string, includeWellKnownCerts bool) error {
 	in := profile.SigningKeyAndCertificate{
 		KeyPath:  signingKeyPath,
 		CertPath: signingCertificatePath,
 	}
 
-	signer, err := in.GetSigner(context.Background()) // context not used
+	signer, err := in.GetSigner(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create signer: %w", err)
 	}

--- a/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
+++ b/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
@@ -46,6 +46,12 @@ var loadbalancerLaunchCmd = &cobra.Command{
 			}
 		}
 
+		go func() {
+			<-cmd.Context().Done()
+			// Errors out only when already stopped.
+			lb.Close() //nolint:errcheck
+		}()
+
 		return lb.Run()
 	},
 }

--- a/cmd/talosctl/cmd/root.go
+++ b/cmd/talosctl/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	_ "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create" // import to get the command registered via the init() function.
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
+	"github.com/siderolabs/talos/pkg/cli"
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -29,10 +30,10 @@ var rootCmd = &cobra.Command{
 	DisableAutoGenTag: true,
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// Execute invokes the user-entered command in a cancellable context (with Ctrl^C).
+// Handles errors related to incorrect usage and prints the error message to stderr.
 func Execute() error {
-	cmd, err := rootCmd.ExecuteContextC(context.Background())
+	cmd, err := cli.WithContextC(context.Background(), rootCmd.ExecuteContextC)
 	if err != nil && !common.SuppressErrors {
 		fmt.Fprintln(os.Stderr, err.Error())
 
@@ -48,6 +49,7 @@ func Execute() error {
 	return err
 }
 
+// init adds all child commands to the base command.
 func init() {
 	const (
 		talosGroup   = "talos"

--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -95,10 +95,10 @@ var applyConfigCmd = &cobra.Command{
 
 		withClient := func(f func(context.Context, *client.Client) error) error {
 			if applyConfigCmdFlags.insecure {
-				return WithClientMaintenance(applyConfigCmdFlags.certFingerprints, f)
+				return WithClientMaintenance(cmd.Context(), applyConfigCmdFlags.certFingerprints, f)
 			}
 
-			return WithClient(f)
+			return WithClient(cmd.Context(), f)
 		}
 
 		return withClient(func(ctx context.Context, c *client.Client) error {

--- a/cmd/talosctl/cmd/talos/bootstrap.go
+++ b/cmd/talosctl/cmd/talos/bootstrap.go
@@ -37,7 +37,7 @@ This command should not be used when "init" type node are used.
 Talos etcd cluster can be recovered from a known snapshot with '--recover-from=' flag.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if len(GlobalArgs.Nodes) > 1 {
 				return errors.New("command \"bootstrap\" is not supported with multiple nodes")
 			}

--- a/cmd/talosctl/cmd/talos/cgroups.go
+++ b/cmd/talosctl/cmd/talos/cgroups.go
@@ -57,7 +57,7 @@ To see schema examples, refer to https://github.com/siderolabs/talos/tree/main/c
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "cgroups"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -414,7 +414,7 @@ var configNewCmd = &cobra.Command{
 
 		path := args[0]
 
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "talosconfig"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/conformance.go
+++ b/cmd/talosctl/cmd/talos/conformance.go
@@ -33,7 +33,7 @@ var conformanceKubernetesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			clientProvider := &cluster.ConfigClientProvider{
 				DefaultClient: c,
 			}

--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -31,7 +31,7 @@ var containersCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var (
 				namespace string
 				driver    common.ContainerDriver

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -36,7 +36,7 @@ captures ownership and permission bits.`,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
-			return completePathFromNode(toComplete), cobra.ShellCompDirectiveNoFileComp
+			return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
 		case 1:
 			return nil, cobra.ShellCompDirectiveDefault
 		}
@@ -44,7 +44,7 @@ captures ownership and permission bits.`,
 		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "copy"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/crashdump.go
+++ b/cmd/talosctl/cmd/talos/crashdump.go
@@ -25,7 +25,7 @@ var crashdumpCmd = &cobra.Command{
 	Args:   cobra.NoArgs,
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			return errors.New("`talosctl crashdump` is deprecated, please use `talosctl support` instead")
 		})
 	},

--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -37,7 +37,7 @@ Keyboard shortcuts:
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			return dashboard.Run(
 				ctx, c,
 				dashboard.WithInterval(dashboardCmdFlags.interval),

--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -52,7 +52,7 @@ var debugCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
 			if len(nodes) != 1 {
 				return fmt.Errorf("expected exactly one node, got %v", nodes)
 			}

--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -39,7 +39,7 @@ var duCmd = &cobra.Command{
 
 		var completeOnlyPaths []string
 
-		for _, path := range completePathFromNode(toComplete) {
+		for _, path := range completePathFromNode(cmd.Context(), toComplete) {
 			if path[len(path)-1:] == "/" {
 				completeOnlyPaths = append(completeOnlyPaths, path)
 			}
@@ -48,7 +48,7 @@ var duCmd = &cobra.Command{
 		return completeOnlyPaths, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var paths []string
 
 			if len(args) == 0 {

--- a/cmd/talosctl/cmd/talos/dmesg.go
+++ b/cmd/talosctl/cmd/talos/dmesg.go
@@ -24,7 +24,7 @@ var dmesgCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			stream, err := c.Dmesg(ctx, follow, dmesgTail)
 			if err != nil {
 				return fmt.Errorf("error getting dmesg: %w", err)

--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -196,7 +196,7 @@ It will open the editor defined by your TALOS_EDITOR,
 or EDITOR environment variables, or fall back to 'vi' for Linux
 or 'notepad' for Windows.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.ClientVersionCheck(ctx, c); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -90,7 +90,7 @@ var etcdAlarmListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			response, err := c.EtcdAlarmList(ctx)
 			if err != nil {
 				if response == nil {
@@ -114,7 +114,7 @@ var etcdAlarmDisarmCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			response, err := c.EtcdAlarmDisarm(ctx)
 			if err != nil {
 				if response == nil {
@@ -139,7 +139,7 @@ var etcdDefragCmd = &cobra.Command{
 Defragmentation is a resource heavy operation and should be performed only when necessary on a single node at a time.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd defrag"); err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ var etcdLeaveCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd leave"); err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ If there is no access to the node, or the node can't access etcd to call etcd le
 Always prefer etcd leave over this command.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			memberID, err := etcdresource.ParseMemberID(args[0])
 			if err != nil {
 				return fmt.Errorf("error parsing member ID: %w", err)
@@ -194,7 +194,7 @@ var etcdForfeitLeadershipCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
 
 			return err
@@ -208,7 +208,7 @@ var etcdMemberListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			response, err := c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
 				QueryLocal: true,
 			})
@@ -270,7 +270,7 @@ var etcdStatusCmd = &cobra.Command{
 	Long:  `Returns the status of etcd member on the node, use multiple nodes to get status of all members.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			response, err := c.EtcdStatus(ctx)
 			if err != nil {
 				if response == nil {
@@ -337,7 +337,7 @@ var etcdSnapshotCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd snapshot"); err != nil {
 				return err
 			}
@@ -417,7 +417,7 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade validate"); err != nil {
 				return err
 			}
@@ -472,7 +472,7 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade enable"); err != nil {
 				return err
 			}
@@ -527,7 +527,7 @@ var etcdDowngradeCancelCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade cancel"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/events.go
+++ b/cmd/talosctl/cmd/talos/events.go
@@ -34,7 +34,7 @@ var eventsCmd = &cobra.Command{
 	Short: "Stream runtime events",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 			fmt.Fprintln(w, "NODE\tID\tEVENT\tACTOR\tSOURCE\tMESSAGE")
 

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -43,9 +43,9 @@ To get a list of all available resource definitions, issue 'talosctl get rd'`,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
-			return completeResourceDefinition(toComplete != "")
+			return completeResourceDefinition(cmd.Context(), toComplete != "")
 		case 1:
-			return completeResourceID(args[0], getCmdFlags.namespace)
+			return completeResourceID(cmd.Context(), args[0], getCmdFlags.namespace)
 		}
 
 		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
@@ -53,10 +53,10 @@ To get a list of all available resource definitions, issue 'talosctl get rd'`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if getCmdFlags.insecure {
-			return WithClientMaintenance(nil, getResources(args))
+			return WithClientMaintenance(cmd.Context(), nil, getResources(args))
 		}
 
-		return WithClient(getResources(args))
+		return WithClient(cmd.Context(), getResources(args))
 	},
 }
 
@@ -230,10 +230,10 @@ func aggregateEvents(ctx context.Context, outCh chan<- nodeAndEvent, watchCh <-c
 }
 
 // completeResourceDefinition represents tab complete options for `get` and `get *` commands.
-func completeResourceDefinition(withAliases bool) ([]string, cobra.ShellCompDirective) {
+func completeResourceDefinition(ctx context.Context, withAliases bool) ([]string, cobra.ShellCompDirective) {
 	var result []string
 
-	if WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
+	if WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		items, err := safe.StateListAll[*meta.ResourceDefinition](ctx, c.COSI)
 		if err != nil {
 			return err
@@ -256,10 +256,10 @@ func completeResourceDefinition(withAliases bool) ([]string, cobra.ShellCompDire
 }
 
 // completeResourceID represents tab complete options for `get` and `get *` commands.
-func completeResourceID(resourceType, namespace string) ([]string, cobra.ShellCompDirective) {
+func completeResourceID(ctx context.Context, resourceType, namespace string) ([]string, cobra.ShellCompDirective) {
 	var result []string
 
-	if WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
+	if WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		if len(GlobalArgs.Nodes) > 0 {
 			ctx = client.WithNode(ctx, GlobalArgs.Nodes[0])
 		}
@@ -287,10 +287,10 @@ func completeResourceID(resourceType, namespace string) ([]string, cobra.ShellCo
 }
 
 // CompleteNodes represents tab completion for `--nodes` argument.
-func CompleteNodes(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func CompleteNodes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var nodes []string
 
-	if WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
+	if WithClientNoNodes(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 		items, err := safe.StateListAll[*cluster.Member](ctx, c.COSI)
 		if err != nil {
 			return err

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -96,24 +96,24 @@ var healthCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runHealth(); err != nil {
+		if err := runHealth(cmd.Context()); err != nil {
 			return err
 		}
 
 		if healthCmdFlags.runE2E {
-			return runE2E()
+			return runE2E(cmd.Context())
 		}
 
 		return nil
 	},
 }
 
-func runHealth() error {
+func runHealth(ctx context.Context) error {
 	if healthCmdFlags.runOnServer {
-		return WithClient(healthOnServer)
+		return WithClient(ctx, healthOnServer)
 	}
 
-	return WithClientNoNodes(healthOnClient)
+	return WithClientNoNodes(ctx, healthOnClient)
 }
 
 func healthOnClient(ctx context.Context, c *client.Client) error {
@@ -122,7 +122,7 @@ func healthOnClient(ctx context.Context, c *client.Client) error {
 	}
 	defer clientProvider.Close() //nolint:errcheck
 
-	clusterInfo, err := buildClusterInfo(healthCmdFlags.clusterState)
+	clusterInfo, err := buildClusterInfo(ctx, healthCmdFlags.clusterState)
 	if err != nil {
 		return err
 	}
@@ -188,8 +188,8 @@ func healthOnServer(ctx context.Context, c *client.Client) error {
 	}
 }
 
-func runE2E() error {
-	return WithClient(func(ctx context.Context, c *client.Client) error {
+func runE2E(ctx context.Context) error {
+	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		clientProvider := &cluster.ConfigClientProvider{
 			DefaultClient: c,
 		}
@@ -222,7 +222,7 @@ func init() {
 	healthCmd.Flags().BoolVar(&healthCmdFlags.runE2E, "run-e2e", false, "run Kubernetes e2e test")
 }
 
-func buildClusterInfo(clusterState clusterNodes) (cluster.Info, error) {
+func buildClusterInfo(ctx context.Context, clusterState clusterNodes) (cluster.Info, error) {
 	// if nodes are set explicitly via command line args, use them
 	if len(clusterState.ControlPlaneNodes) > 0 || len(clusterState.WorkerNodes) > 0 {
 		return &clusterState, nil
@@ -232,7 +232,7 @@ func buildClusterInfo(clusterState clusterNodes) (cluster.Info, error) {
 
 	var members []*clusterres.Member
 
-	err := WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
+	err := WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		items, err := safe.StateListAll[*clusterres.Member](ctx, c.COSI)
 		if err != nil {
 			return err

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -111,12 +111,12 @@ var imageListCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return imageList()
+		return imageList(cmd.Context())
 	},
 }
 
-func imageList() error {
-	return WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+func imageList(ctx context.Context) error {
+	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
@@ -143,7 +143,7 @@ func imageList() error {
 			if resp.Err != nil {
 				if status.Code(resp.Err) == codes.Unimplemented {
 					// fallback to legacy API for older Talos
-					return imageListLegacy()
+					return imageListLegacy(ctx)
 				}
 
 				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
@@ -175,8 +175,8 @@ func imageList() error {
 // imageListLegacy lists images using the legacy ImageList API.
 //
 // Note: remove me in Talos 1.15.
-func imageListLegacy() error {
-	return WithClient(func(ctx context.Context, c *client.Client) error {
+func imageListLegacy(ctx context.Context) error {
+	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		ns, err := imageCmdFlags.apiNamespace()
 		if err != nil {
 			return err
@@ -217,13 +217,13 @@ var imagePullCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return imagePull(args[0])
+		return imagePull(cmd.Context(), args[0])
 	},
 }
 
 // imagePull pulls an image using modern API and showing progress.
-func imagePull(imageRef string) error {
-	return WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+func imagePull(ctx context.Context, imageRef string) error {
+	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
 		rep := reporter.New()
 
 		containerdInstance, err := imageCmdFlags.containerdInstance()
@@ -271,7 +271,7 @@ func imagePullInternal(
 				cancel()
 
 				// fallback to legacy API for older Talos
-				return nil, imagePullLegacy(imageRef)
+				return nil, imagePullLegacy(ctx, imageRef)
 			}
 
 			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
@@ -313,8 +313,8 @@ func imagePullInternal(
 // imagePullLegacy pulls an image using the legacy ImagePull API.
 //
 // Note: remove me in Talos 1.15.
-func imagePullLegacy(imageRef string) error {
-	return WithClient(func(ctx context.Context, c *client.Client) error {
+func imagePullLegacy(ctx context.Context, imageRef string) error {
+	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		ns, err := imageCmdFlags.apiNamespace()
 		if err != nil {
 			return err
@@ -426,13 +426,13 @@ var imageRemoveCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return imageRemove(args[0])
+		return imageRemove(cmd.Context(), args[0])
 	},
 }
 
 // imageRemove removes an image using modern API.
-func imageRemove(imageRef string) error {
-	return WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+func imageRemove(ctx context.Context, imageRef string) error {
+	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
@@ -602,7 +602,7 @@ var imageTalosBundleCmd = &cobra.Command{
 		digestedReferences := []string{}
 
 		if imageTalosBundleCmdFlags.extensions {
-			extensions, err = artifacts.FetchOfficialExtensions(tag)
+			extensions, err = artifacts.FetchOfficialExtensions(cmd.Context(), tag)
 			if err != nil {
 				return fmt.Errorf("error fetching official extensions for %s: %w", tag, err)
 			}
@@ -613,7 +613,7 @@ var imageTalosBundleCmd = &cobra.Command{
 		}
 
 		if imageTalosBundleCmdFlags.overlays {
-			overlays, err = artifacts.FetchOfficialOverlays(tag)
+			overlays, err = artifacts.FetchOfficialOverlays(cmd.Context(), tag)
 			if err != nil {
 				return fmt.Errorf("error fetching official overlays for %s: %w", tag, err)
 			}

--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -41,7 +41,7 @@ to render the graph:
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "inspect dependencies"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/interfaces.go
+++ b/cmd/talosctl/cmd/talos/interfaces.go
@@ -21,7 +21,7 @@ var interfacesCmd = &cobra.Command{
 	Args:   cobra.NoArgs,
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			return errors.New("`talosctl interfaces` is deprecated, please use `talosctl get addresses` and `talosctl get links` instead")
 		})
 	},

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -42,7 +42,7 @@ Otherwise, kubeconfig will be written to PWD or [local-path] if specified.
 If merge flag is false and [local-path] is "-", config will be written to stdout.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "kubeconfig"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/list.go
+++ b/cmd/talosctl/cmd/talos/list.go
@@ -45,14 +45,14 @@ var lsCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return completePathFromNode(toComplete), cobra.ShellCompDirectiveNoFileComp
+		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if recurse && recursionDepth != 1 {
 			return errors.New("only one of flags --recurse and --depth can be specified at the same time")
 		}
 
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			rootDir := "/"
 
 			if len(args) > 0 {

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -41,13 +41,13 @@ var logsCmd = &cobra.Command{
 		}
 
 		if kubernetesFlag {
-			return getContainersFromNode(kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
+			return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return mergeSuggestions(getServiceFromNode(), getContainersFromNode(kubernetesFlag), getLogsContainers()), cobra.ShellCompDirectiveNoFileComp
+		return mergeSuggestions(getServiceFromNode(cmd.Context()), getContainersFromNode(cmd.Context(), kubernetesFlag), getLogsContainers(cmd.Context())), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var (
 				namespace string
 				driver    common.ContainerDriver
@@ -208,11 +208,12 @@ func (slicer *lineSlicer) run(stream machine.MachineService_LogsClient) {
 	}
 }
 
-func getLogsContainers() []string {
+func getLogsContainers(ctx context.Context) []string {
 	var result []string
 
 	//nolint:errcheck
 	WithClient(
+		ctx,
 		func(ctx context.Context, c *client.Client) error {
 			var remotePeer peer.Peer
 

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -30,7 +30,7 @@ var memoryCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var remotePeer peer.Peer
 
 			resp, err := c.Memory(ctx, grpc.Peer(&remotePeer))

--- a/cmd/talosctl/cmd/talos/meta.go
+++ b/cmd/talosctl/cmd/talos/meta.go
@@ -40,10 +40,10 @@ var metaWriteCmd = &cobra.Command{
 		}
 
 		if metaCmdFlags.insecure {
-			return WithClientMaintenance(nil, fn)
+			return WithClientMaintenance(cmd.Context(), nil, fn)
 		}
 
-		return WithClient(fn)
+		return WithClient(cmd.Context(), fn)
 	},
 }
 
@@ -63,10 +63,10 @@ var metaDeleteCmd = &cobra.Command{
 		}
 
 		if metaCmdFlags.insecure {
-			return WithClientMaintenance(nil, fn)
+			return WithClientMaintenance(cmd.Context(), nil, fn)
 		}
 
-		return WithClient(fn)
+		return WithClient(cmd.Context(), fn)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -26,7 +26,7 @@ var mountsCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var remotePeer peer.Peer
 
 			resp, err := c.Mounts(ctx, grpc.Peer(&remotePeer))

--- a/cmd/talosctl/cmd/talos/netstat.go
+++ b/cmd/talosctl/cmd/talos/netstat.go
@@ -62,7 +62,7 @@ If you don't pass an argument, the command will show host connections.`,
 
 		var podList []string
 
-		if WithClient(func(ctx context.Context, c *client.Client) error {
+		if WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			n := netstat{
 				NodeNetNSPods: make(map[string]map[string]string),
 				client:        c,
@@ -89,7 +89,7 @@ If you don't pass an argument, the command will show host connections.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		req := netstatFlagsToRequest()
 
-		return WithClient(func(ctx context.Context, c *client.Client) (err error) {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) (err error) {
 			if netstatCmdFlags.pods && len(args) > 0 {
 				return errors.New("cannot use --pods and specify a pod")
 			}

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -134,7 +134,7 @@ var patchCmd = &cobra.Command{
 	Short: "Patch machine configuration of a Talos node with a local patch.",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if patchCmdFlags.patchFile != "" {
 				patchCmdFlags.patch = append(patchCmdFlags.patch, "@"+patchCmdFlags.patchFile)
 			}

--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -65,7 +65,7 @@ e.g. by excluding packets with the port 50000.
    `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "pcap"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -32,7 +32,7 @@ var processesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			output, err := processesOutput(ctx, c)
 			if err != nil {
 				return err

--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -28,10 +28,10 @@ var readCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return completePathFromNode(toComplete), cobra.ShellCompDirectiveNoFileComp
+		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "read"); err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -53,22 +53,22 @@ var rebootCmd = &cobra.Command{
 			client.WithRebootMode(rebootCmdFlags.rebootMode.Value()),
 		}
 
-		return rebootRun(opts)
+		return rebootRun(cmd.Context(), opts)
 	},
 }
 
-func rebootRun(opts []client.RebootMode) (retErr error) {
+func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 	rep := reporter.New(
 		reporter.WithOutputMode(rebootCmdFlags.progress.Value()),
 	)
 
 	if !rebootCmdFlags.drain {
-		return rebootInternal(rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
+		return rebootInternal(ctx, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 	}
 
 	var nodeNames map[string]string
 
-	if err := WithClientAndNodes(func(ctx context.Context, c *client.Client, nodes []string) error {
+	if err := WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
 		var drainErr error
 
 		nodeNames, drainErr = drainNodes(ctx, c, nodes, rebootCmdFlags.drainTimeout, rep)
@@ -79,19 +79,19 @@ func rebootRun(opts []client.RebootMode) (retErr error) {
 	}
 
 	defer func() {
-		if uncordonErr := WithClientAndNodes(func(ctx context.Context, c *client.Client, _ []string) error {
+		if uncordonErr := WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, _ []string) error {
 			return uncordonNodes(ctx, c, nodeNames, rebootCmdFlags.timeout, rep)
 		}); uncordonErr != nil {
 			retErr = errors.Join(retErr, uncordonErr)
 		}
 	}()
 
-	return rebootInternal(rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
+	return rebootInternal(ctx, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 }
 
-func rebootInternal(wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
+func rebootInternal(ctx context.Context, wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
 	if !wait {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 			if err := helpers.ClientVersionCheck(ctx, c); err != nil {
 				return err
 			}
@@ -112,7 +112,7 @@ func rebootInternal(wait, debug bool, timeout time.Duration, rep *reporter.Repor
 		action.WithDebug(debug),
 		action.WithTimeout(timeout),
 		action.WithReporter(rep),
-	).Run()
+	).Run(ctx)
 }
 
 func rebootGetActorID(opts ...client.RebootMode) func(ctx context.Context, c *client.Client) (string, error) {

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -110,10 +110,10 @@ var resetCmd = &cobra.Command{
 			}
 
 			if resetCmdFlags.insecure {
-				return WithClientMaintenance(nil, resetNoWait)
+				return WithClientMaintenance(cmd.Context(), nil, resetNoWait)
 			}
 
-			return WithClient(resetNoWait)
+			return WithClient(cmd.Context(), resetNoWait)
 		}
 
 		actionFn := func(ctx context.Context, c *client.Client) (string, error) {
@@ -124,7 +124,7 @@ var resetCmd = &cobra.Command{
 
 		if resetCmdFlags.reboot {
 			postCheckFn = func(ctx context.Context, c *client.Client, preActionBootID string) error {
-				err := WithClientMaintenance(nil,
+				err := WithClientMaintenance(ctx, nil,
 					func(ctx context.Context, cli *client.Client) error {
 						_, err := cli.Disks(ctx)
 
@@ -148,7 +148,7 @@ var resetCmd = &cobra.Command{
 			action.WithPostCheck(postCheckFn),
 			action.WithDebug(resetCmdFlags.debug),
 			action.WithTimeout(resetCmdFlags.timeout),
-		).Run()
+		).Run(cmd.Context())
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -26,10 +26,10 @@ var restartCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return getContainersFromNode(kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
+		return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var (
 				namespace string
 				driver    common.ContainerDriver

--- a/cmd/talosctl/cmd/talos/rollback.go
+++ b/cmd/talosctl/cmd/talos/rollback.go
@@ -19,7 +19,7 @@ var rollbackCmd = &cobra.Command{
 	Short: "Rollback a node to the previous installation",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			if err := c.Rollback(ctx); err != nil {
 				return fmt.Errorf("error executing rollback: %s", err)
 			}

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -38,23 +38,23 @@ const pathAutoCompleteLimit = 500
 // WithClientNoNodes wraps common code to initialize Talos client and provide cancellable context.
 //
 // WithClientNoNodes doesn't set any node information on the request context.
-func WithClientNoNodes(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClientNoNodes(action, dialOptions...)
+func WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	return GlobalArgs.WithClientNoNodes(ctx, action, dialOptions...)
 }
 
 // WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
-func WithClient(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClient(action, dialOptions...)
+func WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	return GlobalArgs.WithClient(ctx, action, dialOptions...)
 }
 
 // WithClientAndNodes builds upon WithClientNoNodes to pass a list of nodes via command function.
-func WithClientAndNodes(action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClientAndNodes(action, dialOptions...)
+func WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
+	return GlobalArgs.WithClientAndNodes(ctx, action, dialOptions...)
 }
 
 // WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).
-func WithClientMaintenance(enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
-	return GlobalArgs.WithClientMaintenance(enforceFingerprints, action)
+func WithClientMaintenance(ctx context.Context, enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
+	return GlobalArgs.WithClientMaintenance(ctx, enforceFingerprints, action)
 }
 
 // Commands is a list of commands published by the package.
@@ -93,7 +93,7 @@ func addCommand(cmd *cobra.Command) {
 }
 
 // completePathFromNode represents tab complete options for `ls` and `ls *` commands.
-func completePathFromNode(inputPath string) []string {
+func completePathFromNode(ctx context.Context, inputPath string) []string {
 	pathToSearch := inputPath
 
 	// If the pathToSearch is empty, use root '/'
@@ -110,17 +110,18 @@ func completePathFromNode(inputPath string) []string {
 		pathToSearch = pathToSearch[:index] + "/"
 	}
 
-	paths = getPathFromNode(pathToSearch, inputPath)
+	paths = getPathFromNode(ctx, pathToSearch, inputPath)
 
 	return maps.Keys(paths)
 }
 
 //nolint:gocyclo
-func getPathFromNode(path, filter string) map[string]struct{} {
+func getPathFromNode(ctx context.Context, path, filter string) map[string]struct{} {
 	paths := make(map[string]struct{})
 
 	//nolint:errcheck
 	GlobalArgs.WithClient(
+		ctx,
 		func(ctx context.Context, c *client.Client) error {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -183,11 +184,12 @@ func getPathFromNode(path, filter string) map[string]struct{} {
 	return paths
 }
 
-func getServiceFromNode() []string {
+func getServiceFromNode(ctx context.Context) []string {
 	var svcIDs []string
 
 	//nolint:errcheck
 	GlobalArgs.WithClient(
+		ctx,
 		func(ctx context.Context, c *client.Client) error {
 			var remotePeer peer.Peer
 
@@ -210,11 +212,12 @@ func getServiceFromNode() []string {
 	return svcIDs
 }
 
-func getContainersFromNode(kubernetes bool) []string {
+func getContainersFromNode(ctx context.Context, kubernetes bool) []string {
 	var containerIDs []string
 
 	//nolint:errcheck
 	GlobalArgs.WithClient(
+		ctx,
 		func(ctx context.Context, c *client.Client) error {
 			var (
 				namespace string

--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -49,7 +49,7 @@ PKI can be rotated by applying machine config changes to the controlplane nodes.
 			return err
 		}
 
-		return WithClient(rotateCA)
+		return WithClient(cmd.Context(), rotateCA)
 	},
 }
 
@@ -65,7 +65,7 @@ func rotateCA(ctx context.Context, c *client.Client) error {
 
 	encoderOpt := encoder.WithComments(commentsFlags)
 
-	clusterInfo, err := buildClusterInfo(rotateCACmdFlags.clusterState)
+	clusterInfo, err := buildClusterInfo(ctx, rotateCACmdFlags.clusterState)
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/talos/routes.go
+++ b/cmd/talosctl/cmd/talos/routes.go
@@ -22,7 +22,7 @@ var routesCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Hidden:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			return errors.New("`talosctl routes` is deprecated, please use `talosctl get routes` instead")
 		})
 	},

--- a/cmd/talosctl/cmd/talos/service.go
+++ b/cmd/talosctl/cmd/talos/service.go
@@ -31,7 +31,7 @@ With actions 'start', 'stop', 'restart', service state is updated respectively.`
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
-			return getServiceFromNode(), cobra.ShellCompDirectiveNoFileComp
+			return getServiceFromNode(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
 		case 1:
 			return []string{"start", "stop", "restart", "status"}, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -50,7 +50,7 @@ With actions 'start', 'stop', 'restart', service state is updated respectively.`
 			action = args[1]
 		}
 
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			switch action {
 			case "status":
 				if serviceID == "" {

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -38,7 +38,7 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		if !shutdownCmdFlags.wait {
-			return WithClient(func(ctx context.Context, c *client.Client) error {
+			return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 				if err := helpers.ClientVersionCheck(ctx, c); err != nil {
 					return err
 				}
@@ -57,7 +57,7 @@ var shutdownCmd = &cobra.Command{
 			shutdownGetActorID,
 			action.WithDebug(shutdownCmdFlags.debug),
 			action.WithTimeout(shutdownCmdFlags.timeout),
-		).Run()
+		).Run(cmd.Context())
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -30,7 +30,7 @@ var statsCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var (
 				namespace string
 				driver    common.ContainerDriver

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -67,7 +67,7 @@ var supportCmd = &cobra.Command{
 			return errors.New("please provide at least a single node to gather the debug information from")
 		}
 
-		f, err := openArchive()
+		f, err := openArchive(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ var supportCmd = &cobra.Command{
 			return nil
 		})
 
-		collectErr := collectData(f, progress)
+		collectErr := collectData(cmd.Context(), f, progress)
 
 		close(progress)
 
@@ -111,8 +111,8 @@ var supportCmd = &cobra.Command{
 	},
 }
 
-func collectData(dest *os.File, progress chan bundle.Progress) error {
-	return WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
+func collectData(ctx context.Context, dest *os.File, progress chan bundle.Progress) error {
+	return WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		clientset, err := getKubernetesClient(ctx, c)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to create kubernetes client %s\n", err)
@@ -172,10 +172,10 @@ func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset,
 	return clientset, nil
 }
 
-func getDiscoveryConfig() (*clusterresource.Config, error) {
+func getDiscoveryConfig(ctx context.Context) (*clusterresource.Config, error) {
 	var config *clusterresource.Config
 
-	if e := WithClient(func(ctx context.Context, c *client.Client) error {
+	if e := WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		var err error
 
 		config, err = safe.StateGet[*clusterresource.Config](
@@ -192,11 +192,11 @@ func getDiscoveryConfig() (*clusterresource.Config, error) {
 	return config, nil
 }
 
-func openArchive() (*os.File, error) {
+func openArchive(ctx context.Context) (*os.File, error) {
 	if supportCmdFlags.output == "" {
 		supportCmdFlags.output = "support"
 
-		if config, err := getDiscoveryConfig(); err == nil && config.TypedSpec().DiscoveryEnabled {
+		if config, err := getDiscoveryConfig(ctx); err == nil && config.TypedSpec().DiscoveryEnabled {
 			supportCmdFlags.output += "-" + config.TypedSpec().ServiceClusterID
 		}
 

--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -32,7 +32,7 @@ var timeCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
 			var (
 				resp       *timeapi.TimeResponse
 				remotePeer peer.Peer

--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -28,7 +28,7 @@ var upgradeK8sCmd = &cobra.Command{
 	Long:  `Command runs upgrade of Kubernetes control plane components between specified versions.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(upgradeKubernetes)
+		return WithClient(cmd.Context(), upgradeKubernetes)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -74,12 +74,12 @@ var upgradeCmd = &cobra.Command{
 			return errors.New("cannot use --wait and --insecure together")
 		}
 
-		return upgradeRun()
+		return upgradeRun(cmd.Context())
 	},
 }
 
-func upgradeRun() error {
-	return WithClientAndNodes(upgradeViaLifecycleService)
+func upgradeRun(ctx context.Context) error {
+	return WithClientAndNodes(ctx, upgradeViaLifecycleService)
 }
 
 var talosUpgradeAPIVersionRange = semver.MustParseRange(">1.13.0-alpha.2 <2.0.0")
@@ -96,7 +96,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 	if upgradeCmdFlags.legacy {
 		cli.Warning("Forcing use of legacy upgrade method. This flag is deprecated and will be removed in Talos 1.18.")
 
-		return upgradeLegacy()
+		return upgradeLegacy(ctx)
 	}
 
 	opts := []client.RebootMode{
@@ -112,7 +112,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		reporter.WithOutputMode(upgradeCmdFlags.progress.Value()),
 	)
 
-	err = WithClient(func(ctx context.Context, c *client.Client) error {
+	err = WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		return helpers.TalosVersionCheck(ctx, c, talosUpgradeAPIVersionRange)
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 				Message: "New upgrade API is not available, falling back to legacy",
 			})
 
-			return upgradeLegacy()
+			return upgradeLegacy(ctx)
 		}
 
 		return fmt.Errorf("error checking Talos version compatibility: %w", err)
@@ -159,7 +159,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		}
 	}()
 
-	err = rebootInternal(upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
+	err = rebootInternal(ctx, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
 	if err != nil {
 		return fmt.Errorf("error during upgrade: %w", err)
 	}
@@ -240,7 +240,7 @@ func upgradeInternal(ctx context.Context, c *client.Client, containerdInstance *
 // upgradeLegacy dispatches to the legacy upgrade path, respecting --wait.
 //
 // Note: remove me in Talos 1.18.
-func upgradeLegacy() error {
+func upgradeLegacy(ctx context.Context) error {
 	rebootModeStr := strings.ToUpper(upgradeCmdFlags.rebootMode.String())
 
 	rebootMode, ok := machine.UpgradeRequest_RebootMode_value[rebootModeStr]
@@ -257,7 +257,7 @@ func upgradeLegacy() error {
 	}
 
 	if !upgradeCmdFlags.wait {
-		return runUpgradeLegacyNoWaitWithOpts(opts)
+		return runUpgradeLegacyNoWaitWithOpts(ctx, opts)
 	}
 
 	return action.NewTracker(
@@ -269,20 +269,20 @@ func upgradeLegacy() error {
 		action.WithPostCheck(action.BootIDChangedPostCheckFn),
 		action.WithDebug(upgradeCmdFlags.debug),
 		action.WithTimeout(upgradeCmdFlags.timeout),
-	).Run()
+	).Run(ctx)
 }
 
 // runUpgradeLegacyNoWaitWithOpts runs the legacy upgrade without waiting.
 //
 // Note: remove me in Talos 1.18.
-func runUpgradeLegacyNoWaitWithOpts(opts []client.UpgradeOption) error {
+func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOption) error {
 	if upgradeCmdFlags.insecure {
-		return WithClientMaintenance(nil, func(ctx context.Context, c *client.Client) error {
+		return WithClientMaintenance(ctx, nil, func(ctx context.Context, c *client.Client) error {
 			return doUpgradeLegacy(ctx, c, opts)
 		})
 	}
 
-	return WithClient(func(ctx context.Context, c *client.Client) error {
+	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		return doUpgradeLegacy(ctx, c, opts)
 	})
 }

--- a/cmd/talosctl/cmd/talos/version.go
+++ b/cmd/talosctl/cmd/talos/version.go
@@ -52,10 +52,10 @@ var versionCmd = &cobra.Command{
 		}
 
 		if versionCmdFlags.insecure {
-			return WithClientMaintenance(nil, cmdVersion)
+			return WithClientMaintenance(cmd.Context(), nil, cmdVersion)
 		}
 
-		return WithClient(cmdVersion)
+		return WithClient(cmd.Context(), cmdVersion)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/wipe.go
+++ b/cmd/talosctl/cmd/talos/wipe.go
@@ -40,10 +40,10 @@ Use device names as arguments, for example: vda or sda5.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if wipeDiskCmdFlags.insecure {
-			return WithClientMaintenance(nil, cmdWipe(args))
+			return WithClientMaintenance(cmd.Context(), nil, cmdWipe(args))
 		}
 
-		return WithClient(cmdWipe(args))
+		return WithClient(cmd.Context(), cmdWipe(args))
 	},
 }
 

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -161,7 +161,7 @@ func NewTracker(
 
 // ClientExecutor is the interface for the client executor.
 type ClientExecutor interface {
-	WithClient(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error
+	WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error
 	NodeList() []string
 }
 
@@ -169,12 +169,12 @@ type ClientExecutor interface {
 // After receiving the expected event, if provided, it tracks the progress by running the post check with retries.
 //
 //nolint:gocyclo
-func (a *Tracker) Run() error {
+func (a *Tracker) Run(ctx context.Context) error {
 	var failedNodesToDmesgs containers.ConcurrentMap[string, io.Reader]
 
 	var eg errgroup.Group
 
-	err := a.clientExecutor.WithClient(func(ctx context.Context, c *client.Client) error {
+	err := a.clientExecutor.WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		ctx, cancel := context.WithTimeout(ctx, a.timeout)
 		defer cancel()
 

--- a/cmd/talosctl/pkg/talos/artifacts/fetch.go
+++ b/cmd/talosctl/pkg/talos/artifacts/fetch.go
@@ -52,9 +52,9 @@ func newManager() (*fetchManager, error) {
 	}, nil
 }
 
-func (m *fetchManager) fetchImageByTag(imageName, tag string, imageHandler imageHandler) error {
+func (m *fetchManager) fetchImageByTag(ctx context.Context, imageName, tag string, imageHandler imageHandler) error {
 	// set a timeout for fetching, but don't bind it to any context, as we want fetch operation to finish
-	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
 
 	// light check first - if the image exists, and resolve the digest
@@ -68,15 +68,15 @@ func (m *fetchManager) fetchImageByTag(imageName, tag string, imageHandler image
 
 	digestRef := repoRef.Digest(descriptor.Digest.String())
 
-	return m.fetchImageByDigest(digestRef, imageHandler)
+	return m.fetchImageByDigest(ctx, digestRef, imageHandler)
 }
 
 // fetchImageByDigest fetches an image by digest, verifies signatures, and exports it to the storage.
-func (m *fetchManager) fetchImageByDigest(digestRef name.Digest, imageHandler imageHandler) error {
+func (m *fetchManager) fetchImageByDigest(ctx context.Context, digestRef name.Digest, imageHandler imageHandler) error {
 	var err error
 
 	// set a timeout for fetching, but don't bind it to any context, as we want fetch operation to finish
-	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
 
 	desc, err := m.puller.Get(ctx, digestRef)

--- a/cmd/talosctl/pkg/talos/artifacts/images.go
+++ b/cmd/talosctl/pkg/talos/artifacts/images.go
@@ -7,6 +7,7 @@ package artifacts
 import (
 	"archive/tar"
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -36,7 +37,7 @@ type OverlayRef struct {
 }
 
 // FetchOfficialExtensions fetches list of extensions for specific Talos version.
-func FetchOfficialExtensions(tag string) ([]ExtensionRef, error) {
+func FetchOfficialExtensions(ctx context.Context, tag string) ([]ExtensionRef, error) {
 	var extensions []ExtensionRef
 
 	m, err := newManager()
@@ -44,7 +45,7 @@ func FetchOfficialExtensions(tag string) ([]ExtensionRef, error) {
 		return nil, err
 	}
 
-	if err := m.fetchImageByTag(images.DefaultExtensionsManifestRepository, tag, imageExportHandler(func(r io.Reader) error {
+	if err := m.fetchImageByTag(ctx, images.DefaultExtensionsManifestRepository, tag, imageExportHandler(func(r io.Reader) error {
 		var extractErr error
 
 		extensions, extractErr = extractExtensionList(r)
@@ -58,7 +59,7 @@ func FetchOfficialExtensions(tag string) ([]ExtensionRef, error) {
 }
 
 // FetchOfficialOverlays fetches list of overlays for specific Talos version.
-func FetchOfficialOverlays(tag string) ([]OverlayRef, error) {
+func FetchOfficialOverlays(ctx context.Context, tag string) ([]OverlayRef, error) {
 	var overlays []OverlayRef
 
 	m, err := newManager()
@@ -66,7 +67,7 @@ func FetchOfficialOverlays(tag string) ([]OverlayRef, error) {
 		return nil, err
 	}
 
-	if err := m.fetchImageByTag(images.DefaultOverlaysManifestRepository, tag, imageExportHandler(func(r io.Reader) error {
+	if err := m.fetchImageByTag(ctx, images.DefaultOverlaysManifestRepository, tag, imageExportHandler(func(r io.Reader) error {
 		var extractErr error
 
 		overlays, extractErr = extractOverlayList(r)

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/siderolabs/crypto/x509"
 	"google.golang.org/grpc"
 
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 )
@@ -30,78 +29,75 @@ type Args struct {
 }
 
 // NodeList returns the list of nodes to run the command against.
-func (c *Args) NodeList() []string {
-	return c.Nodes
+func (args *Args) NodeList() []string {
+	return args.Nodes
 }
 
 // WithClientNoNodes wraps common code to initialize Talos client and provide cancellable context.
 //
 // WithClientNoNodes doesn't set any node information on the request context.
-func (c *Args) WithClientNoNodes(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return cli.WithContext(
-		context.Background(), func(ctx context.Context) error {
-			cfg, err := clientconfig.Open(c.Talosconfig)
-			if err != nil {
-				return fmt.Errorf("failed to open config file %q: %w", c.Talosconfig, err)
-			}
+func (args *Args) WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	cfg, err := clientconfig.Open(args.Talosconfig)
+	if err != nil {
+		return fmt.Errorf("failed to open config file %q: %w", args.Talosconfig, err)
+	}
 
-			opts := []client.OptionFunc{
-				client.WithConfig(cfg),
-				client.WithDefaultGRPCDialOptions(),
-				client.WithGRPCDialOptions(dialOptions...),
-				client.WithSideroV1KeysDir(clientconfig.CustomSideroV1KeysDirPath(c.SideroV1KeysDir)),
-			}
+	opts := []client.OptionFunc{
+		client.WithConfig(cfg),
+		client.WithDefaultGRPCDialOptions(),
+		client.WithGRPCDialOptions(dialOptions...),
+		client.WithSideroV1KeysDir(clientconfig.CustomSideroV1KeysDirPath(args.SideroV1KeysDir)),
+	}
 
-			if c.CmdContext != "" {
-				opts = append(opts, client.WithContextName(c.CmdContext))
-			}
+	if args.CmdContext != "" {
+		opts = append(opts, client.WithContextName(args.CmdContext))
+	}
 
-			if len(c.Endpoints) > 0 {
-				// override endpoints from command-line flags
-				opts = append(opts, client.WithEndpoints(c.Endpoints...))
-			}
+	if len(args.Endpoints) > 0 {
+		// override endpoints from command-line flags
+		opts = append(opts, client.WithEndpoints(args.Endpoints...))
+	}
 
-			if c.Cluster != "" {
-				opts = append(opts, client.WithCluster(c.Cluster))
-			}
+	if args.Cluster != "" {
+		opts = append(opts, client.WithCluster(args.Cluster))
+	}
 
-			c, err := client.New(ctx, opts...)
-			if err != nil {
-				return fmt.Errorf("error constructing client: %w", err)
-			}
-			//nolint:errcheck
-			defer c.Close()
+	c, err := client.New(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("error constructing client: %w", err)
+	}
+	//nolint:errcheck
+	defer c.Close()
 
-			return action(ctx, c)
-		},
-	)
+	return action(ctx, c)
 }
 
 // ErrConfigContext is returned when config context cannot be resolved.
 var ErrConfigContext = errors.New("failed to resolve config context")
 
-func (c *Args) getNodes(cli *client.Client) ([]string, error) {
-	if len(c.Nodes) < 1 {
+func (args *Args) getNodes(cli *client.Client) ([]string, error) {
+	if len(args.Nodes) < 1 {
 		configContext := cli.GetConfigContext()
 		if configContext == nil {
 			return nil, ErrConfigContext
 		}
 
-		c.Nodes = configContext.Nodes
+		args.Nodes = configContext.Nodes
 	}
 
-	if len(c.Nodes) < 1 {
+	if len(args.Nodes) < 1 {
 		return nil, errors.New("nodes are not set for the command: please use `--nodes` flag or configuration file to set the nodes to run the command against")
 	}
 
-	return c.Nodes, nil
+	return args.Nodes, nil
 }
 
 // WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
-func (c *Args) WithClient(action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return c.WithClientNoNodes(
+func (args *Args) WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	return args.WithClientNoNodes(
+		ctx,
 		func(ctx context.Context, cli *client.Client) error {
-			nodes, err := c.getNodes(cli)
+			nodes, err := args.getNodes(cli)
 			if err != nil {
 				return err
 			}
@@ -115,10 +111,11 @@ func (c *Args) WithClient(action func(context.Context, *client.Client) error, di
 }
 
 // WithClientAndNodes builds upon WithClientNoNodes to provide a list of nodes to the function.
-func (c *Args) WithClientAndNodes(action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
-	return c.WithClientNoNodes(
+func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
+	return args.WithClientNoNodes(
+		ctx,
 		func(ctx context.Context, cli *client.Client) error {
-			nodes, err := c.getNodes(cli)
+			nodes, err := args.getNodes(cli)
 			if err != nil {
 				return err
 			}
@@ -130,37 +127,33 @@ func (c *Args) WithClientAndNodes(action func(context.Context, *client.Client, [
 }
 
 // WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).
-func (c *Args) WithClientMaintenance(enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
-	return cli.WithContext(
-		context.Background(), func(ctx context.Context) error {
-			tlsConfig := &tls.Config{
-				InsecureSkipVerify: true,
-			}
+func (args *Args) WithClientMaintenance(ctx context.Context, enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
 
-			if len(enforceFingerprints) > 0 {
-				fingerprints := make([]x509.Fingerprint, len(enforceFingerprints))
+	if len(enforceFingerprints) > 0 {
+		fingerprints := make([]x509.Fingerprint, len(enforceFingerprints))
 
-				for i, stringFingerprint := range enforceFingerprints {
-					var err error
+		for i, stringFingerprint := range enforceFingerprints {
+			var err error
 
-					fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
-					if err != nil {
-						return fmt.Errorf("error parsing certificate fingerprint %q: %v", stringFingerprint, err)
-					}
-				}
-
-				tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
-			}
-
-			c, err := client.New(ctx, client.WithDefaultGRPCDialOptions(), client.WithTLSConfig(tlsConfig), client.WithEndpoints(c.Nodes...))
+			fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
 			if err != nil {
-				return err
+				return fmt.Errorf("error parsing certificate fingerprint %q: %v", stringFingerprint, err)
 			}
+		}
 
-			//nolint:errcheck
-			defer c.Close()
+		tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
+	}
 
-			return action(ctx, c)
-		},
-	)
+	cl, err := client.New(ctx, client.WithDefaultGRPCDialOptions(), client.WithTLSConfig(tlsConfig), client.WithEndpoints(args.Nodes...))
+	if err != nil {
+		return err
+	}
+
+	//nolint:errcheck
+	defer cl.Close()
+
+	return action(ctx, cl)
 }

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -10,16 +10,21 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/spf13/cobra"
 )
 
-// WithContext wraps function call to provide a context cancellable with ^C.
-func WithContext(ctx context.Context, f func(context.Context) error) error {
+// WithContextC wraps function call to provide a context cancellable with SIGTERM (Ctrl^C) or SIGINT.
+// Returns the resolved command and error from the function call.
+func WithContextC(ctx context.Context, f func(context.Context) (*cobra.Command, error)) (*cobra.Command, error) {
 	wrappedCtx, wrappedCtxCancel := context.WithCancel(ctx)
 	defer wrappedCtxCancel()
 
 	// listen for ^C and SIGTERM and abort context
 	sigCh := make(chan os.Signal, 1)
+
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 
 	exited := make(chan struct{})
 	defer close(exited)

--- a/pkg/provision/providers/vm/dhcpd.go
+++ b/pkg/provision/providers/vm/dhcpd.go
@@ -5,6 +5,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -223,8 +224,21 @@ func netipAddrsToIPs(addrs []netip.Addr) []net.IP {
 	})
 }
 
+type dhcpServer interface {
+	Serve() error
+	Close() error
+}
+
+func newDHCPServer(ifName string, hwAddr net.HardwareAddr, ip net.IP, statePath string) (dhcpServer, error) {
+	if ip.To4() == nil {
+		return server6.NewServer(ifName, nil, handlerDHCP6(hwAddr, statePath), server6.WithDebugLogger())
+	}
+
+	return server4.NewServer(ifName, nil, handlerDHCP4(ip, statePath), server4.WithSummaryLogger())
+}
+
 // DHCPd entrypoint.
-func DHCPd(ifName string, ips []net.IP, statePath string) error {
+func DHCPd(ctx context.Context, ifName string, ips []net.IP, statePath string) error {
 	iface, err := net.InterfaceByName(ifName)
 	if err != nil {
 		return fmt.Errorf("error looking up interface: %w", err)
@@ -234,39 +248,30 @@ func DHCPd(ifName string, ips []net.IP, statePath string) error {
 		return fmt.Errorf("error disabling TX checksum offload: %w", err)
 	}
 
-	var eg errgroup.Group
+	eg, egCtx := errgroup.WithContext(ctx)
 
 	for _, ip := range ips {
+		server, err := newDHCPServer(ifName, iface.HardwareAddr, ip, statePath)
+		if err != nil {
+			log.Printf("error on dhcp startup: %s", err)
+
+			return err
+		}
+
 		eg.Go(func() error {
-			if ip.To4() == nil {
-				server, err := server6.NewServer(
-					ifName,
-					nil,
-					handlerDHCP6(iface.HardwareAddr, statePath),
-					server6.WithDebugLogger(),
-				)
-				if err != nil {
-					log.Printf("error on dhcp6 startup: %s", err)
+			<-egCtx.Done()
 
-					return err
-				}
+			return server.Close()
+		})
 
-				return server.Serve()
+		eg.Go(func() error {
+			err := server.Serve()
+
+			if egCtx.Err() != nil {
+				return nil //nolint:nilerr
 			}
 
-			server, err := server4.NewServer(
-				ifName,
-				nil,
-				handlerDHCP4(ip, statePath),
-				server4.WithSummaryLogger(),
-			)
-			if err != nil {
-				log.Printf("error on dhcp4 startup: %s", err)
-
-				return err
-			}
-
-			return server.Serve()
+			return err
 		})
 	}
 

--- a/pkg/provision/providers/vm/dnsd.go
+++ b/pkg/provision/providers/vm/dnsd.go
@@ -5,6 +5,7 @@
 package vm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -20,9 +21,36 @@ import (
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
+func dnsServe(ctx context.Context, server *dns.Server, log *slog.Logger) error {
+	// IPv6 address takes longer to become ready, and therefore might need a retry
+	err := retry.Constant(
+		time.Minute,
+		retry.WithUnits(time.Second),
+	).RetryWithContext(ctx, func(_ context.Context) error {
+		log.Info("starting DNS forwarder server")
+
+		err := server.ListenAndServe()
+		if err != nil {
+			log.Warn("Failed to listen", slog.String("err", err.Error()))
+		}
+
+		if errors.Is(err, syscall.EADDRNOTAVAIL) {
+			return retry.ExpectedErrorf("address %s unavailable", server.Addr)
+		}
+
+		return err
+	})
+
+	if ctx.Err() != nil {
+		return nil //nolint:nilerr
+	}
+
+	return err
+}
+
 // DNSd entrypoint.
-func DNSd(ips []net.IP, resolvConfPath string) error {
-	var eg errgroup.Group
+func DNSd(ctx context.Context, ips []net.IP, resolvConfPath string) error {
+	eg, egCtx := errgroup.WithContext(ctx)
 
 	config, err := dns.ClientConfigFromFile(resolvConfPath)
 	if err != nil {
@@ -36,45 +64,34 @@ func DNSd(ips []net.IP, resolvConfPath string) error {
 
 	defer initLog.Info("bye")
 
-	dnsServe := func(ip net.IP, mode string) error {
-		addr := net.JoinHostPort(ip.String(), "53")
-
-		log := initLog.With("mode", mode, "addr", addr)
-
-		server := &dns.Server{
-			Addr:    addr,
-			Net:     mode,
-			Handler: dns.HandlerFunc(forwardHandler(mode, log, config)),
-		}
-
-		// IPv6 address takes longer to become ready, and therefore might need a retry
-		return retry.Constant(
-			time.Minute,
-			retry.WithUnits(time.Second),
-		).Retry(func() error {
-			log.Info("starting DNS forwarder server")
-
-			err := server.ListenAndServe()
-			if err != nil {
-				log.Warn("Failed to listen", slog.String("err", err.Error()))
-			}
-
-			if errors.Is(err, syscall.EADDRNOTAVAIL) {
-				return retry.ExpectedErrorf("address %s unavailable", addr)
-			}
-
-			return err
-		})
-	}
-
 	for _, ip := range ips {
-		eg.Go(func() error {
-			return dnsServe(ip, "udp")
-		})
+		for _, mode := range []string{"udp", "tcp"} {
+			addr := net.JoinHostPort(ip.String(), "53")
+			log := initLog.With("mode", mode, "addr", addr)
 
-		eg.Go(func() error {
-			return dnsServe(ip, "tcp")
-		})
+			server := &dns.Server{
+				Addr:    addr,
+				Net:     mode,
+				Handler: dns.HandlerFunc(forwardHandler(mode, log, config)),
+			}
+
+			eg.Go(func() error {
+				<-egCtx.Done()
+
+				sCtx, sCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer sCancel()
+
+				if err := server.ShutdownContext(sCtx); err != nil && !errors.Is(err, net.ErrClosed) {
+					return err
+				}
+
+				return nil
+			})
+
+			eg.Go(func() error {
+				return dnsServe(egCtx, server, log)
+			})
+		}
 	}
 
 	return eg.Wait()

--- a/pkg/provision/providers/vm/kms.go
+++ b/pkg/provision/providers/vm/kms.go
@@ -56,7 +56,7 @@ func (p *Provisioner) CreateKMS(state *provision.State, clusterReq provision.Clu
 	}
 
 	if err = os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
-		return fmt.Errorf("error writing LB PID file: %w", err)
+		return fmt.Errorf("error writing KMS PID file: %w", err)
 	}
 
 	return nil

--- a/pkg/provision/providers/vm/tftpd.go
+++ b/pkg/provision/providers/vm/tftpd.go
@@ -5,6 +5,7 @@
 package vm
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -15,16 +16,29 @@ import (
 )
 
 // TFTPd starts a TFTP server on the given IPs.
-func TFTPd(ips []net.IP, nextHandler string) error {
+func TFTPd(ctx context.Context, ips []net.IP, nextHandler string) error {
 	server := tftp.NewServer(ipxe.TFTPHandler(nextHandler), nil)
 
 	server.SetTimeout(5 * time.Second)
 
-	var eg errgroup.Group
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		<-egCtx.Done()
+		server.Shutdown()
+
+		return nil
+	})
 
 	for _, ip := range ips {
 		eg.Go(func() error {
-			return server.ListenAndServe(net.JoinHostPort(ip.String(), "69"))
+			err := server.ListenAndServe(net.JoinHostPort(ip.String(), "69"))
+
+			if egCtx.Err() != nil {
+				return nil //nolint:nilerr
+			}
+
+			return err
 		})
 	}
 


### PR DESCRIPTION
Addresses: https://github.com/siderolabs/talos/issues/13183

Currently, `WithClientMaintenance`[[1](https://github.com/siderolabs/talos/blob/4e5ff8fa2191af92d5e8f3833dd279a01ed78d30/cmd/talosctl/pkg/talos/global/client.go#L135)] and `WithClientNoNodes`[[2](https://github.com/siderolabs/talos/blob/4e5ff8fa2191af92d5e8f3833dd279a01ed78d30/cmd/talosctl/pkg/talos/global/client.go#L42)] will spawn a new `context.Background` on each invocation. This effectively severs the chain of context, with respect to the the root/base Cobra command context [[3](https://pkg.go.dev/github.com/spf13/cobra#Command.Context)]. In some cases, this was known to break handling of SIGINT (Ctrl^C), as multiple such signals were required to terminate the running CLI (one SIGINT for every separate context).

What I've done to solve this:
- [cmd/talosctl/cmd/root.go](https://github.com/siderolabs/talos/pull/13283/changes#diff-945b58365d701075eb62c339aa8d5467a33842cdcec14b8ec117ccfd4e5f3e3bL35) provides a root-level Ctrl^C cancelable context to all of the `talosctl` commands.
- Every `talosctl` command now reuses the root context, which is propagated through the Cobra `cmd.Context()`.
- No `talosctl` command creates another `SIGINT` handler, like they did before on an individual basis.
- Termination of processes launched via `*-launch` is also improved. They'll attempt a graceful shutdown as soon as cmd.Context().Done() is closed. This includes `dhcpd`, `dnsd`, `loadbalancer`, `kms`, and `tftpd`.
- It's probably a good idea to ignore whitespace-only changes when rendering the diff. There's a bunch of changes just dropping parentheses.