### PR TITLE
fix: normalize source name for syft consistency

### DIFF
--- a/hack/sbom.sh
+++ b/hack/sbom.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+# We need to normalize name here too remove spaces, make it lowercase, etc. to be consistent with the image name used in the syft SBOM cataloger.
+NORMALIZED_NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | tr -s ' ' '-')
+
 SYFT_FORMAT_PRETTY=1 SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID=1 \
 	go tool \
 	github.com/anchore/syft/cmd/syft \
 	scan --from dir "$1" \
 	--select-catalogers "+sbom-cataloger,go" \
-	--source-name "$NAME" --source-version "$TAG" \
+	--source-name "$NORMALIZED_NAME" --source-version "$TAG" \
 	-o spdx-json > "/rootfs/usr/share/spdx/$2"

--- a/internal/integration/api/sbom.go
+++ b/internal/integration/api/sbom.go
@@ -52,11 +52,13 @@ func (suite *SBOMSuite) TestCommon() {
 	node := suite.RandomDiscoveredNodeInternalIP()
 	ctx := client.WithNode(suite.ctx, node)
 
+	versionName := strings.ToLower(strings.ReplaceAll(version.Name, " ", "-"))
+
 	rtestutils.AssertResources(
 		ctx, suite.T(), suite.Client.COSI,
 		[]resource.ID{
 			// list of common SBOM items which should be present always
-			version.Name,
+			versionName,
 			"github.com/siderolabs/go-kubernetes",
 		},
 		func(item *runtime.SBOMItem, asrt *assert.Assertions) {
@@ -68,9 +70,9 @@ func (suite *SBOMSuite) TestCommon() {
 	// Talos SBOM item should have a matching version.
 	rtestutils.AssertResource(
 		ctx, suite.T(), suite.Client.COSI,
-		version.Name,
+		versionName,
 		func(item *runtime.SBOMItem, asrt *assert.Assertions) {
-			asrt.Equal(version.Name, item.TypedSpec().Name, "SBOM item name should match Talos version name")
+			asrt.Equal(versionName, item.TypedSpec().Name, "SBOM item name should match Talos version name")
 			asrt.Equal(suite.Version, item.TypedSpec().Version, "SBOM item version should match Talos version")
 		},
 	)


### PR DESCRIPTION
Syft SBOM cataloger expects source names in lowercase with hyphens
instead of spaces. Normalize $NAME before passing to syft to match
the image name format used by the cataloger. Prevents SBOM mismatch
errors when source name contains uppercase or spaces.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
