### PR TITLE
refactor: replace the callback strategy for most commands

### DIFF
--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -15,20 +15,21 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var applyConfigCmdFlags struct {
 	helpers.Mode
+	global.InsecureFlags
 
-	certFingerprints []string
 	patches          []string
 	filename         string
-	insecure         bool
 	dryRun           bool
 	configTryTimeout time.Duration
 }
@@ -93,37 +94,48 @@ var applyConfigCmd = &cobra.Command{
 			}
 		}
 
-		withClient := func(f func(context.Context, *client.Client) error) error {
-			if applyConfigCmdFlags.insecure {
-				return WithClientMaintenance(cmd.Context(), applyConfigCmdFlags.certFingerprints, f)
-			}
+		ctx := cmd.Context()
 
-			return WithClient(cmd.Context(), f)
+		clientFactory, err := NewClientFactory(ctx, &applyConfigCmdFlags)
+		if err != nil {
+			return err
 		}
 
-		return withClient(func(ctx context.Context, c *client.Client) error {
-			resp, err := c.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
-				Data:           cfgBytes,
-				Mode:           applyConfigCmdFlags.Mode.Mode,
-				DryRun:         applyConfigCmdFlags.dryRun,
-				TryModeTimeout: durationpb.New(applyConfigCmdFlags.configTryTimeout),
-			})
-			if err != nil {
-				return fmt.Errorf("error applying new configuration: %s", err)
+		defer clientFactory.Close() //nolint:errcheck
+
+		respCh := multiplex.UnaryViaFactory(
+			ctx,
+			clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.ApplyConfigurationResponse, error) {
+				return c.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
+					Data:           cfgBytes,
+					Mode:           applyConfigCmdFlags.Mode.Mode,
+					DryRun:         applyConfigCmdFlags.dryRun,
+					TryModeTimeout: durationpb.New(applyConfigCmdFlags.configTryTimeout),
+				})
+			},
+		)
+
+		var errs error
+
+		for resp := range respCh {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("%s: error applying configuration: %w", resp.Node, resp.Err))
+
+				continue
 			}
 
-			helpers.PrintApplyResults(resp)
+			helpers.PrintApplyResults(resp.Payload)
+		}
 
-			return nil
-		})
+		return errs
 	},
 }
 
 func init() {
+	applyConfigCmdFlags.InsecureFlags.AddFlags(applyConfigCmd)
 	applyConfigCmd.Flags().StringVarP(&applyConfigCmdFlags.filename, "file", "f", "", "the filename of the updated configuration")
-	applyConfigCmd.Flags().BoolVarP(&applyConfigCmdFlags.insecure, "insecure", "i", false, "apply the config using the insecure (encrypted with no auth) maintenance service")
 	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.dryRun, "dry-run", false, "check how the config change will be applied in dry-run mode")
-	applyConfigCmd.Flags().StringSliceVar(&applyConfigCmdFlags.certFingerprints, "cert-fingerprint", nil, "list of server certificate fingeprints to accept (defaults to no check)")
 	applyConfigCmd.Flags().StringArrayVarP(&applyConfigCmdFlags.patches, "config-patch", "p", nil, "the list of config patches to apply to the local config file before sending it to the node")
 	applyConfigCmd.Flags().DurationVar(&applyConfigCmdFlags.configTryTimeout, "timeout", constants.ConfigTryTimeout, "the config will be rolled back after specified timeout (if try mode is selected)")
 	helpers.AddModeFlags(&applyConfigCmdFlags.Mode, applyConfigCmd)

--- a/cmd/talosctl/cmd/talos/bootstrap.go
+++ b/cmd/talosctl/cmd/talos/bootstrap.go
@@ -5,7 +5,6 @@
 package talos
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -14,7 +13,6 @@ import (
 
 	"github.com/siderolabs/talos/pkg/logging"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 var bootstrapCmdFlags struct {
@@ -36,40 +34,52 @@ This command should not be used when "init" type node are used.
 Talos etcd cluster can be recovered from a known snapshot with '--recover-from=' flag.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "bootstrap", func(ctx context.Context, c *client.Client, _ string) error {
-			if bootstrapCmdFlags.recoverFrom != "" {
-				manager := snapshot.NewV3(logging.Wrap(os.Stderr))
+		ctx := cmd.Context()
 
-				status, err := manager.Status(bootstrapCmdFlags.recoverFrom)
-				if err != nil {
-					return err
-				}
+		clientFactory, err := NewClientFactory(ctx, &bootstrapCmdFlags)
+		if err != nil {
+			return err
+		}
 
-				fmt.Printf("recovering from snapshot %q: hash %08x, revision %d, total keys %d, total size %d\n",
-					bootstrapCmdFlags.recoverFrom, status.Hash, status.Revision, status.TotalKey, status.TotalSize)
+		defer clientFactory.Close() //nolint:errcheck
 
-				snapshot, err := os.Open(bootstrapCmdFlags.recoverFrom)
-				if err != nil {
-					return fmt.Errorf("error opening snapshot file: %w", err)
-				}
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "bootstrap")
+		if err != nil {
+			return err
+		}
 
-				defer snapshot.Close() //nolint:errcheck
+		if bootstrapCmdFlags.recoverFrom != "" {
+			manager := snapshot.NewV3(logging.Wrap(os.Stderr))
 
-				_, err = c.EtcdRecover(ctx, snapshot)
-				if err != nil {
-					return fmt.Errorf("error uploading snapshot: %w", err)
-				}
+			status, err := manager.Status(bootstrapCmdFlags.recoverFrom)
+			if err != nil {
+				return err
 			}
 
-			if err := c.Bootstrap(ctx, &machineapi.BootstrapRequest{
-				RecoverEtcd:          bootstrapCmdFlags.recoverFrom != "",
-				RecoverSkipHashCheck: bootstrapCmdFlags.recoverSkipHashCheck,
-			}); err != nil {
-				return fmt.Errorf("error executing bootstrap: %w", err)
+			fmt.Printf("recovering from snapshot %q: hash %08x, revision %d, total keys %d, total size %d\n",
+				bootstrapCmdFlags.recoverFrom, status.Hash, status.Revision, status.TotalKey, status.TotalSize)
+
+			snapshot, err := os.Open(bootstrapCmdFlags.recoverFrom)
+			if err != nil {
+				return fmt.Errorf("error opening snapshot file: %w", err)
 			}
 
-			return nil
-		})
+			defer snapshot.Close() //nolint:errcheck
+
+			_, err = c.EtcdRecover(ctx, snapshot)
+			if err != nil {
+				return fmt.Errorf("error uploading snapshot: %w", err)
+			}
+		}
+
+		if err := c.Bootstrap(ctx, &machineapi.BootstrapRequest{
+			RecoverEtcd:          bootstrapCmdFlags.recoverFrom != "",
+			RecoverSkipHashCheck: bootstrapCmdFlags.recoverSkipHashCheck,
+		}); err != nil {
+			return fmt.Errorf("error executing bootstrap: %w", err)
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/cgroups.go
+++ b/cmd/talosctl/cmd/talos/cgroups.go
@@ -56,87 +56,99 @@ To see schema examples, refer to https://github.com/siderolabs/talos/tree/main/c
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "cgroups", func(ctx context.Context, c *client.Client, _ string) error {
-			var schema cgroupsprinter.Schema
+		ctx := cmd.Context()
 
-			switch {
-			case cgroupsCmdFlags.schemaFile != "":
-				in, err := os.Open(cgroupsCmdFlags.schemaFile)
-				if err != nil {
-					return fmt.Errorf("error opening schema file: %w", err)
-				}
+		clientFactory, err := NewClientFactory(ctx, &cgroupsCmdFlags)
+		if err != nil {
+			return err
+		}
 
-				defer in.Close() //nolint:errcheck
+		defer clientFactory.Close() //nolint:errcheck
 
-				if err = yaml.NewDecoder(in).Decode(&schema); err != nil {
-					return fmt.Errorf("error decoding schema file: %w", err)
-				}
-			case cgroupsCmdFlags.presetName != "":
-				presetNames := cgroupsprinter.GetPresetNames()
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "cgroups")
+		if err != nil {
+			return err
+		}
 
-				if slices.Index(presetNames, cgroupsCmdFlags.presetName) == -1 {
-					return fmt.Errorf("invalid preset name: %s (valid %v)", cgroupsCmdFlags.presetName, presetNames)
-				}
+		var schema cgroupsprinter.Schema
 
-				schema = cgroupsprinter.GetPreset(cgroupsCmdFlags.presetName)
-			default:
-				return fmt.Errorf("either schema file or preset must be specified")
-			}
-
-			if err := schema.Compile(); err != nil {
-				return fmt.Errorf("error compiling schema: %w", err)
-			}
-
-			processResolveMap := buildProcessResolveMap(ctx, c)
-			devicesResolveMap := buildDevicesResolveMap(ctx, c)
-
-			r, err := c.Copy(ctx, constants.CgroupMountPath)
+		switch {
+		case cgroupsCmdFlags.schemaFile != "":
+			in, err := os.Open(cgroupsCmdFlags.schemaFile)
 			if err != nil {
-				return fmt.Errorf("error copying: %w", err)
+				return fmt.Errorf("error opening schema file: %w", err)
 			}
 
-			defer r.Close() //nolint:errcheck
+			defer in.Close() //nolint:errcheck
 
-			tree, err := cgroups.TreeFromTarGz(r)
-			if err != nil {
-				return fmt.Errorf("error reading cgroups: %w", err)
+			if err = yaml.NewDecoder(in).Decode(&schema); err != nil {
+				return fmt.Errorf("error decoding schema file: %w", err)
+			}
+		case cgroupsCmdFlags.presetName != "":
+			presetNames := cgroupsprinter.GetPresetNames()
+
+			if slices.Index(presetNames, cgroupsCmdFlags.presetName) == -1 {
+				return fmt.Errorf("invalid preset name: %s (valid %v)", cgroupsCmdFlags.presetName, presetNames)
 			}
 
-			if !cgroupsCmdFlags.skipCRIResolve {
-				cgroupNameResolveMap := buildCgroupResolveMap(ctx, c)
-				tree.ResolveNames(cgroupNameResolveMap)
-			}
+			schema = cgroupsprinter.GetPreset(cgroupsCmdFlags.presetName)
+		default:
+			return fmt.Errorf("either schema file or preset must be specified")
+		}
 
-			tree.Walk(func(node *cgroups.Node) {
-				node.CgroupProcsResolved = xslices.Map(node.CgroupProcs, func(pid cgroups.Value) cgroups.RawValue {
-					if name, ok := processResolveMap[pid.String()]; ok {
-						return cgroups.RawValue(name)
-					}
+		if err := schema.Compile(); err != nil {
+			return fmt.Errorf("error compiling schema: %w", err)
+		}
 
-					return cgroups.RawValue(pid.String())
-				})
+		processResolveMap := buildProcessResolveMap(ctx, c)
+		devicesResolveMap := buildDevicesResolveMap(ctx, c)
 
-				for dev := range node.IOStat {
-					if name, ok := devicesResolveMap[dev]; ok {
-						node.IOStat[name] = node.IOStat[dev]
-						delete(node.IOStat, dev)
-					}
+		r, err := c.Copy(ctx, constants.CgroupMountPath)
+		if err != nil {
+			return fmt.Errorf("error copying: %w", err)
+		}
+
+		defer r.Close() //nolint:errcheck
+
+		tree, err := cgroups.TreeFromTarGz(r)
+		if err != nil {
+			return fmt.Errorf("error reading cgroups: %w", err)
+		}
+
+		if !cgroupsCmdFlags.skipCRIResolve {
+			cgroupNameResolveMap := buildCgroupResolveMap(ctx, c)
+			tree.ResolveNames(cgroupNameResolveMap)
+		}
+
+		tree.Walk(func(node *cgroups.Node) {
+			node.CgroupProcsResolved = xslices.Map(node.CgroupProcs, func(pid cgroups.Value) cgroups.RawValue {
+				if name, ok := processResolveMap[pid.String()]; ok {
+					return cgroups.RawValue(name)
 				}
+
+				return cgroups.RawValue(pid.String())
 			})
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-
-			defer w.Flush() //nolint:errcheck
-
-			headerLine := "NAME\t" + schema.HeaderLine() + "\n"
-
-			_, err = w.Write([]byte(headerLine))
-			if err != nil {
-				return fmt.Errorf("error writing header line: %w", err)
+			for dev := range node.IOStat {
+				if name, ok := devicesResolveMap[dev]; ok {
+					node.IOStat[name] = node.IOStat[dev]
+					delete(node.IOStat, dev)
+				}
 			}
-
-			return cgroupsprinter.PrintNode(".", w, &schema, tree.Root, nil, 0, nil, false, true)
 		})
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+		defer w.Flush() //nolint:errcheck
+
+		headerLine := "NAME\t" + schema.HeaderLine() + "\n"
+
+		_, err = w.Write([]byte(headerLine))
+		if err != nil {
+			return fmt.Errorf("error writing header line: %w", err)
+		}
+
+		return cgroupsprinter.PrintNode(".", w, &schema, tree.Root, nil, 0, nil, false, true)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"bytes"
-	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/role"
@@ -150,7 +148,7 @@ var configContextCmd = &cobra.Command{
 
 		return nil
 	},
-	ValidArgsFunction: CompleteConfigContext,
+	ValidArgsFunction: completeConfigContext,
 }
 
 // configAddCmdFlags represents the `config add` command flags.
@@ -280,7 +278,7 @@ var configRemoveCmd = &cobra.Command{
 
 		return nil
 	},
-	ValidArgsFunction: CompleteConfigContext,
+	ValidArgsFunction: completeConfigContext,
 }
 
 func sortInPlace(slc []string) []string {
@@ -414,38 +412,50 @@ var configNewCmd = &cobra.Command{
 
 		path := args[0]
 
-		return WithClientAndSingleNode(cmd.Context(), "config new", func(ctx context.Context, c *client.Client, _ string) error {
-			roles, unknownRoles := role.Parse(configNewCmdFlags.roles)
-			if len(unknownRoles) != 0 {
-				return fmt.Errorf("unknown roles: %s", strings.Join(unknownRoles, ", "))
-			}
+		ctx := cmd.Context()
 
-			if _, err := os.Stat(path); err == nil {
-				return fmt.Errorf("talosconfig file already exists: %q", path)
-			}
+		clientFactory, err := NewClientFactory(ctx, &configNewCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			resp, err := c.GenerateClientConfiguration(ctx, &machineapi.GenerateClientConfigurationRequest{
-				Roles:  roles.Strings(),
-				CrtTtl: durationpb.New(configNewCmdFlags.crtTTL),
-			})
-			if err != nil {
-				return err
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			if l := len(resp.Messages); l != 1 {
-				panic(fmt.Sprintf("expected 1 message, got %d", l))
-			}
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "config new")
+		if err != nil {
+			return err
+		}
 
-			config, err := clientconfig.FromBytes(resp.Messages[0].Talosconfig)
-			if err != nil {
-				return err
-			}
+		roles, unknownRoles := role.Parse(configNewCmdFlags.roles)
+		if len(unknownRoles) != 0 {
+			return fmt.Errorf("unknown roles: %s", strings.Join(unknownRoles, ", "))
+		}
 
-			// make the new config immediately useful
-			config.Contexts[config.Context].Endpoints = c.GetEndpoints()
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("talosconfig file already exists: %q", path)
+		}
 
-			return config.Save(path)
+		resp, err := c.GenerateClientConfiguration(ctx, &machineapi.GenerateClientConfigurationRequest{
+			Roles:  roles.Strings(),
+			CrtTtl: durationpb.New(configNewCmdFlags.crtTTL),
 		})
+		if err != nil {
+			return err
+		}
+
+		if l := len(resp.Messages); l != 1 {
+			panic(fmt.Sprintf("expected 1 message, got %d", l))
+		}
+
+		config, err := clientconfig.FromBytes(resp.Messages[0].Talosconfig)
+		if err != nil {
+			return err
+		}
+
+		// make the new config immediately useful
+		config.Contexts[config.Context].Endpoints = c.GetEndpoints()
+
+		return config.Save(path)
 	},
 }
 
@@ -582,11 +592,13 @@ var configInfoCmd = &cobra.Command{
 	},
 }
 
-// CompleteConfigContext represents tab completion for `--context`
+// completeConfigContext represents tab completion for `--context`
 // argument and `config [context|remove]` command.
-func CompleteConfigContext(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func completeConfigContext(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	c, err := clientconfig.Open(GlobalArgs.Talosconfig)
 	if err != nil {
+		cobra.CompError(fmt.Sprintf("error reading config: %v", err))
+
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/talosctl/cmd/talos/conformance.go
+++ b/cmd/talosctl/cmd/talos/conformance.go
@@ -5,14 +5,12 @@
 package talos
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/hydrophone"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // conformanceCmd represents the conformance command.
@@ -33,32 +31,44 @@ var conformanceKubernetesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "conformance", func(ctx context.Context, c *client.Client, _ string) error {
-			clientProvider := &cluster.ConfigClientProvider{
-				DefaultClient: c,
-			}
-			defer clientProvider.Close() //nolint:errcheck
+		ctx := cmd.Context()
 
-			state := struct {
-				cluster.K8sProvider
-			}{
-				K8sProvider: &cluster.KubernetesClient{
-					ClientProvider: clientProvider,
-					ForceEndpoint:  healthCmdFlags.forceEndpoint,
-				},
-			}
+		clientFactory, err := NewClientFactory(ctx, &conformanceKubernetesCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			switch conformanceKubernetesCmdFlags.mode {
-			case "fast":
-				return hydrophone.FastConformance(ctx, &state)
-			case "certified":
-				return hydrophone.CertifiedConformance(ctx, &state)
-			case "network-policy":
-				return hydrophone.NetworkPolicies(ctx, &state)
-			default:
-				return fmt.Errorf("unsupported conformance mode %v", conformanceKubernetesCmdFlags.mode)
-			}
-		})
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "conformance")
+		if err != nil {
+			return err
+		}
+
+		clientProvider := &cluster.ConfigClientProvider{
+			DefaultClient: c,
+		}
+		defer clientProvider.Close() //nolint:errcheck
+
+		state := struct {
+			cluster.K8sProvider
+		}{
+			K8sProvider: &cluster.KubernetesClient{
+				ClientProvider: clientProvider,
+				ForceEndpoint:  healthCmdFlags.forceEndpoint,
+			},
+		}
+
+		switch conformanceKubernetesCmdFlags.mode {
+		case "fast":
+			return hydrophone.FastConformance(ctx, &state)
+		case "certified":
+			return hydrophone.CertifiedConformance(ctx, &state)
+		case "network-policy":
+			return hydrophone.NetworkPolicies(ctx, &state)
+		default:
+			return fmt.Errorf("unsupported conformance mode %v", conformanceKubernetesCmdFlags.mode)
+		}
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -31,73 +31,77 @@ var containersCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			var (
-				namespace string
-				driver    common.ContainerDriver
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			if kubernetesFlag {
-				namespace = constants.K8sContainerdNamespace
-				driver = common.ContainerDriver_CRI
-			} else {
-				namespace = constants.SystemContainerdNamespace
-				driver = common.ContainerDriver_CONTAINERD
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machineapi.ContainersResponse, error) {
-					return c.Containers(ctx, namespace, driver)
-				},
-			)
+		var (
+			namespace string
+			driver    common.ContainerDriver
+		)
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tIMAGE\tPID\tSTATUS")
+		if kubernetesFlag {
+			namespace = constants.K8sContainerdNamespace
+			driver = common.ContainerDriver_CRI
+		} else {
+			namespace = constants.SystemContainerdNamespace
+			driver = common.ContainerDriver_CONTAINERD
+		}
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.ContainersResponse, error) {
+				return c.Containers(ctx, namespace, driver)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tIMAGE\tPID\tSTATUS")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							slices.SortFunc(msg.Containers, func(a, b *machineapi.ContainerInfo) int { return strings.Compare(a.Id, b.Id) })
+		var errs error
 
-							for _, p := range msg.Containers {
-								display := p.Id
-								if p.Id != p.PodId {
-									// container in a sandbox
-									display = "└─ " + display
-								}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-								fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Node, p.Namespace, display, p.Image, p.Pid, p.Status)
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						slices.SortFunc(msg.Containers, func(a, b *machineapi.ContainerInfo) int { return strings.Compare(a.Id, b.Id) })
+
+						for _, p := range msg.Containers {
+							display := p.Id
+							if p.Id != p.PodId {
+								// container in a sandbox
+								display = "└─ " + display
 							}
+
+							fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Node, p.Namespace, display, p.Image, p.Pid, p.Status)
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -5,7 +5,6 @@
 package talos
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // cpCmd represents the cp command.
@@ -44,39 +42,51 @@ captures ownership and permission bits.`,
 		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "copy", func(ctx context.Context, c *client.Client, _ string) error {
-			r, err := c.Copy(ctx, args[0])
-			if err != nil {
-				return fmt.Errorf("error copying: %w", err)
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "copy")
+		if err != nil {
+			return err
+		}
+
+		r, err := c.Copy(ctx, args[0])
+		if err != nil {
+			return fmt.Errorf("error copying: %w", err)
+		}
+
+		localPath := args[1]
+
+		if localPath == "-" {
+			_, err = io.Copy(os.Stdout, r)
+
+			return err
+		}
+
+		localPath = filepath.Clean(localPath)
+
+		fi, err := os.Stat(localPath)
+		if err == nil && !fi.IsDir() {
+			return fmt.Errorf("local path %q should be a directory", args[1])
+		}
+
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("failed to stat local path: %w", err)
 			}
 
-			localPath := args[1]
-
-			if localPath == "-" {
-				_, err = io.Copy(os.Stdout, r)
-
-				return err
+			if err = os.MkdirAll(localPath, 0o777); err != nil {
+				return fmt.Errorf("error creating local path %q: %w", localPath, err)
 			}
+		}
 
-			localPath = filepath.Clean(localPath)
-
-			fi, err := os.Stat(localPath)
-			if err == nil && !fi.IsDir() {
-				return fmt.Errorf("local path %q should be a directory", args[1])
-			}
-
-			if err != nil {
-				if !errors.Is(err, fs.ErrNotExist) {
-					return fmt.Errorf("failed to stat local path: %w", err)
-				}
-
-				if err = os.MkdirAll(localPath, 0o777); err != nil {
-					return fmt.Errorf("error creating local path %q: %w", localPath, err)
-				}
-			}
-
-			return helpers.ExtractTarGz(localPath, r)
-		})
+		return helpers.ExtractTarGz(localPath, r)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -5,13 +5,11 @@
 package talos
 
 import (
-	"context"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/internal/pkg/dashboard"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 var dashboardCmdFlags struct {
@@ -37,15 +35,27 @@ Keyboard shortcuts:
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			return dashboard.Run(
-				ctx, c,
-				dashboard.WithInterval(dashboardCmdFlags.interval),
-				dashboard.WithScreens(dashboard.ScreenSummary, dashboard.ScreenMonitor, dashboard.ScreenResourceExplorer),
-				dashboard.WithAllowExitKeys(true),
-				dashboard.WithNodes(nodes...),
-			)
-		})
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		c, err := clientFactory.BuildRandomEndpointClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		return dashboard.Run(
+			ctx, c,
+			dashboard.WithInterval(dashboardCmdFlags.interval),
+			dashboard.WithScreens(dashboard.ScreenSummary, dashboard.ScreenMonitor, dashboard.ScreenResourceExplorer),
+			dashboard.WithAllowExitKeys(true),
+			dashboard.WithNodes(clientFactory.Nodes()...),
+		)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -27,7 +27,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 var editCmdFlags struct {
@@ -39,7 +38,7 @@ var editCmdFlags struct {
 }
 
 //nolint:gocyclo
-func editFn(c *client.Client) func(context.Context, string, resource.Resource, error) error {
+func editFn() func(ctx context.Context, c *client.Client, node string, mc resource.Resource) error {
 	var (
 		path      string
 		lastError string
@@ -50,21 +49,7 @@ func editFn(c *client.Client) func(context.Context, string, resource.Resource, e
 		"EDITOR",
 	})
 
-	return func(ctx context.Context, node string, mc resource.Resource, callError error) error {
-		if callError != nil {
-			return fmt.Errorf("%s: %w", node, callError)
-		}
-
-		if mc.Metadata().Type() != config.MachineConfigType {
-			return errors.New("only the machineconfig resource can be edited")
-		}
-
-		id := mc.Metadata().ID()
-
-		if id != config.ActiveID {
-			return nil
-		}
-
+	return func(ctx context.Context, c *client.Client, node string, mc resource.Resource) error {
 		body, err := extractMachineConfigBody(mc)
 		if err != nil {
 			return err
@@ -84,7 +69,7 @@ func editFn(c *client.Client) func(context.Context, string, resource.Resource, e
 
 			_, err := fmt.Fprintf(
 				w,
-				"# Editing %s/%s at node %s\n", mc.Metadata().Type(), id, node,
+				"# Editing %s/%s at node %s\n", mc.Metadata().Type(), mc.Metadata().ID(), node,
 			)
 			if err != nil {
 				return err
@@ -104,7 +89,7 @@ func editFn(c *client.Client) func(context.Context, string, resource.Resource, e
 
 			editedDiff := edited
 
-			edited, path, err = edit.LaunchTempFile(fmt.Sprintf("%s-%s-edit-", mc.Metadata().Type(), id), ".yaml", &buf)
+			edited, path, err = edit.LaunchTempFile(fmt.Sprintf("%s-%s-edit-", mc.Metadata().Type(), mc.Metadata().ID()), ".yaml", &buf)
 			if err != nil {
 				return err
 			}
@@ -196,20 +181,20 @@ It will open the editor defined by your TALOS_EDITOR,
 or EDITOR environment variables, or fall back to 'vi' for Linux
 or 'notepad' for Windows.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-				return err
-			}
+		ctx := cmd.Context()
 
-			for _, node := range GlobalArgs.Nodes {
-				nodeCtx := client.WithNodes(ctx, node) //nolint:staticcheck // to be refactored next
-				if err := helpers.ForEachResource(nodeCtx, c, nil, editFn(c), editCmdFlags.namespace, args...); err != nil {
-					return err
-				}
-			}
+		clientFactory, err := NewClientFactory(ctx, &editCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			return nil
-		})
+		defer clientFactory.Close() //nolint:errcheck
+
+		if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+			return err
+		}
+
+		return helpers.MachineConfigUpdater(ctx, clientFactory, editFn(), args)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -47,60 +47,64 @@ var etcdAlarmListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machine.EtcdAlarmListResponse, error) {
-					return c.EtcdAlarmList(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		defer clientFactory.Close() //nolint:errcheck
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.EtcdAlarmListResponse, error) {
+				return c.EtcdAlarmList(ctx)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 
-			var (
-				errs          error
-				headerPrinted bool
-			)
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							for _, alarm := range msg.GetMemberAlarms() {
-								if !headerPrinted {
-									fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+		var (
+			errs          error
+			headerPrinted bool
+		)
 
-									headerPrinted = true
-								}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-								fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						for _, alarm := range msg.GetMemberAlarms() {
+							if !headerPrinted {
+								fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+
+								headerPrinted = true
 							}
+
+							fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 
@@ -111,60 +115,64 @@ var etcdAlarmDisarmCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machine.EtcdAlarmDisarmResponse, error) {
-					return c.EtcdAlarmDisarm(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		defer clientFactory.Close() //nolint:errcheck
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.EtcdAlarmDisarmResponse, error) {
+				return c.EtcdAlarmDisarm(ctx)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 
-			var (
-				errs          error
-				headerPrinted bool
-			)
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							for _, alarm := range msg.GetMemberAlarms() {
-								if !headerPrinted {
-									fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+		var (
+			errs          error
+			headerPrinted bool
+		)
 
-									headerPrinted = true
-								}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-								fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						for _, alarm := range msg.GetMemberAlarms() {
+							if !headerPrinted {
+								fmt.Fprintln(w, "NODE\tMEMBER\tALARM")
+
+								headerPrinted = true
 							}
+
+							fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 
@@ -176,11 +184,23 @@ var etcdDefragCmd = &cobra.Command{
 Defragmentation is a resource heavy operation and should be performed only when necessary on a single node at a time.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd defrag", func(ctx context.Context, c *client.Client, _ string) error {
-			_, err := c.EtcdDefragment(ctx)
+		ctx := cmd.Context()
 
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
 			return err
-		})
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd defrag")
+		if err != nil {
+			return err
+		}
+
+		_, err = c.EtcdDefragment(ctx)
+
+		return err
 	},
 }
 
@@ -190,9 +210,21 @@ var etcdLeaveCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd leave", func(ctx context.Context, c *client.Client, _ string) error {
-			return c.EtcdLeaveCluster(ctx, &machine.EtcdLeaveClusterRequest{})
-		})
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd leave")
+		if err != nil {
+			return err
+		}
+
+		return c.EtcdLeaveCluster(ctx, &machine.EtcdLeaveClusterRequest{})
 	},
 }
 
@@ -204,34 +236,38 @@ If there is no access to the node, or the node can't access etcd to call etcd le
 Always prefer etcd leave over this command.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			memberID, err := etcdresource.ParseMemberID(args[0])
-			if err != nil {
-				return fmt.Errorf("error parsing member ID: %w", err)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		memberID, err := etcdresource.ParseMemberID(args[0])
+		if err != nil {
+			return fmt.Errorf("error parsing member ID: %w", err)
+		}
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.EtcdRemoveMemberByID(ctx, &machine.EtcdRemoveMemberByIDRequest{
+					MemberId: memberID,
+				})
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (struct{}, error) {
-					return struct{}{}, c.EtcdRemoveMemberByID(ctx, &machine.EtcdRemoveMemberByIDRequest{
-						MemberId: memberID,
-					})
-				},
-			)
-
-			var errs error
-
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-				}
-			}
-
-			return errs
-		})
+		return errs
 	},
 }
 
@@ -241,29 +277,33 @@ var etcdForfeitLeadershipCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (struct{}, error) {
-					_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-					return struct{}{}, err
-				},
-			)
+		defer clientFactory.Close() //nolint:errcheck
 
-			var errs error
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
 
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-				}
+				return struct{}{}, err
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			return errs
-		})
+		return errs
 	},
 }
 
@@ -273,62 +313,66 @@ var etcdMemberListCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machine.EtcdMemberListResponse, error) {
-					return c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
-						QueryLocal: true,
-					})
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
+		defer clientFactory.Close() //nolint:errcheck
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.EtcdMemberListResponse, error) {
+				return c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
+					QueryLocal: true,
+				})
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, message := range resp.Payload.Messages {
-							for _, member := range message.Members {
-								fmt.Fprintf(
-									w, "%s\t%s\t%s\t%s\t%s\t%v\n",
-									resp.Node,
-									etcdresource.FormatMemberID(member.Id),
-									member.Hostname,
-									strings.Join(member.PeerUrls, ","),
-									strings.Join(member.ClientUrls, ","),
-									member.IsLearner,
-								)
-							}
+		var errs error
+
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
+
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, message := range resp.Payload.Messages {
+						for _, member := range message.Members {
+							fmt.Fprintf(
+								w, "%s\t%s\t%s\t%s\t%s\t%v\n",
+								resp.Node,
+								etcdresource.FormatMemberID(member.Id),
+								member.Hostname,
+								strings.Join(member.PeerUrls, ","),
+								strings.Join(member.ClientUrls, ","),
+								member.IsLearner,
+							)
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 
@@ -338,71 +382,75 @@ var etcdStatusCmd = &cobra.Command{
 	Long:  `Returns the status of etcd member on the node, use multiple nodes to get status of all members.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machine.EtcdStatusResponse, error) {
-					return c.EtcdStatus(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tMEMBER\tDB SIZE\tIN USE\tLEADER\tRAFT INDEX\tRAFT TERM\tRAFT APPLIED INDEX\tLEARNER\tPROTOCOL\tSTORAGE\tERRORS")
+		defer clientFactory.Close() //nolint:errcheck
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.EtcdStatusResponse, error) {
+				return c.EtcdStatus(ctx)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tMEMBER\tDB SIZE\tIN USE\tLEADER\tRAFT INDEX\tRAFT TERM\tRAFT APPLIED INDEX\tLEARNER\tPROTOCOL\tSTORAGE\tERRORS")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, message := range resp.Payload.Messages {
-							var ratio float64
+		var errs error
 
-							if message.GetMemberStatus().GetDbSize() > 0 {
-								ratio = float64(message.GetMemberStatus().GetDbSizeInUse()) / float64(message.GetMemberStatus().GetDbSize()) * 100.0
-							}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-							fmt.Fprintf(
-								w, "%s\t%s\t%s\t%s (%.2f%%)\t%s\t%d\t%d\t%d\t%v\t%s\t%s\t%s\n",
-								resp.Node,
-								etcdresource.FormatMemberID(message.GetMemberStatus().GetMemberId()),
-								humanize.Bytes(uint64(message.GetMemberStatus().GetDbSize())),
-								humanize.Bytes(uint64(message.GetMemberStatus().GetDbSizeInUse())),
-								ratio,
-								etcdresource.FormatMemberID(message.GetMemberStatus().GetLeader()),
-								message.GetMemberStatus().GetRaftIndex(),
-								message.GetMemberStatus().GetRaftTerm(),
-								message.GetMemberStatus().GetRaftAppliedIndex(),
-								message.GetMemberStatus().GetIsLearner(),
-								message.GetMemberStatus().GetProtocolVersion(),
-								message.GetMemberStatus().GetStorageVersion(),
-								strings.Join(message.GetMemberStatus().GetErrors(), ", "),
-							)
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, message := range resp.Payload.Messages {
+						var ratio float64
+
+						if message.GetMemberStatus().GetDbSize() > 0 {
+							ratio = float64(message.GetMemberStatus().GetDbSizeInUse()) / float64(message.GetMemberStatus().GetDbSize()) * 100.0
 						}
-					}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+						fmt.Fprintf(
+							w, "%s\t%s\t%s\t%s (%.2f%%)\t%s\t%d\t%d\t%d\t%v\t%s\t%s\t%s\n",
+							resp.Node,
+							etcdresource.FormatMemberID(message.GetMemberStatus().GetMemberId()),
+							humanize.Bytes(uint64(message.GetMemberStatus().GetDbSize())),
+							humanize.Bytes(uint64(message.GetMemberStatus().GetDbSizeInUse())),
+							ratio,
+							etcdresource.FormatMemberID(message.GetMemberStatus().GetLeader()),
+							message.GetMemberStatus().GetRaftIndex(),
+							message.GetMemberStatus().GetRaftTerm(),
+							message.GetMemberStatus().GetRaftAppliedIndex(),
+							message.GetMemberStatus().GetIsLearner(),
+							message.GetMemberStatus().GetProtocolVersion(),
+							message.GetMemberStatus().GetStorageVersion(),
+							strings.Join(message.GetMemberStatus().GetErrors(), ", "),
+						)
 					}
 				}
+
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+				}
 			}
-		})
+		}
 	},
 }
 
@@ -412,62 +460,74 @@ var etcdSnapshotCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd snapshot", func(ctx context.Context, c *client.Client, _ string) error {
-			dbPath := args[0]
-			partPath := dbPath + ".part"
+		ctx := cmd.Context()
 
-			defer os.RemoveAll(partPath) //nolint:errcheck
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			dest, err := os.OpenFile(partPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
-			if err != nil {
-				return fmt.Errorf("error creating temporary file: %w", err)
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			defer dest.Close() //nolint:errcheck
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd snapshot")
+		if err != nil {
+			return err
+		}
 
-			r, err := c.EtcdSnapshot(ctx, &machine.EtcdSnapshotRequest{})
-			if err != nil {
-				return fmt.Errorf("error reading file: %w", err)
-			}
+		dbPath := args[0]
+		partPath := dbPath + ".part"
 
-			defer r.Close() //nolint:errcheck
+		defer os.RemoveAll(partPath) //nolint:errcheck
 
-			size, err := io.Copy(dest, r)
-			if err != nil {
-				return fmt.Errorf("error reading: %w", err)
-			}
+		dest, err := os.OpenFile(partPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			return fmt.Errorf("error creating temporary file: %w", err)
+		}
 
-			if err = dest.Sync(); err != nil {
-				return fmt.Errorf("failed to fsync: %w", err)
-			}
+		defer dest.Close() //nolint:errcheck
 
-			// this check is from https://github.com/etcd-io/etcd/blob/client/v3.5.0-alpha.0/client/v3/snapshot/v3_snapshot.go#L46
-			if (size % 512) != sha256.Size {
-				return fmt.Errorf("sha256 checksum not found (size %d)", size)
-			}
+		r, err := c.EtcdSnapshot(ctx, &machine.EtcdSnapshotRequest{})
+		if err != nil {
+			return fmt.Errorf("error reading file: %w", err)
+		}
 
-			if err = dest.Close(); err != nil {
-				return fmt.Errorf("failed to close: %w", err)
-			}
+		defer r.Close() //nolint:errcheck
 
-			if err = os.Rename(partPath, dbPath); err != nil {
-				return fmt.Errorf("error renaming to final location: %w", err)
-			}
+		size, err := io.Copy(dest, r)
+		if err != nil {
+			return fmt.Errorf("error reading: %w", err)
+		}
 
-			fmt.Printf("etcd snapshot saved to %q (%d bytes)\n", dbPath, size)
+		if err = dest.Sync(); err != nil {
+			return fmt.Errorf("failed to fsync: %w", err)
+		}
 
-			manager := snapshot.NewV3(logging.Wrap(os.Stderr))
+		// this check is from https://github.com/etcd-io/etcd/blob/client/v3.5.0-alpha.0/client/v3/snapshot/v3_snapshot.go#L46
+		if (size % 512) != sha256.Size {
+			return fmt.Errorf("sha256 checksum not found (size %d)", size)
+		}
 
-			status, err := manager.Status(dbPath)
-			if err != nil {
-				return err
-			}
+		if err = dest.Close(); err != nil {
+			return fmt.Errorf("failed to close: %w", err)
+		}
 
-			fmt.Printf("snapshot info: hash %08x, revision %d, total keys %d, total size %d\n",
-				status.Hash, status.Revision, status.TotalKey, status.TotalSize)
+		if err = os.Rename(partPath, dbPath); err != nil {
+			return fmt.Errorf("error renaming to final location: %w", err)
+		}
 
-			return nil
-		})
+		fmt.Printf("etcd snapshot saved to %q (%d bytes)\n", dbPath, size)
+
+		manager := snapshot.NewV3(logging.Wrap(os.Stderr))
+
+		status, err := manager.Status(dbPath)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("snapshot info: hash %08x, revision %d, total keys %d, total size %d\n",
+			status.Hash, status.Revision, status.TotalKey, status.TotalSize)
+
+		return nil
 	},
 }
 
@@ -488,34 +548,46 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade validate", func(ctx context.Context, c *client.Client, node string) error {
-			version := args[0]
+		ctx := cmd.Context()
 
-			r, err := c.EtcdDowngradeValidate(ctx, &machine.EtcdDowngradeValidateRequest{Version: version})
-			if err != nil {
-				return err
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, node, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd downgrade validate")
+		if err != nil {
+			return err
+		}
+
+		version := args[0]
+
+		r, err := c.EtcdDowngradeValidate(ctx, &machine.EtcdDowngradeValidateRequest{Version: version})
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		pattern := etcdDowngradePattern
+		header := etcdDowngradeHeader
+
+		for i, message := range r.Messages {
+			if i == 0 {
+				fmt.Fprintln(w, header)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			pattern := etcdDowngradePattern
-			header := etcdDowngradeHeader
+			fmt.Fprintf(
+				w, pattern, node,
+				fmt.Sprintf(
+					"downgrade validate success, cluster version %s",
+					message.GetClusterDowngrade().GetClusterVersion(),
+				),
+			)
+		}
 
-			for i, message := range r.Messages {
-				if i == 0 {
-					fmt.Fprintln(w, header)
-				}
-
-				fmt.Fprintf(
-					w, pattern, node,
-					fmt.Sprintf(
-						"downgrade validate success, cluster version %s",
-						message.GetClusterDowngrade().GetClusterVersion(),
-					),
-				)
-			}
-
-			return w.Flush()
-		})
+		return w.Flush()
 	},
 }
 
@@ -525,35 +597,47 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade enable", func(ctx context.Context, c *client.Client, node string) error {
-			version := args[0]
+		ctx := cmd.Context()
 
-			r, err := c.EtcdDowngradeEnable(ctx, &machine.EtcdDowngradeEnableRequest{Version: version})
-			if err != nil {
-				return err
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, node, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd downgrade enable")
+		if err != nil {
+			return err
+		}
+
+		version := args[0]
+
+		r, err := c.EtcdDowngradeEnable(ctx, &machine.EtcdDowngradeEnableRequest{Version: version})
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		pattern := etcdDowngradePattern
+		header := etcdDowngradeHeader
+
+		for i, message := range r.Messages {
+			if i == 0 {
+				fmt.Fprintln(w, header)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			pattern := etcdDowngradePattern
-			header := etcdDowngradeHeader
+			fmt.Fprintf(
+				w, pattern,
+				node,
+				fmt.Sprintf(
+					"downgrade enable success, cluster version %s",
+					message.GetClusterDowngrade().GetClusterVersion(),
+				),
+			)
+		}
 
-			for i, message := range r.Messages {
-				if i == 0 {
-					fmt.Fprintln(w, header)
-				}
-
-				fmt.Fprintf(
-					w, pattern,
-					node,
-					fmt.Sprintf(
-						"downgrade enable success, cluster version %s",
-						message.GetClusterDowngrade().GetClusterVersion(),
-					),
-				)
-			}
-
-			return w.Flush()
-		})
+		return w.Flush()
 	},
 }
 
@@ -563,32 +647,44 @@ var etcdDowngradeCancelCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "etcd downgrade cancel", func(ctx context.Context, c *client.Client, node string) error {
-			r, err := c.EtcdDowngradeCancel(ctx)
-			if err != nil {
-				return err
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, node, err := clientFactory.BuildClientEnforceSingleNode(ctx, "etcd downgrade cancel")
+		if err != nil {
+			return err
+		}
+
+		r, err := c.EtcdDowngradeCancel(ctx)
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		pattern := etcdDowngradePattern
+		header := etcdDowngradeHeader
+
+		for i, message := range r.Messages {
+			if i == 0 {
+				fmt.Fprintln(w, header)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			pattern := etcdDowngradePattern
-			header := etcdDowngradeHeader
+			fmt.Fprintf(
+				w, pattern, node,
+				fmt.Sprintf(
+					"downgrade cancel success, cluster version %s",
+					message.GetClusterDowngrade().GetClusterVersion(),
+				),
+			)
+		}
 
-			for i, message := range r.Messages {
-				if i == 0 {
-					fmt.Fprintln(w, header)
-				}
-
-				fmt.Fprintf(
-					w, pattern, node,
-					fmt.Sprintf(
-						"downgrade cancel success, cluster version %s",
-						message.GetClusterDowngrade().GetClusterVersion(),
-					),
-				)
-			}
-
-			return w.Flush()
-		})
+		return w.Flush()
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -6,25 +6,24 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/output"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 )
 
 var getCmdFlags struct {
-	insecure bool
+	global.InsecureFlags
 
 	namespace string
 	output    string
@@ -52,160 +51,200 @@ To get a list of all available resource definitions, issue 'talosctl get rd'`,
 	},
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if getCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, getResources(args))
-		}
+		ctx := cmd.Context()
 
-		return WithClient(cmd.Context(), getResources(args))
-	},
-}
-
-//nolint:gocyclo,cyclop
-func getResources(args []string) func(ctx context.Context, c *client.Client) error {
-	return func(ctx context.Context, c *client.Client) error {
-		if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-			return err
-		}
-
-		out, err := output.NewWriter(getCmdFlags.output)
+		clientFactory, err := NewClientFactory(ctx, &getCmdFlags)
 		if err != nil {
 			return err
 		}
 
-		resourceType := args[0]
+		defer clientFactory.Close() //nolint:errcheck
 
-		var resourceID string
+		return getResources(ctx, args, clientFactory)
+	},
+}
 
-		if len(args) == 2 {
-			resourceID = args[1]
+//nolint:gocyclo,cyclop
+func getResources(ctx context.Context, args []string, clientFactory *global.ClientFactory) error {
+	if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil { //nolint:staticcheck // to be refactored next
+		return err
+	}
+
+	out, err := output.NewWriter(getCmdFlags.output)
+	if err != nil {
+		return err
+	}
+
+	resourceType := args[0]
+
+	var resourceID string
+
+	if len(args) == 2 {
+		resourceID = args[1]
+	}
+
+	defer out.Flush() //nolint:errcheck
+
+	if len(clientFactory.Nodes()) == 0 {
+		return nil
+	}
+
+	// resolver resource kind
+	firstCtx, firstC, err := clientFactory.BuildClient(ctx, clientFactory.Nodes()[0])
+	if err != nil {
+		return err
+	}
+
+	rd, err := firstC.ResolveResourceKind(firstCtx, &getCmdFlags.namespace, resourceType)
+	if err != nil {
+		return err
+	}
+
+	if getCmdFlags.watch { // get -w <type> OR get -w <type> <id>
+		return watchResources(ctx, out, clientFactory, rd, resourceID)
+	}
+
+	// get <type>
+	// get <type> <id>
+	return listResources(ctx, out, clientFactory, rd, resourceID)
+}
+
+func listResources(ctx context.Context, out output.Writer, clientFactory *global.ClientFactory, rd *meta.ResourceDefinition, resourceID string) error {
+	if err := out.WriteHeader(rd, false); err != nil {
+		return err
+	}
+
+	resourceType := rd.TypedSpec().Type
+
+	var errs error
+
+	for _, node := range clientFactory.Nodes() {
+		nodeCtx, nodeClient, err := clientFactory.BuildClient(ctx, node)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error building client for node %s: %w", node, err))
+
+			continue
 		}
 
-		defer out.Flush() //nolint:errcheck
-
-		if getCmdFlags.watch { // get -w <type> OR get -w <type> <id>
-			md, _ := metadata.FromOutgoingContext(ctx)
-			nodes := md.Get("nodes")
-
-			if len(nodes) == 0 {
-				// use "current" node
-				nodes = []string{""}
-			}
-
-			// fetch the RD from the first node (it doesn't matter which one to use, so we'll use the first one)
-			rd, err := c.ResolveResourceKind(client.WithNode(ctx, nodes[0]), &getCmdFlags.namespace, resourceType)
+		if resourceID == "" {
+			items, err := nodeClient.COSI.List(
+				nodeCtx,
+				resource.NewMetadata(getCmdFlags.namespace, resourceType, "", resource.VersionUndefined),
+				state.WithListUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
 			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error listing resources on node %s: %w", node, err))
+
+				continue
+			}
+
+			for _, item := range items.Items {
+				if err = out.WriteResource(node, item, 0); err != nil {
+					errs = errors.Join(errs, err)
+				}
+			}
+		} else {
+			r, err := nodeClient.COSI.Get(
+				nodeCtx,
+				resource.NewMetadata(getCmdFlags.namespace, resourceType, resourceID, resource.VersionUndefined),
+				state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error getting resource on node %s: %w", node, err))
+
+				continue
+			}
+
+			if err = out.WriteResource(node, r, 0); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+
+	return errs
+}
+
+//nolint:gocyclo
+func watchResources(ctx context.Context, out output.Writer, clientFactory *global.ClientFactory, rd *meta.ResourceDefinition, resourceID string) error {
+	resourceType := rd.TypedSpec().Type
+
+	if err := out.WriteHeader(rd, true); err != nil {
+		return err
+	}
+
+	aggregatedCh := make(chan nodeAndEvent)
+
+	for _, node := range clientFactory.Nodes() {
+		nodeCtx, nodeClient, err := clientFactory.BuildClient(ctx, node)
+		if err != nil {
+			return fmt.Errorf("error building client for node %s: %w", node, err)
+		}
+
+		watchCh := make(chan state.Event)
+
+		if resourceID == "" {
+			err = nodeClient.COSI.WatchKind(
+				nodeCtx,
+				resource.NewMetadata(getCmdFlags.namespace, resourceType, "", resource.VersionUndefined),
+				watchCh,
+				state.WithBootstrapContents(true),
+				state.WithWatchKindUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
+		} else {
+			err = nodeClient.COSI.Watch(
+				nodeCtx,
+				resource.NewMetadata(getCmdFlags.namespace, resourceType, resourceID, resource.VersionUndefined),
+				watchCh,
+				state.WithWatchUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error setting up watch on node %s: %w", node, err)
+		}
+
+		go aggregateEvents(ctx, aggregatedCh, watchCh, node)
+	}
+
+	bootstrapped := resourceID != "" // if we're watching a specific resource, we can consider it bootstrapped immediately, otherwise we need to wait for the bootstrapped event
+
+	for {
+		var nev nodeAndEvent
+
+		select {
+		case nev = <-aggregatedCh:
+		case <-ctx.Done():
+			return nil
+		}
+
+		if nev.ev.Type == state.Errored {
+			return fmt.Errorf("error watching resource: %w", nev.ev.Error)
+		}
+
+		if nev.ev.Type == state.Bootstrapped {
+			bootstrapped = true
+
+			if err := out.Flush(); err != nil {
 				return err
 			}
 
-			resourceType = rd.TypedSpec().Type
+			continue
+		}
 
-			if err = out.WriteHeader(rd, true); err != nil {
+		if nev.ev.Resource == nil {
+			// new event type without resource, skip it
+			continue
+		}
+
+		if err := out.WriteResource(nev.node, nev.ev.Resource, nev.ev.Type); err != nil {
+			return err
+		}
+
+		if bootstrapped {
+			if err := out.Flush(); err != nil {
 				return err
 			}
-
-			aggregatedCh := make(chan nodeAndEvent)
-
-			for _, node := range nodes {
-				var nodeCtx context.Context
-
-				if node == "" {
-					nodeCtx = ctx
-				} else {
-					nodeCtx = client.WithNode(ctx, node)
-				}
-
-				watchCh := make(chan state.Event)
-
-				if resourceID == "" {
-					err = c.COSI.WatchKind(
-						nodeCtx,
-						resource.NewMetadata(getCmdFlags.namespace, resourceType, "", resource.VersionUndefined),
-						watchCh,
-						state.WithBootstrapContents(true),
-						state.WithWatchKindUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
-					)
-				} else {
-					err = c.COSI.Watch(
-						nodeCtx,
-						resource.NewMetadata(getCmdFlags.namespace, resourceType, resourceID, resource.VersionUndefined),
-						watchCh,
-						state.WithWatchUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
-					)
-				}
-
-				if err != nil {
-					return fmt.Errorf("error setting up watch on node %s: %w", node, err)
-				}
-
-				go aggregateEvents(ctx, aggregatedCh, watchCh, node)
-			}
-
-			var bootstrapped bool
-
-			for {
-				var nev nodeAndEvent
-
-				select {
-				case nev = <-aggregatedCh:
-				case <-ctx.Done():
-					return nil
-				}
-
-				if nev.ev.Type == state.Errored {
-					return fmt.Errorf("error watching resource: %w", nev.ev.Error)
-				}
-
-				if nev.ev.Type == state.Bootstrapped {
-					bootstrapped = true
-
-					if err = out.Flush(); err != nil {
-						return err
-					}
-
-					continue
-				}
-
-				if nev.ev.Resource == nil {
-					// new event type without resource, skip it
-					continue
-				}
-
-				if err = out.WriteResource(nev.node, nev.ev.Resource, nev.ev.Type); err != nil {
-					return err
-				}
-
-				if bootstrapped {
-					if err = out.Flush(); err != nil {
-						return err
-					}
-				}
-			}
 		}
-
-		var multiErr *multierror.Error
-
-		// get <type>
-		// get <type> <id>
-		callbackResource := func(parentCtx context.Context, hostname string, r resource.Resource, callError error) error {
-			if callError != nil {
-				multiErr = multierror.Append(multiErr, callError)
-
-				return nil
-			}
-
-			return out.WriteResource(hostname, r, 0)
-		}
-
-		callbackRD := func(definition *meta.ResourceDefinition) error {
-			return out.WriteHeader(definition, false)
-		}
-
-		helperErr := helpers.ForEachResource(ctx, c, callbackRD, callbackResource, getCmdFlags.namespace, args...)
-		if helperErr != nil {
-			return helperErr
-		}
-
-		return multiErr.ErrorOrNil()
 	}
 }
 
@@ -231,25 +270,37 @@ func aggregateEvents(ctx context.Context, outCh chan<- nodeAndEvent, watchCh <-c
 
 // completeResourceDefinition represents tab complete options for `get` and `get *` commands.
 func completeResourceDefinition(ctx context.Context, withAliases bool) ([]string, cobra.ShellCompDirective) {
+	clientFactory, err := NewClientFactory(ctx, nil)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	ctx, c, err := clientFactory.BuildClientFirstNode(ctx)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error building client: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
 	var result []string
 
-	if WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		items, err := safe.StateListAll[*meta.ResourceDefinition](ctx, c.COSI)
-		if err != nil {
-			return err
-		}
+	items, err := safe.StateListAll[*meta.ResourceDefinition](ctx, c.COSI)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error listing resource definitions: %v", err))
 
-		for res := range items.All() {
-			if withAliases {
-				result = append(result, res.TypedSpec().Aliases...)
-			}
-
-			result = append(result, res.Metadata().ID())
-		}
-
-		return nil
-	}) != nil {
 		return nil, cobra.ShellCompDirectiveError
+	}
+
+	for res := range items.All() {
+		if withAliases {
+			result = append(result, res.TypedSpec().Aliases...)
+		}
+
+		result = append(result, res.Metadata().ID())
 	}
 
 	return result, cobra.ShellCompDirectiveNoFileComp
@@ -257,58 +308,86 @@ func completeResourceDefinition(ctx context.Context, withAliases bool) ([]string
 
 // completeResourceID represents tab complete options for `get` and `get *` commands.
 func completeResourceID(ctx context.Context, resourceType, namespace string) ([]string, cobra.ShellCompDirective) {
+	clientFactory, err := NewClientFactory(ctx, nil)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	ctx, c, err := clientFactory.BuildClientFirstNode(ctx)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error building client: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
 	var result []string
 
-	if WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		if len(GlobalArgs.Nodes) > 0 {
-			ctx = client.WithNode(ctx, GlobalArgs.Nodes[0])
-		}
+	rd, err := c.ResolveResourceKind(ctx, &namespace, resourceType)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error resolving resource kind: %v", err))
 
-		rd, err := c.ResolveResourceKind(ctx, &namespace, resourceType)
-		if err != nil {
-			return err
-		}
-
-		items, err := c.COSI.List(ctx, resource.NewMetadata(namespace, rd.TypedSpec().Type, "", resource.VersionUndefined))
-		if err != nil {
-			return err
-		}
-
-		for _, item := range items.Items {
-			result = append(result, item.Metadata().ID())
-		}
-
-		return nil
-	}) != nil {
 		return nil, cobra.ShellCompDirectiveError
+	}
+
+	items, err := c.COSI.List(ctx, resource.NewMetadata(namespace, rd.TypedSpec().Type, "", resource.VersionUndefined))
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error listing resources: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	for _, item := range items.Items {
+		result = append(result, item.Metadata().ID())
 	}
 
 	return result, cobra.ShellCompDirectiveNoFileComp
 }
 
-// CompleteNodes represents tab completion for `--nodes` argument.
-func CompleteNodes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// completeNodes represents tab completion for `--nodes` argument.
+func completeNodes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ctx := cmd.Context()
+
+	// setup fake nodes list in the args to make NewClientFactory ignore the fact there are no nodes specified
+	// (as we are completing the nodes themselves)
+	GlobalArgs.Nodes = []string{"fake-node"}
+
+	clientFactory, err := NewClientFactory(ctx, nil)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	c, err := clientFactory.BuildRandomEndpointClient(ctx)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error building client: %v", err))
+
+		return nil, cobra.ShellCompDirectiveError
+	}
+
 	var nodes []string
 
-	if WithClientNoNodes(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-		items, err := safe.StateListAll[*cluster.Member](ctx, c.COSI)
-		if err != nil {
-			return err
-		}
+	items, err := safe.StateListAll[*cluster.Member](ctx, c.COSI)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error listing cluster members: %v", err))
 
-		for res := range items.All() {
-			if hostname := res.TypedSpec().Hostname; hostname != "" {
-				nodes = append(nodes, hostname)
-			}
-
-			for _, address := range res.TypedSpec().Addresses {
-				nodes = append(nodes, address.String())
-			}
-		}
-
-		return nil
-	}) != nil {
 		return nil, cobra.ShellCompDirectiveError
+	}
+
+	for res := range items.All() {
+		if hostname := res.TypedSpec().Hostname; hostname != "" {
+			nodes = append(nodes, hostname)
+		}
+
+		for _, address := range res.TypedSpec().Addresses {
+			nodes = append(nodes, address.String())
+		}
 	}
 
 	return nodes, cobra.ShellCompDirectiveNoFileComp
@@ -318,7 +397,7 @@ func init() {
 	getCmd.Flags().StringVar(&getCmdFlags.namespace, "namespace", "", "resource namespace (default is to use default namespace per resource)")
 	getCmd.Flags().StringVarP(&getCmdFlags.output, "output", "o", "table", "output mode (json, table, yaml, jsonpath)")
 	getCmd.Flags().BoolVarP(&getCmdFlags.watch, "watch", "w", false, "watch resource changes")
-	getCmd.Flags().BoolVarP(&getCmdFlags.insecure, "insecure", "i", false, "get resources using the insecure (encrypted with no auth) maintenance service")
+	getCmdFlags.InsecureFlags.AddFlags(getCmd)
 	cli.Should(getCmd.RegisterFlagCompletionFunc("output", output.CompleteOutputArg))
 	addCommand(getCmd)
 }

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
 	"github.com/siderolabs/talos/pkg/cluster/hydrophone"
@@ -95,33 +96,47 @@ var healthCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runHealth(cmd.Context()); err != nil {
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &healthCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		if err := runHealth(ctx, clientFactory); err != nil {
 			return err
 		}
 
 		if healthCmdFlags.runE2E {
-			return runE2E(cmd.Context())
+			return runE2E(ctx, clientFactory)
 		}
 
 		return nil
 	},
 }
 
-func runHealth(ctx context.Context) error {
+func runHealth(ctx context.Context, clientFactory *global.ClientFactory) error {
 	if healthCmdFlags.runOnServer {
-		return WithClientAndSingleNode(ctx, "health", healthOnServer)
+		return healthOnServer(ctx, clientFactory)
 	}
 
-	return WithClientNoNodes(ctx, healthOnClient)
+	return healthOnClient(ctx, clientFactory)
 }
 
-func healthOnClient(ctx context.Context, c *client.Client) error {
+func healthOnClient(ctx context.Context, clientFactory *global.ClientFactory) error {
+	ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "health")
+	if err != nil {
+		return err
+	}
+
 	clientProvider := &cluster.ConfigClientProvider{
 		DefaultClient: c,
 	}
 	defer clientProvider.Close() //nolint:errcheck
 
-	clusterInfo, err := buildClusterInfo(ctx, healthCmdFlags.clusterState)
+	clusterInfo, err := buildClusterInfo(ctx, c, healthCmdFlags.clusterState)
 	if err != nil {
 		return err
 	}
@@ -146,7 +161,12 @@ func healthOnClient(ctx context.Context, c *client.Client) error {
 	return check.Wait(checkCtx, &state, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
 }
 
-func healthOnServer(ctx context.Context, c *client.Client, _ string) error {
+func healthOnServer(ctx context.Context, clientFactory *global.ClientFactory) error {
+	ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "health")
+	if err != nil {
+		return err
+	}
+
 	controlPlaneNodes := healthCmdFlags.clusterState.ControlPlaneNodes
 	if healthCmdFlags.clusterState.InitNode != "" {
 		controlPlaneNodes = append(controlPlaneNodes, healthCmdFlags.clusterState.InitNode)
@@ -179,27 +199,30 @@ func healthOnServer(ctx context.Context, c *client.Client, _ string) error {
 	}
 }
 
-func runE2E(ctx context.Context) error {
-	return WithClientAndSingleNode(ctx, "health", func(ctx context.Context, c *client.Client, _ string) error {
-		clientProvider := &cluster.ConfigClientProvider{
-			DefaultClient: c,
-		}
-		defer clientProvider.Close() //nolint:errcheck
+func runE2E(ctx context.Context, clientFactory *global.ClientFactory) error {
+	ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "health")
+	if err != nil {
+		return err
+	}
 
-		state := &cluster.KubernetesClient{
-			ClientProvider: clientProvider,
-			ForceEndpoint:  healthCmdFlags.forceEndpoint,
-		}
+	clientProvider := &cluster.ConfigClientProvider{
+		DefaultClient: c,
+	}
+	defer clientProvider.Close() //nolint:errcheck
 
-		// Run cluster readiness checks
-		checkCtx, checkCtxCancel := context.WithTimeout(ctx, healthCmdFlags.clusterWaitTimeout)
-		defer checkCtxCancel()
+	state := &cluster.KubernetesClient{
+		ClientProvider: clientProvider,
+		ForceEndpoint:  healthCmdFlags.forceEndpoint,
+	}
 
-		options := hydrophone.DefaultOptions()
-		options.UseSpinner = true
+	// Run cluster readiness checks
+	checkCtx, checkCtxCancel := context.WithTimeout(ctx, healthCmdFlags.clusterWaitTimeout)
+	defer checkCtxCancel()
 
-		return hydrophone.Run(checkCtx, state, options)
-	})
+	options := hydrophone.DefaultOptions()
+	options.UseSpinner = true
+
+	return hydrophone.Run(checkCtx, state, options)
 }
 
 func init() {
@@ -213,29 +236,21 @@ func init() {
 	healthCmd.Flags().BoolVar(&healthCmdFlags.runE2E, "run-e2e", false, "run Kubernetes e2e test")
 }
 
-func buildClusterInfo(ctx context.Context, clusterState clusterNodes) (cluster.Info, error) {
+func buildClusterInfo(ctx context.Context, c *client.Client, clusterState clusterNodes) (cluster.Info, error) {
 	// if nodes are set explicitly via command line args, use them
 	if len(clusterState.ControlPlaneNodes) > 0 || len(clusterState.WorkerNodes) > 0 {
 		return &clusterState, nil
 	}
 
 	// read members from the Talos API
-
 	var members []*clusterres.Member
 
-	err := WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		items, err := safe.StateListAll[*clusterres.Member](ctx, c.COSI)
-		if err != nil {
-			return err
-		}
-
-		items.ForEach(func(item *clusterres.Member) { members = append(members, item) })
-
-		return nil
-	})
+	items, err := safe.StateListAll[*clusterres.Member](ctx, c.COSI)
 	if err != nil {
 		return nil, err
 	}
+
+	items.ForEach(func(item *clusterres.Member) { members = append(members, item) })
 
 	return check.NewDiscoveredClusterInfo(members)
 }

--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -5,14 +5,12 @@
 package talos
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/formatters"
 )
 
@@ -40,18 +38,30 @@ to render the graph:
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "inspect dependencies", func(ctx context.Context, c *client.Client, node string) error {
-			resp, err := c.Inspect.ControllerRuntimeDependencies(ctx)
-			if err != nil {
-				if resp == nil {
-					return fmt.Errorf("error getting controller runtime dependencies: %s", err)
-				}
+		ctx := cmd.Context()
 
-				cli.Warning("%s", err)
+		clientFactory, err := NewClientFactory(ctx, &inspectDependenciesCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "inspect dependencies")
+		if err != nil {
+			return err
+		}
+
+		resp, err := c.Inspect.ControllerRuntimeDependencies(ctx)
+		if err != nil {
+			if resp == nil {
+				return fmt.Errorf("error getting controller runtime dependencies: %s", err)
 			}
 
-			return formatters.RenderGraph(ctx, c, resp, os.Stdout, inspectDependenciesCmdFlags.withResources)
-		})
+			cli.Warning("%s", err)
+		}
+
+		return formatters.RenderGraph(ctx, c, resp, os.Stdout, inspectDependenciesCmdFlags.withResources)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"bufio"
-	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -20,7 +19,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 const stdoutOutput = "-"
@@ -42,81 +40,93 @@ Otherwise, kubeconfig will be written to PWD or [local-path] if specified.
 If merge flag is false and [local-path] is "-", config will be written to stdout.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "kubeconfig", func(ctx context.Context, c *client.Client, _ string) error {
-			var localPath string
+		ctx := cmd.Context()
 
-			if len(args) == 0 {
-				// no path given, use defaults
-				var err error
+		clientFactory, err := NewClientFactory(ctx, &kubeconfigFlags)
+		if err != nil {
+			return err
+		}
 
-				if kubeconfigFlags.merge {
-					localPath, err = kubeconfig.SinglePath()
-					if err != nil {
-						return err
-					}
-				} else {
-					localPath, err = os.Getwd()
-					if err != nil {
-						return fmt.Errorf("error getting current working directory: %s", err)
-					}
-				}
-			} else {
-				localPath = args[0]
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			localPath = filepath.Clean(localPath)
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "kubeconfig")
+		if err != nil {
+			return err
+		}
 
-			st, err := os.Stat(localPath)
-			if err != nil {
-				if !errors.Is(err, fs.ErrNotExist) {
-					return fmt.Errorf("error checking path %q: %w", localPath, err)
-				}
+		var localPath string
 
-				err = os.MkdirAll(filepath.Dir(localPath), 0o755)
+		if len(args) == 0 {
+			// no path given, use defaults
+			var err error
+
+			if kubeconfigFlags.merge {
+				localPath, err = kubeconfig.SinglePath()
 				if err != nil {
 					return err
 				}
-			} else if st.IsDir() {
-				// only dir name was given, append `kubeconfig` by default
-				localPath = filepath.Join(localPath, "kubeconfig")
-			}
-
-			_, err = os.Stat(localPath)
-			if err == nil && !(kubeconfigFlags.force || kubeconfigFlags.merge) {
-				return fmt.Errorf("kubeconfig file already exists, use --force to overwrite: %q", localPath)
-			} else if err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					// merge doesn't make sense if target path doesn't exist
-					kubeconfigFlags.merge = false
-				} else {
-					return fmt.Errorf("error checking path %q: %w", localPath, err)
+			} else {
+				localPath, err = os.Getwd()
+				if err != nil {
+					return fmt.Errorf("error getting current working directory: %s", err)
 				}
 			}
+		} else {
+			localPath = args[0]
+		}
 
-			r, err := c.KubeconfigRaw(ctx)
-			if err != nil {
-				return fmt.Errorf("error copying: %w", err)
+		localPath = filepath.Clean(localPath)
+
+		st, err := os.Stat(localPath)
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("error checking path %q: %w", localPath, err)
 			}
 
-			defer r.Close() //nolint:errcheck
-
-			data, err := helpers.ExtractFileFromTarGz("kubeconfig", r)
+			err = os.MkdirAll(filepath.Dir(localPath), 0o755)
 			if err != nil {
 				return err
 			}
+		} else if st.IsDir() {
+			// only dir name was given, append `kubeconfig` by default
+			localPath = filepath.Join(localPath, "kubeconfig")
+		}
 
-			if kubeconfigFlags.merge {
-				return extractAndMerge(data, localPath)
+		_, err = os.Stat(localPath)
+		if err == nil && !(kubeconfigFlags.force || kubeconfigFlags.merge) {
+			return fmt.Errorf("kubeconfig file already exists, use --force to overwrite: %q", localPath)
+		} else if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// merge doesn't make sense if target path doesn't exist
+				kubeconfigFlags.merge = false
+			} else {
+				return fmt.Errorf("error checking path %q: %w", localPath, err)
 			}
+		}
 
-			if localPath == stdoutOutput {
-				_, err = os.Stdout.Write(data)
+		r, err := c.KubeconfigRaw(ctx)
+		if err != nil {
+			return fmt.Errorf("error copying: %w", err)
+		}
 
-				return err
-			}
+		defer r.Close() //nolint:errcheck
 
-			return os.WriteFile(localPath, data, 0o600)
-		})
+		data, err := helpers.ExtractFileFromTarGz("kubeconfig", r)
+		if err != nil {
+			return err
+		}
+
+		if kubeconfigFlags.merge {
+			return extractAndMerge(data, localPath)
+		}
+
+		if localPath == stdoutOutput {
+			_, err = os.Stdout.Write(data)
+
+			return err
+		}
+
+		return os.WriteFile(localPath, data, 0o600)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -19,7 +19,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
-var verbose bool
+var memoryCmdFlags struct {
+	verbose bool
+}
 
 // memoryCmd represents the processes command.
 var memoryCmd = &cobra.Command{
@@ -29,23 +31,27 @@ var memoryCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machineapi.MemoryResponse, error) {
-					return c.Memory(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, &memoryCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			if verbose {
-				return renderVerbose(responseChan)
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			return renderBrief(responseChan)
-		})
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.MemoryResponse, error) {
+				return c.Memory(ctx)
+			},
+		)
+
+		if memoryCmdFlags.verbose {
+			return renderVerbose(responseChan)
+		}
+
+		return renderBrief(responseChan)
 	},
 }
 
@@ -163,6 +169,6 @@ func renderVerbose(responseChan <-chan multiplex.Response[*machineapi.MemoryResp
 }
 
 func init() {
-	memoryCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "display extended memory statistics")
+	memoryCmd.Flags().BoolVarP(&memoryCmdFlags.verbose, "verbose", "v", false, "display extended memory statistics")
 	addCommand(memoryCmd)
 }

--- a/cmd/talosctl/cmd/talos/meta.go
+++ b/cmd/talosctl/cmd/talos/meta.go
@@ -6,15 +6,19 @@ package talos
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var metaCmdFlags struct {
-	insecure bool
+	global.InsecureFlags
 }
 
 var metaCmd = &cobra.Command{
@@ -30,20 +34,36 @@ var metaWriteCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fn := func(ctx context.Context, c *client.Client) error {
-			key, err := strconv.ParseUint(args[0], 0, 8)
-			if err != nil {
-				return err
+		key, err := strconv.ParseUint(args[0], 0, 8)
+		if err != nil {
+			return err
+		}
+
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &metaCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		respCh := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.MetaWrite(ctx, uint8(key), []byte(args[1]))
+			},
+		)
+
+		var errs error
+
+		for resp := range respCh {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error writing meta to node %s: %w", resp.Node, resp.Err))
 			}
-
-			return c.MetaWrite(ctx, uint8(key), []byte(args[1]))
 		}
 
-		if metaCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, fn)
-		}
-
-		return WithClient(cmd.Context(), fn)
+		return errs
 	},
 }
 
@@ -53,25 +73,41 @@ var metaDeleteCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fn := func(ctx context.Context, c *client.Client) error {
-			key, err := strconv.ParseUint(args[0], 0, 8)
-			if err != nil {
-				return err
+		key, err := strconv.ParseUint(args[0], 0, 8)
+		if err != nil {
+			return err
+		}
+
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &metaCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		respCh := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.MetaDelete(ctx, uint8(key))
+			},
+		)
+
+		var errs error
+
+		for resp := range respCh {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error deleting meta from node %s: %w", resp.Node, resp.Err))
 			}
-
-			return c.MetaDelete(ctx, uint8(key))
 		}
 
-		if metaCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, fn)
-		}
-
-		return WithClient(cmd.Context(), fn)
+		return errs
 	},
 }
 
 func init() {
-	metaCmd.PersistentFlags().BoolVarP(&metaCmdFlags.insecure, "insecure", "i", false, "write|delete meta using the insecure (encrypted with no auth) maintenance service")
+	metaCmdFlags.InsecureFlags.AddFlags(metaCmd)
 
 	metaCmd.AddCommand(metaWriteCmd)
 	metaCmd.AddCommand(metaDeleteCmd)

--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -6,14 +6,19 @@ package talos
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
 	"os"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
-	"github.com/siderolabs/talos/pkg/machinery/formatters"
 )
 
 // mountsCmd represents the mounts command.
@@ -24,20 +29,77 @@ var mountsCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machineapi.MountsResponse, error) {
-					return c.Mounts(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			return formatters.RenderMountsStream(os.Stdout, responseChan)
-		})
+		defer clientFactory.Close() //nolint:errcheck
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.MountsResponse, error) {
+				return c.Mounts(ctx)
+			},
+		)
+
+		return renderMounts(os.Stdout, responseChan)
 	},
+}
+
+// renderMounts renders the mounts output for a stream of multiplexed responses.
+func renderMounts(output io.Writer, responseChan <-chan multiplex.Response[*machineapi.MountsResponse]) error {
+	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NODE\tFILESYSTEM\tSIZE(GB)\tUSED(GB)\tAVAILABLE(GB)\tPERCENT USED\tMOUNTED ON")
+
+	flushTimer := time.NewTimer(outputFlushInterval)
+	defer flushTimer.Stop()
+
+	flushTimer.Stop()
+
+	var errs error
+
+	for {
+		select {
+		case resp, ok := <-responseChan:
+			if !ok {
+				return errors.Join(errs, w.Flush())
+			}
+
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+			} else {
+				for _, msg := range resp.Payload.Messages {
+					for _, r := range msg.Stats {
+						percentAvailable := 100.0 - 100.0*(float64(r.Available)/float64(r.Size))
+
+						if math.IsNaN(percentAvailable) {
+							continue
+						}
+
+						fmt.Fprintf(
+							w, "%s\t%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n",
+							resp.Node,
+							r.Filesystem,
+							float64(r.Size)*1e-9,
+							float64(r.Size-r.Available)*1e-9,
+							float64(r.Available)*1e-9,
+							percentAvailable,
+							r.MountedOn,
+						)
+					}
+				}
+			}
+
+			flushTimer.Reset(outputFlushInterval)
+		case <-flushTimer.C:
+			if err := w.Flush(); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+			}
+		}
+	}
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -24,7 +24,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 var patchCmdFlags struct {
@@ -70,20 +69,8 @@ func extractMachineConfigBody(mc resource.Resource) ([]byte, error) {
 	return []byte(bodyStr), nil
 }
 
-func patchFn(c *client.Client, patches []configpatcher.Patch) func(context.Context, string, resource.Resource, error) error {
-	return func(ctx context.Context, node string, mc resource.Resource, callError error) error {
-		if callError != nil {
-			return fmt.Errorf("%s: %w", node, callError)
-		}
-
-		if mc.Metadata().Type() != config.MachineConfigType {
-			return fmt.Errorf("%s: unsupported resource type: %s", node, mc.Metadata().Type())
-		}
-
-		if mc.Metadata().ID() != config.ActiveID {
-			return nil
-		}
-
+func patchFn(patches []configpatcher.Patch) func(context.Context, *client.Client, string, resource.Resource) error {
+	return func(ctx context.Context, c *client.Client, node string, mc resource.Resource) error {
 		body, err := extractMachineConfigBody(mc)
 		if err != nil {
 			return err
@@ -134,33 +121,33 @@ var patchCmd = &cobra.Command{
 	Short: "Patch machine configuration of a Talos node with a local patch.",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			if patchCmdFlags.patchFile != "" {
-				patchCmdFlags.patch = append(patchCmdFlags.patch, "@"+patchCmdFlags.patchFile)
-			}
+		if patchCmdFlags.patchFile != "" {
+			patchCmdFlags.patch = append(patchCmdFlags.patch, "@"+patchCmdFlags.patchFile)
+		}
 
-			if len(patchCmdFlags.patch) == 0 {
-				return errors.New("either --patch or --patch-file should be defined")
-			}
+		if len(patchCmdFlags.patch) == 0 {
+			return errors.New("either --patch or --patch-file should be defined")
+		}
 
-			patches, err := configpatcher.LoadPatches(patchCmdFlags.patch)
-			if err != nil {
-				return err
-			}
+		patches, err := configpatcher.LoadPatches(patchCmdFlags.patch)
+		if err != nil {
+			return err
+		}
 
-			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-				return err
-			}
+		ctx := cmd.Context()
 
-			for _, node := range GlobalArgs.Nodes {
-				nodeCtx := client.WithNodes(ctx, node) //nolint:staticcheck // to be refactored next
-				if err := helpers.ForEachResource(nodeCtx, c, nil, patchFn(c, patches), patchCmdFlags.namespace, args...); err != nil {
-					return err
-				}
-			}
+		clientFactory, err := NewClientFactory(ctx, &patchCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			return nil
-		})
+		defer clientFactory.Close() //nolint:errcheck
+
+		if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+			return err
+		}
+
+		return helpers.MachineConfigUpdater(ctx, clientFactory, patchFn(patches), args)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -64,54 +64,64 @@ e.g. by excluding packets with the port 50000.
    `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "pcap", func(ctx context.Context, c *client.Client, node string) error {
-			if pcapCmdFlags.duration > 0 {
-				var cancel context.CancelFunc
+		ctx := cmd.Context()
 
-				ctx, cancel = context.WithTimeout(ctx, pcapCmdFlags.duration)
-				defer cancel()
-			}
+		clientFactory, err := NewClientFactory(ctx, &pcapCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			req := machine.PacketCaptureRequest{
-				Interface:   pcapCmdFlags.iface,
-				Promiscuous: pcapCmdFlags.promisc,
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			var err error
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "pcap")
+		if err != nil {
+			return err
+		}
 
-			req.BpfFilter, err = parseBPFInstructions(pcapCmdFlags.bpfFilter)
+		if pcapCmdFlags.duration > 0 {
+			var cancel context.CancelFunc
+
+			ctx, cancel = context.WithTimeout(ctx, pcapCmdFlags.duration)
+			defer cancel()
+		}
+
+		req := machine.PacketCaptureRequest{
+			Interface:   pcapCmdFlags.iface,
+			Promiscuous: pcapCmdFlags.promisc,
+		}
+
+		req.BpfFilter, err = parseBPFInstructions(pcapCmdFlags.bpfFilter)
+		if err != nil {
+			return err
+		}
+
+		r, err := c.PacketCapture(ctx, &req)
+		if err != nil {
+			return fmt.Errorf("error copying: %w", err)
+		}
+
+		if pcapCmdFlags.output == "" {
+			return dumpPackets(ctx, r)
+		}
+
+		var out io.Writer
+
+		if pcapCmdFlags.output == "-" {
+			out = os.Stdout
+		} else {
+			out, err = os.Create(pcapCmdFlags.output)
 			if err != nil {
 				return err
 			}
+		}
 
-			r, err := c.PacketCapture(ctx, &req)
-			if err != nil {
-				return fmt.Errorf("error copying: %w", err)
-			}
+		_, err = io.Copy(out, r)
 
-			if pcapCmdFlags.output == "" {
-				return dumpPackets(ctx, r)
-			}
+		if errors.Is(err, io.EOF) || client.StatusCode(err) == codes.DeadlineExceeded {
+			err = nil
+		}
 
-			var out io.Writer
-
-			if pcapCmdFlags.output == "-" {
-				out = os.Stdout
-			} else {
-				out, err = os.Create(pcapCmdFlags.output)
-				if err != nil {
-					return err
-				}
-			}
-
-			_, err = io.Copy(out, r)
-
-			if errors.Is(err, io.EOF) || client.StatusCode(err) == codes.DeadlineExceeded {
-				err = nil
-			}
-
-			return err
-		})
+		return err
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -23,7 +23,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
-var sortMethod string
+var processesCmdFlags struct {
+	sortMethod string
+}
 
 // processesCmd represents the processes command.
 var processesCmd = &cobra.Command{
@@ -33,66 +35,70 @@ var processesCmd = &cobra.Command{
 	Long:    ``,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machineapi.ProcessesResponse, error) {
-					return c.Processes(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tPID\tSTATE\tTHREADS\tCPU-TIME\tVIRTMEM\tRESMEM\tLABEL\tCOMMAND")
+		defer clientFactory.Close() //nolint:errcheck
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.ProcessesResponse, error) {
+				return c.Processes(ctx)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tPID\tSTATE\tTHREADS\tCPU-TIME\tVIRTMEM\tRESMEM\tLABEL\tCOMMAND")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							procs := msg.Processes
+		var errs error
 
-							switch sortMethod {
-							case "cpu":
-								by(cpu).sort(procs)
-							default:
-								by(rss).sort(procs)
-							}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-							for _, p := range procs {
-								fmt.Fprintf(
-									w, "%s\t%d\t%s\t%d\t%.2f\t%s\t%s\t%s\t%s\n",
-									resp.Node, p.Pid, p.State, p.Threads, p.CpuTime,
-									humanize.Bytes(p.VirtualMemory), humanize.Bytes(p.ResidentMemory),
-									p.Label, processArgs(p),
-								)
-							}
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						procs := msg.Processes
+
+						switch processesCmdFlags.sortMethod {
+						case "cpu":
+							by(cpu).sort(procs)
+						default:
+							by(rss).sort(procs)
+						}
+
+						for _, p := range procs {
+							fmt.Fprintf(
+								w, "%s\t%d\t%s\t%d\t%.2f\t%s\t%s\t%s\t%s\n",
+								resp.Node, p.Pid, p.State, p.Threads, p.CpuTime,
+								humanize.Bytes(p.VirtualMemory), humanize.Bytes(p.ResidentMemory),
+								p.Label, processArgs(p),
+							)
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 
@@ -119,7 +125,7 @@ func processArgs(p *machineapi.ProcessInfo) string {
 }
 
 func init() {
-	processesCmd.Flags().StringVarP(&sortMethod, "sort", "s", "rss", "Column to sort output by. [rss|cpu]")
+	processesCmd.Flags().StringVarP(&processesCmdFlags.sortMethod, "sort", "s", "rss", "Column to sort output by. [rss|cpu]")
 	addCommand(processesCmd)
 }
 

--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -5,14 +5,11 @@
 package talos
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/spf13/cobra"
-
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // readCmd represents the read command.
@@ -30,21 +27,33 @@ var readCmd = &cobra.Command{
 		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "read", func(ctx context.Context, c *client.Client, _ string) error {
-			r, err := c.Read(ctx, args[0])
-			if err != nil {
-				return fmt.Errorf("error reading file: %w", err)
-			}
+		ctx := cmd.Context()
 
-			defer r.Close() //nolint:errcheck
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			_, err = io.Copy(os.Stdout, r)
-			if err != nil {
-				return fmt.Errorf("error reading: %w", err)
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			return r.Close()
-		})
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "read")
+		if err != nil {
+			return err
+		}
+
+		r, err := c.Read(ctx, args[0])
+		if err != nil {
+			return fmt.Errorf("error reading file: %w", err)
+		}
+
+		defer r.Close() //nolint:errcheck
+
+		_, err = io.Copy(os.Stdout, r)
+		if err != nil {
+			return fmt.Errorf("error reading: %w", err)
+		}
+
+		return r.Close()
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -73,7 +73,6 @@ var resetCmdFlags struct {
 
 	graceful           bool
 	reboot             bool
-	insecure           bool
 	wipeMode           WipeMode
 	userDisksToWipe    []string
 	systemLabelsToWipe []string
@@ -92,10 +91,6 @@ var resetCmd = &cobra.Command{
 
 		resetRequest := buildResetRequest()
 
-		if resetCmdFlags.wait && resetCmdFlags.insecure {
-			return errors.New("cannot use --wait and --insecure together")
-		}
-
 		if !resetCmdFlags.wait {
 			resetNoWait := func(ctx context.Context, c *client.Client) error {
 				if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
@@ -109,10 +104,6 @@ var resetCmd = &cobra.Command{
 				return nil
 			}
 
-			if resetCmdFlags.insecure {
-				return WithClientMaintenance(cmd.Context(), nil, resetNoWait)
-			}
-
 			return WithClient(cmd.Context(), resetNoWait)
 		}
 
@@ -120,16 +111,21 @@ var resetCmd = &cobra.Command{
 			return resetGetActorID(ctx, c, resetRequest)
 		}
 
-		var postCheckFn func(context.Context, *client.Client, string) error
+		var postCheckFn func(context.Context, *client.Client, string, string) error
 
 		if resetCmdFlags.reboot {
-			postCheckFn = func(ctx context.Context, c *client.Client, preActionBootID string) error {
-				err := WithClientMaintenance(ctx, nil,
-					func(ctx context.Context, cli *client.Client) error {
-						_, err := cli.Disks(ctx)
+			postCheckFn = func(ctx context.Context, c *client.Client, node, preActionBootID string) error {
+				maintenanceCli, err := client.New(ctx,
+					client.WithDefaultGRPCDialOptions(),
+					client.WithMaintenanceMode(node, nil),
+				)
+				if err != nil {
+					return err
+				}
 
-						return err
-					})
+				defer maintenanceCli.Close() //nolint:errcheck
+
+				_, err = maintenanceCli.Disks(ctx)
 
 				// if we can get into maintenance mode, reset has succeeded
 				if err == nil {
@@ -137,7 +133,7 @@ var resetCmd = &cobra.Command{
 				}
 
 				// try to get the boot ID in the normal mode to see if the node has rebooted
-				return action.BootIDChangedPostCheckFn(ctx, c, preActionBootID)
+				return action.BootIDChangedPostCheckFn(ctx, c, node, preActionBootID)
 			}
 		}
 
@@ -187,7 +183,6 @@ func resetGetActorID(ctx context.Context, c *client.Client, req *machineapi.Rese
 func init() {
 	resetCmd.Flags().BoolVar(&resetCmdFlags.graceful, "graceful", true, "if true, attempt to cordon/drain node and leave etcd (if applicable)")
 	resetCmd.Flags().BoolVar(&resetCmdFlags.reboot, "reboot", false, "if true, reboot the node after resetting instead of shutting down")
-	resetCmd.Flags().BoolVar(&resetCmdFlags.insecure, "insecure", false, "reset using the insecure (encrypted with no auth) maintenance service")
 	resetCmd.Flags().Var(&resetCmdFlags.wipeMode, "wipe-mode", "disk reset mode")
 	resetCmd.Flags().StringSliceVar(&resetCmdFlags.userDisksToWipe, "user-disks-to-wipe", nil, "if set, wipes defined devices in the list")
 	resetCmd.Flags().StringSliceVar(&resetCmdFlags.systemLabelsToWipe, "system-labels-to-wipe", nil, "if set, just wipe selected system disk partitions by label but keep other partitions intact")

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -31,40 +31,44 @@ var restartCmd = &cobra.Command{
 		return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			var (
-				namespace string
-				driver    common.ContainerDriver
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			if kubernetesFlag {
-				namespace = constants.K8sContainerdNamespace
-				driver = common.ContainerDriver_CRI
-			} else {
-				namespace = constants.SystemContainerdNamespace
-				driver = common.ContainerDriver_CONTAINERD
+		defer clientFactory.Close() //nolint:errcheck
+
+		var (
+			namespace string
+			driver    common.ContainerDriver
+		)
+
+		if kubernetesFlag {
+			namespace = constants.K8sContainerdNamespace
+			driver = common.ContainerDriver_CRI
+		} else {
+			namespace = constants.SystemContainerdNamespace
+			driver = common.ContainerDriver_CONTAINERD
+		}
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.Restart(ctx, namespace, driver, args[0])
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error restarting process on node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (struct{}, error) {
-					return struct{}{}, c.Restart(ctx, namespace, driver, args[0])
-				},
-			)
-
-			var errs error
-
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error restarting process on node %s: %w", resp.Node, resp.Err))
-				}
-			}
-
-			return errs
-		})
+		return errs
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/rollback.go
+++ b/cmd/talosctl/cmd/talos/rollback.go
@@ -21,27 +21,31 @@ var rollbackCmd = &cobra.Command{
 	Short: "Rollback a node to the previous installation",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (struct{}, error) {
-					return struct{}{}, c.Rollback(ctx)
-				},
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			var errs error
+		defer clientFactory.Close() //nolint:errcheck
 
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error executing rollback on node %s: %w", resp.Node, resp.Err))
-				}
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.Rollback(ctx)
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error executing rollback on node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			return errs
-		})
+		return errs
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/siderolabs/gen/maps"
 	_ "github.com/siderolabs/proto-codec/codec" // register codec v2
@@ -38,14 +39,7 @@ const pathAutoCompleteLimit = 500
 // outputFlushInterval is the quiet period after the last multiplexed response
 // before flushing the tabwriter, so partial results appear without thrashing
 // column widths while responses are still arriving.
-const outputFlushInterval = formatters.FlushInterval
-
-// WithClientNoNodes wraps common code to initialize Talos client and provide cancellable context.
-//
-// WithClientNoNodes doesn't set any node information on the request context.
-func WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClientNoNodes(ctx, action, dialOptions...)
-}
+const outputFlushInterval = 500 * time.Millisecond
 
 // WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
 func WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
@@ -57,14 +51,9 @@ func WithClientAndNodes(ctx context.Context, action func(context.Context, *clien
 	return GlobalArgs.WithClientAndNodes(ctx, action, dialOptions...)
 }
 
-// WithClientAndSingleNode builds upon WithClientAndNodes to provide a helper which enforces a single node in the list, and uses client.WithNode.
-func WithClientAndSingleNode(ctx context.Context, commandName string, action func(context.Context, *client.Client, string) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClientAndSingleNode(ctx, commandName, action, dialOptions...)
-}
-
-// WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).
-func WithClientMaintenance(ctx context.Context, enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
-	return GlobalArgs.WithClientMaintenance(ctx, enforceFingerprints, action)
+// NewClientFactory creates a new ClientFactory.
+func NewClientFactory(ctx context.Context, flags any) (*global.ClientFactory, error) {
+	return global.NewClientFactory(ctx, &GlobalArgs, flags)
 }
 
 // Commands is a list of commands published by the package.
@@ -76,7 +65,7 @@ func addCommand(cmd *cobra.Command) {
 		"talosconfig",
 		"",
 		fmt.Sprintf(
-			"The path to the Talos configuration file. Defaults to '%s' env variable if set, otherwise '%s' and '%s' in order.",
+			"the path to the Talos configuration file, defaults to '%s' env variable if set, otherwise '%s' and '%s' in order",
 			constants.TalosConfigEnvVar,
 			filepath.Join("$HOME", constants.TalosDir, constants.TalosconfigFilename),
 			filepath.Join(constants.ServiceAccountMountPath, constants.TalosconfigFilename),
@@ -84,20 +73,20 @@ func addCommand(cmd *cobra.Command) {
 	)
 	cmd.PersistentFlags().StringSliceVarP(&GlobalArgs.Nodes, "nodes", "n", []string{}, "target the specified nodes")
 	cmd.PersistentFlags().StringSliceVarP(&GlobalArgs.Endpoints, "endpoints", "e", []string{}, "override default endpoints in Talos configuration")
-	cli.Should(cmd.RegisterFlagCompletionFunc("nodes", CompleteNodes))
-	cmd.PersistentFlags().StringVarP(&GlobalArgs.Cluster, "cluster", "c", "", "Cluster to connect to if a proxy endpoint is used.")
-	cmd.PersistentFlags().StringVar(&GlobalArgs.CmdContext, "context", "", "Context to be used in command")
+	cli.Should(cmd.RegisterFlagCompletionFunc("nodes", completeNodes))
+	cmd.PersistentFlags().StringVarP(&GlobalArgs.Cluster, "cluster", "c", "", "cluster to connect to if a proxy endpoint is used")
+	cmd.PersistentFlags().StringVar(&GlobalArgs.CmdContext, "context", "", "context to be used in command")
 	cmd.PersistentFlags().StringVar(
 		&GlobalArgs.SideroV1KeysDir,
 		"siderov1-keys-dir",
 		"",
 		fmt.Sprintf(
-			"The path to the SideroV1 auth PGP keys directory. Defaults to '%s' env variable if set, otherwise '%s'. Only valid for Contexts that use SideroV1 auth.",
+			"the path to the SideroV1 auth PGP keys directory, defaults to '%s' env variable if set, otherwise '%s'; only valid for Contexts that use SideroV1 auth",
 			constants.SideroV1KeysDirEnvVar,
 			filepath.Join("$HOME", constants.TalosDir, constants.SideroV1KeysDir),
 		),
 	)
-	cli.Should(cmd.RegisterFlagCompletionFunc("context", CompleteConfigContext))
+	cli.Should(cmd.RegisterFlagCompletionFunc("context", completeConfigContext))
 
 	Commands = append(Commands, cmd)
 }
@@ -129,67 +118,77 @@ func completePathFromNode(ctx context.Context, inputPath string) []string {
 func getPathFromNode(ctx context.Context, path, filter string) map[string]struct{} {
 	paths := make(map[string]struct{})
 
-	//nolint:errcheck
-	GlobalArgs.WithClient(
-		ctx,
-		func(ctx context.Context, c *client.Client) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+	clientFactory, err := NewClientFactory(ctx, &GlobalArgs)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
 
-			stream, err := c.LS(
-				ctx, &machineapi.ListRequest{
-					Root: path,
-				},
-			)
-			if err != nil {
-				return err
-			}
+		return paths
+	}
 
-			for {
-				resp, err := stream.Recv()
-				if err != nil {
-					if err == io.EOF || client.StatusCode(err) == codes.Canceled {
-						return nil
-					}
+	defer clientFactory.Close() //nolint:errcheck
 
-					return fmt.Errorf("error streaming results: %s", err)
-				}
+	ctx, c, err := clientFactory.BuildClientFirstNode(ctx)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error building client: %v", err))
 
-				if resp.Metadata != nil && resp.Metadata.Error != "" { //nolint:staticcheck // to be refactored next
-					continue
-				}
+		return paths
+	}
 
-				if resp.Error != "" {
-					continue
-				}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-				// skip reference to the same directory
-				if resp.RelativeName == "." {
-					continue
-				}
-
-				// limit the results to a reasonable amount
-				if len(paths) > pathAutoCompleteLimit {
-					return nil
-				}
-
-				// directories have a trailing slash
-				if resp.IsDir {
-					fullPath := path + resp.RelativeName + "/"
-
-					if relativeTo(fullPath, filter) {
-						paths[fullPath] = struct{}{}
-					}
-				} else {
-					fullPath := path + resp.RelativeName
-
-					if relativeTo(fullPath, filter) {
-						paths[fullPath] = struct{}{}
-					}
-				}
-			}
+	stream, err := c.LS(
+		ctx, &machineapi.ListRequest{
+			Root: path,
 		},
 	)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error listing path: %v", err))
+
+		return paths
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF || client.StatusCode(err) == codes.Canceled {
+				break
+			}
+
+			cobra.CompError(fmt.Sprintf("error streaming results: %s", err))
+
+			break
+		}
+
+		if resp.Error != "" {
+			continue
+		}
+
+		// skip reference to the same directory
+		if resp.RelativeName == "." {
+			continue
+		}
+
+		// limit the results to a reasonable amount
+		if len(paths) > pathAutoCompleteLimit {
+			return nil
+		}
+
+		// directories have a trailing slash
+		if resp.IsDir {
+			fullPath := path + resp.RelativeName + "/"
+
+			if relativeTo(fullPath, filter) {
+				paths[fullPath] = struct{}{}
+			}
+		} else {
+			fullPath := path + resp.RelativeName
+
+			if relativeTo(fullPath, filter) {
+				paths[fullPath] = struct{}{}
+			}
+		}
+	}
 
 	return paths
 }

--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -49,11 +49,25 @@ PKI can be rotated by applying machine config changes to the controlplane nodes.
 			return err
 		}
 
-		return WithClientAndSingleNode(cmd.Context(), "rotate-ca", rotateCA)
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &rotateCACmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "rotate-ca")
+		if err != nil {
+			return err
+		}
+
+		return rotateCA(ctx, c)
 	},
 }
 
-func rotateCA(ctx context.Context, c *client.Client, _ string) error {
+func rotateCA(ctx context.Context, c *client.Client) error {
 	commentsFlags := encoder.CommentsDisabled
 	if rotateCACmdFlags.withDocs {
 		commentsFlags |= encoder.CommentsDocs
@@ -65,7 +79,7 @@ func rotateCA(ctx context.Context, c *client.Client, _ string) error {
 
 	encoderOpt := encoder.WithComments(commentsFlags)
 
-	clusterInfo, err := buildClusterInfo(ctx, rotateCACmdFlags.clusterState)
+	clusterInfo, err := buildClusterInfo(ctx, c, rotateCACmdFlags.clusterState)
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -30,73 +30,77 @@ var statsCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			var (
-				namespace string
-				driver    common.ContainerDriver
-			)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			if kubernetesFlag {
-				namespace = constants.K8sContainerdNamespace
-				driver = common.ContainerDriver_CRI
-			} else {
-				namespace = constants.SystemContainerdNamespace
-				driver = common.ContainerDriver_CONTAINERD
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*machineapi.StatsResponse, error) {
-					return c.Stats(ctx, namespace, driver)
-				},
-			)
+		var (
+			namespace string
+			driver    common.ContainerDriver
+		)
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tMEMORY(MB)\tCPU")
+		if kubernetesFlag {
+			namespace = constants.K8sContainerdNamespace
+			driver = common.ContainerDriver_CRI
+		} else {
+			namespace = constants.SystemContainerdNamespace
+			driver = common.ContainerDriver_CONTAINERD
+		}
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machineapi.StatsResponse, error) {
+				return c.Stats(ctx, namespace, driver)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tMEMORY(MB)\tCPU")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							slices.SortFunc(msg.Stats, func(a, b *machineapi.Stat) int { return strings.Compare(a.Id, b.Id) })
+		var errs error
 
-							for _, s := range msg.Stats {
-								display := s.Id
-								if s.Id != s.PodId {
-									// container in a sandbox
-									display = "└─ " + display
-								}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-								fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						slices.SortFunc(msg.Stats, func(a, b *machineapi.Stat) int { return strings.Compare(a.Id, b.Id) })
+
+						for _, s := range msg.Stats {
+							display := s.Id
+							if s.Id != s.PodId {
+								// container in a sandbox
+								display = "└─ " + display
 							}
+
+							fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
 						}
 					}
+				}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-					}
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
 				}
 			}
-		})
+		}
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -28,6 +28,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clusterresource "github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 )
@@ -72,9 +73,14 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(GlobalArgs.Nodes) == 0 {
-			return errors.New("please provide at least a single node to gather the debug information from")
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &supportCmdFlags)
+		if err != nil {
+			return err
 		}
+
+		defer clientFactory.Close() //nolint:errcheck
 
 		if supportCmdFlags.noEncryption && (len(supportCmdFlags.encryptionRecipients) > 0 || supportCmdFlags.encryptionNoDefaultRecipients) {
 			return errors.New("--encryption-recipients and --encryption-no-default-recipients cannot be used with --no-encryption")
@@ -97,7 +103,7 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 			}
 		}
 
-		f, err := openArchive(cmd.Context())
+		f, err := openArchive(ctx, clientFactory)
 		if err != nil {
 			return err
 		}
@@ -137,7 +143,7 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 			return nil
 		})
 
-		collectErr := collectData(cmd.Context(), archiveOutput, progress)
+		collectErr := collectData(ctx, archiveOutput, progress, clientFactory)
 
 		close(progress)
 
@@ -162,35 +168,38 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 	},
 }
 
-func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progress) error {
-	return WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		clientset, err := getKubernetesClient(ctx, c)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create kubernetes client %s\n", err)
-		}
+func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progress, clientFactory *global.ClientFactory) error {
+	nodeCtx, c, err := clientFactory.BuildClientFirstNode(ctx)
+	if err != nil {
+		return err
+	}
 
-		opts := []bundle.Option{
-			bundle.WithArchiveOutput(dest),
-			bundle.WithKubernetesClient(clientset),
-			bundle.WithTalosClient(c),
-			bundle.WithNodes(GlobalArgs.Nodes...),
-			bundle.WithNumWorkers(supportCmdFlags.numWorkers),
-			bundle.WithProgressChan(progress),
-		}
+	clientset, err := getKubernetesClient(nodeCtx, c)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create kubernetes client %s\n", err)
+	}
 
-		if !supportCmdFlags.verbose {
-			opts = append(opts, bundle.WithLogOutput(io.Discard))
-		}
+	opts := []bundle.Option{
+		bundle.WithArchiveOutput(dest),
+		bundle.WithKubernetesClient(clientset),
+		bundle.WithTalosClient(c),
+		bundle.WithNodes(clientFactory.Nodes()...),
+		bundle.WithNumWorkers(supportCmdFlags.numWorkers),
+		bundle.WithProgressChan(progress),
+	}
 
-		options := bundle.NewOptions(opts...)
+	if !supportCmdFlags.verbose {
+		opts = append(opts, bundle.WithLogOutput(io.Discard))
+	}
 
-		collectors, err := collectors.GetForOptions(ctx, options)
-		if err != nil {
-			return err
-		}
+	options := bundle.NewOptions(opts...)
 
-		return support.CreateSupportBundle(ctx, options, collectors...)
-	})
+	collectors, err := collectors.GetForOptions(ctx, options)
+	if err != nil {
+		return err
+	}
+
+	return support.CreateSupportBundle(ctx, options, collectors...)
 }
 
 func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset, error) {
@@ -223,24 +232,17 @@ func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset,
 	return clientset, nil
 }
 
-func getClusterInfo(ctx context.Context) (*clusterresource.Info, error) {
-	var info *clusterresource.Info
-
-	if e := WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		var err error
-
-		info, err = safe.StateGetByID[*clusterresource.Info](
-			ctx,
-			c.COSI,
-			clusterresource.InfoID,
-		)
-
-		return err
-	}); e != nil {
-		return nil, e
+func getClusterInfo(ctx context.Context, clientFactory *global.ClientFactory) (*clusterresource.Info, error) {
+	ctx, c, err := clientFactory.BuildClientFirstNode(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	return info, nil
+	return safe.StateGetByID[*clusterresource.Info](
+		ctx,
+		c.COSI,
+		clusterresource.InfoID,
+	)
 }
 
 // buildEncryptionOptions builds the age encryption options based on the command
@@ -279,11 +281,11 @@ func buildEncryptionOptions() ([]encryption.Option, []string, error) {
 	return opts, recipients, nil
 }
 
-func openArchive(ctx context.Context) (*os.File, error) {
+func openArchive(ctx context.Context, clientFactory *global.ClientFactory) (*os.File, error) {
 	if supportCmdFlags.output == "" {
 		supportCmdFlags.output = "support"
 
-		if info, err := getClusterInfo(ctx); err == nil && info.TypedSpec().ClusterName != "" {
+		if info, err := getClusterInfo(ctx, clientFactory); err == nil && info.TypedSpec().ClusterName != "" {
 			supportCmdFlags.output += "-" + info.TypedSpec().ClusterName
 		}
 

--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -30,66 +30,70 @@ var timeCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		ctx := cmd.Context()
 
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*timeapi.TimeResponse, error) {
-					if timeCmdFlags.ntpServer == "" {
-						return c.Time(ctx)
-					}
+		clientFactory, err := NewClientFactory(ctx, &timeCmdFlags)
+		if err != nil {
+			return err
+		}
 
-					return c.TimeCheck(ctx, timeCmdFlags.ntpServer)
-				},
-			)
+		defer clientFactory.Close() //nolint:errcheck
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tNTP-SERVER\tNODE-TIME\tNTP-SERVER-TIME")
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*timeapi.TimeResponse, error) {
+				if timeCmdFlags.ntpServer == "" {
+					return c.Time(ctx)
+				}
 
-			flushTimer := time.NewTimer(outputFlushInterval)
-			defer flushTimer.Stop()
+				return c.TimeCheck(ctx, timeCmdFlags.ntpServer)
+			},
+		)
 
-			flushTimer.Stop()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tNTP-SERVER\tNODE-TIME\tNTP-SERVER-TIME")
 
-			var errs error
+		flushTimer := time.NewTimer(outputFlushInterval)
+		defer flushTimer.Stop()
 
-			for {
-				select {
-				case resp, ok := <-responseChan:
-					if !ok {
-						return errors.Join(errs, w.Flush())
-					}
+		flushTimer.Stop()
 
-					if resp.Err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-					} else {
-						for _, msg := range resp.Payload.Messages {
-							if !msg.Localtime.IsValid() {
-								errs = errors.Join(errs, fmt.Errorf("node %s: error parsing local time", resp.Node))
+		var errs error
 
-								continue
-							}
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					return errors.Join(errs, w.Flush())
+				}
 
-							if !msg.Remotetime.IsValid() {
-								errs = errors.Join(errs, fmt.Errorf("node %s: error parsing remote time", resp.Node))
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+				} else {
+					for _, msg := range resp.Payload.Messages {
+						if !msg.Localtime.IsValid() {
+							errs = errors.Join(errs, fmt.Errorf("node %s: error parsing local time", resp.Node))
 
-								continue
-							}
-
-							fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.Node, msg.Server, msg.Localtime.AsTime().String(), msg.Remotetime.AsTime().String())
+							continue
 						}
-					}
 
-					flushTimer.Reset(outputFlushInterval)
-				case <-flushTimer.C:
-					if err := w.Flush(); err != nil {
-						errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+						if !msg.Remotetime.IsValid() {
+							errs = errors.Join(errs, fmt.Errorf("node %s: error parsing remote time", resp.Node))
+
+							continue
+						}
+
+						fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.Node, msg.Server, msg.Localtime.AsTime().String(), msg.Remotetime.AsTime().String())
 					}
 				}
+
+				flushTimer.Reset(outputFlushInterval)
+			case <-flushTimer.C:
+				if err := w.Flush(); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+				}
 			}
-		})
+		}
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -28,7 +28,25 @@ var upgradeK8sCmd = &cobra.Command{
 	Long:  `Command runs upgrade of Kubernetes control plane components between specified versions.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndSingleNode(cmd.Context(), "upgrade-k8s", upgradeKubernetes)
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &upgradeK8sCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+			return err
+		}
+
+		ctx, c, _, err := clientFactory.BuildClientEnforceSingleNode(ctx, "upgrade-k8s")
+		if err != nil {
+			return err
+		}
+
+		return upgradeKubernetes(ctx, c)
 	},
 }
 
@@ -70,11 +88,7 @@ func init() {
 	addCommand(upgradeK8sCmd)
 }
 
-func upgradeKubernetes(ctx context.Context, c *client.Client, node string) error {
-	if err := helpers.ClientVersionCheck(ctx, c, []string{node}); err != nil {
-		return err
-	}
-
+func upgradeKubernetes(ctx context.Context, c *client.Client) error {
 	clientProvider := &cluster.ConfigClientProvider{
 		DefaultClient: c,
 	}

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -47,7 +47,6 @@ var upgradeCmdFlags = struct {
 
 	legacy   bool
 	force    bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
-	insecure bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
 	preserve bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
 	stage    bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
 }{
@@ -68,10 +67,6 @@ var upgradeCmd = &cobra.Command{
 
 		if upgradeCmdFlags.drain {
 			upgradeCmdFlags.wait = true
-		}
-
-		if upgradeCmdFlags.wait && upgradeCmdFlags.insecure {
-			return errors.New("cannot use --wait and --insecure together")
 		}
 
 		return upgradeRun(cmd.Context())
@@ -276,12 +271,6 @@ func upgradeLegacy(ctx context.Context) error {
 //
 // Note: remove me in Talos 1.18.
 func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOption) error {
-	if upgradeCmdFlags.insecure {
-		return WithClientMaintenance(ctx, nil, func(ctx context.Context, c *client.Client) error {
-			return doUpgradeLegacy(ctx, c, opts)
-		})
-	}
-
 	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
 		return doUpgradeLegacy(ctx, c, opts)
 	})
@@ -370,7 +359,6 @@ func init() {
 	upgradeCmdFlags.addTrackActionFlags(upgradeCmd)
 	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.legacy, "legacy", false, "force use of legacy upgrade method")
 	upgradeCmd.Flags().BoolVarP(&upgradeCmdFlags.force, "force", "f", false, "force the upgrade (skip checks on etcd health and members, might lead to data loss)")
-	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.insecure, "insecure", false, "upgrade using the insecure (encrypted with no auth) maintenance service")
 	upgradeCmd.Flags().BoolVarP(&upgradeCmdFlags.preserve, "preserve", "p", false, "preserve data")
 	upgradeCmd.Flags().BoolVarP(&upgradeCmdFlags.stage, "stage", "s", false, "stage the upgrade to perform it after a reboot")
 

--- a/cmd/talosctl/cmd/talos/version.go
+++ b/cmd/talosctl/cmd/talos/version.go
@@ -6,25 +6,28 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 )
 
 // versionCmdFlags represents the `talosctl version` command's flags.
 var versionCmdFlags struct {
+	global.InsecureFlags
+
 	clientOnly   bool
 	shortVersion bool
 	json         bool
-	insecure     bool
 }
 
 // versionCmd represents the `talosctl version` command.
@@ -51,35 +54,40 @@ var versionCmd = &cobra.Command{
 			fmt.Println("Server:")
 		}
 
-		if versionCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, cmdVersion)
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &versionCmdFlags)
+		if err != nil {
+			return err
 		}
 
-		return WithClient(cmd.Context(), cmdVersion)
+		defer clientFactory.Close() //nolint:errcheck
+
+		respCh := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.VersionResponse, error) {
+				return c.Version(ctx)
+			},
+		)
+
+		var errs error
+
+		for resp := range respCh {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error getting version from node %s: %w", resp.Node, resp.Err))
+
+				continue
+			}
+
+			errs = errors.Join(errs, printVersionResponse(resp.Node, resp.Payload))
+		}
+
+		return errs
 	},
 }
 
-func cmdVersion(ctx context.Context, c *client.Client) error {
-	var remotePeer peer.Peer
-
-	resp, err := c.Version(ctx, grpc.Peer(&remotePeer))
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error getting version: %s", err)
-		}
-
-		cli.Warning("%s", err)
-	}
-
-	defaultNode := client.AddrFromPeer(&remotePeer)
-
+func printVersionResponse(node string, resp *machine.VersionResponse) error {
 	for _, msg := range resp.Messages {
-		node := defaultNode
-
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
 		if !versionCmdFlags.json {
 			fmt.Printf("\t%s:        %s\n", "NODE", node)
 
@@ -107,9 +115,9 @@ func cmdVersion(ctx context.Context, c *client.Client) error {
 }
 
 func init() {
+	versionCmdFlags.InsecureFlags.AddFlags(versionCmd)
 	versionCmd.Flags().BoolVar(&versionCmdFlags.shortVersion, "short", false, "Print the short version")
 	versionCmd.Flags().BoolVar(&versionCmdFlags.clientOnly, "client", false, "Print client version only")
-	versionCmd.Flags().BoolVarP(&versionCmdFlags.insecure, "insecure", "i", false, "use Talos maintenance mode API")
 
 	// TODO remove when https://github.com/siderolabs/talos/issues/907 is implemented
 	versionCmd.Flags().BoolVar(&versionCmdFlags.json, "json", false, "")

--- a/cmd/talosctl/cmd/talos/wipe.go
+++ b/cmd/talosctl/cmd/talos/wipe.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -28,11 +29,12 @@ var wipeCmd = &cobra.Command{
 }
 
 var wipeDiskCmdFlags struct {
+	global.InsecureFlags
+
 	wipeMethod         string
 	skipVolumeCheck    bool
 	skipSecondaryCheck bool
 	dropPartition      bool
-	insecure           bool
 }
 
 // wipeDiskCmd represents the wipe disk command.
@@ -44,33 +46,53 @@ var wipeDiskCmd = &cobra.Command{
 Use device names as arguments, for example: vda or sda5.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if wipeDiskCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, cmdWipe(args))
-		}
-
-		return WithClient(cmd.Context(), cmdWipe(args))
+		return cmdWipe(cmd.Context(), args)
 	},
 }
 
-func cmdWipe(args []string) func(ctx context.Context, c *client.Client) error {
-	return func(ctx context.Context, c *client.Client) error {
-		method, ok := storage.BlockDeviceWipeDescriptor_Method_value[wipeDiskCmdFlags.wipeMethod]
-		if !ok {
-			return fmt.Errorf("invalid wipe method %q", wipeDiskCmdFlags.wipeMethod)
-		}
-
-		return c.BlockDeviceWipe(ctx, &storage.BlockDeviceWipeRequest{
-			Devices: xslices.Map(args, func(devName string) *storage.BlockDeviceWipeDescriptor {
-				return &storage.BlockDeviceWipeDescriptor{
-					Device:             devName,
-					Method:             storage.BlockDeviceWipeDescriptor_Method(method),
-					SkipVolumeCheck:    wipeDiskCmdFlags.skipVolumeCheck,
-					SkipSecondaryCheck: wipeDiskCmdFlags.skipSecondaryCheck,
-					DropPartition:      wipeDiskCmdFlags.dropPartition,
-				}
-			}),
-		})
+func cmdWipe(ctx context.Context, args []string) error {
+	clientFactory, err := NewClientFactory(ctx, &wipeDiskCmdFlags)
+	if err != nil {
+		return err
 	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	method, ok := storage.BlockDeviceWipeDescriptor_Method_value[wipeDiskCmdFlags.wipeMethod]
+	if !ok {
+		return fmt.Errorf("invalid wipe method %q", wipeDiskCmdFlags.wipeMethod)
+	}
+
+	respCh := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (struct{}, error) {
+			return struct{}{}, c.BlockDeviceWipe(
+				ctx, &storage.BlockDeviceWipeRequest{
+					Devices: xslices.Map(
+						args, func(devName string) *storage.BlockDeviceWipeDescriptor {
+							return &storage.BlockDeviceWipeDescriptor{
+								Device:             devName,
+								Method:             storage.BlockDeviceWipeDescriptor_Method(method),
+								SkipVolumeCheck:    wipeDiskCmdFlags.skipVolumeCheck,
+								SkipSecondaryCheck: wipeDiskCmdFlags.skipSecondaryCheck,
+								DropPartition:      wipeDiskCmdFlags.dropPartition,
+							}
+						},
+					),
+				},
+			)
+		},
+	)
+
+	var errs error
+
+	for resp := range respCh {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error wiping device on node %s: %w", resp.Node, resp.Err))
+		}
+	}
+
+	return errs
 }
 
 func wipeMethodValues() []string {
@@ -86,7 +108,7 @@ func wipeMethodValues() []string {
 }
 
 var wipeLVMCmdFlags struct {
-	insecure bool
+	global.InsecureFlags
 }
 
 // wipeLVCmd removes a single LVM logical volume.
@@ -103,38 +125,34 @@ The argument is the qualified logical-volume name, e.g. vg0/lv0.`,
 			return fmt.Errorf("invalid logical volume %q, expected <vg>/<lv>", args[0])
 		}
 
-		if wipeLVMCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, func(ctx context.Context, c *client.Client) error {
-				_, err := c.LVMClient.LogicalVolumeRemove(ctx, &machine.LVMServiceLogicalVolumeRemoveRequest{
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &wipeLVMCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*emptypb.Empty, error) {
+				return c.LVMClient.LogicalVolumeRemove(ctx, &machine.LVMServiceLogicalVolumeRemoveRequest{
 					VolumeGroup:   vg,
 					LogicalVolume: lv,
 				})
+			},
+		)
 
-				return err
-			})
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+			}
 		}
 
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*emptypb.Empty, error) {
-					return c.LVMClient.LogicalVolumeRemove(ctx, &machine.LVMServiceLogicalVolumeRemoveRequest{
-						VolumeGroup:   vg,
-						LogicalVolume: lv,
-					})
-				},
-			)
-
-			var errs error
-
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-				}
-			}
-
-			return errs
-		})
+		return errs
 	},
 }
 
@@ -152,36 +170,33 @@ labels and remain claimable until you run "talosctl wipe pv".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vg := args[0]
 
-		if wipeLVMCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, func(ctx context.Context, c *client.Client) error {
-				_, err := c.LVMClient.VolumeGroupRemove(ctx, &machine.LVMServiceVolumeGroupRemoveRequest{
-					VolumeGroup: vg,
-				})
+		ctx := cmd.Context()
 
-				return err
-			})
+		clientFactory, err := NewClientFactory(ctx, &wipeLVMCmdFlags)
+		if err != nil {
+			return err
 		}
 
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*emptypb.Empty, error) {
-					return c.LVMClient.VolumeGroupRemove(ctx, &machine.LVMServiceVolumeGroupRemoveRequest{
-						VolumeGroup: vg,
-					})
-				},
-			)
+		defer clientFactory.Close() //nolint:errcheck
 
-			var errs error
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*emptypb.Empty, error) {
+				return c.LVMClient.VolumeGroupRemove(ctx, &machine.LVMServiceVolumeGroupRemoveRequest{
+					VolumeGroup: vg,
+				})
+			},
+		)
 
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-				}
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			return errs
-		})
+		return errs
 	},
 }
 
@@ -198,36 +213,33 @@ The argument is a full device path, e.g. /dev/sda1.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		device := args[0]
 
-		if wipeLVMCmdFlags.insecure {
-			return WithClientMaintenance(cmd.Context(), nil, func(ctx context.Context, c *client.Client) error {
-				_, err := c.LVMClient.PhysicalVolumeRemove(ctx, &machine.LVMServicePhysicalVolumeRemoveRequest{
-					Device: device,
-				})
+		ctx := cmd.Context()
 
-				return err
-			})
+		clientFactory, err := NewClientFactory(ctx, &wipeLVMCmdFlags)
+		if err != nil {
+			return err
 		}
 
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			responseChan := multiplex.Unary(
-				ctx, nodes,
-				func(ctx context.Context) (*emptypb.Empty, error) {
-					return c.LVMClient.PhysicalVolumeRemove(ctx, &machine.LVMServicePhysicalVolumeRemoveRequest{
-						Device: device,
-					})
-				},
-			)
+		defer clientFactory.Close() //nolint:errcheck
 
-			var errs error
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*emptypb.Empty, error) {
+				return c.LVMClient.PhysicalVolumeRemove(ctx, &machine.LVMServicePhysicalVolumeRemoveRequest{
+					Device: device,
+				})
+			},
+		)
 
-			for resp := range responseChan {
-				if resp.Err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-				}
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 			}
+		}
 
-			return errs
-		})
+		return errs
 	},
 }
 
@@ -240,10 +252,10 @@ func init() {
 	wipeDiskCmd.Flags().BoolVar(&wipeDiskCmdFlags.dropPartition, "drop-partition", false, "drop partition after wipe (if applicable)")
 	wipeDiskCmd.Flags().MarkHidden("skip-volume-check")    //nolint:errcheck
 	wipeDiskCmd.Flags().MarkHidden("skip-secondary-check") //nolint:errcheck
-	wipeDiskCmd.Flags().BoolVarP(&wipeDiskCmdFlags.insecure, "insecure", "i", false, "use Talos maintenance mode API")
+	wipeDiskCmdFlags.InsecureFlags.AddFlags(wipeDiskCmd)
 
 	for _, c := range []*cobra.Command{wipeLVCmd, wipeVGCmd, wipePVCmd} {
-		c.Flags().BoolVarP(&wipeLVMCmdFlags.insecure, "insecure", "i", false, "use Talos maintenance mode API")
+		wipeLVMCmdFlags.InsecureFlags.AddFlags(c)
 	}
 
 	wipeCmd.AddCommand(wipeDiskCmd, wipeLVCmd, wipeVGCmd, wipePVCmd)

--- a/cmd/talosctl/pkg/talos/action/node.go
+++ b/cmd/talosctl/pkg/talos/action/node.go
@@ -188,7 +188,7 @@ func (a *nodeTracker) runPostCheckWithRetry(preActionBootID string) error {
 	return retry.Constant(a.tracker.timeout).RetryWithContext(a.ctx, func(ctx context.Context) error {
 		// retryable function
 		err := func() error {
-			err := a.tracker.postCheckFn(ctx, a.cli, preActionBootID)
+			err := a.tracker.postCheckFn(ctx, a.cli, a.node, preActionBootID)
 			if err != nil {
 				return err
 			}

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
@@ -58,7 +57,7 @@ var (
 	}
 
 	// BootIDChangedPostCheckFn is a post check function that returns nil if the boot ID has changed.
-	BootIDChangedPostCheckFn = func(ctx context.Context, c *client.Client, preActionBootID string) error {
+	BootIDChangedPostCheckFn = func(ctx context.Context, c *client.Client, _, preActionBootID string) error {
 		if preActionBootID == unauthorizedBootIDFallback {
 			return nil
 		}
@@ -85,7 +84,7 @@ type nodeUpdate struct {
 type Tracker struct {
 	expectedEventFn          func(event client.EventResult) bool
 	actionFn                 func(ctx context.Context, c *client.Client) (string, error)
-	postCheckFn              func(ctx context.Context, c *client.Client, preActionBootID string) error
+	postCheckFn              func(ctx context.Context, c *client.Client, node, preActionBootID string) error
 	reporter                 *reporter.Reporter
 	nodeToLatestStatusUpdate map[string]reporter.Update
 	reportCh                 chan nodeUpdate
@@ -115,7 +114,7 @@ func WithTimeout(timeout time.Duration) TrackerOption {
 }
 
 // WithPostCheck sets the post check function.
-func WithPostCheck(postCheckFn func(ctx context.Context, c *client.Client, preActionBootID string) error) TrackerOption {
+func WithPostCheck(postCheckFn func(ctx context.Context, c *client.Client, node, preActionBootID string) error) TrackerOption {
 	return func(t *Tracker) {
 		t.postCheckFn = postCheckFn
 	}
@@ -178,9 +177,10 @@ func (a *Tracker) Run(ctx context.Context) error {
 		ctx, cancel := context.WithTimeout(ctx, a.timeout)
 		defer cancel()
 
-		if err := helpers.ClientVersionCheck(ctx, c, a.clientExecutor.NodeList()); err != nil {
-			return err
-		}
+		// TODO: refactor this with Tracker refactor to use client factory
+		// if err := helpers.ClientVersionCheck(ctx, c, a.clientExecutor.NodeList()); err != nil {
+		// 	return err
+		// }
 
 		eg.Go(func() error {
 			return a.runReporter(ctx)

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -7,16 +7,15 @@ package global
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
-	"fmt"
 
-	"github.com/siderolabs/crypto/x509"
 	"google.golang.org/grpc"
 
 	"github.com/siderolabs/talos/pkg/machinery/client"
-	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 )
+
+// ErrConfigContext is returned when config context cannot be resolved.
+var ErrConfigContext = errors.New("failed to resolve config context")
 
 // Args is a context for the Talos command line client.
 type Args struct {
@@ -29,6 +28,8 @@ type Args struct {
 }
 
 // NodeList returns the list of nodes to run the command against.
+//
+// Deprecated: returns wrong information.
 func (args *Args) NodeList() []string {
 	return args.Nodes
 }
@@ -37,138 +38,53 @@ func (args *Args) NodeList() []string {
 //
 // WithClientNoNodes doesn't set any node information on the request context.
 func (args *Args) WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	cfg, err := clientconfig.Open(args.Talosconfig)
-	if err != nil {
-		return fmt.Errorf("failed to open config file %q: %w", args.Talosconfig, err)
-	}
-
-	opts := []client.OptionFunc{
-		client.WithConfig(cfg),
-		client.WithDefaultGRPCDialOptions(),
-		client.WithGRPCDialOptions(dialOptions...),
-		client.WithSideroV1KeysDir(clientconfig.CustomSideroV1KeysDirPath(args.SideroV1KeysDir)),
-	}
-
-	if args.CmdContext != "" {
-		opts = append(opts, client.WithContextName(args.CmdContext))
-	}
-
-	if len(args.Endpoints) > 0 {
-		// override endpoints from command-line flags
-		opts = append(opts, client.WithEndpoints(args.Endpoints...))
-	}
-
-	if args.Cluster != "" {
-		opts = append(opts, client.WithCluster(args.Cluster))
-	}
-
-	c, err := client.New(ctx, opts...)
-	if err != nil {
-		return fmt.Errorf("error constructing client: %w", err)
-	}
-	//nolint:errcheck
-	defer c.Close()
-
-	return action(ctx, c)
-}
-
-// ErrConfigContext is returned when config context cannot be resolved.
-var ErrConfigContext = errors.New("failed to resolve config context")
-
-func (args *Args) getNodes(cli *client.Client) ([]string, error) {
-	if len(args.Nodes) < 1 {
-		configContext := cli.GetConfigContext()
-		if configContext == nil {
-			return nil, ErrConfigContext
-		}
-
-		args.Nodes = configContext.Nodes
-	}
-
-	if len(args.Nodes) < 1 {
-		return nil, errors.New("nodes are not set for the command: please use `--nodes` flag or configuration file to set the nodes to run the command against")
-	}
-
-	return args.Nodes, nil
-}
-
-// WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
-func (args *Args) WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return args.WithClientNoNodes(
-		ctx,
-		func(ctx context.Context, cli *client.Client) error {
-			nodes, err := args.getNodes(cli)
-			if err != nil {
-				return err
-			}
-
-			ctx = client.WithNodes(ctx, nodes...) //nolint:staticcheck // to be refactored next
-
-			return action(ctx, cli)
-		},
-		dialOptions...,
-	)
-}
-
-// WithClientAndNodes builds upon WithClientNoNodes to provide a list of nodes to the function.
-func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
-	return args.WithClientNoNodes(
-		ctx,
-		func(ctx context.Context, cli *client.Client) error {
-			nodes, err := args.getNodes(cli)
-			if err != nil {
-				return err
-			}
-
-			return action(ctx, cli, nodes)
-		},
-		dialOptions...,
-	)
-}
-
-// WithClientAndSingleNode builds upon WithClientAndNodes to provide a helper which enforces a single node in the list, and uses client.WithNode.
-func (args *Args) WithClientAndSingleNode(ctx context.Context, commandName string, action func(context.Context, *client.Client, string) error, dialOptions ...grpc.DialOption) error {
-	return args.WithClientAndNodes(
-		ctx,
-		func(ctx context.Context, cli *client.Client, nodes []string) error {
-			if len(nodes) != 1 {
-				return fmt.Errorf("command %q requires exactly one node (got %d)", commandName, len(nodes))
-			}
-
-			return action(client.WithNode(ctx, nodes[0]), cli, nodes[0])
-		},
-		dialOptions...,
-	)
-}
-
-// WithClientMaintenance wraps common code to initialize Talos client in maintenance (insecure mode).
-func (args *Args) WithClientMaintenance(ctx context.Context, enforceFingerprints []string, action func(context.Context, *client.Client) error) error {
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
-	if len(enforceFingerprints) > 0 {
-		fingerprints := make([]x509.Fingerprint, len(enforceFingerprints))
-
-		for i, stringFingerprint := range enforceFingerprints {
-			var err error
-
-			fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
-			if err != nil {
-				return fmt.Errorf("error parsing certificate fingerprint %q: %v", stringFingerprint, err)
-			}
-		}
-
-		tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
-	}
-
-	cl, err := client.New(ctx, client.WithDefaultGRPCDialOptions(), client.WithTLSConfig(tlsConfig), client.WithEndpoints(args.Nodes...))
+	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
 	if err != nil {
 		return err
 	}
 
-	//nolint:errcheck
-	defer cl.Close()
+	defer factory.Close() //nolint:errcheck
 
-	return action(ctx, cl)
+	_, c, err := factory.BuildClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	return action(ctx, c)
+}
+
+// WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
+func (args *Args) WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
+	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
+	if err != nil {
+		return err
+	}
+
+	defer factory.Close() //nolint:errcheck
+
+	_, c, err := factory.BuildClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	ctx = client.WithNodes(ctx, factory.Nodes()...) //nolint:staticcheck // to be refactored next
+
+	return action(ctx, c)
+}
+
+// WithClientAndNodes builds upon WithClientNoNodes to provide a list of nodes to the function.
+func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
+	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
+	if err != nil {
+		return err
+	}
+
+	defer factory.Close() //nolint:errcheck
+
+	_, c, err := factory.BuildClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	return action(ctx, c, factory.Nodes())
 }

--- a/cmd/talosctl/pkg/talos/global/factory.go
+++ b/cmd/talosctl/pkg/talos/global/factory.go
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package global
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+)
+
+// ClientFactory produces Talos clients and nodes arguments.
+type ClientFactory struct {
+	args          *Args
+	insecureFlags InsecureArgser
+	dialOptions   []grpc.DialOption
+	nodes         []string
+
+	mu             sync.Mutex
+	client         *client.Client
+	perNodeClients map[string]*client.Client
+}
+
+// NewClientFactory creates a new ClientFactory.
+func NewClientFactory(ctx context.Context, args *Args, flags any, dialOptions ...grpc.DialOption) (*ClientFactory, error) {
+	factory := &ClientFactory{
+		args:        args,
+		dialOptions: dialOptions,
+	}
+
+	if insecureFlags, ok := flags.(InsecureArgser); ok {
+		factory.insecureFlags = insecureFlags
+	}
+
+	// if args were set on the command line, always prefer them
+	if len(args.Nodes) > 0 {
+		factory.nodes = args.Nodes
+	} else if factory.insecureFlags == nil || !factory.insecureFlags.GetInsecureFlag() {
+		// in secure mode, we can pull nodes from the config context, so build a client to parse the config
+		c, err := factory.buildClientFromConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		configContext := c.GetConfigContext()
+		if configContext == nil {
+			factory.Close() //nolint:errcheck
+
+			return nil, ErrConfigContext
+		}
+
+		factory.nodes = configContext.Nodes
+		factory.client = c
+
+		// TODO: this is a temporary hack, remove it once global tracker refactoring is done
+		args.Nodes = factory.nodes
+	}
+
+	if len(factory.nodes) < 1 {
+		factory.Close() //nolint:errcheck
+
+		return nil, errors.New("nodes are not set for the command: please use `--nodes` flag or configuration file to set the nodes to run the command against")
+	}
+
+	return factory, nil
+}
+
+// Nodes provides a list of nodes to run the command against.
+func (f *ClientFactory) Nodes() []string {
+	return f.nodes
+}
+
+// Close all clients created by the factory.
+func (f *ClientFactory) Close() error {
+	var errs error
+
+	if f.client != nil {
+		errs = errors.Join(errs, f.client.Close())
+	}
+
+	for _, perNodeClient := range f.perNodeClients {
+		if err := perNodeClient.Close(); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
+}
+
+func (f *ClientFactory) buildMaintenanceClient(ctx context.Context, node string) (*client.Client, error) {
+	return client.New(
+		ctx,
+		client.WithDefaultGRPCDialOptions(),
+		client.WithMaintenanceMode(node, f.insecureFlags.GetCertFingerprints()),
+		client.WithGRPCDialOptions(f.dialOptions...),
+	)
+}
+
+func (f *ClientFactory) buildClientFromConfig(ctx context.Context) (*client.Client, error) {
+	cfg, err := clientconfig.Open(f.args.Talosconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file %q: %w", f.args.Talosconfig, err)
+	}
+
+	opts := []client.OptionFunc{
+		client.WithConfig(cfg),
+		client.WithDefaultGRPCDialOptions(),
+		client.WithGRPCDialOptions(f.dialOptions...),
+		client.WithSideroV1KeysDir(clientconfig.CustomSideroV1KeysDirPath(f.args.SideroV1KeysDir)),
+	}
+
+	if f.args.CmdContext != "" {
+		opts = append(opts, client.WithContextName(f.args.CmdContext))
+	}
+
+	if len(f.args.Endpoints) > 0 {
+		// override endpoints from command-line flags
+		opts = append(opts, client.WithEndpoints(f.args.Endpoints...))
+	}
+
+	if f.args.Cluster != "" {
+		opts = append(opts, client.WithCluster(f.args.Cluster))
+	}
+
+	return client.New(ctx, opts...)
+}
+
+// BuildClient builds a Talos client and for a specific node.
+//
+//nolint:gocyclo
+func (f *ClientFactory) BuildClient(ctx context.Context, node string) (context.Context, *client.Client, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.client != nil {
+		return client.WithNode(ctx, node), f.client, nil
+	}
+
+	if perNodeClient, ok := f.perNodeClients[node]; ok {
+		return ctx, perNodeClient, nil
+	}
+
+	if f.insecureFlags != nil && f.insecureFlags.GetInsecureFlag() {
+		c, err := f.buildMaintenanceClient(ctx, node)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error constructing maintenance mode client for node %q: %w", node, err)
+		}
+
+		if f.perNodeClients == nil {
+			f.perNodeClients = make(map[string]*client.Client)
+		}
+
+		f.perNodeClients[node] = c
+
+		return ctx, c, nil
+	}
+
+	c, err := f.buildClientFromConfig(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error constructing client: %w", err)
+	}
+
+	f.client = c
+
+	return client.WithNode(ctx, node), c, nil
+}
+
+// BuildClientFirstNode is a helper which builds a client for the first node in the list.
+func (f *ClientFactory) BuildClientFirstNode(ctx context.Context) (context.Context, *client.Client, error) {
+	// the nodes list is non-empty (see NewClientFactory), so this is safe
+	return f.BuildClient(ctx, f.nodes[0])
+}
+
+// BuildClientEnforceSingleNode is a helper which enforces that there is exactly one node in the list, and builds a client for it.
+func (f *ClientFactory) BuildClientEnforceSingleNode(ctx context.Context, commandName string) (context.Context, *client.Client, string, error) {
+	if len(f.nodes) != 1 {
+		return nil, nil, "", fmt.Errorf("command %q requires exactly one node (got %d)", commandName, len(f.nodes))
+	}
+
+	ctx, c, err := f.BuildClientFirstNode(ctx)
+
+	return ctx, c, f.nodes[0], err
+}
+
+// BuildRandomEndpointClient is a helper which builds which talks to a random endpoint in the cluster.
+//
+// Note: this method is dangerous, as every new gRPC call might land on a different node.
+//
+// This method can't build maintenance mode clients.
+func (f *ClientFactory) BuildRandomEndpointClient(ctx context.Context) (*client.Client, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.insecureFlags != nil && f.insecureFlags.GetInsecureFlag() {
+		return nil, errors.New("random endpoint client can't be used in insecure mode")
+	}
+
+	if f.client != nil {
+		return f.client, nil
+	}
+
+	c, err := f.buildClientFromConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing client: %w", err)
+	}
+
+	f.client = c
+
+	return c, nil
+}

--- a/cmd/talosctl/pkg/talos/global/insecure.go
+++ b/cmd/talosctl/pkg/talos/global/insecure.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package global
+
+import "github.com/spf13/cobra"
+
+// InsecureFlags is a mix-in args struct for commands that support the --insecure flag.
+type InsecureFlags struct {
+	Insecure         bool
+	CertFingerprints []string
+}
+
+// AddFlags adds the InsecureFlags flags to the given command.
+func (a *InsecureFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&a.Insecure, "insecure", "i", false, "use the insecure (encrypted with no auth) maintenance service")
+	cmd.Flags().StringSliceVar(&a.CertFingerprints, "cert-fingerprint", nil, "list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)")
+}
+
+// GetInsecureFlag returns the value of the --insecure flag.
+func (a *InsecureFlags) GetInsecureFlag() bool {
+	return a.Insecure
+}
+
+// GetCertFingerprints returns the value of the --cert-fingerprint flag.
+func (a *InsecureFlags) GetCertFingerprints() []string {
+	return a.CertFingerprints
+}
+
+// InsecureArgser is an interface for commands that support the --insecure flag.
+type InsecureArgser interface {
+	GetInsecureFlag() bool
+	GetCertFingerprints() []string
+}
+
+// Check interface implementation.
+var _ InsecureArgser = (*InsecureFlags)(nil)

--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/xerrors"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -76,10 +77,10 @@ func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Ran
 }
 
 // ClientVersionCheck verifies that client is not outdated vs. Talos version.
-func ClientVersionCheck(ctx context.Context, c *client.Client, nodes []string) error {
-	respCh := multiplex.Unary(
-		ctx, nodes,
-		func(ctx context.Context) (*machine.VersionResponse, error) {
+func ClientVersionCheck(ctx context.Context, clientFactory *global.ClientFactory) error {
+	respCh := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machine.VersionResponse, error) {
 			return c.Version(ctx)
 		},
 	)

--- a/cmd/talosctl/pkg/talos/helpers/resources.go
+++ b/cmd/talosctl/pkg/talos/helpers/resources.go
@@ -7,24 +7,23 @@ package helpers
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/state"
-	"google.golang.org/grpc/metadata"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
-// ForEachResource gets resources from the controller runtime and runs a callback for each resource.
+// MachineConfigUpdater gets resources from the controller runtime and runs a callback for each resource.
 //
 //nolint:gocyclo
-func ForEachResource(ctx context.Context,
-	c *client.Client,
-	callbackRD func(rd *meta.ResourceDefinition) error,
-	callback func(ctx context.Context, hostname string, r resource.Resource, callError error) error,
-	namespace string,
-	args ...string,
+func MachineConfigUpdater(ctx context.Context,
+	clientFactory *global.ClientFactory,
+	callback func(ctx context.Context, client *client.Client, node string, mc resource.Resource) error,
+	args []string,
 ) error {
 	if len(args) == 0 {
 		return errors.New("not enough arguments: at least 1 is expected")
@@ -32,70 +31,50 @@ func ForEachResource(ctx context.Context,
 
 	resourceType := args[0]
 
-	var resourceID string
+	// ignore args[1], always patch in current machine config resource ID
+	resourceID := config.ActiveID
 
-	if len(args) > 1 {
-		resourceID = args[1]
+	// resolve resource type, we don't support anything but machineconfig now
+	if len(clientFactory.Nodes()) == 0 {
+		return nil
 	}
 
-	md, _ := metadata.FromOutgoingContext(ctx)
-	nodes := md.Get("nodes")
-
-	if len(nodes) == 0 {
-		nodes = []string{""}
-	}
-
-	// fetch the RD from the first node (it doesn't matter which one to use, so we'll use the first one)
-	rd, err := c.ResolveResourceKind(client.WithNode(ctx, nodes[0]), &namespace, resourceType)
+	// resolve resource kind
+	firstCtx, firstC, err := clientFactory.BuildClient(ctx, clientFactory.Nodes()[0])
 	if err != nil {
 		return err
 	}
 
-	if callbackRD != nil {
-		if err = callbackRD(rd); err != nil {
-			return err
-		}
+	var namespace string
+
+	rd, err := firstC.ResolveResourceKind(firstCtx, &namespace, resourceType)
+	if err != nil {
+		return err
+	}
+
+	if rd.TypedSpec().Type != config.MachineConfigType {
+		return errors.New("only machineconfig resource type is supported")
 	}
 
 	resourceType = rd.TypedSpec().Type
 
-	for _, node := range nodes {
-		var nodeCtx context.Context
-
-		if node == "" {
-			nodeCtx = ctx
-		} else {
-			nodeCtx = client.WithNode(ctx, node)
+	for _, node := range clientFactory.Nodes() {
+		nodeCtx, nodeClient, err := clientFactory.BuildClient(ctx, node)
+		if err != nil {
+			return fmt.Errorf("error building client for node %s: %w", node, err)
 		}
 
-		if resourceID != "" {
-			r, callErr := c.COSI.Get(
-				nodeCtx,
-				resource.NewMetadata(namespace, rd.TypedSpec().Type, resourceID, resource.VersionUndefined),
-				state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
-			)
-			if err = callback(ctx, node, r, callErr); err != nil {
-				return err
-			}
-		} else {
-			items, callErr := c.COSI.List(
-				nodeCtx,
-				resource.NewMetadata(namespace, resourceType, "", resource.VersionUndefined),
-				state.WithListUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
-			)
-			if callErr != nil {
-				if err = callback(ctx, node, nil, callErr); err != nil {
-					return err
-				}
+		r, err := nodeClient.COSI.Get(
+			nodeCtx,
+			resource.NewMetadata(namespace, resourceType, resourceID, resource.VersionUndefined),
+			state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+		)
+		if err != nil {
+			return fmt.Errorf("error getting resource on node %s: %w", node, err)
+		}
 
-				continue
-			}
-
-			for _, r := range items.Items {
-				if err = callback(ctx, node, r, nil); err != nil {
-					return err
-				}
-			}
+		if err = callback(nodeCtx, nodeClient, node, r); err != nil {
+			return err
 		}
 	}
 

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -78,7 +78,14 @@ func (suite *HealthSuite) TestServerSide() {
 }
 
 func (suite *HealthSuite) testClientSide(extraArgs ...string) {
-	args := append([]string{"--server=false"}, extraArgs...)
+	randomControlPlaneNodeInternalIP := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	args := append(
+		[]string{
+			"--server=false",
+			"--nodes", randomControlPlaneNodeInternalIP,
+		},
+		extraArgs...,
+	)
 
 	if suite.K8sEndpoint != "" {
 		args = append(args, "--k8s-endpoint", suite.K8sEndpoint)

--- a/internal/integration/cli/reboot.go
+++ b/internal/integration/cli/reboot.go
@@ -72,7 +72,10 @@ func (suite *RebootSuite) TestReboot() {
 	suite.T().Logf("running the cluster health check")
 
 	// run the health check to make sure cluster is fully healthy after a node reboot
-	args := []string{"--server=false"}
+	args := []string{
+		"--server=false",
+		"--nodes", controlPlaneNode,
+	}
 
 	if suite.K8sEndpoint != "" {
 		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])
@@ -92,6 +95,7 @@ func (suite *RebootSuite) TestRebootWithDrain() {
 		suite.T().Skip("skipping in short mode")
 	}
 
+	controlPlaneNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 	workerNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 
 	suite.T().Logf("rebooting node %s with --drain via the CLI", workerNode)
@@ -151,7 +155,10 @@ func (suite *RebootSuite) TestRebootWithDrain() {
 
 	suite.T().Logf("running the cluster health check")
 
-	args := []string{"--server=false"}
+	args := []string{
+		"--server=false",
+		"--nodes", controlPlaneNode,
+	}
 
 	if suite.K8sEndpoint != "" {
 		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])
@@ -171,6 +178,7 @@ func (suite *RebootSuite) TestRebootWithDrainForcesWait() {
 		suite.T().Skip("skipping in short mode")
 	}
 
+	controlPlaneNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 	workerNode := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 
 	suite.T().Logf("rebooting node %s with --drain --wait=false via the CLI", workerNode)
@@ -225,7 +233,10 @@ func (suite *RebootSuite) TestRebootWithDrainForcesWait() {
 
 	suite.T().Logf("running the cluster health check")
 
-	args := []string{"--server=false"}
+	args := []string{
+		"--server=false",
+		"--nodes", controlPlaneNode,
+	}
 
 	if suite.K8sEndpoint != "" {
 		args = append(args, "--k8s-endpoint", strings.Split(suite.K8sEndpoint, ":")[0])

--- a/internal/integration/provision/maintenance_basic.go
+++ b/internal/integration/provision/maintenance_basic.go
@@ -83,8 +83,7 @@ func (suite *MaintenanceBasicSuite) TestAPI() {
 
 		maintenanceClients[i], err = client.New(
 			suite.ctx,
-			client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-			client.WithEndpoints(machine.IPs[0].String()),
+			client.WithMaintenanceMode(machine.IPs[0].String(), nil),
 		)
 		suite.Require().NoError(err)
 	}

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -8,7 +8,6 @@ package provision
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -89,8 +88,7 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 
 		maintenanceClients[i], err = client.New(
 			suite.ctx,
-			client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-			client.WithEndpoints(machine.IPs[0].String()),
+			client.WithMaintenanceMode(machine.IPs[0].String(), nil),
 		)
 		suite.Require().NoError(err)
 	}
@@ -166,8 +164,7 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 
 		sideroLinkMaintenanceClients[i], err = client.New(
 			suite.ctx,
-			client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-			client.WithEndpoints(sideroLinkIP.String()),
+			client.WithMaintenanceMode(sideroLinkIP.String(), nil),
 		)
 		suite.Require().NoError(err)
 	}

--- a/pkg/machinery/client/multiplex/multiplex.go
+++ b/pkg/machinery/client/multiplex/multiplex.go
@@ -5,9 +5,21 @@
 // Package multiplex implements client-side multiplexing helpers.
 package multiplex
 
+import (
+	"context"
+
+	"github.com/siderolabs/talos/pkg/machinery/client"
+)
+
 // Response represents a multiplexed response from a specific node.
 type Response[ResponseT any] struct {
 	Node    string
 	Payload ResponseT
 	Err     error
+}
+
+// ClientFactory is an interface of a client provider.
+type ClientFactory interface {
+	BuildClient(ctx context.Context, node string) (context.Context, *client.Client, error)
+	Nodes() []string
 }

--- a/pkg/machinery/client/multiplex/stream.go
+++ b/pkg/machinery/client/multiplex/stream.go
@@ -75,3 +75,78 @@ func Streaming[ResponseT any](ctx context.Context, nodes []string, initiate func
 
 	return responseCh
 }
+
+// StreamingViaFactory is a helper which performs streaming multiplexing using a ClientFactory to create clients for each node.
+func StreamingViaFactory[ResponseT any](
+	ctx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (grpc.ServerStreamingClient[ResponseT], error),
+) <-chan Response[*ResponseT] {
+	responseCh := make(chan Response[*ResponseT])
+
+	var wg sync.WaitGroup
+
+	for _, node := range factory.Nodes() {
+		wg.Go(func() {
+			ctx, client, err := factory.BuildClient(ctx, node)
+			if err != nil {
+				channel.SendWithContext(
+					ctx, responseCh,
+					Response[*ResponseT]{
+						Node: node,
+						Err:  err,
+					},
+				)
+
+				return
+			}
+
+			stream, err := initiate(ctx, client)
+			if err != nil {
+				channel.SendWithContext(
+					ctx, responseCh,
+					Response[*ResponseT]{
+						Node: node,
+						Err:  err,
+					},
+				)
+
+				return
+			}
+
+			for {
+				payload, err := stream.Recv()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return
+					}
+
+					channel.SendWithContext(
+						ctx, responseCh,
+						Response[*ResponseT]{
+							Node: node,
+							Err:  err,
+						},
+					)
+
+					return
+				}
+
+				if !channel.SendWithContext(
+					ctx, responseCh,
+					Response[*ResponseT]{
+						Node:    node,
+						Payload: payload,
+					},
+				) {
+					return
+				}
+			}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(responseCh)
+	}()
+
+	return responseCh
+}

--- a/pkg/machinery/client/multiplex/unary.go
+++ b/pkg/machinery/client/multiplex/unary.go
@@ -51,3 +51,55 @@ func Unary[ResponseT any](ctx context.Context, nodes []string, initiate func(con
 
 	return responseCh
 }
+
+// UnaryViaFactory is a helper which performs unary multiplexing using a ClientFactory to create clients for each node.
+func UnaryViaFactory[ResponseT any](ctx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (ResponseT, error)) <-chan Response[ResponseT] {
+	responseCh := make(chan Response[ResponseT])
+
+	var wg sync.WaitGroup
+
+	for _, node := range factory.Nodes() {
+		wg.Go(func() {
+			ctx, client, err := factory.BuildClient(ctx, node)
+			if err != nil {
+				channel.SendWithContext(
+					ctx, responseCh,
+					Response[ResponseT]{
+						Node: node,
+						Err:  err,
+					},
+				)
+
+				return
+			}
+
+			response, err := initiate(ctx, client)
+			if err != nil {
+				channel.SendWithContext(
+					ctx, responseCh,
+					Response[ResponseT]{
+						Node: node,
+						Err:  err,
+					},
+				)
+
+				return
+			}
+
+			channel.SendWithContext(
+				ctx, responseCh,
+				Response[ResponseT]{
+					Node:    node,
+					Payload: response,
+				},
+			)
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(responseCh)
+	}()
+
+	return responseCh
+}

--- a/pkg/machinery/client/options.go
+++ b/pkg/machinery/client/options.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
+	"github.com/siderolabs/crypto/x509"
 	"google.golang.org/grpc"
 
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
@@ -165,6 +166,37 @@ func WithSideroV1KeysDir(keysDir string) OptionFunc {
 func WithServiceAccount(serviceAccountBase64 string) OptionFunc {
 	return func(o *Options) error {
 		o.serviceAccountBase64 = serviceAccountBase64
+
+		return nil
+	}
+}
+
+// WithMaintenanceMode creates a Client which connects to Talos API in maintenance mode.
+//
+// In this mode, the certificate fingerprints might be verified if the list supplied
+// is not empty.
+func WithMaintenanceMode(node string, enforceFingerprints []string) OptionFunc {
+	return func(o *Options) error {
+		o.tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		if len(enforceFingerprints) > 0 {
+			fingerprints := make([]x509.Fingerprint, len(enforceFingerprints))
+
+			for i, stringFingerprint := range enforceFingerprints {
+				var err error
+
+				fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
+				if err != nil {
+					return fmt.Errorf("error parsing certificate fingerprint %q: %w", stringFingerprint, err)
+				}
+			}
+
+			o.tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
+		}
+
+		o.endpointsOverride = []string{node}
 
 		return nil
 	}

--- a/pkg/machinery/formatters/formatters.go
+++ b/pkg/machinery/formatters/formatters.go
@@ -7,7 +7,6 @@ package formatters
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -24,13 +23,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/inspect"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
-	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
-
-// FlushInterval is the quiet period after the last multiplexed response
-// before flushing the tabwriter, so partial results appear without thrashing
-// column widths while responses are still arriving.
-const FlushInterval = 500 * time.Millisecond
 
 // RenderMounts renders mounts output.
 //
@@ -76,59 +69,6 @@ func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *pe
 	}
 
 	return w.Flush()
-}
-
-// RenderMountsStream renders the mounts output for a stream of multiplexed responses.
-func RenderMountsStream(output io.Writer, responseChan <-chan multiplex.Response[*machine.MountsResponse]) error {
-	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NODE\tFILESYSTEM\tSIZE(GB)\tUSED(GB)\tAVAILABLE(GB)\tPERCENT USED\tMOUNTED ON")
-
-	flushTimer := time.NewTimer(FlushInterval)
-	defer flushTimer.Stop()
-
-	flushTimer.Stop()
-
-	var errs error
-
-	for {
-		select {
-		case resp, ok := <-responseChan:
-			if !ok {
-				return errors.Join(errs, w.Flush())
-			}
-
-			if resp.Err != nil {
-				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-			} else {
-				for _, msg := range resp.Payload.Messages {
-					for _, r := range msg.Stats {
-						percentAvailable := 100.0 - 100.0*(float64(r.Available)/float64(r.Size))
-
-						if math.IsNaN(percentAvailable) {
-							continue
-						}
-
-						fmt.Fprintf(
-							w, "%s\t%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n",
-							resp.Node,
-							r.Filesystem,
-							float64(r.Size)*1e-9,
-							float64(r.Size-r.Available)*1e-9,
-							float64(r.Available)*1e-9,
-							percentAvailable,
-							r.MountedOn,
-						)
-					}
-				}
-			}
-
-			flushTimer.Reset(FlushInterval)
-		case <-flushTimer.C:
-			if err := w.Flush(); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
-			}
-		}
-	}
 }
 
 // RenderGraph renders inspect controller runtime graph.

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -16,19 +16,19 @@ talosctl apply-config [flags]
 ### Options
 
 ```
-      --cert-fingerprint strings                    list of server certificate fingeprints to accept (defaults to no check)
-  -c, --cluster string                              Cluster to connect to if a proxy endpoint is used.
+      --cert-fingerprint strings                    list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
   -p, --config-patch stringArray                    the list of config patches to apply to the local config file before sending it to the node
-      --context string                              Context to be used in command
+      --context string                              context to be used in command
       --dry-run                                     check how the config change will be applied in dry-run mode
   -e, --endpoints strings                           override default endpoints in Talos configuration
   -f, --file string                                 the filename of the updated configuration
   -h, --help                                        help for apply-config
-  -i, --insecure                                    apply the config using the insecure (encrypted with no auth) maintenance service
+  -i, --insecure                                    use the insecure (encrypted with no auth) maintenance service
   -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
   -n, --nodes strings                               target the specified nodes
-      --siderov1-keys-dir string                    The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                          The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
@@ -58,15 +58,15 @@ talosctl bootstrap [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for bootstrap
   -n, --nodes strings              target the specified nodes
       --recover-from string        recover etcd cluster from the snapshot
       --recover-skip-hash-check    skip integrity check when recovering etcd (use when recovering from data directory copy)
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -102,16 +102,16 @@ talosctl cgroups [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for cgroups
   -n, --nodes strings              target the specified nodes
       --preset string              preset name (one of: [cpu cpuset io memory process psi swap])
       --schema-file string         path to the columns schema file
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --skip-cri-resolve           do not resolve cgroup names via a request to CRI
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -818,12 +818,12 @@ talosctl config add <context> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -847,12 +847,12 @@ talosctl config context <context> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -876,12 +876,12 @@ talosctl config contexts [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -905,12 +905,12 @@ talosctl config endpoint <endpoint>... [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -935,12 +935,12 @@ talosctl config info [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -968,12 +968,12 @@ talosctl config merge <from> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -999,12 +999,12 @@ talosctl config new [<path>] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1028,12 +1028,12 @@ talosctl config node <endpoint>... [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1059,12 +1059,12 @@ talosctl config remove <context> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1078,13 +1078,13 @@ Manage the client configuration file (talosconfig)
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for config
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1118,12 +1118,12 @@ talosctl conformance kubernetes [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1137,13 +1137,13 @@ Run conformance tests
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for conformance
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1162,14 +1162,14 @@ talosctl containers [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for containers
   -k, --kubernetes                 use the k8s.io containerd namespace
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1198,13 +1198,13 @@ talosctl copy <src-path> -|<local-path> [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for copy
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1238,13 +1238,13 @@ talosctl dashboard [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for dashboard
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -d, --update-interval duration   interval between updates (default 3s)
 ```
 
@@ -1274,14 +1274,14 @@ talosctl debug <image-tar-path|image ref> [args] [flags]
 
 ```
       --args strings               arguments to pass to the container
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for debug
       --namespace system           namespace to use: system (CRI containerd) or `inmem` for in-memory containerd instance (default "inmem")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1299,15 +1299,15 @@ talosctl dmesg [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -f, --follow                     specify if the kernel log should be streamed
   -h, --help                       help for dmesg
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --tail                       specify if only new messages should be sent (makes sense only when combined with --follow)
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1334,16 +1334,16 @@ talosctl edit machineconfig [flags]
 ### Options
 
 ```
-  -c, --cluster string                              Cluster to connect to if a proxy endpoint is used.
-      --context string                              Context to be used in command
+  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
+      --context string                              context to be used in command
       --dry-run                                     do not apply the change after editing and print the change summary instead
   -e, --endpoints strings                           override default endpoints in Talos configuration
   -h, --help                                        help for edit
   -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
       --namespace string                            resource namespace (default is to use default namespace per resource)
   -n, --nodes strings                               target the specified nodes
-      --siderov1-keys-dir string                    The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                          The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
@@ -1368,12 +1368,12 @@ talosctl etcd alarm disarm [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1397,12 +1397,12 @@ talosctl etcd alarm list [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1422,12 +1422,12 @@ Manage etcd alarms
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1458,12 +1458,12 @@ talosctl etcd defrag [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1487,12 +1487,12 @@ talosctl etcd downgrade cancel [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1516,12 +1516,12 @@ talosctl etcd downgrade enable <version> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1545,12 +1545,12 @@ talosctl etcd downgrade validate <version> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1570,12 +1570,12 @@ Manage etcd storage system downgrades
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1602,12 +1602,12 @@ talosctl etcd forfeit-leadership [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1631,12 +1631,12 @@ talosctl etcd leave [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1660,12 +1660,12 @@ talosctl etcd members [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1695,12 +1695,12 @@ talosctl etcd remove-member <member ID> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1724,12 +1724,12 @@ talosctl etcd snapshot <path> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1757,12 +1757,12 @@ talosctl etcd status [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1776,13 +1776,13 @@ Manage etcd
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for etcd
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -1810,16 +1810,16 @@ talosctl events [flags]
 
 ```
       --actor-id string            filter events by the specified actor ID (default is no filter)
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
       --duration duration          show events for the past duration interval (one second resolution, default is to show no history)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for events
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --since string               show events after the specified event ID (default is to show no history)
       --tail int32                 show specified number of past events (use -1 to show full history, default is to show no history)
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2180,16 +2180,17 @@ talosctl get <type> [<id>] [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for get
-  -i, --insecure                   get resources using the insecure (encrypted with no auth) maintenance service
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
       --namespace string           resource namespace (default is to use default namespace per resource)
   -n, --nodes strings              target the specified nodes
   -o, --output string              output mode (json, table, yaml, jsonpath) (default "table")
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -w, --watch                      watch resource changes
 ```
 
@@ -2208,8 +2209,8 @@ talosctl health [flags]
 ### Options
 
 ```
-  -c, --cluster string                Cluster to connect to if a proxy endpoint is used.
-      --context string                Context to be used in command
+  -c, --cluster string                cluster to connect to if a proxy endpoint is used
+      --context string                context to be used in command
       --control-plane-nodes strings   specify IPs of control plane nodes
   -e, --endpoints strings             override default endpoints in Talos configuration
   -h, --help                          help for health
@@ -2218,8 +2219,8 @@ talosctl health [flags]
   -n, --nodes strings                 target the specified nodes
       --run-e2e                       run Kubernetes e2e test
       --server                        run server-side check (default true)
-      --siderov1-keys-dir string      The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string            The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string      the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string            the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --wait-timeout duration         timeout to wait for the cluster to be ready (default 20m0s)
       --worker-nodes strings          specify IPs of worker nodes
 ```
@@ -2254,13 +2255,13 @@ talosctl image cache-cert-gen [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2306,13 +2307,13 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2345,13 +2346,13 @@ talosctl image cache-serve [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2380,13 +2381,13 @@ talosctl image k8s-bundle [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2410,13 +2411,13 @@ talosctl image list [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2440,13 +2441,13 @@ talosctl image pull <image> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2470,13 +2471,13 @@ talosctl image remove <image> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2502,13 +2503,13 @@ talosctl image talos-bundle [talos-version] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2522,14 +2523,14 @@ Manage container images
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for image
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2617,12 +2618,12 @@ talosctl inspect dependencies [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2636,13 +2637,13 @@ Inspect internals of Talos
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for inspect
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2669,16 +2670,16 @@ talosctl kubeconfig [local-path] [flags]
 ### Options
 
 ```
-  -c, --cluster string              Cluster to connect to if a proxy endpoint is used.
-      --context string              Context to be used in command
+  -c, --cluster string              cluster to connect to if a proxy endpoint is used
+      --context string              context to be used in command
   -e, --endpoints strings           override default endpoints in Talos configuration
   -f, --force                       Force overwrite of kubeconfig if already present, force overwrite on kubeconfig merge
       --force-context-name string   Force context name for kubeconfig merge
   -h, --help                        help for kubeconfig
   -m, --merge                       Merge with existing kubeconfig (default true)
   -n, --nodes strings               target the specified nodes
-      --siderov1-keys-dir string    The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string          The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2696,8 +2697,8 @@ talosctl list [path] [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -d, --depth int32                maximum recursion depth (default 1)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for list
@@ -2705,8 +2706,8 @@ talosctl list [path] [flags]
   -l, --long                       display additional file details
   -n, --nodes strings              target the specified nodes
   -r, --recurse                    recurse into subdirectories
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -t, --type strings               filter by specified types:
                                    f	regular file
                                    d	directory
@@ -2728,16 +2729,16 @@ talosctl logs <service name> [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -f, --follow                     specify if the logs should be streamed
   -h, --help                       help for logs
   -k, --kubernetes                 use the k8s.io containerd namespace
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --tail int32                 lines of log file to display (default is to show from the beginning) (default -1)
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2816,13 +2817,13 @@ talosctl memory [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for memory
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -v, --verbose                    display extended memory statistics
 ```
 
@@ -2847,13 +2848,12 @@ talosctl meta delete key [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-  -i, --insecure                   write|delete meta using the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2877,13 +2877,12 @@ talosctl meta write key value [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-  -i, --insecure                   write|delete meta using the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2897,14 +2896,15 @@ Write and delete keys in the META partition
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for meta
-  -i, --insecure                   write|delete meta using the insecure (encrypted with no auth) maintenance service
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2924,13 +2924,13 @@ talosctl mounts [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for mounts
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -2958,8 +2958,8 @@ talosctl netstat [flags]
 
 ```
   -a, --all                        display all sockets states (default: connected)
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -x, --extend                     show detailed socket information
   -h, --help                       help for netstat
@@ -2970,8 +2970,8 @@ talosctl netstat [flags]
   -k, --pods                       show sockets used by Kubernetes pods
   -p, --programs                   show process using socket
   -w, --raw                        display only RAW sockets
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -t, --tcp                        display only TCP sockets
   -o, --timers                     display timers
   -u, --udp                        display only UDP sockets
@@ -2994,8 +2994,8 @@ talosctl patch machineconfig [flags]
 ### Options
 
 ```
-  -c, --cluster string                              Cluster to connect to if a proxy endpoint is used.
-      --context string                              Context to be used in command
+  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
+      --context string                              context to be used in command
       --dry-run                                     print the change summary and patch preview without applying the changes
   -e, --endpoints strings                           override default endpoints in Talos configuration
   -h, --help                                        help for patch
@@ -3004,8 +3004,8 @@ talosctl patch machineconfig [flags]
   -n, --nodes strings                               target the specified nodes
   -p, --patch stringArray                           the patch to be applied to the resource file, use @file to read a patch from file.
       --patch-file string                           a file containing a patch to be applied to the resource.
-      --siderov1-keys-dir string                    The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                          The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
@@ -3057,8 +3057,8 @@ e.g. by excluding packets with the port 50000.
 
 ```
       --bpf-filter string          bpf filter to apply, tcpdump -dd format
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
       --duration duration          duration of the capture
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for pcap
@@ -3066,8 +3066,8 @@ e.g. by excluding packets with the port 50000.
   -n, --nodes strings              target the specified nodes
   -o, --output string              if not set, decode packets to stdout; if set write raw pcap data to a file, use '-' for stdout
       --promiscuous                put interface into promiscuous mode
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3085,14 +3085,14 @@ talosctl processes [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for processes
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
   -s, --sort string                Column to sort output by. [rss|cpu] (default "rss")
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3110,13 +3110,13 @@ talosctl read <path> [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for read
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3134,8 +3134,8 @@ talosctl reboot [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
       --drain                      drain the Kubernetes node before rebooting (cordon + evict pods)
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
@@ -3144,8 +3144,8 @@ talosctl reboot [flags]
   -m, --mode string                select the reboot mode during upgrade. Mode "powercycle" bypasses kexec. Values: [default force powercycle] (default "default")
   -n, --nodes strings              target the specified nodes
       --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration           time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
       --wait                       wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
@@ -3165,18 +3165,17 @@ talosctl reset [flags]
 ### Options
 
 ```
-  -c, --cluster string                           Cluster to connect to if a proxy endpoint is used.
-      --context string                           Context to be used in command
+  -c, --cluster string                           cluster to connect to if a proxy endpoint is used
+      --context string                           context to be used in command
       --debug                                    debug operation from kernel logs. --wait is set to true when this flag is set
   -e, --endpoints strings                        override default endpoints in Talos configuration
       --graceful                                 if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
   -h, --help                                     help for reset
-      --insecure                                 reset using the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings                            target the specified nodes
       --reboot                                   if true, reboot the node after resetting instead of shutting down
-      --siderov1-keys-dir string                 The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string                 the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --system-labels-to-wipe strings            if set, just wipe selected system disk partitions by label but keep other partitions intact
-      --talosconfig string                       The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string                       the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration                         time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
       --user-disks-to-wipe strings               if set, wipes defined devices in the list
       --wait                                     wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
@@ -3198,14 +3197,14 @@ talosctl restart <id> [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for restart
   -k, --kubernetes                 use the k8s.io containerd namespace
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3223,13 +3222,13 @@ talosctl rollback [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for rollback
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3256,8 +3255,8 @@ talosctl rotate-ca [flags]
 ### Options
 
 ```
-  -c, --cluster string                Cluster to connect to if a proxy endpoint is used.
-      --context string                Context to be used in command
+  -c, --cluster string                cluster to connect to if a proxy endpoint is used
+      --context string                context to be used in command
       --control-plane-nodes strings   specify IPs of control plane nodes
       --dry-run                       dry-run mode (no changes to the cluster) (default true)
   -e, --endpoints strings             override default endpoints in Talos configuration
@@ -3267,9 +3266,9 @@ talosctl rotate-ca [flags]
       --kubernetes                    rotate Kubernetes API CA (default true)
   -n, --nodes strings                 target the specified nodes
   -o, --output talosconfig            path to the output new talosconfig (default "talosconfig")
-      --siderov1-keys-dir string      The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --siderov1-keys-dir string      the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talos                         rotate Talos API CA (default true)
-      --talosconfig string            The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --talosconfig string            the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --with-docs                     patch all machine configs adding the documentation for each field (default true)
       --with-examples                 patch all machine configs with the commented examples (default true)
       --worker-nodes strings          specify IPs of worker nodes
@@ -3296,13 +3295,13 @@ talosctl service [<id> [start|stop|restart|status]] [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for service
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3320,15 +3319,15 @@ talosctl shutdown [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
   -e, --endpoints strings          override default endpoints in Talos configuration
       --force                      if true, force a node to shutdown without a cordon/drain
   -h, --help                       help for shutdown
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration           time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
       --wait                       wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
@@ -3348,14 +3347,14 @@ talosctl stats [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for stats
   -k, --kubernetes                 use the k8s.io containerd namespace
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3401,8 +3400,8 @@ talosctl support [flags]
 ### Options
 
 ```
-  -c, --cluster string                      Cluster to connect to if a proxy endpoint is used.
-      --context string                      Context to be used in command
+  -c, --cluster string                      cluster to connect to if a proxy endpoint is used
+      --context string                      context to be used in command
       --encryption-no-default-recipients    do not encrypt to the default recipients, only to the ones provided via --encryption-recipients
       --encryption-recipients stringArray   additional age recipients (SSH or age public keys) to encrypt the support bundle to (can be specified multiple times)
   -e, --endpoints strings                   override default endpoints in Talos configuration
@@ -3411,8 +3410,8 @@ talosctl support [flags]
   -n, --nodes strings                       target the specified nodes
   -w, --num-workers int                     number of workers per node (default 1)
   -O, --output string                       output file to write support archive to
-      --siderov1-keys-dir string            The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                  The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string            the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                  the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -v, --verbose                             verbose output
 ```
 
@@ -3432,13 +3431,13 @@ talosctl time [--check server] [flags]
 
 ```
       --check string               checks server time against specified ntp server
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for time
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3456,8 +3455,8 @@ talosctl upgrade [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
       --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
       --drain                      drain the Kubernetes node before rebooting (cordon + evict pods) (default true)
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
@@ -3469,8 +3468,8 @@ talosctl upgrade [flags]
   -n, --nodes strings              target the specified nodes
       --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")
   -m, --reboot-mode string         select the reboot mode during upgrade. Mode "powercycle" bypasses kexec. Values: [default force powercycle] (default "default")
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --timeout duration           time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
       --wait                       wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
@@ -3495,8 +3494,8 @@ talosctl upgrade-k8s [flags]
 
 ```
       --apiserver-image string                 kube-apiserver image to use (default "registry.k8s.io/kube-apiserver")
-  -c, --cluster string                         Cluster to connect to if a proxy endpoint is used.
-      --context string                         Context to be used in command
+  -c, --cluster string                         cluster to connect to if a proxy endpoint is used
+      --context string                         context to be used in command
       --controller-manager-image string        kube-controller-manager image to use (default "registry.k8s.io/kube-controller-manager")
       --dry-run                                skip the actual upgrade and show the upgrade plan instead
       --endpoint string                        the cluster control plane endpoint
@@ -3512,8 +3511,8 @@ talosctl upgrade-k8s [flags]
       --pre-pull-images                        pre-pull images before upgrade (default true)
       --proxy-image string                     kube-proxy image to use (default "registry.k8s.io/kube-proxy")
       --scheduler-image string                 kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
-      --siderov1-keys-dir string               The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string                     The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string               the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                     the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
       --to string                              the Kubernetes control plane version to upgrade to (default "1.36.1")
       --upgrade-kubelet                        upgrade kubelet service (default true)
       --with-docs                              patch all machine configs adding the documentation for each field (default true)
@@ -3536,15 +3535,15 @@ talosctl usage [path1] [path2] ... [pathN] [flags]
 
 ```
   -a, --all                        write counts for all files, not just directories
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -d, --depth int32                maximum recursion depth
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for usage
   -H, --humanize                   humanize size and time in the output
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
   -t, --threshold int              threshold exclude entries smaller than SIZE if positive, or entries greater than SIZE if negative
 ```
 
@@ -3584,16 +3583,17 @@ talosctl version [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
       --client                     Print client version only
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for version
-  -i, --insecure                   use Talos maintenance mode API
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --short                      Print the short version
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3617,21 +3617,22 @@ talosctl wipe disk <device names>... [flags]
 ### Options
 
 ```
-      --drop-partition   drop partition after wipe (if applicable)
-  -h, --help             help for disk
-  -i, --insecure         use Talos maintenance mode API
-      --method string    wipe method to use [FAST ZEROES] (default "FAST")
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+      --drop-partition             drop partition after wipe (if applicable)
+  -h, --help                       help for disk
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
+      --method string              wipe method to use [FAST ZEROES] (default "FAST")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3655,19 +3656,20 @@ talosctl wipe lv <vg/lv> [flags]
 ### Options
 
 ```
-  -h, --help       help for lv
-  -i, --insecure   use Talos maintenance mode API
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -h, --help                       help for lv
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3693,19 +3695,20 @@ talosctl wipe pv <device> [flags]
 ### Options
 
 ```
-  -h, --help       help for pv
-  -i, --insecure   use Talos maintenance mode API
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -h, --help                       help for pv
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3732,19 +3735,20 @@ talosctl wipe vg <name> [flags]
 ### Options
 
 ```
-  -h, --help       help for vg
-  -i, --insecure   use Talos maintenance mode API
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -h, --help                       help for vg
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO
@@ -3758,13 +3762,13 @@ Wipe block device or volumes
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for wipe
   -n, --nodes strings              target the specified nodes
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Fixes #13493

Fixes #13498 

Fixes #13492

Instead of using `With*` helpers, switch to a generic `ClientFactory` which can build any kind of clients in any possible scenario:

* clients with "normal" mode, proxying over endpoints using `WithNdoe`
* clients in maintenance mode, where each node becomes an endpoint

Fix numerous bugs and inconsistencies (probably introduced some new bugs on the way 🤣 )

The next PR will remove all `With*` helpers, refactor execution tracker, all streaming commands following the same pattern, bringing the whole code to a state of consistency.
