### PR TITLE
fix: image verification issue with registry.k8s.io

### DIFF
--- a/internal/app/images/verify.go
+++ b/internal/app/images/verify.go
@@ -45,6 +45,7 @@ func (svc *Service) Verify(ctx context.Context, req *machine.ImageServiceVerifyR
 	}
 
 	resolver := image.NewResolver(registries)
+	tagFetcher := image.NewTagFetcher(registries)
 
-	return verify.ImageSignature(ctx, svc.logger, svc.controller.Runtime().State().V1Alpha2().Resources(), resolver, req.GetImageRef())
+	return verify.ImageSignature(ctx, svc.logger, svc.controller.Runtime().State().V1Alpha2().Resources(), resolver, tagFetcher, req.GetImageRef())
 }

--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -170,8 +170,9 @@ func Pull(
 		}
 
 		resolver := NewResolver(registriesConfig)
+		tagFetcher := NewTagFetcher(registriesConfig)
 
-		verifyResult, err := verify.ImageSignature(ctx, zap.NewNop(), resources, resolver, ref)
+		verifyResult, err := verify.ImageSignature(ctx, zap.NewNop(), resources, resolver, tagFetcher, ref)
 		if err != nil {
 			switch status.Code(err) { //nolint:exhaustive
 			case codes.PermissionDenied:

--- a/internal/pkg/containers/image/tagfetch.go
+++ b/internal/pkg/containers/image/tagfetch.go
@@ -1,0 +1,265 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/errdefs"
+	"github.com/google/go-containerregistry/pkg/name"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/verify"
+	"github.com/siderolabs/talos/pkg/machinery/resources/cri"
+)
+
+// maxTagManifestSize bounds the response body read by the tag-based manifest fallback.
+const maxTagManifestSize = 4 * 1024 * 1024
+
+// tagFetchAccept is the Accept header sent on tag-based manifest requests, matching
+// the resolver's resolveHeader so the registry returns the same media types.
+var tagFetchAccept = strings.Join([]string{
+	ocispec.MediaTypeImageManifest,
+	ocispec.MediaTypeImageIndex,
+	"application/vnd.docker.distribution.manifest.v2+json",
+	"application/vnd.docker.distribution.manifest.list.v2+json",
+	"*/*",
+}, ", ")
+
+// NewTagFetcher builds a verify.TagFetcher that fetches a manifest by its tag URL
+// through the same RegistryHosts (auth + TLS + mirror list) used by the resolver.
+//
+// It is the fallback used by signature verification when the resolver's
+// digest-based manifest fetch returns NotFound, e.g. against registry.k8s.io's
+// CDN where the HEAD-by-tag and GET-by-digest requests can be routed to
+// different regional backends with inconsistent replication.
+func NewTagFetcher(reg cri.Registries) verify.TagFetcher {
+	hosts := RegistryHosts(reg)
+
+	return func(ctx context.Context, repo name.Repository, tag string, expectedDigest digest.Digest) ([]byte, error) {
+		registryHosts, err := hosts(repo.RegistryStr())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get registry hosts for %q: %w", repo.RegistryStr(), err)
+		}
+
+		if len(registryHosts) == 0 {
+			return nil, fmt.Errorf("no registry hosts for %q: %w", repo.RegistryStr(), errdefs.ErrNotFound)
+		}
+
+		var firstErr error
+
+		for _, h := range registryHosts {
+			body, err := fetchManifestByTagFromHost(ctx, h, repo, tag, expectedDigest)
+			if err == nil {
+				return body, nil
+			}
+
+			// Prefer a non-NotFound error over a NotFound one, so the caller surfaces the
+			// most actionable diagnostic (auth/TLS/network) rather than the generic 404.
+			if firstErr == nil || (errdefs.IsNotFound(firstErr) && !errdefs.IsNotFound(err)) {
+				firstErr = err
+			}
+		}
+
+		return nil, firstErr
+	}
+}
+
+// fetchManifestByTagFromHost issues a GET against host's tag URL for the
+// manifest, performs the same 401/Authorize handshake the docker resolver does,
+// and validates the returned content against expectedDigest.
+func fetchManifestByTagFromHost(
+	ctx context.Context, host docker.RegistryHost, repo name.Repository, tag string, expectedDigest digest.Digest,
+) ([]byte, error) {
+	reqURL := buildTagManifestURL(host, repo, tag)
+
+	const maxAuthRetries = 5
+
+	// Authorizer.AddResponses inspects the trailing responses to detect repeated
+	// challenges from the same request (see containerd's invalidAuthorization),
+	// so we accumulate the slice across retries rather than passing only the
+	// latest response.
+	var responses []*http.Response
+
+	for range maxAuthRetries {
+		//nolint:bodyclose // body is read and closed inside doTagManifestRequest; the returned *http.Response is a body-less snapshot for Authorizer.AddResponses
+		body, status, header, snap, err := doTagManifestRequest(ctx, host, reqURL)
+		if err != nil {
+			return nil, err
+		}
+
+		if status == http.StatusUnauthorized && host.Authorizer != nil {
+			responses = append(responses, snap) //nolint:bodyclose // snap has no body
+
+			retry, authErr := tryRefreshAuthorization(ctx, host.Authorizer, responses)
+			if authErr != nil {
+				return nil, authErr
+			}
+
+			if retry {
+				continue
+			}
+
+			return nil, fmt.Errorf("unauthorized fetching %s", reqURL)
+		}
+
+		if err := checkTagManifestStatus(status, reqURL); err != nil {
+			return nil, err
+		}
+
+		if err := verifyTagManifestDigest(body, header.Get("Docker-Content-Digest"), expectedDigest); err != nil {
+			return nil, err
+		}
+
+		return body, nil
+	}
+
+	return nil, errors.New("too many authorization retries")
+}
+
+// doTagManifestRequest sends a single GET to the manifest tag URL. It returns the
+// decoded body bytes plus only the response fields the caller needs (status,
+// headers, and a body-less snapshot suitable for [docker.Authorizer.AddResponses]).
+// The response body is fully read and closed before returning, so the caller has
+// no body lifecycle to manage.
+func doTagManifestRequest(
+	ctx context.Context, host docker.RegistryHost, reqURL string,
+) ([]byte, int, http.Header, *http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, 0, nil, nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	req.Header.Set("Accept", tagFetchAccept)
+
+	if host.Authorizer != nil {
+		if err := host.Authorizer.Authorize(ctx, req); err != nil {
+			return nil, 0, nil, nil, fmt.Errorf("failed to authorize: %w", err)
+		}
+	}
+
+	client := host.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, nil, nil, fmt.Errorf("failed to GET %s: %w", reqURL, err)
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxTagManifestSize))
+
+	if closeErr := resp.Body.Close(); closeErr != nil && readErr == nil {
+		readErr = closeErr
+	}
+
+	if readErr != nil {
+		return nil, 0, nil, nil, fmt.Errorf("failed to read manifest body: %w", readErr)
+	}
+
+	// Authorizer.AddResponses only inspects status/headers, not the body, so a snapshot
+	// without the body is sufficient and avoids keeping the connection open.
+	snap := &http.Response{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
+		Request:    resp.Request,
+	}
+
+	return body, resp.StatusCode, resp.Header, snap, nil
+}
+
+// tryRefreshAuthorization invokes the authorizer's response handler so it can
+// extract bearer challenges. Returns true when the caller should retry.
+func tryRefreshAuthorization(ctx context.Context, authorizer docker.Authorizer, responses []*http.Response) (bool, error) {
+	addErr := authorizer.AddResponses(ctx, responses)
+	if addErr == nil {
+		return true, nil
+	}
+
+	if errdefs.IsNotImplemented(addErr) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("failed to refresh authorization: %w", addErr)
+}
+
+func checkTagManifestStatus(status int, reqURL string) error {
+	if status == http.StatusNotFound {
+		return fmt.Errorf("manifest at %s: %w", reqURL, errdefs.ErrNotFound)
+	}
+
+	if status >= 300 {
+		return fmt.Errorf("unexpected status %d fetching %s", status, reqURL)
+	}
+
+	return nil
+}
+
+// buildTagManifestURL mirrors how containerd's dockerBase builds a manifests URL:
+// <scheme>://<host>/<host.Path>/<repo>/manifests/<tag>, with the proxy-namespace
+// query argument added when the configured host is not the image's registry.
+func buildTagManifestURL(host docker.RegistryHost, repo name.Repository, tag string) string {
+	p := path.Join("/", host.Path, repo.RepositoryStr(), "manifests", tag)
+
+	u := url.URL{
+		Scheme: host.Scheme,
+		Host:   host.Host,
+		Path:   p,
+	}
+
+	// Proxy hosts (mirror endpoints whose Host differs from the image's registry) expect
+	// the upstream namespace as ?ns=<registry> so they know what to proxy.
+	// docker.DefaultHost handles aliases such as docker.io → registry-1.docker.io,
+	// so we don't have to duplicate that mapping here.
+	refHost := repo.RegistryStr()
+
+	canonicalRefHost, err := docker.DefaultHost(refHost)
+	if err != nil {
+		canonicalRefHost = refHost
+	}
+
+	if canonicalRefHost != host.Host {
+		q := u.Query()
+		q.Set("ns", refHost)
+		u.RawQuery = q.Encode()
+	}
+
+	return u.String()
+}
+
+func verifyTagManifestDigest(body []byte, serverDigestHeader string, expectedDigest digest.Digest) error {
+	// Compute the body digest using the same algorithm the expected digest uses,
+	// rather than hard-coding sha256 via digest.FromBytes: OCI permits other
+	// algorithms (e.g. sha512) and the comparison must track whatever the
+	// resolver advertised.
+	algo := expectedDigest.Algorithm()
+	if !algo.Available() {
+		return fmt.Errorf("tag fetch digest algorithm %q is not available", algo)
+	}
+
+	actualDigest := algo.FromBytes(body)
+	if actualDigest != expectedDigest {
+		return fmt.Errorf("tag fetch digest mismatch: got %s, expected %s", actualDigest, expectedDigest)
+	}
+
+	if serverDigestHeader != "" {
+		serverDigest := digest.Digest(serverDigestHeader)
+		if serverDigest != expectedDigest {
+			return fmt.Errorf("tag fetch server digest mismatch: header %s, expected %s", serverDigest, expectedDigest)
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/containers/image/tagfetch_test.go
+++ b/internal/pkg/containers/image/tagfetch_test.go
@@ -1,0 +1,208 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image"
+	"github.com/siderolabs/talos/pkg/machinery/resources/cri"
+)
+
+// TestTagFetcher covers the by-tag manifest fallback against an httptest server,
+// so the regression for siderolabs/talos#13342 is exercised without depending on
+// live CDN behavior.
+func TestTagFetcher(t *testing.T) {
+	t.Parallel()
+
+	const (
+		repoStr = "library/etcd"
+		tag     = "v3.6.11"
+	)
+
+	// NewTagFetcher only returns the body bytes and validates against expectedDigest,
+	// so the body just has to be a deterministic byte sequence — the JSON shape is for
+	// readability.
+	manifestBody := []byte(`{"schemaVersion":2,"layers":[]}`)
+	expectedDigest := digest.FromBytes(manifestBody)
+
+	tagPath := "/v2/" + repoStr + "/manifests/" + tag
+	digestPath := "/v2/" + repoStr + "/manifests/" + expectedDigest.String()
+
+	for _, tt := range []struct {
+		name string
+
+		handler http.HandlerFunc
+
+		expectedBody   []byte
+		expectedErrIs  error
+		expectedErrSub string
+	}{
+		{
+			name: "by-digest 404, by-tag 200 returns body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case digestPath:
+					w.WriteHeader(http.StatusNotFound)
+				case tagPath:
+					w.Header().Set("Docker-Content-Digest", expectedDigest.String())
+					w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+					w.Write(manifestBody) //nolint:errcheck
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			expectedBody: manifestBody,
+		},
+		{
+			name: "by-tag 200 without Docker-Content-Digest header still verifies body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tagPath {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+				w.Write(manifestBody) //nolint:errcheck
+			},
+			expectedBody: manifestBody,
+		},
+		{
+			name: "by-tag 404 surfaces NotFound",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			expectedErrIs: errdefs.ErrNotFound,
+		},
+		{
+			name: "by-tag body digest mismatch is reported",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tagPath {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+
+				w.Write([]byte("not-the-real-manifest")) //nolint:errcheck
+			},
+			expectedErrSub: "tag fetch digest mismatch",
+		},
+		{
+			name: "by-tag mismatched Docker-Content-Digest header is reported",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tagPath {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+
+				w.Header().Set("Docker-Content-Digest", "sha256:dead")
+				w.Write(manifestBody) //nolint:errcheck
+			},
+			expectedErrSub: "tag fetch server digest mismatch",
+		},
+		{
+			name: "by-tag 5xx surfaces a non-NotFound error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectedErrSub: "unexpected status 500",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(tt.handler)
+			t.Cleanup(srv.Close)
+
+			// Route requests for the synthetic registry through the test server using
+			// a mirror, the same way a user would set up an in-cluster mirror.
+			cfg := &mockConfig{
+				mirrors: map[string]*cri.RegistryMirrorConfig{
+					"example.com": {
+						MirrorEndpoints:    []cri.RegistryEndpointConfig{{EndpointEndpoint: srv.URL}},
+						MirrorSkipFallback: true,
+					},
+				},
+			}
+
+			fetcher := image.NewTagFetcher(cfg)
+
+			repo, err := name.NewRepository("example.com/" + repoStr)
+			require.NoError(t, err)
+
+			body, err := fetcher(t.Context(), repo, tag, expectedDigest)
+
+			if tt.expectedErrIs != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectedErrIs), "expected error to wrap %v, got %v", tt.expectedErrIs, err)
+
+				return
+			}
+
+			if tt.expectedErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrSub)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedBody, body)
+		})
+	}
+}
+
+// TestTagFetcherMaxBodySize verifies that the fetcher rejects oversize bodies
+// (digest of the truncated read won't match the expected digest).
+func TestTagFetcherMaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	const (
+		repoStr = "library/etcd"
+		tag     = "v3.6.11"
+	)
+
+	// A body larger than maxTagManifestSize (4 MiB) gets truncated by the fetcher,
+	// so its digest will not match what the server claims via Docker-Content-Digest.
+	oversize := strings.Repeat("a", 5*1024*1024)
+	advertisedDigest := digest.FromBytes([]byte(oversize))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Docker-Content-Digest", advertisedDigest.String())
+		io.WriteString(w, oversize) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &mockConfig{
+		mirrors: map[string]*cri.RegistryMirrorConfig{
+			"example.com": {
+				MirrorEndpoints:    []cri.RegistryEndpointConfig{{EndpointEndpoint: srv.URL}},
+				MirrorSkipFallback: true,
+			},
+		},
+	}
+
+	fetcher := image.NewTagFetcher(cfg)
+
+	repo, err := name.NewRepository("example.com/" + repoStr)
+	require.NoError(t, err)
+
+	_, err = fetcher(t.Context(), repo, tag, advertisedDigest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag fetch digest mismatch")
+}

--- a/internal/pkg/containers/image/verify/internal/cosign/cosign.go
+++ b/internal/pkg/containers/image/verify/internal/cosign/cosign.go
@@ -44,6 +44,16 @@ type VerifyResult struct {
 	Message string
 }
 
+// TagFetcher fetches a manifest by its tag URL through the registry hosts that
+// back the resolver, validating the response body against expectedDigest before
+// returning it.
+//
+// It is used as a fallback when the resolver's by-digest manifest fetch returns
+// NotFound, working around CDNs (notably registry.k8s.io) where the HEAD-by-tag
+// and GET-by-digest requests can land on different regional backends with
+// inconsistent replication. When nil, the fallback is skipped.
+type TagFetcher func(ctx context.Context, repository name.Repository, tag string, expectedDigest digest.Digest) ([]byte, error)
+
 // VerifyImage verifies the given image reference and digest against the provided verification configuration.
 //
 // It checks in priority order:
@@ -52,9 +62,13 @@ type VerifyResult struct {
 //  3. The legacy .sig tag (sha256-xxx.sig) for legacy cosign signature layers.
 //
 // All registry I/O goes through the provided resolver, which handles authentication and mirror routing.
+// tagFetcher is an optional fallback invoked when the resolver's digest-based manifest fetch returns
+// NotFound (see TagFetcher).
 //
 // The verifiers are in opts, if any of the verifiers returns true for bundle verification, the image is considered verified.
-func VerifyImage(ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, imageRef name.Digest, co cosign.CheckOpts) (*VerifyResult, error) {
+func VerifyImage(
+	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher, imageRef name.Digest, co cosign.CheckOpts,
+) (*VerifyResult, error) {
 	logger = logger.With(zap.Stringer("image", imageRef))
 
 	imageDigest, err := v1.NewHash(imageRef.DigestStr())
@@ -91,7 +105,7 @@ func VerifyImage(ctx context.Context, logger *zap.Logger, resolver remotes.Resol
 	// Step 2: try bundle tag (sha256-xxx) for new-style sigstore bundles stored as a tag.
 	logger.Debug("no bundle referrers found, trying bundle tag")
 
-	verified, result, bundleErr := verifyFromBundleTag(ctx, logger, resolver, imageRef, artifactPolicyOption, co)
+	verified, result, bundleErr := verifyFromBundleTag(ctx, logger, resolver, tagFetcher, imageRef, artifactPolicyOption, co)
 
 	if verified {
 		return result, bundleErr
@@ -100,7 +114,7 @@ func VerifyImage(ctx context.Context, logger *zap.Logger, resolver remotes.Resol
 	// Step 3: fall back to the legacy .sig tag (sha256-xxx.sig).
 	logger.Debug("no bundle tag found, falling back to legacy .sig tag")
 
-	result, legacyErr := verifyFromLegacySigTag(ctx, logger, resolver, imageRef, imageDigest, co)
+	result, legacyErr := verifyFromLegacySigTag(ctx, logger, resolver, tagFetcher, imageRef, imageDigest, co)
 	if legacyErr != nil {
 		return nil, fmt.Errorf("no valid signature found: %w", errors.Join(bundleErr, legacyErr))
 	}
@@ -169,7 +183,8 @@ func verifyBundleReferrers(
 //
 //nolint:gocyclo
 func verifyFromBundleTag(
-	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, imageRef name.Digest, artifactPolicyOption verify.ArtifactPolicyOption, co cosign.CheckOpts,
+	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher,
+	imageRef name.Digest, artifactPolicyOption verify.ArtifactPolicyOption, co cosign.CheckOpts,
 ) (bool, *VerifyResult, error) {
 	bundleTag := strings.ReplaceAll(imageRef.DigestStr(), ":", "-")
 
@@ -197,7 +212,7 @@ func verifyFromBundleTag(
 
 	switch desc.MediaType {
 	case ocispec.MediaTypeImageManifest:
-		manifest, err := fetchManifest(ctx, fetcher, desc)
+		manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, bundleTag)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to fetch bundle manifest: %w", err)
 		}
@@ -210,7 +225,7 @@ func verifyFromBundleTag(
 	case ocispec.MediaTypeImageIndex:
 		// The bundle tag may be an OCI image index wrapping individual bundle manifests.
 		// Walk each manifest entry and collect bundle layers from all of them.
-		index, err := fetchIndex(ctx, fetcher, desc)
+		index, err := fetchIndexWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, bundleTag)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to fetch bundle index: %w", err)
 		}
@@ -220,6 +235,8 @@ func verifyFromBundleTag(
 				continue
 			}
 
+			// Sub-manifests inside an index are addressed only by digest (no tag for fallback),
+			// so the by-digest fetcher remains the only option here.
 			manifest, err := fetchManifest(ctx, fetcher, manifestDesc)
 			if err != nil {
 				logger.Debug("failed to fetch manifest from bundle index", zap.String("digest", manifestDesc.Digest.String()), zap.Error(err))
@@ -252,7 +269,10 @@ func verifyFromBundleTag(
 
 // verifyFromLegacySigTag fetches the legacy .sig tag (sha256-xxx.sig) and verifies via legacy
 // cosign signature layers.
-func verifyFromLegacySigTag(ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, imageRef name.Digest, imageDigest v1.Hash, co cosign.CheckOpts) (*VerifyResult, error) {
+func verifyFromLegacySigTag(
+	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher,
+	imageRef name.Digest, imageDigest v1.Hash, co cosign.CheckOpts,
+) (*VerifyResult, error) {
 	signatureTag := strings.ReplaceAll(imageRef.DigestStr(), ":", "-") + ".sig"
 
 	logger.Debug("resolving .sig tag", zap.String("signatureTag", signatureTag))
@@ -277,7 +297,7 @@ func verifyFromLegacySigTag(ctx context.Context, logger *zap.Logger, resolver re
 		return nil, fmt.Errorf("failed to get fetcher for .sig manifest: %w", err)
 	}
 
-	manifest, err := fetchManifest(ctx, fetcher, desc)
+	manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, signatureTag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch .sig manifest: %w", err)
 	}
@@ -395,6 +415,74 @@ func fetchIndex(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descr
 	var index ocispec.Index
 	if err := json.NewDecoder(io.LimitReader(rc, maxManifestSize)).Decode(&index); err != nil {
 		return ocispec.Index{}, fmt.Errorf("failed to decode index: %w", err)
+	}
+
+	return index, nil
+}
+
+// fetchManifestWithTagFallback fetches a manifest by digest via the resolver, and on
+// NotFound falls back to fetching it by tag through tagFetcher.
+//
+// See siderolabs/talos#13342: registry.k8s.io's CDN can route HEAD-by-tag and
+// GET-by-digest to different regional backends; the by-tag path can succeed while
+// the by-digest path returns 404. The tagFetcher uses the same registry hosts as
+// the resolver (auth + TLS + mirrors), so it does not bypass user configuration.
+//
+//nolint:dupl // not a duplicate of fetchIndexWithTagFallback - decodes a different type
+func fetchManifestWithTagFallback(
+	ctx context.Context, logger *zap.Logger, fetcher remotes.Fetcher, tagFetcher TagFetcher,
+	desc ocispec.Descriptor, repo name.Repository, tag string,
+) (ocispec.Manifest, error) {
+	manifest, err := fetchManifest(ctx, fetcher, desc)
+	if err == nil {
+		return manifest, nil
+	}
+
+	if tagFetcher == nil || !errdefs.IsNotFound(err) {
+		return ocispec.Manifest{}, err
+	}
+
+	logger.Debug("digest-based manifest fetch returned NotFound; falling back to tag-based fetch",
+		zap.String("tag", tag), zap.Stringer("digest", desc.Digest), zap.Error(err))
+
+	body, fbErr := tagFetcher(ctx, repo, tag, desc.Digest)
+	if fbErr != nil {
+		return ocispec.Manifest{}, fmt.Errorf("digest fetch: %w; tag fallback: %w", err, fbErr)
+	}
+
+	if jsonErr := json.Unmarshal(body, &manifest); jsonErr != nil {
+		return ocispec.Manifest{}, fmt.Errorf("failed to decode manifest from tag fallback: %w", jsonErr)
+	}
+
+	return manifest, nil
+}
+
+// fetchIndexWithTagFallback is the OCI image index counterpart to fetchManifestWithTagFallback.
+//
+//nolint:dupl // not a duplicate of fetchManifestWithTagFallback - decodes a different type
+func fetchIndexWithTagFallback(
+	ctx context.Context, logger *zap.Logger, fetcher remotes.Fetcher, tagFetcher TagFetcher,
+	desc ocispec.Descriptor, repo name.Repository, tag string,
+) (ocispec.Index, error) {
+	index, err := fetchIndex(ctx, fetcher, desc)
+	if err == nil {
+		return index, nil
+	}
+
+	if tagFetcher == nil || !errdefs.IsNotFound(err) {
+		return ocispec.Index{}, err
+	}
+
+	logger.Debug("digest-based index fetch returned NotFound; falling back to tag-based fetch",
+		zap.String("tag", tag), zap.Stringer("digest", desc.Digest), zap.Error(err))
+
+	body, fbErr := tagFetcher(ctx, repo, tag, desc.Digest)
+	if fbErr != nil {
+		return ocispec.Index{}, fmt.Errorf("digest fetch: %w; tag fallback: %w", err, fbErr)
+	}
+
+	if jsonErr := json.Unmarshal(body, &index); jsonErr != nil {
+		return ocispec.Index{}, fmt.Errorf("failed to decode index from tag fallback: %w", jsonErr)
 	}
 
 	return index, nil

--- a/internal/pkg/containers/image/verify/internal/cosign/cosign_test.go
+++ b/internal/pkg/containers/image/verify/internal/cosign/cosign_test.go
@@ -37,6 +37,7 @@ func TestVerifyImage(t *testing.T) {
 	t.Parallel()
 
 	resolver := image.NewResolver(mockRegistriesConfig{})
+	tagFetcher := image.NewTagFetcher(mockRegistriesConfig{})
 	trustedRoot, err := cosign.TrustedRoot()
 	require.NoError(t, err)
 
@@ -50,6 +51,25 @@ func TestVerifyImage(t *testing.T) {
 	}{
 		{
 			imageRef: "registry.k8s.io/etcd:v3.6.8@sha256:397189418d1a00e500c0605ad18d1baf3b541a1004d768448c367e48071622e5",
+			checkOpts: cosign.CheckOpts{
+				TrustedMaterial: trustedRoot,
+				Identities: []cosign.Identity{
+					{
+						Issuer:  "https://accounts.google.com",
+						Subject: "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+					},
+				},
+			},
+
+			expectedResultMessage: "verified via legacy signature (bundle verified true)",
+		},
+		{
+			// Regression for siderolabs/talos#13342: registry.k8s.io's CDN serves the .sig
+			// manifest by tag (e.g. us-central1) but can return 404 for the same manifest
+			// fetched by digest from another region (e.g. europe-west4). The TagFetcher
+			// fallback fetches by tag through the same RegistryHosts (auth/TLS/mirror)
+			// the resolver uses.
+			imageRef: "registry.k8s.io/etcd:v3.6.11@sha256:fbab3d2954652f592b2653cc1b9decdbe2a633de9320735e9f364b185b6b309a",
 			checkOpts: cosign.CheckOpts{
 				TrustedMaterial: trustedRoot,
 				Identities: []cosign.Identity{
@@ -128,7 +148,7 @@ func TestVerifyImage(t *testing.T) {
 			imageRef, err := name.NewDigest(test.imageRef)
 			require.NoError(t, err)
 
-			result, err := ourcosign.VerifyImage(t.Context(), logger, resolver, imageRef, test.checkOpts)
+			result, err := ourcosign.VerifyImage(t.Context(), logger, resolver, tagFetcher, imageRef, test.checkOpts)
 
 			if test.expectedError != "" {
 				require.Error(t, err)

--- a/internal/pkg/containers/image/verify/verify.go
+++ b/internal/pkg/containers/image/verify/verify.go
@@ -28,11 +28,18 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/security"
 )
 
+// TagFetcher is the fallback used when a resolver's digest-based manifest fetch
+// returns NotFound; see [ourcosign.TagFetcher].
+type TagFetcher = ourcosign.TagFetcher
+
 // ImageSignature verifies image signature within Talos source code.
+//
+// tagFetcher (optional) is invoked when the resolver's digest-based manifest
+// fetch returns NotFound — see [TagFetcher].
 //
 //nolint:gocyclo
 func ImageSignature(
-	ctx context.Context, logger *zap.Logger, resources state.State, resolver remotes.Resolver, imageRef string,
+	ctx context.Context, logger *zap.Logger, resources state.State, resolver remotes.Resolver, tagFetcher TagFetcher, imageRef string,
 ) (*machine.ImageServiceVerifyResponse, error) {
 	logger = logger.With(zap.String("image_ref", imageRef))
 
@@ -103,7 +110,7 @@ func ImageSignature(
 		return nil, status.Errorf(codes.Internal, "failed to convert verification rule to cosign check options: %s", err)
 	}
 
-	result, err := ourcosign.VerifyImage(ctx, logger, resolver, digestRef, checkOpts)
+	result, err := ourcosign.VerifyImage(ctx, logger, resolver, tagFetcher, digestRef, checkOpts)
 	if err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, "image verification failed: %s", err)
 	}


### PR DESCRIPTION
This is a workaround for registry.k8s.io issue which seems to have problems with replicating data across regions.

Fixes #13342
