### PR TITLE
fix: rework how scheduler config is marshaled

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-kubernetes/kubernetes/compatibility"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
@@ -277,17 +278,32 @@ func auditPolicyConfig(spec *k8s.AuditPolicyConfigSpec) func() (runtime.Object, 
 
 func schedulerConfig(spec *k8s.SchedulerConfigSpec) func() (runtime.Object, error) {
 	return func() (runtime.Object, error) {
+		// Validate against the typed schema, but emit the user-provided map so
+		// fields the user didn't set don't leak into the YAML as zero values —
+		// older Kubernetes releases reject keys they don't know about.
 		var cfg schedulerv1.KubeSchedulerConfiguration
 
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(spec.Config, &cfg, false); err != nil {
 			return nil, fmt.Errorf("error unmarshaling scheduler configuration: %w", err)
 		}
 
-		cfg.APIVersion = "kubescheduler.config.k8s.io/v1"
-		cfg.Kind = "KubeSchedulerConfiguration"
-		cfg.ClientConnection.Kubeconfig = filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")
+		out := runtime.DeepCopyJSON(spec.Config)
+		if out == nil {
+			out = map[string]any{}
+		}
 
-		return &cfg, nil
+		out["apiVersion"] = "kubescheduler.config.k8s.io/v1"
+		out["kind"] = "KubeSchedulerConfiguration"
+
+		clientConn, _ := out["clientConnection"].(map[string]any)
+		if clientConn == nil {
+			clientConn = map[string]any{}
+			out["clientConnection"] = clientConn
+		}
+
+		clientConn["kubeconfig"] = filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")
+
+		return &unstructured.Unstructured{Object: out}, nil
 	}
 }
 


### PR DESCRIPTION
This is a small fix for the issue, more complete refactoring of this code is expected to be part of #13094.

Fixes #13352

Previosly (default) config renders as:

```yaml
apiVersion: kubescheduler.config.k8s.io/v1
clientConnection:
  acceptContentTypes: ""
  burst: 0
  contentType: ""
  kubeconfig: /system/secrets/kubernetes/kube-scheduler/kubeconfig
  qps: 0
kind: KubeSchedulerConfiguration
leaderElection:
  leaderElect: null
  leaseDuration: 0s
  renewDeadline: 0s
  resourceLock: ""
  resourceName: ""
  resourceNamespace: ""
  retryPeriod: 0s
```

Now:

```yaml
apiVersion: kubescheduler.config.k8s.io/v1
clientConnection:
  kubeconfig: /system/secrets/kubernetes/kube-scheduler/kubeconfig
kind: KubeSchedulerConfiguration
```

Config validation is still in place, but going through Unstructured allows to skip any fields which are not set explicitly.
