### PR TITLE
fix(ci): aws nvidia tests

### DIFF
--- a/internal/integration/api/extensions_nvidia.go
+++ b/internal/integration/api/extensions_nvidia.go
@@ -91,15 +91,15 @@ func (suite *ExtensionsSuiteNVIDIA) TestExtensionsNVIDIA() {
 	missingCDIFilesData := map[string]map[string]int{
 		"amd64": {
 			"nvidia-open-gpu-kernel-modules-production": 13,
-			"nvidia-open-gpu-kernel-modules-lts":        9,
+			"nvidia-open-gpu-kernel-modules-lts":        11,
 			"nonfree-kmod-nvidia-production":            13,
-			"nonfree-kmod-nvidia-lts":                   9,
+			"nonfree-kmod-nvidia-lts":                   11,
 		},
 		"arm64": {
 			"nvidia-open-gpu-kernel-modules-production": 11,
-			"nvidia-open-gpu-kernel-modules-lts":        9,
+			"nvidia-open-gpu-kernel-modules-lts":        11,
 			"nonfree-kmod-nvidia-production":            11,
-			"nonfree-kmod-nvidia-lts":                   9,
+			"nonfree-kmod-nvidia-lts":                   11,
 		},
 	}
 


### PR DESCRIPTION
nvidia-container-toolkit v1.19.1 added two more files which the drivers don't ship yet.

See: https://github.com/NVIDIA/nvidia-container-toolkit/commit/465237b92d600293333e9b4e32acf036dadf3f2f
Toolkit was bumped in extensions at: https://github.com/siderolabs/extensions/pull/1102