### PR TITLE
fix: classify installer and imager exits

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v4"
@@ -23,6 +24,7 @@ import (
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/imager"
 	"github.com/siderolabs/talos/pkg/imager/profile"
+	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/overlay"
 	"github.com/siderolabs/talos/pkg/reporter"
@@ -73,7 +75,7 @@ var rootCmd = &cobra.Command{
 
 		if baseProfile == "-" {
 			if err := yaml.NewDecoder(os.Stdin).Decode(&prof); err != nil {
-				return err
+				return xerrors.NewTaggedf[profile.InvalidInputTag]("%w", err)
 			}
 		} else {
 			prof = profile.Profile{
@@ -92,14 +94,14 @@ var rootCmd = &cobra.Command{
 				if strings.HasPrefix(option, "@") {
 					data, err := os.ReadFile(option[1:])
 					if err != nil {
-						return err
+						return xerrors.NewTaggedf[imager.IOTag]("%w", err)
 					}
 
 					decoder := yaml.NewDecoder(bytes.NewReader(data))
 					decoder.KnownFields(true)
 
 					if err := decoder.Decode(&extraOverlayOptions); err != nil {
-						return err
+						return xerrors.NewTaggedf[profile.InvalidInputTag]("%w", err)
 					}
 
 					continue
@@ -110,7 +112,7 @@ var rootCmd = &cobra.Command{
 				if strings.HasPrefix(v, "@") {
 					data, err := os.ReadFile(v[1:])
 					if err != nil {
-						return err
+						return xerrors.NewTaggedf[imager.IOTag]("%w", err)
 					}
 
 					v = string(data)
@@ -144,7 +146,7 @@ var rootCmd = &cobra.Command{
 			if cmdFlags.OutputKind != "" {
 				outKind, err := profile.OutputKindString(cmdFlags.OutputKind)
 				if err != nil {
-					return err
+					return xerrors.NewTaggedf[profile.InvalidInputTag]("%w", err)
 				}
 
 				prof.Output.Kind = outKind
@@ -206,7 +208,7 @@ var rootCmd = &cobra.Command{
 			if cmdFlags.EmbeddedConfigPath != "" {
 				data, err := os.ReadFile(cmdFlags.EmbeddedConfigPath)
 				if err != nil {
-					return fmt.Errorf("error reading embedded config file: %w", err)
+					return xerrors.NewTaggedf[imager.IOTag]("error reading embedded config file: %w", err)
 				}
 
 				prof.Customization.EmbeddedMachineConfiguration = string(data)
@@ -214,15 +216,15 @@ var rootCmd = &cobra.Command{
 		}
 
 		if err := os.MkdirAll(cmdFlags.OutputPath, 0o755); err != nil {
-			return err
+			return xerrors.NewTaggedf[imager.IOTag]("%w", err)
 		}
 
-		imager, err := imager.New(prof)
+		imgr, err := imager.New(prof)
 		if err != nil {
 			return err
 		}
 
-		if _, err = imager.Execute(ctx, cmdFlags.OutputPath, report); err != nil {
+		if _, err = imgr.Execute(ctx, cmdFlags.OutputPath, report); err != nil {
 			report.Report(reporter.Update{
 				Message: err.Error(),
 				Status:  reporter.StatusError,
@@ -232,7 +234,9 @@ var rootCmd = &cobra.Command{
 		}
 
 		if cmdFlags.TarToStdout {
-			return archiver.TarGz(ctx, cmdFlags.OutputPath, os.Stdout)
+			if err := archiver.TarGz(ctx, cmdFlags.OutputPath, os.Stdout); err != nil {
+				return xerrors.NewTaggedf[imager.IOTag]("%w", err)
+			}
 		}
 
 		return nil
@@ -242,12 +246,20 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if _, err := cli.WithContextC(context.Background(), rootCmd.ExecuteContextC); err != nil {
-		os.Exit(1)
+	if err := execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(installerexitcode.Resolve(err))
 	}
 }
 
+func execute() error {
+	_, err := cli.WithContextC(context.Background(), rootCmd.ExecuteContextC)
+
+	return err
+}
+
 func init() {
+	rootCmd.SilenceErrors = true
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.Arch, "arch", runtime.GOARCH, "The target architecture")
 	rootCmd.PersistentFlags().StringVar(&cmdFlags.BaseInstallerImage, "base-installer-image", "", "Base installer image to use")

--- a/cmd/installer/cmd/imager/root_test.go
+++ b/cmd/installer/cmd/imager/root_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:testpackage
+package imager
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func TestExecuteInvalidProfileStdin(t *testing.T) {
+	oldStdin := os.Stdin
+	oldOutputPath := cmdFlags.OutputPath
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	_, err = w.WriteString("not: [valid\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	os.Stdin = r
+	cmdFlags.OutputPath = t.TempDir()
+
+	rootCmd.SetArgs([]string{"-"})
+
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		cmdFlags.OutputPath = oldOutputPath
+
+		rootCmd.SetArgs(nil)
+
+		require.NoError(t, r.Close())
+	})
+
+	err = execute()
+	require.Error(t, err)
+	require.Equal(t, constants.ExitInvalidInput, installerexitcode.Resolve(err))
+}

--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -7,9 +7,9 @@ package installer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/installer/pkg/install"
@@ -44,7 +44,7 @@ func runInstallCmd(ctx context.Context) (err error) {
 
 	p, err := platform.NewPlatform(options.Platform)
 	if err != nil {
-		return err
+		return xerrors.NewTaggedf[install.InvalidInputTag]("%w", err)
 	}
 
 	config, err := configloader.NewFromStdin()
@@ -55,14 +55,14 @@ func runInstallCmd(ctx context.Context) (err error) {
 			// machine configuration can be only missing while running an upgrade in maintenance mode, assume that we should follow GrubUseUKICmdline
 			options.GrubUseUKICmdline = true
 		} else {
-			return fmt.Errorf("error loading machine configuration: %w", err)
+			return xerrors.NewTaggedf[install.InvalidInputTag]("error loading machine configuration: %w", err)
 		}
 	} else {
 		var warnings []string
 
 		warnings, err = config.ValidateAsClient(p.Mode())
 		if err != nil {
-			return fmt.Errorf("machine configuration is invalid: %w", err)
+			return xerrors.NewTaggedf[install.InvalidInputTag]("machine configuration is invalid: %w", err)
 		}
 
 		if len(warnings) > 0 {

--- a/cmd/installer/cmd/installer/root.go
+++ b/cmd/installer/cmd/installer/root.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/installer/pkg/install"
+	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -26,7 +28,7 @@ var rootCmd = &cobra.Command{
 func setFlagsFromEnvironment() error {
 	if metaEnvBase64 := os.Getenv(constants.MetaValuesEnvVar); metaEnvBase64 != "" {
 		if err := options.MetaValues.Decode(metaEnvBase64); err != nil {
-			return err
+			return xerrors.NewTaggedf[install.InvalidInputTag]("%w", err)
 		}
 	}
 
@@ -36,21 +38,26 @@ func setFlagsFromEnvironment() error {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	// Set defaults for flags from the environment variables.
-	if err := setFlagsFromEnvironment(); err != nil {
+	if err := execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(installerexitcode.Resolve(err))
+	}
+}
+
+func execute() error {
+	if err := setFlagsFromEnvironment(); err != nil {
+		return err
 	}
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	return rootCmd.Execute()
 }
 
 var options = &install.Options{}
 
 func init() {
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+
 	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
 	rootCmd.PersistentFlags().StringVar(&options.DiskPath, "disk", "", "The path to the disk to install to")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)

--- a/cmd/installer/cmd/installer/root_test.go
+++ b/cmd/installer/cmd/installer/root_test.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:testpackage
+package installer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func TestExecuteInvalidMetaEnv(t *testing.T) {
+	t.Setenv(constants.MetaValuesEnvVar, "!!!")
+
+	err := execute()
+	require.Error(t, err)
+	require.Equal(t, constants.ExitInvalidInput, installerexitcode.Resolve(err))
+}

--- a/cmd/installer/pkg/install/errata.go
+++ b/cmd/installer/pkg/install/errata.go
@@ -6,11 +6,11 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
 
+	"github.com/siderolabs/gen/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -55,7 +55,7 @@ func readHostTalosVersion() (*compatibility.TalosVersion, error) {
 		),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to the machine service: %w", err)
+		return nil, xerrors.NewTaggedf[EnvironmentTag]("error connecting to the machine service: %w", err)
 	}
 
 	defer c.Close() //nolint:errcheck
@@ -65,14 +65,14 @@ func readHostTalosVersion() (*compatibility.TalosVersion, error) {
 
 	resp, err := c.Version(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Talos version: %w", err)
+		return nil, xerrors.NewTaggedf[EnvironmentTag]("error getting Talos version: %w", err)
 	}
 
 	hostVersion := unpack(resp.Messages)
 
 	talosVersion, err := compatibility.ParseTalosVersion(hostVersion.Version)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Talos version: %w", err)
+		return nil, xerrors.NewTaggedf[EnvironmentTag]("error parsing Talos version: %w", err)
 	}
 
 	return talosVersion, nil

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-blockdevice/v2/blkid"
 	"github.com/siderolabs/go-blockdevice/v2/block"
@@ -117,7 +118,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 	if overlayPresent() {
 		extraOptionsBytes, err := os.ReadFile(constants.ImagerOverlayExtraOptionsPath)
 		if err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 
 		var extraOptions overlay.ExtraOptions
@@ -126,7 +127,7 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		decoder.KnownFields(true)
 
 		if err := decoder.Decode(&extraOptions); err != nil {
-			return fmt.Errorf("failed to decode extra options: %w", err)
+			return xerrors.NewTaggedf[InvalidInputTag]("failed to decode extra options: %w", err)
 		}
 
 		opts.OverlayInstaller = executor.New(constants.ImagerOverlayInstallerDefaultPath)
@@ -145,13 +146,13 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
 	if err := cmdline.AppendAll(kernel.DefaultArgs(quirks.Quirks{})); err != nil {
-		return err
+		return xerrors.NewTagged[InvalidInputTag](err)
 	}
 
 	if opts.OverlayInstaller != nil {
 		overlayOpts, getOptsErr := opts.OverlayInstaller.GetOptions(ctx, opts.ExtraOptions)
 		if getOptsErr != nil {
-			return fmt.Errorf("failed to get overlay installer options: %w", getOptsErr)
+			return xerrors.NewTaggedf[DependencyTag]("failed to get overlay installer options: %w", getOptsErr)
 		}
 
 		opts.OverlayName = overlayOpts.Name
@@ -174,16 +175,16 @@ func Install(ctx context.Context, p runtime.Platform, mode Mode, opts *Options) 
 		procfs.WithOverwriteArgs(constants.KernelParamPlatform),
 		procfs.WithDeleteNegatedArgs(),
 	); err != nil {
-		return err
+		return xerrors.NewTagged[InvalidInputTag](err)
 	}
 
 	i, err := NewInstaller(ctx, cmdline, mode, opts)
 	if err != nil {
-		return err
+		return xerrors.NewTagged[InstallTag](err)
 	}
 
 	if err = i.Install(ctx, mode); err != nil {
-		return err
+		return xerrors.NewTagged[InstallTag](err)
 	}
 
 	i.options.Printf("installation of %s complete", version.Tag)

--- a/cmd/installer/pkg/install/preflight.go
+++ b/cmd/installer/pkg/install/preflight.go
@@ -6,10 +6,10 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 
+	"github.com/siderolabs/gen/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -19,6 +19,16 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 	"github.com/siderolabs/talos/pkg/machinery/version"
+)
+
+// Exit-code tags for installer runtime failures.
+//
+//nolint:revive
+type (
+	InvalidInputTag struct{}
+	EnvironmentTag  struct{}
+	DependencyTag   struct{}
+	InstallTag      struct{}
 )
 
 // PreflightChecks runs the preflight checks.
@@ -46,7 +56,7 @@ func NewPreflightChecks(ctx context.Context) (*PreflightChecks, error) {
 		),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to the machine service: %w", err)
+		return nil, xerrors.NewTaggedf[EnvironmentTag]("error connecting to the machine service: %w", err)
 	}
 
 	return &PreflightChecks{
@@ -78,7 +88,7 @@ func (checks *PreflightChecks) Run(ctx context.Context) error {
 		checks.talosVersion,
 	} {
 		if err := check(ctx); err != nil {
-			return fmt.Errorf("pre-flight checks failed: %w", err)
+			return xerrors.NewTaggedf[EnvironmentTag]("pre-flight checks failed: %w", err)
 		}
 	}
 
@@ -90,7 +100,7 @@ func (checks *PreflightChecks) Run(ctx context.Context) error {
 func (checks *PreflightChecks) talosVersion(ctx context.Context) error {
 	resp, err := checks.client.Version(ctx)
 	if err != nil {
-		return fmt.Errorf("error getting Talos version: %w", err)
+		return xerrors.NewTaggedf[EnvironmentTag]("error getting Talos version: %w", err)
 	}
 
 	hostVersion := unpack(resp.Messages)
@@ -99,15 +109,19 @@ func (checks *PreflightChecks) talosVersion(ctx context.Context) error {
 
 	checks.hostTalosVersion, err = compatibility.ParseTalosVersion(hostVersion.Version)
 	if err != nil {
-		return fmt.Errorf("error parsing host Talos version: %w", err)
+		return xerrors.NewTaggedf[EnvironmentTag]("error parsing host Talos version: %w", err)
 	}
 
 	checks.installerTalosVersion, err = compatibility.ParseTalosVersion(version.NewVersion())
 	if err != nil {
-		return fmt.Errorf("error parsing installer Talos version: %w", err)
+		return xerrors.NewTaggedf[EnvironmentTag]("error parsing installer Talos version: %w", err)
 	}
 
-	return checks.installerTalosVersion.UpgradeableFrom(checks.hostTalosVersion)
+	if err := checks.installerTalosVersion.UpgradeableFrom(checks.hostTalosVersion); err != nil {
+		return xerrors.NewTagged[EnvironmentTag](err)
+	}
+
+	return nil
 }
 
 func unpack[T any](s []T) T {

--- a/pkg/imager/embed.go
+++ b/pkg/imager/embed.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/siderolabs/gen/xerrors"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/pkg/imager/profile"
@@ -29,19 +30,19 @@ func (i *Imager) handleEmbeddedConfig() error {
 
 	contents, err := BuildEmbeddedConfigExtension([]byte(i.prof.Customization.EmbeddedMachineConfiguration))
 	if err != nil {
-		return fmt.Errorf("failed to build embedded config extension: %w", err)
+		return xerrors.NewTaggedf[InvalidInputTag]("failed to build embedded config extension: %w", err)
 	}
 
 	tmpPath := filepath.Join(i.tempDir, "embedded-config.tar")
 
 	f, err := os.Create(tmpPath)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary file: %w", err)
+		return xerrors.NewTaggedf[IOTag]("failed to create temporary file: %w", err)
 	}
 	defer f.Close() //nolint:errcheck
 
 	if _, err := io.Copy(f, contents); err != nil {
-		return fmt.Errorf("failed to write embedded config to temporary file: %w", err)
+		return xerrors.NewTaggedf[IOTag]("failed to write embedded config to temporary file: %w", err)
 	}
 
 	i.prof.Input.SystemExtensions = append(

--- a/pkg/imager/imager.go
+++ b/pkg/imager/imager.go
@@ -7,13 +7,16 @@ package imager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/go-procfs/procfs"
 	"go.yaml.in/yaml/v4"
 
@@ -52,6 +55,17 @@ type Imager struct {
 	xattrsMap map[string]string
 }
 
+// Exit-code tags for imager failures.
+//
+//nolint:revive
+type (
+	InvalidInputTag struct{}
+	UnsupportedTag  struct{}
+	DependencyTag   struct{}
+	IOTag           struct{}
+	InstallTag      struct{}
+)
+
 // New creates a new Imager.
 func New(prof profile.Profile) (*Imager, error) {
 	return &Imager{
@@ -66,14 +80,14 @@ func New(prof profile.Profile) (*Imager, error) {
 func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporter.Reporter) (outputAssetPath string, err error) {
 	i.tempDir, err = os.MkdirTemp("", "imager")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+		return "", xerrors.NewTagged[IOTag](fmt.Errorf("failed to create temporary directory: %w", err))
 	}
 
 	defer os.RemoveAll(i.tempDir) //nolint:errcheck
 
 	// 0. Handle overlays first
 	if err = i.handleOverlay(ctx, report); err != nil {
-		return "", err
+		return "", tagPathOrPass(err, DependencyTag{})
 	}
 
 	if err = i.handleProf(); err != nil {
@@ -81,7 +95,7 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 	}
 
 	if err = i.handleEmbeddedConfig(); err != nil {
-		return "", err
+		return "", tagPathOrPass(err, IOTag{})
 	}
 
 	report.Report(reporter.Update{
@@ -91,7 +105,7 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 
 	// 1. Dump the profile.
 	if err = i.prof.Dump(os.Stderr); err != nil {
-		return "", err
+		return "", xerrors.NewTagged[IOTag](err)
 	}
 
 	// 2. Transform `initramfs.xz` with system extensions
@@ -115,7 +129,7 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 	switch i.prof.Output.Kind {
 	case profile.OutKindUKI:
 		if !needBuildUKI {
-			return "", fmt.Errorf("UKI output is not supported in this Talos version")
+			return "", xerrors.NewTagged[UnsupportedTag](fmt.Errorf("UKI output is not supported in this Talos version"))
 		}
 	case profile.OutKindISO, profile.OutKindInstaller, profile.OutKindImage:
 		needBuildUKI = needBuildUKI || quirks.New(i.prof.Version).UseSDBootForUEFI()
@@ -124,7 +138,7 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 	case profile.OutKindUnknown:
 		fallthrough
 	default:
-		return "", fmt.Errorf("unknown output kind: %s", i.prof.Output.Kind)
+		return "", xerrors.NewTagged[InvalidInputTag](fmt.Errorf("unknown output kind: %s", i.prof.Output.Kind))
 	}
 
 	if needBuildUKI {
@@ -182,7 +196,7 @@ func (i *Imager) Execute(ctx context.Context, outputPath string, report *reporte
 	case profile.OutFormatUnknown:
 		fallthrough
 	default:
-		return "", fmt.Errorf("unknown output format: %s", i.prof.Output.OutFormat)
+		return "", xerrors.NewTagged[InvalidInputTag](fmt.Errorf("unknown output format: %s", i.prof.Output.OutFormat))
 	}
 }
 
@@ -199,17 +213,17 @@ func (i *Imager) handleOverlay(ctx context.Context, report *reporter.Reporter) e
 	tempOverlayPath := filepath.Join(i.tempDir, constants.ImagerOverlayBasePath)
 
 	if err := os.MkdirAll(tempOverlayPath, 0o755); err != nil {
-		return fmt.Errorf("failed to create overlay directory: %w", err)
+		return xerrors.NewTagged[IOTag](fmt.Errorf("failed to create overlay directory: %w", err))
 	}
 
 	if err := i.prof.Overlay.Image.Extract(ctx, tempOverlayPath, runtime.GOARCH, progressPrintf(report, reporter.Update{Message: "pulling overlay...", Status: reporter.StatusRunning}), nil); err != nil {
-		return err
+		return xerrors.NewTagged[DependencyTag](err)
 	}
 
 	// find all *.yaml files in the overlay/profiles/ directory
 	profileYAMLs, err := filepath.Glob(filepath.Join(i.tempDir, constants.ImagerOverlayProfilesPath, "*.yaml"))
 	if err != nil {
-		return fmt.Errorf("failed to find profiles: %w", err)
+		return xerrors.NewTagged[IOTag](fmt.Errorf("failed to find profiles: %w", err))
 	}
 
 	if i.prof.Overlay.Name == "" {
@@ -229,11 +243,11 @@ func (i *Imager) handleOverlay(ctx context.Context, report *reporter.Reporter) e
 
 		profileDataBytes, err := os.ReadFile(profilePath)
 		if err != nil {
-			return fmt.Errorf("failed to read profile: %w", err)
+			return xerrors.NewTagged[IOTag](fmt.Errorf("failed to read profile: %w", err))
 		}
 
 		if err := yaml.Unmarshal(profileDataBytes, &overlayProfile); err != nil {
-			return fmt.Errorf("failed to unmarshal profile: %w", err)
+			return xerrors.NewTagged[InvalidInputTag](fmt.Errorf("failed to unmarshal profile: %w", err))
 		}
 
 		i.extraProfiles[profileName] = overlayProfile
@@ -252,14 +266,14 @@ func (i *Imager) handleProf() error {
 		}
 
 		if !ok {
-			return fmt.Errorf("unknown base profile: %s", i.prof.BaseProfileName)
+			return xerrors.NewTagged[InvalidInputTag](fmt.Errorf("unknown base profile: %s", i.prof.BaseProfileName))
 		}
 
 		baseProfile = baseProfile.DeepCopy()
 
 		// merge the profiles
 		if err := merge.Merge(&baseProfile, &i.prof); err != nil {
-			return err
+			return xerrors.NewTagged[InvalidInputTag](err)
 		}
 
 		i.prof = baseProfile
@@ -278,7 +292,7 @@ func (i *Imager) handleProf() error {
 	i.prof.Output.FillDefaults(i.prof.Arch, i.prof.Version, i.prof.SecureBootEnabled())
 
 	if err := i.prof.Validate(); err != nil {
-		return fmt.Errorf("profile is invalid: %w", err)
+		return xerrors.NewTagged[InvalidInputTag](fmt.Errorf("profile is invalid: %w", err))
 	}
 
 	return nil
@@ -309,7 +323,7 @@ func (i *Imager) buildInitramfs(ctx context.Context, report *reporter.Reporter) 
 	tempInitramfsPath := filepath.Join(i.tempDir, "initramfs.xz")
 
 	if err := utils.CopyFiles(printf, utils.SourceDestination(i.prof.Input.Initramfs.Path, tempInitramfsPath)); err != nil {
-		return fmt.Errorf("failed to copy initramfs: %w", err)
+		return xerrors.NewTagged[IOTag](fmt.Errorf("failed to copy initramfs: %w", err))
 	}
 
 	i.initramfsPath = tempInitramfsPath
@@ -321,11 +335,11 @@ func (i *Imager) buildInitramfs(ctx context.Context, report *reporter.Reporter) 
 		extensionDir := filepath.Join(extensionsCheckoutDir, strconv.Itoa(j))
 
 		if err := os.MkdirAll(extensionDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create extension directory: %w", err)
+			return xerrors.NewTagged[IOTag](fmt.Errorf("failed to create extension directory: %w", err))
 		}
 
 		if err := ext.Extract(ctx, extensionDir, i.prof.Arch, printf, i.xattrsMap); err != nil {
-			return err
+			return xerrors.NewTagged[DependencyTag](err)
 		}
 	}
 
@@ -340,7 +354,7 @@ func (i *Imager) buildInitramfs(ctx context.Context, report *reporter.Reporter) 
 	}
 
 	if err := builder.Build(ctx); err != nil {
-		return err
+		return xerrors.NewTagged[DependencyTag](err)
 	}
 
 	report.Report(reporter.Update{
@@ -357,7 +371,7 @@ func (i *Imager) buildInitramfs(ctx context.Context, report *reporter.Reporter) 
 func (i *Imager) buildCmdline(ctx context.Context) error {
 	p, err := platform.NewPlatform(i.prof.Platform)
 	if err != nil {
-		return err
+		return xerrors.NewTagged[InvalidInputTag](err)
 	}
 
 	q := quirks.New(i.prof.Version)
@@ -377,7 +391,7 @@ func (i *Imager) buildCmdline(ctx context.Context) error {
 	if i.overlayInstaller != nil {
 		options, optsErr := i.overlayInstaller.GetOptions(ctx, i.prof.Overlay.ExtraOptions)
 		if optsErr != nil {
-			return optsErr
+			return xerrors.NewTagged[DependencyTag](optsErr)
 		}
 
 		cmdline.SetAll(options.KernelArgs)
@@ -385,12 +399,12 @@ func (i *Imager) buildCmdline(ctx context.Context) error {
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
 	if err = cmdline.AppendAll(kernel.DefaultArgs(q)); err != nil {
-		return err
+		return xerrors.NewTagged[InvalidInputTag](err)
 	}
 
 	if i.prof.SecureBootEnabled() {
 		if err = cmdline.AppendAll(kernel.SecureBootArgs(q)); err != nil {
-			return err
+			return xerrors.NewTagged[InvalidInputTag](err)
 		}
 	}
 
@@ -410,7 +424,7 @@ func (i *Imager) buildCmdline(ctx context.Context) error {
 		procfs.WithOverwriteArgs(constants.KernelParamPlatform),
 		procfs.WithDeleteNegatedArgs(),
 	); err != nil {
-		return err
+		return xerrors.NewTagged[InvalidInputTag](err)
 	}
 
 	i.cmdline = cmdline.String()
@@ -466,14 +480,14 @@ func (i *Imager) buildUKI(ctx context.Context, report *reporter.Reporter) error 
 
 		pcrSigner, err := i.prof.Input.SecureBoot.PCRSigner.GetSigner(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get PCR signer: %w", err)
+			return xerrors.NewTagged[DependencyTag](fmt.Errorf("failed to get PCR signer: %w", err))
 		}
 
 		defer pcrSigner.Close() //nolint:errcheck
 
 		securebootSigner, err := i.prof.Input.SecureBoot.SecureBootSigner.GetSigner(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get SecureBoot signer: %w", err)
+			return xerrors.NewTagged[DependencyTag](fmt.Errorf("failed to get SecureBoot signer: %w", err))
 		}
 
 		defer securebootSigner.Close() //nolint:errcheck
@@ -485,7 +499,7 @@ func (i *Imager) buildUKI(ctx context.Context, report *reporter.Reporter) error 
 	}
 
 	if err := buildFunc(printf); err != nil {
-		return err
+		return xerrors.NewTagged[DependencyTag](err)
 	}
 
 	report.Report(reporter.Update{
@@ -494,4 +508,18 @@ func (i *Imager) buildUKI(ctx context.Context, report *reporter.Reporter) error 
 	})
 
 	return nil
+}
+
+func tagPathOrPass[T xerrors.Tag](err error, _ T) error {
+	if err == nil || xerrors.TagIs[T](err) {
+		return err
+	}
+
+	var pathErr *fs.PathError
+
+	if errors.As(err, &pathErr) || os.IsNotExist(err) || os.IsExist(err) || os.IsPermission(err) {
+		return xerrors.NewTagged[T](err)
+	}
+
+	return err
 }

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/go-procfs/procfs"
 	"go.yaml.in/yaml/v4"
@@ -45,7 +46,7 @@ func (i *Imager) outInitramfs(path string, report *reporter.Reporter) error {
 	printf := progressPrintf(report, reporter.Update{Message: "copying initramfs...", Status: reporter.StatusRunning})
 
 	if err := utils.CopyFiles(printf, utils.SourceDestination(i.initramfsPath, path)); err != nil {
-		return err
+		return xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: "initramfs output ready", Status: reporter.StatusSucceeded})
@@ -57,7 +58,7 @@ func (i *Imager) outKernel(path string, report *reporter.Reporter) error {
 	printf := progressPrintf(report, reporter.Update{Message: "copying kernel...", Status: reporter.StatusRunning})
 
 	if err := utils.CopyFiles(printf, utils.SourceDestination(i.prof.Input.Kernel.Path, path)); err != nil {
-		return err
+		return xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: "kernel output ready", Status: reporter.StatusSucceeded})
@@ -69,7 +70,7 @@ func (i *Imager) outUKI(path string, report *reporter.Reporter) error {
 	printf := progressPrintf(report, reporter.Update{Message: "copying kernel...", Status: reporter.StatusRunning})
 
 	if err := utils.CopyFiles(printf, utils.SourceDestination(i.ukiPath, path)); err != nil {
-		return err
+		return xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: "UKI output ready", Status: reporter.StatusSucceeded})
@@ -78,7 +79,11 @@ func (i *Imager) outUKI(path string, report *reporter.Reporter) error {
 }
 
 func (i *Imager) outCmdline(path string) error {
-	return os.WriteFile(path, []byte(i.cmdline), 0o644)
+	if err := os.WriteFile(path, []byte(i.cmdline), 0o644); err != nil {
+		return xerrors.NewTaggedf[IOTag]("%w", err)
+	}
+
+	return nil
 }
 
 //nolint:gocyclo,cyclop
@@ -94,11 +99,11 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 	if i.prof.Input.ImageCache != zeroContainerAsset {
 		if err := os.MkdirAll(filepath.Join(scratchSpace, "imagecache"), 0o755); err != nil {
-			return err
+			return xerrors.NewTaggedf[IOTag]("%w", err)
 		}
 
 		if err := i.prof.Input.ImageCache.Extract(ctx, filepath.Join(scratchSpace, "imagecache"), i.prof.Arch, printf, nil); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	}
 
@@ -110,7 +115,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		signer, err := i.prof.Input.SecureBoot.SecureBootSigner.GetSigner(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get SecureBoot signer: %w", err)
+			return xerrors.NewTaggedf[DependencyTag]("failed to get SecureBoot signer: %w", err)
 		}
 
 		defer signer.Close() //nolint:errcheck
@@ -118,7 +123,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 		derCrtPath := filepath.Join(i.tempDir, "uki.der")
 
 		if err = os.WriteFile(derCrtPath, signer.Certificate().Raw, 0o600); err != nil {
-			return fmt.Errorf("failed to write uki.der: %w", err)
+			return xerrors.NewTaggedf[IOTag]("failed to write uki.der: %w", err)
 		}
 
 		options := iso.Options{
@@ -151,7 +156,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		generator, err = options.CreateUEFI(ctx, printf)
 		if err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	case quirks.New(i.prof.Version).ISOSupportsSettingBootloader():
 		options := iso.Options{
@@ -175,20 +180,20 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 		case profile.BootLoaderKindDualBoot:
 			generator, err = options.CreateHybrid(ctx, printf)
 			if err != nil {
-				return err
+				return xerrors.NewTaggedf[DependencyTag]("%w", err)
 			}
 		case profile.BootLoaderKindSDBoot:
 			generator, err = options.CreateUEFI(ctx, printf)
 			if err != nil {
-				return err
+				return xerrors.NewTaggedf[DependencyTag]("%w", err)
 			}
 		case profile.BootLoaderKindGrub:
 			generator, err = options.CreateGRUB(printf)
 			if err != nil {
-				return err
+				return xerrors.NewTaggedf[DependencyTag]("%w", err)
 			}
 		case profile.BootLoaderKindNone:
-			return fmt.Errorf("cannot create ISO with no bootloader")
+			return xerrors.NewTaggedf[InvalidInputTag]("cannot create ISO with no bootloader")
 		}
 	case quirks.New(i.prof.Version).UseSDBootForUEFI():
 		options := iso.Options{
@@ -210,7 +215,7 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		generator, err = options.CreateHybrid(ctx, printf)
 		if err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	default:
 		options := iso.Options{
@@ -227,12 +232,12 @@ func (i *Imager) outISO(ctx context.Context, path string, report *reporter.Repor
 
 		generator, err = options.CreateGRUB(printf)
 		if err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	}
 
 	if err := generator.Generate(ctx); err != nil {
-		return err
+		return xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: "ISO ready", Status: reporter.StatusSucceeded})
@@ -252,22 +257,22 @@ func (i *Imager) outImage(ctx context.Context, path string, report *reporter.Rep
 		// nothing to do
 	case profile.DiskFormatQCOW2:
 		if err := qemuimg.Convert(ctx, "raw", "qcow2", i.prof.Output.ImageOptions.DiskFormatOptions, path, printf); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	case profile.DiskFormatVPC:
 		if err := qemuimg.Convert(ctx, "raw", "vpc", i.prof.Output.ImageOptions.DiskFormatOptions, path, printf); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	case profile.DiskFormatOVA:
 		scratchPath := filepath.Join(i.tempDir, "ova")
 
 		if err := ova.CreateOVAFromRAW(ctx, path, i.prof.Arch, scratchPath, i.prof.Output.ImageOptions.DiskSize, printf); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	case profile.DiskFormatUnknown:
 		fallthrough
 	default:
-		return fmt.Errorf("unsupported disk format: %s", i.prof.Output.ImageOptions.DiskFormat)
+		return xerrors.NewTaggedf[UnsupportedTag]("unsupported disk format: %s", i.prof.Output.ImageOptions.DiskFormat)
 	}
 
 	report.Report(reporter.Update{Message: "disk image ready", Status: reporter.StatusSucceeded})
@@ -302,7 +307,7 @@ func (i *Imager) prepareEnrollmentDBs(signer pesign.CertificateSigner) (pkPath, 
 		}
 
 		if len(missing) > 0 {
-			return "", "", "", fmt.Errorf("partial SecureBoot pre-built database configuration: missing %s", strings.Join(missing, ", "))
+			return "", "", "", xerrors.NewTaggedf[InvalidInputTag]("partial SecureBoot pre-built database configuration: missing %s", strings.Join(missing, ", "))
 		}
 
 		return pkPath, kekPath, dbPath, nil
@@ -315,14 +320,14 @@ func (i *Imager) prepareEnrollmentDBs(signer pesign.CertificateSigner) (pkPath, 
 
 	entries, err := database.Generate(enrolledPEM, signer, database.IncludeWellKnownCertificates(i.prof.Input.SecureBoot.IncludeWellKnownCerts))
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to generate database: %w", err)
+		return "", "", "", xerrors.NewTaggedf[DependencyTag]("failed to generate database: %w", err)
 	}
 
 	for _, entry := range entries {
 		entryPath := filepath.Join(i.tempDir, entry.Name)
 
 		if err := os.WriteFile(entryPath, entry.Contents, 0o600); err != nil {
-			return "", "", "", err
+			return "", "", "", xerrors.NewTaggedf[IOTag]("%w", err)
 		}
 
 		switch entry.Name {
@@ -333,7 +338,7 @@ func (i *Imager) prepareEnrollmentDBs(signer pesign.CertificateSigner) (pkPath, 
 		case constants.SignatureKeyAsset:
 			dbPath = entryPath
 		default:
-			return "", "", "", fmt.Errorf("unknown database entry: %s", entry.Name)
+			return "", "", "", xerrors.NewTaggedf[DependencyTag]("unknown database entry: %s", entry.Name)
 		}
 	}
 
@@ -389,7 +394,7 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 	if i.prof.SecureBootEnabled() && i.prof.Output.ImageOptions.SDBootEnrollKeys != profile.SDBootEnrollKeysOff {
 		signer, err := i.prof.Input.SecureBoot.SecureBootSigner.GetSigner(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get SecureBoot signer: %w", err)
+			return xerrors.NewTaggedf[DependencyTag]("failed to get SecureBoot signer: %w", err)
 		}
 
 		defer signer.Close() //nolint:errcheck
@@ -409,18 +414,18 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 		imageCacheDir := filepath.Join(i.tempDir, "imagecache")
 
 		if err := os.MkdirAll(imageCacheDir, 0o755); err != nil {
-			return err
+			return xerrors.NewTaggedf[IOTag]("%w", err)
 		}
 
 		if err := i.prof.Input.ImageCache.Extract(ctx, imageCacheDir, i.prof.Arch, printf, nil); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 
 		opts.ImageCachePath = imageCacheDir
 
 		imageCacheSize, err := calculateDirectorySizeWithOverhead(imageCacheDir, 20)
 		if err != nil {
-			return fmt.Errorf("failed to calculate image cache size: %w", err)
+			return xerrors.NewTaggedf[IOTag]("failed to calculate image cache size: %w", err)
 		}
 
 		// Align to a 1MiB boundary so both 512 and 4K sector sizes are covered.
@@ -439,16 +444,16 @@ func (i *Imager) buildImage(ctx context.Context, path string, printf func(string
 	}
 
 	if err := utils.CreateRawDisk(printf, path, i.prof.Output.ImageOptions.DiskSize, false); err != nil {
-		return err
+		return xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	installer, err := install.NewInstaller(ctx, cmdline, install.ModeImage, opts)
 	if err != nil {
-		return fmt.Errorf("failed to create installer: %w", err)
+		return xerrors.NewTaggedf[InstallTag]("failed to create installer: %w", err)
 	}
 
 	if err := installer.Install(ctx, install.ModeImage); err != nil {
-		return fmt.Errorf("failed to install: %w", err)
+		return xerrors.NewTaggedf[InstallTag]("failed to install: %w", err)
 	}
 
 	return nil
@@ -459,7 +464,7 @@ func calculateDirectorySizeWithOverhead(dir string, overheadPercentage int) (int
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return xerrors.NewTaggedf[IOTag]("%w", err)
 		}
 
 		if !info.IsDir() {
@@ -469,7 +474,7 @@ func calculateDirectorySizeWithOverhead(dir string, overheadPercentage int) (int
 		return nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	overhead := (totalSize * int64(overheadPercentage)) / 100
@@ -484,17 +489,17 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 	baseInstallerImg, err := i.prof.Input.BaseInstaller.Pull(ctx, i.prof.Arch, printf)
 	if err != nil {
-		return err
+		return xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	baseLayers, err := baseInstallerImg.Layers()
 	if err != nil {
-		return fmt.Errorf("failed to get layers: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to get layers: %w", err)
 	}
 
 	configFile, err := baseInstallerImg.ConfigFile()
 	if err != nil {
-		return fmt.Errorf("failed to get config file: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to get config file: %w", err)
 	}
 
 	config := *configFile.Config.DeepCopy()
@@ -511,17 +516,17 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 	newInstallerImg, err = mutate.ConfigFile(newInstallerImg, newCfgFile)
 	if err != nil {
-		return fmt.Errorf("failed to set image architecture: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to set image architecture: %w", err)
 	}
 
 	newInstallerImg, err = mutate.Config(newInstallerImg, config)
 	if err != nil {
-		return fmt.Errorf("failed to set config: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to set config: %w", err)
 	}
 
 	newInstallerImg, err = mutate.CreatedAt(newInstallerImg, v1.Time{Time: time.Now()})
 	if err != nil {
-		return fmt.Errorf("failed to set created at: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to set created at: %w", err)
 	}
 
 	// Talos v1.5+ optimizes the install layers to be easily replaceable with new artifacts
@@ -533,7 +538,7 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 	newInstallerImg, err = mutate.AppendLayers(newInstallerImg, baseLayers...)
 	if err != nil {
-		return fmt.Errorf("failed to append layers: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to append layers: %w", err)
 	}
 
 	var artifacts []filemap.File
@@ -576,19 +581,19 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 	artifactsLayer, err := filemap.Layer(artifacts)
 	if err != nil {
-		return fmt.Errorf("failed to create artifacts layer: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to create artifacts layer: %w", err)
 	}
 
 	newInstallerImg, err = mutate.AppendLayers(newInstallerImg, artifactsLayer)
 	if err != nil {
-		return fmt.Errorf("failed to append artifacts layer: %w", err)
+		return xerrors.NewTaggedf[DependencyTag]("failed to append artifacts layer: %w", err)
 	}
 
 	if i.overlayInstaller != nil {
 		tempOverlayPath := filepath.Join(i.tempDir, "overlay-installer", constants.ImagerOverlayBasePath)
 
 		if err := os.MkdirAll(tempOverlayPath, 0o755); err != nil {
-			return fmt.Errorf("failed to create overlay directory: %w", err)
+			return xerrors.NewTaggedf[IOTag]("failed to create overlay directory: %w", err)
 		}
 
 		if err := i.prof.Input.OverlayInstaller.Extract(
@@ -598,16 +603,16 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 			progressPrintf(report, reporter.Update{Message: "pulling overlay for installer...", Status: reporter.StatusRunning}),
 			nil,
 		); err != nil {
-			return err
+			return xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 
 		extraOpts, internalErr := yaml.Marshal(i.prof.Overlay.ExtraOptions)
 		if internalErr != nil {
-			return fmt.Errorf("failed to marshal extra options: %w", internalErr)
+			return xerrors.NewTaggedf[InvalidInputTag]("failed to marshal extra options: %w", internalErr)
 		}
 
 		if internalErr = os.WriteFile(filepath.Join(i.tempDir, constants.ImagerOverlayExtraOptionsPath), extraOpts, 0o644); internalErr != nil {
-			return fmt.Errorf("failed to write extra options yaml: %w", internalErr)
+			return xerrors.NewTaggedf[IOTag]("failed to write extra options yaml: %w", internalErr)
 		}
 
 		printf("generating overlay installer layer")
@@ -635,7 +640,7 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 			extraFiles, err = filemap.Walk(extraArtifact.sourcePath, extraArtifact.imagePath)
 			if err != nil {
-				return fmt.Errorf("failed to walk extra artifact %s: %w", extraArtifact.sourcePath, err)
+				return xerrors.NewTaggedf[IOTag]("failed to walk extra artifact %s: %w", extraArtifact.sourcePath, err)
 			}
 
 			overlayArtifacts = append(overlayArtifacts, extraFiles...)
@@ -643,24 +648,24 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 
 		overlayArtifactsLayer, internalErr := filemap.Layer(overlayArtifacts)
 		if internalErr != nil {
-			return fmt.Errorf("failed to create overlay artifacts layer: %w", internalErr)
+			return xerrors.NewTaggedf[DependencyTag]("failed to create overlay artifacts layer: %w", internalErr)
 		}
 
 		newInstallerImg, internalErr = mutate.AppendLayers(newInstallerImg, overlayArtifactsLayer)
 		if internalErr != nil {
-			return fmt.Errorf("failed to append overlay artifacts layer: %w", internalErr)
+			return xerrors.NewTaggedf[DependencyTag]("failed to append overlay artifacts layer: %w", internalErr)
 		}
 	}
 
 	ref, err := name.ParseReference(i.prof.Input.BaseInstaller.ImageRef)
 	if err != nil {
-		return fmt.Errorf("failed to parse image reference: %w", err)
+		return xerrors.NewTaggedf[InvalidInputTag]("failed to parse image reference: %w", err)
 	}
 
 	printf("writing image tarball")
 
 	if err := tarball.WriteToFile(path, ref, newInstallerImg); err != nil {
-		return fmt.Errorf("failed to write image tarball: %w", err)
+		return xerrors.NewTaggedf[IOTag]("failed to write image tarball: %w", err)
 	}
 
 	report.Report(reporter.Update{Message: "installer container image ready", Status: reporter.StatusSucceeded})

--- a/pkg/imager/post.go
+++ b/pkg/imager/post.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/go-cmd/pkg/cmd"
 
 	"github.com/siderolabs/talos/pkg/imager/utils"
@@ -27,19 +28,19 @@ func (i *Imager) postProcessTar(ctx context.Context, filename string, report *re
 	src := "disk.raw"
 
 	if err := os.Rename(filename, filepath.Join(dir, src)); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	outPath := filename + ".tar.gz"
 
 	pipeR, pipeW, err := os.Pipe()
 	if err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	timestamp, ok, err := utils.SourceDateEpoch()
 	if err != nil {
-		return "", fmt.Errorf("failed to get SOURCE_DATE_EPOCH: %w", err)
+		return "", xerrors.NewTaggedf[InvalidInputTag]("failed to get SOURCE_DATE_EPOCH: %w", err)
 	}
 
 	if !ok {
@@ -66,16 +67,16 @@ func (i *Imager) postProcessTar(ctx context.Context, filename string, report *re
 	cmd1.Stderr = os.Stderr
 
 	if err := cmd1.Start(); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	if err = pipeW.Close(); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	destination, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	defer destination.Close() //nolint:errcheck
@@ -86,11 +87,11 @@ func (i *Imager) postProcessTar(ctx context.Context, filename string, report *re
 	cmd2.Stderr = os.Stderr
 
 	if err := cmd2.Start(); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	if err = pipeR.Close(); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	errCh := make(chan error, 1)
@@ -105,16 +106,16 @@ func (i *Imager) postProcessTar(ctx context.Context, filename string, report *re
 
 	for range 2 {
 		if err = <-errCh; err != nil {
-			return "", err
+			return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 		}
 	}
 
 	if err := destination.Sync(); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	if err := os.Remove(filepath.Join(dir, src)); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[IOTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: fmt.Sprintf("archive is ready: %s", outPath), Status: reporter.StatusSucceeded})
@@ -126,7 +127,7 @@ func (i *Imager) postProcessGz(ctx context.Context, filename string, report *rep
 	report.Report(reporter.Update{Message: "compressing .gz", Status: reporter.StatusRunning})
 
 	if _, err := cmd.RunWithOptions(ctx, "pigz", []string{"-6", "--no-time", "-f", filename}); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: fmt.Sprintf("compression done: %s.gz", filename), Status: reporter.StatusSucceeded})
@@ -138,7 +139,7 @@ func (i *Imager) postProcessXz(ctx context.Context, filename string, report *rep
 	report.Report(reporter.Update{Message: "compressing .xz", Status: reporter.StatusRunning})
 
 	if _, err := cmd.RunWithOptions(ctx, "xz", []string{"-0", "-f", "-T", "0", filename}); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: fmt.Sprintf("compression done: %s.xz", filename), Status: reporter.StatusSucceeded})
@@ -152,7 +153,7 @@ func (i *Imager) postProcessZstd(ctx context.Context, filename string, report *r
 	out := filename + ".zst"
 
 	if _, err := cmd.RunWithOptions(ctx, "zstd", []string{"-T0", "--rm", "-18", "--quiet", "--force", "-o", out, filename}); err != nil {
-		return "", err
+		return "", xerrors.NewTaggedf[DependencyTag]("%w", err)
 	}
 
 	report.Report(reporter.Update{Message: fmt.Sprintf("compression done: %s", out), Status: reporter.StatusSucceeded})

--- a/pkg/imager/profile/profile.go
+++ b/pkg/imager/profile/profile.go
@@ -7,9 +7,9 @@ package profile
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/go-pointer"
 	"go.yaml.in/yaml/v4"
 
@@ -49,6 +49,14 @@ type Profile struct {
 	Output Output `yaml:"output"`
 }
 
+// Exit-code tags for profile validation failures.
+//
+//nolint:revive
+type (
+	InvalidInputTag struct{}
+	UnsupportedTag  struct{}
+)
+
 // OverlayOptions describes overlay options for image generation.
 type OverlayOptions struct {
 	// Name of the overlay installer, defaults to `default` if not set.
@@ -69,25 +77,25 @@ func (p *Profile) SecureBootEnabled() bool {
 //nolint:gocyclo,cyclop
 func (p *Profile) Validate() error {
 	if p.Arch != amd64 && p.Arch != arm64 {
-		return fmt.Errorf("invalid arch %q", p.Arch)
+		return xerrors.NewTaggedf[InvalidInputTag]("invalid arch %q", p.Arch)
 	}
 
 	if p.Platform == "" {
-		return errors.New("platform is required")
+		return xerrors.NewTagged[InvalidInputTag](errors.New("platform is required"))
 	}
 
 	if p.SecureBootEnabled() && !quirks.New(p.Version).SupportsUKI() {
-		return fmt.Errorf("secureboot is not supported for Talos version %q", p.Version)
+		return xerrors.NewTaggedf[UnsupportedTag]("secureboot is not supported for Talos version %q", p.Version)
 	}
 
 	switch p.Output.Kind {
 	case OutKindUnknown:
-		return errors.New("unknown output kind")
+		return xerrors.NewTagged[InvalidInputTag](errors.New("unknown output kind"))
 	case OutKindISO:
 		// ISO supports all kinds of customization
 		if quirks.New(p.Version).ISOSupportsSettingBootloader() {
 			if p.Output.ISOOptions != nil && p.Output.ISOOptions.Bootloader == BootLoaderKindNone {
-				return errors.New("bootloader cannot be 'none' for ISO output")
+				return xerrors.NewTagged[InvalidInputTag](errors.New("bootloader cannot be 'none' for ISO output"))
 			}
 		}
 	case OutKindCmdline:
@@ -95,31 +103,31 @@ func (p *Profile) Validate() error {
 	case OutKindImage:
 		// Image supports all kinds of customization
 		if p.Output.ImageOptions == nil {
-			return errors.New("image options are required for image output")
+			return xerrors.NewTagged[InvalidInputTag](errors.New("image options are required for image output"))
 		}
 
 		if p.Output.ImageOptions.DiskSize == 0 {
-			return errors.New("disk size is required for image output")
+			return xerrors.NewTagged[InvalidInputTag](errors.New("disk size is required for image output"))
 		}
 
 		if p.Output.ImageOptions.Bootloader == BootLoaderKindNone {
-			return errors.New("bootloader cannot be 'none' for disk image output")
+			return xerrors.NewTagged[InvalidInputTag](errors.New("bootloader cannot be 'none' for disk image output"))
 		}
 	case OutKindInstaller:
 		if len(p.Customization.MetaContents) > 0 {
-			return fmt.Errorf("customization of meta partition is not supported for %s output", p.Output.Kind)
+			return xerrors.NewTaggedf[UnsupportedTag]("customization of meta partition is not supported for %s output", p.Output.Kind)
 		}
 	case OutKindKernel, OutKindInitramfs:
 		if p.SecureBootEnabled() {
-			return fmt.Errorf("secureboot is not supported for %s output", p.Output.Kind)
+			return xerrors.NewTaggedf[UnsupportedTag]("secureboot is not supported for %s output", p.Output.Kind)
 		}
 
 		if len(p.Customization.ExtraKernelArgs) > 0 {
-			return fmt.Errorf("customization of kernel args is not supported for %s output", p.Output.Kind)
+			return xerrors.NewTaggedf[UnsupportedTag]("customization of kernel args is not supported for %s output", p.Output.Kind)
 		}
 
 		if len(p.Customization.MetaContents) > 0 {
-			return fmt.Errorf("customization of meta partition is not supported for %s output", p.Output.Kind)
+			return xerrors.NewTaggedf[UnsupportedTag]("customization of meta partition is not supported for %s output", p.Output.Kind)
 		}
 	case OutKindUKI:
 	}

--- a/pkg/installer/exitcode/exitcode.go
+++ b/pkg/installer/exitcode/exitcode.go
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package exitcode resolves installer/imager errors to stable process exit codes.
+package exitcode
+
+import (
+	"github.com/siderolabs/gen/xerrors"
+
+	installpkg "github.com/siderolabs/talos/cmd/installer/pkg/install"
+	pkgimager "github.com/siderolabs/talos/pkg/imager"
+	profilepkg "github.com/siderolabs/talos/pkg/imager/profile"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// Tagged reports whether err already carries a known installer/imager exit tag.
+func Tagged(err error) bool {
+	return err != nil && Resolve(err) != constants.ExitUnknownError
+}
+
+// Resolve returns stable installer/imager exit code for err.
+//
+// Priority order is explicit and deterministic. More specific caller-actionable
+// categories win over broader execution failures.
+func Resolve(err error) int {
+	if err == nil {
+		return constants.ExitSuccess
+	}
+
+	switch {
+	case xerrors.TagIs[profilepkg.InvalidInputTag](err),
+		xerrors.TagIs[pkgimager.InvalidInputTag](err),
+		xerrors.TagIs[installpkg.InvalidInputTag](err):
+		return constants.ExitInvalidInput
+	case xerrors.TagIs[profilepkg.UnsupportedTag](err),
+		xerrors.TagIs[pkgimager.UnsupportedTag](err):
+		return constants.ExitUnsupported
+	case xerrors.TagIs[installpkg.EnvironmentTag](err):
+		return constants.ExitEnvironment
+	case xerrors.TagIs[installpkg.DependencyTag](err),
+		xerrors.TagIs[pkgimager.DependencyTag](err):
+		return constants.ExitDependency
+	case xerrors.TagIs[pkgimager.IOTag](err):
+		return constants.ExitIO
+	case xerrors.TagIs[installpkg.InstallTag](err),
+		xerrors.TagIs[pkgimager.InstallTag](err):
+		return constants.ExitInstall
+	default:
+		return constants.ExitUnknownError
+	}
+}

--- a/pkg/installer/exitcode/exitcode_test.go
+++ b/pkg/installer/exitcode/exitcode_test.go
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package exitcode_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/assert"
+
+	installpkg "github.com/siderolabs/talos/cmd/installer/pkg/install"
+	pkgimager "github.com/siderolabs/talos/pkg/imager"
+	profilepkg "github.com/siderolabs/talos/pkg/imager/profile"
+	"github.com/siderolabs/talos/pkg/installer/exitcode"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, constants.ExitSuccess, exitcode.Resolve(nil))
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, constants.ExitUnknownError, exitcode.Resolve(errors.New("boom")))
+	})
+
+	for _, test := range []struct {
+		name string
+		err  error
+		code int
+	}{
+		{name: "invalid-input", err: xerrors.NewTagged[profilepkg.InvalidInputTag](errors.New("bad input")), code: constants.ExitInvalidInput},
+		{name: "unsupported", err: xerrors.NewTagged[profilepkg.UnsupportedTag](errors.New("unsupported")), code: constants.ExitUnsupported},
+		{name: "environment", err: xerrors.NewTagged[installpkg.EnvironmentTag](errors.New("env")), code: constants.ExitEnvironment},
+		{name: "dependency", err: xerrors.NewTagged[pkgimager.DependencyTag](errors.New("dep")), code: constants.ExitDependency},
+		{name: "io", err: xerrors.NewTagged[pkgimager.IOTag](errors.New("io")), code: constants.ExitIO},
+		{name: "install", err: xerrors.NewTagged[installpkg.InstallTag](errors.New("install")), code: constants.ExitInstall},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.code, exitcode.Resolve(test.err))
+			assert.Equal(t, test.code, exitcode.Resolve(fmt.Errorf("wrapped: %w", test.err)))
+		})
+	}
+}
+
+func TestResolvePriority(t *testing.T) {
+	t.Parallel()
+
+	err := xerrors.NewTagged[installpkg.InstallTag](
+		xerrors.NewTagged[pkgimager.DependencyTag](
+			xerrors.NewTagged[profilepkg.InvalidInputTag](errors.New("bad")),
+		),
+	)
+
+	assert.Equal(t, constants.ExitInvalidInput, exitcode.Resolve(err))
+}
+
+func TestTagged(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, exitcode.Tagged(errors.New("boom")))
+	assert.True(t, exitcode.Tagged(xerrors.NewTagged[installpkg.InstallTag](errors.New("boom"))))
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1413,3 +1413,32 @@ BUG_REPORT_URL="https://github.com/siderolabs/talos/issues"
 VENDOR_NAME="Sidero Labs"
 VENDOR_URL="https://www.siderolabs.com/"
 `
+
+// Installer/imager exit codes.
+//
+// These values are part of Talos public CLI API for the `installer` and
+// `imager` binaries. Their semantic meaning is stable across releases and may
+// be relied on by automation.
+const (
+	// ExitSuccess indicates successful completion.
+	ExitSuccess = 0
+	// ExitUnknownError is used when no known error category matches.
+	ExitUnknownError = 1
+	// ExitInvalidInput indicates invalid CLI input, profile/config content, or
+	// other user-supplied values rejected before execution can proceed.
+	ExitInvalidInput = 2
+	// ExitUnsupported indicates a requested operation is known but unsupported
+	// for the selected version/output/feature combination.
+	ExitUnsupported = 3
+	// ExitEnvironment indicates host runtime prerequisites are missing or
+	// unavailable.
+	ExitEnvironment = 4
+	// ExitDependency indicates failure in an external dependency such as image
+	// pulls, signer backends, or post-processing tooling.
+	ExitDependency = 5
+	// ExitIO indicates local filesystem or generic I/O failures.
+	ExitIO = 6
+	// ExitInstall indicates installation or image assembly failed after runtime
+	// execution began.
+	ExitInstall = 7
+)


### PR DESCRIPTION
Make automation distinguish invalid input, unsupported configs, host
environment issues, dependency failures, I/O problems, and install
runtime failures instead of treating every failure as exit code 1.

Fixes #13503

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
