### PR TITLE
chore: fix typos in comments

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -38,7 +38,7 @@ type Controller struct {
 	priorityLock *PriorityLock[runtime.Sequence]
 }
 
-// NewController intializes and returns a controller.
+// NewController initializes and returns a controller.
 func NewController() (*Controller, error) {
 	s, err := NewState()
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -21,7 +21,7 @@ import (
 // Sequencer implements the sequencer interface.
 type Sequencer struct{}
 
-// NewSequencer intializes and returns a sequencer.
+// NewSequencer initializes and returns a sequencer.
 func NewSequencer() *Sequencer {
 	return &Sequencer{}
 }

--- a/internal/integration/cli/completion.go
+++ b/internal/integration/cli/completion.go
@@ -20,7 +20,7 @@ func (suite *CompletionSuite) SuiteName() string {
 	return "cli.CompletionSuite"
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *CompletionSuite) TestSuccess() {
 	suite.RunCLI([]string{"completion", "bash"})
 	suite.RunCLI([]string{"completion", "fish"})

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -24,7 +24,7 @@ func (suite *CopySuite) SuiteName() string {
 	return "cli.CopySuite"
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *CopySuite) TestSuccess() {
 	tempDir := suite.T().TempDir()
 

--- a/internal/integration/cli/debug.go
+++ b/internal/integration/cli/debug.go
@@ -25,7 +25,7 @@ func (suite *DebugSuite) SuiteName() string {
 	return "cli.DebugSuite"
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *DebugSuite) TestSuccess() {
 	suite.RunCLI(
 		[]string{"debug", debugImage, "--nodes", suite.RandomDiscoveredNodeInternalIP()},

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -69,7 +69,7 @@ func parseLine(line string) (*duInfo, error) {
 	return res, nil
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *DiskUsageSuite) TestSuccess() {
 	folder := "/etc"
 	node := suite.RandomDiscoveredNodeInternalIP()
@@ -130,7 +130,7 @@ func (suite *DiskUsageSuite) TestSuccess() {
 		}))
 }
 
-// TestError runs comand with error.
+// TestError runs command with error.
 func (suite *DiskUsageSuite) TestError() {
 	suite.RunCLI(
 		[]string{

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -30,7 +30,7 @@ func (suite *ListSuite) SuiteName() string {
 	return "cli.ListSuite"
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *ListSuite) TestSuccess() {
 	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/etc"},
 		base.StdoutShouldMatch(regexp.MustCompile(`os-release`)))

--- a/internal/integration/cli/patch.go
+++ b/internal/integration/cli/patch.go
@@ -52,7 +52,7 @@ func (suite *PatchSuite) TestSuccess() {
 	)
 }
 
-// TestError runs comand with error.
+// TestError runs command with error.
 func (suite *PatchSuite) TestError() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 

--- a/internal/integration/cli/read.go
+++ b/internal/integration/cli/read.go
@@ -22,7 +22,7 @@ func (suite *ReadSuite) SuiteName() string {
 	return "cli.ReadSuite"
 }
 
-// TestSuccess runs comand with success.
+// TestSuccess runs command with success.
 func (suite *ReadSuite) TestSuccess() {
 	suite.RunCLI([]string{"read", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "/etc/os-release"},
 		base.StdoutShouldMatch(regexp.MustCompile(`ID=talos`)))


### PR DESCRIPTION
# Pull Request

## What? (description)
Fix typos in doc comments:
- `intializes` → `initializes` in `v1alpha1_controller.go` and `v1alpha1_sequencer.go`
- `runs comand` → `runs command` in 7 files under `internal/integration/cli/`

## Why? (reasoning)
Minor spelling corrections in comments. No functional changes.

## Acceptance

- [x] you linked an issue (if applicable) — N/A, trivial fix
- [x] you included tests (if applicable) — N/A, comment-only change
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`) — N/A, no API/config chang