### PR TITLE
fix: clarify documentation for image verification pattern

### DIFF
--- a/pkg/machinery/config/types/security/image_verification.go
+++ b/pkg/machinery/config/types/security/image_verification.go
@@ -7,6 +7,7 @@ package security
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-pointer"
@@ -94,7 +95,7 @@ func (r *ImageVerificationRules) Merge(other any) error {
 type ImageVerificationRuleV1Alpha1 struct {
 	//   description: |
 	//     Image reference pattern to match for this rule.
-	//     Supports glob patterns.
+	//     Supports glob patterns, matches only on the image registry and repository, not on the tag or digest.
 	//   examples:
 	//     - value: >
 	//         "docker.io/library/nginx"
@@ -197,7 +198,7 @@ func (s *ImageVerificationConfigV1Alpha1) Clone() config.Document {
 
 // Validate implements config.Validator interface.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (s *ImageVerificationConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Option) ([]string, error) {
 	var (
 		errs     error
@@ -207,6 +208,23 @@ func (s *ImageVerificationConfigV1Alpha1) Validate(validation.RuntimeMode, ...va
 	for i, rule := range s.ConfigRules {
 		if rule.RuleImagePattern == "" {
 			errs = errors.Join(errs, fmt.Errorf("rule %d: imagePattern must be specified", i))
+		}
+
+		if strings.ContainsRune(rule.RuleImagePattern, '@') {
+			warnings = append(warnings, fmt.Sprintf("rule %d: imagePattern contains '@' but matching only applies to the image registry and repository, not the tag or digest", i))
+		}
+
+		// the ':' might be part of the registry (e.g. localhost:5000) so we cannot simply disallow it, but we can warn about it as it's a common mistake to include the tag in the pattern
+		// warn if the `:` is after the first `/` (if any), which means it's likely part of the repository name or tag, not the registry
+		if strings.ContainsRune(rule.RuleImagePattern, ':') {
+			_, withoutRegistry, ok := strings.Cut(rule.RuleImagePattern, "/")
+			if ok && strings.ContainsRune(withoutRegistry, ':') {
+				warnings = append(warnings, fmt.Sprintf("rule %d: imagePattern contains ':' but matching only applies to the image registry and repository, not the tag or digest", i))
+			}
+		}
+
+		if !strings.ContainsRune(rule.RuleImagePattern, '/') && rule.RuleImagePattern != "*" && rule.RuleImagePattern != "" {
+			warnings = append(warnings, fmt.Sprintf("rule %d: imagePattern does not contain a '/', image references like 'nginx' are matched as 'docker.io/nginx' (normalized)", i))
 		}
 
 		skip := pointer.SafeDeref(rule.RuleSkip)

--- a/pkg/machinery/config/types/security/image_verification_test.go
+++ b/pkg/machinery/config/types/security/image_verification_test.go
@@ -146,7 +146,8 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 
 		cfg func() *security.ImageVerificationConfigV1Alpha1
 
-		expectedErrors string
+		expectedErrors   string
+		expectedWarnings []string
 	}{
 		{
 			name: "valid config",
@@ -160,6 +161,10 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 							KeylessIssuer:       "https://token.actions.githubusercontent.com",
 							KeylessSubjectRegex: "https://github.com/myorg/.*",
 						},
+					},
+					{
+						RuleImagePattern: "localhost:3000/*",
+						RuleDeny:         new(true),
 					},
 				}
 
@@ -322,6 +327,35 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 
 			expectedErrors: "rule 0: imagePattern must be specified\nrule 1: at least one verifier must be configured",
 		},
+		{
+			name: "warnings for in imagePattern",
+
+			cfg: func() *security.ImageVerificationConfigV1Alpha1 {
+				c := security.NewImageVerificationConfigV1Alpha1()
+				c.ConfigRules = []security.ImageVerificationRuleV1Alpha1{
+					{
+						RuleImagePattern: "localhost:3000/*/:latest",
+						RuleDeny:         new(true),
+					},
+					{
+						RuleImagePattern: "docker.io/my-image@*",
+						RuleSkip:         new(true),
+					},
+					{
+						RuleImagePattern: "nginx",
+						RuleSkip:         new(true),
+					},
+				}
+
+				return c
+			},
+
+			expectedWarnings: []string{
+				"rule 0: imagePattern contains ':' but matching only applies to the image registry and repository, not the tag or digest",
+				"rule 1: imagePattern contains '@' but matching only applies to the image registry and repository, not the tag or digest",
+				"rule 2: imagePattern does not contain a '/', image references like 'nginx' are matched as 'docker.io/nginx' (normalized)",
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -329,10 +363,10 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 			cfg := test.cfg()
 
 			warnings, err := cfg.Validate(validationMode{})
+			assert.Equal(t, test.expectedWarnings, warnings)
 
 			if test.expectedErrors == "" {
 				require.NoError(t, err)
-				assert.Empty(t, warnings)
 			} else {
 				require.Error(t, err)
 				assert.EqualError(t, err, test.expectedErrors)

--- a/pkg/machinery/config/types/security/security_doc.go
+++ b/pkg/machinery/config/types/security/security_doc.go
@@ -83,7 +83,7 @@ func (ImageVerificationRuleV1Alpha1) Doc() *encoder.Doc {
 				Name:        "image",
 				Type:        "string",
 				Note:        "",
-				Description: "Image reference pattern to match for this rule.\nSupports glob patterns.",
+				Description: "Image reference pattern to match for this rule.\nSupports glob patterns, matches only on the image registry and repository, not on the tag or digest.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Image reference pattern to match for this rule." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{

--- a/website/content/v1.14/reference/configuration/security/imageverificationconfig.md
+++ b/website/content/v1.14/reference/configuration/security/imageverificationconfig.md
@@ -54,7 +54,7 @@ ImageVerificationRuleV1Alpha1 defines a verification rule.
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`image` |string |Image reference pattern to match for this rule.<br>Supports glob patterns. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`image` |string |Image reference pattern to match for this rule.<br>Supports glob patterns, matches only on the image registry and repository, not on the tag or digest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 image: docker.io/library/nginx
 {{< /highlight >}}{{< highlight yaml >}}
 image: registry.k8s.io/*


### PR DESCRIPTION
We already had this in the full docs, but clarify reference docs and add validation with warnings (as we can't be sure with glob patterns that it's totally invalid).
