### PR TITLE
chore: stop publishing installer to ghcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -685,15 +685,14 @@ conformance:
 release-notes:
 	ARTIFACTS=$(ARTIFACTS) ./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
 
-push: ## Pushes the installer, imager, talos and talosctl images to the configured container registry with the generated tag.
+push: ## Pushes the installer-base, imager, talos and talosctl images to the configured container registry with the generated tag.
 	@$(MAKE) installer-base PUSH=true
 	@$(MAKE) imager PUSH=true
-	@$(MAKE) installer PUSH=true
 	@$(MAKE) talos PUSH=true
 	@$(MAKE) talosctl-image PUSH=true
 	@$(MAKE) talosctl-all-image PUSH=true
 
-push-%: ## Pushes the installer, imager, talos and talosctl images to the configured container registry with the specified tag (e.g. push-latest).
+push-%: ## Pushes the installer-base, imager, talos and talosctl images to the configured container registry with the specified tag (e.g. push-latest).
 	@$(MAKE) push IMAGE_TAG_OUT=$*
 
 .PHONY: clean
@@ -702,7 +701,7 @@ clean: ## Cleans up all artifacts.
 
 .PHONY: image-list
 image-list: ## Prints a list of all images built by this Makefile with digests.
-	@echo -n installer$(IMAGE_NAME_SUFFIX) installer-base$(IMAGE_NAME_SUFFIX) talos$(IMAGE_NAME_SUFFIX) imager$(IMAGE_NAME_SUFFIX) talosctl$(IMAGE_NAME_SUFFIX) talosctl-all$(IMAGE_NAME_SUFFIX) | xargs -d ' ' -I{} sh -c 'echo $(REGISTRY_AND_USERNAME)/{}:$(IMAGE_TAG_IN)' | xargs -I{} sh -c 'echo {}@$$(crane digest {})'
+	@echo -n installer-base$(IMAGE_NAME_SUFFIX) talos$(IMAGE_NAME_SUFFIX) imager$(IMAGE_NAME_SUFFIX) talosctl$(IMAGE_NAME_SUFFIX) talosctl-all$(IMAGE_NAME_SUFFIX) | xargs -d ' ' -I{} sh -c 'echo $(REGISTRY_AND_USERNAME)/{}:$(IMAGE_TAG_IN)' | xargs -I{} sh -c 'echo {}@$$(crane digest {})'
 
 $(ARTIFACTS)/image-signer: $(ARTIFACTS) ## Downloads image-signer binary
 	@curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(ARCH) -o $(ARTIFACTS)/image-signer

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -46,6 +46,7 @@ Custom settings for cipher suites have been removed, as they are ignored when TL
         title = "Default Installer Image"
         description = """\
 The default installer image has been updated to use the Image Factory.
+The `ghcr.io/siderolabs/installer` image is no longer published with releases; use the Image Factory installer image instead.
 """
 
     [notes.hostdnsconfig]

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_examples.go
@@ -89,7 +89,7 @@ func kubeletImageExample() string {
 func machineInstallExample() *InstallConfig {
 	return &InstallConfig{
 		InstallDisk:              "/dev/sda",
-		InstallImage:             "ghcr.io/siderolabs/installer:latest",
+		InstallImage:             "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest",
 		InstallWipe:              new(false),
 		InstallGrubUseUKICmdline: new(true),
 	}

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -42,7 +42,7 @@ machine:
     # InstallConfig represents the installation options for preparing a node.
     install:
         disk: /dev/sda # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
+        image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 
@@ -145,7 +145,7 @@ pods:
 |`install` |<a href="#Config.machine.install">InstallConfig</a> |Used to provide instructions for installations.<br><br>Note that this configuration section gets silently ignored by Talos images that are considered pre-installed.<br>To make sure Talos installs according to the provided configuration, Talos should be booted with ISO or PXE-booted. <details><summary>Show example(s)</summary>MachineInstall config usage example.:{{< highlight yaml >}}
 install:
     disk: /dev/sda # The disk used for installations.
-    image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
+    image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest # Allows for supplying the image used to perform the installation.
     wipe: false # Indicates if the installation disk should be wiped at installation time.
     grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 
@@ -539,7 +539,7 @@ InstallConfig represents the installation options for preparing a node.
 machine:
     install:
         disk: /dev/sda # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:latest # Allows for supplying the image used to perform the installation.
+        image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         grubUseUKICmdline: true # Indicates if legacy GRUB bootloader should use kernel cmdline from the UKI instead of building it on the host.
 


### PR DESCRIPTION
Installer defaults to factory.talos.dev via #13202. Remove from
release push pipeline and signing list. CI still builds installer
for tests against dev registry.

Closes #13138

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
