### PR TITLE
fix: flaky test

### DIFF
--- a/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
+++ b/internal/app/machined/pkg/controllers/network/dns_resolve_cache_test.go
@@ -331,7 +331,7 @@ func TestDNSServer(t *testing.T) {
 func getDynamicPort(t *testing.T) string {
 	t.Helper()
 
-	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", net.JoinHostPort("127.0.0.53", "0"))
 	require.NoError(t, err)
 
 	addr := l.Addr().String()


### PR DESCRIPTION
DNS test was using 127.0.0.53 as the IP but `getDynamicPort` was checking for 127.0.0.1 instead.