### PR TITLE
fix: create parent directories in ExtractTarGz for nested tar entries

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/archive.go
+++ b/cmd/talosctl/pkg/talos/helpers/archive.go
@@ -74,7 +74,7 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 				break
 			}
 
-			return fmt.Errorf("error reading tar header: %s", err)
+			return fmt.Errorf("error reading tar header: %w", err)
 		}
 
 		hdrPath := safepath.CleanPath(hdr.Name)
@@ -83,14 +83,13 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 		}
 
 		path := filepath.Join(localPath, hdrPath)
-		// TODO: do we need to clean up any '..' references?
 
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			mode := hdr.FileInfo().Mode()
 			mode |= 0o700 // make rwx for the owner
 
-			if err = os.Mkdir(path, mode); err != nil {
+			if err = os.MkdirAll(path, mode); err != nil {
 				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)
 			}
 
@@ -99,12 +98,20 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 			}
 
 		case tar.TypeSymlink:
+			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("error creating parent directory for symlink %q: %w", path, err)
+			}
+
 			if err = os.Symlink(hdr.Linkname, path); err != nil {
 				return fmt.Errorf("error creating symlink %q -> %q: %w", path, hdr.Linkname, err)
 			}
 
 		default:
 			mode := hdr.FileInfo().Mode()
+
+			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("error creating parent directory for file %q: %w", path, err)
+			}
 
 			fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
 			if err != nil {

--- a/cmd/talosctl/pkg/talos/helpers/helpers_test.go
+++ b/cmd/talosctl/pkg/talos/helpers/helpers_test.go
@@ -5,10 +5,16 @@
 package helpers_test
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
@@ -37,4 +43,34 @@ func TestExtractFileFromTarGz(t *testing.T) {
 
 	_, err = helpers.ExtractFileFromTarGz("void", file)
 	assert.Error(t, err)
+}
+
+func TestExtractTarGzCreatesParentDirectories(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	payload := []byte("hello")
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "nested/path/file.txt",
+		Mode: 0o644,
+		Size: int64(len(payload)),
+	}))
+
+	_, err := tw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	dir := t.TempDir()
+
+	require.NoError(t, helpers.ExtractTarGz(dir, io.NopCloser(bytes.NewReader(buf.Bytes()))))
+
+	data, err := os.ReadFile(filepath.Join(dir, "nested/path/file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, payload, data)
 }


### PR DESCRIPTION
Same gap that was just fixed in `pkg/archiver/untar.go` (#1e31deda3) also exists in `cmd/talosctl/pkg/talos/helpers/archive.go` — the function used by `talosctl cp`.

`ExtractTarGz` uses `os.Mkdir` and never pre-creates parent dirs before writing files/symlinks. A valid tar archive with entries like `nested/path/file.txt` but no explicit dir headers will blow up with:

```
error creating file "nested/path/file.txt" mode -rw-r--r--: open nested/path/file.txt: no such file or directory
```

## Reproduce

```go
var buf bytes.Buffer
gzw := gzip.NewWriter(&buf)
tw := tar.NewWriter(gzw)
tw.WriteHeader(&tar.Header{Name: "nested/path/file.txt", Mode: 0o644, Size: 5})
tw.Write([]byte("hello"))
tw.Close(); gzw.Close()

// fails before this fix
helpers.ExtractTarGz("/tmp/out", io.NopCloser(bytes.NewReader(buf.Bytes())))
```

## Changes

- `os.Mkdir` -> `os.MkdirAll` for dir entries
- pre-create parent dirs before symlinks and regular files
- `%s` -> `%w` in error wrap
- drop stale TODO (already handled by `safepath.CleanPath`)
- add regression test