### PR TITLE
fix: align flannel MTU with kubespan to avoid permanent fragmentation

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -80,6 +80,7 @@ message BootstrapManifestsConfigSpec {
   bool flannel_kube_network_policies_enabled = 19;
   string flannel_kube_network_policies_image = 20;
   string cni_name = 21;
+  uint32 flannel_mtu = 22;
 }
 
 // ConfigStatusSpec describes status of rendered secrets.

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -306,6 +306,25 @@ func NewControlPlaneSchedulerController() *ControlPlaneSchedulerController {
 	)
 }
 
+// resolveFlannelMTU returns the underlay MTU flannel should advertise as
+// Backend.MTU in its net-conf.json. Explicit user override wins; otherwise,
+// if KubeSpan is enabled, default to the KubeSpan link MTU so that the
+// encapsulated VXLAN traffic fits within the WireGuard tunnel without
+// permanent fragmentation. Returns 0 when no override applies, which omits
+// the field from net-conf.json (flannel then auto-detects from the external
+// interface as it does today).
+func resolveFlannelMTU(cfgProvider talosconfig.Config) uint32 {
+	if mtu := cfgProvider.Cluster().Network().CNI().Flannel().MTU(); mtu != 0 {
+		return mtu
+	}
+
+	if ks := cfgProvider.NetworkKubeSpanConfig(); ks != nil && ks.Enabled() {
+		return ks.MTU()
+	}
+
+	return 0
+}
+
 // ControlPlaneBootstrapManifestsController manages k8s.BootstrapManifestsConfig based on configuration.
 type ControlPlaneBootstrapManifestsController = transform.Controller[*config.MachineConfig, *k8s.BootstrapManifestsConfig]
 
@@ -379,6 +398,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					FlannelKubeServicePort:            flannelKubeServicePort,
 					FlannelKubeNetworkPoliciesEnabled: cfgProvider.Cluster().Network().CNI().Flannel().KubeNetworkPoliciesEnabled(),
 					FlannelKubeNetworkPoliciesImage:   images.KubeNetworkPolicies.String(),
+					FlannelMTU:                        resolveFlannelMTU(cfgProvider),
 
 					TalosAPIServiceEnabled: cfgProvider.Machine().Features().KubernetesTalosAPIAccess().Enabled(),
 

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
@@ -147,12 +147,14 @@ func FlannelConfigMapTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 		Backend        struct {
 			Type string `json:"Type"`
 			Port int    `json:"Port"`
+			MTU  uint32 `json:"MTU,omitempty"`
 		} `json:"Backend"`
 	}
 
 	netConf.EnableNFTables = new(true)
 	netConf.Backend.Type = "vxlan"
 	netConf.Backend.Port = 4789
+	netConf.Backend.MTU = spec.FlannelMTU
 
 	hasIPv4 := false
 

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
@@ -275,6 +275,15 @@ func TestTemplates(t *testing.T) {
 				})
 			},
 		},
+		{
+			name: "flannel-configmap-with-mtu",
+			obj: func() runtime.Object {
+				return k8stemplates.FlannelConfigMapTemplate(&k8s.BootstrapManifestsConfigSpec{
+					PodCIDRs:   []string{"10.96.0.0/12"},
+					FlannelMTU: 1420,
+				})
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-with-mtu.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-with-mtu.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+data:
+  cni-conf.json: |-
+    {
+      "name": "cbr0",
+      "cniVersion": "1.0.0",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |-
+    {
+      "Network": "10.96.0.0/12",
+      "EnableNFTables": true,
+      "Backend": {
+        "Type": "vxlan",
+        "Port": 4789,
+        "MTU": 1420
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    k8s-app: flannel
+    tier: node
+  name: kube-flannel-cfg
+  namespace: kube-system

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -476,6 +476,7 @@ type BootstrapManifestsConfigSpec struct {
 	FlannelKubeNetworkPoliciesEnabled bool                   `protobuf:"varint,19,opt,name=flannel_kube_network_policies_enabled,json=flannelKubeNetworkPoliciesEnabled,proto3" json:"flannel_kube_network_policies_enabled,omitempty"`
 	FlannelKubeNetworkPoliciesImage   string                 `protobuf:"bytes,20,opt,name=flannel_kube_network_policies_image,json=flannelKubeNetworkPoliciesImage,proto3" json:"flannel_kube_network_policies_image,omitempty"`
 	CniName                           string                 `protobuf:"bytes,21,opt,name=cni_name,json=cniName,proto3" json:"cni_name,omitempty"`
+	FlannelMtu                        uint32                 `protobuf:"varint,22,opt,name=flannel_mtu,json=flannelMtu,proto3" json:"flannel_mtu,omitempty"`
 	unknownFields                     protoimpl.UnknownFields
 	sizeCache                         protoimpl.SizeCache
 }
@@ -648,6 +649,13 @@ func (x *BootstrapManifestsConfigSpec) GetCniName() string {
 		return x.CniName
 	}
 	return ""
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelMtu() uint32 {
+	if x != nil {
+		return x.FlannelMtu
+	}
+	return 0
 }
 
 // ConfigStatusSpec describes status of rendered secrets.
@@ -2531,7 +2539,7 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\awebhook\x18\x03 \x01(\v2\x17.google.protobuf.StructR\awebhook\"\x85\x01\n" +
 	"\x17AuthorizationConfigSpec\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12T\n" +
-	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xa8\a\n" +
+	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xc9\a\n" +
 	"\x1cBootstrapManifestsConfigSpec\x12\x16\n" +
 	"\x06server\x18\x01 \x01(\tR\x06server\x12%\n" +
 	"\x0ecluster_domain\x18\x02 \x01(\tR\rclusterDomain\x12\x1c\n" +
@@ -2556,7 +2564,9 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\x19flannel_kube_service_port\x18\x12 \x01(\tR\x16flannelKubeServicePort\x12P\n" +
 	"%flannel_kube_network_policies_enabled\x18\x13 \x01(\bR!flannelKubeNetworkPoliciesEnabled\x12L\n" +
 	"#flannel_kube_network_policies_image\x18\x14 \x01(\tR\x1fflannelKubeNetworkPoliciesImage\x12\x19\n" +
-	"\bcni_name\x18\x15 \x01(\tR\acniName\"B\n" +
+	"\bcni_name\x18\x15 \x01(\tR\acniName\x12\x1f\n" +
+	"\vflannel_mtu\x18\x16 \x01(\rR\n" +
+	"flannelMtu\"B\n" +
 	"\x10ConfigStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\"\x91\x06\n" +

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -491,6 +491,13 @@ func (m *BootstrapManifestsConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.FlannelMtu != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FlannelMtu))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
 	if len(m.CniName) > 0 {
 		i -= len(m.CniName)
 		copy(dAtA[i:], m.CniName)
@@ -2895,6 +2902,9 @@ func (m *BootstrapManifestsConfigSpec) SizeVT() (n int) {
 	l = len(m.CniName)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FlannelMtu != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.FlannelMtu))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5501,6 +5511,25 @@ func (m *BootstrapManifestsConfigSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.CniName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 22:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelMtu", wireType)
+			}
+			m.FlannelMtu = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FlannelMtu |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/cluster.go
+++ b/pkg/machinery/config/config/cluster.go
@@ -70,6 +70,7 @@ type CNI interface {
 type FlannelCNI interface {
 	ExtraArgs() []string
 	KubeNetworkPoliciesEnabled() bool
+	MTU() uint32
 }
 
 // APIServer defines the requirements for a config that pertains to apiserver related

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -4993,6 +4993,13 @@
           "description": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.\n",
           "markdownDescription": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
           "x-intellij-html-description": "\u003cp\u003eDeploys kube-network-policies along with Flannel.\u003c/p\u003e\n\n\u003cp\u003eThis enables Kubernetes Network Policies support in the cluster.\u003c/p\u003e\n"
+        },
+        "mtu": {
+          "type": "integer",
+          "title": "mtu",
+          "description": "Override the underlay MTU Flannel should use, rendered as Backend.MTU\nin flannel’s net-conf.json. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the flannel.1\ninterface (i.e. flannel.1 ends up at mtu - 50).\n\nWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.\n",
+          "markdownDescription": "Override the underlay MTU Flannel should use, rendered as `Backend.MTU`\nin flannel's `net-conf.json`. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the `flannel.1`\ninterface (i.e. `flannel.1` ends up at `mtu - 50`).\n\nWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.",
+          "x-intellij-html-description": "\u003cp\u003eOverride the underlay MTU Flannel should use, rendered as \u003ccode\u003eBackend.MTU\u003c/code\u003e\nin flannel\u0026rsquo;s \u003ccode\u003enet-conf.json\u003c/code\u003e. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the \u003ccode\u003eflannel.1\u003c/code\u003e\ninterface (i.e. \u003ccode\u003eflannel.1\u003c/code\u003e ends up at \u003ccode\u003emtu - 50\u003c/code\u003e).\u003c/p\u003e\n\n\u003cp\u003eWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
@@ -42,3 +42,12 @@ func (c *FlannelCNIConfig) KubeNetworkPoliciesEnabled() bool {
 
 	return pointer.SafeDeref(c.FlannelKubeNetworkPoliciesEnabled)
 }
+
+// MTU implements the config.FlannelCNI interface.
+func (c *FlannelCNIConfig) MTU() uint32 {
+	if c == nil {
+		return 0
+	}
+
+	return pointer.SafeDeref(c.FlannelMTU)
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1454,6 +1454,16 @@ type FlannelCNIConfig struct {
 	//
 	//     This enables Kubernetes Network Policies support in the cluster.
 	FlannelKubeNetworkPoliciesEnabled *bool `yaml:"kubeNetworkPoliciesEnabled,omitempty"`
+	//   description: |
+	//     Override the underlay MTU Flannel should use, rendered as `Backend.MTU`
+	//     in flannel's `net-conf.json`. Flannel internally subtracts the VXLAN
+	//     header overhead (50 bytes) from this when creating the `flannel.1`
+	//     interface (i.e. `flannel.1` ends up at `mtu - 50`).
+	//
+	//     When KubeSpan is enabled and this value is not set, Talos defaults
+	//     it to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits
+	//     within the WireGuard tunnel without permanent fragmentation.
+	FlannelMTU *uint32 `yaml:"mtu,omitempty"`
 }
 
 var _ config.ExternalCloudProvider = (*ExternalCloudProviderConfig)(nil)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1419,6 +1419,13 @@ func (FlannelCNIConfig) Doc() *encoder.Doc {
 				Description: "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Deploys kube-network-policies along with Flannel." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "mtu",
+				Type:        "uint32",
+				Note:        "",
+				Description: "Override the underlay MTU Flannel should use, rendered as `Backend.MTU`\nin flannel's `net-conf.json`. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the `flannel.1`\ninterface (i.e. `flannel.1` ends up at `mtu - 50`).\n\nWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Override the underlay MTU Flannel should use, rendered as `Backend.MTU`" /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/pkg/machinery/resources/k8s/manifests_config.go
+++ b/pkg/machinery/resources/k8s/manifests_config.go
@@ -49,6 +49,7 @@ type BootstrapManifestsConfigSpec struct {
 	FlannelKubeServicePort            string   `yaml:"flannelKubeServicePort" protobuf:"18"`
 	FlannelKubeNetworkPoliciesEnabled bool     `yaml:"flannelKubeNetworkPoliciesEnabled" protobuf:"19"`
 	FlannelKubeNetworkPoliciesImage   string   `yaml:"flannelKubeNetworkPoliciesImage" protobuf:"20"`
+	FlannelMTU                        uint32   `yaml:"flannelMTU" protobuf:"22"`
 
 	PodSecurityPolicyEnabled bool `yaml:"podSecurityPolicyEnabled" protobuf:"14"`
 

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -7754,6 +7754,7 @@ BootstrapManifestsConfigSpec is configuration for bootstrap manifests.
 | flannel_kube_network_policies_enabled | [bool](#bool) |  |  |
 | flannel_kube_network_policies_image | [string](#string) |  |  |
 | cni_name | [string](#string) |  |  |
+| flannel_mtu | [uint32](#uint32) |  |  |
 
 
 

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -1177,6 +1177,7 @@ extraArgs:
     - --iface-can-reach=192.168.1.1
 {{< /highlight >}}</details> | |
 |`kubeNetworkPoliciesEnabled` |bool |Deploys kube-network-policies along with Flannel.<br><br>This enables Kubernetes Network Policies support in the cluster.  | |
+|`mtu` |uint32 |Override the underlay MTU Flannel should use, rendered as `Backend.MTU`<br>in flannel's `net-conf.json`. Flannel internally subtracts the VXLAN<br>header overhead (50 bytes) from this when creating the `flannel.1`<br>interface (i.e. `flannel.1` ends up at `mtu - 50`).<br><br>When KubeSpan is enabled and this value is not set, Talos defaults<br>it to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits<br>within the WireGuard tunnel without permanent fragmentation.  | |
 
 
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -4993,6 +4993,13 @@
           "description": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.\n",
           "markdownDescription": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
           "x-intellij-html-description": "\u003cp\u003eDeploys kube-network-policies along with Flannel.\u003c/p\u003e\n\n\u003cp\u003eThis enables Kubernetes Network Policies support in the cluster.\u003c/p\u003e\n"
+        },
+        "mtu": {
+          "type": "integer",
+          "title": "mtu",
+          "description": "Override the underlay MTU Flannel should use, rendered as Backend.MTU\nin flannel’s net-conf.json. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the flannel.1\ninterface (i.e. flannel.1 ends up at mtu - 50).\n\nWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.\n",
+          "markdownDescription": "Override the underlay MTU Flannel should use, rendered as `Backend.MTU`\nin flannel's `net-conf.json`. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the `flannel.1`\ninterface (i.e. `flannel.1` ends up at `mtu - 50`).\n\nWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.",
+          "x-intellij-html-description": "\u003cp\u003eOverride the underlay MTU Flannel should use, rendered as \u003ccode\u003eBackend.MTU\u003c/code\u003e\nin flannel\u0026rsquo;s \u003ccode\u003enet-conf.json\u003c/code\u003e. Flannel internally subtracts the VXLAN\nheader overhead (50 bytes) from this when creating the \u003ccode\u003eflannel.1\u003c/code\u003e\ninterface (i.e. \u003ccode\u003eflannel.1\u003c/code\u003e ends up at \u003ccode\u003emtu - 50\u003c/code\u003e).\u003c/p\u003e\n\n\u003cp\u003eWhen KubeSpan is enabled and this value is not set, Talos defaults\nit to the KubeSpan link MTU, so the encapsulated VXLAN traffic fits\nwithin the WireGuard tunnel without permanent fragmentation.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
When kubespan is enabled, flannel auto-detects its underlay MTU from
the host's primary interface (typically 1500) and creates flannel.1
at MTU 1450 (= 1500 - 50 VXLAN overhead). Encapsulated VXLAN packets
are then routed through kubespan's WireGuard tunnel (default MTU
1420), forcing permanent fragmentation and degraded throughput.

Fix it in two parts:

* Render `Backend.MTU` in flannel's net-conf.json from a new
  `cluster.network.cni.flannel.mtu` field. Counter-intuitively,
  flannel's `Backend.MTU` represents the *underlay* transport MTU,
  not the resulting flannel.1 MTU — flannel internally subtracts
  the VXLAN overhead when creating the device. See:
  https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan

* In ControlPlaneBootstrapManifestsController, default
  `Backend.MTU` to the kubespan link MTU when kubespan is enabled
  and the field is unset. Explicit user override always wins.

With the default kubespan MTU of 1420, flannel.1 ends up at 1370,
so encapsulated VXLAN traffic fits within the WireGuard MTU without
fragmentation. When kubespan is disabled and the field is unset,
behavior is unchanged: `Backend.MTU` is omitted from net-conf.json
and flannel auto-detects from the external interface as before.

Fixes #13457

Signed-off-by: Fritz Schaal <fritz.schaal@siderolabs.com>
Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>
