### PR TITLE
fix: suppress ICMP redirects by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -139,6 +139,15 @@ Talos now supports mounting and provisioning `btrfs` filesystem for user volumes
 Support for `btrfs` is enabled by installing `btrfs` system extension.
 """
 
+    [notes.sendRedirects]
+        title = "ICMP send_redirects Disabled by Default"
+        description = """\
+Talos now sets `net.ipv4.conf.all.send_redirects=0` and `net.ipv4.conf.default.send_redirects=0` by default,
+preventing the node from emitting ICMP redirect messages. This aligns with CIS Benchmark recommendations and
+does not affect normal Kubernetes pod or service traffic. Nodes that deliberately act as L3 gateways relying
+on ICMP redirects can override this via `machine.sysctls`.
+"""
+
     [notes.lvm_status]
         title = "LVM Status"
         description = """\

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -88,6 +88,14 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 			Key:   "proc.sys.net.ipv4.icmp_echo_ignore_broadcasts",
 			Value: "1",
 		},
+		{
+			Key:   "proc.sys.net.ipv4.conf.all.send_redirects",
+			Value: "0",
+		},
+		{
+			Key:   "proc.sys.net.ipv4.conf.default.send_redirects",
+			Value: "0",
+		},
 	}
 
 	// block apid and trustd from the ephemeral port range

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -52,6 +52,14 @@ func getParams(mode runtime.Mode) []*kernel.Param {
 			Key:   "proc.sys.net.ipv4.ip_local_reserved_ports",
 			Value: "50000,50001",
 		},
+		{
+			Key:   "proc.sys.net.ipv4.conf.all.send_redirects",
+			Value: "0",
+		},
+		{
+			Key:   "proc.sys.net.ipv4.conf.default.send_redirects",
+			Value: "0",
+		},
 	}
 
 	if mode != runtime.ModeContainer {


### PR DESCRIPTION
Make one of the CIS benchmark items enabled by default.
