### PR TITLE
fix: handle empty GCP operation errors

### DIFF
--- a/tools/cloud-image-uploader/gcp.go
+++ b/tools/cloud-image-uploader/gcp.go
@@ -186,12 +186,8 @@ func (u *GCPUploder) registerImage(arch string) error {
 			return fmt.Errorf("gcp: failed to get operation: %w", err)
 		}
 
-		if op.HTTPStatusCode != http.StatusOK {
-			return fmt.Errorf("gcp: operation failed with http error message: %s", op.HttpErrorMessage)
-		}
-
-		if op.Error != nil {
-			return fmt.Errorf("gcp: operation faild with error message: %s", op.Error.Errors[0].Message)
+		if err := gcpOperationError(op); err != nil {
+			return err
 		}
 
 		if op.Status == "DONE" {
@@ -215,6 +211,22 @@ func (u *GCPUploder) registerImage(arch string) error {
 	})
 
 	return nil
+}
+
+func gcpOperationError(op *compute.Operation) error {
+	if op.HTTPStatusCode != http.StatusOK {
+		return fmt.Errorf("gcp: operation failed with http error message: %s", op.HttpErrorMessage)
+	}
+
+	if op.Error == nil {
+		return nil
+	}
+
+	if len(op.Error.Errors) == 0 {
+		return errors.New("gcp: operation failed")
+	}
+
+	return fmt.Errorf("gcp: operation failed with error message: %s", op.Error.Errors[0].Message)
 }
 
 func (u *GCPUploder) checkImageExists(imageName string) (bool, error) {

--- a/tools/cloud-image-uploader/gcp_test.go
+++ b/tools/cloud-image-uploader/gcp_test.go
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func TestGCPOperationError(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		op          *compute.Operation
+		expectedErr string
+	}{
+		{
+			name: "success",
+			op: &compute.Operation{
+				ServerResponse: googleapi.ServerResponse{
+					HTTPStatusCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name: "http error",
+			op: &compute.Operation{
+				HttpErrorMessage: "not found",
+				ServerResponse: googleapi.ServerResponse{
+					HTTPStatusCode: http.StatusNotFound,
+				},
+			},
+			expectedErr: "gcp: operation failed with http error message: not found",
+		},
+		{
+			name: "operation error",
+			op: &compute.Operation{
+				Error: &compute.OperationError{
+					Errors: []*compute.OperationErrorErrors{
+						{
+							Message: "quota exceeded",
+						},
+					},
+				},
+				ServerResponse: googleapi.ServerResponse{
+					HTTPStatusCode: http.StatusOK,
+				},
+			},
+			expectedErr: "gcp: operation failed with error message: quota exceeded",
+		},
+		{
+			name: "operation error without details",
+			op: &compute.Operation{
+				Error: &compute.OperationError{},
+				ServerResponse: googleapi.ServerResponse{
+					HTTPStatusCode: http.StatusOK,
+				},
+			},
+			expectedErr: "gcp: operation failed",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := gcpOperationError(test.op)
+			if test.expectedErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %q", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", test.expectedErr)
+			}
+
+			if err.Error() != test.expectedErr {
+				t.Fatalf("expected error %q, got %q", test.expectedErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What?

Small guard in the GCP cloud image uploader. If Compute returns an operation with `error` set but no detailed `errors` entries, return a normal `gcp: operation failed` error instead of indexing into an empty slice. Also fixes the tiny `faild` typo, oops.

## Why?

Repro is pretty small: build a `compute.Operation` with `HTTPStatusCode: 200` and `Error: &compute.OperationError{}`. The old path tried `op.Error.Errors[0].Message` and panicked. New test covers this exact thing, so it should stay fixed.

## Acceptance

- [x] issue linked if applicable: none found
- [x] tests included
- [ ] conformance (`make conformance`) attempted locally; commit-body is fixed, but `gpg-identity` requires a Sidero Labs org signer
- [x] lint: `sudo make lint`
- [x] unit check: `cd hack/cloud-image-uploader && go test ./...`

Tiny patch, no big rewrite. just making the error path less spicy.