### PR TITLE
feat: add golangci-lint fmt target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1268,6 +1268,31 @@ RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool git
 WORKDIR /src
 RUN --mount=type=cache,target=/.cache,id=talos/.cache go tool github.com/siderolabs/importvet/cmd/importvet github.com/siderolabs/talos/...
 
+# The lint-golangci-lint-fmt target runs the golangci-lint formatter and fixes issues automatically.
+FROM base AS lint-golangci-lint-fmt-run
+COPY .golangci.yml .
+ENV GOGC=50
+ENV GOLANGCI_LINT_CACHE=/.cache/lint
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint fmt --config .golangci.yml
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run --fix --issues-exit-code 0 --config .golangci.yml
+WORKDIR /src/pkg/machinery
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint fmt --config ../../.golangci.yml
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run --fix --issues-exit-code 0 --config ../../.golangci.yml
+COPY ./hack/cloud-image-uploader /src/hack/cloud-image-uploader
+WORKDIR /src/hack/cloud-image-uploader
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint fmt --config ../../.golangci.yml
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=locked go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run --fix --issues-exit-code 0 --config ../../.golangci.yml
+WORKDIR /src
+
+# clean golangci-lint fmt output
+# exclude files populated by the `base` stage (gendata build args, generated os-release)
+# so running this target doesn't dirty the source tree with build-time values.
+FROM scratch AS lint-golangci-lint-fmt
+COPY --from=lint-golangci-lint-fmt-run \
+    --exclude=pkg/machinery/gendata/data \
+    --exclude=pkg/machinery/version/os-release \
+    /src .
+
 # The protolint target performs linting on protobuf files.
 
 FROM base AS lint-protobuf

--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,10 @@ lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdo
 lint: ## Runs linters on go, vulncheck, deadcode, protobuf, and markdown file types.
 	@$(MAKE) lint-go lint-vulncheck lint-deadcode lint-protobuf lint-markdown
 
+.PHONY: lint-fmt
+lint-fmt: ## Run all linter formatters and fix up the source tree.
+	@$(MAKE) local-lint-golangci-lint-fmt DEST=./ PLATFORM=linux/$(ARCH)
+
 check-dirty: ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
 


### PR DESCRIPTION
Adds Docker target + Makefile target for running golangci-lint
formatter across codebase. Auto-fixes lint issues instead of just
reporting.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
