### PR TITLE
fix: perform backwards-compatible kernel args cleanup

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -318,11 +318,22 @@ func (a *AWS) Mode() runtime.Mode {
 }
 
 // KernelArgs implements the runtime.Platform interface.
-func (a *AWS) KernelArgs(string, quirks.Quirks) procfs.Parameters {
-	return []*procfs.Parameter{
+func (a *AWS) KernelArgs(_ string, q quirks.Quirks) procfs.Parameters {
+	result := []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
 		procfs.NewParameter(constants.KernelParamNetIfnames).Append("0"),
 	}
+
+	if q.NvmeCoreIoTimeoutAWSOnly() {
+		// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
+		// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
+		result = append(
+			result,
+			procfs.NewParameter("nvme_core.io_timeout").Append("4294967295"),
+		)
+	}
+
+	return result
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.

--- a/pkg/imager/imager_test.go
+++ b/pkg/imager/imager_test.go
@@ -148,6 +148,126 @@ func TestImager(t *testing.T) {
 
 			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on selinux=1", //nolint:lll
 		},
+		{
+			name: "cmdline-1.13-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.13.0",
+			},
+
+			expected: "talos.platform=metal console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-1.13-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.13.0",
+			},
+
+			expected: "talos.platform=metal console=ttyAMA0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-aws-1.13-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "aws",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.13.0",
+			},
+
+			expected: "talos.platform=aws console=tty1 console=ttyS0 net.ifnames=0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-aws-1.13-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "aws",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.13.0",
+			},
+
+			expected: "talos.platform=aws console=tty1 console=ttyS0 net.ifnames=0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-1.14-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.14.0",
+			},
+
+			expected: "talos.platform=metal console=tty0 slab_nomerge pti=on consoleblank=0 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-1.14-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "metal",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.14.0",
+			},
+
+			expected: "talos.platform=metal console=ttyAMA0 console=tty0 slab_nomerge pti=on consoleblank=0 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-aws-1.14-amd64",
+
+			prof: profile.Profile{
+				BaseProfileName: "aws",
+				Arch:            "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.14.0",
+			},
+
+			expected: "talos.platform=aws console=tty1 console=ttyS0 net.ifnames=0 nvme_core.io_timeout=4294967295 slab_nomerge pti=on consoleblank=0 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
+		{
+			name: "cmdline-aws-1.14-arm64",
+
+			prof: profile.Profile{
+				BaseProfileName: "aws",
+				Arch:            "arm64",
+				Output: profile.Output{
+					Kind:      profile.OutKindCmdline,
+					OutFormat: profile.OutFormatRaw,
+				},
+				Version: "1.14.0",
+			},
+
+			expected: "talos.platform=aws console=tty1 console=ttyS0 net.ifnames=0 nvme_core.io_timeout=4294967295 slab_nomerge pti=on consoleblank=0 printk.devkmsg=on selinux=1 module.sig_enforce=1 proc_mem.force_override=never", //nolint:lll
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/kernel/kspp/kspp.go
+++ b/pkg/kernel/kspp/kspp.go
@@ -17,8 +17,10 @@ import (
 // RequiredKSPPKernelParameters is the set of kernel parameters required to
 // satisfy the KSPP.
 var RequiredKSPPKernelParameters = procfs.Parameters{
-	// init_on_alloc and init_on_free are not enforced, as they default to '1' in kernel config
-	// this way they can be overridden via installer extra args in case of severe performance issues
+	// init_on_alloc and init_on_free are not enforced, as:
+	// - init_on_alloc is enabled by default in the kernel config, but can be disabled with init_on_alloc=0 for performance reasons;
+	// - init_on_free is disabled by default in the kernel config, as it has a significant performance impact, and is not required for security when init_on_alloc=1 is enabled.
+	//
 	// procfs.NewParameter("init_on_alloc").Append("1"),
 	// procfs.NewParameter("init_on_free").Append("1"),
 	procfs.NewParameter("slab_nomerge").Append(""),

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -336,3 +336,27 @@ func (q Quirks) SupportsFactoryTalosctlDownload() bool {
 
 	return q.v.GTE(minTalosVersionFactoryTalosctlDownload)
 }
+
+var minTalosVersionDropInitOnAllocInArgs = semver.MustParse("1.14.0")
+
+// DropInitOnAllocInArgs returns true if the Talos version should have no init_on_alloc=1 by default.
+func (q Quirks) DropInitOnAllocInArgs() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minTalosVersionDropInitOnAllocInArgs)
+}
+
+var minTalosVersionNvmeCoreIoTimeoutAWSOnly = semver.MustParse("1.14.0")
+
+// NvmeCoreIoTimeoutAWSOnly returns true if the Talos version should have nvme_core.io_timeout=4294967295 only for AWS.
+func (q Quirks) NvmeCoreIoTimeoutAWSOnly() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return true
+	}
+
+	return q.v.GTE(minTalosVersionNvmeCoreIoTimeoutAWSOnly)
+}

--- a/pkg/machinery/imager/quirks/quirks_test.go
+++ b/pkg/machinery/imager/quirks/quirks_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestSupportsResetOption(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		version string
 
@@ -31,12 +33,16 @@ func TestSupportsResetOption(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, test.expected, quirks.New(test.version).SupportsResetGRUBOption())
 		})
 	}
 }
 
 func TestSupportsCompressedEncodedMETA(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		version string
 
@@ -59,12 +65,16 @@ func TestSupportsCompressedEncodedMETA(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, test.expected, quirks.New(test.version).SupportsCompressedEncodedMETA())
 		})
 	}
 }
 
 func TestSupportsOverlay(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		version string
 
@@ -95,12 +105,16 @@ func TestSupportsOverlay(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, test.expected, quirks.New(test.version).SupportsOverlay())
 		})
 	}
 }
 
 func TestSupportsZstd(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		version string
 
@@ -127,12 +141,16 @@ func TestSupportsZstd(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, test.expected, quirks.New(test.version).UseZSTDCompression())
 		})
 	}
 }
 
 func TestXFSMkfsConfigFile(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		version string
 
@@ -176,12 +194,16 @@ func TestXFSMkfsConfigFile(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, test.expected, quirks.New(test.version).XFSMkfsConfig())
 		})
 	}
 }
 
 func TestPartitionSizes(t *testing.T) {
+	t.Parallel()
+
 	const (
 		MiB = 1024 * 1024
 		GiB = 1024 * MiB
@@ -241,6 +263,8 @@ func TestPartitionSizes(t *testing.T) {
 		},
 	} {
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
 			ps := quirks.New(test.version).PartitionSizes()
 
 			assert.Equal(t, test.grubEFISize, ps.GrubEFISize())
@@ -250,6 +274,56 @@ func TestPartitionSizes(t *testing.T) {
 			assert.Equal(t, test.metaSize, ps.METASize())
 			assert.Equal(t, test.stateSize, ps.StateSize())
 			assert.Equal(t, test.ephemeralMinSize, ps.EphemeralMinSize())
+		})
+	}
+}
+
+func TestDropInitOnAllocInArgs(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		version string
+
+		expected bool
+	}{
+		{
+			version:  "1.13.0",
+			expected: false,
+		},
+		{
+			version:  "1.14.0-alpha.1",
+			expected: true,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, quirks.New(test.version).DropInitOnAllocInArgs())
+		})
+	}
+}
+
+func TestNvmeCoreIoTimeoutAWSOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		version string
+
+		expected bool
+	}{
+		{
+			version:  "1.13.0",
+			expected: false,
+		},
+		{
+			version:  "1.14.0-alpha.1",
+			expected: true,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, quirks.New(test.version).NvmeCoreIoTimeoutAWSOnly())
 		})
 	}
 }

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -22,17 +22,36 @@ const (
 
 // DefaultArgs returns the Talos default kernel commandline options.
 func DefaultArgs(quirks quirks.Quirks) []string {
-	result := []string{
-		"init_on_alloc=1",
+	var result []string
+
+	if !quirks.DropInitOnAllocInArgs() {
+		result = append(
+			result,
+			"init_on_alloc=1",
+		)
+	}
+
+	result = append(
+		result,
 		"slab_nomerge=",
 		"pti=on",
 		"consoleblank=0",
+	)
+
+	if !quirks.NvmeCoreIoTimeoutAWSOnly() {
 		// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
 		// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
-		"nvme_core.io_timeout=4294967295",
-		// Disable rate limited printk
-		"printk.devkmsg=on",
+		result = append(
+			result,
+			"nvme_core.io_timeout=4294967295",
+		)
 	}
+
+	// Disable rate limited printk
+	result = append(
+		result,
+		"printk.devkmsg=on",
+	)
 
 	if quirks.SupportsIMA() {
 		// Enable IMAs for integrity measurement

--- a/pkg/machinery/kernel/kernel_test.go
+++ b/pkg/machinery/kernel/kernel_test.go
@@ -83,11 +83,9 @@ func TestDefaultKernelArgs(t *testing.T) {
 			name: "latest",
 
 			expected: []string{
-				"init_on_alloc=1",
 				"slab_nomerge=",
 				"pti=on",
 				"consoleblank=0",
-				"nvme_core.io_timeout=4294967295",
 				"printk.devkmsg=on",
 				"selinux=1",
 				"module.sig_enforce=1",
@@ -138,6 +136,21 @@ func TestDefaultKernelArgs(t *testing.T) {
 				"pti=on",
 				"consoleblank=0",
 				"nvme_core.io_timeout=4294967295",
+				"printk.devkmsg=on",
+				"selinux=1",
+				"module.sig_enforce=1",
+				"proc_mem.force_override=never",
+			},
+		},
+		{
+			name: "v1.14",
+
+			quirks: quirks.New("v1.14.0"),
+
+			expected: []string{
+				"slab_nomerge=",
+				"pti=on",
+				"consoleblank=0",
 				"printk.devkmsg=on",
 				"selinux=1",
 				"module.sig_enforce=1",

--- a/website/content/v1.14/reference/kernel.md
+++ b/website/content/v1.14/reference/kernel.md
@@ -16,11 +16,6 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 * `slab_nomerge`: required by KSPP
 * `pti=on`: required by KSPP
 
-**Recommended** parameters:
-
-* `init_on_alloc=1`: advised by KSPP, enabled by default in kernel config
-* `init_on_free=1`: advised by KSPP, enabled by default in kernel config
-
 ### Available Talos-specific parameters
 
 #### `ip`


### PR DESCRIPTION
Two changes:

* `nvme_core.io_timeout` is AWS-specific, move into AWS platform code
* `init_on_alloc` is enabled by default in the kernel config, so a kernel arg is no-op and confusing (as removing it won't disable it)
