### PR TITLE
fix: add --fail to image-signer curl, fix %w error wrapping in two controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -737,7 +737,7 @@ image-list: ## Prints a list of all images built by this Makefile with digests.
 	@echo -n installer-base$(IMAGE_NAME_SUFFIX) talos$(IMAGE_NAME_SUFFIX) imager$(IMAGE_NAME_SUFFIX) talosctl$(IMAGE_NAME_SUFFIX) talosctl-all$(IMAGE_NAME_SUFFIX) | xargs -d ' ' -I{} sh -c 'echo $(REGISTRY_AND_USERNAME)/{}:$(IMAGE_TAG_IN)' | xargs -I{} sh -ec 'digest=$$(crane digest {}) || exit 1; echo {}@$$digest'
 
 $(ARTIFACTS)/image-signer-$(IMAGE_SIGNER_RELEASE): | $(ARTIFACTS) ## Downloads image-signer binary
-	@curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(ARCH) -o $(ARTIFACTS)/image-signer-$(IMAGE_SIGNER_RELEASE)
+	@curl --fail -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(ARCH) -o $(ARTIFACTS)/image-signer-$(IMAGE_SIGNER_RELEASE)
 	@chmod +x $(ARTIFACTS)/image-signer-$(IMAGE_SIGNER_RELEASE)
 
 

--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -137,7 +137,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline, linkNameResolver *network.Link
 
 					ip, err = netip.ParseAddr(fields[0])
 					if err != nil {
-						return settings, fmt.Errorf("cmdline address parse failure: %s", err)
+						return settings, fmt.Errorf("cmdline address parse failure: %w", err)
 					}
 
 					// default is to have complete address masked
@@ -145,7 +145,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline, linkNameResolver *network.Link
 				case 2:
 					linkConfig.Gateway, err = netip.ParseAddr(fields[2])
 					if err != nil {
-						return settings, fmt.Errorf("cmdline gateway parse failure: %s", err)
+						return settings, fmt.Errorf("cmdline gateway parse failure: %w", err)
 					}
 				case 3:
 					var (
@@ -157,7 +157,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline, linkNameResolver *network.Link
 					if err != nil {
 						netmask, err = netip.ParseAddr(fields[3])
 						if err != nil {
-							return settings, fmt.Errorf("cmdline netmask parse failure: %s", err)
+							return settings, fmt.Errorf("cmdline netmask parse failure: %w", err)
 						}
 
 						ones, _ = net.IPMask(netmask.AsSlice()).Size()

--- a/internal/app/machined/pkg/controllers/runtime/watchdog_timer.go
+++ b/internal/app/machined/pkg/controllers/runtime/watchdog_timer.go
@@ -130,7 +130,7 @@ func (ctrl *WatchdogTimerController) Run(ctx context.Context, r controller.Runti
 			if wd == nil {
 				wd, err = os.OpenFile(cfg.TypedSpec().Device, syscall.O_RDWR, 0o600)
 				if err != nil {
-					return fmt.Errorf("failed to open watchdog device: %s", err)
+					return fmt.Errorf("failed to open watchdog device: %w", err)
 				}
 
 				logger.Info("opened hardware watchdog", zap.String("path", cfg.TypedSpec().Device))


### PR DESCRIPTION
## What? (description)

- Add `--fail` to the `image-signer` curl download (Makefile)
- Fix `%s` -> `%w` in `fmt.Errorf` calls in `cmdline.go` and `watchdog_timer.go`

## Why? (reasoning)

PR #13447 added `--fail` to curl calls to catch HTTP errors, but the `image-signer` download got missed. Without `--fail`, a 404 silently writes HTML to the binary, `chmod +x` still succeeds, and `make sign-images` blows up with "Exec format error" later - annoying to debug.

Reproduce:

```sh
IMAGE_SIGNER_RELEASE=v0.0.0-bogus make _out/image-signer-v0.0.0-bogus
# before: exits 0, file is an HTML error page
# after:  curl exits non-zero right away
```

The `%s` -> `%w` fixes are consistency cleanup - `cmdline.go` and `watchdog_timer.go` use `%w` everywhere except in a couple spots. Broken error wrapping silently breaks `errors.Is`/`errors.As` chains.

## Acceptance

- [ ] you linked an issue (if applicable) - n/a
- [ ] you included tests (if applicable) - n/a
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`) - n/a
- [x] you ran unit-tests (`make unit-tests`)