### PR TITLE
feat: redact more machine config secrets and audit redactors

### DIFF
--- a/pkg/machinery/config/internal/registry/registry.go
+++ b/pkg/machinery/config/internal/registry/registry.go
@@ -8,6 +8,7 @@ package registry
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -50,6 +51,11 @@ func New(kind, version string) (config.Document, error) {
 	return registry.New(kind, version)
 }
 
+// Kinds returns the sorted list of registered document kinds.
+func Kinds() []string {
+	return registry.Kinds()
+}
+
 // Register registers a document kind with the registry.
 func (r *Registry) Register(kind string, f NewDocumentFunc) {
 	r.m.Lock()
@@ -60,6 +66,21 @@ func (r *Registry) Register(kind string, f NewDocumentFunc) {
 	}
 
 	r.registered[kind] = f
+}
+
+// Kinds returns the sorted list of registered document kinds.
+func (r *Registry) Kinds() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	kinds := make([]string, 0, len(r.registered))
+	for k := range r.registered {
+		kinds = append(kinds, k)
+	}
+
+	slices.Sort(kinds)
+
+	return kinds
 }
 
 // New creates a new instance of the requested document.

--- a/pkg/machinery/config/types/block/encryption.go
+++ b/pkg/machinery/config/types/block/encryption.go
@@ -88,6 +88,19 @@ func (s EncryptionSpec) IsZero() bool {
 	return s.EncryptionProvider == block.EncryptionProviderNone && len(s.EncryptionKeys) == 0
 }
 
+// Redact replaces any embedded static passphrases with the given replacement.
+func (s *EncryptionSpec) Redact(replacement string) {
+	for i := range s.EncryptionKeys {
+		if s.EncryptionKeys[i].KeyStatic == nil {
+			continue
+		}
+
+		if s.EncryptionKeys[i].KeyStatic.KeyData != "" {
+			s.EncryptionKeys[i].KeyStatic.KeyData = replacement
+		}
+	}
+}
+
 // EncryptionKey represents configuration for disk encryption key.
 type EncryptionKey struct {
 	//   description: >

--- a/pkg/machinery/config/types/block/raw_volume_config.go
+++ b/pkg/machinery/config/types/block/raw_volume_config.go
@@ -40,6 +40,7 @@ var (
 	_ config.RawVolumeConfig = &RawVolumeConfigV1Alpha1{}
 	_ config.NamedDocument   = &RawVolumeConfigV1Alpha1{}
 	_ config.Validator       = &RawVolumeConfigV1Alpha1{}
+	_ config.SecretDocument  = &RawVolumeConfigV1Alpha1{}
 )
 
 const maxRawVolumeNameLength = constants.PartitionLabelLength - len(constants.RawVolumePrefix)
@@ -104,6 +105,11 @@ func (s *RawVolumeConfigV1Alpha1) Name() string {
 // Clone implements config.Document interface.
 func (s *RawVolumeConfigV1Alpha1) Clone() config.Document {
 	return s.DeepCopy()
+}
+
+// Redact implements config.SecretDocument interface.
+func (s *RawVolumeConfigV1Alpha1) Redact(replacement string) {
+	s.EncryptionSpec.Redact(replacement)
 }
 
 // Validate implements config.Validator interface.

--- a/pkg/machinery/config/types/block/redact_test.go
+++ b/pkg/machinery/config/types/block/redact_test.go
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package block_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+func encryptedSpec() block.EncryptionSpec {
+	return block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:   0,
+				KeyStatic: &block.EncryptionKeyStatic{KeyData: "static-passphrase-0"},
+			},
+			{
+				KeySlot:   1,
+				KeyNodeID: &block.EncryptionKeyNodeID{},
+			},
+			{
+				KeySlot:   2,
+				KeyStatic: &block.EncryptionKeyStatic{KeyData: "static-passphrase-2"},
+			},
+		},
+	}
+}
+
+func TestEncryptionSpecRedact(t *testing.T) {
+	t.Parallel()
+
+	spec := encryptedSpec()
+	spec.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", spec.EncryptionKeys[0].KeyStatic.KeyData)
+	assert.Nil(t, spec.EncryptionKeys[1].KeyStatic)
+	assert.Equal(t, "REDACTED", spec.EncryptionKeys[2].KeyStatic.KeyData)
+}
+
+func TestVolumeConfigRedact(t *testing.T) {
+	t.Parallel()
+
+	cfg := block.NewVolumeConfigV1Alpha1()
+	cfg.MetaName = "EPHEMERAL"
+	cfg.EncryptionSpec = encryptedSpec()
+
+	cfg.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[0].KeyStatic.KeyData)
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[2].KeyStatic.KeyData)
+}
+
+func TestRawVolumeConfigRedact(t *testing.T) {
+	t.Parallel()
+
+	cfg := block.NewRawVolumeConfigV1Alpha1()
+	cfg.MetaName = "raw1"
+	cfg.EncryptionSpec = encryptedSpec()
+
+	cfg.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[0].KeyStatic.KeyData)
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[2].KeyStatic.KeyData)
+}
+
+func TestUserVolumeConfigRedact(t *testing.T) {
+	t.Parallel()
+
+	cfg := block.NewUserVolumeConfigV1Alpha1()
+	cfg.MetaName = "user1"
+	cfg.EncryptionSpec = encryptedSpec()
+
+	cfg.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[0].KeyStatic.KeyData)
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[2].KeyStatic.KeyData)
+}
+
+func TestSwapVolumeConfigRedact(t *testing.T) {
+	t.Parallel()
+
+	cfg := block.NewSwapVolumeConfigV1Alpha1()
+	cfg.MetaName = "swap1"
+	cfg.EncryptionSpec = encryptedSpec()
+
+	cfg.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[0].KeyStatic.KeyData)
+	assert.Equal(t, "REDACTED", cfg.EncryptionSpec.EncryptionKeys[2].KeyStatic.KeyData)
+}

--- a/pkg/machinery/config/types/block/swap_volume_config.go
+++ b/pkg/machinery/config/types/block/swap_volume_config.go
@@ -40,6 +40,7 @@ var (
 	_ config.SwapVolumeConfig = &SwapVolumeConfigV1Alpha1{}
 	_ config.NamedDocument    = &SwapVolumeConfigV1Alpha1{}
 	_ config.Validator        = &SwapVolumeConfigV1Alpha1{}
+	_ config.SecretDocument   = &SwapVolumeConfigV1Alpha1{}
 )
 
 const maxSwapVolumeNameLength = constants.PartitionLabelLength - len(constants.SwapVolumePrefix)
@@ -115,6 +116,11 @@ func (s *SwapVolumeConfigV1Alpha1) Name() string {
 // Clone implements config.Document interface.
 func (s *SwapVolumeConfigV1Alpha1) Clone() config.Document {
 	return s.DeepCopy()
+}
+
+// Redact implements config.SecretDocument interface.
+func (s *SwapVolumeConfigV1Alpha1) Redact(replacement string) {
+	s.EncryptionSpec.Redact(replacement)
 }
 
 // Validate implements config.Validator interface.

--- a/pkg/machinery/config/types/block/user_volume_config.go
+++ b/pkg/machinery/config/types/block/user_volume_config.go
@@ -44,6 +44,7 @@ var (
 	_ config.ConflictingDocument = &UserVolumeConfigV1Alpha1{}
 	_ config.NamedDocument       = &UserVolumeConfigV1Alpha1{}
 	_ config.Validator           = &UserVolumeConfigV1Alpha1{}
+	_ config.SecretDocument      = &UserVolumeConfigV1Alpha1{}
 )
 
 const maxUserVolumeNameLength = constants.PartitionLabelLength - len(constants.UserVolumePrefix)
@@ -199,6 +200,11 @@ func (s *UserVolumeConfigV1Alpha1) Name() string {
 // Clone implements config.Document interface.
 func (s *UserVolumeConfigV1Alpha1) Clone() config.Document {
 	return s.DeepCopy()
+}
+
+// Redact implements config.SecretDocument interface.
+func (s *UserVolumeConfigV1Alpha1) Redact(replacement string) {
+	s.EncryptionSpec.Redact(replacement)
 }
 
 // ConflictsWithKinds implements config.ConflictingDocument interface.

--- a/pkg/machinery/config/types/block/volume_config.go
+++ b/pkg/machinery/config/types/block/volume_config.go
@@ -45,6 +45,7 @@ var (
 	_ config.VolumeConfig                 = &VolumeConfigV1Alpha1{}
 	_ config.NamedDocument                = &VolumeConfigV1Alpha1{}
 	_ config.Validator                    = &VolumeConfigV1Alpha1{}
+	_ config.SecretDocument               = &VolumeConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &VolumeConfigV1Alpha1{}
 )
 
@@ -176,6 +177,11 @@ func (s *VolumeConfigV1Alpha1) Name() string {
 // Clone implements config.Document interface.
 func (s *VolumeConfigV1Alpha1) Clone() config.Document {
 	return s.DeepCopy()
+}
+
+// Redact implements config.SecretDocument interface.
+func (s *VolumeConfigV1Alpha1) Redact(replacement string) {
+	s.EncryptionSpec.Redact(replacement)
 }
 
 // Validate implements config.Validator interface.

--- a/pkg/machinery/config/types/cri/registry_tls.go
+++ b/pkg/machinery/config/types/cri/registry_tls.go
@@ -185,13 +185,7 @@ func (s *RegistryTLSConfigV1Alpha1) InsecureSkipVerify() bool {
 
 // Redact implements config.SecretDocument interface.
 func (s *RegistryTLSConfigV1Alpha1) Redact(replacement string) {
-	if s.TLSClientIdentity != nil {
-		if s.TLSClientIdentity.Key != "" {
-			s.TLSClientIdentity.Key = replacement
-		}
-	}
-
-	if s.TLSCA != "" {
-		s.TLSCA = replacement
+	if s.TLSClientIdentity != nil && s.TLSClientIdentity.Key != "" {
+		s.TLSClientIdentity.Key = replacement
 	}
 }

--- a/pkg/machinery/config/types/network/hcloud_vip.go
+++ b/pkg/machinery/config/types/network/hcloud_vip.go
@@ -37,6 +37,7 @@ var (
 	_ config.ConflictingDocument    = &HCloudVIPConfigV1Alpha1{}
 	_ config.NamedDocument          = &HCloudVIPConfigV1Alpha1{}
 	_ config.Validator              = &HCloudVIPConfigV1Alpha1{}
+	_ config.SecretDocument         = &HCloudVIPConfigV1Alpha1{}
 )
 
 // HCloudVIPConfigV1Alpha1 is a config document to configure virtual IP using Hetzner Cloud APIs for announcement.
@@ -147,4 +148,11 @@ func (s *HCloudVIPConfigV1Alpha1) HCloudAPIToken() string {
 // ConflictsWithKinds implements config.ConflictingDocument interface.
 func (s *HCloudVIPConfigV1Alpha1) ConflictsWithKinds() []string {
 	return []string{Layer2VIPKind}
+}
+
+// Redact implements config.SecretDocument interface.
+func (s *HCloudVIPConfigV1Alpha1) Redact(replacement string) {
+	if s.APIToken != "" {
+		s.APIToken = replacement
+	}
 }

--- a/pkg/machinery/config/types/network/hcloud_vip_test.go
+++ b/pkg/machinery/config/types/network/hcloud_vip_test.go
@@ -57,6 +57,19 @@ func TestHCloudVIPConfigUnmarshal(t *testing.T) {
 	assert.Equal(t, c, docs[0])
 }
 
+func TestHCloudVIPConfigRedact(t *testing.T) {
+	t.Parallel()
+
+	cfg := network.NewHCloudVIPConfigV1Alpha1("1.2.3.4")
+	cfg.LinkName = "net33"
+	cfg.APIToken = "s3cr3t-t0k3n"
+
+	cfg.Redact("REDACTED")
+
+	assert.Equal(t, "REDACTED", cfg.APIToken)
+	assert.Equal(t, "net33", cfg.LinkName, "non-secret fields must be untouched")
+}
+
 func TestHCloudVIPValidate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/machinery/config/types/registry_audit_test.go
+++ b/pkg/machinery/config/types/registry_audit_test.go
@@ -1,0 +1,248 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package types_test
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/internal/registry"
+	_ "github.com/siderolabs/talos/pkg/machinery/config/types" // register all document kinds
+)
+
+// TestRegistryRedactAudit walks every registered document kind, looks for
+// fields whose yaml tag name suggests a secret, and asserts that:
+//
+//  1. The document implements config.SecretDocument.
+//  2. Calling Redact actually replaces the field's value.
+//
+// Detection is a pure case-insensitive substring match on the yaml tag against
+// a small keyword list. Tags in this codebase are camelCase, so no separator
+// handling is needed. New documents added in the future will be picked up
+// automatically without an allowlist to maintain.
+//
+// The frozen v1alpha1 Config is registered too and gets walked here, but in
+// practice it never grows new fields, so its Redact is also covered by
+// v1alpha1_redact_test.go for direct coverage of its existing surface.
+func TestRegistryRedactAudit(t *testing.T) {
+	t.Parallel()
+
+	kinds := registry.Kinds()
+	require.NotEmpty(t, kinds, "no document kinds registered, blank imports in types.go are missing")
+
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			doc, err := registry.New(kind, "v1alpha1")
+			require.NoError(t, err)
+
+			findings := findSecretFields(reflect.ValueOf(doc), "")
+			if len(findings) == 0 {
+				return
+			}
+
+			// Seed each finding with a unique sentinel so we can tell which one
+			// (if any) failed to be redacted.
+			const replacement = "__REDACTED__"
+
+			for i := range findings {
+				findings[i].set("sentinel-" + findings[i].path)
+			}
+
+			secretDoc, ok := doc.(config.SecretDocument)
+			if !ok {
+				paths := make([]string, len(findings))
+				for i, f := range findings {
+					paths[i] = f.path
+				}
+
+				t.Fatalf("kind %q has secret-looking fields but does not implement config.SecretDocument:\n  %s",
+					kind, strings.Join(paths, "\n  "))
+			}
+
+			secretDoc.Redact(replacement)
+
+			for _, f := range findings {
+				assert.Equal(t, replacement, f.get(),
+					"field %s.%s was not redacted by Redact", kind, f.path)
+			}
+		})
+	}
+}
+
+// secretKeywords is the case-insensitive substring set used to flag suspect yaml tags.
+// Deliberately narrow: bare "auth" and "key" would generate false positives
+// (authorizationConfig, publicKey, encryptionKeySize, ...).
+var secretKeywords = regexp.MustCompile(`(?i)(password|passphrase|token|secret|privatekey|presharedkey|apikey)`)
+
+// finding holds a single leaf field flagged by the heuristic, with closures to
+// read and write its value through whatever pointer/slice chain leads to it.
+type finding struct {
+	path string
+	set  func(string)
+	get  func() string
+}
+
+// findSecretFields walks v (expected to be a pointer to a document struct or
+// any struct/pointer/slice/map reachable from one) and returns every string or
+// []byte leaf whose yaml tag matches the heuristic.
+//
+// The walk instantiates nil pointers, adds one element to empty slices of
+// structs, and inserts one entry into empty maps so nested secrets are
+// reachable. It skips:
+//   - non-Talos packages (e.g., url.URL, time.Time) to avoid runaway recursion.
+//   - cycles, via a depth cap.
+//
+//nolint:gocyclo,cyclop
+func findSecretFields(v reflect.Value, path string) []finding {
+	const maxDepth = 8
+
+	if strings.Count(path, ".")+strings.Count(path, "[0]") > maxDepth {
+		return nil
+	}
+
+	//nolint:exhaustive // intentionally only handles pointer/slice/map/struct, everything else (scalars, channels, etc.) returns nil via the default.
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return nil
+			}
+
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+
+		return findSecretFields(v.Elem(), path)
+
+	case reflect.Slice:
+		// []byte leaf is handled at the field level in the Struct case below.
+		// Here we only descend into slices of struct / *struct, adding one
+		// element so nested fields become reachable.
+		elemType := v.Type().Elem()
+		if elemType.Kind() != reflect.Struct && !(elemType.Kind() == reflect.Pointer && elemType.Elem().Kind() == reflect.Struct) {
+			return nil
+		}
+
+		if v.Len() == 0 {
+			if !v.CanSet() {
+				return nil
+			}
+
+			v.Set(reflect.Append(v, reflect.New(elemType).Elem()))
+		}
+
+		return findSecretFields(v.Index(0), path+"[0]")
+
+	case reflect.Map:
+		// Only descend into maps whose value type is *struct. With a pointer
+		// element, the inserted map entry and our walk target share the same
+		// underlying struct, so reflect-based mutations and later Redact calls
+		// see each other. map[K]struct (value, not pointer) would need a more
+		// complex round-trip and is not used by any registered kind today.
+		elemType := v.Type().Elem()
+		if elemType.Kind() != reflect.Pointer || elemType.Elem().Kind() != reflect.Struct {
+			return nil
+		}
+
+		if v.IsNil() {
+			if !v.CanSet() {
+				return nil
+			}
+
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+
+		key := reflect.New(v.Type().Key()).Elem()
+		if key.Kind() != reflect.String {
+			// No registered kind uses non-string map keys for secret-bearing structs.
+			return nil
+		}
+
+		key.SetString("audit")
+
+		entry := reflect.New(elemType.Elem())
+		v.SetMapIndex(key, entry)
+
+		return findSecretFields(entry, path+`["audit"]`)
+
+	case reflect.Struct:
+		if !isTalosType(v.Type()) {
+			return nil
+		}
+
+		var out []finding
+
+		for i := range v.NumField() {
+			field := v.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+
+			tagName := yamlTagName(field.Tag.Get("yaml"))
+			fieldPath := path
+
+			switch {
+			case field.Anonymous:
+				// Embedded struct (e.g., meta.Meta), recurse without extending path.
+			case tagName == "" || tagName == "-":
+				continue
+			default:
+				if fieldPath != "" {
+					fieldPath += "."
+				}
+
+				fieldPath += tagName
+			}
+
+			fv := v.Field(i)
+
+			// Leaf string field with a secret-looking tag.
+			if fv.Kind() == reflect.String && secretKeywords.MatchString(tagName) {
+				out = append(out, finding{
+					path: fieldPath,
+					set:  func(s string) { fv.SetString(s) },
+					get:  fv.String,
+				})
+
+				continue
+			}
+
+			// Leaf []byte field with a secret-looking tag.
+			if fv.Kind() == reflect.Slice && fv.Type().Elem().Kind() == reflect.Uint8 && secretKeywords.MatchString(tagName) {
+				out = append(out, finding{
+					path: fieldPath,
+					set:  func(s string) { fv.SetBytes([]byte(s)) },
+					get:  func() string { return string(fv.Bytes()) },
+				})
+
+				continue
+			}
+
+			out = append(out, findSecretFields(fv, fieldPath)...)
+		}
+
+		return out
+
+	default:
+		return nil
+	}
+}
+
+func yamlTagName(tag string) string {
+	name, _, _ := strings.Cut(tag, ",")
+
+	return name
+}
+
+func isTalosType(t reflect.Type) bool {
+	return strings.HasPrefix(t.PkgPath(), "github.com/siderolabs/talos/")
+}

--- a/pkg/machinery/config/types/siderolink/siderolink.go
+++ b/pkg/machinery/config/types/siderolink/siderolink.go
@@ -102,6 +102,10 @@ func (s *ConfigV1Alpha1) Redact(replacement string) {
 
 		s.APIUrlConfig.RawQuery = query.Encode()
 	}
+
+	if s.UniqueTokenConfig != "" {
+		s.UniqueTokenConfig = replacement
+	}
 }
 
 // SideroLink implements config.SideroLink interface.

--- a/pkg/machinery/config/types/siderolink/siderolink_test.go
+++ b/pkg/machinery/config/types/siderolink/siderolink_test.go
@@ -22,12 +22,15 @@ func TestRedact(t *testing.T) {
 
 	cfg := siderolink.NewConfigV1Alpha1()
 	cfg.APIUrlConfig.URL = ensure.Value(url.Parse("https://siderolink.api/?jointoken=secret&user=alice"))
+	cfg.UniqueTokenConfig = "unique-secret"
 
 	assert.Equal(t, "https://siderolink.api/?jointoken=secret&user=alice", cfg.SideroLink().APIUrl().String())
+	assert.Equal(t, "unique-secret", cfg.SideroLink().UniqueToken())
 
 	cfg.Redact("REDACTED")
 
 	assert.Equal(t, "https://siderolink.api/?jointoken=REDACTED&user=alice", cfg.APIUrlConfig.String())
+	assert.Equal(t, "REDACTED", cfg.SideroLink().UniqueToken())
 }
 
 //go:embed testdata/document.yaml

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -121,7 +121,7 @@ func (c *Config) Cluster() config.ClusterConfig {
 
 // Redact implements the config.SecretDocument interface.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (c *Config) Redact(replacement string) {
 	if c == nil {
 		return
@@ -143,6 +143,59 @@ func (c *Config) Redact(replacement string) {
 		c.MachineConfig.MachineToken = redactStr(c.MachineConfig.MachineToken)
 		if c.MachineConfig.MachineCA != nil {
 			c.MachineConfig.MachineCA.Key = redactBytes(c.MachineConfig.MachineCA.Key)
+		}
+
+		for _, registry := range c.MachineConfig.MachineRegistries.RegistryConfig {
+			if registry == nil {
+				continue
+			}
+
+			if registry.RegistryAuth != nil {
+				registry.RegistryAuth.RegistryPassword = redactStr(registry.RegistryAuth.RegistryPassword)
+				registry.RegistryAuth.RegistryAuth = redactStr(registry.RegistryAuth.RegistryAuth)
+				registry.RegistryAuth.RegistryIdentityToken = redactStr(registry.RegistryAuth.RegistryIdentityToken)
+			}
+
+			if registry.RegistryTLS != nil && registry.RegistryTLS.TLSClientIdentity != nil {
+				registry.RegistryTLS.TLSClientIdentity.Key = redactBytes(registry.RegistryTLS.TLSClientIdentity.Key)
+			}
+		}
+
+		if c.MachineConfig.MachineNetwork != nil {
+			for _, device := range c.MachineConfig.MachineNetwork.NetworkInterfaces {
+				if device == nil {
+					continue
+				}
+
+				redactDeviceSecrets(device, redactStr)
+
+				for _, vlan := range device.DeviceVlans {
+					if vlan == nil {
+						continue
+					}
+
+					redactVIPSecrets(vlan.VlanVIP, redactStr)
+				}
+			}
+		}
+
+		if c.MachineConfig.MachineSystemDiskEncryption != nil {
+			for _, partition := range []*EncryptionConfig{
+				c.MachineConfig.MachineSystemDiskEncryption.StatePartition,
+				c.MachineConfig.MachineSystemDiskEncryption.EphemeralPartition,
+			} {
+				if partition == nil {
+					continue
+				}
+
+				for _, key := range partition.EncryptionKeys {
+					if key == nil || key.KeyStatic == nil {
+						continue
+					}
+
+					key.KeyStatic.KeyData = redactStr(key.KeyStatic.KeyData)
+				}
+			}
 		}
 	}
 
@@ -167,6 +220,28 @@ func (c *Config) Redact(replacement string) {
 		if c.ClusterConfig.EtcdConfig != nil && c.ClusterConfig.EtcdConfig.RootCA != nil {
 			c.ClusterConfig.EtcdConfig.RootCA.Key = redactBytes(c.ClusterConfig.EtcdConfig.RootCA.Key)
 		}
+	}
+}
+
+func redactDeviceSecrets(device *Device, redactStr func(string) string) {
+	if device.DeviceWireguardConfig != nil {
+		device.DeviceWireguardConfig.WireguardPrivateKey = redactStr(device.DeviceWireguardConfig.WireguardPrivateKey)
+	}
+
+	redactVIPSecrets(device.DeviceVIPConfig, redactStr)
+}
+
+func redactVIPSecrets(vip *DeviceVIPConfig, redactStr func(string) string) {
+	if vip == nil {
+		return
+	}
+
+	if vip.EquinixMetalConfig != nil {
+		vip.EquinixMetalConfig.EquinixMetalAPIToken = redactStr(vip.EquinixMetalConfig.EquinixMetalAPIToken)
+	}
+
+	if vip.HCloudConfig != nil {
+		vip.HCloudConfig.HCloudAPIToken = redactStr(vip.HCloudConfig.HCloudAPIToken)
 	}
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_redact_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_redact_test.go
@@ -7,14 +7,17 @@ package v1alpha1_test
 import (
 	"testing"
 
+	"github.com/siderolabs/crypto/x509"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
+//nolint:gocyclo
 func TestRedactSecrets(t *testing.T) {
 	t.Parallel()
 
@@ -69,4 +72,106 @@ func TestRedactSecrets(t *testing.T) {
 			}
 		})
 	}
+}
+
+//nolint:gocyclo
+func TestRedactExtendedSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg := &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineRegistries: v1alpha1.RegistriesConfig{
+				RegistryConfig: map[string]*v1alpha1.RegistryConfig{
+					"my-registry.local:5000": {
+						RegistryAuth: &v1alpha1.RegistryAuthConfig{
+							RegistryUsername:      "alice",
+							RegistryPassword:      "topsecret",
+							RegistryAuth:          "raw-auth",
+							RegistryIdentityToken: "id-token",
+						},
+						RegistryTLS: &v1alpha1.RegistryTLSConfig{
+							TLSClientIdentity: &x509.PEMEncodedCertificateAndKey{
+								Crt: []byte("cert"),
+								Key: []byte("private-key"),
+							},
+							TLSCA: []byte("ca-bundle"),
+						},
+					},
+					"empty-registry.local": nil,
+				},
+			},
+			MachineNetwork: &v1alpha1.NetworkConfig{
+				NetworkInterfaces: v1alpha1.NetworkDeviceList{
+					{
+						DeviceInterface: "eth0",
+						DeviceWireguardConfig: &v1alpha1.DeviceWireguardConfig{
+							WireguardPrivateKey: "wg-priv-key",
+						},
+						DeviceVIPConfig: &v1alpha1.DeviceVIPConfig{
+							EquinixMetalConfig: &v1alpha1.VIPEquinixMetalConfig{
+								EquinixMetalAPIToken: "equinix-token",
+							},
+							HCloudConfig: &v1alpha1.VIPHCloudConfig{
+								HCloudAPIToken: "hcloud-token",
+							},
+						},
+						DeviceVlans: v1alpha1.VlanList{
+							{
+								VlanID: 42,
+								VlanVIP: &v1alpha1.DeviceVIPConfig{
+									EquinixMetalConfig: &v1alpha1.VIPEquinixMetalConfig{
+										EquinixMetalAPIToken: "equinix-vlan-token",
+									},
+									HCloudConfig: &v1alpha1.VIPHCloudConfig{
+										HCloudAPIToken: "hcloud-vlan-token",
+									},
+								},
+							},
+							nil,
+						},
+					},
+					nil,
+				},
+			},
+			MachineSystemDiskEncryption: &v1alpha1.SystemDiskEncryptionConfig{
+				StatePartition: &v1alpha1.EncryptionConfig{
+					EncryptionKeys: []*v1alpha1.EncryptionKey{
+						{KeyStatic: &v1alpha1.EncryptionKeyStatic{KeyData: "state-passphrase"}},
+						{KeyNodeID: &v1alpha1.EncryptionKeyNodeID{}},
+						nil,
+					},
+				},
+				EphemeralPartition: &v1alpha1.EncryptionConfig{
+					EncryptionKeys: []*v1alpha1.EncryptionKey{
+						{KeyStatic: &v1alpha1.EncryptionKeyStatic{KeyData: "ephemeral-passphrase"}},
+					},
+				},
+			},
+		},
+	}
+
+	const replacement = "**.***"
+
+	cfg.Redact(replacement)
+
+	registry := cfg.MachineConfig.MachineRegistries.RegistryConfig["my-registry.local:5000"]
+	require.Equal(t, "alice", registry.RegistryAuth.RegistryUsername, "username is not a secret and must not be redacted")
+	require.Equal(t, replacement, registry.RegistryAuth.RegistryPassword)
+	require.Equal(t, replacement, registry.RegistryAuth.RegistryAuth)
+	require.Equal(t, replacement, registry.RegistryAuth.RegistryIdentityToken)
+	require.Equal(t, "cert", string(registry.RegistryTLS.TLSClientIdentity.Crt), "client cert is public and must not be redacted")
+	require.Equal(t, replacement, string(registry.RegistryTLS.TLSClientIdentity.Key))
+	require.Equal(t, "ca-bundle", string(registry.RegistryTLS.TLSCA), "CA bundle is public and must not be redacted")
+
+	device := cfg.MachineConfig.MachineNetwork.NetworkInterfaces[0]
+	require.Equal(t, replacement, device.DeviceWireguardConfig.WireguardPrivateKey)
+	require.Equal(t, replacement, device.DeviceVIPConfig.EquinixMetalConfig.EquinixMetalAPIToken)
+	require.Equal(t, replacement, device.DeviceVIPConfig.HCloudConfig.HCloudAPIToken)
+
+	vlan := device.DeviceVlans[0]
+	require.Equal(t, replacement, vlan.VlanVIP.EquinixMetalConfig.EquinixMetalAPIToken)
+	require.Equal(t, replacement, vlan.VlanVIP.HCloudConfig.HCloudAPIToken)
+
+	require.Equal(t, replacement, cfg.MachineConfig.MachineSystemDiskEncryption.StatePartition.EncryptionKeys[0].KeyStatic.KeyData)
+	require.Equal(t, replacement, cfg.MachineConfig.MachineSystemDiskEncryption.EphemeralPartition.EncryptionKeys[0].KeyStatic.KeyData)
 }


### PR DESCRIPTION
The legacy machine config now redacts registry credentials, mutual TLS client keys, WireGuard private keys, the Equinix Metal and Hetzner Cloud VIP API tokens, and disk encryption static passphrases.

The same fields are redacted in the multi-doc successors. SideroLink now also clears the unique connection token, not only the join token in the API URL.

A new test walks every registered document kind, picks out string and byte fields whose yaml tag name looks like a secret, and checks that the document's Redact replaces them. New kinds that miss one will fail the test.
