### PR TITLE
feat: add Azure Secure Boot imager profile

### DIFF
--- a/pkg/imager/profile/default.go
+++ b/pkg/imager/profile/default.go
@@ -135,6 +135,19 @@ var Default = map[string]Profile{
 			},
 		},
 	},
+	"secureboot-azure": {
+		Platform:   "azure",
+		SecureBoot: new(true),
+		Output: Output{
+			Kind:      OutKindImage,
+			OutFormat: OutFormatZSTD,
+			ImageOptions: &ImageOptions{
+				DiskSize:          DefaultRAWDiskSize,
+				DiskFormat:        DiskFormatVPC,
+				DiskFormatOptions: "subformat=fixed,force_size",
+			},
+		},
+	},
 	"cloudstack": {
 		Platform:   "cloudstack",
 		SecureBoot: new(false),

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.10.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.11.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.12.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.13.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.14.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-amd64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-amd64-1.9.0.yaml
@@ -1,0 +1,29 @@
+arch: amd64
+platform: azure
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/amd64/vmlinuz
+  initramfs:
+    path: /usr/install/amd64/initramfs.xz
+  sdStub:
+    path: /usr/install/amd64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/amd64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.10.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.10.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.10.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.10.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.11.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.11.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.11.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.11.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.12.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.12.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.12.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.12.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.13.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.13.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.13.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.13.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.14.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.14.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.14.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer-base:1.14.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 9638510592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/imager/profile/testdata/secureboot-azure-arm64-1.9.0.yaml
+++ b/pkg/imager/profile/testdata/secureboot-azure-arm64-1.9.0.yaml
@@ -1,0 +1,29 @@
+arch: arm64
+platform: azure
+secureboot: true
+version: 1.9.0
+input:
+  kernel:
+    path: /usr/install/arm64/vmlinuz
+  initramfs:
+    path: /usr/install/arm64/initramfs.xz
+  sdStub:
+    path: /usr/install/arm64/systemd-stub.efi
+  sdBoot:
+    path: /usr/install/arm64/systemd-boot.efi
+  baseInstaller:
+    imageRef: ghcr.io/siderolabs/installer:1.9.0
+  secureboot:
+    secureBootSigner:
+      keyPath: /secureboot/uki-signing-key.pem
+      certPath: /secureboot/uki-signing-cert.pem
+    pcrSigner:
+      keyPath: /secureboot/pcr-signing-key.pem
+output:
+  kind: image
+  imageOptions:
+    diskSize: 8589934592
+    diskFormat: vhd
+    diskFormatOptions: subformat=fixed,force_size
+    bootloader: sd-boot
+  outFormat: .zst

--- a/pkg/machinery/platforms/platforms.go
+++ b/pkg/machinery/platforms/platforms.go
@@ -199,6 +199,7 @@ func CloudPlatforms() []Platform {
 			BootMethods: []BootMethod{
 				BootMethodDiskImage,
 			},
+			SecureBootSupported: true,
 		},
 		{
 			Name: "digital-ocean",


### PR DESCRIPTION
# Pull Request

## What? (description)

Add a built-in `secureboot-azure` imager profile and golden profile fixtures for supported test versions and architectures.

## Why? (reasoning)

Fixes #13360. This allows imager to build Azure-compatible Secure Boot VHD images directly, without using `secureboot-metal` plus manual raw-to-VHD conversion.

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

Ran:

- `go test ./pkg/imager/profile`
- `go test ./pkg/imager/...`