### PR TITLE
fix: streamline config validation flow

### DIFF
--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -60,7 +60,7 @@ func runInstallCmd(ctx context.Context) (err error) {
 	} else {
 		var warnings []string
 
-		warnings, err = config.Validate(p.Mode())
+		warnings, err = config.ValidateAsClient(p.Mode())
 		if err != nil {
 			return fmt.Errorf("machine configuration is invalid: %w", err)
 		}

--- a/cmd/talosctl/cmd/mgmt/validate.go
+++ b/cmd/talosctl/cmd/mgmt/validate.go
@@ -43,7 +43,7 @@ var validateCmd = &cobra.Command{
 			opts = append(opts, validation.WithStrict())
 		}
 
-		warnings, err := cfg.Validate(mode, opts...)
+		warnings, err := cfg.ValidateAsClient(mode, opts...)
 		for _, w := range warnings {
 			cli.Warning("%s", w)
 		}

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -207,17 +207,10 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		installed: s.Controller.Runtime().State().Machine().Installed(),
 	}
 
-	warnings, err := cfgProvider.Validate(validationMode)
+	warnings, err := cfgProvider.ValidateAtRuntime(ctx, s.Controller.Runtime().State().V1Alpha2().Resources(), validationMode)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
-	warningsRuntime, err := cfgProvider.RuntimeValidate(ctx, s.Controller.Runtime().State().V1Alpha2().Resources(), validationMode)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	warnings = slices.Concat(warnings, warningsRuntime)
 
 	if inMaintenance && in.Mode == machine.ApplyConfigurationRequest_REBOOT {
 		in.Mode = machine.ApplyConfigurationRequest_NO_REBOOT

--- a/internal/app/machined/pkg/controllers/config/acquire.go
+++ b/internal/app/machined/pkg/controllers/config/acquire.go
@@ -16,7 +16,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -370,7 +369,7 @@ func (ctrl *AcquireController) loadConfigFromDisk(ctx context.Context, r control
 		}
 
 		// if the STATE partition is present & contains machine config, Talos is already installed
-		warnings, err := cfg.Validate(validationModeDiskConfig{})
+		warnings, err := cfg.ValidateAtRuntime(ctx, ctrl.ResourceState, validationModeDiskConfig{})
 		if err != nil {
 			return fmt.Errorf("failed to validate on-disk config: %w", err)
 		}
@@ -395,7 +394,7 @@ func (ctrl *AcquireController) loadConfigFromDisk(ctx context.Context, r control
 //	--> cmdlineEarly: config loaded from embedded, but it's incomplete, or no config: proceed to cmdlineEarly
 //	--> done: config loaded from cmdline, and it's complete
 func (ctrl *AcquireController) stateEmbedded(ctx context.Context, r controller.Runtime, logger *zap.Logger) (stateMachineFunc, config.Provider, error) {
-	cfg, err := ctrl.loadConfigFromEmbedded(logger)
+	cfg, err := ctrl.loadConfigFromEmbedded(ctx, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -457,7 +456,7 @@ func (ctrl *AcquireController) processEmbeddedConfig(logger *zap.Logger) error {
 	return nil
 }
 
-func (ctrl *AcquireController) loadConfigFromEmbedded(logger *zap.Logger) (config.Provider, error) {
+func (ctrl *AcquireController) loadConfigFromEmbedded(ctx context.Context, logger *zap.Logger) (config.Provider, error) {
 	if ctrl.storedEmbeddedConfig == nil {
 		// no embedded config
 		return nil, nil
@@ -471,7 +470,7 @@ func (ctrl *AcquireController) loadConfigFromEmbedded(logger *zap.Logger) (confi
 	}
 
 	// if the STATE partition is present & contains machine config, Talos is already installed
-	warnings, err := cfg.Validate(validationModeDiskConfig{})
+	warnings, err := cfg.ValidateAtRuntime(ctx, ctrl.ResourceState, ctrl.ValidationMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate embedded config: %w", err)
 	}
@@ -567,17 +566,12 @@ func (ctrl *AcquireController) loadFromPlatform(ctx context.Context, logger *zap
 		return nil, fmt.Errorf("failed to load config via platform %s: %w", platformName, err)
 	}
 
-	warnings, err := cfg.Validate(ctrl.ValidationMode)
+	warnings, err := cfg.ValidateAtRuntime(ctx, ctrl.ResourceState, ctrl.ValidationMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate config acquired via platform %s: %w", platformName, err)
 	}
 
-	warningsRuntime, err := cfg.RuntimeValidate(ctx, ctrl.ResourceState, ctrl.ValidationMode)
-	if err != nil {
-		return nil, fmt.Errorf("failed to runtime validate config acquired via platform %s: %w", platformName, err)
-	}
-
-	for _, warning := range slices.Concat(warnings, warningsRuntime) {
+	for _, warning := range warnings {
 		logger.Warn("config validation warning", zap.String("platform", platformName), zap.String("warning", warning))
 	}
 
@@ -675,17 +669,12 @@ func (ctrl *AcquireController) loadFromCmdline(ctx context.Context, logger *zap.
 		return nil, fmt.Errorf("failed to load config via cmdline %s: %w", paramName, err)
 	}
 
-	warnings, err := cfg.Validate(ctrl.ValidationMode)
+	warnings, err := cfg.ValidateAtRuntime(ctx, ctrl.ResourceState, ctrl.ValidationMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate config acquired via cmdline %s: %w", paramName, err)
 	}
 
-	warningsRuntime, err := cfg.RuntimeValidate(ctx, ctrl.ResourceState, ctrl.ValidationMode)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate config acquired via cmdline %s: %w", paramName, err)
-	}
-
-	for _, warning := range slices.Concat(warnings, warningsRuntime) {
+	for _, warning := range warnings {
 		logger.Warn("config validation warning", zap.String("cmdline", paramName), zap.String("warning", warning))
 	}
 

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -7,6 +7,7 @@ package container
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
@@ -17,14 +18,48 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 )
 
-// Validate checks configuration and returns warnings and fatal errors (as multierror).
+// ValidateAsClient validates the config in the client context (outside of Talos).
+//
+// The method returns warnings and fatal errors (as multierror).
+func (container *Container) ValidateAsClient(mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+	return container.validate(mode, opt...)
+}
+
+// ValidateAtRuntime validates the config in the runtime context (inside Talos).
+//
+// This method performs full machine configuration validation, including validation which requires runtime context.
+//
+// The method returns warnings and fatal errors (as multierror).
+func (container *Container) ValidateAtRuntime(ctx context.Context, st state.State, mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+	warnings, err := container.validate(mode, opt...)
+
+	extraWarnings, extraErr := container.runtimeValidate(ctx, st, mode, opt...)
+
+	warnings = slices.Concat(warnings, extraWarnings)
+
+	var multiErr *multierror.Error
+
+	if err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	if extraErr != nil {
+		multiErr = multierror.Append(multiErr, extraErr)
+	}
+
+	return warnings, multiErr.ErrorOrNil()
+}
+
+// validate checks configuration and returns warnings and fatal errors (as multierror).
+//
+// It performs validation which can be done client-side (outside of Talos) and is used by both ValidateAsClient and ValidateAtRuntime.
 //
 // The validation first validates each individual document, then it does conflict validation of new
 // documents with v1alpha1.Config (if it exists).
 // Finally, whole container is validated according to the mode.
 //
 //nolint:gocyclo
-func (container *Container) Validate(mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+func (container *Container) validate(mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
 	var (
 		warnings []string
 		err      error
@@ -74,8 +109,10 @@ func (container *Container) Validate(mode validation.RuntimeMode, opt ...validat
 	return warnings, multiErr.ErrorOrNil()
 }
 
-// RuntimeValidate validates the config in the runtime context.
-func (container *Container) RuntimeValidate(ctx context.Context, st state.State, mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+// runtimeValidate validates the config in the runtime context.
+//
+// The method returns warnings and fatal errors (as multierror).
+func (container *Container) runtimeValidate(ctx context.Context, st state.State, mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
 	var (
 		warnings []string
 		err      error
@@ -170,4 +207,18 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 	}
 
 	return errs
+}
+
+// Validate is the legacy validation method.
+//
+// Deprecated: use ValidateAsClient instead for client-side validation (outside of Talos).
+func (container *Container) Validate(mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+	return container.validate(mode, opt...)
+}
+
+// RuntimeValidate is the legacy runtime validation method.
+//
+// Deprecated: use ValidateAtRuntime instead for runtime validation (inside Talos).
+func (container *Container) RuntimeValidate(ctx context.Context, st state.State, mode validation.RuntimeMode, opt ...validation.Option) ([]string, error) {
+	return container.runtimeValidate(ctx, st, mode, opt...)
 }

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -24,7 +24,7 @@ import (
 	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
-func TestValidate(t *testing.T) {
+func TestValidateAsClient(t *testing.T) {
 	t.Parallel()
 
 	sideroLinkCfg := siderolink.NewConfigV1Alpha1()
@@ -94,7 +94,7 @@ func TestValidate(t *testing.T) {
 			ctr, err := container.New(tt.documents...)
 			require.NoError(t, err)
 
-			warnings, err := ctr.Validate(validationMode{})
+			warnings, err := ctr.ValidateAsClient(validationMode{})
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestCrossValidateEncryption(t *testing.T) {
 			ctr, err := container.New(tt.documents...)
 			require.NoError(t, err)
 
-			warnings, err := ctr.Validate(validationMode{})
+			warnings, err := ctr.ValidateAsClient(validationMode{})
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestValidateContainer(t *testing.T) {
 			ctr, err := container.New(tt.documents...)
 			require.NoError(t, err)
 
-			_, err = ctr.Validate(validationMode{inContainer: tt.inContainer})
+			_, err = ctr.ValidateAsClient(validationMode{inContainer: tt.inContainer})
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)

--- a/pkg/machinery/config/generate/generate_test.go
+++ b/pkg/machinery/config/generate/generate_test.go
@@ -112,7 +112,7 @@ func (suite *GenerateSuite) TestGenerateControlPlaneSuccess() {
 	cfg, err := suite.input.Config(machine.TypeControlPlane)
 	suite.Require().NoError(err)
 
-	_, err = cfg.Validate(runtimeMode{false})
+	_, err = cfg.ValidateAsClient(runtimeMode{false})
 	suite.Require().NoError(err)
 
 	suite.NotEmpty(cfg.Machine().Security().IssuingCA())

--- a/pkg/machinery/config/generate/stdpatches/stdpatches_test.go
+++ b/pkg/machinery/config/generate/stdpatches/stdpatches_test.go
@@ -95,7 +95,7 @@ func TestPatches(t *testing.T) {
 					patchedCfg, err := patched.Config()
 					require.NoError(t, err)
 
-					_, err = patchedCfg.Validate(mockValidationMode{}, validation.WithLocal())
+					_, err = patchedCfg.ValidateAsClient(mockValidationMode{}, validation.WithLocal())
 					require.NoError(t, err)
 
 					test.assertion(t, patchedCfg)

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -5,8 +5,13 @@
 package config
 
 import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/state"
+
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/config/validation"
 )
 
 // Encoder provides the interface to encode configuration documents.
@@ -24,8 +29,28 @@ type RuntimeValidator = config.RuntimeValidator
 // validation, and other operations.
 type Container interface {
 	Encoder
-	Validator
-	RuntimeValidator
+
+	// Validate checks configuration and returns warnings and fatal errors (as multierror).
+	//
+	// Deprecated: use ValidateAsClient instead for client-side validation (outside of Talos).
+	Validate(validation.RuntimeMode, ...validation.Option) ([]string, error)
+
+	// RuntimeValidate validates the config in the runtime context.
+	//
+	// The method returns warnings and fatal errors (as multierror).
+	//
+	// Deprecated: use ValidateAtRuntime instead for runtime validation (inside Talos).
+	RuntimeValidate(context.Context, state.State, validation.RuntimeMode, ...validation.Option) ([]string, error)
+
+	// ValidateAsClient validates the config in the client context (outside of Talos).
+	//
+	// The method returns warnings and fatal errors (as multierror).
+	ValidateAsClient(validation.RuntimeMode, ...validation.Option) ([]string, error)
+
+	// ValidateAtRuntime validates the config in the runtime context (inside Talos).
+	//
+	// The method returns warnings and fatal errors (as multierror).
+	ValidateAtRuntime(context.Context, state.State, validation.RuntimeMode, ...validation.Option) ([]string, error)
 
 	Readonly() bool
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -372,6 +372,11 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 		}
 	}
 
+	// don't validate Kubernetes version in local mode, as it depends on Talos version
+	if !opts.Local {
+		result = multierror.Append(result, c.ValidateKubernetesVersions())
+	}
+
 	if opts.Strict {
 		for _, w := range warnings {
 			result = multierror.Append(result, fmt.Errorf("warning: %s", w))
@@ -963,6 +968,45 @@ func (e *EtcdConfig) Validate() error {
 	return result.ErrorOrNil()
 }
 
+// ValidateKubernetesVersions validates Kubernetes versions in the config.
+func (c *Config) ValidateKubernetesVersions() error {
+	var result *multierror.Error
+
+	if c.MachineConfig != nil {
+		if err := ValidateKubernetesImageTag(c.Machine().Kubelet().Image()); err != nil {
+			result = multierror.Append(result, fmt.Errorf("kubelet image is not valid: %w", err))
+		}
+	}
+
+	if c.ClusterConfig != nil && c.MachineConfig != nil {
+		if c.Machine().Type().IsControlPlane() {
+			for _, spec := range []struct {
+				name     string
+				imageRef string
+			}{
+				{
+					name:     "kube-apiserver",
+					imageRef: c.Cluster().APIServer().Image(),
+				},
+				{
+					name:     "kube-controller-manager",
+					imageRef: c.Cluster().ControllerManager().Image(),
+				},
+				{
+					name:     "kube-scheduler",
+					imageRef: c.Cluster().Scheduler().Image(),
+				},
+			} {
+				if err := ValidateKubernetesImageTag(spec.imageRef); err != nil {
+					result = multierror.Append(result, fmt.Errorf("%s image is not valid: %w", spec.name, err))
+				}
+			}
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
 // RuntimeValidate validates the config in runtime context.
 //
 // In runtime context, resource state is available.
@@ -1001,36 +1045,6 @@ func (c *Config) RuntimeValidate(ctx context.Context, st state.State, mode valid
 		if len(c.MachineConfig.Install().Extensions()) > 0 {
 			warnings = append(warnings, ".machine.install.extensions is deprecated, please see https://docs.siderolabs.com/talos/latest/platform-specific-installations/boot-assets")
 		}
-
-		if err := ValidateKubernetesImageTag(c.Machine().Kubelet().Image()); err != nil {
-			result = multierror.Append(result, fmt.Errorf("kubelet image is not valid: %w", err))
-		}
-	}
-
-	if c.ClusterConfig != nil && c.MachineConfig != nil {
-		if c.Machine().Type().IsControlPlane() {
-			for _, spec := range []struct {
-				name     string
-				imageRef string
-			}{
-				{
-					name:     "kube-apiserver",
-					imageRef: c.Cluster().APIServer().Image(),
-				},
-				{
-					name:     "kube-controller-manager",
-					imageRef: c.Cluster().ControllerManager().Image(),
-				},
-				{
-					name:     "kube-scheduler",
-					imageRef: c.Cluster().Scheduler().Image(),
-				},
-			} {
-				if err := ValidateKubernetesImageTag(spec.imageRef); err != nil {
-					result = multierror.Append(result, fmt.Errorf("%s image is not valid: %w", spec.name, err))
-				}
-			}
-		}
 	}
 
 	return warnings, result.ErrorOrNil()
@@ -1038,7 +1052,7 @@ func (c *Config) RuntimeValidate(ctx context.Context, st state.State, mode valid
 
 // ValidateKubernetesImageTag validates the Kubernetes image tag format.
 func ValidateKubernetesImageTag(imageRef string) error {
-	// this method is called from RuntimeValidate, so we are inside running Talos,
+	// this method is called from Validate in !Local mode, so we are inside running Talos,
 	// so the version of Talos is available, and we can check compatibility
 	currentTalosVersion, err := compatibility.ParseTalosVersion(version.NewVersion())
 	if err != nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2265,19 +2263,16 @@ func TestKubernetesVersionFromImageRef(t *testing.T) {
 	}
 }
 
-func TestRuntimeValidate(t *testing.T) {
+func TestValidateKubernetesVersions(t *testing.T) {
 	t.Parallel()
 
 	endpointURL, err := url.Parse("https://localhost:6443/")
 	require.NoError(t, err)
 
 	for _, test := range []struct {
-		name             string
-		config           *v1alpha1.Config
-		requiresInstall  bool
-		strict           bool
-		expectedWarnings []string
-		expectedError    string
+		name          string
+		config        *v1alpha1.Config
+		expectedError string
 	}{
 		{
 			name: "valid",
@@ -2367,16 +2362,7 @@ func TestRuntimeValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			var opts []validation.Option
-			if test.strict {
-				opts = append(opts, validation.WithStrict())
-			}
-
-			st := state.WrapCore(inmem.NewState(""))
-
-			warnings, errors := test.config.RuntimeValidate(t.Context(), st, runtimeMode{test.requiresInstall}, opts...)
-
-			assert.Equal(t, test.expectedWarnings, warnings)
+			errors := test.config.ValidateKubernetesVersions()
 
 			currentTalosVersion, err := compatibility.ParseTalosVersion(version.NewVersion())
 			require.NoError(t, err)


### PR DESCRIPTION
And specifically, for Kubernetes versions.

Fixes https://github.com/siderolabs/talos/discussions/13361

First of all, refactor (confusing) method names for config validation, deprecate the old ones and introduce two new entrypoints:

* `ValidateAsClient` - used in the `talosctl validate` CLI (when outside of Talos)
* `ValidateAtRuntime` - used by Talos itself, and _includes_ `ValidateAsClient` as well.

This avoids previous pattern than you have to call two methods: `Validate` and `RuntimeValidate` on the config and join their results.

Move Kubernetes version validation from `RuntimeValidate` into regular `Validate`, but guard it under the `!Local` condition to make it run only inside the Talos context. This exposes it cases when we can't call `ValidateAtRuntime`, e.g. in the `installer` on upgrade, when access to host Talos resource state is not guaranteed.
