### PR TITLE
refactor: talosctl streaming commands and more fixes

### DIFF
--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -23,6 +23,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
+var containersCmdFlags struct {
+	kubernetesNamespaceFlag
+}
+
 // containersCmd represents the processes command.
 var containersCmd = &cobra.Command{
 	Use:     "containers",
@@ -33,7 +37,7 @@ var containersCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		clientFactory, err := NewClientFactory(ctx, nil)
+		clientFactory, err := NewClientFactory(ctx, &containersCmdFlags)
 		if err != nil {
 			return err
 		}
@@ -45,7 +49,7 @@ var containersCmd = &cobra.Command{
 			driver    common.ContainerDriver
 		)
 
-		if kubernetesFlag {
+		if containersCmdFlags.kubernetes {
 			namespace = constants.K8sContainerdNamespace
 			driver = common.ContainerDriver_CRI
 		} else {
@@ -106,7 +110,7 @@ var containersCmd = &cobra.Command{
 }
 
 func init() {
-	containersCmd.Flags().BoolVarP(&kubernetesFlag, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	containersCmd.Flags().BoolVarP(&containersCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 
 	containersCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	containersCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -34,7 +34,7 @@ captures ownership and permission bits.`,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
-			return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
+			return completePathFromNode(cmd.Context(), nil, toComplete), cobra.ShellCompDirectiveNoFileComp
 		case 1:
 			return nil, cobra.ShellCompDirectiveDefault
 		}

--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -16,15 +16,17 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
-var (
+var duCmdFlags struct {
+	humanize  bool
 	all       bool
 	threshold int64
-)
+	depth     int32
+}
 
 // duCmd represents the du command.
 var duCmd = &cobra.Command{
@@ -39,7 +41,7 @@ var duCmd = &cobra.Command{
 
 		var completeOnlyPaths []string
 
-		for _, path := range completePathFromNode(cmd.Context(), toComplete) {
+		for _, path := range completePathFromNode(cmd.Context(), &duCmdFlags, toComplete) {
 			if path[len(path)-1:] == "/" {
 				completeOnlyPaths = append(completeOnlyPaths, path)
 			}
@@ -48,84 +50,100 @@ var duCmd = &cobra.Command{
 		return completeOnlyPaths, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			var paths []string
+		ctx := cmd.Context()
 
-			if len(args) == 0 {
-				paths = []string{"/"}
-			} else {
-				paths = args
+		clientFactory, err := NewClientFactory(ctx, &duCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		var paths []string
+
+		if len(args) == 0 {
+			paths = []string{"/"}
+		} else {
+			paths = args
+		}
+
+		multipleNodes := len(clientFactory.Nodes()) > 1
+
+		responseChan := multiplex.StreamingViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (machineapi.MachineService_DiskUsageClient, error) {
+				return c.DiskUsage(ctx, &machineapi.DiskUsageRequest{
+					RecursionDepth: duCmdFlags.depth + 1,
+					All:            duCmdFlags.all,
+					Threshold:      duCmdFlags.threshold,
+					Paths:          paths,
+				})
+			},
+		)
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		defer w.Flush() //nolint:errcheck
+
+		stringifySize := func(s int64) string {
+			if duCmdFlags.humanize {
+				return humanize.Bytes(uint64(s))
 			}
 
-			stream, err := c.DiskUsage(ctx, &machineapi.DiskUsageRequest{
-				RecursionDepth: recursionDepth + 1,
-				All:            all,
-				Threshold:      threshold,
-				Paths:          paths,
-			})
-			if err != nil {
-				return fmt.Errorf("error fetching disk usage: %s", err)
+			return strconv.FormatInt(s, 10)
+		}
+
+		var (
+			errs          error
+			headerWritten bool
+		)
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
 			}
 
-			addedHeader := false
+			info := resp.Payload
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+			if info.Error != "" {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %s", resp.Node, info.Error))
 
-			stringifySize := func(s int64) string {
-				if humanizeFlag {
-					return humanize.Bytes(uint64(s))
-				}
-
-				return strconv.FormatInt(s, 10)
+				continue
 			}
 
-			defer w.Flush() //nolint:errcheck
-
-			return helpers.ReadGRPCStream(stream, func(info *machineapi.DiskUsageInfo, node string, multipleNodes bool) error {
-				if info.Error != "" {
-					return helpers.NonFatalError(errors.New(info.Error))
-				}
-
-				pattern := "%s\t%s\n"
-
-				size := stringifySize(info.Size)
-
-				args := []any{
-					size, info.RelativeName,
-				}
-
-				if info.Metadata != nil && info.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					multipleNodes = true
-					node = info.Metadata.Hostname //nolint:staticcheck // to be refactored next
-				}
-
-				if !addedHeader {
-					if multipleNodes {
-						fmt.Fprintln(w, "NODE\tSIZE\tNAME")
-					} else {
-						fmt.Fprintln(w, "SIZE\tNAME")
-					}
-
-					addedHeader = true
-				}
-
+			if !headerWritten {
 				if multipleNodes {
-					pattern = "%s\t%s\t%s\n"
-					args = slices.Insert(args, 0, any(node))
+					fmt.Fprintln(w, "NODE\tSIZE\tNAME")
+				} else {
+					fmt.Fprintln(w, "SIZE\tNAME")
 				}
 
-				fmt.Fprintf(w, pattern, args...)
+				headerWritten = true
+			}
 
-				return nil
-			})
-		})
+			pattern := "%s\t%s\n"
+
+			outputArgs := []any{
+				stringifySize(info.Size), info.RelativeName,
+			}
+
+			if multipleNodes {
+				pattern = "%s\t%s\t%s\n"
+				outputArgs = slices.Insert(outputArgs, 0, any(resp.Node))
+			}
+
+			fmt.Fprintf(w, pattern, outputArgs...)
+		}
+
+		return errs
 	},
 }
 
 func init() {
-	duCmd.Flags().BoolVarP(&humanizeFlag, "humanize", "H", false, "humanize size and time in the output")
-	duCmd.Flags().BoolVarP(&all, "all", "a", false, "write counts for all files, not just directories")
-	duCmd.Flags().Int64VarP(&threshold, "threshold", "t", 0, "threshold exclude entries smaller than SIZE if positive, or entries greater than SIZE if negative")
-	duCmd.Flags().Int32VarP(&recursionDepth, "depth", "d", 0, "maximum recursion depth")
+	duCmd.Flags().BoolVarP(&duCmdFlags.humanize, "humanize", "H", false, "humanize size and time in the output")
+	duCmd.Flags().BoolVarP(&duCmdFlags.all, "all", "a", false, "write counts for all files, not just directories")
+	duCmd.Flags().Int64VarP(&duCmdFlags.threshold, "threshold", "t", 0, "threshold exclude entries smaller than SIZE if positive, or entries greater than SIZE if negative")
+	duCmd.Flags().Int32VarP(&duCmdFlags.depth, "depth", "d", 0, "maximum recursion depth")
 	addCommand(duCmd)
 }

--- a/cmd/talosctl/cmd/talos/dmesg.go
+++ b/cmd/talosctl/cmd/talos/dmesg.go
@@ -6,16 +6,20 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
-var dmesgTail bool
+var dmesgCmdFlags struct {
+	follow bool
+	tail   bool
+}
 
 // dmesgCmd represents the dmesg command.
 var dmesgCmd = &cobra.Command{
@@ -24,25 +28,42 @@ var dmesgCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			stream, err := c.Dmesg(ctx, follow, dmesgTail)
-			if err != nil {
-				return fmt.Errorf("error getting dmesg: %w", err)
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &dmesgCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		responseChan := multiplex.StreamingViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (machineapi.MachineService_DmesgClient, error) {
+				return c.Dmesg(ctx, dmesgCmdFlags.follow, dmesgCmdFlags.tail)
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
 			}
 
-			return helpers.ReadGRPCStream(stream, func(data *common.Data, node string, multipleNodes bool) error {
-				if data.Bytes != nil {
-					fmt.Printf("%s: %s", node, data.Bytes)
-				}
+			if resp.Payload.Bytes != nil {
+				fmt.Printf("%s: %s", resp.Node, resp.Payload.Bytes)
+			}
+		}
 
-				return nil
-			})
-		})
+		return errs
 	},
 }
 
 func init() {
 	addCommand(dmesgCmd)
-	dmesgCmd.Flags().BoolVarP(&follow, "follow", "f", false, "specify if the kernel log should be streamed")
-	dmesgCmd.Flags().BoolVarP(&dmesgTail, "tail", "", false, "specify if only new messages should be sent (makes sense only when combined with --follow)")
+	dmesgCmd.Flags().BoolVarP(&dmesgCmdFlags.follow, "follow", "f", false, "specify if the kernel log should be streamed")
+	dmesgCmd.Flags().BoolVarP(&dmesgCmdFlags.tail, "tail", "", false, "specify if only new messages should be sent (makes sense only when combined with --follow)")
 }

--- a/cmd/talosctl/cmd/talos/events.go
+++ b/cmd/talosctl/cmd/talos/events.go
@@ -16,9 +16,9 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var eventsCmdFlags struct {
@@ -34,89 +34,112 @@ var eventsCmd = &cobra.Command{
 	Short: "Stream runtime events",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tID\tEVENT\tACTOR\tSOURCE\tMESSAGE")
+		ctx := cmd.Context()
 
-			var opts []client.EventsOptionFunc
+		clientFactory, err := NewClientFactory(ctx, &eventsCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			if eventsCmdFlags.tailEvents != 0 {
-				opts = append(opts, client.WithTailEvents(eventsCmdFlags.tailEvents))
+		defer clientFactory.Close() //nolint:errcheck
+
+		var opts []client.EventsOptionFunc
+
+		if eventsCmdFlags.tailEvents != 0 {
+			opts = append(opts, client.WithTailEvents(eventsCmdFlags.tailEvents))
+		}
+
+		if eventsCmdFlags.tailDuration != 0 {
+			opts = append(opts, client.WithTailDuration(eventsCmdFlags.tailDuration))
+		}
+
+		if eventsCmdFlags.tailID != "" {
+			opts = append(opts, client.WithTailID(eventsCmdFlags.tailID))
+		}
+
+		if eventsCmdFlags.actorID != "" {
+			opts = append(opts, client.WithActorID(eventsCmdFlags.actorID))
+		}
+
+		responseChan := multiplex.StreamingViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (machine.MachineService_EventsClient, error) {
+				return c.Events(ctx, opts...)
+			},
+		)
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NODE\tID\tEVENT\tACTOR\tSOURCE\tMESSAGE")
+
+		const format = "%s\t%s\t%s\n%s\t%s\t%s\n"
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
 			}
 
-			if eventsCmdFlags.tailDuration != 0 {
-				opts = append(opts, client.WithTailDuration(eventsCmdFlags.tailDuration))
-			}
-
-			if eventsCmdFlags.tailID != "" {
-				opts = append(opts, client.WithTailID(eventsCmdFlags.tailID))
-			}
-
-			if eventsCmdFlags.actorID != "" {
-				opts = append(opts, client.WithActorID(eventsCmdFlags.actorID))
-			}
-
-			events, err := c.Events(ctx, opts...)
+			event, err := client.UnmarshalEvent(resp.Payload)
 			if err != nil {
-				return err
+				if _, ok := errors.AsType[client.EventNotSupportedError](err); ok { //nolint:errcheck // wrong linter error
+					continue
+				}
+
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, err))
+
+				continue
 			}
 
-			return helpers.ReadGRPCStream(events, func(ev *machine.Event, node string, multipleNodes bool) error {
-				format := "%s\t%s\t%s\n%s\t%s\t%s\n"
+			var eventArgs []any
 
-				event, err := client.UnmarshalEvent(ev)
-				if err != nil {
-					if _, ok := errors.AsType[client.EventNotSupportedError](err); ok { //nolint:errcheck // wrong linter error
-						return nil
-					}
-
-					return err
+			switch msg := event.Payload.(type) {
+			case *machine.SequenceEvent:
+				eventArgs = []any{msg.GetSequence()}
+				if msg.Error != nil {
+					eventArgs = append(eventArgs, "error:"+" "+msg.GetError().GetMessage())
+				} else {
+					eventArgs = append(eventArgs, msg.GetAction().String())
 				}
-
-				var args []any
-
-				switch msg := event.Payload.(type) {
-				case *machine.SequenceEvent:
-					args = []any{msg.GetSequence()}
-					if msg.Error != nil {
-						args = append(args, "error:"+" "+msg.GetError().GetMessage())
-					} else {
-						args = append(args, msg.GetAction().String())
-					}
-				case *machine.PhaseEvent:
-					args = []any{msg.GetPhase(), msg.GetAction().String()}
-				case *machine.TaskEvent:
-					args = []any{msg.GetTask(), msg.GetAction().String()}
-				case *machine.ServiceStateEvent:
-					args = []any{msg.GetService(), fmt.Sprintf("%s: %s", msg.GetAction(), msg.GetMessage())}
-				case *machine.ConfigLoadErrorEvent:
-					args = []any{"error", msg.GetError()}
-				case *machine.ConfigValidationErrorEvent:
-					args = []any{"error", msg.GetError()}
-				case *machine.AddressEvent:
-					args = []any{msg.GetHostname(), fmt.Sprintf("ADDRESSES: %s", strings.Join(msg.GetAddresses(), ","))}
-				case *machine.MachineStatusEvent:
-					args = []any{
-						msg.GetStage().String(),
-						fmt.Sprintf(
-							"ready: %v, unmet conditions: %v",
-							msg.GetStatus().Ready,
-							xslices.Map(
-								msg.GetStatus().GetUnmetConditions(),
-								func(c *machine.MachineStatusEvent_MachineStatus_UnmetCondition) string {
-									return c.Name
-								},
-							),
+			case *machine.PhaseEvent:
+				eventArgs = []any{msg.GetPhase(), msg.GetAction().String()}
+			case *machine.TaskEvent:
+				eventArgs = []any{msg.GetTask(), msg.GetAction().String()}
+			case *machine.ServiceStateEvent:
+				eventArgs = []any{msg.GetService(), fmt.Sprintf("%s: %s", msg.GetAction(), msg.GetMessage())}
+			case *machine.ConfigLoadErrorEvent:
+				eventArgs = []any{"error", msg.GetError()}
+			case *machine.ConfigValidationErrorEvent:
+				eventArgs = []any{"error", msg.GetError()}
+			case *machine.AddressEvent:
+				eventArgs = []any{msg.GetHostname(), fmt.Sprintf("ADDRESSES: %s", strings.Join(msg.GetAddresses(), ","))}
+			case *machine.MachineStatusEvent:
+				eventArgs = []any{
+					msg.GetStage().String(),
+					fmt.Sprintf(
+						"ready: %v, unmet conditions: %v",
+						msg.GetStatus().Ready,
+						xslices.Map(
+							msg.GetStatus().GetUnmetConditions(),
+							func(c *machine.MachineStatusEvent_MachineStatus_UnmetCondition) string {
+								return c.Name
+							},
 						),
-					}
+					),
 				}
+			}
 
-				args = append([]any{event.Node, event.ID, event.TypeURL, event.ActorID}, args...)
-				fmt.Fprintf(w, format, args...)
+			eventArgs = append([]any{resp.Node, event.ID, event.TypeURL, event.ActorID}, eventArgs...)
+			fmt.Fprintf(w, format, eventArgs...)
 
-				return w.Flush()
-			})
-		})
+			if err := w.Flush(); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))
+			}
+		}
+
+		return errs
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -176,37 +176,48 @@ func imageList(ctx context.Context) error {
 //
 // Note: remove me in Talos 1.15.
 func imageListLegacy(ctx context.Context) error {
-	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-		ns, err := imageCmdFlags.apiNamespace()
-		if err != nil {
-			return err
+	clientFactory, err := NewClientFactory(ctx, &imageCmdFlags)
+	if err != nil {
+		return err
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	ns, err := imageCmdFlags.apiNamespace()
+	if err != nil {
+		return err
+	}
+
+	responseChan := multiplex.StreamingViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (machine.MachineService_ImageListClient, error) {
+			return c.ImageList(ctx, ns) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.15
+		},
+	)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tCREATED")
+
+	var errs error
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+			continue
 		}
 
-		rcv, err := c.ImageList(ctx, ns) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.15
-		if err != nil {
-			return fmt.Errorf("error listing images: %w", err)
-		}
+		fmt.Fprintf(
+			w, "%s\t%s\t%s\t%s\t%s\n",
+			resp.Node,
+			resp.Payload.Name,
+			resp.Payload.Digest,
+			humanize.Bytes(uint64(resp.Payload.Size)),
+			resp.Payload.CreatedAt.AsTime().Format(time.RFC3339),
+		)
+	}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tCREATED")
-
-		if err = helpers.ReadGRPCStream(rcv, func(msg *machine.ImageListResponse, node string, multipleNodes bool) error {
-			fmt.Fprintf(
-				w, "%s\t%s\t%s\t%s\t%s\n",
-				node,
-				msg.Name,
-				msg.Digest,
-				humanize.Bytes(uint64(msg.Size)),
-				msg.CreatedAt.AsTime().Format(time.RFC3339),
-			)
-
-			return nil
-		}); err != nil {
-			return err
-		}
-
-		return w.Flush()
-	})
+	return errors.Join(errs, w.Flush())
 }
 
 // imagePullCmd represents the image pull command.
@@ -314,19 +325,34 @@ func imagePullInternal(
 //
 // Note: remove me in Talos 1.15.
 func imagePullLegacy(ctx context.Context, imageRef string) error {
-	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-		ns, err := imageCmdFlags.apiNamespace()
-		if err != nil {
-			return err
-		}
+	clientFactory, err := NewClientFactory(ctx, &imageCmdFlags)
+	if err != nil {
+		return err
+	}
 
-		err = c.ImagePull(ctx, ns, imageRef) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.15
-		if err != nil {
-			return fmt.Errorf("error pulling image: %w", err)
-		}
+	defer clientFactory.Close() //nolint:errcheck
 
-		return nil
-	})
+	ns, err := imageCmdFlags.apiNamespace()
+	if err != nil {
+		return err
+	}
+
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (struct{}, error) {
+			return struct{}{}, c.ImagePull(ctx, ns, imageRef) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.15
+		},
+	)
+
+	var errs error
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error pulling image on node %s: %w", resp.Node, resp.Err))
+		}
+	}
+
+	return errs
 }
 
 // imageImportInternal imports an image from a tarball.

--- a/cmd/talosctl/cmd/talos/list.go
+++ b/cmd/talosctl/cmd/talos/list.go
@@ -18,20 +18,20 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 const sixMonths = 6 * time.Hour * 24 * 30
 
-var (
-	long           bool
-	recurse        bool
-	recursionDepth int32
-	humanizeFlag   bool
-	types          []string
-)
+var lsCmdFlags struct {
+	long     bool
+	recurse  bool
+	depth    int32
+	humanize bool
+	types    []string
+}
 
 // lsCmd represents the ls command.
 var lsCmd = &cobra.Command{
@@ -45,140 +45,193 @@ var lsCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
+		return completePathFromNode(cmd.Context(), &lsCmdFlags, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if recurse && recursionDepth != 1 {
+		if lsCmdFlags.recurse && lsCmdFlags.depth != 1 {
 			return errors.New("only one of flags --recurse and --depth can be specified at the same time")
 		}
 
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			rootDir := "/"
+		ctx := cmd.Context()
 
-			if len(args) > 0 {
-				rootDir = args[0]
-			}
+		clientFactory, err := NewClientFactory(ctx, &lsCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			// handle all variants: --type=f,l; -tfl; etc
-			var reqTypes []machineapi.ListRequest_Type
+		defer clientFactory.Close() //nolint:errcheck
 
-			for _, typ := range types {
-				for _, t := range typ {
-					// handle both `find -type X` and os.FileMode.String() designations
-					switch t {
-					case 'f':
-						reqTypes = append(reqTypes, machineapi.ListRequest_REGULAR)
-					case 'd':
-						reqTypes = append(reqTypes, machineapi.ListRequest_DIRECTORY)
-					case 'l', 'L':
-						reqTypes = append(reqTypes, machineapi.ListRequest_SYMLINK)
-					default:
-						return fmt.Errorf("invalid file type: %s", string(t))
-					}
+		rootDir := "/"
+
+		if len(args) > 0 {
+			rootDir = args[0]
+		}
+
+		// handle all variants: --type=f,l; -tfl; etc
+		var reqTypes []machineapi.ListRequest_Type
+
+		for _, typ := range lsCmdFlags.types {
+			for _, t := range typ {
+				// handle both `find -type X` and os.FileMode.String() designations
+				switch t {
+				case 'f':
+					reqTypes = append(reqTypes, machineapi.ListRequest_REGULAR)
+				case 'd':
+					reqTypes = append(reqTypes, machineapi.ListRequest_DIRECTORY)
+				case 'l', 'L':
+					reqTypes = append(reqTypes, machineapi.ListRequest_SYMLINK)
+				default:
+					return fmt.Errorf("invalid file type: %s", string(t))
 				}
 			}
+		}
 
-			if recurse {
-				recursionDepth = -1
-			}
+		recursionDepth := lsCmdFlags.depth
 
-			stream, err := c.LS(ctx, &machineapi.ListRequest{
-				Root:           rootDir,
-				Recurse:        recursionDepth > 1 || recurse,
-				RecursionDepth: recursionDepth,
-				Types:          reqTypes,
-				ReportXattrs:   long,
-			})
-			if err != nil {
-				return fmt.Errorf("error fetching logs: %s", err)
-			}
+		if lsCmdFlags.recurse {
+			recursionDepth = -1
+		}
 
-			if !long {
-				w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-				fmt.Fprintln(w, "NODE\tNAME")
+		multipleNodes := len(clientFactory.Nodes()) > 1
 
-				defer w.Flush() //nolint:errcheck
-
-				return helpers.ReadGRPCStream(stream, func(info *machineapi.FileInfo, node string, multipleNodes bool) error {
-					if info.Error != "" {
-						return helpers.NonFatalError(fmt.Errorf("%s: error reading file %s: %s", node, info.Name, info.Error))
-					}
-
-					if !multipleNodes {
-						fmt.Println(info.RelativeName)
-					} else {
-						fmt.Fprintf(
-							w, "%s\t%s\n",
-							node,
-							info.RelativeName,
-						)
-					}
-
-					return nil
+		responseChan := multiplex.StreamingViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (machineapi.MachineService_ListClient, error) {
+				return c.LS(ctx, &machineapi.ListRequest{
+					Root:           rootDir,
+					Recurse:        recursionDepth > 1 || lsCmdFlags.recurse,
+					RecursionDepth: recursionDepth,
+					Types:          reqTypes,
+					ReportXattrs:   lsCmdFlags.long,
 				})
-			}
+			},
+		)
 
+		if !lsCmdFlags.long {
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 			defer w.Flush() //nolint:errcheck
 
-			fmt.Fprintln(w, "NODE\tMODE\tUID\tGID\tSIZE(B)\tLASTMOD\tLABEL\tNAME")
+			var (
+				errs          error
+				headerWritten bool
+			)
 
-			return helpers.ReadGRPCStream(stream, func(info *machineapi.FileInfo, node string, multipleNodes bool) error {
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+					continue
+				}
+
+				info := resp.Payload
+
 				if info.Error != "" {
-					return helpers.NonFatalError(fmt.Errorf("%s: error reading file %s: %s", node, info.Name, info.Error))
+					errs = errors.Join(errs, fmt.Errorf("%s: error reading file %s: %s", resp.Node, info.Name, info.Error))
+
+					continue
 				}
 
-				display := info.RelativeName
-				if info.Link != "" {
-					display += " -> " + info.Link
+				if !multipleNodes {
+					fmt.Println(info.RelativeName)
+
+					continue
 				}
 
-				size := strconv.FormatInt(info.Size, 10)
+				if !headerWritten {
+					fmt.Fprintln(w, "NODE\tNAME")
 
-				if humanizeFlag {
-					size = humanize.Bytes(uint64(info.Size))
-				}
-
-				timestamp := time.Unix(info.Modified, 0)
-				timestampFormatted := ""
-
-				if humanizeFlag {
-					timestampFormatted = humanize.Time(timestamp)
-				} else {
-					if time.Since(timestamp) < sixMonths {
-						timestampFormatted = timestamp.Format("Jan _2 15:04:05")
-					} else {
-						timestampFormatted = timestamp.Format("Jan _2 2006 15:04")
-					}
-				}
-
-				label := ""
-
-				if info.Xattrs != nil {
-					for _, l := range info.Xattrs {
-						if l.Name == "security.selinux" {
-							label = string(bytes.Trim(l.Data, "\x00\n"))
-
-							break
-						}
-					}
+					headerWritten = true
 				}
 
 				fmt.Fprintf(
-					w, "%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n",
-					node,
-					os.FileMode(info.Mode).String(),
-					info.Uid,
-					info.Gid,
-					size,
-					timestampFormatted,
-					label,
-					display,
+					w, "%s\t%s\n",
+					resp.Node,
+					info.RelativeName,
 				)
+			}
 
-				return nil
-			})
-		})
+			return errs
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		defer w.Flush() //nolint:errcheck
+
+		var (
+			errs          error
+			headerWritten bool
+		)
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
+			}
+
+			info := resp.Payload
+
+			if info.Error != "" {
+				errs = errors.Join(errs, fmt.Errorf("%s: error reading file %s: %s", resp.Node, info.Name, info.Error))
+
+				continue
+			}
+
+			if !headerWritten {
+				fmt.Fprintln(w, "NODE\tMODE\tUID\tGID\tSIZE(B)\tLASTMOD\tLABEL\tNAME")
+
+				headerWritten = true
+			}
+
+			display := info.RelativeName
+			if info.Link != "" {
+				display += " -> " + info.Link
+			}
+
+			size := strconv.FormatInt(info.Size, 10)
+
+			if lsCmdFlags.humanize {
+				size = humanize.Bytes(uint64(info.Size))
+			}
+
+			timestamp := time.Unix(info.Modified, 0)
+			timestampFormatted := ""
+
+			if lsCmdFlags.humanize {
+				timestampFormatted = humanize.Time(timestamp)
+			} else {
+				if time.Since(timestamp) < sixMonths {
+					timestampFormatted = timestamp.Format("Jan _2 15:04:05")
+				} else {
+					timestampFormatted = timestamp.Format("Jan _2 2006 15:04")
+				}
+			}
+
+			label := ""
+
+			if info.Xattrs != nil {
+				for _, l := range info.Xattrs {
+					if l.Name == "security.selinux" {
+						label = string(bytes.Trim(l.Data, "\x00\n"))
+
+						break
+					}
+				}
+			}
+
+			fmt.Fprintf(
+				w, "%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n",
+				resp.Node,
+				os.FileMode(info.Mode).String(),
+				info.Uid,
+				info.Gid,
+				size,
+				timestampFormatted,
+				label,
+				display,
+			)
+		}
+
+		return errs
 	},
 }
 
@@ -190,10 +243,10 @@ func init() {
 		"l, L" + "\t" + "symbolic link",
 	}, "\n")
 
-	lsCmd.Flags().BoolVarP(&long, "long", "l", false, "display additional file details")
-	lsCmd.Flags().BoolVarP(&recurse, "recurse", "r", false, "recurse into subdirectories")
-	lsCmd.Flags().BoolVarP(&humanizeFlag, "humanize", "H", false, "humanize size and time in the output")
-	lsCmd.Flags().Int32VarP(&recursionDepth, "depth", "d", 1, "maximum recursion depth")
-	lsCmd.Flags().StringSliceVarP(&types, "type", "t", nil, typesHelp)
+	lsCmd.Flags().BoolVarP(&lsCmdFlags.long, "long", "l", false, "display additional file details")
+	lsCmd.Flags().BoolVarP(&lsCmdFlags.recurse, "recurse", "r", false, "recurse into subdirectories")
+	lsCmd.Flags().BoolVarP(&lsCmdFlags.humanize, "humanize", "H", false, "humanize size and time in the output")
+	lsCmd.Flags().Int32VarP(&lsCmdFlags.depth, "depth", "d", 1, "maximum recursion depth")
+	lsCmd.Flags().StringSliceVarP(&lsCmdFlags.types, "type", "t", nil, typesHelp)
 	addCommand(lsCmd)
 }

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -5,30 +5,32 @@
 package talos
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"io"
-	"os"
-	"sync"
+	"maps"
+	"slices"
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
-var (
-	follow    bool
-	tailLines int32
-)
+var logsCmdFlags struct {
+	global.InsecureFlags
+	kubernetesNamespaceFlag
+
+	follow bool
+	tail   int32
+}
 
 var logsCmd = &cobra.Command{
 	Use:   "logs <service name>",
@@ -40,204 +42,143 @@ var logsCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if kubernetesFlag {
-			return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
+		if logsCmdFlags.kubernetes {
+			return getContainersFromNode(cmd.Context(), &logsCmdFlags), cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return mergeSuggestions(getServiceFromNode(cmd.Context()), getContainersFromNode(cmd.Context(), kubernetesFlag), getLogsContainers(cmd.Context())), cobra.ShellCompDirectiveNoFileComp
+		return mergeSuggestions(
+			getServiceFromNode(cmd.Context(), &logsCmdFlags),
+			getContainersFromNode(cmd.Context(), &logsCmdFlags),
+			getLogsContainers(cmd.Context(), &logsCmdFlags),
+		), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			var (
-				namespace string
-				driver    common.ContainerDriver
-			)
+		ctx := cmd.Context()
 
-			if kubernetesFlag {
-				namespace = constants.K8sContainerdNamespace
-				driver = common.ContainerDriver_CRI
-			} else {
-				namespace = constants.SystemContainerdNamespace
-				driver = common.ContainerDriver_CONTAINERD
-			}
+		clientFactory, err := NewClientFactory(ctx, &logsCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			stream, err := c.Logs(ctx, namespace, driver, args[0], follow, tailLines)
-			if err != nil {
-				return fmt.Errorf("error fetching logs: %s", err)
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			defaultNode := client.RemotePeer(stream.Context())
+		var (
+			namespace string
+			driver    common.ContainerDriver
+		)
 
-			respCh, errCh := newLineSlicer(stream)
+		if logsCmdFlags.kubernetes {
+			namespace = constants.K8sContainerdNamespace
+			driver = common.ContainerDriver_CRI
+		} else {
+			namespace = constants.SystemContainerdNamespace
+			driver = common.ContainerDriver_CONTAINERD
+		}
 
-			var gotErrors bool
+		responseChan := multiplex.StreamingViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (machine.MachineService_LogsClient, error) {
+				return c.Logs(ctx, namespace, driver, args[0], logsCmdFlags.follow, logsCmdFlags.tail)
+			},
+		)
 
-			for data := range respCh {
-				if data.Metadata != nil && data.Metadata.Error != "" { //nolint:staticcheck // to be refactored next
-					_, err = fmt.Fprintf(os.Stderr, "ERROR: %s\n", data.Metadata.Error) //nolint:staticcheck // to be refactored next
-					if err != nil {
-						return err
-					}
+		// logs arrive as arbitrary byte chunks per node, so buffer each node's bytes
+		// until a newline is seen and emit complete lines: this keeps the output
+		// line-aligned even when interleaving logs from multiple nodes.
+		lineBuffers := map[string][]byte{}
 
-					gotErrors = true
+		emit := func(node string, line []byte) error {
+			_, err := fmt.Printf("%s: %s\n", node, line)
 
+			return err
+		}
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				// the stream is canceled on Ctrl-C (or context cancellation), which is a normal termination
+				if client.StatusCode(resp.Err) == codes.Canceled {
 					continue
 				}
 
-				node := defaultNode
-				if data.Metadata != nil && data.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-					node = data.Metadata.Hostname //nolint:staticcheck // to be refactored next
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
+			}
+
+			buf := append(lineBuffers[resp.Node], resp.Payload.Bytes...)
+
+			for {
+				idx := bytes.IndexByte(buf, '\n')
+				if idx < 0 {
+					break
 				}
 
-				_, err = fmt.Printf("%s: %s\n", node, data.Bytes)
-				if err != nil {
+				if err := emit(resp.Node, buf[:idx]); err != nil {
+					return err
+				}
+
+				buf = buf[idx+1:]
+			}
+
+			lineBuffers[resp.Node] = buf
+		}
+
+		// flush trailing bytes which were not terminated by a newline
+		for _, node := range slices.Sorted(maps.Keys(lineBuffers)) {
+			if buf := lineBuffers[node]; len(buf) > 0 {
+				if err := emit(node, buf); err != nil {
 					return err
 				}
 			}
+		}
 
-			if err = <-errCh; err != nil {
-				return fmt.Errorf("error getting logs: %v", err)
-			}
-
-			if gotErrors {
-				os.Exit(1)
-			}
-
-			return nil
-		})
+		return errs
 	},
 }
 
-// lineSlicer splits random chunks of bytes coming from nodes into a stream
-// of lines aggregated per node.
-type lineSlicer struct {
-	respCh chan *common.Data
-	errCh  chan error
-	pipes  map[string]*io.PipeWriter
-	wg     sync.WaitGroup
-}
+func getLogsContainers(ctx context.Context, flags any) []string {
+	clientFactory, err := NewClientFactory(ctx, flags)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
 
-func newLineSlicer(stream machine.MachineService_LogsClient) (chan *common.Data, chan error) {
-	slicer := &lineSlicer{
-		respCh: make(chan *common.Data),
-		errCh:  make(chan error, 1),
-		pipes:  map[string]*io.PipeWriter{},
+		return nil
 	}
 
-	go slicer.run(stream)
+	defer clientFactory.Close() //nolint:errcheck
 
-	return slicer.respCh, slicer.errCh
-}
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machine.LogsContainersResponse, error) {
+			return c.LogsContainers(ctx)
+		},
+	)
 
-func (slicer *lineSlicer) chopper(r io.Reader, hostname string) {
-	defer slicer.wg.Done()
+	var result []string
 
-	scanner := bufio.NewScanner(r)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		line = xslices.CopyN(line, len(line))
-
-		slicer.respCh <- &common.Data{
-			Metadata: &common.Metadata{ //nolint:staticcheck // to be refactored next
-				Hostname: hostname,
-			},
-			Bytes: line,
-		}
-	}
-}
-
-func (slicer *lineSlicer) getPipe(node string) *io.PipeWriter {
-	pipe, ok := slicer.pipes[node]
-	if !ok {
-		var piper *io.PipeReader
-
-		piper, pipe = io.Pipe()
-
-		slicer.wg.Add(1)
-
-		go slicer.chopper(piper, node)
-
-		slicer.pipes[node] = pipe
-	}
-
-	return pipe
-}
-
-func (slicer *lineSlicer) cleanupChoppers() {
-	for _, p := range slicer.pipes {
-		_ = p.Close() //nolint:errcheck
-	}
-
-	slicer.wg.Wait()
-}
-
-func (slicer *lineSlicer) run(stream machine.MachineService_LogsClient) {
-	defer close(slicer.errCh)
-	defer close(slicer.respCh)
-
-	defer slicer.cleanupChoppers()
-
-	for {
-		data, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF || client.StatusCode(err) == codes.Canceled {
-				return
-			}
-
-			slicer.errCh <- err
-
-			return
-		}
-
-		if data.Metadata != nil && data.Metadata.Error != "" { //nolint:staticcheck // to be refactored next
-			// errors are delivered OOB
-			slicer.respCh <- data
+	for resp := range responseChan {
+		if resp.Err != nil {
+			cobra.CompError(fmt.Sprintf("error from node %s: %v", resp.Node, resp.Err))
 
 			continue
 		}
 
-		node := ""
-
-		if data.Metadata != nil {
-			node = data.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
-		_, err = slicer.getPipe(node).Write(data.Bytes)
-		cli.Should(err)
+		result = append(result, xslices.FlatMap(resp.Payload.Messages, func(lc *machine.LogsContainer) []string { return lc.Ids })...)
 	}
-}
-
-func getLogsContainers(ctx context.Context) []string {
-	var result []string
-
-	//nolint:errcheck
-	WithClient(
-		ctx,
-		func(ctx context.Context, c *client.Client) error {
-			var remotePeer peer.Peer
-
-			resp, err := c.LogsContainers(ctx, grpc.Peer(&remotePeer))
-			if err != nil {
-				return err
-			}
-
-			result = xslices.FlatMap(resp.Messages, func(lc *machine.LogsContainer) []string { return lc.Ids })
-
-			return nil
-		},
-	)
 
 	return result
 }
 
 func init() {
-	logsCmd.Flags().BoolVarP(&kubernetesFlag, "kubernetes", "k", false, "use the k8s.io containerd namespace")
-	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "specify if the logs should be streamed")
-	logsCmd.Flags().Int32VarP(&tailLines, "tail", "", -1, "lines of log file to display (default is to show from the beginning)")
+	logsCmd.Flags().BoolVarP(&logsCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	logsCmd.Flags().BoolVarP(&logsCmdFlags.follow, "follow", "f", false, "specify if the logs should be streamed")
+	logsCmd.Flags().Int32VarP(&logsCmdFlags.tail, "tail", "", -1, "lines of log file to display (default is to show from the beginning)")
 
 	logsCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	logsCmd.Flags().MarkHidden("use-cri") //nolint:errcheck
+
+	logsCmdFlags.InsecureFlags.AddFlags(logsCmd)
 
 	addCommand(logsCmd)
 }

--- a/cmd/talosctl/cmd/talos/netstat.go
+++ b/cmd/talosctl/cmd/talos/netstat.go
@@ -15,10 +15,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -38,9 +40,12 @@ var netstatCmdFlags struct {
 	ipv6      bool
 }
 
-type netstat struct {
-	client        *client.Client
-	NodeNetNSPods map[string]map[string]string
+// netstatPrinter renders netstat responses, attaching the node explicitly and
+// resolving pod names from the per-node network namespace map.
+type netstatPrinter struct {
+	w             *tabwriter.Writer
+	nodeNetNSPods map[string]map[string]string
+	headerWritten bool
 }
 
 // netstatCmd represents the netstat command.
@@ -60,68 +65,81 @@ If you don't pass an argument, the command will show host connections.`,
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &netstatCmdFlags)
+		if err != nil {
+			cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
+
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		nodeNetNSPods, err := getPodNetNs(ctx, clientFactory)
+		if err != nil {
+			cobra.CompError(fmt.Sprintf("error getting pod network namespaces: %v", err))
+
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
 		var podList []string
 
-		if WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			n := netstat{
-				NodeNetNSPods: make(map[string]map[string]string),
-				client:        c,
+		for _, netNsPods := range nodeNetNSPods {
+			for _, podName := range netNsPods {
+				podList = append(podList, podName)
 			}
-
-			err := n.getPodNetNsFromNode(ctx)
-			if err != nil {
-				return err
-			}
-
-			for _, netNsPods := range n.NodeNetNSPods {
-				for _, podName := range netNsPods {
-					podList = append(podList, podName)
-				}
-			}
-
-			return nil
-		}) != nil {
-			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
 		return podList, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if netstatCmdFlags.pods && len(args) > 0 {
+			return errors.New("cannot use --pods and specify a pod")
+		}
+
 		req := netstatFlagsToRequest()
 
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) (err error) {
-			if netstatCmdFlags.pods && len(args) > 0 {
-				return errors.New("cannot use --pods and specify a pod")
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &netstatCmdFlags)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		findThePod := len(args) > 0
+
+		var nodeNetNSPods map[string]map[string]string
+
+		if findThePod || netstatCmdFlags.pods {
+			nodeNetNSPods, err = getPodNetNs(ctx, clientFactory)
+			if err != nil {
+				return err
+			}
+		}
+
+		printer := &netstatPrinter{
+			w:             tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0),
+			nodeNetNSPods: nodeNetNSPods,
+		}
+
+		// Finding a specific pod changes the flow: instead of multiplexing across all
+		// nodes, we locate the single node hosting the pod and query only that node.
+		if findThePod {
+			foundNode, foundNetNs := findPodNetNs(nodeNetNSPods, args[0])
+
+			if foundNetNs == "" {
+				cli.Fatalf("pod %s not found", args[0])
 			}
 
-			findThePod := len(args) > 0
+			req.Netns.Netns = []string{foundNetNs}
+			req.Netns.Hostnetwork = false
 
-			n := netstat{
-				client: c,
-			}
-
-			n.NodeNetNSPods = make(map[string]map[string]string)
-
-			if findThePod || netstatCmdFlags.pods {
-				err = n.getPodNetNsFromNode(ctx)
-				if err != nil {
-					return err
-				}
-			}
-
-			if findThePod {
-				var foundNode, foundNetNs string
-
-				foundNode, foundNetNs = n.findPodNetNs(args[0])
-
-				if foundNetNs == "" {
-					cli.Fatalf("pod %s not found", args[0])
-				}
-
-				ctx = client.WithNode(ctx, foundNode)
-
-				req.Netns.Netns = []string{foundNetNs}
-				req.Netns.Hostnetwork = false
+			ctx, c, err := clientFactory.BuildClient(ctx, foundNode)
+			if err != nil {
+				return err
 			}
 
 			response, err := c.Netstat(ctx, req)
@@ -133,10 +151,31 @@ If you don't pass an argument, the command will show host connections.`,
 				cli.Warning("%s", err)
 			}
 
-			err = n.printNetstat(response)
+			printer.printResponse(foundNode, response)
 
-			return err
-		})
+			return printer.flush()
+		}
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (*machine.NetstatResponse, error) {
+				return c.Netstat(ctx, req)
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+				continue
+			}
+
+			printer.printResponse(resp.Node, resp.Payload)
+		}
+
+		return errors.Join(errs, printer.flush())
 	},
 }
 
@@ -206,43 +245,56 @@ func netstatFlagsToRequest() *machine.NetstatRequest {
 	return &req
 }
 
-func (n *netstat) getPodNetNsFromNode(ctx context.Context) (err error) {
-	resp, err := n.client.Containers(ctx, constants.K8sContainerdNamespace, common.ContainerDriver_CRI)
-	if err != nil {
-		cli.Warning("error getting containers: %v", err)
+// getPodNetNs builds a per-node map of network namespace -> pod ID across all nodes.
+func getPodNetNs(ctx context.Context, clientFactory *global.ClientFactory) (map[string]map[string]string, error) {
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machine.ContainersResponse, error) {
+			return c.Containers(ctx, constants.K8sContainerdNamespace, common.ContainerDriver_CRI)
+		},
+	)
 
-		return err
-	}
+	nodeNetNSPods := map[string]map[string]string{}
 
-	for _, msg := range resp.Messages {
-		for _, p := range msg.Containers {
-			if p.NetworkNamespace == "" {
-				continue
+	var errs error
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error getting containers from node %s: %w", resp.Node, resp.Err))
+
+			continue
+		}
+
+		for _, msg := range resp.Payload.Messages {
+			for _, p := range msg.Containers {
+				if p.NetworkNamespace == "" {
+					continue
+				}
+
+				if p.Pid == 0 {
+					continue
+				}
+
+				if p.Id != p.PodId {
+					continue
+				}
+
+				if nodeNetNSPods[resp.Node] == nil {
+					nodeNetNSPods[resp.Node] = make(map[string]string)
+				}
+
+				nodeNetNSPods[resp.Node][p.NetworkNamespace] = p.Id
 			}
-
-			if p.Pid == 0 {
-				continue
-			}
-
-			if p.Id != p.PodId {
-				continue
-			}
-
-			if n.NodeNetNSPods[msg.Metadata.Hostname] == nil { //nolint:staticcheck // to be refactored next
-				n.NodeNetNSPods[msg.Metadata.Hostname] = make(map[string]string) //nolint:staticcheck // to be refactored next
-			}
-
-			n.NodeNetNSPods[msg.Metadata.Hostname][p.NetworkNamespace] = p.Id //nolint:staticcheck // to be refactored next
 		}
 	}
 
-	return nil
+	return nodeNetNSPods, errs
 }
 
-func (n *netstat) findPodNetNs(findNamespaceAndPod string) (string, string) {
+func findPodNetNs(nodeNetNSPods map[string]map[string]string, findNamespaceAndPod string) (string, string) {
 	var foundNetNs, foundNode string
 
-	for node, netNSPods := range n.NodeNetNSPods {
+	for node, netNSPods := range nodeNetNSPods {
 		for NetNs, podName := range netNSPods {
 			if podName == strings.ToLower(findNamespaceAndPod) {
 				foundNetNs = NetNs
@@ -257,35 +309,20 @@ func (n *netstat) findPodNetNs(findNamespaceAndPod string) (string, string) {
 }
 
 //nolint:gocyclo
-func (n *netstat) printNetstat(response *machine.NetstatResponse) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	node := ""
-
-	for i, message := range response.Messages {
-		if message.Metadata != nil && message.Metadata.Hostname != "" { //nolint:staticcheck // to be refactored next
-			node = message.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
+func (p *netstatPrinter) printResponse(node string, response *machine.NetstatResponse) {
+	for _, message := range response.Messages {
 		if len(message.Connectrecord) == 0 {
 			continue
 		}
 
-		for j, record := range message.Connectrecord {
-			if i == 0 && j == 0 {
-				labels := netstatSummaryLabels()
+		for _, record := range message.Connectrecord {
+			if !p.headerWritten {
+				fmt.Fprintln(p.w, "NODE\t"+netstatSummaryLabels())
 
-				if node != "" {
-					fmt.Fprintln(w, "NODE\t"+labels)
-				} else {
-					fmt.Fprintln(w, labels)
-				}
+				p.headerWritten = true
 			}
 
-			var args []any
-
-			if node != "" {
-				args = append(args, node)
-			}
+			args := []any{node}
 
 			state := ""
 			if record.State != 7 {
@@ -321,13 +358,13 @@ func (n *netstat) printNetstat(response *machine.NetstatResponse) error {
 			}
 
 			if netstatCmdFlags.pods {
-				if record.Netns == "" || node == "" || n.NodeNetNSPods[node] == nil {
+				if record.Netns == "" || p.nodeNetNSPods[node] == nil {
 					args = append(args, []any{
 						"-",
 					}...)
 				} else {
 					args = append(args, []any{
-						n.NodeNetNSPods[node][record.Netns],
+						p.nodeNetNSPods[node][record.Netns],
 					}...)
 				}
 			}
@@ -343,11 +380,13 @@ func (n *netstat) printNetstat(response *machine.NetstatResponse) error {
 			pattern := strings.Repeat("%s\t", len(args))
 			pattern = strings.TrimSpace(pattern) + "\n"
 
-			fmt.Fprintf(w, pattern, args...)
+			fmt.Fprintf(p.w, pattern, args...)
 		}
 	}
+}
 
-	return w.Flush()
+func (p *netstatPrinter) flush() error {
+	return p.w.Flush()
 }
 
 func netstatSummaryLabels() (labels string) {

--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -24,7 +24,7 @@ var readCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return completePathFromNode(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp
+		return completePathFromNode(cmd.Context(), nil, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
@@ -91,17 +92,33 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 
 func rebootInternal(ctx context.Context, wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
 	if !wait {
-		return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-			if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-				return err
-			}
+		clientFactory, err := NewClientFactory(ctx, &rebootCmdFlags)
+		if err != nil {
+			return err
+		}
 
-			if err := c.Reboot(ctx, opts...); err != nil {
-				return fmt.Errorf("error executing reboot: %s", err)
-			}
+		defer clientFactory.Close() //nolint:errcheck
 
-			return nil
-		})
+		if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+			return err
+		}
+
+		responseChan := multiplex.UnaryViaFactory(
+			ctx, clientFactory,
+			func(ctx context.Context, c *client.Client) (struct{}, error) {
+				return struct{}{}, c.Reboot(ctx, opts...)
+			},
+		)
+
+		var errs error
+
+		for resp := range responseChan {
+			if resp.Err != nil {
+				errs = errors.Join(errs, fmt.Errorf("error executing reboot on node %s: %w", resp.Node, resp.Err))
+			}
+		}
+
+		return errs
 	}
 
 	return action.NewTracker(

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var wipeOptions = map[string]machineapi.ResetRequest_WipeMode{
@@ -92,19 +93,35 @@ var resetCmd = &cobra.Command{
 		resetRequest := buildResetRequest()
 
 		if !resetCmdFlags.wait {
-			resetNoWait := func(ctx context.Context, c *client.Client) error {
-				if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-					return err
-				}
+			ctx := cmd.Context()
 
-				if err := c.ResetGeneric(ctx, resetRequest); err != nil {
-					return fmt.Errorf("error executing reset: %s", err)
-				}
-
-				return nil
+			clientFactory, err := NewClientFactory(ctx, &resetCmdFlags)
+			if err != nil {
+				return err
 			}
 
-			return WithClient(cmd.Context(), resetNoWait)
+			defer clientFactory.Close() //nolint:errcheck
+
+			if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+				return err
+			}
+
+			responseChan := multiplex.UnaryViaFactory(
+				ctx, clientFactory,
+				func(ctx context.Context, c *client.Client) (struct{}, error) {
+					return struct{}{}, c.ResetGeneric(ctx, resetRequest)
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error executing reset on node %s: %w", resp.Node, resp.Err))
+				}
+			}
+
+			return errs
 		}
 
 		actionFn := func(ctx context.Context, c *client.Client) (string, error) {

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -17,6 +17,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
+var restartCmdFlags struct {
+	kubernetesNamespaceFlag
+}
+
 // restartCmd represents the restart command.
 var restartCmd = &cobra.Command{
 	Use:   "restart <id>",
@@ -28,12 +32,12 @@ var restartCmd = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return getContainersFromNode(cmd.Context(), kubernetesFlag), cobra.ShellCompDirectiveNoFileComp
+		return getContainersFromNode(cmd.Context(), &restartCmdFlags), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		clientFactory, err := NewClientFactory(ctx, nil)
+		clientFactory, err := NewClientFactory(ctx, &restartCmdFlags)
 		if err != nil {
 			return err
 		}
@@ -45,7 +49,7 @@ var restartCmd = &cobra.Command{
 			driver    common.ContainerDriver
 		)
 
-		if kubernetesFlag {
+		if restartCmdFlags.kubernetes {
 			namespace = constants.K8sContainerdNamespace
 			driver = common.ContainerDriver_CRI
 		} else {
@@ -73,7 +77,7 @@ var restartCmd = &cobra.Command{
 }
 
 func init() {
-	restartCmd.Flags().BoolVarP(&kubernetesFlag, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	restartCmd.Flags().BoolVarP(&restartCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 
 	restartCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	restartCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -18,21 +18,35 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
-	"github.com/siderolabs/talos/pkg/machinery/formatters"
 )
-
-var kubernetesFlag bool
 
 // GlobalArgs is the common arguments for the root command.
 var GlobalArgs global.Args
+
+// kubernetesNamespaceFlag is embedded into command flag structs that select between
+// the system and Kubernetes containerd namespaces via the --kubernetes flag.
+type kubernetesNamespaceFlag struct {
+	kubernetes bool
+}
+
+// useKubernetesNamespace reports whether the Kubernetes containerd namespace is selected.
+func (f kubernetesNamespaceFlag) useKubernetesNamespace() bool {
+	return f.kubernetes
+}
+
+// containerNamespaceFlags is implemented by command flag structs carrying the
+// --kubernetes namespace selector; used by the container completion helpers.
+type containerNamespaceFlags interface {
+	useKubernetesNamespace() bool
+}
 
 const pathAutoCompleteLimit = 500
 
@@ -40,11 +54,6 @@ const pathAutoCompleteLimit = 500
 // before flushing the tabwriter, so partial results appear without thrashing
 // column widths while responses are still arriving.
 const outputFlushInterval = 500 * time.Millisecond
-
-// WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
-func WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClient(ctx, action, dialOptions...)
-}
 
 // WithClientAndNodes builds upon WithClientNoNodes to pass a list of nodes via command function.
 func WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
@@ -92,7 +101,7 @@ func addCommand(cmd *cobra.Command) {
 }
 
 // completePathFromNode represents tab complete options for `ls` and `ls *` commands.
-func completePathFromNode(ctx context.Context, inputPath string) []string {
+func completePathFromNode(ctx context.Context, flags any, inputPath string) []string {
 	pathToSearch := inputPath
 
 	// If the pathToSearch is empty, use root '/'
@@ -109,16 +118,16 @@ func completePathFromNode(ctx context.Context, inputPath string) []string {
 		pathToSearch = pathToSearch[:index] + "/"
 	}
 
-	paths = getPathFromNode(ctx, pathToSearch, inputPath)
+	paths = getPathFromNode(ctx, flags, pathToSearch, inputPath)
 
 	return maps.Keys(paths)
 }
 
 //nolint:gocyclo
-func getPathFromNode(ctx context.Context, path, filter string) map[string]struct{} {
+func getPathFromNode(ctx context.Context, flags any, path, filter string) map[string]struct{} {
 	paths := make(map[string]struct{})
 
-	clientFactory, err := NewClientFactory(ctx, &GlobalArgs)
+	clientFactory, err := NewClientFactory(ctx, flags)
 	if err != nil {
 		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
 
@@ -193,76 +202,97 @@ func getPathFromNode(ctx context.Context, path, filter string) map[string]struct
 	return paths
 }
 
-func getServiceFromNode(ctx context.Context) []string {
-	var svcIDs []string
+func getServiceFromNode(ctx context.Context, flags any) []string {
+	clientFactory, err := NewClientFactory(ctx, flags)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
 
-	//nolint:errcheck
-	GlobalArgs.WithClient(
-		ctx,
-		func(ctx context.Context, c *client.Client) error {
-			var remotePeer peer.Peer
+		return nil
+	}
 
-			resp, err := c.ServiceList(ctx, grpc.Peer(&remotePeer))
-			if err != nil {
-				return err
-			}
+	defer clientFactory.Close() //nolint:errcheck
 
-			for _, msg := range resp.Messages {
-				for _, s := range msg.Services {
-					svc := formatters.ServiceInfoWrapper{ServiceInfo: s}
-					svcIDs = append(svcIDs, svc.Id)
-				}
-			}
-
-			return nil
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ServiceListResponse, error) {
+			return c.ServiceList(ctx)
 		},
 	)
+
+	var svcIDs []string
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			cobra.CompError(fmt.Sprintf("error from node %s: %v", resp.Node, resp.Err))
+
+			continue
+		}
+
+		for _, msg := range resp.Payload.Messages {
+			for _, s := range msg.Services {
+				svcIDs = append(svcIDs, s.Id)
+			}
+		}
+	}
 
 	return svcIDs
 }
 
-func getContainersFromNode(ctx context.Context, kubernetes bool) []string {
-	var containerIDs []string
+func getContainersFromNode(ctx context.Context, flags containerNamespaceFlags) []string {
+	clientFactory, err := NewClientFactory(ctx, flags)
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error creating client factory: %v", err))
 
-	//nolint:errcheck
-	GlobalArgs.WithClient(
-		ctx,
-		func(ctx context.Context, c *client.Client) error {
-			var (
-				namespace string
-				driver    common.ContainerDriver
-			)
+		return nil
+	}
 
-			if kubernetes {
-				namespace = constants.K8sContainerdNamespace
-				driver = common.ContainerDriver_CRI
-			} else {
-				namespace = constants.SystemContainerdNamespace
-				driver = common.ContainerDriver_CONTAINERD
-			}
+	defer clientFactory.Close() //nolint:errcheck
 
-			resp, err := c.Containers(ctx, namespace, driver)
-			if err != nil {
-				return err
-			}
+	kubernetes := flags.useKubernetesNamespace()
 
-			for _, msg := range resp.Messages {
-				for _, p := range msg.Containers {
-					if p.Pid == 0 {
-						continue
-					}
+	var (
+		namespace string
+		driver    common.ContainerDriver
+	)
 
-					if kubernetes && p.Id == p.PodId {
-						continue
-					}
+	if kubernetes {
+		namespace = constants.K8sContainerdNamespace
+		driver = common.ContainerDriver_CRI
+	} else {
+		namespace = constants.SystemContainerdNamespace
+		driver = common.ContainerDriver_CONTAINERD
+	}
 
-					containerIDs = append(containerIDs, p.Id)
-				}
-			}
-
-			return nil
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ContainersResponse, error) {
+			return c.Containers(ctx, namespace, driver)
 		},
 	)
+
+	var containerIDs []string
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			cobra.CompError(fmt.Sprintf("error from node %s: %v", resp.Node, resp.Err))
+
+			continue
+		}
+
+		for _, msg := range resp.Payload.Messages {
+			for _, p := range msg.Containers {
+				if p.Pid == 0 {
+					continue
+				}
+
+				if kubernetes && p.Id == p.PodId {
+					continue
+				}
+
+				containerIDs = append(containerIDs, p.Id)
+			}
+		}
+	}
 
 	return containerIDs
 }

--- a/cmd/talosctl/cmd/talos/service.go
+++ b/cmd/talosctl/cmd/talos/service.go
@@ -6,17 +6,19 @@ package talos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
+	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
-	"github.com/siderolabs/talos/pkg/machinery/formatters"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 // serviceCmd represents the service command.
@@ -31,7 +33,7 @@ With actions 'start', 'stop', 'restart', service state is updated respectively.`
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
-			return getServiceFromNode(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+			return getServiceFromNode(cmd.Context(), nil), cobra.ShellCompDirectiveNoFileComp
 		case 1:
 			return []string{"start", "stop", "restart", "status"}, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -50,170 +52,231 @@ With actions 'start', 'stop', 'restart', service state is updated respectively.`
 			action = args[1]
 		}
 
-		return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-			switch action {
-			case "status":
-				if serviceID == "" {
-					return serviceList(ctx, c)
-				}
+		ctx := cmd.Context()
 
-				return serviceInfo(ctx, c, serviceID)
-			case "start":
-				return serviceStart(ctx, c, serviceID)
-			case "stop":
-				return serviceStop(ctx, c, serviceID)
-			case "restart":
-				return serviceRestart(ctx, c, serviceID)
-			default:
-				return fmt.Errorf("unsupported service action: %q", action)
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
+		switch action {
+		case "status":
+			if serviceID == "" {
+				return serviceList(ctx, clientFactory)
 			}
-		})
+
+			return serviceInfo(ctx, clientFactory, serviceID)
+		case "start":
+			return serviceStart(ctx, clientFactory, serviceID)
+		case "stop":
+			return serviceStop(ctx, clientFactory, serviceID)
+		case "restart":
+			return serviceRestart(ctx, clientFactory, serviceID)
+		default:
+			return fmt.Errorf("unsupported service action: %q", action)
+		}
 	},
 }
 
-func serviceList(ctx context.Context, c *client.Client) error {
-	var remotePeer peer.Peer
-
-	resp, err := c.ServiceList(ctx, grpc.Peer(&remotePeer))
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error listing services: %w", err)
-		}
-
-		cli.Warning("%s", err)
-	}
+func serviceList(ctx context.Context, clientFactory *global.ClientFactory) error {
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ServiceListResponse, error) {
+			return c.ServiceList(ctx)
+		},
+	)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tSERVICE\tSTATE\tHEALTH\tLAST CHANGE\tLAST EVENT")
 
-	defaultNode := client.AddrFromPeer(&remotePeer)
+	var errs error
 
-	for _, msg := range resp.Messages {
-		for _, s := range msg.Services {
-			svc := formatters.ServiceInfoWrapper{ServiceInfo: s}
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 
-			node := defaultNode
+			continue
+		}
 
-			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+		for _, msg := range resp.Payload.Messages {
+			for _, s := range msg.Services {
+				svc := serviceInfoWrapper{s}
+
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s\n", resp.Node, svc.Id, svc.State, svc.healthStatus(), svc.lastUpdated(), svc.lastEvent())
 			}
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s\n", node, svc.Id, svc.State, svc.HealthStatus(), svc.LastUpdated(), svc.LastEvent())
 		}
 	}
 
-	return w.Flush()
+	return errors.Join(errs, w.Flush())
 }
 
-func serviceInfo(ctx context.Context, c *client.Client, id string) error {
-	var remotePeer peer.Peer
+func serviceInfo(ctx context.Context, clientFactory *global.ClientFactory, id string) error {
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) ([]client.ServiceInfo, error) {
+			return c.ServiceInfo(ctx, id)
+		},
+	)
 
-	services, err := c.ServiceInfo(ctx, id, grpc.Peer(&remotePeer))
-	if err != nil {
-		if services == nil {
-			return fmt.Errorf("error listing services: %w", err)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	var (
+		errs  error
+		found bool
+	)
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+			continue
 		}
 
-		cli.Warning("%s", err)
+		for _, s := range resp.Payload {
+			found = true
+
+			renderServiceInfo(w, resp.Node, s.Service)
+		}
 	}
 
-	defaultNode := client.AddrFromPeer(&remotePeer)
+	if err := w.Flush(); err != nil {
+		errs = errors.Join(errs, err)
+	}
 
-	if len(services) == 0 {
+	if !found && errs == nil {
 		return fmt.Errorf("service %q is not registered on any nodes", id)
 	}
 
-	return formatters.RenderServicesInfo(services, os.Stdout, defaultNode, true)
+	return errs
 }
 
-func serviceStart(ctx context.Context, c *client.Client, id string) error {
-	var remotePeer peer.Peer
+// renderServiceInfo writes detailed human readable service information for a single node.
+func renderServiceInfo(w *tabwriter.Writer, node string, s *machineapi.ServiceInfo) {
+	svc := serviceInfoWrapper{s}
 
-	resp, err := c.ServiceStart(ctx, id, grpc.Peer(&remotePeer))
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error starting service: %w", err)
-		}
+	fmt.Fprintf(w, "NODE\t%s\n", node)
+	fmt.Fprintf(w, "ID\t%s\n", svc.Id)
+	fmt.Fprintf(w, "STATE\t%s\n", svc.State)
+	fmt.Fprintf(w, "HEALTH\t%s\n", svc.healthStatus())
 
-		cli.Warning("%s", err)
+	if svc.Health.LastMessage != "" {
+		fmt.Fprintf(w, "LAST HEALTH MESSAGE\t%s\n", svc.Health.LastMessage)
 	}
 
-	defaultNode := client.AddrFromPeer(&remotePeer)
+	label := "EVENTS"
+
+	for i := range svc.Events.Events {
+		event := svc.Events.Events[len(svc.Events.Events)-1-i]
+
+		ts := event.Ts.AsTime()
+		fmt.Fprintf(w, "%s\t[%s]: %s (%s ago)\n", label, event.State, event.Msg, time.Since(ts).Round(time.Second))
+		label = ""
+	}
+}
+
+func serviceStart(ctx context.Context, clientFactory *global.ClientFactory, id string) error {
+	return serviceActionRun(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ServiceStartResponse, error) {
+			return c.ServiceStart(ctx, id)
+		},
+		func(resp *machineapi.ServiceStartResponse) []string {
+			return xslices.Map(resp.Messages, (*machineapi.ServiceStart).GetResp)
+		},
+	)
+}
+
+func serviceStop(ctx context.Context, clientFactory *global.ClientFactory, id string) error {
+	return serviceActionRun(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ServiceStopResponse, error) {
+			return c.ServiceStop(ctx, id)
+		},
+		func(resp *machineapi.ServiceStopResponse) []string {
+			return xslices.Map(resp.Messages, (*machineapi.ServiceStop).GetResp)
+		},
+	)
+}
+
+func serviceRestart(ctx context.Context, clientFactory *global.ClientFactory, id string) error {
+	return serviceActionRun(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machineapi.ServiceRestartResponse, error) {
+			return c.ServiceRestart(ctx, id)
+		},
+		func(resp *machineapi.ServiceRestartResponse) []string {
+			return xslices.Map(resp.Messages, (*machineapi.ServiceRestart).GetResp)
+		},
+	)
+}
+
+// serviceActionRun runs a service control action across all nodes and renders the per-node responses.
+func serviceActionRun[RespT any](
+	ctx context.Context,
+	clientFactory *global.ClientFactory,
+	call func(context.Context, *client.Client) (RespT, error),
+	responses func(RespT) []string,
+) error {
+	responseChan := multiplex.UnaryViaFactory(ctx, clientFactory, call)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tRESPONSE")
 
-	for _, msg := range resp.Messages {
-		node := defaultNode
+	var errs error
 
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+			continue
 		}
 
-		fmt.Fprintf(w, "%s\t%s\n", node, msg.Resp)
+		for _, r := range responses(resp.Payload) {
+			fmt.Fprintf(w, "%s\t%s\n", resp.Node, r)
+		}
 	}
 
-	return w.Flush()
+	return errors.Join(errs, w.Flush())
 }
 
-func serviceStop(ctx context.Context, c *client.Client, id string) error {
-	var remotePeer peer.Peer
-
-	resp, err := c.ServiceStop(ctx, id, grpc.Peer(&remotePeer))
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error starting service: %w", err)
-		}
-
-		cli.Warning("%s", err)
-	}
-
-	defaultNode := client.AddrFromPeer(&remotePeer)
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NODE\tRESPONSE")
-
-	for _, msg := range resp.Messages {
-		node := defaultNode
-
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
-		fmt.Fprintf(w, "%s\t%s\n", node, msg.Resp)
-	}
-
-	return w.Flush()
+// serviceInfoWrapper helper that allows generating rich service information.
+type serviceInfoWrapper struct {
+	*machineapi.ServiceInfo
 }
 
-func serviceRestart(ctx context.Context, c *client.Client, id string) error {
-	var remotePeer peer.Peer
-
-	resp, err := c.ServiceRestart(ctx, id, grpc.Peer(&remotePeer))
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error starting service: %w", err)
-		}
-
-		cli.Warning("%s", err)
+// lastUpdated derives last updated time from the events stream.
+func (svc serviceInfoWrapper) lastUpdated() string {
+	if len(svc.Events.Events) == 0 {
+		return ""
 	}
 
-	defaultNode := client.AddrFromPeer(&remotePeer)
+	ts := svc.Events.Events[len(svc.Events.Events)-1].Ts.AsTime()
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NODE\tRESPONSE")
+	return time.Since(ts).Round(time.Second).String()
+}
 
-	for _, msg := range resp.Messages {
-		node := defaultNode
-
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
-		fmt.Fprintf(w, "%s\t%s\n", node, msg.Resp)
+// lastEvent returns the last service event.
+func (svc serviceInfoWrapper) lastEvent() string {
+	if len(svc.Events.Events) == 0 {
+		return "<none>"
 	}
 
-	return w.Flush()
+	return svc.Events.Events[len(svc.Events.Events)-1].Msg
+}
+
+// healthStatus returns the service health status.
+func (svc serviceInfoWrapper) healthStatus() string {
+	if svc.Health.Unknown {
+		return "?"
+	}
+
+	if svc.Health.Healthy {
+		return "OK"
+	}
+
+	return "Fail"
 }
 
 func init() {

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -14,6 +14,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var shutdownCmdFlags struct {
@@ -38,17 +39,35 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		if !shutdownCmdFlags.wait {
-			return WithClient(cmd.Context(), func(ctx context.Context, c *client.Client) error {
-				if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
-					return err
-				}
+			ctx := cmd.Context()
 
-				if err := c.Shutdown(ctx, opts...); err != nil {
-					return fmt.Errorf("error executing shutdown: %s", err)
-				}
+			clientFactory, err := NewClientFactory(ctx, &shutdownCmdFlags)
+			if err != nil {
+				return err
+			}
 
-				return nil
-			})
+			defer clientFactory.Close() //nolint:errcheck
+
+			if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+				return err
+			}
+
+			responseChan := multiplex.UnaryViaFactory(
+				ctx, clientFactory,
+				func(ctx context.Context, c *client.Client) (struct{}, error) {
+					return struct{}{}, c.Shutdown(ctx, opts...)
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error executing shutdown on node %s: %w", resp.Node, resp.Err))
+				}
+			}
+
+			return errs
 		}
 
 		return action.NewTracker(

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -23,6 +23,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
+var statsCmdFlags struct {
+	kubernetesNamespaceFlag
+}
+
 // statsCmd represents the stats command.
 var statsCmd = &cobra.Command{
 	Use:   "stats",
@@ -32,7 +36,7 @@ var statsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		clientFactory, err := NewClientFactory(ctx, nil)
+		clientFactory, err := NewClientFactory(ctx, &statsCmdFlags)
 		if err != nil {
 			return err
 		}
@@ -44,7 +48,7 @@ var statsCmd = &cobra.Command{
 			driver    common.ContainerDriver
 		)
 
-		if kubernetesFlag {
+		if statsCmdFlags.kubernetes {
 			namespace = constants.K8sContainerdNamespace
 			driver = common.ContainerDriver_CRI
 		} else {
@@ -105,7 +109,7 @@ var statsCmd = &cobra.Command{
 }
 
 func init() {
-	statsCmd.Flags().BoolVarP(&kubernetesFlag, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	statsCmd.Flags().BoolVarP(&statsCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 
 	statsCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	statsCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -17,10 +17,10 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/lifecycle"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
 	"github.com/siderolabs/talos/pkg/cli"
@@ -271,49 +271,60 @@ func upgradeLegacy(ctx context.Context) error {
 //
 // Note: remove me in Talos 1.18.
 func runUpgradeLegacyNoWaitWithOpts(ctx context.Context, opts []client.UpgradeOption) error {
-	return WithClient(ctx, func(ctx context.Context, c *client.Client) error {
-		return doUpgradeLegacy(ctx, c, opts)
-	})
-}
-
-// doUpgradeLegacy performs the legacy MachineService.Upgrade call on an existing client.
-//
-// Note: remove me in Talos 1.18.
-func doUpgradeLegacy(ctx context.Context, c *client.Client, opts []client.UpgradeOption) error {
-	if err := helpers.ClientVersionCheckLegacy(ctx, c); err != nil { //nolint:staticcheck // to be refactored next
+	clientFactory, err := NewClientFactory(ctx, &upgradeCmdFlags)
+	if err != nil {
 		return err
 	}
 
-	var remotePeer peer.Peer
+	defer clientFactory.Close() //nolint:errcheck
 
-	opts = append(opts, client.WithUpgradeGRPCCallOptions(grpc.Peer(&remotePeer)))
+	return doUpgradeLegacy(ctx, clientFactory, opts)
+}
 
-	// TODO: See if we can validate version and prevent starting upgrades to an unknown version
-	resp, err := c.UpgradeWithOptions(ctx, opts...) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.18
-	if err != nil {
-		if resp == nil {
-			return fmt.Errorf("error performing upgrade: %s", err)
-		}
-
-		cli.Warning("%s", err)
+// doUpgradeLegacy performs the legacy MachineService.Upgrade call across all nodes.
+//
+// Note: remove me in Talos 1.18.
+func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, opts []client.UpgradeOption) error {
+	if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+		return err
 	}
+
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machine.UpgradeResponse, error) {
+			// TODO: See if we can validate version and prevent starting upgrades to an unknown version
+			resp, err := c.UpgradeWithOptions(ctx, opts...) //nolint:staticcheck // legacy talosctl methods, to be removed in Talos 1.18
+			if err != nil {
+				if resp == nil {
+					return nil, fmt.Errorf("error performing upgrade: %w", err)
+				}
+
+				// partial success: the upgrade was acknowledged but some non-fatal error occurred
+				cli.Warning("%s", err)
+			}
+
+			return resp, nil
+		},
+	)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tACK\tSTARTED")
 
-	defaultNode := client.AddrFromPeer(&remotePeer)
+	var errs error
 
-	for _, msg := range resp.Messages {
-		node := defaultNode
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 
-		if msg.Metadata != nil {
-			node = msg.Metadata.Hostname //nolint:staticcheck // to be refactored next
+			continue
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t\n", node, msg.Ack, time.Now())
+		for _, msg := range resp.Payload.Messages {
+			fmt.Fprintf(w, "%s\t%s\t%s\t\n", resp.Node, msg.Ack, time.Now())
+		}
 	}
 
-	return w.Flush()
+	return errors.Join(errs, w.Flush())
 }
 
 // upgradeGetActorID is used by the legacy action tracker path.

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -53,25 +53,6 @@ func (args *Args) WithClientNoNodes(ctx context.Context, action func(context.Con
 	return action(ctx, c)
 }
 
-// WithClient builds upon WithClientNoNodes to provide set of nodes on request context based on config & flags.
-func (args *Args) WithClient(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
-	if err != nil {
-		return err
-	}
-
-	defer factory.Close() //nolint:errcheck
-
-	_, c, err := factory.BuildClient(ctx, "")
-	if err != nil {
-		return err
-	}
-
-	ctx = client.WithNodes(ctx, factory.Nodes()...) //nolint:staticcheck // to be refactored next
-
-	return action(ctx, c)
-}
-
 // WithClientAndNodes builds upon WithClientNoNodes to provide a list of nodes to the function.
 func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
 	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -83,13 +83,12 @@ func runAndCheck(t *testing.T, expectedSeparators int, cmdFn func() *exec.Cmd, f
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	assert.Greater(t, len(lines), 2)
-	assert.Equal(t, []string{"NODE", "NAME"}, strings.Fields(lines[0]))
-	assert.Equal(t, []string{"."}, strings.Fields(lines[1])[1:])
+	assert.Equal(t, ".", lines[0])
 
 	var maxActualSeparators int
 
-	for _, line := range lines[2:] {
-		actualSeparators := strings.Count(strings.Fields(line)[1], string(os.PathSeparator))
+	for _, line := range lines[1:] {
+		actualSeparators := strings.Count(line, string(os.PathSeparator))
 
 		if expectedSeparators >= 0 && !assert.LessOrEqual(
 			t,

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -55,7 +55,7 @@ func (suite *LogsSuite) TestServiceNotFound() {
 		[]string{"logs", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "servicenotfound"},
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile(`ERROR:.+ log "servicenotfound" was not registered`)),
+		base.StderrShouldMatch(regexp.MustCompile(`error.+ log "servicenotfound" was not registered`)),
 		base.ShouldFail(),
 	)
 }

--- a/pkg/machinery/formatters/formatters.go
+++ b/pkg/machinery/formatters/formatters.go
@@ -207,6 +207,9 @@ func RenderGraph(ctx context.Context, c *client.Client, resp *inspect.Controller
 }
 
 // RenderServicesInfo writes human readable service information to the io.Writer.
+//
+// Deprecated: this relies on the legacy per-message node metadata; new code should
+// format the node explicitly from the multiplexed response (see the `service` command).
 func RenderServicesInfo(services []client.ServiceInfo, output io.Writer, defaultNode string, withNodeInfo bool) error {
 	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
 
@@ -245,6 +248,9 @@ func RenderServicesInfo(services []client.ServiceInfo, output io.Writer, default
 }
 
 // ServiceInfoWrapper helper that allows generating rich service information.
+//
+// Deprecated: new code should format service information from the multiplexed
+// response with the node attached explicitly (see the `service` command).
 type ServiceInfoWrapper struct {
 	*machine.ServiceInfo
 }

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -2729,11 +2729,13 @@ talosctl logs <service name> [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -f, --follow                     specify if the logs should be streamed
   -h, --help                       help for logs
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -k, --kubernetes                 use the k8s.io containerd namespace
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth


### PR DESCRIPTION
Refactor by eliminating all remaining users of `WithClient`, this wrapper is now gone completely.

The remaining legacy flows are now around the action tracker, which is coming next in the pipeline.

Fixes #13489
