### PR TITLE
feat: allow overriding kubelet kubeconfig tls-server-name when KubePrism is enabled

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_service.go
@@ -208,7 +208,7 @@ func (ctrl *KubeletServiceController) Run(ctx context.Context, r controller.Runt
 			return err
 		}
 
-		if err = ctrl.updateKubeconfig(secretSpec.Endpoint, secretSpec.AcceptedCAs, logger); err != nil {
+		if err = ctrl.updateKubeconfig(secretSpec.Endpoint, secretSpec.EndpointTLSServerName, secretSpec.AcceptedCAs, logger); err != nil {
 			return err
 		}
 
@@ -306,6 +306,7 @@ func (ctrl *KubeletServiceController) writePKI(secretSpec *secrets.KubeletSpec) 
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"local": {
 				Server:                   secretSpec.Endpoint.String(),
+				TLSServerName:            secretSpec.EndpointTLSServerName,
 				CertificateAuthorityData: acceptedCAs,
 			},
 		},
@@ -394,7 +395,7 @@ func (ctrl *KubeletServiceController) writeKubeletCredentialProviderConfig(cfgSp
 }
 
 // updateKubeconfig updates the kubeconfig of kubelet with the given endpoint if it exists.
-func (ctrl *KubeletServiceController) updateKubeconfig(newEndpoint *url.URL, acceptedCAs []*talosx509.PEMEncodedCertificate, logger *zap.Logger) error {
+func (ctrl *KubeletServiceController) updateKubeconfig(newEndpoint *url.URL, newTLSServerName string, acceptedCAs []*talosx509.PEMEncodedCertificate, logger *zap.Logger) error {
 	config, err := clientcmd.LoadFromFile(constants.KubeletKubeconfig)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -422,6 +423,7 @@ func (ctrl *KubeletServiceController) updateKubeconfig(newEndpoint *url.URL, acc
 	}
 
 	cluster.Server = newEndpoint.String()
+	cluster.TLSServerName = newTLSServerName
 	cluster.CertificateAuthorityData = bytes.Join(xslices.Map(acceptedCAs, func(ca *talosx509.PEMEncodedCertificate) []byte { return ca.Crt }), nil)
 
 	return clientcmd.WriteToFile(*config, constants.KubeletKubeconfig)

--- a/internal/app/machined/pkg/controllers/secrets/kubelet.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubelet.go
@@ -43,6 +43,8 @@ func NewKubeletController() *KubeletController {
 				cfgProvider := cfg.Config()
 				kubeletSecrets := res.TypedSpec()
 
+				kubeletSecrets.EndpointTLSServerName = ""
+
 				switch {
 				case cfgProvider.Machine().Features().KubePrism().Enabled():
 					// use cluster endpoint for controlplane nodes with loadbalancer support
@@ -52,6 +54,7 @@ func NewKubeletController() *KubeletController {
 					}
 
 					kubeletSecrets.Endpoint = localEndpoint
+					kubeletSecrets.EndpointTLSServerName = cfgProvider.Machine().Features().KubePrism().TLSServerName()
 				case cfgProvider.Machine().Type().IsControlPlane():
 					// use localhost endpoint for controlplane nodes
 					localEndpoint, err := url.Parse(fmt.Sprintf("https://localhost:%d", cfgProvider.Cluster().LocalAPIServerPort()))

--- a/internal/app/machined/pkg/controllers/secrets/kubelet_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubelet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/crypto/x509"
+	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
 
@@ -92,6 +93,82 @@ func (suite *KubeletSuite) TestReconcile() {
 				suite.Assert().Equal([]*x509.PEMEncodedCertificate{{Crt: k8sCA.Crt}}, spec.AcceptedCAs)
 				suite.Assert().Equal("abc", spec.BootstrapTokenID)
 				suite.Assert().Equal("def", spec.BootstrapTokenSecret)
+				suite.Assert().Equal("", spec.EndpointTLSServerName)
+
+				return nil
+			},
+		),
+	)
+}
+
+// TestReconcileKubePrismTLSServerName verifies that when KubePrism is enabled
+// with a tlsServerName, the kubelet endpoint stays on loopback and the
+// EndpointTLSServerName is propagated to the resource for kubeconfig generation.
+func (suite *KubeletSuite) TestReconcileKubePrismTLSServerName() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	ca, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(false))
+	suite.Require().NoError(err)
+
+	k8sCA := x509.NewCertificateAndKeyFromCertificateAuthority(ca)
+
+	cfg := config.NewMachineConfig(
+		container.NewV1Alpha1(
+			&v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineFeatures: &v1alpha1.FeaturesConfig{
+						KubePrismSupport: &v1alpha1.KubePrism{
+							ServerEnabled:       pointer.To(true),
+							ServerPort:          7445,
+							ServerTLSServerName: "cluster-xyz.example.com",
+						},
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							URL: u,
+						},
+					},
+					ClusterCA:      k8sCA,
+					BootstrapToken: "abc.def",
+				},
+			},
+		),
+	)
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), cfg))
+
+	suite.Assert().NoError(
+		retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				kubeletSecrets, err := ctest.Get[*secrets.Kubelet](
+					suite,
+					resource.NewMetadata(
+						secrets.NamespaceName,
+						secrets.KubeletType,
+						secrets.KubeletID,
+						resource.VersionUndefined,
+					),
+				)
+				if err != nil {
+					if state.IsNotFoundError(err) {
+						return retry.ExpectedError(err)
+					}
+
+					return err
+				}
+
+				spec := kubeletSecrets.TypedSpec()
+
+				if spec.EndpointTLSServerName != "cluster-xyz.example.com" {
+					return retry.ExpectedErrorf("EndpointTLSServerName not propagated yet: %q", spec.EndpointTLSServerName)
+				}
+
+				suite.Assert().Equal("https://127.0.0.1:7445", spec.Endpoint.String())
+				suite.Assert().Equal("cluster-xyz.example.com", spec.EndpointTLSServerName)
 
 				return nil
 			},

--- a/pkg/machinery/config/config/machine.go
+++ b/pkg/machinery/config/config/machine.go
@@ -384,6 +384,7 @@ type KubernetesTalosAPIAccess interface {
 type KubePrism interface {
 	Enabled() bool
 	Port() int
+	TLSServerName() string
 }
 
 // UdevConfig describes configuration for udev.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_features.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_features.go
@@ -60,6 +60,11 @@ func (a *KubePrism) Port() int {
 	return a.ServerPort
 }
 
+// TLSServerName implements [config.KubePrism].
+func (a *KubePrism) TLSServerName() string {
+	return a.ServerTLSServerName
+}
+
 // HostDNSEnabled implements config.NetworkHostDNSConfig interface.
 func (h *HostDNSConfig) HostDNSEnabled() bool {
 	return pointer.SafeDeref(h.HostDNSConfigEnabled)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -2293,6 +2293,22 @@ type KubePrism struct {
 	//   description: |
 	//     KubePrism port.
 	ServerPort int `yaml:"port,omitempty"`
+	//   description: |
+	//     Override the TLS server name (SNI) used by the kubelet when connecting to
+	//     the KubePrism endpoint.
+	//
+	//     KubePrism still listens on `127.0.0.1:<port>` and the kubelet still dials
+	//     that address, but the generated kubelet kubeconfig will carry
+	//     `clusters[0].cluster.tls-server-name` set to this value, so the kubelet
+	//     uses it for SNI and certificate hostname verification.
+	//
+	//     This is useful when KubePrism's upstream apiserver is reached through an
+	//     SNI-routing L4 proxy (for example nginx-ingress in ssl-passthrough mode in
+	//     front of a Kamaji-hosted apiserver), where SNI=127.0.0.1 doesn't match any
+	//     route and the proxy serves a fallback certificate.
+	//
+	//     When empty (default), no `tls-server-name` is set and behavior is unchanged.
+	ServerTLSServerName string `yaml:"tlsServerName,omitempty"`
 }
 
 // ImageCacheConfig describes the configuration for the Image Cache feature.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1793,6 +1793,13 @@ func (KubePrism) Doc() *encoder.Doc {
 				Description: "KubePrism port.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "KubePrism port." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "tlsServerName",
+				Type:        "string",
+				Note:        "",
+				Description: "Override the TLS server name (SNI) used by the kubelet when connecting to\nthe KubePrism endpoint.\n\nKubePrism still listens on `127.0.0.1:<port>` and the kubelet still dials\nthat address, but the generated kubelet kubeconfig will carry\n`clusters[0].cluster.tls-server-name` set to this value, so the kubelet\nuses it for SNI and certificate hostname verification.\n\nThis is useful when KubePrism's upstream apiserver is reached through an\nSNI-routing L4 proxy (for example nginx-ingress in ssl-passthrough mode in\nfront of a Kamaji-hosted apiserver), where SNI=127.0.0.1 doesn't match any\nroute and the proxy serves a fallback certificate.\n\nWhen empty (default), no `tls-server-name` is set and behavior is unchanged.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Override the TLS server name (SNI) used by the kubelet when connecting to" /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/pkg/machinery/resources/secrets/kubelet.go
+++ b/pkg/machinery/resources/secrets/kubelet.go
@@ -31,6 +31,12 @@ type Kubelet = typed.Resource[KubeletSpec, KubeletExtension]
 type KubeletSpec struct {
 	Endpoint *url.URL `yaml:"endpoint" protobuf:"1"`
 
+	// EndpointTLSServerName, when non-empty, is propagated to the generated
+	// kubelet kubeconfig as `clusters[0].cluster.tls-server-name`, overriding
+	// the SNI/hostname the kubelet uses while still dialing Endpoint as the
+	// TCP destination.
+	EndpointTLSServerName string `yaml:"endpointTLSServerName,omitempty" protobuf:"6"`
+
 	AcceptedCAs []*x509.PEMEncodedCertificate `yaml:"acceptedCAs" protobuf:"5"`
 
 	BootstrapTokenID     string `yaml:"bootstrapTokenID" protobuf:"3"`

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -701,6 +701,7 @@ KubePrism describes the configuration for the KubePrism load balancer.
 |-------|------|-------------|----------|
 |`enabled` |bool |Enable KubePrism support - will start local load balancing proxy.  | |
 |`port` |int |KubePrism port.  | |
+|`tlsServerName` |string |<details><summary>Override the TLS server name (SNI) used by the kubelet when connecting to the KubePrism endpoint.</summary>KubePrism still listens on `127.0.0.1:<port>` and the kubelet still dials that address, but the generated kubelet kubeconfig will carry `clusters[0].cluster.tls-server-name` set to this value, so the kubelet uses it for SNI and certificate hostname verification.<br><br>This is useful when KubePrism's upstream apiserver is reached through an SNI-routing L4 proxy (for example nginx-ingress in ssl-passthrough mode in front of a Kamaji-hosted apiserver), where SNI=127.0.0.1 doesn't match any route and the proxy serves a fallback certificate.<br><br>When empty (default), no `tls-server-name` is set and behavior is unchanged.</details>  | |
 
 
 


### PR DESCRIPTION
# Pull Request

Refs siderolabs/talos#13424

## What? (description)

Add a new optional field `tlsServerName` to the KubePrism feature config:

```yaml
machine:
  features:
    kubePrism:
      enabled: true
      port: 7445
      tlsServerName: cluster-xyz.example.com   # new, optional, default empty
```

When set, the generated kubelet kubeconfig carries `clusters[0].cluster.tls-server-name` set to that value, so the kubelet uses it for SNI and certificate hostname verification. KubePrism keeps binding to `127.0.0.1:<port>` and the kubelet keeps dialing `https://127.0.0.1:<port>` as the TCP destination. Only the TLS SNI/hostname that the kubelet sends and verifies against is decoupled from the TCP target.

When the field is empty (default), behavior is unchanged.

## Why? (reasoning)

In `internal/app/machined/pkg/controllers/secrets/kubelet.go` the endpoint is hardcoded:

```go
localEndpoint, err := url.Parse(fmt.Sprintf("https://127.0.0.1:%d", cfgProvider.Machine().Features().KubePrism().Port()))
```

This forces SNI=`127.0.0.1` over the proxied connection. In setups where KubePrism's upstream is reached through an SNI-routing L4 proxy (for example nginx-ingress in `ssl-passthrough` mode in front of a Kamaji-hosted apiserver), SNI=`127.0.0.1` does not match any ingress route and the proxy serves a fallback certificate without IP SANs, so the kubelet rejects with:

```
cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
```

Setting `tls-server-name` in the kubeconfig makes Go's `tls.Config.ServerName` (and therefore SNI) be the configured value, while the TCP destination stays loopback. This is the natural Kubernetes-native way to decouple the two, and aligns with how kubeconfigs already support this field.

## Changes

- New optional `tlsServerName` field on `KubePrism` in `pkg/machinery/config/types/v1alpha1`.
- New `TLSServerName() string` method on the `config.KubePrism` provider interface.
- New `EndpointTLSServerName` field on `secrets.KubeletSpec` resource (protobuf id `6`, `omitempty`), so the kubeconfig writer has access to the value.
- `secrets.KubeletController` populates `EndpointTLSServerName` from the KubePrism config when KubePrism is enabled, and leaves it empty otherwise.
- `k8s.KubeletServiceController.writePKI` sets `cluster.TLSServerName` on the bootstrap kubeconfig.
- `k8s.KubeletServiceController.updateKubeconfig` sets `cluster.TLSServerName` when refreshing the kubelet runtime kubeconfig.
- Regenerated `v1alpha1_types_doc.go` and updated the website config reference for `v1.14`.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

Notes on the unchecked items:

- `make conformance` and `make lint` go through the project's Docker/buildkit pipeline and were not run locally; CI will exercise them.
- Unit tests for the touched packages compile and run cleanly locally (`go test ./pkg/machinery/config/...` passes; secrets/k8s controllers compile cleanly with `GOOS=linux`).
- The new test case `TestReconcileKubePrismTLSServerName` in `internal/app/machined/pkg/controllers/secrets/kubelet_test.go` asserts that `EndpointTLSServerName` is propagated when configured.

## Test plan

- Build a Talos image with this change.
- On a cluster where KubePrism's upstream apiserver is fronted by an SNI-routing L4 proxy, set `machine.features.kubePrism.tlsServerName` to the apiserver's hostname.
- Verify `/etc/kubernetes/kubelet.conf` and `/etc/kubernetes/bootstrap-kubeconfig` contain `tls-server-name: <hostname>` under the cluster entry.
- Verify the kubelet successfully connects and registers the node.
- Verify that leaving `tlsServerName` unset produces an unchanged kubeconfig (no `tls-server-name` key) and behaves identically to current Talos.
