### PR TITLE
fix: handle cluster-scoped resources with a namespace correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/siderolabs/go-debug v0.6.2
 	github.com/siderolabs/go-kmsg v0.1.6
 	github.com/siderolabs/go-kubeconfig v0.1.2
-	github.com/siderolabs/go-kubernetes v0.2.37
+	github.com/siderolabs/go-kubernetes v0.2.38
 	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pcidb v0.3.3
 	github.com/siderolabs/go-pointer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,8 @@ github.com/siderolabs/go-kmsg v0.1.6 h1:ZrJPExUnJubqiNA7T8RUi/ySvJsnIen+bdiY+pea
 github.com/siderolabs/go-kmsg v0.1.6/go.mod h1:fryspKc1f6nMIOK5YbUPutz2v2rdBTBeLqW/ci9BDfk=
 github.com/siderolabs/go-kubeconfig v0.1.2 h1:0D0v3lXUKon+A2qRFwOnc9m4qSB+e+5WDmvGjiJPH8Y=
 github.com/siderolabs/go-kubeconfig v0.1.2/go.mod h1:FMl17PHjjAJjdeUTMN+gBzGH0lhsCbj2IX9/HNMpMh0=
-github.com/siderolabs/go-kubernetes v0.2.37 h1:A7/8XZpsdHoJxkXrFL88cJ3t2KpB+tWzBaMGDsakHmY=
-github.com/siderolabs/go-kubernetes v0.2.37/go.mod h1:n9K8JCv6bRfK1P7c8insZglPsHMdUcvWmm/9LGLRNcc=
+github.com/siderolabs/go-kubernetes v0.2.38 h1:HzBHnSE0zA/7eXpqRnfDYS94F5KO9QMW6tOqIQ33O2Y=
+github.com/siderolabs/go-kubernetes v0.2.38/go.mod h1:4DBVXLASGnJIhbDRJNl9DayYohYLu3VhQ1cpY/Gj2nw=
 github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
 github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pcidb v0.3.3 h1:Cxng3j6gUrWCh1tHlt524A4cC+dyRU+3j1AWQM6ULPc=

--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -278,16 +278,6 @@ func (ctrl *ManifestApplyController) apply(
 		gvk := obj.GroupVersionKind()
 		objName := fmt.Sprintf("%s/%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind, obj.GetName())
 
-		objMeta, err := object.RuntimeToObjMeta(obj)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve object metadata of %q: %w", objName, err)
-		}
-
-		// check if the resource is already in the inventory, if so, skip applying it
-		if inv.Contains(objMeta) {
-			continue
-		}
-
 		mapping, err := mapper.RESTMapping(obj.GroupVersionKind().GroupKind(), obj.GroupVersionKind().Version)
 		if err != nil {
 			switch {
@@ -319,6 +309,32 @@ func (ctrl *ManifestApplyController) apply(
 		} else {
 			// for cluster-wide resources
 			dr = dyn.Resource(mapping.Resource)
+
+			objMeta, err := object.RuntimeToObjMeta(obj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve object metadata of %q: %w", objName, err)
+			}
+
+			// Talos v1.13 inserted the cluster-wide resources to the inventory with a namespace if they had one set, remove them from the inventory
+			if obj.GetNamespace() != "" && inv.Contains(objMeta) {
+				inv = inv.Remove(objMeta)
+
+				// The object was already in the inventory - skip applying it
+				continue
+			}
+
+			// user might have set the namespace by accident
+			obj.SetNamespace("")
+		}
+
+		objMeta, err := object.RuntimeToObjMeta(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve object metadata of %q: %w", objName, err)
+		}
+
+		// check if the resource is already in the inventory, if so, skip applying it
+		if inv.Contains(objMeta) {
+			continue
 		}
 
 		_, err = dr.Get(ctx, obj.GetName(), metav1.GetOptions{})


### PR DESCRIPTION
bump to-kubernetes that contains a fix and remove the ns on cluster-scoped resources such that they get correctly entered into the inventory

closes #13453
