### PR TITLE
chore: make oci images reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,8 @@ COMMON_ARGS := --file=Dockerfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)
+COMMON_ARGS += --provenance=false
+COMMON_ARGS += --sbom=false
 
 COMMON_ARGS += --build-arg=ABBREV_TAG=$(ABBREV_TAG)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)


### PR DESCRIPTION
We don't rely on provenance or sbom data from buildkit, drop them as it makes the OCI images non-reproducible due to extra layers which are never used anywhere.