### PR TITLE
feat: enable Flannel nftables mode

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -117,6 +117,12 @@ Talos now supports a new `ImageCacheConfig` document for configuring the Image C
 Old configuration is still supported for backwards compatibility.
 """
 
+    [notes.flannel]
+        title = "Flannel CNI"
+        description = """\
+Talos now configures Flannel with the `EnableNFTables` option enabled, which uses nftables native backend instead of `iptables-nft` compatibility layer.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
@@ -139,16 +139,18 @@ func FlannelConfigMapTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 	}
 
 	var netConf struct {
-		Network     string `json:"Network,omitempty"`
-		IPv6Network string `json:"IPv6Network,omitempty"`
-		EnableIPv6  *bool  `json:"EnableIPv6,omitempty"`
-		EnableIPv4  *bool  `json:"EnableIPv4,omitempty"`
-		Backend     struct {
+		Network        string `json:"Network,omitempty"`
+		IPv6Network    string `json:"IPv6Network,omitempty"`
+		EnableIPv6     *bool  `json:"EnableIPv6,omitempty"`
+		EnableIPv4     *bool  `json:"EnableIPv4,omitempty"`
+		EnableNFTables *bool  `json:"EnableNFTables,omitempty"`
+		Backend        struct {
 			Type string `json:"Type"`
 			Port int    `json:"Port"`
 		} `json:"Backend"`
 	}
 
+	netConf.EnableNFTables = new(true)
 	netConf.Backend.Type = "vxlan"
 	netConf.Backend.Port = 4789
 

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-dual.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-dual.yaml
@@ -25,6 +25,7 @@ data:
       "Network": "10.96.0.0/12",
       "IPv6Network": "fd00::/112",
       "EnableIPv6": true,
+      "EnableNFTables": true,
       "Backend": {
         "Type": "vxlan",
         "Port": 4789

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v4.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v4.yaml
@@ -23,6 +23,7 @@ data:
   net-conf.json: |-
     {
       "Network": "10.96.0.0/12",
+      "EnableNFTables": true,
       "Backend": {
         "Type": "vxlan",
         "Port": 4789

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v6.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v6.yaml
@@ -25,6 +25,7 @@ data:
       "IPv6Network": "fd00::/112",
       "EnableIPv6": true,
       "EnableIPv4": false,
+      "EnableNFTables": true,
       "Backend": {
         "Type": "vxlan",
         "Port": 4789


### PR DESCRIPTION
Use native nftables (it uses `nft` CLI internally) instead of going via `iptables-nft` shim.
