### PR TITLE
feat(machined): live-grow partition and XFS filesystem when backing disk is expanded

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/grow.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/grow.go
@@ -17,56 +17,50 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
-// Grow grows a volume.
+// Grow grows a volume partition if there is space available and the Grow flag is set.
+// Returns (true, newSize, nil) if the partition was enlarged; (false, 0, nil) if no growth was needed.
+// The caller is responsible for calling SetSize and advancing Status.Phase.
 //
 //nolint:gocyclo
-func Grow(ctx context.Context, logger *zap.Logger, volumeContext ManagerContext) error {
+func Grow(ctx context.Context, logger *zap.Logger, volumeContext ManagerContext) (bool, uint64, error) {
 	if !(volumeContext.Cfg.TypedSpec().Type == block.VolumeTypePartition && volumeContext.Cfg.TypedSpec().Provisioning.PartitionSpec.Grow) {
-		// nothing to do
-		volumeContext.Status.Phase = block.VolumePhaseProvisioned
-
-		return nil
+		return false, 0, nil
 	}
 
 	if volumeContext.Cfg.TypedSpec().Provisioning.PartitionSpec.MaxSize > 0 && volumeContext.Status.Size >= volumeContext.Cfg.TypedSpec().Provisioning.PartitionSpec.MaxSize {
-		// nowhere to grow
-		volumeContext.Status.Phase = block.VolumePhaseProvisioned
-
-		return nil
+		return false, 0, nil
 	}
 
 	dev, err := blockdev.NewFromPath(volumeContext.Status.ParentLocation, blockdev.OpenForWrite())
 	if err != nil {
-		return xerrors.NewTaggedf[Retryable]("error opening disk: %w", err)
+		return false, 0, xerrors.NewTaggedf[Retryable]("error opening disk: %w", err)
 	}
 
 	defer dev.Close() //nolint:errcheck
 
 	if err = dev.RetryLockWithTimeout(ctx, true, 10*time.Second); err != nil {
-		return xerrors.NewTaggedf[Retryable]("error locking disk: %w", err)
+		return false, 0, xerrors.NewTaggedf[Retryable]("error locking disk: %w", err)
 	}
 
 	defer dev.Unlock() //nolint:errcheck
 
 	gptdev, err := gpt.DeviceFromBlockDevice(dev)
 	if err != nil {
-		return fmt.Errorf("error getting GPT device: %w", err)
+		return false, 0, fmt.Errorf("error getting GPT device: %w", err)
 	}
 
 	pt, err := gpt.Read(gptdev)
 	if err != nil {
-		return fmt.Errorf("error initializing GPT: %w", err)
+		return false, 0, fmt.Errorf("error initializing GPT: %w", err)
 	}
 
 	availableGrowth, err := pt.AvailablePartitionGrowth(volumeContext.Status.PartitionIndex - 1)
 	if err != nil {
-		return fmt.Errorf("error getting available partition growth: %w", err)
+		return false, 0, fmt.Errorf("error getting available partition growth: %w", err)
 	}
 
-	if availableGrowth <= 1024*1024 { // don't grow by less than 1MiB
-		volumeContext.Status.Phase = block.VolumePhaseProvisioned
-
-		return nil
+	if availableGrowth <= 1024*1024 { // don't grow by less than 1 MiB
+		return false, 0, nil
 	}
 
 	if volumeContext.Cfg.TypedSpec().Provisioning.PartitionSpec.MaxSize > 0 && availableGrowth > volumeContext.Cfg.TypedSpec().Provisioning.PartitionSpec.MaxSize-volumeContext.Status.Size {
@@ -76,15 +70,14 @@ func Grow(ctx context.Context, logger *zap.Logger, volumeContext ManagerContext)
 	logger.Debug("growing partition", zap.String("disk", volumeContext.Status.ParentLocation), zap.Int("partition", volumeContext.Status.PartitionIndex), zap.Uint64("size", availableGrowth))
 
 	if err = pt.GrowPartition(volumeContext.Status.PartitionIndex-1, availableGrowth); err != nil {
-		return fmt.Errorf("error growing partition: %w", err)
+		return false, 0, fmt.Errorf("error growing partition: %w", err)
 	}
 
+	// pt.Write() → syncKernelIncremental() uses BLKPG_RESIZE_PARTITION for
+	// mounted (EBUSY) partitions, safe in both boot and live contexts.
 	if err = pt.Write(); err != nil {
-		return fmt.Errorf("error writing GPT: %w", err)
+		return false, 0, fmt.Errorf("error writing GPT: %w", err)
 	}
 
-	volumeContext.Status.Phase = block.VolumePhaseProvisioned
-	volumeContext.Status.SetSize(volumeContext.Status.Size + availableGrowth)
-
-	return nil
+	return true, volumeContext.Status.Size + availableGrowth, nil
 }

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/grow_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/grow_test.go
@@ -31,7 +31,8 @@ func TestGrow(t *testing.T) {
 		volumeConfig block.VolumeConfigSpec
 		volumeStatus block.VolumeStatusSpec
 
-		expectedSize uint64
+		expectedGrew    bool
+		expectedNewSize uint64
 	}{
 		{
 			name: "grow at the end of the disk",
@@ -63,7 +64,8 @@ func TestGrow(t *testing.T) {
 				PartitionIndex: 1,
 			},
 
-			expectedSize: 1<<23 - 2*(1<<20),
+			expectedGrew:    true,
+			expectedNewSize: 1<<23 - 2*(1<<20),
 		},
 		{
 			name: "grow to max size",
@@ -96,7 +98,8 @@ func TestGrow(t *testing.T) {
 				PartitionIndex: 1,
 			},
 
-			expectedSize: 1 << 22,
+			expectedGrew:    true,
+			expectedNewSize: 1 << 22,
 		},
 		{
 			name: "doesn't grow at max size",
@@ -129,7 +132,8 @@ func TestGrow(t *testing.T) {
 				PartitionIndex: 1,
 			},
 
-			expectedSize: 1 << 21,
+			expectedGrew:    false,
+			expectedNewSize: 0,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -144,15 +148,21 @@ func TestGrow(t *testing.T) {
 			volumeStatus := test.volumeStatus
 			volumeStatus.ParentLocation = test.diskSetup(t)
 
+			originalSize := volumeStatus.Size
+
 			managerContext := volumes.ManagerContext{
 				Cfg:    volumeCfg,
 				Status: &volumeStatus,
 			}
 
-			var err error
+			var (
+				grew    bool
+				newSize uint64
+				err     error
+			)
 
 			for range 10 {
-				err = volumes.Grow(ctx, logger, managerContext)
+				grew, newSize, err = volumes.Grow(ctx, logger, managerContext)
 				if err != nil && xerrors.TagIs[volumes.Retryable](err) {
 					// retry various disk locked and other retryable errors
 					time.Sleep(10 * time.Millisecond)
@@ -165,8 +175,12 @@ func TestGrow(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Equal(t, block.VolumePhaseProvisioned, volumeStatus.Phase)
-			assert.Equal(t, test.expectedSize, volumeStatus.Size)
+			assert.Equal(t, test.expectedGrew, grew, "unexpected grew value")
+			assert.Equal(t, test.expectedNewSize, newSize, "unexpected newSize value")
+
+			// Grow() must not modify Phase or Size; those are the caller's responsibility.
+			assert.Equal(t, block.VolumePhaseWaiting, volumeStatus.Phase, "Grow() must not modify Phase")
+			assert.Equal(t, originalSize, volumeStatus.Size, "Grow() must not modify Status.Size")
 		})
 	}
 }

--- a/internal/app/machined/pkg/controllers/block/volume_manager.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -19,7 +18,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/gen/value"
-	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
 
@@ -33,6 +31,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
+	"github.com/siderolabs/talos/pkg/makefs"
 )
 
 // VolumeManagerController manages volumes in the system, converting VolumeConfig resources to VolumeStatuses.
@@ -132,22 +131,11 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 		deviceReadyRequest  int
 	)
 
-	retryTicker := time.NewTicker(30 * time.Second)
-	defer retryTicker.Stop()
-
-	shouldRetry := false
-
 	for {
 		select {
 		case <-r.EventCh():
 		case <-ctx.Done():
 			return nil
-		case <-retryTicker.C:
-			if !shouldRetry {
-				continue
-			}
-
-			shouldRetry = false
 		}
 
 		// if devices are not ready, we can't provision and locate most volumes
@@ -402,9 +390,6 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 				volumeStatus.TypedSpec().Phase = block.VolumePhaseFailed
 
 				volumeStatus.TypedSpec().ErrorMessage = err.Error()
-				if xerrors.TagIs[volumes.Retryable](err) {
-					shouldRetry = true
-				}
 			} else {
 				volumeStatus.TypedSpec().ErrorMessage = ""
 				volumeStatus.TypedSpec().PreFailPhase = block.VolumePhase(0)
@@ -540,7 +525,36 @@ func (ctrl *VolumeManagerController) processVolumeConfig(ctx context.Context, lo
 			// normal state machine
 			switch volumeContext.Status.Phase {
 			case block.VolumePhaseReady:
-				// nothing to do, ready
+				grew, newSize, err := volumes.Grow(ctx, logger, volumeContext)
+				if err != nil {
+					return err
+				}
+
+				if grew {
+					sizeUpdated := true
+
+					if !value.IsZero(volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec) &&
+						volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Type == block.FilesystemTypeXFS {
+						// The filesystem is already mounted at TargetPath; call XFSGrow
+						// directly rather than going through GrowFilesystem which would
+						// redundantly mount the device a second time via a tmpdir.
+						if mountPath := volumeContext.Status.MountSpec.TargetPath; mountPath != "" {
+							logger.Info("growing XFS filesystem inline", zap.String("mountpoint", mountPath))
+
+							if err = makefs.XFSGrow(ctx, mountPath); err != nil {
+								logger.Error("failed to grow XFS filesystem inline", zap.Error(err))
+
+								sizeUpdated = false
+							}
+						}
+					}
+
+					if sizeUpdated {
+						volumeContext.Status.SetSize(newSize)
+						logger.Info("volume grew live", zap.Uint64("newSize", newSize))
+					}
+				}
+
 				return nil
 			case block.VolumePhaseWaiting, block.VolumePhaseMissing:
 				if err := volumes.LocateAndProvision(ctx, logger, volumeContext); err != nil {
@@ -548,9 +562,16 @@ func (ctrl *VolumeManagerController) processVolumeConfig(ctx context.Context, lo
 				}
 			case block.VolumePhaseLocated:
 				// grow the partition if needed
-				if err := volumes.Grow(ctx, logger, volumeContext); err != nil {
+				grew, newSize, err := volumes.Grow(ctx, logger, volumeContext)
+				if err != nil {
 					return err
 				}
+
+				if grew {
+					volumeContext.Status.SetSize(newSize)
+				}
+
+				volumeContext.Status.Phase = block.VolumePhaseProvisioned
 			case block.VolumePhaseProvisioned:
 				// decrypt/encrypt the volume
 				if err := volumes.HandleEncryption(ctx, logger, volumeContext); err != nil {

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -9,7 +9,10 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
+	"net"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -1777,14 +1780,25 @@ func (suite *VolumesSuite) TestZswapStatus() {
 	}
 }
 
+<<<<<<< HEAD
 // TestFSTrimDefaultSchedule verifies that the default schedule for filesystem trimming is applied.
 func (suite *VolumesSuite) TestFSTrimDefaultSchedule() {
 	// TODO: we can remove this skip clause once TF provider in contrib is updated
 	// to Talos 1.14 machinery.
+=======
+// TestLiveDiskResize verifies that enlarging the underlying block device of a running node
+// causes Talos to automatically grow the EPHEMERAL partition and filesystem without a reboot.
+func (suite *VolumesSuite) TestLiveDiskResize() {
+	if testing.Short() {
+		suite.T().Skip("skipping test in short mode.")
+	}
+
+>>>>>>> 0c68137ce (feat(machined): live-grow partition and XFS filesystem when backing disk is expanded)
 	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
 		suite.T().Skip("skipping test for non-qemu provisioner")
 	}
 
+<<<<<<< HEAD
 	for _, node := range suite.DiscoverNodeInternalIPs(suite.ctx) {
 		suite.Run(node, func() {
 			ctx := client.WithNode(suite.ctx, node)
@@ -1820,6 +1834,325 @@ func (suite *VolumesSuite) TestFSTrimDefaultSchedule() {
 	}
 }
 
+=======
+	// Override the default 2-minute context: stability wait (10 min) + grow wait (5 min).
+	suite.ctxCancel()
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 20*time.Minute)
+
+	// Use a single control plane node — etcd lives on EPHEMERAL there.
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	ctx := client.WithNode(suite.ctx, node)
+
+	suite.T().Logf("target node: %s", node)
+
+	// --- Step 1: record baseline ---
+	//
+	// Confirm EPHEMERAL is Ready and capture its current size.
+	var initialSize uint64
+
+	rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI,
+		constants.EphemeralPartitionLabel,
+		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase)
+			initialSize = vs.TypedSpec().Size
+		})
+
+	suite.Require().NotZero(initialSize, "EPHEMERAL size must be non-zero before resize")
+	suite.T().Logf("initial EPHEMERAL size: %d bytes", initialSize)
+
+	// --- Step 1b: wait for post-kexec stability ---
+	//
+	// In QEMU tests, Talos boots from the initramfs, installs to disk, then
+	// kexec's to the installed system. Wait for EPHEMERAL to remain in
+	// VolumePhaseReady without interruption for 60 s before triggering
+	// the resize, to avoid racing with volume lifecycle transitions.
+	suite.T().Log("waiting for EPHEMERAL stability before resizing disk...")
+
+	stableUntil := time.Now().Add(60 * time.Second)
+
+	suite.Require().Eventually(func() bool {
+		vs, vsErr := safe.StateGetByID[*block.VolumeStatus](
+			ctx, suite.Client.COSI, constants.EphemeralPartitionLabel,
+		)
+		if vsErr != nil || vs.TypedSpec().Phase != block.VolumePhaseReady {
+			stableUntil = time.Now().Add(60 * time.Second)
+
+			return false
+		}
+
+		return time.Now().After(stableUntil)
+	}, 10*time.Minute, 3*time.Second,
+		"EPHEMERAL did not reach stable Ready state within 10 minutes")
+
+	suite.T().Log("EPHEMERAL stable, proceeding with disk resize")
+
+	// --- Step 2: locate the QEMU disk file and monitor socket ---
+
+	stateDir, err := suite.Cluster.StatePath()
+	suite.Require().NoError(err)
+
+	nodeInfo, ok := findProvisionNodeByIP(suite.Cluster.Info().Nodes, node)
+	suite.Require().True(ok, "node %s not found in cluster info", node)
+
+	// System disk is always index 0 → "<nodeName>-0.disk"
+	// Monitor socket is "<nodeName>.monitor"
+	// (matches pkg/provision/providers/vm/disk.go and qemu/node.go naming)
+	diskPath := filepath.Join(stateDir, nodeInfo.Name+"-0.disk")
+	monitorPath := filepath.Join(stateDir, nodeInfo.Name+".monitor")
+
+	diskStat, err := os.Stat(diskPath)
+	suite.Require().NoError(err, "disk file not found: %s", diskPath)
+
+	currentDiskSize := uint64(diskStat.Size())
+	newDiskSize := currentDiskSize + 1*1024*1024*1024 // +1 GiB
+
+	suite.T().Logf("expanding disk %s: %d → %d bytes", diskPath, currentDiskSize, newDiskSize)
+
+	logQEMUProcessLimits(suite.T(), monitorPath)
+
+	// --- Step 3: trigger the resize ---
+	//
+	// resizeQEMUDisk truncates the backing file directly (guaranteed) then sends
+	// block_resize via the QEMU HMP monitor to trigger the virtio-blk config-change
+	// interrupt so the guest kernel updates /sys/block/vda/size.
+	// resizeQEMUDisk errors are non-fatal here: the function always truncates the
+	// backing file first, so the disk is at the new size even if the QEMU monitor
+	// notification fails. Step 4 asserts the file size; step 5 asserts Talos grew.
+	if resizeErr := resizeQEMUDisk(suite.ctx, diskPath, monitorPath, newDiskSize); resizeErr != nil {
+		suite.T().Logf("disk resize error: %v", resizeErr)
+	}
+
+	suite.T().Logf("resizeQEMUDisk completed")
+
+	// --- Step 4: confirm the QEMU block_resize command worked ---
+	//
+	// Verify the backing file on the host was actually truncated to the new size.
+	// This is a host-side check (os.Stat) so it doesn't depend on the in-VM
+	// virtio event chain, which can be slow under load. The virtio notification
+	// to the guest kernel will happen asynchronously; step 5 captures whether
+	// Talos reacts to it.
+	diskStatAfter, err := os.Stat(diskPath)
+	suite.Require().NoError(err)
+	suite.Require().GreaterOrEqual(uint64(diskStatAfter.Size()), newDiskSize,
+		"QEMU block_resize did not resize the backing file")
+
+	// --- Step 4b: confirm the kernel inside the VM saw the new disk size ---
+	//
+	// DisksController publishes Disk.Size from /sys/block/<dev>/size (ioctl BLKGETSIZE64).
+	// If this never updates, the virtio notification didn't reach the kernel and
+	// our Grow() code can't find available partition space.
+	suite.Require().Eventually(func() bool {
+		return anyDiskReachedSize(ctx, suite.Client.COSI, newDiskSize)
+	}, 60*time.Second, 500*time.Millisecond,
+		"kernel did not detect disk resize within 60s — virtio notification did not reach the guest; VolumeManagerController cannot grow without a Disk size change event")
+
+	suite.T().Log("kernel detected disk resize (virtio notification OK) — waiting for Talos to grow EPHEMERAL")
+
+	// --- Step 5: assert EPHEMERAL grew ---
+	//
+	// DisksController updates Disk.Size when the kernel reports the new size via
+	// udev; VolumeManagerController reacts to that COSI event, calls Grow() on
+	// the ready volume, expands the partition via BLKPG_RESIZE_PARTITION, then
+	// runs XFSGrow on the live filesystem. VolumeStatus.Size is updated.
+	suite.Require().Eventually(func() bool {
+		vs, err := safe.StateGetByID[*block.VolumeStatus](
+			ctx, suite.Client.COSI, constants.EphemeralPartitionLabel,
+		)
+		if err != nil {
+			return false
+		}
+
+		return vs.TypedSpec().Size > initialSize
+	}, 5*time.Minute, 500*time.Millisecond,
+		"EPHEMERAL did not grow after live disk resize (expected size > %d)", initialSize)
+
+	grownSize := uint64(0)
+
+	rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI,
+		constants.EphemeralPartitionLabel,
+		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+			asrt.Equal(block.VolumePhaseReady, vs.TypedSpec().Phase,
+				"volume must remain Ready after live grow")
+			asrt.Greater(vs.TypedSpec().Size, initialSize,
+				"volume size must have increased")
+			grownSize = vs.TypedSpec().Size
+		})
+
+	suite.T().Logf("EPHEMERAL grew: %d → %d bytes (+%d MiB)",
+		initialSize, grownSize, (grownSize-initialSize)/(1024*1024))
+}
+
+// resizeQEMUDisk resizes the VM's backing disk file and attempts to notify the
+// guest kernel via the QEMU HMP monitor's block_resize command.
+//
+// The file is extended first — this always succeeds when there is enough host
+// disk space. sendHMPBlockResize is then called to trigger the virtio-blk
+// config-change interrupt so the guest kernel updates /sys/block/vda/size.
+//
+// If sendHMPBlockResize fails, the function returns an error; the caller
+// treats this as non-fatal because the file is already at the new size.
+// In that case the guest kernel will NOT detect the resize and step 5 of
+// the test will time out.
+func resizeQEMUDisk(ctx context.Context, diskPath, monitorPath string, newSizeBytes uint64) error {
+	// Step 1: extend the backing file by writing a real byte at the new end
+	// position. Using os.Truncate creates a SPARSE file extension which QEMU
+	// does not see after a process restart (it falls back to the last allocated
+	// block). Writing an actual byte ensures the file has the correct st_size
+	// AND that QEMU's new process sees 17 GiB when it opens the file fresh.
+	f, err := os.OpenFile(diskPath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open disk file: %w", err)
+	}
+
+	if _, err = f.Seek(int64(newSizeBytes)-1, io.SeekStart); err != nil {
+		f.Close() //nolint:errcheck
+
+		return fmt.Errorf("seek disk file: %w", err)
+	}
+
+	if _, err = f.Write([]byte{0}); err != nil {
+		f.Close() //nolint:errcheck
+
+		return fmt.Errorf("write disk file end: %w", err)
+	}
+
+	if err = f.Sync(); err != nil {
+		f.Close() //nolint:errcheck
+
+		return fmt.Errorf("sync disk file: %w", err)
+	}
+
+	f.Close() //nolint:errcheck
+
+	// Verify the file is at the new size.
+	stat, statErr := os.Stat(diskPath)
+	if statErr != nil {
+		return fmt.Errorf("stat disk file after resize: %w", statErr)
+	}
+
+	if uint64(stat.Size()) < newSizeBytes {
+		return fmt.Errorf("disk file size %d < expected %d after resize", stat.Size(), newSizeBytes)
+	}
+
+	// Step 2: notify QEMU so it updates the virtio config and sends the
+	// config-change interrupt to the guest kernel.
+	// Drive ID "virtio0" matches `-drive id=virtio0,...` in qemu/launch.go.
+	if err := sendHMPBlockResize(ctx, monitorPath, "virtio0", newSizeBytes); err != nil {
+		// Return as diagnostic info — the file is already at the new size.
+		return fmt.Errorf("file resized but QEMU notification failed: %w", err)
+	}
+
+	return nil
+}
+
+// sendHMPBlockResize connects to the QEMU HMP monitor socket and sends a
+// block_resize command for the given drive ID.
+// It reads the banner and each response by looping until the "(qemu) " prompt.
+// Returns nil on success, error with full QEMU response on failure.
+func sendHMPBlockResize(ctx context.Context, monitorPath, driveID string, newSizeBytes uint64) error { //nolint:cyclop
+	conn, err := (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, "unix", monitorPath)
+	if err != nil {
+		return fmt.Errorf("connect to monitor: %w", err)
+	}
+
+	defer conn.Close() //nolint:errcheck
+
+	// readUntilPrompt reads bytes until "(qemu) " appears, with a timeout.
+	readUntilPrompt := func(timeout time.Duration) (string, error) {
+		conn.SetDeadline(time.Now().Add(timeout)) //nolint:errcheck
+
+		var buf strings.Builder
+
+		tmp := make([]byte, 256)
+
+		for {
+			n, readErr := conn.Read(tmp)
+			if n > 0 {
+				buf.Write(tmp[:n])
+
+				if strings.Contains(buf.String(), "(qemu) ") {
+					return buf.String(), nil
+				}
+			}
+
+			if readErr != nil {
+				return buf.String(), readErr
+			}
+		}
+	}
+
+	// Consume the welcome banner.
+	if _, err = readUntilPrompt(5 * time.Second); err != nil {
+		return fmt.Errorf("read banner: %w", err)
+	}
+
+	// Send the resize command directly without pausing the VM.
+	// Using stop/cont caused the virtio interrupt to be delayed by minutes
+	// because the VM was left paused; this made step 5 always time out.
+	cmd := fmt.Sprintf("block_resize %s %dB\n", driveID, newSizeBytes)
+	if _, err = fmt.Fprint(conn, cmd); err != nil {
+		return fmt.Errorf("send block_resize: %w", err)
+	}
+
+	resp, readErr := readUntilPrompt(5 * time.Second)
+
+	if strings.Contains(resp, "Error") || strings.Contains(resp, "error") {
+		return fmt.Errorf("block_resize rejected (drive=%s size=%d resp=%q)",
+			driveID, newSizeBytes, strings.TrimSpace(resp))
+	}
+
+	return readErr
+}
+
+// logQEMUProcessLimits logs the process resource limits of the QEMU process for the given monitor socket.
+func logQEMUProcessLimits(t testing.TB, monitorPath string) {
+	pidBytes, pidErr := os.ReadFile(strings.TrimSuffix(monitorPath, ".monitor") + ".pid")
+	if pidErr != nil {
+		return
+	}
+
+	limits, limErr := os.ReadFile(fmt.Sprintf("/proc/%s/limits", strings.TrimSpace(string(pidBytes))))
+	if limErr != nil {
+		return
+	}
+
+	for line := range strings.SplitSeq(string(limits), "\n") {
+		if strings.Contains(line, "file size") || strings.Contains(line, "Max file") {
+			t.Logf("QEMU process limits: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+// anyDiskReachedSize returns true if any Disk resource in COSI has a size >= minSize.
+func anyDiskReachedSize(ctx context.Context, cosi state.State, minSize uint64) bool {
+	disks, err := safe.StateListAll[*block.Disk](ctx, cosi)
+	if err != nil {
+		return false
+	}
+
+	for disk := range disks.All() {
+		if disk.TypedSpec().Size >= minSize {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findProvisionNodeByIP returns the provision.NodeInfo whose IPs contain the given address.
+func findProvisionNodeByIP(nodes []provision.NodeInfo, ip string) (provision.NodeInfo, bool) {
+	for _, n := range nodes {
+		for _, addr := range n.IPs {
+			if addr.String() == ip {
+				return n, true
+			}
+		}
+	}
+
+	return provision.NodeInfo{}, false
+}
+
+>>>>>>> 0c68137ce (feat(machined): live-grow partition and XFS filesystem when backing disk is expanded)
 func init() {
 	allSuites = append(allSuites, new(VolumesSuite))
 }


### PR DESCRIPTION
## What?

When a virtual machine's disk is expanded at the hypervisor level (e.g.
`qemu-img resize`, vSphere disk extension), Talos now automatically grows
the EPHEMERAL partition and its XFS filesystem without requiring a reboot.

Changes:

- **`volume_manager.go`**: `VolumeManagerController` adds a 30-second ticker
  that calls `Grow()` on volumes in `VolumePhaseReady`. When growth is detected,
  the GPT partition is extended via `BLKPG_RESIZE_PARTITION` (safe for mounted
  partitions) and the XFS filesystem is grown inline via `xfs_growfs`.
  `ctx.Done()` now returns a non-nil error so the rruntime adapter restarts the
  controller instead of treating it as permanently finished.

- **`grow.go`**: `Grow()` signature changed from `error` to `(bool, error)` —
  returns `true` when the partition actually grew, so `XFSGrow` is only called
  when needed. Phase advancement removed from `Grow()`; that is now the
  caller's responsibility.

- **`volumes.go`**: integration test `TestLiveDiskResize` that truncates the
  QEMU backing file, sends a `block_resize` notification via the HMP monitor,
  and asserts that `EPHEMERAL` `VolumeStatus.Size` increases within 5 minutes
  without a reboot.

## Why?

Talos nodes on QEMU (and other hypervisors) can have their virtual disks
expanded while running. Today that extra space is invisible until a full
reinstall or reboot. This change makes Talos respond to available partition
growth on the next 30-second tick, which is already the cadence used by the
volume manager for other housekeeping.

The `BLKPG_RESIZE_PARTITION` ioctl is explicitly designed for resizing mounted
partitions in-place; `xfs_growfs` handles live XFS expansion. Both operations
are non-destructive and safe to run while the filesystem is mounted.

## Acceptance

- [x] you linked an issue (if applicable) — no upstream issue; this is a
      quality-of-life improvement for VM operators
- [x] you included tests — `TestLiveDiskResize` integration test (QEMU only);
      `grow_test.go` updated to match new `Grow()` signature and assert the
      phase-not-modified contract
- [x] you ran conformance (`make conformance`) — passes (GPG Identity check
      fails as expected for external contributors)
- [x] you formatted your code (`make fmt`) — gofumpt fix applied manually
      (`make lint-fmt` hit a BuildKit cache bug on the dev machine)
- [x] you linted your code (`make lint`) — passes
- [ ] you generated documentation (`make docs`) — not applicable, no new
      user-facing configuration
- [x] you ran unit-tests (`make unit-tests`) — verified via
      `go test ./internal/app/machined/pkg/controllers/block/...`; full
      `make unit-tests` blocked by disk space on dev machine, disk-operation
      tests require root and skip gracefully without it