### PR TITLE
fix: relax hostname config validation

### DIFF
--- a/internal/app/machined/pkg/controllers/network/hostname_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config_test.go
@@ -199,6 +199,21 @@ func (suite *HostnameConfigSuite) TestMachineConfigurationDefaultStable() {
 	}, rtestutils.WithNamespace(network.ConfigNamespaceName))
 }
 
+func (suite *HostnameConfigSuite) TestMachineConfigurationDefaultOff() {
+	suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.HostnameConfigController{}))
+
+	hostnameCfg := networkcfg.NewHostnameConfigV1Alpha1()
+	hostnameCfg.ConfigAuto = new(nethelpers.AutoHostnameKindOff)
+
+	ctr, err := container.New(hostnameCfg)
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(ctr)
+	suite.Create(cfg)
+
+	ctest.AssertNoResource[*network.HostnameSpec](suite, "default/hostname", rtestutils.WithNamespace(network.ConfigNamespaceName))
+}
+
 func TestHostnameConfigSuite(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/machinery/config/types/network/hostname.go
+++ b/pkg/machinery/config/types/network/hostname.go
@@ -115,7 +115,7 @@ func (s *HostnameConfigV1Alpha1) Clone() config.Document {
 func (s *HostnameConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Option) ([]string, error) {
 	var errs error
 
-	if pointer.SafeDeref(s.ConfigAuto) == nethelpers.AutoHostnameKindOff && s.ConfigHostname == "" {
+	if s.ConfigAuto == nil && s.ConfigHostname == "" {
 		errs = errors.Join(errs, errors.New("either 'auto' or 'hostname' must be set"))
 	}
 

--- a/pkg/machinery/config/types/network/hostname_test.go
+++ b/pkg/machinery/config/types/network/hostname_test.go
@@ -136,6 +136,15 @@ func TestHostnameConfigValidate(t *testing.T) {
 				return cfg
 			},
 		},
+		{
+			name: "valid 3",
+			cfg: func() *network.HostnameConfigV1Alpha1 {
+				cfg := network.NewHostnameConfigV1Alpha1()
+				cfg.ConfigAuto = new(nethelpers.AutoHostnameKindOff)
+
+				return cfg
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
It was a bug that it didn't accept a config like:

```yaml
apiVersion: v1alpha1
kind: HostnameConfig
auto: off
```

The only invalid was to never specify nor `auto`, nor `hostname`.

With this config Talos will never come up with a hostname on its own.

Fixes https://github.com/siderolabs/talos/discussions/1340