### PR TITLE
fix: recreate dns server and listeners on host DNS runner restart

### DIFF
--- a/internal/pkg/dns/dns_test.go
+++ b/internal/pkg/dns/dns_test.go
@@ -168,6 +168,85 @@ func Test_ServeBackground(t *testing.T) {
 	require.NoError(t, m.ClearAll(false))
 }
 
+// TestRunnerRestart ensures a [dns.Runner] can be started, stopped, and
+// started again. Previously the runner reused a single dns.Server across
+// restarts, so the second start failed permanently with
+// "dns: server already started", leaving nothing bound to the listen address.
+func TestRunnerRestart(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	newOpts := func() (dns.RunnerOptions, error) {
+		pc, err := dns.NewUDPPacketConn("udp", "127.0.0.1:0", nil)
+		if err != nil {
+			return dns.RunnerOptions{}, err
+		}
+
+		return dns.RunnerOptions{
+			PacketConn: pc,
+			Handler:    dnssrv.HandlerFunc(func(dnssrv.ResponseWriter, *dnssrv.Msg) {}),
+		}, nil
+	}
+
+	runner := dns.NewRunner(newOpts, zaptest.NewLogger(t))
+
+	for i := range 2 {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- runner.Serve(ctx) }()
+
+		// Give the server time to come up, then assert below that it did not
+		// exit early (e.g. returning "already started" on the second start).
+		time.Sleep(200 * time.Millisecond)
+
+		select {
+		case err := <-errCh:
+			t.Fatalf("runner exited early on start %d: %v", i, err)
+		default:
+		}
+
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if err != nil && strings.Contains(err.Error(), "already started") {
+				t.Fatalf("runner restart failed on start %d: %v", i, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting for runner to stop on start %d", i)
+		}
+	}
+}
+
+// TestRunAllReportsBindFailure ensures that a socket bind failure is reported
+// synchronously through RunAll (wrapped in [dns.ErrCreatingRunner]) rather than
+// being deferred to the supervisor. This keeps the caller able to surface the
+// error, ignore IPv6-only failures, or retry, as it did before the runner was
+// changed to rebuild its listeners on restart.
+func TestRunAllReportsBindFailure(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	m := dns.NewManager(&testMemberReader{}, &testStaticHostReader{}, func(e suture.Event) { t.Log("dns-runners event:", e) }, zaptest.NewLogger(t))
+
+	m.ServeBackground(t.Context())
+
+	var gotErr error
+
+	for _, err := range m.RunAll(slices.Values([]dns.AddressPair{
+		// 192.0.2.0/24 (TEST-NET-1) is not assigned to any interface, so the
+		// bind fails with "cannot assign requested address".
+		{Network: "udp", Addr: netip.MustParseAddrPort("192.0.2.1:10700")},
+	}), false) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+
+	require.ErrorIs(t, gotErr, dns.ErrCreatingRunner)
+
+	require.NoError(t, m.ClearAll(false))
+}
+
 func newManager(t *testing.T, nameservers ...string) func() {
 	m := dns.NewManager(
 		&testMemberReader{},

--- a/internal/pkg/dns/manager.go
+++ b/internal/pkg/dns/manager.go
@@ -100,11 +100,23 @@ func (m *Manager) RunAll(pairs iter.Seq[AddressPair], forwardEnabled bool) iter.
 				continue
 			}
 
+			// Bind the sockets up front so a construction failure (e.g. an
+			// unsupported address family, or an address already in use) is
+			// reported synchronously here, exactly as before: the caller can
+			// then surface it, ignore IPv6-only failures, or retry.
 			opts, err := newDNSRunnerOpts(cfg, m.cacheHandler, forwardEnabled)
 			if err != nil {
 				err = fmt.Errorf("%w: %w", ErrCreatingRunner, err)
 			} else {
-				m.runners[cfg] = m.s.Add(NewRunner(opts, m.logger))
+				// A dns.Server and its listeners are single-use, so the runner
+				// must rebuild them on every (re)start. The first start reuses
+				// the opts bound just above; subsequent restarts call
+				// newDNSRunnerOpts again to bind fresh, restartable instances.
+				newOpts := reuseFirst(opts, func() (RunnerOptions, error) {
+					return newDNSRunnerOpts(cfg, m.cacheHandler, forwardEnabled)
+				})
+
+				m.runners[cfg] = m.s.Add(NewRunner(newOpts, m.logger))
 			}
 
 			if !yield(makeResult(cfg, StatusNew), err) {
@@ -268,6 +280,28 @@ type MemberReader interface {
 // StaticHostReader is an interface to read static hosts.
 type StaticHostReader interface {
 	ReadStaticHosts(ctx context.Context, name string) (iter.Seq[netip.Addr], error)
+}
+
+// reuseFirst returns a [Runner] opts factory that yields prebuilt on its first
+// call and calls build (binding fresh sockets) on every subsequent call. This
+// lets the initial bind happen eagerly in RunAll — so failures are reported
+// synchronously — while still handing the runner a factory that rebuilds the
+// single-use dns.Server and listeners on each supervisor restart.
+//
+// suture invokes a service's Serve (and therefore this factory) serially, so no
+// synchronization is required.
+func reuseFirst(prebuilt RunnerOptions, build func() (RunnerOptions, error)) func() (RunnerOptions, error) {
+	used := false
+
+	return func() (RunnerOptions, error) {
+		if !used {
+			used = true
+
+			return prebuilt, nil
+		}
+
+		return build()
+	}
 }
 
 func newDNSRunnerOpts(cfg AddressPair, rootHandler dnssrv.Handler, forwardEnabled bool) (RunnerOptions, error) {

--- a/internal/pkg/dns/runnner.go
+++ b/internal/pkg/dns/runnner.go
@@ -27,43 +27,70 @@ type RunnerOptions struct {
 }
 
 // NewRunner creates a new [Runner].
-func NewRunner(opts RunnerOptions, l *zap.Logger) *Runner {
+//
+// newOpts is invoked on every (re)start to build a fresh [dns.Server] with
+// fresh listeners. Both are single-use: once [dns.Server.ActivateAndServe]
+// returns it leaves the server marked as started and miekg/dns closes the
+// underlying listener/packet conn. Reusing the same instances across a
+// supervisor restart therefore fails permanently with
+// "dns: server already started", so the runner must reconstruct them.
+func NewRunner(newOpts func() (RunnerOptions, error), l *zap.Logger) *Runner {
 	return &Runner{
-		srv: &dns.Server{
-			Listener:      opts.Listener,
-			PacketConn:    opts.PacketConn,
-			Handler:       opts.Handler,
-			UDPSize:       dns.DefaultMsgSize, // 4096 since default is [dns.MinMsgSize] = 512 bytes, which is too small.
-			ReadTimeout:   opts.ReadTimeout,
-			WriteTimeout:  opts.WriteTimeout,
-			IdleTimeout:   opts.IdleTimeout,
-			MaxTCPQueries: opts.MaxTCPQueries,
-		},
-		logger: l,
+		newOpts: newOpts,
+		logger:  l,
 	}
 }
 
 // Runner is a DNS server runner.
 type Runner struct {
-	srv    *dns.Server
-	logger *zap.Logger
+	newOpts func() (RunnerOptions, error)
+	logger  *zap.Logger
 }
 
 // Serve starts the DNS server. Implements [suture.Service] interface.
 func (r *Runner) Serve(ctx context.Context) error {
-	errCh := make(chan error)
+	opts, err := r.newOpts()
+	if err != nil {
+		return err
+	}
+
+	srv := &dns.Server{
+		Listener:      opts.Listener,
+		PacketConn:    opts.PacketConn,
+		Handler:       opts.Handler,
+		UDPSize:       dns.DefaultMsgSize, // 4096 since default is [dns.MinMsgSize] = 512 bytes, which is too small.
+		ReadTimeout:   opts.ReadTimeout,
+		WriteTimeout:  opts.WriteTimeout,
+		IdleTimeout:   opts.IdleTimeout,
+		MaxTCPQueries: opts.MaxTCPQueries,
+	}
+
+	// Buffered so the goroutine never blocks on send if Serve returns early
+	// (e.g. via the close timeout below), avoiding a leaked goroutine.
+	errCh := make(chan error, 1)
 
 	go func() {
-		errCh <- r.srv.ActivateAndServe()
+		errCh <- srv.ActivateAndServe()
 	}()
 
 	select {
 	case err := <-errCh:
+		// ActivateAndServe returned on its own (a serve error, or an early
+		// return such as a setUDPSocketOptions failure). The server has already
+		// stopped, but on some early-return paths miekg/dns does not close the
+		// freshly-bound listener/conn, so close it here to avoid leaking the
+		// socket across restarts. ShutdownContext is not needed: the server is
+		// already stopped, and calling it would only report "server not
+		// started" on the paths that never marked it started.
+		r.closeListener(srv)
+
 		return err
 	case <-ctx.Done():
 	}
 
-	r.close()
+	// Graceful stop requested: shut the server down and wait for the serve
+	// goroutine to return.
+	r.shutdown(srv)
 
 	select {
 	case err := <-errCh:
@@ -73,33 +100,51 @@ func (r *Runner) Serve(ctx context.Context) error {
 	}
 }
 
-func (r *Runner) close() {
-	l := r.logger
-
-	if r.srv.Listener != nil {
-		l = l.With(zap.String("net", "tcp"), zap.String("local_addr", r.srv.Listener.Addr().String()))
-	} else if r.srv.PacketConn != nil {
-		l = l.With(zap.String("net", "udp"), zap.String("local_addr", r.srv.PacketConn.LocalAddr().String()))
+// loggerFor returns the runner logger annotated with the server's network and
+// local address.
+func (r *Runner) loggerFor(srv *dns.Server) *zap.Logger {
+	switch {
+	case srv.Listener != nil:
+		return r.logger.With(zap.String("net", "tcp"), zap.String("local_addr", srv.Listener.Addr().String()))
+	case srv.PacketConn != nil:
+		return r.logger.With(zap.String("net", "udp"), zap.String("local_addr", srv.PacketConn.LocalAddr().String()))
+	default:
+		return r.logger
 	}
+}
 
-	closer := io.Closer(r.srv.Listener)
+// closeListener closes the server's listener/packet conn, treating an
+// already-closed socket (e.g. closed by the serve loop on its own return) as a
+// no-op.
+func (r *Runner) closeListener(srv *dns.Server) {
+	closer := io.Closer(srv.Listener)
 	if closer == nil {
-		closer = r.srv.PacketConn
+		closer = srv.PacketConn
 	}
 
-	if closer != nil {
-		if err := closer.Close(); err != nil {
-			l.Error("error closing dns server listener", zap.Error(err))
-		} else {
-			l.Debug("dns server listener closed")
-		}
+	if closer == nil {
+		return
 	}
+
+	switch err := closer.Close(); {
+	case err == nil:
+		r.loggerFor(srv).Debug("dns server listener closed")
+	case errors.Is(err, net.ErrClosed):
+		// Already closed; nothing to do.
+	default:
+		r.loggerFor(srv).Error("error closing dns server listener", zap.Error(err))
+	}
+}
+
+// shutdown gracefully stops a running server: it closes the listener and waits
+// for in-flight queries to drain.
+func (r *Runner) shutdown(srv *dns.Server) {
+	r.closeListener(srv)
 
 	sCtx, sCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer sCancel()
 
-	err := r.srv.ShutdownContext(sCtx)
-	if err != nil && !errors.Is(err, net.ErrClosed) {
-		l.Error("error shutting down dns server", zap.Error(err))
+	if err := srv.ShutdownContext(sCtx); err != nil && !errors.Is(err, net.ErrClosed) {
+		r.loggerFor(srv).Error("error shutting down dns server", zap.Error(err))
 	}
 }


### PR DESCRIPTION
> Supersedes #13481, which was accidentally closed and could not be reopened (a force-push left its recorded head with no common history with `main`). This PR contains the identical change from the same branch.

## Problem

On a node running Talos v1.13.2 we hit a permanent host-DNS outage. `dns-resolve-cache` logged this in a tight loop and never recovered:

```
dns-resolve-cache-runners: Failed service '&dns.Runner{srv:(*dns.Server)(0x174496be4360), ...}'
  (5.99 failures of 5.00), restarting: false, error: dns: server already started
```

Note the `*dns.Server` pointer is identical across the entire multi-hour run — the same server object is restarted forever. Nothing stayed bound to `127.0.0.53:53`, so host DNS was down until the node was rebooted. Toggling `machine.features.hostDNS.enabled` false→true (which tears the runner down and recreates it) also clears it.

## Root cause

`Runner` builds one `*dns.Server` — together with its `net.Listener`/`net.PacketConn` — once in `NewRunner` and reuses it on every supervisor restart. Both are single-use:

- When `ActivateAndServe()` returns on its own (a transient serve error), `Serve()` takes the first `select` case and returns the error **without** calling `close()`, so `ShutdownContext()` never runs and miekg/dns leaves the server flagged `started`.
- `suture` restarts the runner, `ActivateAndServe()` runs against the already-started server and fails immediately with `dns: server already started` — and that path again skips `close()`.
- Every retry repeats this; the runner exhausts its failure budget and gives up. (miekg/dns also closes the listener when the serve loop exits, so the listener can't be reused either.)

## Fix

Construct the `dns.Server` and its listeners lazily via an opts factory invoked on **every** `Serve()` call, so each (re)start gets fresh, restartable instances. The result channel is also buffered so the serve goroutine can't leak if `Serve()` returns via the close timeout.

## Behaviour change

Runner option construction (which binds sockets) now happens inside `Serve()` rather than eagerly in `RunAll`. A persistent construction error therefore surfaces through the supervisor event hook and is retried, rather than being returned synchronously from `RunAll` as `StatusNew`'s error. This also makes a transient bind failure (e.g. address briefly in use during reconfiguration) self-heal instead of being reported once.

## Testing

- `go test ./internal/pkg/dns/...` passes (incl. `goleak`).
- Added `TestRunnerRestart`, which starts/stops/restarts a `Runner` and asserts it never returns `dns: server already started`. The two start cycles bind distinct ephemeral ports, confirming fresh listeners per restart. This test fails against the previous reuse-based implementation.