### PR TITLE
fix: health request server-side

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api_cert_sans.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_cert_sans.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -120,6 +121,7 @@ func (ctrl *APICertSANsController) Run(ctx context.Context, r controller.Runtime
 
 			spec.AppendIPs(apiRoot.CertSANIPs...)
 			spec.AppendIPs(nodeAddresses.IPs()...)
+			spec.AppendIPs(netip.MustParseAddr("127.0.0.1"))
 
 			spec.AppendDNSNames(apiRoot.CertSANDNSNames...)
 			spec.AppendDNSNames(hostnameStatus.Hostname, hostnameStatus.FQDN())

--- a/internal/app/machined/pkg/controllers/secrets/api_cert_sans_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_cert_sans_test.go
@@ -80,7 +80,7 @@ func (suite *APICertSANsSuite) TestReconcileControlPlane() {
 		spec := certSANs.TypedSpec()
 
 		suite.Assert().Equal([]string{"bar", "bar.some.org", "some.org"}, spec.DNSNames)
-		suite.Assert().Equal("[10.2.1.3 10.4.3.2 172.16.0.1]", fmt.Sprintf("%v", spec.IPs))
+		suite.Assert().Equal("[10.2.1.3 10.4.3.2 127.0.0.1 172.16.0.1]", fmt.Sprintf("%v", spec.IPs))
 		suite.Assert().Equal("bar.some.org", spec.FQDN)
 
 		return nil

--- a/pkg/cluster/local.go
+++ b/pkg/cluster/local.go
@@ -15,7 +15,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	secretsgen "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
-	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
@@ -54,17 +53,8 @@ func (c *LocalClientProvider) Client(endpoints ...string) (*client.Client, error
 		return nil, fmt.Errorf("failed to get OS root secrets: %w", err)
 	}
 
-	nodeAddress, err := safe.StateGetByID[*network.NodeAddress](ctx, c.resources, network.NodeAddressDefaultID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node address: %w", err)
-	}
-
-	if len(nodeAddress.TypedSpec().IPs()) == 0 {
-		return nil, fmt.Errorf("no node IPs found in node address")
-	}
-
 	if len(endpoints) == 0 {
-		endpoints = []string{nodeAddress.TypedSpec().IPs()[0].String()}
+		endpoints = []string{"127.0.0.1"}
 	}
 
 	// use a short-lived certificate, as we need to connect once


### PR DESCRIPTION
Fixes #13474

The issue was that default node IP is not always the one which is handled correctly by `apid` (like in the issue described).

In fact, we should stop using default IP, as it's not a good choice.

Instead, add localhost to `apid` certSANs, and make connect over localhost. A simple solution which should fix the problem.
