### PR TITLE
fix(machined): Rework KernelModuleStatus state management

### DIFF
--- a/api/resource/definitions/enums/enums.proto
+++ b/api/resource/definitions/enums/enums.proto
@@ -5,12 +5,12 @@ package talos.resource.definitions.enums;
 option go_package = "github.com/siderolabs/talos/pkg/machinery/api/resource/definitions/enums";
 option java_package = "dev.talos.api.resource.definitions.enums";
 
-// RuntimeKernelModuleState represents the operational state of a dynamically loaded kernel module.
+// RuntimeKernelModuleState represents the operational state of a kernel module.
 enum RuntimeKernelModuleState {
-  KERNEL_MODULE_STATE_INACTIVE = 0;
-  KERNEL_MODULE_STATE_ACTIVE = 1;
-  KERNEL_MODULE_STATE_LOADING = 2;
-  KERNEL_MODULE_STATE_UNLOADING = 3;
+  KERNEL_MODULE_STATE_LIVE = 0;
+  KERNEL_MODULE_STATE_LOADING = 1;
+  KERNEL_MODULE_STATE_UNLOADING = 2;
+  KERNEL_MODULE_STATE_BUILTIN = 3;
 }
 
 // RuntimeKernelModuleType represents whether a kernel module is built into the kernel or dynamically loaded.

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_status.go
@@ -7,7 +7,6 @@ package runtime
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,7 +33,6 @@ type KernelModuleStatusController struct {
 
 	ProcModulesPath        string
 	ModulesBuiltinFilePath string
-	SysModulePath          string
 
 	// This never changes during the lifetime of the controller, so we can cache it here to avoid re-reading modules.builtin on every reconcile loop.
 	BuiltinModuleNames []string
@@ -80,10 +78,6 @@ func (ctrl *KernelModuleStatusController) Run(ctx context.Context, r controller.
 
 	if ctrl.ModulesBuiltinFilePath == "" {
 		ctrl.ModulesBuiltinFilePath = constants.ModulesBuiltinPath
-	}
-
-	if ctrl.SysModulePath == "" {
-		ctrl.SysModulePath = constants.SysModulePath
 	}
 
 	// Pre-load built-in modules first
@@ -165,23 +159,12 @@ func (ctrl *KernelModuleStatusController) reconcile(ctx context.Context, r contr
 
 func (ctrl *KernelModuleStatusController) reconcileBuiltinModules(ctx context.Context, r controller.Runtime) error {
 	for _, name := range ctrl.BuiltinModuleNames {
-		var state runtime.KernelModuleState
-
-		if _, err := os.Stat(ctrl.SysModulePath + "/" + name); err == nil {
-			// module_init() must've been called for this built-in module, so we can consider it active.
-			state = runtime.KernelModuleStateActive
-		} else if errors.Is(err, os.ErrNotExist) {
-			state = runtime.KernelModuleStateInactive
-		} else {
-			return fmt.Errorf("error checking if built-in module %s is active: %w", name, err)
-		}
-
 		if err := safe.WriterModify(
 			ctx, r,
 			runtime.NewKernelModuleStatus(runtime.NamespaceName, name),
 			func(res *runtime.KernelModuleStatus) error {
 				res.TypedSpec().Type = runtime.KernelModuleTypeBuiltin
-				res.TypedSpec().State = state
+				res.TypedSpec().State = runtime.KernelModuleStateBuiltin
 
 				return nil
 			},
@@ -228,11 +211,16 @@ func (ctrl *KernelModuleStatusController) reconcileDynamicModules(ctx context.Co
 			ctx, r,
 			runtime.NewKernelModuleStatus(runtime.NamespaceName, module.Name),
 			func(res *runtime.KernelModuleStatus) error {
+				state, err := runtime.ParseDynamicModuleState(module.State)
+				if err != nil {
+					return fmt.Errorf("error parsing dynamic module state for module %q from raw state %q: %w", module.Name, module.State, err)
+				}
+
 				res.TypedSpec().Type = runtime.KernelModuleTypeDynamic
 				res.TypedSpec().Size = module.Size
 				res.TypedSpec().ReferenceCount = module.ReferenceCount
 				res.TypedSpec().Dependencies = module.Dependencies
-				res.TypedSpec().State = runtime.ParseDynamicModuleState(module.State)
+				res.TypedSpec().State = state
 				res.TypedSpec().Address = module.Address
 
 				return nil

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_status_test.go
@@ -50,7 +50,6 @@ func (suite *KernelModuleStatusSuite) TestParseMock() {
 		&runtimectrl.KernelModuleStatusController{
 			ProcModulesPath:        "testdata/kernel-modules/proc-modules.txt",
 			ModulesBuiltinFilePath: "testdata/kernel-modules/modules-builtin.txt",
-			SysModulePath:          suite.T().TempDir(),
 		},
 	))
 
@@ -62,43 +61,12 @@ func (suite *KernelModuleStatusSuite) TestParseMock() {
 		"ext4",
 	}, func(module *runtime.KernelModuleStatus, asrt *assert.Assertions) {
 		asrt.Equal(runtime.KernelModuleTypeBuiltin, module.TypedSpec().Type)
-		asrt.Equal(runtime.KernelModuleStateInactive, module.TypedSpec().State)
+		asrt.Equal(runtime.KernelModuleStateBuiltin, module.TypedSpec().State)
 	})
 
 	malformedEntryNames := []string{"firstmalformed", "secondmalformed"}
 	ctest.AssertNoResources[*runtime.LoadedKernelModule](suite, malformedEntryNames)
 	ctest.AssertNoResources[*runtime.KernelModuleStatus](suite, malformedEntryNames)
-}
-
-func (suite *KernelModuleStatusSuite) TestBuiltinModuleStates() {
-	sysModulePath := suite.T().TempDir()
-
-	// Create a /sys/module/loopback directory to mark loopback as active.
-	suite.Require().NoError(os.MkdirAll(filepath.Join(sysModulePath, "loopback"), 0o755))
-
-	modulesBuiltinPath := filepath.Join(suite.T().TempDir(), "modules-builtin.txt")
-	suite.Require().NoError(os.WriteFile(modulesBuiltinPath, []byte(
-		"kernel/drivers/net/loopback.ko\n"+
-			"kernel/crypto/aes_generic.ko\n",
-	), 0o644))
-
-	suite.Require().NoError(suite.Runtime().RegisterController(
-		&runtimectrl.KernelModuleStatusController{
-			ProcModulesPath:        "testdata/kernel-modules/proc-modules.txt",
-			ModulesBuiltinFilePath: modulesBuiltinPath,
-			SysModulePath:          sysModulePath,
-		},
-	))
-
-	ctest.AssertResource(suite, "loopback", func(res *runtime.KernelModuleStatus, asrt *assert.Assertions) {
-		asrt.Equal(runtime.KernelModuleTypeBuiltin, res.TypedSpec().Type)
-		asrt.Equal(runtime.KernelModuleStateActive, res.TypedSpec().State)
-	})
-
-	ctest.AssertResource(suite, "aes_generic", func(res *runtime.KernelModuleStatus, asrt *assert.Assertions) {
-		asrt.Equal(runtime.KernelModuleTypeBuiltin, res.TypedSpec().Type)
-		asrt.Equal(runtime.KernelModuleStateInactive, res.TypedSpec().State)
-	})
 }
 
 func (suite *KernelModuleStatusSuite) TestLoadedKernelModuleFields() {
@@ -143,7 +111,7 @@ func (suite *KernelModuleStatusSuite) TestKernelModuleStatusFields() {
 		asrt.Equal(114688, res.TypedSpec().Size)
 		asrt.Equal(0, res.TypedSpec().ReferenceCount)
 		asrt.Equal([]string{}, res.TypedSpec().Dependencies)
-		asrt.Equal(runtime.KernelModuleStateActive, res.TypedSpec().State)
+		asrt.Equal(runtime.KernelModuleStateLive, res.TypedSpec().State)
 		asrt.Equal("0x0000000000000000", res.TypedSpec().Address)
 	})
 }
@@ -164,6 +132,11 @@ func (suite *KernelModuleStatusSuite) TestDynamicModuleStateVariants() {
 	ctest.AssertResource(suite, "modunloading", func(res *runtime.KernelModuleStatus, asrt *assert.Assertions) {
 		asrt.Equal(runtime.KernelModuleTypeDynamic, res.TypedSpec().Type)
 		asrt.Equal(runtime.KernelModuleStateUnloading, res.TypedSpec().State)
+	})
+
+	ctest.AssertResource(suite, "wireguard", func(res *runtime.KernelModuleStatus, asrt *assert.Assertions) {
+		asrt.Equal(runtime.KernelModuleTypeDynamic, res.TypedSpec().Type)
+		asrt.Equal(runtime.KernelModuleStateLive, res.TypedSpec().State)
 	})
 }
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -508,7 +508,7 @@ func (apiSuite *APISuite) AssertServicesRunning(ctx context.Context, node string
 	}
 }
 
-// AssertExpectedModules verifies that expected kernel modules are loaded on the node as dynamic type and active state.
+// AssertExpectedModules verifies that expected kernel modules are loaded on the node as dynamic type and live state.
 func (apiSuite *APISuite) AssertExpectedModules(ctx context.Context, node string, expectedModules []string) {
 	nodeCtx := client.WithNode(ctx, node)
 
@@ -518,8 +518,8 @@ func (apiSuite *APISuite) AssertExpectedModules(ctx context.Context, node string
 
 		apiSuite.Assert().Equal(runtimeres.KernelModuleTypeDynamic, status.TypedSpec().Type,
 			"expected kernel module %q to be of dynamic type", moduleName)
-		apiSuite.Assert().Equal(runtimeres.KernelModuleStateActive, status.TypedSpec().State,
-			"expected kernel module %q to be in active state (Live)", moduleName)
+		apiSuite.Assert().Equal(runtimeres.KernelModuleStateLive, status.TypedSpec().State,
+			"expected kernel module %q to be in live state", moduleName)
 	}
 }
 

--- a/pkg/machinery/api/resource/definitions/enums/enums.pb.go
+++ b/pkg/machinery/api/resource/definitions/enums/enums.pb.go
@@ -22,29 +22,29 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// RuntimeKernelModuleState represents the operational state of a dynamically loaded kernel module.
+// RuntimeKernelModuleState represents the operational state of a kernel module.
 type RuntimeKernelModuleState int32
 
 const (
-	RuntimeKernelModuleState_KERNEL_MODULE_STATE_INACTIVE  RuntimeKernelModuleState = 0
-	RuntimeKernelModuleState_KERNEL_MODULE_STATE_ACTIVE    RuntimeKernelModuleState = 1
-	RuntimeKernelModuleState_KERNEL_MODULE_STATE_LOADING   RuntimeKernelModuleState = 2
-	RuntimeKernelModuleState_KERNEL_MODULE_STATE_UNLOADING RuntimeKernelModuleState = 3
+	RuntimeKernelModuleState_KERNEL_MODULE_STATE_LIVE      RuntimeKernelModuleState = 0
+	RuntimeKernelModuleState_KERNEL_MODULE_STATE_LOADING   RuntimeKernelModuleState = 1
+	RuntimeKernelModuleState_KERNEL_MODULE_STATE_UNLOADING RuntimeKernelModuleState = 2
+	RuntimeKernelModuleState_KERNEL_MODULE_STATE_BUILTIN   RuntimeKernelModuleState = 3
 )
 
 // Enum value maps for RuntimeKernelModuleState.
 var (
 	RuntimeKernelModuleState_name = map[int32]string{
-		0: "KERNEL_MODULE_STATE_INACTIVE",
-		1: "KERNEL_MODULE_STATE_ACTIVE",
-		2: "KERNEL_MODULE_STATE_LOADING",
-		3: "KERNEL_MODULE_STATE_UNLOADING",
+		0: "KERNEL_MODULE_STATE_LIVE",
+		1: "KERNEL_MODULE_STATE_LOADING",
+		2: "KERNEL_MODULE_STATE_UNLOADING",
+		3: "KERNEL_MODULE_STATE_BUILTIN",
 	}
 	RuntimeKernelModuleState_value = map[string]int32{
-		"KERNEL_MODULE_STATE_INACTIVE":  0,
-		"KERNEL_MODULE_STATE_ACTIVE":    1,
-		"KERNEL_MODULE_STATE_LOADING":   2,
-		"KERNEL_MODULE_STATE_UNLOADING": 3,
+		"KERNEL_MODULE_STATE_LIVE":      0,
+		"KERNEL_MODULE_STATE_LOADING":   1,
+		"KERNEL_MODULE_STATE_UNLOADING": 2,
+		"KERNEL_MODULE_STATE_BUILTIN":   3,
 	}
 )
 
@@ -3897,12 +3897,12 @@ var File_resource_definitions_enums_enums_proto protoreflect.FileDescriptor
 
 const file_resource_definitions_enums_enums_proto_rawDesc = "" +
 	"\n" +
-	"&resource/definitions/enums/enums.proto\x12 talos.resource.definitions.enums*\xa0\x01\n" +
-	"\x18RuntimeKernelModuleState\x12 \n" +
-	"\x1cKERNEL_MODULE_STATE_INACTIVE\x10\x00\x12\x1e\n" +
-	"\x1aKERNEL_MODULE_STATE_ACTIVE\x10\x01\x12\x1f\n" +
-	"\x1bKERNEL_MODULE_STATE_LOADING\x10\x02\x12!\n" +
-	"\x1dKERNEL_MODULE_STATE_UNLOADING\x10\x03*y\n" +
+	"&resource/definitions/enums/enums.proto\x12 talos.resource.definitions.enums*\x9d\x01\n" +
+	"\x18RuntimeKernelModuleState\x12\x1c\n" +
+	"\x18KERNEL_MODULE_STATE_LIVE\x10\x00\x12\x1f\n" +
+	"\x1bKERNEL_MODULE_STATE_LOADING\x10\x01\x12!\n" +
+	"\x1dKERNEL_MODULE_STATE_UNLOADING\x10\x02\x12\x1f\n" +
+	"\x1bKERNEL_MODULE_STATE_BUILTIN\x10\x03*y\n" +
 	"\x17RuntimeKernelModuleType\x12\x1e\n" +
 	"\x1aKERNEL_MODULE_TYPE_UNKNOWN\x10\x00\x12\x1e\n" +
 	"\x1aKERNEL_MODULE_TYPE_BUILTIN\x10\x01\x12\x1e\n" +

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1110,9 +1110,6 @@ const (
 	// ProcModulesPath is the path to /proc/modules.
 	ProcModulesPath = "/proc/modules"
 
-	// SysModulePath is the path to /sys/module.
-	SysModulePath = "/sys/module"
-
 	// GoVersion is the version of Go compiler this release was built with.
 	GoVersion = "go1.26.3"
 

--- a/pkg/machinery/resources/runtime/kernel_module_state.go
+++ b/pkg/machinery/resources/runtime/kernel_module_state.go
@@ -4,34 +4,33 @@
 
 package runtime
 
-// KernelModuleState represents the operational state of a dynamically loaded kernel module.
+import "fmt"
+
+// KernelModuleState represents the operational state of a kernel module.
 type KernelModuleState int
 
 // KernelModuleState constants.
 //
 //structprotogen:gen_enum
 const (
-	KernelModuleStateInactive  KernelModuleState = iota // inactive
-	KernelModuleStateActive                             // active
+	KernelModuleStateLive      KernelModuleState = iota // live
 	KernelModuleStateLoading                            // loading
 	KernelModuleStateUnloading                          // unloading
+	KernelModuleStateBuiltin                            // built-in
 )
 
 // ParseDynamicModuleState converts a string representation of a kernel module state into
 // its corresponding KernelModuleState constant.
-func ParseDynamicModuleState(s string) KernelModuleState {
-	var state KernelModuleState
-
+// 'Builtin' is intentionally omitted as it is not a valid state for dynamically loaded modules.
+func ParseDynamicModuleState(s string) (KernelModuleState, error) {
 	switch s {
 	case "Live":
-		state = KernelModuleStateActive
+		return KernelModuleStateLive, nil
 	case "Loading":
-		state = KernelModuleStateLoading
+		return KernelModuleStateLoading, nil
 	case "Unloading":
-		state = KernelModuleStateUnloading
+		return KernelModuleStateUnloading, nil
 	default:
-		state = KernelModuleStateInactive
+		return 0, fmt.Errorf("unknown kernel module state %q", s)
 	}
-
-	return state
 }

--- a/pkg/machinery/resources/runtime/kernel_module_state_test.go
+++ b/pkg/machinery/resources/runtime/kernel_module_state_test.go
@@ -16,17 +16,22 @@ func TestParseDynamicModuleState(t *testing.T) {
 	for _, tt := range []struct {
 		input    string
 		expected runtime.KernelModuleState
+		wantErr  bool
 	}{
-		{"Live", runtime.KernelModuleStateActive},
-		{"Loading", runtime.KernelModuleStateLoading},
-		{"Unloading", runtime.KernelModuleStateUnloading},
-		{"", runtime.KernelModuleStateInactive},
-		{"unknown", runtime.KernelModuleStateInactive},
+		{"Live", runtime.KernelModuleStateLive, false},
+		{"Loading", runtime.KernelModuleStateLoading, false},
+		{"Unloading", runtime.KernelModuleStateUnloading, false},
+		{"", 0, true},
+		{"unknown", 0, true},
 	} {
 		t.Run(tt.input, func(t *testing.T) {
-			result := runtime.ParseDynamicModuleState(tt.input)
-			assert.NotNil(t, result)
-			assert.Equal(t, tt.expected, result)
+			result, err := runtime.ParseDynamicModuleState(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
 		})
 	}
 }

--- a/pkg/machinery/resources/runtime/kernelmodulestate_enumer.go
+++ b/pkg/machinery/resources/runtime/kernelmodulestate_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _KernelModuleStateName = "inactiveactiveloadingunloading"
+const _KernelModuleStateName = "liveloadingunloadingbuilt-in"
 
-var _KernelModuleStateIndex = [...]uint8{0, 8, 14, 21, 30}
+var _KernelModuleStateIndex = [...]uint8{0, 4, 11, 20, 28}
 
-const _KernelModuleStateLowerName = "inactiveactiveloadingunloading"
+const _KernelModuleStateLowerName = "liveloadingunloadingbuilt-in"
 
 func (i KernelModuleState) String() string {
 	if i < 0 || i >= KernelModuleState(len(_KernelModuleStateIndex)-1) {
@@ -24,30 +24,30 @@ func (i KernelModuleState) String() string {
 // Re-run the stringer command to generate them again.
 func _KernelModuleStateNoOp() {
 	var x [1]struct{}
-	_ = x[KernelModuleStateInactive-(0)]
-	_ = x[KernelModuleStateActive-(1)]
-	_ = x[KernelModuleStateLoading-(2)]
-	_ = x[KernelModuleStateUnloading-(3)]
+	_ = x[KernelModuleStateLive-(0)]
+	_ = x[KernelModuleStateLoading-(1)]
+	_ = x[KernelModuleStateUnloading-(2)]
+	_ = x[KernelModuleStateBuiltin-(3)]
 }
 
-var _KernelModuleStateValues = []KernelModuleState{KernelModuleStateInactive, KernelModuleStateActive, KernelModuleStateLoading, KernelModuleStateUnloading}
+var _KernelModuleStateValues = []KernelModuleState{KernelModuleStateLive, KernelModuleStateLoading, KernelModuleStateUnloading, KernelModuleStateBuiltin}
 
 var _KernelModuleStateNameToValueMap = map[string]KernelModuleState{
-	_KernelModuleStateName[0:8]:        KernelModuleStateInactive,
-	_KernelModuleStateLowerName[0:8]:   KernelModuleStateInactive,
-	_KernelModuleStateName[8:14]:       KernelModuleStateActive,
-	_KernelModuleStateLowerName[8:14]:  KernelModuleStateActive,
-	_KernelModuleStateName[14:21]:      KernelModuleStateLoading,
-	_KernelModuleStateLowerName[14:21]: KernelModuleStateLoading,
-	_KernelModuleStateName[21:30]:      KernelModuleStateUnloading,
-	_KernelModuleStateLowerName[21:30]: KernelModuleStateUnloading,
+	_KernelModuleStateName[0:4]:        KernelModuleStateLive,
+	_KernelModuleStateLowerName[0:4]:   KernelModuleStateLive,
+	_KernelModuleStateName[4:11]:       KernelModuleStateLoading,
+	_KernelModuleStateLowerName[4:11]:  KernelModuleStateLoading,
+	_KernelModuleStateName[11:20]:      KernelModuleStateUnloading,
+	_KernelModuleStateLowerName[11:20]: KernelModuleStateUnloading,
+	_KernelModuleStateName[20:28]:      KernelModuleStateBuiltin,
+	_KernelModuleStateLowerName[20:28]: KernelModuleStateBuiltin,
 }
 
 var _KernelModuleStateNames = []string{
-	_KernelModuleStateName[0:8],
-	_KernelModuleStateName[8:14],
-	_KernelModuleStateName[14:21],
-	_KernelModuleStateName[21:30],
+	_KernelModuleStateName[0:4],
+	_KernelModuleStateName[4:11],
+	_KernelModuleStateName[11:20],
+	_KernelModuleStateName[20:28],
 }
 
 // KernelModuleStateString retrieves an enum value from the enum constants string name.

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -6066,14 +6066,14 @@ RuntimeFIPSState describes the current FIPS status.
 <a name="talos.resource.definitions.enums.RuntimeKernelModuleState"></a>
 
 ### RuntimeKernelModuleState
-RuntimeKernelModuleState represents the operational state of a dynamically loaded kernel module.
+RuntimeKernelModuleState represents the operational state of a kernel module.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| KERNEL_MODULE_STATE_INACTIVE | 0 |  |
-| KERNEL_MODULE_STATE_ACTIVE | 1 |  |
-| KERNEL_MODULE_STATE_LOADING | 2 |  |
-| KERNEL_MODULE_STATE_UNLOADING | 3 |  |
+| KERNEL_MODULE_STATE_LIVE | 0 |  |
+| KERNEL_MODULE_STATE_LOADING | 1 |  |
+| KERNEL_MODULE_STATE_UNLOADING | 2 |  |
+| KERNEL_MODULE_STATE_BUILTIN | 3 |  |
 
 
 


### PR DESCRIPTION
Follow-up to https://github.com/siderolabs/talos/pull/13309

The initial impl. considered a built-in module as 'active' if a matching entry existed in sysfs: `/sys/module/<mod name>`.  While this criteria was sufficient for some of the cases, it wasn't completely correct.  As we've learned, built-in modules that don't export any parameters, will not have a sysfs entry, hence stat-ing `/sys/module/<mod name>` will fail (non-existent), and we would incorrectly mark that module as 'inactive', even if it has been init-ed. This was the case for XFS on Talos Linux.

Later we've also evaluated checking `/proc/kallsyms` for relevant symbol names. This was effective, but poses a risk of false positives. That is, a 'contains' check on a symbol's name will match any symbol name that contains the module's name we're looking for - i.e.  `foobar_init_baz` contains `foo`, while it may actually belong to the module `foobar`. This approach is closer to guesswork, than anything else. There are ways to resolve the module-symbols relations, but it's too complex to pursue for our current needs.

This PR reworks the possible module states:
- Adds `built-in`, which is reserved for and unconditionally assigned to built-in modules.
- Renames the `active` state to `live`, aligning it with the Linux naming convention that people may be more familiar with.
- Removes the `inactive` state, as it's not used anymore (apart from being a zero-value for the enum).

---

Sample:
```sh
talosctl get -n 172.20.0.2 kernelmodulestatus
# ...
172.20.0.2   runtime     KernelModuleStatus   aesni_intel                         1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   af_packet                           1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   af_packet_diag                      1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   ah4                                 1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   ah6                                 1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   ahci                                1         dynamic    live
172.20.0.2   runtime     KernelModuleStatus   akcipher                            1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   amd_uncore                          1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   asn1_decoder                        1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   atkbd                               1         built-in   built-in
172.20.0.2   runtime     KernelModuleStatus   auth_rpcgss                         1         built-in   built-in
# ...
```