### PR TITLE
feat: add quirks for RegistryAuthConfig support

### DIFF
--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -336,3 +336,15 @@ func (q Quirks) SupportsFactoryTalosctlDownload() bool {
 
 	return q.v.GTE(minTalosVersionFactoryTalosctlDownload)
 }
+
+var minVersionRegistryAuthConfig = semver.MustParse("1.12.0")
+
+// SupportsRegistryAuthConfig reports whether the given Talos version supports the
+// RegistryAuthConfig multi-doc config document.
+func (q Quirks) SupportsRegistryAuthConfig() bool {
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minVersionRegistryAuthConfig)
+}

--- a/pkg/machinery/imager/quirks/quirks_test.go
+++ b/pkg/machinery/imager/quirks/quirks_test.go
@@ -253,3 +253,31 @@ func TestPartitionSizes(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsRegistryAuthConfig(t *testing.T) {
+	for _, test := range []struct {
+		version string
+
+		expected bool
+	}{
+		{
+			version:  "1.11.0",
+			expected: false,
+		},
+		{
+			version:  "1.12.0-beta.0",
+			expected: true,
+		},
+		{
+			version:  "1.12.0",
+			expected: true,
+		},
+		{
+			expected: true,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			assert.Equal(t, test.expected, quirks.New(test.version).SupportsRegistryAuthConfig())
+		})
+	}
+}


### PR DESCRIPTION
Config is supported starting from Talos version 1.12.0.