### PR TITLE
fix: reset QEMU UEFI variable store when disk is wiped

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -46,6 +46,7 @@ type LaunchConfig struct {
 	UKIPath                   string
 	ExtraISOPath              string
 	PFlashImages              []string
+	PFlashSpec                []PFlash
 	KernelArgs                string
 	SDStubKernelArgs          string
 	MonitorPath               string
@@ -274,6 +275,21 @@ func launchVM(config *LaunchConfig) error {
 	diskBootable, err := checkPartitions(config)
 	if err != nil {
 		return err
+	}
+
+	if !diskBootable {
+		// When the guest disk has been wiped externally we will re-attach
+		// boot media (ISO/USB/UKI/kernel) below - but UEFI keeps the
+		// previous Talos install's Boot#### entries in the variable store
+		// (flash1.img), and they point at the now-erased ESP. Without a
+		// reset, UEFI tries those entries first, fails, and never falls
+		// through to the freshly-attached boot media. Convention: pflash
+		// index 1 is the variable store, index 0 is the firmware code.
+		if len(config.PFlashSpec) >= 2 && len(config.PFlashImages) >= 2 {
+			if err := writePFlashImage(config.PFlashImages[1], config.PFlashSpec[1]); err != nil {
+				return fmt.Errorf("reset UEFI variable store: %w", err)
+			}
+		}
 	}
 
 	if config.TPMConfig.NodeName != "" {

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -37,13 +37,18 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 	arch := Arch(opts.TargetArch)
 	pidPath := state.GetRelativePath(fmt.Sprintf("%s.pid", nodeReq.Name))
 
-	var pflashImages []string
+	var (
+		pflashImages []string
+		pflashSpec   []PFlash
+	)
 
-	if pflashSpec := arch.PFlash(opts.UEFIEnabled, opts.ExtraUEFISearchPaths); pflashSpec != nil {
+	if spec := arch.PFlash(opts.UEFIEnabled, opts.ExtraUEFISearchPaths); spec != nil {
 		var err error
-		if pflashImages, err = p.createPFlashImages(state, nodeReq.Name, pflashSpec); err != nil {
+		if pflashImages, err = p.createPFlashImages(state, nodeReq.Name, spec); err != nil {
 			return provision.NodeInfo{}, fmt.Errorf("error creating flash images: %w", err)
 		}
+
+		pflashSpec = spec
 	}
 
 	vcpuCount := int64(math.RoundToEven(float64(nodeReq.NanoCPUs) / 1000 / 1000 / 1000))
@@ -172,6 +177,7 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 		KernelArgs:                cmdline.String(),
 		ExtraISOPath:              extraISOPath,
 		PFlashImages:              pflashImages,
+		PFlashSpec:                pflashSpec,
 		MonitorPath:               state.GetRelativePath(fmt.Sprintf("%s.monitor", nodeReq.Name)),
 		BadRTC:                    nodeReq.BadRTC,
 		DefaultBootOrder:          defaultBootOrder,

--- a/pkg/provision/providers/qemu/pflash.go
+++ b/pkg/provision/providers/qemu/pflash.go
@@ -14,59 +14,65 @@ import (
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
-//nolint:gocyclo
 func (p *provisioner) createPFlashImages(state *provision.State, nodeName string, pflashSpec []PFlash) ([]string, error) {
-	var images []string
+	images := make([]string, 0, len(pflashSpec))
 
 	for i, pflash := range pflashSpec {
-		if err := func(i int, pflash PFlash) error {
-			path := state.GetRelativePath(fmt.Sprintf("%s-flash%d.img", nodeName, i))
+		path := state.GetRelativePath(fmt.Sprintf("%s-flash%d.img", nodeName, i))
 
-			f, err := os.Create(path)
-			if err != nil {
-				return err
-			}
-
-			defer f.Close() //nolint:errcheck
-
-			if err = f.Truncate(pflash.Size); err != nil {
-				return err
-			}
-
-			if pflash.SourcePaths != nil {
-				for _, sourcePath := range pflash.SourcePaths {
-					var src *os.File
-
-					src, err = os.Open(sourcePath)
-					if err != nil {
-						if errors.Is(err, fs.ErrNotExist) {
-							continue
-						}
-
-						return err
-					}
-
-					defer src.Close() //nolint:errcheck
-
-					if _, err = io.Copy(f, src); err != nil {
-						return err
-					}
-
-					break
-				}
-
-				if err != nil {
-					return err
-				}
-			}
-
-			images = append(images, path)
-
-			return nil
-		}(i, pflash); err != nil {
-			return nil, err
+		if err := writePFlashImage(path, pflash); err != nil {
+			return nil, fmt.Errorf("failed to write pflash image %s: %w", path, err)
 		}
+
+		images = append(images, path)
 	}
 
 	return images, nil
+}
+
+// writePFlashImage materializes a single pflash image at path from the first
+// readable source in pflash.SourcePaths.
+func writePFlashImage(path string, pflash PFlash) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	if err = f.Truncate(pflash.Size); err != nil {
+		return err
+	}
+
+	if len(pflash.SourcePaths) == 0 {
+		return nil
+	}
+
+	for _, sourcePath := range pflash.SourcePaths {
+		src, err := os.Open(sourcePath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+
+			return err
+		}
+
+		var r io.Reader = src
+		if pflash.Size > 0 {
+			r = io.LimitReader(src, pflash.Size)
+		}
+
+		_, copyErr := io.Copy(f, r)
+
+		src.Close() //nolint:errcheck
+
+		if copyErr != nil {
+			return copyErr
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("no readable pflash source found in %v", pflash.SourcePaths)
 }


### PR DESCRIPTION
When the guest disk is wiped externally and boot media is re-attached, UEFI keeps the previous Talos install's Boot#### entries in the variable store and tries them first, failing to fall through to the newly-attached ISO/USB/UKI. Recreate flash1.img alongside flash0.img in that path so the firmware starts from a clean variable store.