### PR TITLE
feat: add unix scheme for log sender

### DIFF
--- a/internal/app/machined/pkg/runtime/logging/sender_jsonlines.go
+++ b/internal/app/machined/pkg/runtime/logging/sender_jsonlines.go
@@ -72,7 +72,7 @@ func (j *jsonLinesSender) Send(ctx context.Context, e *runtime.LogEvent) error {
 		return fmt.Errorf("%w: %s", runtime.ErrDontRetry, err)
 	}
 
-	if j.endpoint.Scheme == "tcp" {
+	if j.endpoint.Scheme == "tcp" || j.endpoint.Scheme == "unix" {
 		b = append(b, '\n')
 	}
 
@@ -85,7 +85,12 @@ func (j *jsonLinesSender) Send(ctx context.Context, e *runtime.LogEvent) error {
 
 	// Connect (or "connect" for UDP) if no connection is established already.
 	if j.conn == nil {
-		conn, err := new(net.Dialer).DialContext(ctx, j.endpoint.Scheme, j.endpoint.Host)
+		host := j.endpoint.Host
+		if j.endpoint.Scheme == "unix" {
+			host = j.endpoint.Path
+		}
+
+		conn, err := new(net.Dialer).DialContext(ctx, j.endpoint.Scheme, host)
 		if err != nil {
 			return err
 		}

--- a/internal/app/machined/pkg/runtime/logging/sender_jsonlines_test.go
+++ b/internal/app/machined/pkg/runtime/logging/sender_jsonlines_test.go
@@ -8,6 +8,8 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"sync"
@@ -69,19 +71,13 @@ func tcpHandler(ctx context.Context, t *testing.T, conn net.Listener, sendCh cha
 		default:
 		}
 
-		if err := conn.(*net.TCPListener).SetDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
-			t.Logf("failed to set accept deadline: %v", err)
-
-			return
-		}
-
 		c, err := conn.Accept()
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				continue
 			}
 
-			t.Logf("failed to accept UDP connection: %v", err)
+			t.Logf("failed to accept TCP connection: %v", err)
 
 			return
 		}
@@ -134,8 +130,16 @@ func TestSenderJSONLines(t *testing.T) { //nolint:tparallel
 		require.NoError(t, lisTCP.Close())
 	})
 
+	lisUNIX, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", fmt.Sprintf("/tmp/logs-%04x.sock", rand.Int32()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, lisUNIX.Close())
+	})
+
 	udpEndpoint := lisUDP.LocalAddr().String()
 	tcpEndpoint := lisTCP.Addr().String()
+	unixEndpoint := lisUNIX.Addr().String()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -149,7 +153,23 @@ func TestSenderJSONLines(t *testing.T) { //nolint:tparallel
 	})
 
 	wg.Go(func() {
+		if err := (lisTCP.(*net.TCPListener)).SetDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
+			t.Logf("failed to set accept deadline: %v", err)
+
+			return
+		}
+
 		tcpHandler(ctx, t, lisTCP, sendCh)
+	})
+
+	wg.Go(func() {
+		if err := (lisUNIX.(*net.UnixListener)).SetDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
+			t.Logf("failed to set accept deadline: %v", err)
+
+			return
+		}
+
+		tcpHandler(ctx, t, lisUNIX, sendCh)
 	})
 
 	t.Cleanup(wg.Wait)
@@ -268,6 +288,60 @@ func TestSenderJSONLines(t *testing.T) { //nolint:tparallel
 			name: "TCP with extra tags",
 
 			endpoint: ensure.Value(url.Parse("tcp://" + tcpEndpoint)),
+			extraTags: map[string]string{
+				"extra1": "value1",
+			},
+
+			messages: []*runtime.LogEvent{
+				{
+					Msg:   "hello",
+					Time:  ensure.Value(time.Parse(time.RFC3339Nano, "2021-01-01T00:00:00Z")),
+					Level: zapcore.InfoLevel,
+					Fields: map[string]any{
+						"field1": "value1",
+					},
+				},
+			},
+
+			expected: []map[string]any{
+				{
+					"field1":      "value1",
+					"extra1":      "value1",
+					"msg":         "hello",
+					"talos-level": "info",
+					"talos-time":  "2021-01-01T00:00:00Z",
+				},
+			},
+		},
+		{
+			name: "UNIX",
+
+			endpoint: ensure.Value(url.Parse("unix://" + unixEndpoint)),
+
+			messages: []*runtime.LogEvent{
+				{
+					Msg:   "hello",
+					Time:  ensure.Value(time.Parse(time.RFC3339Nano, "2021-01-01T00:00:00Z")),
+					Level: zapcore.InfoLevel,
+					Fields: map[string]any{
+						"field1": "value1",
+					},
+				},
+			},
+
+			expected: []map[string]any{
+				{
+					"field1":      "value1",
+					"msg":         "hello",
+					"talos-level": "info",
+					"talos-time":  "2021-01-01T00:00:00Z",
+				},
+			},
+		},
+		{
+			name: "UNIX with extra tags",
+
+			endpoint: ensure.Value(url.Parse("unix://" + unixEndpoint)),
 			extraTags: map[string]string{
 				"extra1": "value1",
 			},

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_logging.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_logging.go
@@ -33,7 +33,7 @@ func (lc *LoggingConfig) Validate() error {
 				errs = multierror.Append(errs, errors.New("empty logging endpoint's host"))
 			}
 
-			if endpoint.Scheme != "tcp" && endpoint.Scheme != "udp" {
+			if endpoint.Scheme != "tcp" && endpoint.Scheme != "udp" && endpoint.Scheme != "unix" {
 				errs = multierror.Append(errs, fmt.Errorf("unexpected logging endpoint scheme %q", endpoint.Scheme))
 			}
 		}

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -134,7 +134,7 @@ talosctl cluster create dev [flags]
       --bad-rtc                                  launch VM with bad RTC state
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                     search path for CNI binaries (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/v1.14.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/d6310c9c1/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                     CNI cache directory path (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (default "/home/user/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
@@ -349,7 +349,7 @@ talosctl cluster create dev [flags]
       --bad-rtc                                  launch VM with bad RTC state
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                     search path for CNI binaries (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/v1.14.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/d6310c9c1/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                     CNI cache directory path (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (default "/home/user/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
@@ -3454,7 +3454,7 @@ talosctl upgrade [flags]
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for upgrade
-  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-alpha.1")
+  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:d6310c9c1")
       --legacy                     force use of legacy upgrade method
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
   -n, --nodes strings              target the specified nodes


### PR DESCRIPTION
# Pull Request

## What? (description)

Adding support for UNIX scheme in log sender implementation

## Why? (reasoning)

Can be use with a local running collector (Vector or Logstash) to buffer log while the network is starting.
Can also be use to avoid exposing IP when decorating/transforming logs with a local collector (Talos -> Vector (transform/add meta) -> and then send to OTLP/...)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
