### PR TITLE
fix: create parent directories when extracting tar archives

### DIFF
--- a/pkg/archiver/untar.go
+++ b/pkg/archiver/untar.go
@@ -56,7 +56,7 @@ func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[stri
 			mode := hdr.FileInfo().Mode() & os.ModePerm
 			mode |= 0o700 // make rwx for the owner
 
-			if err = os.Mkdir(path, mode); err != nil && !os.IsExist(err) {
+			if err = os.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)
 			}
 
@@ -65,12 +65,20 @@ func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[stri
 			}
 
 		case tar.TypeSymlink:
+			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("error creating parent directory for symlink %q: %w", path, err)
+			}
+
 			if err = os.Symlink(hdr.Linkname, path); err != nil {
 				return fmt.Errorf("error creating symlink %q -> %q: %w", path, hdr.Linkname, err)
 			}
 
 		default:
 			mode := hdr.FileInfo().Mode()
+
+			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("error creating parent directory for file %q: %w", path, err)
+			}
 
 			fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
 			if err != nil {

--- a/pkg/archiver/untar_test.go
+++ b/pkg/archiver/untar_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package archiver_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/archiver"
+)
+
+func TestUntarCreatesParentDirectories(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	tw := tar.NewWriter(&buf)
+
+	payload := []byte("hello")
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "nested/path/file.txt",
+		Mode: 0o644,
+		Size: int64(len(payload)),
+	}))
+
+	_, err := tw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	dir := t.TempDir()
+
+	require.NoError(t, archiver.Untar(context.Background(), bytes.NewReader(buf.Bytes()), dir, nil))
+
+	data, err := os.ReadFile(filepath.Join(dir, "nested/path/file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, payload, data)
+}


### PR DESCRIPTION
## What?

Make `archiver.Untar` create parent dirs before writing file and symlink entries.
Added a small regression test too.

## Why?

Valid tar archives can contain `nested/path/file.txt` without separate dir headers first.
Today that blows up with `no such file or directory` during imager extraction of user supplied tarballs. Kinda a small footgun.

Repro:

```bash
mkdir -p src/nested/path
printf hello > src/nested/path/file.txt
tar --format=ustar --no-recursion -cf archive.tar -C src nested/path/file.txt
```

Then feed `archive.tar` into the imager path that calls `archiver.Untar`.
Before this PR it fails on file create, after this PR it extracts fine.

Related: #9772

## Acceptance

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`go test ./pkg/archiver/... ./pkg/imager/...`)
