### PR TITLE
refactor: update talosctl commands to stop using WithNodes

### DIFF
--- a/cmd/talosctl/cmd/talos/bootstrap.go
+++ b/cmd/talosctl/cmd/talos/bootstrap.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -37,11 +36,7 @@ This command should not be used when "init" type node are used.
 Talos etcd cluster can be recovered from a known snapshot with '--recover-from=' flag.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if len(GlobalArgs.Nodes) > 1 {
-				return errors.New("command \"bootstrap\" is not supported with multiple nodes")
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "bootstrap", func(ctx context.Context, c *client.Client, _ string) error {
 			if bootstrapCmdFlags.recoverFrom != "" {
 				manager := snapshot.NewV3(logging.Wrap(os.Stderr))
 

--- a/cmd/talosctl/cmd/talos/cgroups.go
+++ b/cmd/talosctl/cmd/talos/cgroups.go
@@ -21,7 +21,6 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/cgroupsprinter"
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/internal/pkg/cgroups"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -57,11 +56,7 @@ To see schema examples, refer to https://github.com/siderolabs/talos/tree/main/c
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "cgroups"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "cgroups", func(ctx context.Context, c *client.Client, _ string) error {
 			var schema cgroupsprinter.Schema
 
 			switch {

--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -414,11 +414,7 @@ var configNewCmd = &cobra.Command{
 
 		path := args[0]
 
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "talosconfig"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "config new", func(ctx context.Context, c *client.Client, _ string) error {
 			roles, unknownRoles := role.Parse(configNewCmdFlags.roles)
 			if len(unknownRoles) != 0 {
 				return fmt.Errorf("unknown roles: %s", strings.Join(unknownRoles, ", "))

--- a/cmd/talosctl/cmd/talos/conformance.go
+++ b/cmd/talosctl/cmd/talos/conformance.go
@@ -33,7 +33,7 @@ var conformanceKubernetesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
+		return WithClientAndSingleNode(cmd.Context(), "conformance", func(ctx context.Context, c *client.Client, _ string) error {
 			clientProvider := &cluster.ConfigClientProvider{
 				DefaultClient: c,
 			}

--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -6,20 +6,20 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -31,7 +31,10 @@ var containersCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			var (
 				namespace string
 				driver    common.ContainerDriver
@@ -45,49 +48,57 @@ var containersCmd = &cobra.Command{
 				driver = common.ContainerDriver_CONTAINERD
 			}
 
-			var remotePeer peer.Peer
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machineapi.ContainersResponse, error) {
+					return c.Containers(ctx, namespace, driver)
+				},
+			)
 
-			resp, err := c.Containers(ctx, namespace, driver, grpc.Peer(&remotePeer))
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error getting container list: %s", err)
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+			fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tIMAGE\tPID\tSTATUS")
+
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
+
+			flushTimer.Stop()
+
+			var errs error
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							slices.SortFunc(msg.Containers, func(a, b *machineapi.ContainerInfo) int { return strings.Compare(a.Id, b.Id) })
+
+							for _, p := range msg.Containers {
+								display := p.Id
+								if p.Id != p.PodId {
+									// container in a sandbox
+									display = "└─ " + display
+								}
+
+								fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Node, p.Namespace, display, p.Image, p.Pid, p.Status)
+							}
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-
-				cli.Warning("%s", err)
 			}
-
-			return containerRender(&remotePeer, resp)
 		})
 	},
-}
-
-func containerRender(remotePeer *peer.Peer, resp *machineapi.ContainersResponse) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tIMAGE\tPID\tSTATUS")
-
-	defaultNode := client.AddrFromPeer(remotePeer)
-
-	for _, msg := range resp.Messages {
-		slices.SortFunc(msg.Containers, func(a, b *machineapi.ContainerInfo) int { return strings.Compare(a.Id, b.Id) })
-
-		for _, p := range msg.Containers {
-			display := p.Id
-			if p.Id != p.PodId {
-				// container in a sandbox
-				display = "└─ " + display
-			}
-
-			node := defaultNode
-
-			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-			}
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", node, p.Namespace, display, p.Image, p.Pid, p.Status)
-		}
-	}
-
-	return w.Flush()
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -44,11 +44,7 @@ captures ownership and permission bits.`,
 		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "copy"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "copy", func(ctx context.Context, c *client.Client, _ string) error {
 			r, err := c.Copy(ctx, args[0])
 			if err != nil {
 				return fmt.Errorf("error copying: %w", err)

--- a/cmd/talosctl/cmd/talos/crashdump.go
+++ b/cmd/talosctl/cmd/talos/crashdump.go
@@ -5,12 +5,9 @@
 package talos
 
 import (
-	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
-
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 var crashdumpCmdFlags struct {
@@ -25,9 +22,7 @@ var crashdumpCmd = &cobra.Command{
 	Args:   cobra.NoArgs,
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			return errors.New("`talosctl crashdump` is deprecated, please use `talosctl support` instead")
-		})
+		return errors.New("`talosctl crashdump` is deprecated, please use `talosctl support` instead")
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -197,7 +197,7 @@ or EDITOR environment variables, or fall back to 'vi' for Linux
 or 'notepad' for Windows.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 				return err
 			}
 

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -7,24 +7,22 @@ package talos
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 	snapshot "go.etcd.io/etcd/etcdutl/v3/snapshot"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/logging"
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	etcdresource "github.com/siderolabs/talos/pkg/machinery/resources/etcd"
 )
 
@@ -42,47 +40,6 @@ var etcdAlarmCmd = &cobra.Command{
 	Long:  ``,
 }
 
-type alarmMessage interface {
-	GetMetadata() *common.Metadata //nolint:staticcheck // to be refactored next
-	GetMemberAlarms() []*machine.EtcdMemberAlarm
-}
-
-func displayAlarms(messages []alarmMessage) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	node := ""
-	pattern := "%s\t%s\n"
-	header := "MEMBER\tALARM"
-
-	for i, message := range messages {
-		if message.GetMetadata() != nil && message.GetMetadata().GetHostname() != "" { //nolint:staticcheck // to be refactored next
-			node = message.GetMetadata().GetHostname() //nolint:staticcheck // to be refactored next
-		}
-
-		for j, alarm := range message.GetMemberAlarms() {
-			if i == 0 && j == 0 {
-				if node != "" {
-					header = "NODE\t" + header
-					pattern = "%s\t" + pattern
-				}
-
-				fmt.Fprintln(w, header)
-			}
-
-			args := []any{
-				etcdresource.FormatMemberID(alarm.GetMemberId()),
-				alarm.GetAlarm().String(),
-			}
-			if node != "" {
-				args = slices.Insert(args, 0, any(node))
-			}
-
-			fmt.Fprintf(w, pattern, args...)
-		}
-	}
-
-	return w.Flush()
-}
-
 // etcdAlarmListCmd represents the etcd alarm list command.
 var etcdAlarmListCmd = &cobra.Command{
 	Use:   "list",
@@ -90,19 +47,59 @@ var etcdAlarmListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			response, err := c.EtcdAlarmList(ctx)
-			if err != nil {
-				if response == nil {
-					return fmt.Errorf("error getting alarms: %w", err)
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machine.EtcdAlarmListResponse, error) {
+					return c.EtcdAlarmList(ctx)
+				},
+			)
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
+
+			flushTimer.Stop()
+
+			var (
+				errs          error
+				headerPrinted bool
+			)
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							for _, alarm := range msg.GetMemberAlarms() {
+								if !headerPrinted {
+									fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+
+									headerPrinted = true
+								}
+
+								fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+							}
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-
-				cli.Warning("%s", err)
 			}
-
-			return displayAlarms(xslices.Map(response.Messages, func(v *machine.EtcdAlarm) alarmMessage {
-				return v
-			}))
 		})
 	},
 }
@@ -114,19 +111,59 @@ var etcdAlarmDisarmCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			response, err := c.EtcdAlarmDisarm(ctx)
-			if err != nil {
-				if response == nil {
-					return fmt.Errorf("error disarming alarms: %w", err)
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machine.EtcdAlarmDisarmResponse, error) {
+					return c.EtcdAlarmDisarm(ctx)
+				},
+			)
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
+
+			flushTimer.Stop()
+
+			var (
+				errs          error
+				headerPrinted bool
+			)
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							for _, alarm := range msg.GetMemberAlarms() {
+								if !headerPrinted {
+									fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+
+									headerPrinted = true
+								}
+
+								fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+							}
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-
-				cli.Warning("%s", err)
 			}
-
-			return displayAlarms(xslices.Map(response.Messages, func(v *machine.EtcdAlarmDisarm) alarmMessage {
-				return v
-			}))
 		})
 	},
 }
@@ -139,11 +176,7 @@ var etcdDefragCmd = &cobra.Command{
 Defragmentation is a resource heavy operation and should be performed only when necessary on a single node at a time.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd defrag"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd defrag", func(ctx context.Context, c *client.Client, _ string) error {
 			_, err := c.EtcdDefragment(ctx)
 
 			return err
@@ -157,11 +190,7 @@ var etcdLeaveCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd leave"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd leave", func(ctx context.Context, c *client.Client, _ string) error {
 			return c.EtcdLeaveCluster(ctx, &machine.EtcdLeaveClusterRequest{})
 		})
 	},
@@ -175,15 +204,33 @@ If there is no access to the node, or the node can't access etcd to call etcd le
 Always prefer etcd leave over this command.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			memberID, err := etcdresource.ParseMemberID(args[0])
 			if err != nil {
 				return fmt.Errorf("error parsing member ID: %w", err)
 			}
 
-			return c.EtcdRemoveMemberByID(ctx, &machine.EtcdRemoveMemberByIDRequest{
-				MemberId: memberID,
-			})
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (struct{}, error) {
+					return struct{}{}, c.EtcdRemoveMemberByID(ctx, &machine.EtcdRemoveMemberByIDRequest{
+						MemberId: memberID,
+					})
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				}
+			}
+
+			return errs
 		})
 	},
 }
@@ -194,10 +241,28 @@ var etcdForfeitLeadershipCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-			return err
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (struct{}, error) {
+					_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
+
+					return struct{}{}, err
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				}
+			}
+
+			return errs
 		})
 	},
 }
@@ -208,58 +273,61 @@ var etcdMemberListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			response, err := c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
-				QueryLocal: true,
-			})
-			if err != nil {
-				if response == nil {
-					return fmt.Errorf("error getting members: %w", err)
-				}
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-				cli.Warning("%s", err)
-			}
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machine.EtcdMemberListResponse, error) {
+					return c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
+						QueryLocal: true,
+					})
+				},
+			)
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			node := ""
-			pattern := "%s\t%s\t%s\t%s\t%v\n"
+			fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
 
-			for i, message := range response.Messages {
-				if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
 
-				if len(message.Members) == 0 {
-					continue
-				}
+			flushTimer.Stop()
 
-				for j, member := range message.Members {
-					if i == 0 && j == 0 {
-						if node != "" {
-							fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
+			var errs error
 
-							pattern = "%s\t" + pattern
-						} else {
-							fmt.Fprintln(w, "ID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, message := range resp.Payload.Messages {
+							for _, member := range message.Members {
+								fmt.Fprintf(
+									w, "%s\t%s\t%s\t%s\t%s\t%v\n",
+									resp.Node,
+									etcdresource.FormatMemberID(member.Id),
+									member.Hostname,
+									strings.Join(member.PeerUrls, ","),
+									strings.Join(member.ClientUrls, ","),
+									member.IsLearner,
+								)
+							}
 						}
 					}
 
-					args := []any{
-						etcdresource.FormatMemberID(member.Id),
-						member.Hostname,
-						strings.Join(member.PeerUrls, ","),
-						strings.Join(member.ClientUrls, ","),
-						member.IsLearner,
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 					}
-					if node != "" {
-						args = slices.Insert(args, 0, any(node))
-					}
-
-					fmt.Fprintf(w, pattern, args...)
 				}
 			}
-
-			return w.Flush()
 		})
 	},
 }
@@ -270,63 +338,70 @@ var etcdStatusCmd = &cobra.Command{
 	Long:  `Returns the status of etcd member on the node, use multiple nodes to get status of all members.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			response, err := c.EtcdStatus(ctx)
-			if err != nil {
-				if response == nil {
-					return fmt.Errorf("error getting status: %w", err)
-				}
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-				cli.Warning("%s", err)
-			}
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machine.EtcdStatusResponse, error) {
+					return c.EtcdStatus(ctx)
+				},
+			)
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			node := ""
-			pattern := "%s\t%s\t%s (%.2f%%)\t%s\t%d\t%d\t%d\t%v\t%s\t%s\t%s\n"
-			header := "MEMBER\tDB SIZE\tIN USE\tLEADER\tRAFT INDEX\tRAFT TERM\tRAFT APPLIED INDEX\tLEARNER\tPROTOCOL\tSTORAGE\tERRORS"
+			fmt.Fprintln(w, "NODE\tMEMBER\tDB SIZE\tIN USE\tLEADER\tRAFT INDEX\tRAFT TERM\tRAFT APPLIED INDEX\tLEARNER\tPROTOCOL\tSTORAGE\tERRORS")
 
-			for i, message := range response.Messages {
-				if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
 
-				if i == 0 {
-					if node != "" {
-						header = "NODE\t" + header
-						pattern = "%s\t" + pattern
+			flushTimer.Stop()
+
+			var errs error
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
 					}
 
-					fmt.Fprintln(w, header)
-				}
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, message := range resp.Payload.Messages {
+							var ratio float64
 
-				var ratio float64
+							if message.GetMemberStatus().GetDbSize() > 0 {
+								ratio = float64(message.GetMemberStatus().GetDbSizeInUse()) / float64(message.GetMemberStatus().GetDbSize()) * 100.0
+							}
 
-				if message.GetMemberStatus().GetDbSize() > 0 {
-					ratio = float64(message.GetMemberStatus().GetDbSizeInUse()) / float64(message.GetMemberStatus().GetDbSize()) * 100.0
-				}
+							fmt.Fprintf(
+								w, "%s\t%s\t%s\t%s (%.2f%%)\t%s\t%d\t%d\t%d\t%v\t%s\t%s\t%s\n",
+								resp.Node,
+								etcdresource.FormatMemberID(message.GetMemberStatus().GetMemberId()),
+								humanize.Bytes(uint64(message.GetMemberStatus().GetDbSize())),
+								humanize.Bytes(uint64(message.GetMemberStatus().GetDbSizeInUse())),
+								ratio,
+								etcdresource.FormatMemberID(message.GetMemberStatus().GetLeader()),
+								message.GetMemberStatus().GetRaftIndex(),
+								message.GetMemberStatus().GetRaftTerm(),
+								message.GetMemberStatus().GetRaftAppliedIndex(),
+								message.GetMemberStatus().GetIsLearner(),
+								message.GetMemberStatus().GetProtocolVersion(),
+								message.GetMemberStatus().GetStorageVersion(),
+								strings.Join(message.GetMemberStatus().GetErrors(), ", "),
+							)
+						}
+					}
 
-				args := []any{
-					etcdresource.FormatMemberID(message.GetMemberStatus().GetMemberId()),
-					humanize.Bytes(uint64(message.GetMemberStatus().GetDbSize())),
-					humanize.Bytes(uint64(message.GetMemberStatus().GetDbSizeInUse())),
-					ratio,
-					etcdresource.FormatMemberID(message.GetMemberStatus().GetLeader()),
-					message.GetMemberStatus().GetRaftIndex(),
-					message.GetMemberStatus().GetRaftTerm(),
-					message.GetMemberStatus().GetRaftAppliedIndex(),
-					message.GetMemberStatus().GetIsLearner(),
-					message.GetMemberStatus().GetProtocolVersion(),
-					message.GetMemberStatus().GetStorageVersion(),
-					strings.Join(message.GetMemberStatus().GetErrors(), ", "),
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-				if node != "" {
-					args = slices.Insert(args, 0, any(node))
-				}
-
-				fmt.Fprintf(w, pattern, args...)
 			}
-
-			return w.Flush()
 		})
 	},
 }
@@ -337,11 +412,7 @@ var etcdSnapshotCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd snapshot"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd snapshot", func(ctx context.Context, c *client.Client, _ string) error {
 			dbPath := args[0]
 			partPath := dbPath + ".part"
 
@@ -407,8 +478,8 @@ var etcdDowngradeCmd = &cobra.Command{
 }
 
 const (
-	etcdDowngradePattern = "%s\n"
-	etcdDowngradeHeader  = "MESSAGE"
+	etcdDowngradePattern = "%s\t%s\n"
+	etcdDowngradeHeader  = "NODE\tMESSAGE"
 )
 
 var etcdDowngradeValidateCmd = &cobra.Command{
@@ -417,11 +488,7 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade validate"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade validate", func(ctx context.Context, c *client.Client, node string) error {
 			version := args[0]
 
 			r, err := c.EtcdDowngradeValidate(ctx, &machine.EtcdDowngradeValidateRequest{Version: version})
@@ -430,35 +497,21 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			node := ""
 			pattern := etcdDowngradePattern
 			header := etcdDowngradeHeader
 
 			for i, message := range r.Messages {
-				if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
-
 				if i == 0 {
-					if node != "" {
-						header = "NODE\t" + header
-						pattern = "%s\t" + pattern
-					}
-
 					fmt.Fprintln(w, header)
 				}
 
-				args := []any{
+				fmt.Fprintf(
+					w, pattern, node,
 					fmt.Sprintf(
 						"downgrade validate success, cluster version %s",
 						message.GetClusterDowngrade().GetClusterVersion(),
 					),
-				}
-				if node != "" {
-					args = slices.Insert(args, 0, any(node))
-				}
-
-				fmt.Fprintf(w, pattern, args...)
+				)
 			}
 
 			return w.Flush()
@@ -472,11 +525,7 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade enable"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade enable", func(ctx context.Context, c *client.Client, node string) error {
 			version := args[0]
 
 			r, err := c.EtcdDowngradeEnable(ctx, &machine.EtcdDowngradeEnableRequest{Version: version})
@@ -485,35 +534,22 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			node := ""
 			pattern := etcdDowngradePattern
 			header := etcdDowngradeHeader
 
 			for i, message := range r.Messages {
-				if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
-
 				if i == 0 {
-					if node != "" {
-						header = "NODE\t" + header
-						pattern = "%s\t" + pattern
-					}
-
 					fmt.Fprintln(w, header)
 				}
 
-				args := []any{
+				fmt.Fprintf(
+					w, pattern,
+					node,
 					fmt.Sprintf(
 						"downgrade enable success, cluster version %s",
 						message.GetClusterDowngrade().GetClusterVersion(),
 					),
-				}
-				if node != "" {
-					args = slices.Insert(args, 0, any(node))
-				}
-
-				fmt.Fprintf(w, pattern, args...)
+				)
 			}
 
 			return w.Flush()
@@ -527,46 +563,28 @@ var etcdDowngradeCancelCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "etcd downgrade cancel"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade cancel", func(ctx context.Context, c *client.Client, node string) error {
 			r, err := c.EtcdDowngradeCancel(ctx)
 			if err != nil {
 				return err
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			node := ""
 			pattern := etcdDowngradePattern
 			header := etcdDowngradeHeader
 
 			for i, message := range r.Messages {
-				if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
-
 				if i == 0 {
-					if node != "" {
-						header = "NODE\t" + header
-						pattern = "%s\t" + pattern
-					}
-
 					fmt.Fprintln(w, header)
 				}
 
-				args := []any{
+				fmt.Fprintf(
+					w, pattern, node,
 					fmt.Sprintf(
 						"downgrade cancel success, cluster version %s",
 						message.GetClusterDowngrade().GetClusterVersion(),
 					),
-				}
-				if node != "" {
-					args = slices.Insert(args, 0, any(node))
-				}
-
-				fmt.Fprintf(w, pattern, args...)
+				)
 			}
 
 			return w.Flush()

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -63,7 +63,7 @@ To get a list of all available resource definitions, issue 'talosctl get rd'`,
 //nolint:gocyclo,cyclop
 func getResources(args []string) func(ctx context.Context, c *client.Client) error {
 	return func(ctx context.Context, c *client.Client) error {
-		if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+		if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 			return err
 		}
 

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
 	"github.com/siderolabs/talos/pkg/cluster/hydrophone"
@@ -110,7 +109,7 @@ var healthCmd = &cobra.Command{
 
 func runHealth(ctx context.Context) error {
 	if healthCmdFlags.runOnServer {
-		return WithClient(ctx, healthOnServer)
+		return WithClientAndSingleNode(ctx, "health", healthOnServer)
 	}
 
 	return WithClientNoNodes(ctx, healthOnClient)
@@ -147,11 +146,7 @@ func healthOnClient(ctx context.Context, c *client.Client) error {
 	return check.Wait(checkCtx, &state, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
 }
 
-func healthOnServer(ctx context.Context, c *client.Client) error {
-	if err := helpers.FailIfMultiNodes(ctx, "health"); err != nil {
-		return err
-	}
-
+func healthOnServer(ctx context.Context, c *client.Client, _ string) error {
 	controlPlaneNodes := healthCmdFlags.clusterState.ControlPlaneNodes
 	if healthCmdFlags.clusterState.InitNode != "" {
 		controlPlaneNodes = append(controlPlaneNodes, healthCmdFlags.clusterState.InitNode)
@@ -180,16 +175,12 @@ func healthOnServer(ctx context.Context, c *client.Client) error {
 			return err
 		}
 
-		if msg.GetMetadata().GetError() != "" { //nolint:staticcheck // to be refactored next
-			return fmt.Errorf("healthcheck error: %s", msg.GetMetadata().GetError()) //nolint:staticcheck // to be refactored next
-		}
-
 		fmt.Fprintln(os.Stderr, msg.GetMessage())
 	}
 }
 
 func runE2E(ctx context.Context) error {
-	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
+	return WithClientAndSingleNode(ctx, "health", func(ctx context.Context, c *client.Client, _ string) error {
 		clientProvider := &cluster.ConfigClientProvider{
 			DefaultClient: c,
 		}

--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/formatters"
@@ -41,11 +40,7 @@ to render the graph:
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "inspect dependencies"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "inspect dependencies", func(ctx context.Context, c *client.Client, node string) error {
 			resp, err := c.Inspect.ControllerRuntimeDependencies(ctx)
 			if err != nil {
 				if resp == nil {

--- a/cmd/talosctl/cmd/talos/interfaces.go
+++ b/cmd/talosctl/cmd/talos/interfaces.go
@@ -5,12 +5,9 @@
 package talos
 
 import (
-	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
-
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // interfacesCmd represents the net interfaces command.
@@ -21,9 +18,7 @@ var interfacesCmd = &cobra.Command{
 	Args:   cobra.NoArgs,
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			return errors.New("`talosctl interfaces` is deprecated, please use `talosctl get addresses` and `talosctl get links` instead")
-		})
+		return errors.New("`talosctl interfaces` is deprecated, please use `talosctl get addresses` and `talosctl get links` instead")
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -42,11 +42,7 @@ Otherwise, kubeconfig will be written to PWD or [local-path] if specified.
 If merge flag is false and [local-path] is "-", config will be written to stdout.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "kubeconfig"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "kubeconfig", func(ctx context.Context, c *client.Client, _ string) error {
 			var localPath string
 
 			if len(args) == 0 {

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -6,18 +6,17 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/siderolabs/talos/pkg/cli"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var verbose bool
@@ -30,123 +29,137 @@ var memoryCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			var remotePeer peer.Peer
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-			resp, err := c.Memory(ctx, grpc.Peer(&remotePeer))
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error getting memory stats: %s", err)
-				}
-
-				cli.Warning("%s", err)
-			}
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machineapi.MemoryResponse, error) {
+					return c.Memory(ctx)
+				},
+			)
 
 			if verbose {
-				verboseRender(&remotePeer, resp)
-			} else {
-				err = briefRender(&remotePeer, resp)
-				if err != nil {
-					return err
-				}
+				return renderVerbose(responseChan)
 			}
 
-			return helpers.CheckErrors(resp.Messages...)
+			return renderBrief(responseChan)
 		})
 	},
 }
 
-func briefRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) error {
+func renderBrief(responseChan <-chan multiplex.Response[*machineapi.MemoryResponse]) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tTOTAL\tUSED\tFREE\tSHARED\tBUFFERS\tCACHE\tAVAILABLE")
 
-	defaultNode := client.AddrFromPeer(remotePeer)
+	flushTimer := time.NewTimer(outputFlushInterval)
+	defer flushTimer.Stop()
 
-	for _, msg := range resp.Messages {
-		node := defaultNode
+	flushTimer.Stop()
 
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+	var errs error
+
+	for {
+		select {
+		case resp, ok := <-responseChan:
+			if !ok {
+				return errors.Join(errs, w.Flush())
+			}
+
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+			} else {
+				for _, msg := range resp.Payload.Messages {
+					// Default to displaying output as MB
+					fmt.Fprintf(
+						w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+						resp.Node,
+						msg.Meminfo.Memtotal/1024,
+						(msg.Meminfo.Memtotal-msg.Meminfo.Memfree-msg.Meminfo.Cached-msg.Meminfo.Buffers)/1024,
+						msg.Meminfo.Memfree/1024,
+						msg.Meminfo.Shmem/1024,
+						msg.Meminfo.Buffers/1024,
+						msg.Meminfo.Cached/1024,
+						msg.Meminfo.Memavailable/1024,
+					)
+				}
+			}
+
+			flushTimer.Reset(outputFlushInterval)
+		case <-flushTimer.C:
+			if err := w.Flush(); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+			}
 		}
-
-		// Default to displaying output as MB
-		fmt.Fprintf(
-			w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			node,
-			msg.Meminfo.Memtotal/1024,
-			(msg.Meminfo.Memtotal-msg.Meminfo.Memfree-msg.Meminfo.Cached-msg.Meminfo.Buffers)/1024,
-			msg.Meminfo.Memfree/1024,
-			msg.Meminfo.Shmem/1024,
-			msg.Meminfo.Buffers/1024,
-			msg.Meminfo.Cached/1024,
-			msg.Meminfo.Memavailable/1024,
-		)
 	}
-
-	return w.Flush()
 }
 
-func verboseRender(remotePeer *peer.Peer, resp *machineapi.MemoryResponse) {
-	defaultNode := client.AddrFromPeer(remotePeer)
+func renderVerbose(responseChan <-chan multiplex.Response[*machineapi.MemoryResponse]) error {
+	var errs error
 
-	// Dump as /proc/meminfo
-	for _, msg := range resp.Messages {
-		node := defaultNode
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+			continue
 		}
 
-		fmt.Printf("%s: %s\n", "NODE", node)
-		fmt.Printf("%s: %d %s\n", "MemTotal", msg.Meminfo.Memtotal, "kB")
-		fmt.Printf("%s: %d %s\n", "MemFree", msg.Meminfo.Memfree, "kB")
-		fmt.Printf("%s: %d %s\n", "MemAvailable", msg.Meminfo.Memavailable, "kB")
-		fmt.Printf("%s: %d %s\n", "Buffers", msg.Meminfo.Buffers, "kB")
-		fmt.Printf("%s: %d %s\n", "Cached", msg.Meminfo.Cached, "kB")
-		fmt.Printf("%s: %d %s\n", "SwapCached", msg.Meminfo.Swapcached, "kB")
-		fmt.Printf("%s: %d %s\n", "Active", msg.Meminfo.Active, "kB")
-		fmt.Printf("%s: %d %s\n", "Inactive", msg.Meminfo.Inactive, "kB")
-		fmt.Printf("%s: %d %s\n", "ActiveAnon", msg.Meminfo.Activeanon, "kB")
-		fmt.Printf("%s: %d %s\n", "InactiveAnon", msg.Meminfo.Inactiveanon, "kB")
-		fmt.Printf("%s: %d %s\n", "ActiveFile", msg.Meminfo.Activefile, "kB")
-		fmt.Printf("%s: %d %s\n", "InactiveFile", msg.Meminfo.Inactivefile, "kB")
-		fmt.Printf("%s: %d %s\n", "Unevictable", msg.Meminfo.Unevictable, "kB")
-		fmt.Printf("%s: %d %s\n", "Mlocked", msg.Meminfo.Mlocked, "kB")
-		fmt.Printf("%s: %d %s\n", "SwapTotal", msg.Meminfo.Swaptotal, "kB")
-		fmt.Printf("%s: %d %s\n", "SwapFree", msg.Meminfo.Swapfree, "kB")
-		fmt.Printf("%s: %d %s\n", "Dirty", msg.Meminfo.Dirty, "kB")
-		fmt.Printf("%s: %d %s\n", "Writeback", msg.Meminfo.Writeback, "kB")
-		fmt.Printf("%s: %d %s\n", "AnonPages", msg.Meminfo.Anonpages, "kB")
-		fmt.Printf("%s: %d %s\n", "Mapped", msg.Meminfo.Mapped, "kB")
-		fmt.Printf("%s: %d %s\n", "Shmem", msg.Meminfo.Shmem, "kB")
-		fmt.Printf("%s: %d %s\n", "Slab", msg.Meminfo.Slab, "kB")
-		fmt.Printf("%s: %d %s\n", "SReclaimable", msg.Meminfo.Sreclaimable, "kB")
-		fmt.Printf("%s: %d %s\n", "SUnreclaim", msg.Meminfo.Sunreclaim, "kB")
-		fmt.Printf("%s: %d %s\n", "KernelStack", msg.Meminfo.Kernelstack, "kB")
-		fmt.Printf("%s: %d %s\n", "PageTables", msg.Meminfo.Pagetables, "kB")
-		fmt.Printf("%s: %d %s\n", "NFSUnstable", msg.Meminfo.Nfsunstable, "kB")
-		fmt.Printf("%s: %d %s\n", "Bounce", msg.Meminfo.Bounce, "kB")
-		fmt.Printf("%s: %d %s\n", "WritebackTmp", msg.Meminfo.Writebacktmp, "kB")
-		fmt.Printf("%s: %d %s\n", "CommitLimit", msg.Meminfo.Commitlimit, "kB")
-		fmt.Printf("%s: %d %s\n", "CommittedAS", msg.Meminfo.Committedas, "kB")
-		fmt.Printf("%s: %d %s\n", "VmallocTotal", msg.Meminfo.Vmalloctotal, "kB")
-		fmt.Printf("%s: %d %s\n", "VmallocUsed", msg.Meminfo.Vmallocused, "kB")
-		fmt.Printf("%s: %d %s\n", "VmallocChunk", msg.Meminfo.Vmallocchunk, "kB")
-		fmt.Printf("%s: %d %s\n", "HardwareCorrupted", msg.Meminfo.Hardwarecorrupted, "kB")
-		fmt.Printf("%s: %d %s\n", "AnonHugePages", msg.Meminfo.Anonhugepages, "kB")
-		fmt.Printf("%s: %d %s\n", "ShmemHugePages", msg.Meminfo.Shmemhugepages, "kB")
-		fmt.Printf("%s: %d %s\n", "ShmemPmdMapped", msg.Meminfo.Shmempmdmapped, "kB")
-		fmt.Printf("%s: %d %s\n", "CmaTotal", msg.Meminfo.Cmatotal, "kB")
-		fmt.Printf("%s: %d %s\n", "CmaFree", msg.Meminfo.Cmafree, "kB")
-		fmt.Printf("%s: %d\n", "HugePagesTotal", msg.Meminfo.Hugepagestotal)
-		fmt.Printf("%s: %d\n", "HugePagesFree", msg.Meminfo.Hugepagesfree)
-		fmt.Printf("%s: %d\n", "HugePagesRsvd", msg.Meminfo.Hugepagesrsvd)
-		fmt.Printf("%s: %d\n", "HugePagesSurp", msg.Meminfo.Hugepagessurp)
-		fmt.Printf("%s: %d %s\n", "Hugepagesize", msg.Meminfo.Hugepagesize, "kB")
-		fmt.Printf("%s: %d %s\n", "DirectMap4k", msg.Meminfo.Directmap4K, "kB")
-		fmt.Printf("%s: %d %s\n", "DirectMap2M", msg.Meminfo.Directmap2M, "kB")
-		fmt.Printf("%s: %d %s\n", "DirectMap1G", msg.Meminfo.Directmap1G, "kB")
+		// Dump as /proc/meminfo
+		for _, msg := range resp.Payload.Messages {
+			fmt.Printf("%s: %s\n", "NODE", resp.Node)
+			fmt.Printf("%s: %d %s\n", "MemTotal", msg.Meminfo.Memtotal, "kB")
+			fmt.Printf("%s: %d %s\n", "MemFree", msg.Meminfo.Memfree, "kB")
+			fmt.Printf("%s: %d %s\n", "MemAvailable", msg.Meminfo.Memavailable, "kB")
+			fmt.Printf("%s: %d %s\n", "Buffers", msg.Meminfo.Buffers, "kB")
+			fmt.Printf("%s: %d %s\n", "Cached", msg.Meminfo.Cached, "kB")
+			fmt.Printf("%s: %d %s\n", "SwapCached", msg.Meminfo.Swapcached, "kB")
+			fmt.Printf("%s: %d %s\n", "Active", msg.Meminfo.Active, "kB")
+			fmt.Printf("%s: %d %s\n", "Inactive", msg.Meminfo.Inactive, "kB")
+			fmt.Printf("%s: %d %s\n", "ActiveAnon", msg.Meminfo.Activeanon, "kB")
+			fmt.Printf("%s: %d %s\n", "InactiveAnon", msg.Meminfo.Inactiveanon, "kB")
+			fmt.Printf("%s: %d %s\n", "ActiveFile", msg.Meminfo.Activefile, "kB")
+			fmt.Printf("%s: %d %s\n", "InactiveFile", msg.Meminfo.Inactivefile, "kB")
+			fmt.Printf("%s: %d %s\n", "Unevictable", msg.Meminfo.Unevictable, "kB")
+			fmt.Printf("%s: %d %s\n", "Mlocked", msg.Meminfo.Mlocked, "kB")
+			fmt.Printf("%s: %d %s\n", "SwapTotal", msg.Meminfo.Swaptotal, "kB")
+			fmt.Printf("%s: %d %s\n", "SwapFree", msg.Meminfo.Swapfree, "kB")
+			fmt.Printf("%s: %d %s\n", "Dirty", msg.Meminfo.Dirty, "kB")
+			fmt.Printf("%s: %d %s\n", "Writeback", msg.Meminfo.Writeback, "kB")
+			fmt.Printf("%s: %d %s\n", "AnonPages", msg.Meminfo.Anonpages, "kB")
+			fmt.Printf("%s: %d %s\n", "Mapped", msg.Meminfo.Mapped, "kB")
+			fmt.Printf("%s: %d %s\n", "Shmem", msg.Meminfo.Shmem, "kB")
+			fmt.Printf("%s: %d %s\n", "Slab", msg.Meminfo.Slab, "kB")
+			fmt.Printf("%s: %d %s\n", "SReclaimable", msg.Meminfo.Sreclaimable, "kB")
+			fmt.Printf("%s: %d %s\n", "SUnreclaim", msg.Meminfo.Sunreclaim, "kB")
+			fmt.Printf("%s: %d %s\n", "KernelStack", msg.Meminfo.Kernelstack, "kB")
+			fmt.Printf("%s: %d %s\n", "PageTables", msg.Meminfo.Pagetables, "kB")
+			fmt.Printf("%s: %d %s\n", "NFSUnstable", msg.Meminfo.Nfsunstable, "kB")
+			fmt.Printf("%s: %d %s\n", "Bounce", msg.Meminfo.Bounce, "kB")
+			fmt.Printf("%s: %d %s\n", "WritebackTmp", msg.Meminfo.Writebacktmp, "kB")
+			fmt.Printf("%s: %d %s\n", "CommitLimit", msg.Meminfo.Commitlimit, "kB")
+			fmt.Printf("%s: %d %s\n", "CommittedAS", msg.Meminfo.Committedas, "kB")
+			fmt.Printf("%s: %d %s\n", "VmallocTotal", msg.Meminfo.Vmalloctotal, "kB")
+			fmt.Printf("%s: %d %s\n", "VmallocUsed", msg.Meminfo.Vmallocused, "kB")
+			fmt.Printf("%s: %d %s\n", "VmallocChunk", msg.Meminfo.Vmallocchunk, "kB")
+			fmt.Printf("%s: %d %s\n", "HardwareCorrupted", msg.Meminfo.Hardwarecorrupted, "kB")
+			fmt.Printf("%s: %d %s\n", "AnonHugePages", msg.Meminfo.Anonhugepages, "kB")
+			fmt.Printf("%s: %d %s\n", "ShmemHugePages", msg.Meminfo.Shmemhugepages, "kB")
+			fmt.Printf("%s: %d %s\n", "ShmemPmdMapped", msg.Meminfo.Shmempmdmapped, "kB")
+			fmt.Printf("%s: %d %s\n", "CmaTotal", msg.Meminfo.Cmatotal, "kB")
+			fmt.Printf("%s: %d %s\n", "CmaFree", msg.Meminfo.Cmafree, "kB")
+			fmt.Printf("%s: %d\n", "HugePagesTotal", msg.Meminfo.Hugepagestotal)
+			fmt.Printf("%s: %d\n", "HugePagesFree", msg.Meminfo.Hugepagesfree)
+			fmt.Printf("%s: %d\n", "HugePagesRsvd", msg.Meminfo.Hugepagesrsvd)
+			fmt.Printf("%s: %d\n", "HugePagesSurp", msg.Meminfo.Hugepagessurp)
+			fmt.Printf("%s: %d %s\n", "Hugepagesize", msg.Meminfo.Hugepagesize, "kB")
+			fmt.Printf("%s: %d %s\n", "DirectMap4k", msg.Meminfo.Directmap4K, "kB")
+			fmt.Printf("%s: %d %s\n", "DirectMap2M", msg.Meminfo.Directmap2M, "kB")
+			fmt.Printf("%s: %d %s\n", "DirectMap1G", msg.Meminfo.Directmap1G, "kB")
+		}
 	}
+
+	return errs
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -6,15 +6,13 @@ package talos
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/formatters"
 )
 
@@ -26,19 +24,18 @@ var mountsCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			var remotePeer peer.Peer
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-			resp, err := c.Mounts(ctx, grpc.Peer(&remotePeer))
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error getting mount information: %s", err)
-				}
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machineapi.MountsResponse, error) {
+					return c.Mounts(ctx)
+				},
+			)
 
-				cli.Warning("%s", err)
-			}
-
-			return formatters.RenderMounts(resp, os.Stdout, &remotePeer)
+			return formatters.RenderMountsStream(os.Stdout, responseChan)
 		})
 	},
 }

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -148,7 +148,7 @@ var patchCmd = &cobra.Command{
 				return err
 			}
 
-			if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 				return err
 			}
 

--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
@@ -65,11 +64,7 @@ e.g. by excluding packets with the port 50000.
    `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "pcap"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "pcap", func(ctx context.Context, c *client.Client, node string) error {
 			if pcapCmdFlags.duration > 0 {
 				var cancel context.CancelFunc
 

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -6,20 +6,21 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var sortMethod string
@@ -32,17 +33,89 @@ var processesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			output, err := processesOutput(ctx, c)
-			if err != nil {
-				return err
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machineapi.ProcessesResponse, error) {
+					return c.Processes(ctx)
+				},
+			)
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+			fmt.Fprintln(w, "NODE\tPID\tSTATE\tTHREADS\tCPU-TIME\tVIRTMEM\tRESMEM\tLABEL\tCOMMAND")
+
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
+
+			flushTimer.Stop()
+
+			var errs error
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							procs := msg.Processes
+
+							switch sortMethod {
+							case "cpu":
+								by(cpu).sort(procs)
+							default:
+								by(rss).sort(procs)
+							}
+
+							for _, p := range procs {
+								fmt.Fprintf(
+									w, "%s\t%d\t%s\t%d\t%.2f\t%s\t%s\t%s\t%s\n",
+									resp.Node, p.Pid, p.State, p.Threads, p.CpuTime,
+									humanize.Bytes(p.VirtualMemory), humanize.Bytes(p.ResidentMemory),
+									p.Label, processArgs(p),
+								)
+							}
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
+				}
 			}
-
-			fmt.Println(output)
-
-			return nil
 		})
 	},
+}
+
+func processArgs(p *machineapi.ProcessInfo) string {
+	var args string
+
+	switch {
+	case p.Executable == "":
+		args = p.Command
+	case p.Args != "" && strings.Fields(p.Args)[0] == filepath.Base(strings.Fields(p.Executable)[0]):
+		args = strings.Replace(p.Args, strings.Fields(p.Args)[0], p.Executable, 1)
+	default:
+		args = p.Args
+	}
+
+	// filter out non-printable characters
+	return strings.Map(func(r rune) rune {
+		if r < 32 || r > 126 {
+			return ' '
+		}
+
+		return r
+	}, args)
 }
 
 func init() {
@@ -89,67 +162,4 @@ var rss = func(p1, p2 *machineapi.ProcessInfo) bool {
 var cpu = func(p1, p2 *machineapi.ProcessInfo) bool {
 	// Reverse sort ( Descending )
 	return p1.CpuTime > p2.CpuTime
-}
-
-//nolint:gocyclo
-func processesOutput(ctx context.Context, c *client.Client) (output string, err error) {
-	var remotePeer peer.Peer
-
-	resp, err := c.Processes(ctx, grpc.Peer(&remotePeer))
-	if err != nil {
-		return output, err
-	}
-
-	defaultNode := client.AddrFromPeer(&remotePeer)
-
-	var s []string
-
-	s = append(s, "NODE | PID | STATE | THREADS | CPU-TIME | VIRTMEM | RESMEM | LABEL | COMMAND")
-
-	for _, msg := range resp.Messages {
-		procs := msg.Processes
-
-		switch sortMethod {
-		case "cpu":
-			by(cpu).sort(procs)
-		default:
-			by(rss).sort(procs)
-		}
-
-		var args string
-
-		for _, p := range procs {
-			switch {
-			case p.Executable == "":
-				args = p.Command
-			case p.Args != "" && strings.Fields(p.Args)[0] == filepath.Base(strings.Fields(p.Executable)[0]):
-				args = strings.Replace(p.Args, strings.Fields(p.Args)[0], p.Executable, 1)
-			default:
-				args = p.Args
-			}
-
-			// filter out non-printable characters
-			args = strings.Map(func(r rune) rune {
-				if r < 32 || r > 126 {
-					return ' '
-				}
-
-				return r
-			}, args)
-
-			node := defaultNode
-
-			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-			}
-
-			s = append(s,
-				fmt.Sprintf("%12s | %6d | %1s | %4d | %8.2f | %7s | %7s | %64s | %s",
-					node, p.Pid, p.State, p.Threads, p.CpuTime, humanize.Bytes(p.VirtualMemory), humanize.Bytes(p.ResidentMemory), p.Label, args))
-		}
-	}
-
-	res := columnize.SimpleFormat(s)
-
-	return res, helpers.CheckErrors(resp.Messages...)
 }

--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
@@ -31,11 +30,7 @@ var readCmd = &cobra.Command{
 		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.FailIfMultiNodes(ctx, "read"); err != nil {
-				return err
-			}
-
+		return WithClientAndSingleNode(cmd.Context(), "read", func(ctx context.Context, c *client.Client, _ string) error {
 			r, err := c.Read(ctx, args[0])
 			if err != nil {
 				return fmt.Errorf("error reading file: %w", err)

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -92,7 +92,7 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 func rebootInternal(ctx context.Context, wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
 	if !wait {
 		return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-			if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 				return err
 			}
 

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -98,7 +98,7 @@ var resetCmd = &cobra.Command{
 
 		if !resetCmdFlags.wait {
 			resetNoWait := func(ctx context.Context, c *client.Client) error {
-				if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+				if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 					return err
 				}
 

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -6,12 +6,14 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -29,7 +31,10 @@ var restartCmd = &cobra.Command{
 		return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			var (
 				namespace string
 				driver    common.ContainerDriver
@@ -43,11 +48,22 @@ var restartCmd = &cobra.Command{
 				driver = common.ContainerDriver_CONTAINERD
 			}
 
-			if err := c.Restart(ctx, namespace, driver, args[0]); err != nil {
-				return fmt.Errorf("error restarting process: %s", err)
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (struct{}, error) {
+					return struct{}{}, c.Restart(ctx, namespace, driver, args[0])
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error restarting process on node %s: %w", resp.Node, resp.Err))
+				}
 			}
 
-			return nil
+			return errs
 		})
 	},
 }

--- a/cmd/talosctl/cmd/talos/rollback.go
+++ b/cmd/talosctl/cmd/talos/rollback.go
@@ -6,11 +6,13 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 // rollbackCmd represents the rollback command.
@@ -19,12 +21,26 @@ var rollbackCmd = &cobra.Command{
 	Short: "Rollback a node to the previous installation",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := c.Rollback(ctx); err != nil {
-				return fmt.Errorf("error executing rollback: %s", err)
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (struct{}, error) {
+					return struct{}{}, c.Rollback(ctx)
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error executing rollback on node %s: %w", resp.Node, resp.Err))
+				}
 			}
 
-			return nil
+			return errs
 		})
 	},
 }

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -35,6 +35,11 @@ var GlobalArgs global.Args
 
 const pathAutoCompleteLimit = 500
 
+// outputFlushInterval is the quiet period after the last multiplexed response
+// before flushing the tabwriter, so partial results appear without thrashing
+// column widths while responses are still arriving.
+const outputFlushInterval = formatters.FlushInterval
+
 // WithClientNoNodes wraps common code to initialize Talos client and provide cancellable context.
 //
 // WithClientNoNodes doesn't set any node information on the request context.
@@ -50,6 +55,11 @@ func WithClient(ctx context.Context, action func(context.Context, *client.Client
 // WithClientAndNodes builds upon WithClientNoNodes to pass a list of nodes via command function.
 func WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
 	return GlobalArgs.WithClientAndNodes(ctx, action, dialOptions...)
+}
+
+// WithClientAndSingleNode builds upon WithClientAndNodes to provide a helper which enforces a single node in the list, and uses client.WithNode.
+func WithClientAndSingleNode(ctx context.Context, commandName string, action func(context.Context, *client.Client, string) error, dialOptions ...grpc.DialOption) error {
+	return GlobalArgs.WithClientAndSingleNode(ctx, commandName, action, dialOptions...)
 }
 
 // WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).

--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -49,11 +49,11 @@ PKI can be rotated by applying machine config changes to the controlplane nodes.
 			return err
 		}
 
-		return WithClient(cmd.Context(), rotateCA)
+		return WithClientAndSingleNode(cmd.Context(), "rotate-ca", rotateCA)
 	},
 }
 
-func rotateCA(ctx context.Context, c *client.Client) error {
+func rotateCA(ctx context.Context, c *client.Client, _ string) error {
 	commentsFlags := encoder.CommentsDisabled
 	if rotateCACmdFlags.withDocs {
 		commentsFlags |= encoder.CommentsDocs

--- a/cmd/talosctl/cmd/talos/routes.go
+++ b/cmd/talosctl/cmd/talos/routes.go
@@ -5,12 +5,9 @@
 package talos
 
 import (
-	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
-
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // routesCmd represents the net routes command.
@@ -22,9 +19,7 @@ var routesCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Hidden:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			return errors.New("`talosctl routes` is deprecated, please use `talosctl get routes` instead")
-		})
+		return errors.New("`talosctl routes` is deprecated, please use `talosctl get routes` instead")
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -39,7 +39,7 @@ var shutdownCmd = &cobra.Command{
 
 		if !shutdownCmdFlags.wait {
 			return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-				if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+				if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 					return err
 				}
 

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -6,20 +6,20 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -30,7 +30,10 @@ var statsCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			var (
 				namespace string
 				driver    common.ContainerDriver
@@ -44,50 +47,57 @@ var statsCmd = &cobra.Command{
 				driver = common.ContainerDriver_CONTAINERD
 			}
 
-			var remotePeer peer.Peer
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*machineapi.StatsResponse, error) {
+					return c.Stats(ctx, namespace, driver)
+				},
+			)
 
-			resp, err := c.Stats(ctx, namespace, driver, grpc.Peer(&remotePeer))
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error getting stats: %s", err)
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+			fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tMEMORY(MB)\tCPU")
+
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
+
+			flushTimer.Stop()
+
+			var errs error
+
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							slices.SortFunc(msg.Stats, func(a, b *machineapi.Stat) int { return strings.Compare(a.Id, b.Id) })
+
+							for _, s := range msg.Stats {
+								display := s.Id
+								if s.Id != s.PodId {
+									// container in a sandbox
+									display = "└─ " + display
+								}
+
+								fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
+							}
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-
-				cli.Warning("%s", err)
 			}
-
-			return statsRender(&remotePeer, resp)
 		})
 	},
-}
-
-func statsRender(remotePeer *peer.Peer, resp *machineapi.StatsResponse) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-
-	fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tMEMORY(MB)\tCPU")
-
-	defaultNode := client.AddrFromPeer(remotePeer)
-
-	for _, msg := range resp.Messages {
-		slices.SortFunc(msg.Stats, func(a, b *machineapi.Stat) int { return strings.Compare(a.Id, b.Id) })
-
-		for _, s := range msg.Stats {
-			display := s.Id
-			if s.Id != s.PodId {
-				// container in a sandbox
-				display = "└─ " + display
-			}
-
-			node := defaultNode
-
-			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-			}
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
-		}
-	}
-
-	return w.Flush()
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -13,12 +13,10 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
 	timeapi "github.com/siderolabs/talos/pkg/machinery/api/time"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var timeCmdFlags struct {
@@ -32,56 +30,65 @@ var timeCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			var (
-				resp       *timeapi.TimeResponse
-				remotePeer peer.Peer
-				err        error
+		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			responseChan := multiplex.Unary(
+				ctx, nodes,
+				func(ctx context.Context) (*timeapi.TimeResponse, error) {
+					if timeCmdFlags.ntpServer == "" {
+						return c.Time(ctx)
+					}
+
+					return c.TimeCheck(ctx, timeCmdFlags.ntpServer)
+				},
 			)
-
-			if timeCmdFlags.ntpServer == "" {
-				resp, err = c.Time(ctx, grpc.Peer(&remotePeer))
-			} else {
-				resp, err = c.TimeCheck(ctx, timeCmdFlags.ntpServer, grpc.Peer(&remotePeer))
-			}
-
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error fetching time: %w", err)
-				}
-
-				cli.Warning("%s", err)
-			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 			fmt.Fprintln(w, "NODE\tNTP-SERVER\tNODE-TIME\tNTP-SERVER-TIME")
 
-			defaultNode := client.AddrFromPeer(&remotePeer)
+			flushTimer := time.NewTimer(outputFlushInterval)
+			defer flushTimer.Stop()
 
-			var localtime, remotetime time.Time
+			flushTimer.Stop()
 
-			for _, msg := range resp.Messages {
-				node := defaultNode
+			var errs error
 
-				if msg.Metadata != nil {
-					node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+			for {
+				select {
+				case resp, ok := <-responseChan:
+					if !ok {
+						return errors.Join(errs, w.Flush())
+					}
+
+					if resp.Err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+					} else {
+						for _, msg := range resp.Payload.Messages {
+							if !msg.Localtime.IsValid() {
+								errs = errors.Join(errs, fmt.Errorf("node %s: error parsing local time", resp.Node))
+
+								continue
+							}
+
+							if !msg.Remotetime.IsValid() {
+								errs = errors.Join(errs, fmt.Errorf("node %s: error parsing remote time", resp.Node))
+
+								continue
+							}
+
+							fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.Node, msg.Server, msg.Localtime.AsTime().String(), msg.Remotetime.AsTime().String())
+						}
+					}
+
+					flushTimer.Reset(outputFlushInterval)
+				case <-flushTimer.C:
+					if err := w.Flush(); err != nil {
+						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+					}
 				}
-
-				if !msg.Localtime.IsValid() {
-					return errors.New("error parsing local time")
-				}
-
-				if !msg.Remotetime.IsValid() {
-					return errors.New("error parsing remote time")
-				}
-
-				localtime = msg.Localtime.AsTime()
-				remotetime = msg.Remotetime.AsTime()
-
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", node, msg.Server, localtime.String(), remotetime.String())
 			}
-
-			return w.Flush()
 		})
 	},
 }

--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -28,7 +28,7 @@ var upgradeK8sCmd = &cobra.Command{
 	Long:  `Command runs upgrade of Kubernetes control plane components between specified versions.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), upgradeKubernetes)
+		return WithClientAndSingleNode(cmd.Context(), "upgrade-k8s", upgradeKubernetes)
 	},
 }
 
@@ -70,12 +70,8 @@ func init() {
 	addCommand(upgradeK8sCmd)
 }
 
-func upgradeKubernetes(ctx context.Context, c *client.Client) error {
-	if err := helpers.FailIfMultiNodes(ctx, "upgrade-k8s"); err != nil {
-		return err
-	}
-
-	if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+func upgradeKubernetes(ctx context.Context, c *client.Client, node string) error {
+	if err := helpers.ClientVersionCheck(ctx, c, []string{node}); err != nil {
 		return err
 	}
 

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -112,8 +112,8 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		reporter.WithOutputMode(upgradeCmdFlags.progress.Value()),
 	)
 
-	err = WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-		return helpers.TalosVersionCheck(ctx, c, talosUpgradeAPIVersionRange)
+	err = WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
+		return helpers.TalosVersionCheck(ctx, c, talosUpgradeAPIVersionRange, nodes)
 	})
 	if err != nil {
 		if xerrors.TagIs[helpers.VersionOutsideRangeError](err) {
@@ -291,7 +291,7 @@ func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOp
 //
 // Note: remove me in Talos 1.18.
 func doUpgradeLegacy(ctx context.Context, c *client.Client, opts []client.UpgradeOption) error {
-	if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+	if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
 		return err
 	}
 

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -161,7 +161,7 @@ func NewTracker(
 
 // ClientExecutor is the interface for the client executor.
 type ClientExecutor interface {
-	WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error
+	WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error
 	NodeList() []string
 }
 
@@ -174,11 +174,11 @@ func (a *Tracker) Run(ctx context.Context) error {
 
 	var eg errgroup.Group
 
-	err := a.clientExecutor.WithClient(ctx, func(ctx context.Context, c *client.Client) error {
+	err := a.clientExecutor.WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		ctx, cancel := context.WithTimeout(ctx, a.timeout)
 		defer cancel()
 
-		if err := helpers.ClientVersionCheck(ctx, c); err != nil {
+		if err := helpers.ClientVersionCheck(ctx, c, a.clientExecutor.NodeList()); err != nil {
 			return err
 		}
 

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -126,6 +126,21 @@ func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Co
 	)
 }
 
+// WithClientAndSingleNode builds upon WithClientAndNodes to provide a helper which enforces a single node in the list, and uses client.WithNode.
+func (args *Args) WithClientAndSingleNode(ctx context.Context, commandName string, action func(context.Context, *client.Client, string) error, dialOptions ...grpc.DialOption) error {
+	return args.WithClientAndNodes(
+		ctx,
+		func(ctx context.Context, cli *client.Client, nodes []string) error {
+			if len(nodes) != 1 {
+				return fmt.Errorf("command %q requires exactly one node (got %d)", commandName, len(nodes))
+			}
+
+			return action(client.WithNode(ctx, nodes[0]), cli, nodes[0])
+		},
+		dialOptions...,
+	)
+}
+
 // WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).
 func (args *Args) WithClientMaintenance(ctx context.Context, enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
 	tlsConfig := &tls.Config{

--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -13,26 +13,13 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/xerrors"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 )
-
-// FailIfMultiNodes checks if ctx contains multi-node request metadata.
-func FailIfMultiNodes(ctx context.Context, command string) error {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return nil
-	}
-
-	if len(md.Get("nodes")) <= 1 {
-		return nil
-	}
-
-	return fmt.Errorf("command %q is not supported with multiple nodes", command)
-}
 
 // CheckErrors goes through the returned message list and checks if any messages have errors set.
 //
@@ -54,24 +41,34 @@ func CheckErrors[T interface{ GetMetadata() *common.Metadata }](messages ...T) e
 type VersionOutsideRangeError struct{}
 
 // TalosVersionCheck verifies that all nodes are running the desired Talos version.
-func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Range) error {
-	serverVersions, err := c.Version(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting server versions: %w", err)
-	}
+func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Range, nodes []string) error {
+	respCh := multiplex.Unary(
+		ctx, nodes,
+		func(ctx context.Context) (*machine.VersionResponse, error) {
+			return c.Version(ctx)
+		},
+	)
 
 	var errs error
 
-	for _, msg := range serverVersions.GetMessages() {
-		node := msg.GetMetadata().GetHostname() //nolint:staticcheck // to be refactored next
+	for resp := range respCh {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("%s: error getting server version: %w", resp.Node, resp.Err))
 
-		serverVersion, err := semver.ParseTolerant(msg.GetVersion().Tag)
-		if err != nil {
-			return fmt.Errorf("%s: error parsing server version: %w", node, err)
+			continue
 		}
 
-		if !desired(serverVersion) {
-			errs = errors.Join(errs, xerrors.NewTaggedf[VersionOutsideRangeError]("%s: server version %s is outside the desired range", node, serverVersion))
+		for _, msg := range resp.Payload.GetMessages() {
+			serverVersion, err := semver.ParseTolerant(msg.GetVersion().Tag)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("%s: error parsing server version: %w", resp.Node, err))
+
+				continue
+			}
+
+			if !desired(serverVersion) {
+				errs = errors.Join(errs, xerrors.NewTaggedf[VersionOutsideRangeError]("%s: server version %s is outside the desired range", resp.Node, serverVersion))
+			}
 		}
 	}
 
@@ -79,7 +76,56 @@ func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Ran
 }
 
 // ClientVersionCheck verifies that client is not outdated vs. Talos version.
-func ClientVersionCheck(ctx context.Context, c *client.Client) error {
+func ClientVersionCheck(ctx context.Context, c *client.Client, nodes []string) error {
+	respCh := multiplex.Unary(
+		ctx, nodes,
+		func(ctx context.Context) (*machine.VersionResponse, error) {
+			return c.Version(ctx)
+		},
+	)
+
+	clientVersion, err := semver.ParseTolerant(version.NewVersion().Tag)
+	if err != nil {
+		return fmt.Errorf("error parsing client version: %w", err)
+	}
+
+	var (
+		warnings []string
+		errs     error
+	)
+
+	for resp := range respCh {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("%s: error getting server version: %w", resp.Node, resp.Err))
+
+			continue
+		}
+
+		for _, msg := range resp.Payload.GetMessages() {
+			serverVersion, err := semver.ParseTolerant(msg.GetVersion().Tag)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("%s: error parsing server version: %w", resp.Node, err))
+
+				continue
+			}
+
+			if serverVersion.Compare(clientVersion) < 0 {
+				warnings = append(warnings, fmt.Sprintf("%s: server version %s is older than client version %s", resp.Node, serverVersion, clientVersion))
+			}
+		}
+	}
+
+	if warnings != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: %s\n", strings.Join(warnings, ", "))
+	}
+
+	return errs
+}
+
+// ClientVersionCheckLegacy verifies that client is not outdated vs. Talos version.
+//
+// Deprecated: this function relies on client.WithNodes behavior which is deprecated; use ClientVersionCheck instead.
+func ClientVersionCheckLegacy(ctx context.Context, c *client.Client) error {
 	// ignore the error, as we are only interested in the nodes which respond
 	serverVersions, _ := c.Version(ctx) //nolint:errcheck
 

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -227,8 +227,8 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 		suite.Require().NoError(<-errCh)
 	}
 
-	respCh := multiplex.Unary(suite.ctx, nodes, func(ctx context.Context) (*struct{}, error) {
-		return &struct{}{}, base.IgnoreGRPCUnavailable(suite.Client.Reboot(ctx))
+	respCh := multiplex.Unary(suite.ctx, nodes, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, base.IgnoreGRPCUnavailable(suite.Client.Reboot(ctx))
 	})
 
 	for resp := range respCh {

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -40,7 +40,7 @@ func (suite *CopySuite) TestMultiNodeFail() {
 	suite.RunCLI([]string{"copy", "--nodes", "127.0.0.1", "--nodes", "127.0.0.1", "/etc/os-release", "."},
 		base.ShouldFail(),
 		base.StdoutEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile(`is not supported with multiple nodes`)))
+		base.StderrShouldMatch(regexp.MustCompile(`requires exactly one node \(got 2\)`)))
 }
 
 func init() {

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -73,7 +73,7 @@ func (suite *KubeconfigSuite) TestMultiNodeFail() {
 	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", "127.0.0.1", "--nodes", "127.0.0.1", "."},
 		base.ShouldFail(),
 		base.StdoutEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile(`is not supported with multiple nodes`)))
+		base.StderrShouldMatch(regexp.MustCompile(`requires exactly one node \(got 2\)`)))
 }
 
 // TestMergeRename tests merge config into existing kubeconfig with default rename conflict resolution.

--- a/internal/integration/cli/read.go
+++ b/internal/integration/cli/read.go
@@ -33,7 +33,7 @@ func (suite *ReadSuite) TestMultiNodeFail() {
 	suite.RunCLI([]string{"read", "--nodes", "127.0.0.1", "--nodes", "127.0.0.1", "/etc/os-release"},
 		base.ShouldFail(),
 		base.StdoutEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile(`is not supported with multiple nodes`)))
+		base.StderrShouldMatch(regexp.MustCompile(`requires exactly one node \(got 2\)`)))
 }
 
 func init() {

--- a/pkg/machinery/formatters/formatters.go
+++ b/pkg/machinery/formatters/formatters.go
@@ -7,6 +7,7 @@ package formatters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -23,9 +24,17 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/inspect"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
+// FlushInterval is the quiet period after the last multiplexed response
+// before flushing the tabwriter, so partial results appear without thrashing
+// column widths while responses are still arriving.
+const FlushInterval = 500 * time.Millisecond
+
 // RenderMounts renders mounts output.
+//
+// Deprecated: use [RenderMountsStream] which handles multi-node responses via [multiplex.Unary].
 func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *peer.Peer) error {
 	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
 	parts := []string{"FILESYSTEM", "SIZE(GB)", "USED(GB)", "AVAILABLE(GB)", "PERCENT USED", "MOUNTED ON"}
@@ -50,7 +59,7 @@ func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *pe
 			node := defaultNode
 
 			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+				node = msg.Metadata.Hostname //nolint:staticcheck // deprecated path, kept for backwards compatibility
 			}
 
 			format := "%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n"
@@ -67,6 +76,59 @@ func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *pe
 	}
 
 	return w.Flush()
+}
+
+// RenderMountsStream renders the mounts output for a stream of multiplexed responses.
+func RenderMountsStream(output io.Writer, responseChan <-chan multiplex.Response[*machine.MountsResponse]) error {
+	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NODE\tFILESYSTEM\tSIZE(GB)\tUSED(GB)\tAVAILABLE(GB)\tPERCENT USED\tMOUNTED ON")
+
+	flushTimer := time.NewTimer(FlushInterval)
+	defer flushTimer.Stop()
+
+	flushTimer.Stop()
+
+	var errs error
+
+	for {
+		select {
+		case resp, ok := <-responseChan:
+			if !ok {
+				return errors.Join(errs, w.Flush())
+			}
+
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+			} else {
+				for _, msg := range resp.Payload.Messages {
+					for _, r := range msg.Stats {
+						percentAvailable := 100.0 - 100.0*(float64(r.Available)/float64(r.Size))
+
+						if math.IsNaN(percentAvailable) {
+							continue
+						}
+
+						fmt.Fprintf(
+							w, "%s\t%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n",
+							resp.Node,
+							r.Filesystem,
+							float64(r.Size)*1e-9,
+							float64(r.Size-r.Available)*1e-9,
+							float64(r.Available)*1e-9,
+							percentAvailable,
+							r.MountedOn,
+						)
+					}
+				}
+			}
+
+			flushTimer.Reset(FlushInterval)
+		case <-flushTimer.C:
+			if err := w.Flush(); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+			}
+		}
+	}
 }
 
 // RenderGraph renders inspect controller runtime graph.


### PR DESCRIPTION
This touches the initial set of commands:

* the commands which require a single node for operations (e.g.
  `talosctl bootstrap`) now use a special helper which does
  `client.WithNode`.
* the commands which don't support maintenance mode, and use unary APIs,
  now use `multiplex.Unary` to schedule the call without `WithNodes`
* some small fixes to command which are deprecated and don't use the API
  at all

There are several groups of commands I haven't toched yet:

* commands which have mixed maintenance API/normal API modes (need a new
  wrapper)
* `go-talos-support` should be updated to handle `WithNode` everywhere
  properly
* commands which issue streaming APIs need to be handled separately (the
  fix is similar, but it's a separate set of changes).

In the end it the change should be no-op for users, except for better
output when one of the machines is not responsive.
