### PR TITLE
feat: implement support bundle encryption

### DIFF
--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/fatih/color"
 	"github.com/gosuri/uiprogress"
 	"github.com/siderolabs/go-talos-support/support"
 	"github.com/siderolabs/go-talos-support/support/bundle"
+	"github.com/siderolabs/go-talos-support/support/bundle/encryption"
 	"github.com/siderolabs/go-talos-support/support/collectors"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -33,9 +33,12 @@ import (
 )
 
 var supportCmdFlags struct {
-	output     string
-	numWorkers int
-	verbose    bool
+	output                        string
+	numWorkers                    int
+	verbose                       bool
+	noEncryption                  bool
+	encryptionRecipients          []string
+	encryptionNoDefaultRecipients bool
 }
 
 // supportCmd represents the support command.
@@ -60,11 +63,38 @@ var supportCmd = &cobra.Command{
 - For the cluster:
 
 	- Kubernetes nodes and kube-system pods manifests.
+
+By default, the generated bundle is encrypted using age encryption to the list of recipients
+set by the members of the 'siderolabs' GitHub organization. The encrypted bundle by default will
+only be decryptable by the Sidero Labs team, but you can also specify additional recipients using the
+--encryption-recipients flag, or disable encryption completely using the --no-encryption flag.
+Default encryption recipients can be removed by setting --encryption-no-default-recipients flag.
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(GlobalArgs.Nodes) == 0 {
 			return errors.New("please provide at least a single node to gather the debug information from")
+		}
+
+		if supportCmdFlags.noEncryption && (len(supportCmdFlags.encryptionRecipients) > 0 || supportCmdFlags.encryptionNoDefaultRecipients) {
+			return errors.New("--encryption-recipients and --encryption-no-default-recipients cannot be used with --no-encryption")
+		}
+
+		var encryptionOpts []encryption.Option
+
+		if !supportCmdFlags.noEncryption {
+			opts, recipients, err := buildEncryptionOptions()
+			if err != nil {
+				return err
+			}
+
+			encryptionOpts = opts
+
+			fmt.Fprintln(os.Stderr, "Encrypting support bundle to the following recipients:")
+
+			for _, r := range recipients {
+				fmt.Fprintf(os.Stderr, "  - %s\n", r)
+			}
 		}
 
 		f, err := openArchive(cmd.Context())
@@ -73,6 +103,20 @@ var supportCmd = &cobra.Command{
 		}
 
 		defer f.Close() //nolint:errcheck
+
+		var (
+			archiveOutput io.Writer = f
+			encWriter     io.WriteCloser
+		)
+
+		if !supportCmdFlags.noEncryption {
+			encWriter, err = encryption.Encrypt(f, encryptionOpts...)
+			if err != nil {
+				return err
+			}
+
+			archiveOutput = encWriter
+		}
 
 		progress := make(chan bundle.Progress)
 
@@ -93,12 +137,19 @@ var supportCmd = &cobra.Command{
 			return nil
 		})
 
-		collectErr := collectData(cmd.Context(), f, progress)
+		collectErr := collectData(cmd.Context(), archiveOutput, progress)
 
 		close(progress)
 
 		if e := eg.Wait(); e != nil {
 			return e
+		}
+
+		// flush the age encryption layer before reporting success.
+		if encWriter != nil {
+			if err = encWriter.Close(); err != nil {
+				return err
+			}
 		}
 
 		if err = errors.print(); err != nil {
@@ -111,7 +162,7 @@ var supportCmd = &cobra.Command{
 	},
 }
 
-func collectData(ctx context.Context, dest *os.File, progress chan bundle.Progress) error {
+func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progress) error {
 	return WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		clientset, err := getKubernetesClient(ctx, c)
 		if err != nil {
@@ -172,16 +223,16 @@ func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset,
 	return clientset, nil
 }
 
-func getDiscoveryConfig(ctx context.Context) (*clusterresource.Config, error) {
-	var config *clusterresource.Config
+func getClusterInfo(ctx context.Context) (*clusterresource.Info, error) {
+	var info *clusterresource.Info
 
-	if e := WithClient(ctx, func(ctx context.Context, c *client.Client) error {
+	if e := WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
 		var err error
 
-		config, err = safe.StateGet[*clusterresource.Config](
+		info, err = safe.StateGetByID[*clusterresource.Info](
 			ctx,
 			c.COSI,
-			resource.NewMetadata(clusterresource.NamespaceName, clusterresource.IdentityType, clusterresource.LocalIdentity, resource.VersionUndefined),
+			clusterresource.InfoID,
 		)
 
 		return err
@@ -189,18 +240,58 @@ func getDiscoveryConfig(ctx context.Context) (*clusterresource.Config, error) {
 		return nil, e
 	}
 
-	return config, nil
+	return info, nil
+}
+
+// buildEncryptionOptions builds the age encryption options based on the command
+// flags and returns the list of recipients (for display) the bundle is encrypted to.
+func buildEncryptionOptions() ([]encryption.Option, []string, error) {
+	var (
+		opts       []encryption.Option
+		recipients []string
+	)
+
+	if supportCmdFlags.encryptionNoDefaultRecipients {
+		if len(supportCmdFlags.encryptionRecipients) == 0 {
+			return nil, nil, errors.New("no recipients to encrypt to: --encryption-no-default-recipients is set but no --encryption-recipients provided")
+		}
+
+		opts = append(opts, encryption.WithRecipients(supportCmdFlags.encryptionRecipients...))
+		recipients = append(recipients, supportCmdFlags.encryptionRecipients...)
+
+		return opts, recipients, nil
+	}
+
+	defaults, err := encryption.DefaultRecipients()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, r := range defaults {
+		recipients = append(recipients, r.String())
+	}
+
+	if len(supportCmdFlags.encryptionRecipients) > 0 {
+		opts = append(opts, encryption.WithAdditionalRecipients(supportCmdFlags.encryptionRecipients...))
+		recipients = append(recipients, supportCmdFlags.encryptionRecipients...)
+	}
+
+	return opts, recipients, nil
 }
 
 func openArchive(ctx context.Context) (*os.File, error) {
 	if supportCmdFlags.output == "" {
 		supportCmdFlags.output = "support"
 
-		if config, err := getDiscoveryConfig(ctx); err == nil && config.TypedSpec().DiscoveryEnabled {
-			supportCmdFlags.output += "-" + config.TypedSpec().ServiceClusterID
+		if info, err := getClusterInfo(ctx); err == nil && info.TypedSpec().ClusterName != "" {
+			supportCmdFlags.output += "-" + info.TypedSpec().ClusterName
 		}
 
 		supportCmdFlags.output += ".zip"
+
+		if !supportCmdFlags.noEncryption {
+			supportCmdFlags.output += ".age"
+		}
 	}
 
 	if _, err := os.Stat(supportCmdFlags.output); err != nil {
@@ -340,4 +431,16 @@ func init() {
 	supportCmd.Flags().StringVarP(&supportCmdFlags.output, "output", "O", "", "output file to write support archive to")
 	supportCmd.Flags().IntVarP(&supportCmdFlags.numWorkers, "num-workers", "w", 1, "number of workers per node")
 	supportCmd.Flags().BoolVarP(&supportCmdFlags.verbose, "verbose", "v", false, "verbose output")
+	supportCmd.Flags().BoolVar(
+		&supportCmdFlags.noEncryption, "no-encryption", false,
+		"do not encrypt the support bundle (output is written as-is)",
+	)
+	supportCmd.Flags().StringArrayVar(
+		&supportCmdFlags.encryptionRecipients, "encryption-recipients", nil,
+		"additional age recipients (SSH or age public keys) to encrypt the support bundle to (can be specified multiple times)",
+	)
+	supportCmd.Flags().BoolVar(
+		&supportCmdFlags.encryptionNoDefaultRecipients, "encryption-no-default-recipients", false,
+		"do not encrypt to the default recipients, only to the ones provided via --encryption-recipients",
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-smbios v0.3.4
 	github.com/siderolabs/go-tail v0.1.1
-	github.com/siderolabs/go-talos-support v0.2.1
+	github.com/siderolabs/go-talos-support v0.2.2
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/siderolabs/kms-client v0.2.0
 	github.com/siderolabs/net v0.4.0
@@ -195,6 +195,9 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.1 // indirect
+	filippo.io/age v1.3.1 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
+	filippo.io/hpke v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -19,8 +21,12 @@ cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7
 cloud.google.com/go/longrunning v0.8.0/go.mod h1:UmErU2Onzi+fKDg2gR7dusz11Pe26aknR4kHmJJqIfk=
 codeberg.org/miekg/dns v0.6.79 h1:ixlSbch4aCtV/GuhBgbPw33V3tqovMFSOGyPA9u48FM=
 codeberg.org/miekg/dns v0.6.79/go.mod h1:58Y3ZTg6Z5ZEm/ZAAwHehbZfrD4u5mE4RByHoPEMyKk=
+filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
+filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
+filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230919221257-8b5d3ce2d11d h1:zjqpY4C7H15HjRPEenkS4SAn3Jy2eRRjkjZbGR30TOg=
@@ -827,8 +833,8 @@ github.com/siderolabs/go-smbios v0.3.4 h1:3HvW8lf+kw+HnC67XzdCH8WhkDeX+K9W4VmV54
 github.com/siderolabs/go-smbios v0.3.4/go.mod h1:lNA6mNOsqhDQcE7HnAtATOa8F9CU8Q69M5wyNUSU0Co=
 github.com/siderolabs/go-tail v0.1.1 h1:3XeJgd97OHyFAIE7nQEMcRhOfnv7DvXbu0BRKbtT6u8=
 github.com/siderolabs/go-tail v0.1.1/go.mod h1:IihAL39acadXHfb5fEAOKK2DaDFIrG2+VD3b2H/ziZ0=
-github.com/siderolabs/go-talos-support v0.2.1 h1:QVFhcmGw1ZTTXEtukBgrdjNxYbsPAOTMpopisV4EbgU=
-github.com/siderolabs/go-talos-support v0.2.1/go.mod h1:tfwP9mpPdmqLU8DuCDgcAd0ficLlJuB/XMtrIV8g+20=
+github.com/siderolabs/go-talos-support v0.2.2 h1:5urNuBSZdWrJhScWrjuaxf9xXmJFWTdx5YJO/iP3fko=
+github.com/siderolabs/go-talos-support v0.2.2/go.mod h1:IB9sOkhUgjGJFuuBs+TZVdjgG01ly8/Ku9SOshINvSU=
 github.com/siderolabs/grpc-proxy v0.5.2 h1:o34tS02IxbX3qeXe0MM99zE2XhfWHuvdBtSWWRD9HNI=
 github.com/siderolabs/grpc-proxy v0.5.2/go.mod h1:ygf+gqFxWdymAXuP4qMHTa+j6SvasdcFg3XkhpvUvDw=
 github.com/siderolabs/kms-client v0.2.0 h1:8RniCStUI75RTZO8qkhHOSVOnEU1AvvsKqJ7FqW/8NA=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -186,6 +186,13 @@ This feature allows for selective wiping of logical volumes, volume groups, and 
 With `talosctl wipe lv/vg/pv <name>`, users can wipe LVM metadata from a specific logical volume, volume group, or physical volume.
 """
 
+    [notes.support_bundle]
+        title = "Support Bundle Encryption"
+        description = """\
+The `talosctl support` command now encrypts support bundles using the age encryption tool, enhancing the security of support data.
+The default set of recipients includes the 'siderolabs' GitHub organization members, but it can be overridden with custom recipients.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/cli/support.go
+++ b/internal/integration/cli/support.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"archive/zip"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -26,8 +27,10 @@ func (suite *SupportSuite) SuiteName() string {
 	return "cli.SupportSuite"
 }
 
-// TestSupport does successful support run.
-func (suite *SupportSuite) TestSupport() {
+// TestSupportNoEncryption does successful support run without encryption.
+//
+// Encryption is disabled to verify support bundled contents.
+func (suite *SupportSuite) TestSupportNoEncryption() {
 	tempDir := suite.T().TempDir()
 
 	output := filepath.Join(tempDir, "support.zip")
@@ -35,7 +38,7 @@ func (suite *SupportSuite) TestSupport() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
 	suite.RunCLI(
-		[]string{"support", "--nodes", node, "-w", "5", "-O", output},
+		[]string{"support", "--nodes", node, "-w", "5", "-O", output, "--no-encryption"},
 		base.StderrNotEmpty(),
 	)
 
@@ -97,6 +100,29 @@ func (suite *SupportSuite) TestSupport() {
 	} {
 		suite.Require().Contains(files, name, "File %s doesn't exist in the support bundle", name)
 	}
+}
+
+// TestSupportWithEncryption does successful support run with encryption.
+//
+// Support bundle contents are not verified as they are encrypted.
+func (suite *SupportSuite) TestSupportWithEncryption() {
+	tempDir := suite.T().TempDir()
+
+	output := filepath.Join(tempDir, "support.zip.age")
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+
+	suite.RunCLI(
+		[]string{"support", "--nodes", node, "-w", "5", "-O", output},
+		base.StderrNotEmpty(),
+	)
+
+	suite.Require().FileExists(output)
+
+	st, err := os.Stat(output)
+	suite.Require().NoError(err)
+
+	suite.Require().Greater(st.Size(), int64(1024))
 }
 
 func init() {

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -3387,6 +3387,12 @@ Generated bundle contains the following debug information:
 
 	- Kubernetes nodes and kube-system pods manifests.
 
+By default, the generated bundle is encrypted using age encryption to the list of recipients
+set by the members of the 'siderolabs' GitHub organization. The encrypted bundle by default will
+only be decryptable by the Sidero Labs team, but you can also specify additional recipients using the
+--encryption-recipients flag, or disable encryption completely using the --no-encryption flag.
+Default encryption recipients can be removed by setting --encryption-no-default-recipients flag.
+
 
 ```
 talosctl support [flags]
@@ -3395,16 +3401,19 @@ talosctl support [flags]
 ### Options
 
 ```
-  -c, --cluster string             Cluster to connect to if a proxy endpoint is used.
-      --context string             Context to be used in command
-  -e, --endpoints strings          override default endpoints in Talos configuration
-  -h, --help                       help for support
-  -n, --nodes strings              target the specified nodes
-  -w, --num-workers int            number of workers per node (default 1)
-  -O, --output string              output file to write support archive to
-      --siderov1-keys-dir string   The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
-      --talosconfig string         The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
-  -v, --verbose                    verbose output
+  -c, --cluster string                      Cluster to connect to if a proxy endpoint is used.
+      --context string                      Context to be used in command
+      --encryption-no-default-recipients    do not encrypt to the default recipients, only to the ones provided via --encryption-recipients
+      --encryption-recipients stringArray   additional age recipients (SSH or age public keys) to encrypt the support bundle to (can be specified multiple times)
+  -e, --endpoints strings                   override default endpoints in Talos configuration
+  -h, --help                                help for support
+      --no-encryption                       do not encrypt the support bundle (output is written as-is)
+  -n, --nodes strings                       target the specified nodes
+  -w, --num-workers int                     number of workers per node (default 1)
+  -O, --output string                       output file to write support archive to
+      --siderov1-keys-dir string            The path to the SideroV1 auth PGP keys directory. Defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'. Only valid for Contexts that use SideroV1 auth.
+      --talosconfig string                  The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
+  -v, --verbose                             verbose output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
See https://github.com/siderolabs/go-talos-support/pull/16

By default, support bunlde is encrypted to the members of siderolabs GitHub org, but a user can override this, or supply a custom set of recipients.

This way support bundle is more safe to be shared e.g. in the GitHub issue.
