### PR TITLE
docs: drop controlplane endpoint examples

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
@@ -323,18 +323,6 @@ func machineSeccompExample() []*MachineSeccompProfile {
 	}
 }
 
-func clusterEndpointExample1() *Endpoint {
-	return &Endpoint{
-		mustParseURL("https://1.2.3.4:6443"),
-	}
-}
-
-func clusterEndpointExample2() *Endpoint {
-	return &Endpoint{
-		mustParseURL("https://cluster1.internal:6443"),
-	}
-}
-
 func kubeletExtraMountsExample() []ExtraMount {
 	return []ExtraMount{
 		{
@@ -425,24 +413,30 @@ func kubeletCredentialProviderConfigExample() meta.Unstructured {
 	}
 }
 
-func loggingEndpointExample1() *Endpoint {
-	return &Endpoint{
-		mustParseURL("udp://127.0.0.1:12345"),
-	}
-}
-
-func loggingEndpointExample2() *Endpoint {
-	return &Endpoint{
-		mustParseURL("tcp://1.2.3.4:12345"),
-	}
-}
-
-func machineLoggingExample() LoggingConfig {
+func machineLoggingExample1() LoggingConfig {
 	return LoggingConfig{
 		LoggingDestinations: []LoggingDestination{
 			{
-				LoggingEndpoint: loggingEndpointExample2(),
-				LoggingFormat:   constants.LoggingFormatJSONLines,
+				LoggingEndpoint: &Endpoint{
+					mustParseURL("tcp://1.2.3.4:12345"),
+				},
+				LoggingFormat: constants.LoggingFormatJSONLines,
+			},
+		},
+	}
+}
+
+func machineLoggingExample2() LoggingConfig {
+	return LoggingConfig{
+		LoggingDestinations: []LoggingDestination{
+			{
+				LoggingEndpoint: &Endpoint{
+					mustParseURL("udp://127.0.0.1:12345"),
+				},
+				LoggingFormat: constants.LoggingFormatJSONLines,
+				LoggingExtraTags: map[string]string{
+					"machine": "worker-1",
+				},
 			},
 		},
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -358,7 +358,8 @@ type MachineConfig struct {
 	//   description: |
 	//     Configures the logging system.
 	//   examples:
-	//     - value: machineLoggingExample()
+	//     - value: machineLoggingExample1()
+	//     - value: machineLoggingExample2()
 	MachineLogging *LoggingConfig `yaml:"logging,omitempty"`
 	//   description: |
 	//     Configures the kernel.
@@ -1161,9 +1162,6 @@ type ControlPlaneConfig struct {
 	//   description: |
 	//     Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
 	//     It is single-valued, and may optionally include a port number.
-	//   examples:
-	//     - value: clusterEndpointExample1()
-	//     - value: clusterEndpointExample2()
 	//   schema:
 	//     type: string
 	//     format: uri
@@ -2671,9 +2669,6 @@ type LoggingConfig struct {
 type LoggingDestination struct {
 	// description: |
 	//   Where to send logs. Supported protocols are "tcp" and "udp".
-	// examples:
-	//   - value: loggingEndpointExample1()
-	//   - value: loggingEndpointExample2()
 	LoggingEndpoint *Endpoint `yaml:"endpoint"`
 	// description: |
 	//   Logs format.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -249,7 +249,8 @@ func (MachineConfig) Doc() *encoder.Doc {
 	doc.Fields[15].AddExample("MachineSysfs usage example.", machineSysfsExample())
 	doc.Fields[18].AddExample("", machineFeaturesExample())
 	doc.Fields[19].AddExample("", machineUdevExample())
-	doc.Fields[20].AddExample("", machineLoggingExample())
+	doc.Fields[20].AddExample("", machineLoggingExample1())
+	doc.Fields[20].AddExample("", machineLoggingExample2())
 	doc.Fields[21].AddExample("", machineKernelExample())
 	doc.Fields[22].AddExample("", machineSeccompExample())
 	doc.Fields[23].AddExample("override default open file limit", machineBaseRuntimeSpecOverridesExample())
@@ -1085,14 +1086,6 @@ func (Endpoint) Doc() *encoder.Doc {
 		},
 	}
 
-	doc.AddExample("", clusterEndpointExample1())
-
-	doc.AddExample("", clusterEndpointExample2())
-
-	doc.AddExample("", loggingEndpointExample1())
-
-	doc.AddExample("", loggingEndpointExample2())
-
 	return doc
 }
 
@@ -1126,9 +1119,6 @@ func (ControlPlaneConfig) Doc() *encoder.Doc {
 	}
 
 	doc.AddExample("Setting controlplane endpoint address to 1.2.3.4 and port to 443 example.", clusterControlPlaneExample())
-
-	doc.Fields[0].AddExample("", clusterEndpointExample1())
-	doc.Fields[0].AddExample("", clusterEndpointExample2())
 
 	return doc
 }
@@ -2220,7 +2210,9 @@ func (LoggingConfig) Doc() *encoder.Doc {
 		},
 	}
 
-	doc.AddExample("", machineLoggingExample())
+	doc.AddExample("", machineLoggingExample1())
+
+	doc.AddExample("", machineLoggingExample2())
 
 	return doc
 }
@@ -2263,9 +2255,6 @@ func (LoggingDestination) Doc() *encoder.Doc {
 			},
 		},
 	}
-
-	doc.Fields[0].AddExample("", loggingEndpointExample1())
-	doc.Fields[0].AddExample("", loggingEndpointExample2())
 
 	return doc
 }

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -198,6 +198,15 @@ logging:
     destinations:
         - endpoint: tcp://1.2.3.4:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
           format: json_lines # Logs format.
+{{< /highlight >}}{{< highlight yaml >}}
+logging:
+    # Logging destination.
+    destinations:
+        - endpoint: udp://127.0.0.1:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+          format: json_lines # Logs format.
+          # Extra tags (key-value) pairs to attach to every log message sent.
+          extraTags:
+            machine: worker-1
 {{< /highlight >}}</details> | |
 |`kernel` |<a href="#Config.machine.kernel">KernelConfig</a> |Configures the kernel. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 kernel:
@@ -775,6 +784,18 @@ machine:
               format: json_lines # Logs format.
 {{< /highlight >}}
 
+{{< highlight yaml >}}
+machine:
+    logging:
+        # Logging destination.
+        destinations:
+            - endpoint: udp://127.0.0.1:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+              format: json_lines # Logs format.
+              # Extra tags (key-value) pairs to attach to every log message sent.
+              extraTags:
+                machine: worker-1
+{{< /highlight >}}
+
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
@@ -792,11 +813,7 @@ LoggingDestination struct configures Talos logging destination.
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`endpoint` |<a href="#Config.machine.logging.destinations..endpoint">Endpoint</a> |Where to send logs. Supported protocols are "tcp" and "udp". <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-endpoint: udp://127.0.0.1:12345
-{{< /highlight >}}{{< highlight yaml >}}
-endpoint: tcp://1.2.3.4:12345
-{{< /highlight >}}</details> | |
+|`endpoint` |<a href="#Config.machine.logging.destinations..endpoint">Endpoint</a> |Where to send logs. Supported protocols are "tcp" and "udp".  | |
 |`format` |string |Logs format.  |`json_lines`<br /> |
 |`extraTags` |map[string]string |Extra tags (key-value) pairs to attach to every log message sent.  | |
 
@@ -808,34 +825,6 @@ endpoint: tcp://1.2.3.4:12345
 Endpoint represents the endpoint URL parsed out of the machine config.
 
 
-
-{{< highlight yaml >}}
-machine:
-    logging:
-        destinations:
-            - endpoint: https://1.2.3.4:6443
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-machine:
-    logging:
-        destinations:
-            - endpoint: https://cluster1.internal:6443
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-machine:
-    logging:
-        destinations:
-            - endpoint: udp://127.0.0.1:12345
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-machine:
-    logging:
-        destinations:
-            - endpoint: tcp://1.2.3.4:12345
-{{< /highlight >}}
 
 
 | Field | Type | Description | Value(s) |
@@ -1162,11 +1151,7 @@ cluster:
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`endpoint` |<a href="#Config.cluster.controlPlane.endpoint">Endpoint</a> |Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.<br>It is single-valued, and may optionally include a port number. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
-endpoint: https://1.2.3.4:6443
-{{< /highlight >}}{{< highlight yaml >}}
-endpoint: https://cluster1.internal:6443
-{{< /highlight >}}</details> | |
+|`endpoint` |<a href="#Config.cluster.controlPlane.endpoint">Endpoint</a> |Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.<br>It is single-valued, and may optionally include a port number.  | |
 |`localAPIServerPort` |int |The port that the API server listens on internally.<br>This may be different than the port portion listed in the endpoint field above.<br>The default is `6443`.  | |
 
 
@@ -1177,30 +1162,6 @@ endpoint: https://cluster1.internal:6443
 Endpoint represents the endpoint URL parsed out of the machine config.
 
 
-
-{{< highlight yaml >}}
-cluster:
-    controlPlane:
-        endpoint: https://1.2.3.4:6443
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-cluster:
-    controlPlane:
-        endpoint: https://cluster1.internal:6443
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-cluster:
-    controlPlane:
-        endpoint: udp://127.0.0.1:12345
-{{< /highlight >}}
-
-{{< highlight yaml >}}
-cluster:
-    controlPlane:
-        endpoint: tcp://1.2.3.4:12345
-{{< /highlight >}}
 
 
 | Field | Type | Description | Value(s) |


### PR DESCRIPTION
They seem to be redundant, and as they attach to a common `Endpoint` type, the doc generator attaches it to the logging endpoint, which is wrong.

This seems to be the easiest way out.

Fixes #13325
