### PR TITLE
feat: revert update CoreDNS to 1.14.3

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -21,7 +21,6 @@ preface = """
 Linux: 6.18.27
 Kubernetes: 1.36.0
 containerd: 2.3.0
-CoreDNS: 1.14.3
 
 Talos is built with Go 1.26.2.
 """

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -391,7 +391,7 @@ const (
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
 	// renovate: datasource=docker depName=registry.k8s.io/coredns/coredns
-	DefaultCoreDNSVersion = "v1.14.3"
+	DefaultCoreDNSVersion = "v1.14.2"
 
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -2369,7 +2369,7 @@ talosctl image k8s-bundle [flags]
 ### Options
 
 ```
-      --coredns-version semver                 CoreDNS semantic version (default v1.14.3)
+      --coredns-version semver                 CoreDNS semantic version (default v1.14.2)
       --etcd-version semver                    ETCD semantic version (default v3.6.11)
       --flannel-version semver                 Flannel CNI semantic version (default v0.28.4)
   -h, --help                                   help for k8s-bundle

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -1123,7 +1123,7 @@ etcd:
 {{< /highlight >}}</details> | |
 |`coreDNS` |<a href="#Config.cluster.coreDNS">CoreDNS</a> |Core DNS specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 coreDNS:
-    image: registry.k8s.io/coredns/coredns:v1.14.3 # The `image` field is an override to the default coredns image.
+    image: registry.k8s.io/coredns/coredns:v1.14.2 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}</details> | |
 |`externalCloudProvider` |<a href="#Config.cluster.externalCloudProvider">ExternalCloudProviderConfig</a> |External cloud provider configuration. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 externalCloudProvider:
@@ -1939,7 +1939,7 @@ CoreDNS represents the CoreDNS config values.
 {{< highlight yaml >}}
 cluster:
     coreDNS:
-        image: registry.k8s.io/coredns/coredns:v1.14.3 # The `image` field is an override to the default coredns image.
+        image: registry.k8s.io/coredns/coredns:v1.14.2 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}
 
 


### PR DESCRIPTION
This reverts commit 2b6c06ef51fdd3c7ffcbf621eacbb37d798e5228.

The published image is linux/amd64 only.
