### PR TITLE
refactor: Deprecate `LoadedKernelModule`, don't document deprecated resources.

### DIFF
--- a/api/docs.markdown.tmpl
+++ b/api/docs.markdown.tmpl
@@ -7,12 +7,12 @@ description: Talos gRPC API reference.
 {{range .Files}}
 {{$file_name := .Name}}- [{{.Name}}](#{{.Name}})
   {{- if .Messages }}
-  {{range .Messages}}  - [{{.LongName}}](#{{.FullName}})
-  {{end}}
+  {{range .Messages}}{{if not (index .Options "deprecated")}}  - [{{.LongName}}](#{{.FullName}})
+  {{end}}{{end}}
   {{- end -}}
   {{- if .Enums }}
-  {{range .Enums}}  - [{{.LongName}}](#{{.FullName}})
-  {{end}}
+  {{range .Enums}}{{if not (index .Options "deprecated")}}  - [{{.LongName}}](#{{.FullName}})
+  {{end}}{{end}}
   {{- end -}}
   {{- if .Extensions }}
   {{range (list .Extensions | uniq)}}  - [File-level Extensions](#{{$file_name}}-extensions)
@@ -33,7 +33,7 @@ description: Talos gRPC API reference.
 ## {{.Name}}
 {{.Description}}
 
-{{range .Messages}}
+{{range .Messages}}{{if not (index .Options "deprecated")}}
 <a name="{{.FullName}}"></a>
 
 ### {{.LongName}}
@@ -54,10 +54,10 @@ description: Talos gRPC API reference.
   | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description | replace "\n\n" "<br><br>"}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
 {{end}}
 {{end}}
-
+{{end}}
 {{end}} <!-- end messages -->
 
-{{range .Enums}}
+{{range .Enums}}{{if not (index .Options "deprecated")}}
 <a name="{{.FullName}}"></a>
 
 ### {{.LongName}}
@@ -69,7 +69,7 @@ description: Talos gRPC API reference.
   | {{.Name}} | {{.Number}} | {{nobr .Description | replace "\n\n" "<br><br>"}} |
 {{end}}
 
-{{end}} <!-- end enums -->
+{{end}}{{end}} <!-- end enums -->
 
 {{if .HasExtensions}}
 <a name="{{$file_name}}-extensions"></a>

--- a/api/resource/definitions/runtime/runtime.proto
+++ b/api/resource/definitions/runtime/runtime.proto
@@ -109,7 +109,10 @@ message KmsgLogConfigSpec {
 }
 
 // LoadedKernelModuleSpec describes loaded Linux kernel modules.
+//
+// Deprecated: use KernelModuleStatus instead.
 message LoadedKernelModuleSpec {
+  option deprecated = true;
   int64 size = 1;
   int64 reference_count = 2;
   repeated string dependencies = 3;

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_status.go
@@ -55,7 +55,7 @@ func (ctrl *KernelModuleStatusController) Inputs() []controller.Input {
 func (ctrl *KernelModuleStatusController) Outputs() []controller.Output {
 	return []controller.Output{
 		{
-			Type: runtime.LoadedKernelModuleType,
+			Type: runtime.LoadedKernelModuleType, //nolint:staticcheck
 			Kind: controller.OutputExclusive,
 		},
 		{
@@ -152,7 +152,7 @@ func (ctrl *KernelModuleStatusController) reconcile(ctx context.Context, r contr
 
 	return r.CleanupOutputs(
 		ctx,
-		resource.NewMetadata(runtime.NamespaceName, runtime.LoadedKernelModuleType, "", resource.VersionUndefined),
+		resource.NewMetadata(runtime.NamespaceName, runtime.LoadedKernelModuleType, "", resource.VersionUndefined), //nolint:staticcheck
 		resource.NewMetadata(runtime.NamespaceName, runtime.KernelModuleStatusType, "", resource.VersionUndefined),
 	)
 }
@@ -193,8 +193,8 @@ func (ctrl *KernelModuleStatusController) reconcileDynamicModules(ctx context.Co
 	for _, module := range rawModules {
 		if err := safe.WriterModify(
 			ctx, r,
-			runtime.NewLoadedKernelModule(runtime.NamespaceName, module.Name),
-			func(res *runtime.LoadedKernelModule) error {
+			runtime.NewLoadedKernelModule(runtime.NamespaceName, module.Name), //nolint:staticcheck
+			func(res *runtime.LoadedKernelModule) error { //nolint:staticcheck
 				res.TypedSpec().Size = module.Size
 				res.TypedSpec().ReferenceCount = module.ReferenceCount
 				res.TypedSpec().Dependencies = module.Dependencies

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_status_test.go
@@ -41,7 +41,7 @@ func (suite *KernelModuleStatusSuite) TestParseFromLiveKernel() {
 
 	suite.Require().NoError(suite.Runtime().RegisterController(&runtimectrl.KernelModuleStatusController{}))
 
-	ctest.AssertNotEmpty[*runtime.LoadedKernelModule](suite)
+	ctest.AssertNotEmpty[*runtime.LoadedKernelModule](suite) //nolint:staticcheck
 	ctest.AssertNotEmpty[*runtime.KernelModuleStatus](suite)
 }
 
@@ -65,7 +65,7 @@ func (suite *KernelModuleStatusSuite) TestParseMock() {
 	})
 
 	malformedEntryNames := []string{"firstmalformed", "secondmalformed"}
-	ctest.AssertNoResources[*runtime.LoadedKernelModule](suite, malformedEntryNames)
+	ctest.AssertNoResources[*runtime.LoadedKernelModule](suite, malformedEntryNames) //nolint:staticcheck
 	ctest.AssertNoResources[*runtime.KernelModuleStatus](suite, malformedEntryNames)
 }
 
@@ -77,7 +77,7 @@ func (suite *KernelModuleStatusSuite) TestLoadedKernelModuleFields() {
 		},
 	))
 
-	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(12288, res.TypedSpec().Size)
 		asrt.Equal(0, res.TypedSpec().ReferenceCount)
 		asrt.Equal([]string{}, res.TypedSpec().Dependencies)
@@ -85,13 +85,13 @@ func (suite *KernelModuleStatusSuite) TestLoadedKernelModuleFields() {
 		asrt.Equal("0x0000000000000000", res.TypedSpec().Address)
 	})
 
-	ctest.AssertResource(suite, "curve25519_x86_64", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "curve25519_x86_64", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(36864, res.TypedSpec().Size)
 		asrt.Equal(1, res.TypedSpec().ReferenceCount)
 		asrt.Equal([]string{"wireguard"}, res.TypedSpec().Dependencies)
 	})
 
-	ctest.AssertResource(suite, "libcurve25519_generic", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "libcurve25519_generic", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(45056, res.TypedSpec().Size)
 		asrt.Equal(2, res.TypedSpec().ReferenceCount)
 		asrt.Equal([]string{"wireguard", "curve25519_x86_64"}, res.TypedSpec().Dependencies)
@@ -159,10 +159,10 @@ func (suite *KernelModuleStatusSuite) TestStaleResourceCleanup() {
 		},
 	))
 
-	ctest.AssertResource(suite, "wireguard", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "wireguard", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(114688, res.TypedSpec().Size)
 	})
-	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(12288, res.TypedSpec().Size)
 	})
 
@@ -172,10 +172,10 @@ func (suite *KernelModuleStatusSuite) TestStaleResourceCleanup() {
 
 	reconcileCh <- struct{}{}
 
-	ctest.AssertNoResource[*runtime.LoadedKernelModule](suite, "wireguard")
+	ctest.AssertNoResource[*runtime.LoadedKernelModule](suite, "wireguard") //nolint:staticcheck
 	ctest.AssertNoResource[*runtime.KernelModuleStatus](suite, "wireguard")
 
-	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+	ctest.AssertResource(suite, "cpuid", func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 		asrt.Equal(12288, res.TypedSpec().Size)
 	})
 }

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -229,7 +229,7 @@ func NewState() (*State, error) {
 		&runtime.KernelParamDefaultSpec{},
 		&runtime.KernelParamStatus{},
 		&runtime.KmsgLogConfig{},
-		&runtime.LoadedKernelModule{},
+		&runtime.LoadedKernelModule{}, //nolint:staticcheck
 		&runtime.MaintenanceServiceConfig{},
 		&runtime.MaintenanceServiceRequest{},
 		&runtime.MachineResetSignal{},

--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -634,7 +634,7 @@ func (suite *ExtensionsSuiteQEMU) TestLoadedKernelModule() {
 			"virtio_pci_legacy_dev",
 			"virtio_pci_modern_dev",
 		},
-		func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) {
+		func(res *runtime.LoadedKernelModule, asrt *assert.Assertions) { //nolint:staticcheck
 			asrt.NotEmpty(res.TypedSpec().Size, "kernel module size should not be empty")
 			asrt.NotEmpty(res.TypedSpec().Address, "kernel module address should not be empty")
 			asrt.GreaterOrEqual(res.TypedSpec().ReferenceCount, 0, "kernel module instances should be non-negative")

--- a/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
@@ -831,6 +831,10 @@ func (x *KmsgLogConfigSpec) GetDestinations() []*common.URL {
 }
 
 // LoadedKernelModuleSpec describes loaded Linux kernel modules.
+//
+// Deprecated: use KernelModuleStatus instead.
+//
+// Deprecated: Marked as deprecated in resource/definitions/runtime/runtime.proto.
 type LoadedKernelModuleSpec struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Size           int64                  `protobuf:"varint,1,opt,name=size,proto3" json:"size,omitempty"`
@@ -1977,13 +1981,13 @@ const file_resource_definitions_runtime_runtime_proto_rawDesc = "" +
 	"\adefault\x18\x02 \x01(\tR\adefault\x12 \n" +
 	"\vunsupported\x18\x03 \x01(\bR\vunsupported\"D\n" +
 	"\x11KmsgLogConfigSpec\x12/\n" +
-	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\"\xa9\x01\n" +
+	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\"\xad\x01\n" +
 	"\x16LoadedKernelModuleSpec\x12\x12\n" +
 	"\x04size\x18\x01 \x01(\x03R\x04size\x12'\n" +
 	"\x0freference_count\x18\x02 \x01(\x03R\x0ereferenceCount\x12\"\n" +
 	"\fdependencies\x18\x03 \x03(\tR\fdependencies\x12\x14\n" +
 	"\x05state\x18\x04 \x01(\tR\x05state\x12\x18\n" +
-	"\aaddress\x18\x05 \x01(\tR\aaddress\"\xb1\x01\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress:\x02\x18\x01\"\xb1\x01\n" +
 	"\x11MachineStatusSpec\x12K\n" +
 	"\x05stage\x18\x01 \x01(\x0e25.talos.resource.definitions.enums.RuntimeMachineStageR\x05stage\x12O\n" +
 	"\x06status\x18\x02 \x01(\v27.talos.resource.definitions.runtime.MachineStatusStatusR\x06status\"\x8a\x01\n" +

--- a/pkg/machinery/resources/runtime/loaded_kernel_module.go
+++ b/pkg/machinery/resources/runtime/loaded_kernel_module.go
@@ -14,14 +14,18 @@ import (
 )
 
 // LoadedKernelModuleType is type of LoadedKernelModule resource.
+//
+// Deprecated: use KernelModuleStatus instead.
 const LoadedKernelModuleType = resource.Type("LoadedKernelModules.runtime.talos.dev")
 
 // LoadedKernelModule resource holds information about loaded Linux kernel modules.
 //
-// Note: this resource is superseded by KernelModuleStatus.
+// Deprecated: use KernelModuleStatus instead.
 type LoadedKernelModule = typed.Resource[LoadedKernelModuleSpec, LoadedKernelModuleExtension]
 
 // LoadedKernelModuleSpec describes loaded Linux kernel modules.
+//
+// Deprecated: use KernelModuleStatus instead.
 //
 //gotagsrewrite:gen
 type LoadedKernelModuleSpec struct {
@@ -33,6 +37,8 @@ type LoadedKernelModuleSpec struct {
 }
 
 // NewLoadedKernelModule initializes a LoadedKernelModule resource.
+//
+// Deprecated: use NewKernelModuleStatus instead.
 func NewLoadedKernelModule(namespace resource.Namespace, id resource.ID) *LoadedKernelModule {
 	return typed.NewResource[LoadedKernelModuleSpec, LoadedKernelModuleExtension](
 		resource.NewMetadata(namespace, LoadedKernelModuleType, id, resource.VersionUndefined),
@@ -41,6 +47,8 @@ func NewLoadedKernelModule(namespace resource.Namespace, id resource.ID) *Loaded
 }
 
 // LoadedKernelModuleExtension is auxiliary resource data for LoadedKernelModule.
+//
+// Deprecated: use KernelModuleStatusExtension instead.
 type LoadedKernelModuleExtension struct{}
 
 // ResourceDefinition implements meta.ResourceDefinitionProvider interface.

--- a/tools/structprotogen/proto/proto.go
+++ b/tools/structprotogen/proto/proto.go
@@ -114,8 +114,9 @@ func (p *Pkg) Format(w io.Writer) {
 type protoDef struct {
 	name string
 
-	goPkg    string
-	comments []string
+	goPkg      string
+	comments   []string
+	deprecated bool
 
 	isInit bool
 	fields slices.Sorted[protoField]
@@ -145,6 +146,10 @@ func (p *protoDef) WriteDebug(w io.Writer) {
 
 	fmt.Fprintf(w, "message %s { //%s.%s\n", p.name, p.goPkg, p.name)
 
+	if p.deprecated {
+		fmt.Fprintln(w, "  option deprecated = true;")
+	}
+
 	for i := range p.fields.Len() {
 		fmt.Fprintf(w, "  ")
 		p.fields.Get(i).WriteDebug(w)
@@ -159,6 +164,10 @@ func (p *protoDef) Format(w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "message %s {\n", p.name)
+
+	if p.deprecated {
+		fmt.Fprintln(w, "  option deprecated = true;")
+	}
 
 	for i := range p.fields.Len() {
 		fmt.Fprintf(w, "  ")
@@ -212,6 +221,18 @@ func (pf protoField) Format(w io.Writer) {
 	fmt.Fprintf(w, "%s %s = %d;\n", pf.typ, ToSnakeCase(pf.name), pf.num)
 }
 
+// isDeprecated reports whether the type's doc comment carries a Go-style `// Deprecated: ...` marker. Such types are
+// annotated with `option deprecated = true;` in the generated proto, which in turn excludes them from the API docs.
+func isDeprecated(comments []string) bool {
+	for _, c := range comments {
+		if strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(c, "//")), "Deprecated:") {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PrepareProtoData prepares the data for the protobuf generation.
 //
 //nolint:gocyclo,cyclop
@@ -227,9 +248,10 @@ func PrepareProtoData(pkgsTypes slices.Sorted[*types.Type], constants consts.Con
 		})
 
 		def := sliceutil.GetOrAdd(protoPkg.Defs(), &protoDef{
-			name:     pkgType.Name,
-			goPkg:    pkgType.Pkg,
-			comments: pkgType.Comments,
+			name:       pkgType.Name,
+			goPkg:      pkgType.Pkg,
+			comments:   pkgType.Comments,
+			deprecated: isDeprecated(pkgType.Comments),
 		})
 
 		for j := range pkgType.Fields().Len() {

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -12,7 +12,6 @@ description: Talos gRPC API reference.
     - [Empty](#common.Empty)
     - [EmptyResponse](#common.EmptyResponse)
     - [Error](#common.Error)
-    - [Metadata](#common.Metadata)
     - [NetIP](#common.NetIP)
     - [NetIPPort](#common.NetIPPort)
     - [NetIPPrefix](#common.NetIPPrefix)
@@ -507,7 +506,6 @@ description: Talos gRPC API reference.
     - [KernelParamSpecSpec](#talos.resource.definitions.runtime.KernelParamSpecSpec)
     - [KernelParamStatusSpec](#talos.resource.definitions.runtime.KernelParamStatusSpec)
     - [KmsgLogConfigSpec](#talos.resource.definitions.runtime.KmsgLogConfigSpec)
-    - [LoadedKernelModuleSpec](#talos.resource.definitions.runtime.LoadedKernelModuleSpec)
     - [MachineStatusSpec](#talos.resource.definitions.runtime.MachineStatusSpec)
     - [MachineStatusStatus](#talos.resource.definitions.runtime.MachineStatusStatus)
     - [MaintenanceServiceConfigSpec](#talos.resource.definitions.runtime.MaintenanceServiceConfigSpec)
@@ -770,22 +768,6 @@ description: Talos gRPC API reference.
 | message | [string](#string) |  |  |
 | details | [google.protobuf.Any](#google.protobuf.Any) | repeated |  |
 
-
-
-
-
-
-<a name="common.Metadata"></a>
-
-### Metadata
-Common metadata message nested in all reply message types
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| hostname | [string](#string) |  | **Deprecated.** hostname of the server response comes from (injected by proxy) |
-| error | [string](#string) |  | **Deprecated.** error is set if request failed to the upstream (rest of response is undefined) |
-| status | [google.rpc.Status](#google.rpc.Status) |  | **Deprecated.** error as gRPC Status |
 
 
 
@@ -8832,24 +8814,6 @@ KmsgLogConfigSpec describes configuration for kmsg log streaming.
 | ----- | ---- | ----- | ----------- |
 | destinations | [common.URL](#common.URL) | repeated |  |
 
-
-
-
-
-
-<a name="talos.resource.definitions.runtime.LoadedKernelModuleSpec"></a>
-
-### LoadedKernelModuleSpec
-LoadedKernelModuleSpec describes loaded Linux kernel modules.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| size | [int64](#int64) |  |  |
-| reference_count | [int64](#int64) |  |  |
-| dependencies | [string](#string) | repeated |  |
-| state | [string](#string) |  |  |
-| address | [string](#string) |  |  |
 
 
 


### PR DESCRIPTION
Follow-up to https://github.com/siderolabs/talos/pull/13309

- Deprecates the `LoadedKernelModule` resource, it's now superseded by `KernelModuleStatus`. 
    - `LoadedKernelModule` must not be removed until Omni stops consuming it.
    - Ignores lint errors regarding usage of a deprecated resource for all existing `LoadedKernelModule` references (`//nolint:staticcheck`).
- Implements a mechanism for hiding deprecated resources from generated docs.
    - Resources whose proto `deprecated` option is set to `true`, are skipped in the docs template. 
    - Deprecation is controlled through annotating the resource with a `// Deprecated: ...` comment.
    - `Metadata` was deprecated in https://github.com/siderolabs/talos/pull/13471 . It's just being hidden from docs only now, with the new deprecation logic.