### PR TITLE
fix: etcd client leak in the (legacy) Upgrade API

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -531,11 +531,13 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (*mach
 		return nil, fmt.Errorf("error validating installer image %q: %w", in.GetImage(), err)
 	}
 
-	if !inMaintenance && s.Controller.Runtime().Config().Machine().Type() != machinetype.TypeWorker && !in.GetForce() {
+	if !inMaintenance && s.Controller.Runtime().Config().Machine().Type() != machinetype.TypeWorker && !in.GetForce() && !in.GetPreserve() {
 		etcdClient, err := etcd.NewClientFromControlPlaneIPs(ctx, s.Controller.Runtime().State().V1Alpha2().Resources())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create etcd client: %w", err)
 		}
+
+		defer etcdClient.Close() //nolint:errcheck
 
 		// acquire the upgrade mutex
 		unlocker, err := tryLockUpgradeMutex(ctx, etcdClient)

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -145,6 +145,8 @@ func validateMemberHealth(ctx context.Context, memberURIs []string) (err error) 
 		return fmt.Errorf("failed to create client to member: %w", err)
 	}
 
+	defer c.Close() //nolint:errcheck
+
 	return c.ValidateQuorum(ctx)
 }
 


### PR DESCRIPTION
This doesn't affect new upgrade API.

There were two leaks in the validate path, usually they are harmless, as the Upgrade triggers a reboot, so a couple of leaking clients doesn't matter, but if they API is called repeatedly (and it fails to upgrade), the leak accumulates until `etcd` container runs out of file descriptor, eventually preventing new connections to `etcd` from being established.

Also put the etcd pre-checks under the `!preserve` condition (means the API requests wipe). The wipe behavior was disabled by default for a long time, and all etcd pre-checks only make sense if the wipe is called, otherwise upgrade doesn't affect etcd membership in any way.
