### PR TITLE
fix: marshal kube-scheduler config correctly with int types

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	schedulerv1 "k8s.io/kube-scheduler/config/v1"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8sjson"
 	"github.com/siderolabs/talos/pkg/argsbuilder"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -186,8 +187,8 @@ func NewControlPlaneSchedulerFinalController() *ControlPlaneSchedulerFinalContro
 					return fmt.Errorf("error unmarshaling scheduler configuration: %w", err)
 				}
 
-				outCfg := runtime.DeepCopyJSON(in.TypedSpec().Config)
-				if outCfg == nil {
+				outCfg, ok := k8sjson.DeepCopyToJSON(in.TypedSpec().Config).(map[string]any)
+				if !ok || outCfg == nil {
 					outCfg = map[string]any{}
 				}
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
@@ -111,6 +111,69 @@ func (suite *ControlPlaneSchedulerFinalSuite) TestTransform() {
 			},
 		},
 		{
+			// Regression for siderolabs/talos#13445: the YAML parser emits Go
+			// ints for integers, and runtime.DeepCopyJSON panics on those.
+			name: "go int values in config are normalized to int64",
+			input: k8s.SchedulerConfigSpec{
+				Enabled: true,
+				Image:   "registry.k8s.io/kube-scheduler:v1.32.0",
+				Config: map[string]any{
+					"profiles": []any{
+						map[string]any{
+							"schedulerName": "default-scheduler",
+							"pluginConfig": []any{
+								map[string]any{
+									"name": "PodTopologySpread",
+									"args": map[string]any{
+										"defaultingType": "List",
+										"defaultConstraints": []any{
+											map[string]any{
+												"maxSkew":           int(1),
+												"topologyKey":       "kubernetes.io/hostname",
+												"whenUnsatisfiable": "ScheduleAnyway",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: k8s.SchedulerConfigSpec{
+				Enabled: true,
+				Image:   "registry.k8s.io/kube-scheduler:v1.32.0",
+				Args:    defaultArgs,
+				Config: map[string]any{
+					"apiVersion": "kubescheduler.config.k8s.io/v1",
+					"kind":       "KubeSchedulerConfiguration",
+					"clientConnection": map[string]any{
+						"kubeconfig": kubeconfigPath,
+					},
+					"profiles": []any{
+						map[string]any{
+							"schedulerName": "default-scheduler",
+							"pluginConfig": []any{
+								map[string]any{
+									"name": "PodTopologySpread",
+									"args": map[string]any{
+										"defaultingType": "List",
+										"defaultConstraints": []any{
+											map[string]any{
+												"maxSkew":           int64(1),
+												"topologyKey":       "kubernetes.io/hostname",
+												"whenUnsatisfiable": "ScheduleAnyway",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "pass-through fields and config preserved alongside injected keys",
 			input: k8s.SchedulerConfigSpec{
 				Enabled: true,

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/k8sjson.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/k8sjson.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package k8sjson provides a bridge and helpers for working with unstructured/json/yaml Kubernetes objects.
+package k8sjson
+
+// DeepCopyToJSON deep-copies a YAML-decoded value into one that uses only
+// JSON-compatible types (string, bool, int64, float64, nil, []any,
+// map[string]any).
+//
+// The YAML parser emits Go int / uint values for integers,
+// but k8s.io/apimachinery's runtime.DeepCopyJSON and unstructured helpers
+// panic on those, so any int-shaped field (e.g. topologySpread maxSkew) would
+// crash the controller. Unknown types are returned as-is so the typed schema
+// validation upstream is what surfaces invalid input, not this helper.
+//
+//nolint:gocyclo
+func DeepCopyToJSON(x any) any {
+	switch x := x.(type) {
+	case map[string]any:
+		if x == nil {
+			return x
+		}
+
+		clone := make(map[string]any, len(x))
+		for k, v := range x {
+			clone[k] = DeepCopyToJSON(v)
+		}
+
+		return clone
+	case []any:
+		if x == nil {
+			return x
+		}
+
+		clone := make([]any, len(x))
+		for i, v := range x {
+			clone[i] = DeepCopyToJSON(v)
+		}
+
+		return clone
+	case int:
+		return int64(x)
+	case int8:
+		return int64(x)
+	case int16:
+		return int64(x)
+	case int32:
+		return int64(x)
+	case uint:
+		return int64(x)
+	case uint8:
+		return int64(x)
+	case uint16:
+		return int64(x)
+	case uint32:
+		return int64(x)
+	case uint64:
+		return float64(x)
+	case float32:
+		return float64(x)
+	default:
+		return x
+	}
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/k8sjson_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/k8sjson_test.go
@@ -1,0 +1,293 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8sjson_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sjsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8sjson"
+)
+
+//nolint:gocyclo
+func TestDeepCopyToJSON(t *testing.T) {
+	t.Parallel()
+
+	type stringly string
+
+	for _, tt := range []struct {
+		name     string
+		input    any
+		expected any
+	}{
+		{
+			name:     "nil any",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "typed nil map",
+			input:    map[string]any(nil),
+			expected: map[string]any(nil),
+		},
+		{
+			name:     "typed nil slice",
+			input:    []any(nil),
+			expected: []any(nil),
+		},
+		{
+			name:     "string passes through",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "bool passes through",
+			input:    true,
+			expected: true,
+		},
+		{
+			name:     "int -> int64",
+			input:    int(42),
+			expected: int64(42),
+		},
+		{
+			name:     "negative int -> int64",
+			input:    int(-7),
+			expected: int64(-7),
+		},
+		{
+			name:     "int8 -> int64",
+			input:    int8(8),
+			expected: int64(8),
+		},
+		{
+			name:     "int16 -> int64",
+			input:    int16(16),
+			expected: int64(16),
+		},
+		{
+			name:     "int32 -> int64",
+			input:    int32(32),
+			expected: int64(32),
+		},
+		{
+			name:     "int64 passes through",
+			input:    int64(64),
+			expected: int64(64),
+		},
+		{
+			name:     "uint -> int64",
+			input:    uint(1),
+			expected: int64(1),
+		},
+		{
+			name:     "uint8 -> int64",
+			input:    uint8(8),
+			expected: int64(8),
+		},
+		{
+			name:     "uint16 -> int64",
+			input:    uint16(16),
+			expected: int64(16),
+		},
+		{
+			name:     "uint32 -> int64",
+			input:    uint32(32),
+			expected: int64(32),
+		},
+		{
+			name:     "uint64 -> float64",
+			input:    uint64(1 << 40),
+			expected: float64(1 << 40),
+		},
+		{
+			name:     "float32 -> float64",
+			input:    float32(1.5),
+			expected: float64(float32(1.5)),
+		},
+		{
+			name:     "float64 passes through",
+			input:    float64(2.5),
+			expected: float64(2.5),
+		},
+		{
+			name:     "unknown type passes through unchanged",
+			input:    stringly("named"),
+			expected: stringly("named"),
+		},
+		{
+			name: "flat map normalizes ints",
+			input: map[string]any{
+				"a": int(1),
+				"b": "two",
+				"c": float64(3.5),
+			},
+			expected: map[string]any{
+				"a": int64(1),
+				"b": "two",
+				"c": float64(3.5),
+			},
+		},
+		{
+			name:  "flat slice normalizes ints",
+			input: []any{int(1), int32(2), "three", nil},
+			expected: []any{
+				int64(1),
+				int64(2),
+				"three",
+				nil,
+			},
+		},
+		{
+			name: "deeply nested ints are normalized",
+			input: map[string]any{
+				"profiles": []any{
+					map[string]any{
+						"pluginConfig": []any{
+							map[string]any{
+								"args": map[string]any{
+									"defaultConstraints": []any{
+										map[string]any{
+											"maxSkew":           int(1),
+											"topologyKey":       "kubernetes.io/hostname",
+											"whenUnsatisfiable": "ScheduleAnyway",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]any{
+				"profiles": []any{
+					map[string]any{
+						"pluginConfig": []any{
+							map[string]any{
+								"args": map[string]any{
+									"defaultConstraints": []any{
+										map[string]any{
+											"maxSkew":           int64(1),
+											"topologyKey":       "kubernetes.io/hostname",
+											"whenUnsatisfiable": "ScheduleAnyway",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty map is preserved as non-nil",
+			input: map[string]any{
+				"empty": map[string]any{},
+			},
+			expected: map[string]any{
+				"empty": map[string]any{},
+			},
+		},
+		{
+			name: "empty slice is preserved as non-nil",
+			input: map[string]any{
+				"empty": []any{},
+			},
+			expected: map[string]any{
+				"empty": []any{},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := k8sjson.DeepCopyToJSON(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestDeepCopyToJSON_DeepCopySemantics verifies that mutating the returned
+// value does not mutate the input — this is a deep copy, not a normalize
+// in-place.
+func TestDeepCopyToJSON_DeepCopySemantics(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"outer": map[string]any{
+			"inner": []any{int(1), int(2)},
+		},
+	}
+
+	cloned, ok := k8sjson.DeepCopyToJSON(input).(map[string]any)
+	require.True(t, ok)
+
+	clonedOuter := cloned["outer"].(map[string]any) //nolint:forcetypeassert
+	clonedOuter["inner"] = []any{int64(99)}
+	clonedOuter["added"] = "new"
+
+	inputOuter := input["outer"].(map[string]any) //nolint:forcetypeassert
+	assert.Equal(t, []any{int(1), int(2)}, inputOuter["inner"], "input slice should be untouched")
+	assert.NotContains(t, inputOuter, "added", "input map should be untouched")
+}
+
+// TestDeepCopyToJSON_Serializer verifies the full pipeline: a YAML document
+// from testdata/ is parsed, normalized via DeepCopyToJSON, wrapped in
+// unstructured.Unstructured, and serialized to JSON using the same Kubernetes
+// JSON serializer that render_config_static_pods.go uses. The result is
+// compared to the expected JSON from testdata/. Without DeepCopyToJSON, the
+// serializer panics on go-yaml's native int values.
+func TestDeepCopyToJSON_Serializer(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"scheduler-int-fields",
+		"scheduler-topology-spread",
+		"scheduler-mixed-types",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			yamlBytes, err := os.ReadFile(filepath.Join("testdata", name+".yaml"))
+			require.NoError(t, err)
+
+			var raw map[string]any
+
+			require.NoError(t, yaml.Unmarshal(yamlBytes, &raw))
+
+			normalized, ok := k8sjson.DeepCopyToJSON(raw).(map[string]any)
+			require.True(t, ok)
+
+			obj := runtime.Object(&unstructured.Unstructured{Object: normalized})
+
+			serializer := k8sjsonserializer.NewSerializerWithOptions(
+				k8sjsonserializer.DefaultMetaFactory, nil, nil,
+				k8sjsonserializer.SerializerOptions{
+					Yaml:   false,
+					Pretty: true,
+					Strict: true,
+				},
+			)
+
+			var buf bytes.Buffer
+
+			require.NoError(t, serializer.Encode(obj, &buf))
+
+			expected, err := os.ReadFile(filepath.Join("testdata", name+".json"))
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expected), buf.String())
+		})
+	}
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-int-fields.json
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-int-fields.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "kubescheduler.config.k8s.io/v1",
+  "kind": "KubeSchedulerConfiguration",
+  "parallelism": 16,
+  "percentageOfNodesToScore": 50,
+  "clientConnection": {
+    "burst": 200,
+    "qps": 100.5,
+    "kubeconfig": "/system/secrets/kubernetes/kube-scheduler/kubeconfig"
+  }
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-int-fields.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-int-fields.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+parallelism: 16
+percentageOfNodesToScore: 50
+clientConnection:
+  burst: 200
+  qps: 100.5
+  kubeconfig: /system/secrets/kubernetes/kube-scheduler/kubeconfig

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-mixed-types.json
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-mixed-types.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "kubescheduler.config.k8s.io/v1",
+  "kind": "KubeSchedulerConfiguration",
+  "leaderElection": {
+    "leaderElect": true,
+    "leaseDuration": "15s"
+  },
+  "percentageOfNodesToScore": 0,
+  "profiles": [
+    {
+      "schedulerName": "default-scheduler",
+      "pluginConfig": [
+        {
+          "name": "NodeResourcesFit",
+          "args": {
+            "scoringStrategy": {
+              "type": "LeastAllocated",
+              "resources": [
+                { "name": "cpu", "weight": 1 },
+                { "name": "memory", "weight": 2 }
+              ]
+            }
+          }
+        },
+        {
+          "name": "VolumeBinding",
+          "args": {
+            "bindTimeoutSeconds": 600,
+            "shape": [
+              { "utilization": 0, "score": 0 },
+              { "utilization": 100, "score": 10 }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-mixed-types.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-mixed-types.yaml
@@ -1,0 +1,26 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: true
+  leaseDuration: 15s
+percentageOfNodesToScore: 0
+profiles:
+  - schedulerName: default-scheduler
+    pluginConfig:
+      - name: NodeResourcesFit
+        args:
+          scoringStrategy:
+            type: LeastAllocated
+            resources:
+              - name: cpu
+                weight: 1
+              - name: memory
+                weight: 2
+      - name: VolumeBinding
+        args:
+          bindTimeoutSeconds: 600
+          shape:
+            - utilization: 0
+              score: 0
+            - utilization: 100
+              score: 10

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-topology-spread.json
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-topology-spread.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": "kubescheduler.config.k8s.io/v1",
+  "kind": "KubeSchedulerConfiguration",
+  "clientConnection": {
+    "kubeconfig": "/system/secrets/kubernetes/kube-scheduler/kubeconfig"
+  },
+  "profiles": [
+    {
+      "schedulerName": "default-scheduler",
+      "plugins": {
+        "score": {
+          "disabled": [
+            { "name": "ImageLocality" }
+          ]
+        }
+      },
+      "pluginConfig": [
+        {
+          "name": "PodTopologySpread",
+          "args": {
+            "defaultingType": "List",
+            "defaultConstraints": [
+              {
+                "maxSkew": 1,
+                "topologyKey": "kubernetes.io/hostname",
+                "whenUnsatisfiable": "ScheduleAnyway"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-topology-spread.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8sjson/testdata/scheduler-topology-spread.yaml
@@ -1,0 +1,18 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /system/secrets/kubernetes/kube-scheduler/kubeconfig
+profiles:
+  - schedulerName: default-scheduler
+    plugins:
+      score:
+        disabled:
+          - name: ImageLocality
+    pluginConfig:
+      - name: PodTopologySpread
+        args:
+          defaultingType: List
+          defaultConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
Fixes #13445

Normalize the struct to contain only types which are safe for JSON marshaling, which Kubernetes conversion restricts.
