### PR TITLE
fix: normalize log fields

### DIFF
--- a/internal/app/debug/debug.go
+++ b/internal/app/debug/debug.go
@@ -55,7 +55,7 @@ func (s *Service) ContainerRun(srv grpc.BidiStreamingServer[machine.DebugContain
 		return status.Errorf(codes.InvalidArgument, "unsupported debug container profile: %s", spec.GetProfile())
 	}
 
-	log.Printf("debug container request received: image=%s args=%v env=%v profile=%s", spec.GetImageName(), spec.GetArgs(), spec.GetEnv(), spec.GetProfile())
+	log.Printf("debug container request received: image=%s arg_count=%d env_count=%d profile=%s", spec.GetImageName(), len(spec.GetArgs()), len(spec.GetEnv()), spec.GetProfile())
 
 	// 2. connect to containerd with a lease
 	ctx, detachedContext, c8dClient, err := ctrhelper.ContainerdInstanceHelper(ctx, spec.GetContainerd())

--- a/internal/app/lifecycle/lifecycle.go
+++ b/internal/app/lifecycle/lifecycle.go
@@ -7,7 +7,6 @@ package lifecycle
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 	"sync"
 
@@ -89,7 +88,7 @@ func (s *Service) Install(req *machine.LifecycleServiceInstallRequest, ss grpc.S
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("invalid disk path: %v", err))
 	}
 
-	log.Printf("starting installation: installer_image=%s, disk=%s\n", installerImage, targetDisk)
+	s.logger.Info("starting installation", zap.String("installer_image", installerImage), zap.String("disk", targetDisk))
 
 	//nolint:dupl
 	err = runInstallerContainer(ctx,
@@ -117,9 +116,9 @@ func (s *Service) Install(req *machine.LifecycleServiceInstallRequest, ss grpc.S
 			},
 			sendExitCode: func(exitCode int32) error {
 				if exitCode == 0 {
-					log.Printf("installation completed successfully: exit_code=%d\n", exitCode)
+					s.logger.Info("installation completed", zap.Int32("exit_code", exitCode))
 				} else {
-					log.Printf("installation failed: exit_code=%d\n", exitCode)
+					s.logger.Warn("installation failed", zap.Int32("exit_code", exitCode))
 				}
 
 				return ss.Send(&machine.LifecycleServiceInstallResponse{
@@ -182,7 +181,7 @@ func (s *Service) Upgrade(req *machine.LifecycleServiceUpgradeRequest, ss grpc.S
 
 	devname := systemDisk.DevPath
 
-	log.Printf("starting upgrade: installer_image=%s, disk=%s\n", installerImage, devname)
+	s.logger.Info("starting upgrade", zap.String("installer_image", installerImage), zap.String("disk", devname))
 
 	//nolint:dupl
 	err = runInstallerContainer(ctx,
@@ -210,9 +209,9 @@ func (s *Service) Upgrade(req *machine.LifecycleServiceUpgradeRequest, ss grpc.S
 			},
 			sendExitCode: func(exitCode int32) error {
 				if exitCode == 0 {
-					log.Printf("upgrade completed successfully: exit_code=%d\n", exitCode)
+					s.logger.Info("upgrade completed", zap.Int32("exit_code", exitCode))
 				} else {
-					log.Printf("upgrade failed: exit_code=%d\n", exitCode)
+					s.logger.Warn("upgrade failed", zap.Int32("exit_code", exitCode))
 				}
 
 				return ss.Send(&machine.LifecycleServiceUpgradeResponse{

--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -235,7 +235,7 @@ func (ctrl *AddressConfigController) processDevicesConfiguration(logger *zap.Log
 		for _, cidr := range device.Addresses() {
 			ipPrefix, err := parseIPOrIPPrefix(cidr)
 			if err != nil {
-				logger.Info(fmt.Sprintf("skipping address %q on interface %q", cidr, device.Interface()), zap.Error(err))
+				logger.Info("skipping address", zap.String("address", cidr), zap.String("interface", device.Interface()), zap.Error(err))
 
 				continue
 			}
@@ -261,7 +261,7 @@ func (ctrl *AddressConfigController) processDevicesConfiguration(logger *zap.Log
 			for _, cidr := range vlan.Addresses() {
 				ipPrefix, err := netip.ParsePrefix(cidr)
 				if err != nil {
-					logger.Info(fmt.Sprintf("skipping address %q on interface %q vlan %d", cidr, device.Interface(), vlan.ID()), zap.Error(err))
+					logger.Info("skipping address", zap.String("address", cidr), zap.String("interface", device.Interface()), zap.Uint16("vlan", vlan.ID()), zap.Error(err))
 
 					continue
 				}

--- a/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
@@ -288,7 +288,7 @@ func (d *DHCP6) isIPv6LinkReady(iface *net.Interface, conn *rtnetlink.Conn) (boo
 
 		if addr.Attributes.Address.IsLinkLocalUnicast() && (addr.Flags&unix.IFA_F_TENTATIVE == 0) {
 			if addr.Flags&unix.IFA_F_DADFAILED != 0 {
-				d.logger.Warn("DADFAILED for %v, continuing anyhow", zap.Stringer("address", addr.Attributes.Address), zap.String("link", d.linkName))
+				d.logger.Warn("DAD failed, continuing", zap.Stringer("address", addr.Attributes.Address), zap.String("link", d.linkName))
 			}
 
 			return true, nil


### PR DESCRIPTION
Use structured fields instead of printf-style messages so logs stay queryable.
Avoid leaking full debug container args/env payloads.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
