### PR TITLE
feat: expose disk and BIOS firmware versions

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -94,6 +94,7 @@ message DiskSpec {
   repeated string secondary_disks = 16;
   string uuid = 17;
   repeated string symlinks = 18;
+  string firmware_version = 19;
 }
 
 // EncryptionKey is the spec for volume encryption key.

--- a/api/resource/definitions/hardware/hardware.proto
+++ b/api/resource/definitions/hardware/hardware.proto
@@ -69,5 +69,6 @@ message SystemInformationSpec {
   string uuid = 5;
   string wake_up_type = 6;
   string sku_number = 7;
+  string bios_version = 8;
 }
 

--- a/internal/app/machined/pkg/controllers/block/disks.go
+++ b/internal/app/machined/pkg/controllers/block/disks.go
@@ -258,6 +258,8 @@ func (ctrl *DisksController) analyzeBlockDevice(
 			d.TypedSpec().Symlinks = nil
 		}
 
+		d.TypedSpec().FirmwareVersion = props.FirmwareRevision
+
 		return nil
 	})
 }

--- a/internal/app/machined/pkg/controllers/hardware/system.go
+++ b/internal/app/machined/pkg/controllers/hardware/system.go
@@ -151,6 +151,7 @@ func (ctrl *SystemInfoController) reconcileSystemInformation(ctx context.Context
 
 	if err := safe.WriterModify(ctx, r, hardware.NewSystemInformation(hardware.SystemInformationID), func(res *hardware.SystemInformation) error {
 		hwadapter.SystemInformation(res).Update(&ctrl.SMBIOS.SystemInformation, uuidRewrite)
+		res.TypedSpec().BIOSVersion = ctrl.SMBIOS.BIOSInformation.Version
 
 		return nil
 	}); err != nil {

--- a/internal/app/machined/pkg/controllers/hardware/system_test.go
+++ b/internal/app/machined/pkg/controllers/hardware/system_test.go
@@ -50,6 +50,7 @@ func (suite *SystemInfoSuite) TestPopulateSystemInformation() {
 		UUID:         "00000000-0000-0000-0000-002590eb9628",
 		WakeUpType:   "Power Switch",
 		SKUNumber:    "",
+		BIOSVersion:  "3.0c",
 	}
 
 	cpuSpecs := map[string]hardware.ProcessorSpec{

--- a/internal/integration/api/hardware.go
+++ b/internal/integration/api/hardware.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 )
 
@@ -89,6 +91,55 @@ func (suite *HardwareSuite) TestPCRStatus() {
 	ctx := client.WithNode(suite.ctx, node)
 
 	rtestutils.AssertNoResource[*hardware.PCRStatus](ctx, suite.T(), suite.Client.COSI, hardware.NewPCCRStatus(constants.UKIPCR).Metadata().ID())
+}
+
+// TestBIOSVersion tests that SystemInformation.BIOSVersion is populated.
+//
+// BIOSVersion comes from SMBIOS. SMBIOS is essentially always present on
+// amd64, so we require non-empty there. On other architectures (most embedded
+// arm64 hardware exposes no SMBIOS) we accept empty.
+func (suite *HardwareSuite) TestBIOSVersion() {
+	node := suite.RandomDiscoveredNodeInternalIP()
+	ctx := client.WithNode(suite.ctx, node)
+
+	sysInfo, err := safe.StateGetByID[*hardware.SystemInformation](
+		ctx, suite.Client.COSI, hardware.SystemInformationID,
+	)
+	suite.Require().NoError(err)
+
+	if arch := suite.ReadMachineArch(ctx); arch != "amd64" {
+		suite.T().Skipf("skipping BIOS version check on arch %q", arch)
+	}
+
+	suite.Assert().NotEmpty(sysInfo.TypedSpec().BIOSVersion, "amd64 node reported no BIOSVersion")
+}
+
+// TestDiskFirmwareVersion tests that Disk.FirmwareVersion is populated for NVMe disks.
+func (suite *HardwareSuite) TestDiskFirmwareVersion() {
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+	ctx := client.WithNode(suite.ctx, node)
+
+	items, err := safe.StateListAll[*block.Disk](
+		ctx,
+		suite.Client.COSI,
+	)
+	suite.Require().NoError(err)
+
+	var nvmeChecked int
+
+	for disk := range items.All() {
+		if disk.TypedSpec().Transport != "nvme" {
+			continue
+		}
+
+		nvmeChecked++
+
+		suite.Assert().NotEmpty(disk.TypedSpec().FirmwareVersion)
+	}
+
+	if nvmeChecked == 0 {
+		suite.T().Skip("no NVMe disks discovered")
+	}
 }
 
 func init() {

--- a/internal/integration/api/images.go
+++ b/internal/integration/api/images.go
@@ -150,12 +150,7 @@ func (suite *ImagesSuite) TestImportRemove() {
 	suite.T().Logf("using node %s", node)
 
 	// we can only import the image if it matches Talos architecture
-	versionResp, err := suite.Client.Version(ctx)
-	suite.Require().NoError(err)
-	suite.Require().Len(versionResp.GetMessages(), 1)
-
-	arch := versionResp.GetMessages()[0].GetVersion().GetArch()
-	if arch != "amd64" {
+	if arch := suite.ReadMachineArch(ctx); arch != "amd64" {
 		suite.T().Skipf("skipping import test on unsupported architecture %q", arch)
 	}
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -760,6 +760,15 @@ func (apiSuite *APISuite) ReadCmdline(nodeCtx context.Context) string {
 	return apiSuite.ReadFile(nodeCtx, "/proc/cmdline")
 }
 
+// ReadMachineArch reads machine architecture from the node.
+func (apiSuite *APISuite) ReadMachineArch(nodeCtx context.Context) string {
+	versionResp, err := apiSuite.Client.Version(nodeCtx)
+	apiSuite.Require().NoError(err)
+	apiSuite.Require().Len(versionResp.GetMessages(), 1)
+
+	return versionResp.GetMessages()[0].GetVersion().GetArch()
+}
+
 // TearDownSuite closes Talos API client.
 func (apiSuite *APISuite) TearDownSuite() {
 	if apiSuite.Client != nil {

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -505,11 +505,12 @@ type DiskSpec struct {
 	//
 	// E.g. if the blockdevice secondary is vda5, the secondary disk will be set as vda.
 	// This allows to map secondaries between disks ignoring the partitions.
-	SecondaryDisks []string `protobuf:"bytes,16,rep,name=secondary_disks,json=secondaryDisks,proto3" json:"secondary_disks,omitempty"`
-	Uuid           string   `protobuf:"bytes,17,opt,name=uuid,proto3" json:"uuid,omitempty"`
-	Symlinks       []string `protobuf:"bytes,18,rep,name=symlinks,proto3" json:"symlinks,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	SecondaryDisks  []string `protobuf:"bytes,16,rep,name=secondary_disks,json=secondaryDisks,proto3" json:"secondary_disks,omitempty"`
+	Uuid            string   `protobuf:"bytes,17,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Symlinks        []string `protobuf:"bytes,18,rep,name=symlinks,proto3" json:"symlinks,omitempty"`
+	FirmwareVersion string   `protobuf:"bytes,19,opt,name=firmware_version,json=firmwareVersion,proto3" json:"firmware_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DiskSpec) Reset() {
@@ -666,6 +667,13 @@ func (x *DiskSpec) GetSymlinks() []string {
 		return x.Symlinks
 	}
 	return nil
+}
+
+func (x *DiskSpec) GetFirmwareVersion() string {
+	if x != nil {
+		return x.FirmwareVersion
+	}
+	return ""
 }
 
 // EncryptionKey is the spec for volume encryption key.
@@ -2580,7 +2588,7 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\arequest\x18\x01 \x01(\x03R\arequest\"g\n" +
 	"\fDiskSelector\x12;\n" +
 	"\x05match\x18\x01 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\x05match\x12\x1a\n" +
-	"\bexternal\x18\x02 \x01(\tR\bexternal\"\xf5\x03\n" +
+	"\bexternal\x18\x02 \x01(\tR\bexternal\"\xa0\x04\n" +
 	"\bDiskSpec\x12\x12\n" +
 	"\x04size\x18\x01 \x01(\x04R\x04size\x12\x17\n" +
 	"\aio_size\x18\x02 \x01(\x04R\x06ioSize\x12\x1f\n" +
@@ -2605,7 +2613,8 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"prettySize\x12'\n" +
 	"\x0fsecondary_disks\x18\x10 \x03(\tR\x0esecondaryDisks\x12\x12\n" +
 	"\x04uuid\x18\x11 \x01(\tR\x04uuid\x12\x1a\n" +
-	"\bsymlinks\x18\x12 \x03(\tR\bsymlinks\"\xfb\x02\n" +
+	"\bsymlinks\x18\x12 \x03(\tR\bsymlinks\x12)\n" +
+	"\x10firmware_version\x18\x13 \x01(\tR\x0ffirmwareVersion\"\xfb\x02\n" +
 	"\rEncryptionKey\x12\x12\n" +
 	"\x04slot\x18\x01 \x01(\x03R\x04slot\x12L\n" +
 	"\x04type\x18\x02 \x01(\x0e28.talos.resource.definitions.enums.BlockEncryptionKeyTypeR\x04type\x12+\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -448,6 +448,15 @@ func (m *DiskSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.FirmwareVersion) > 0 {
+		i -= len(m.FirmwareVersion)
+		copy(dAtA[i:], m.FirmwareVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.FirmwareVersion)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
 	if len(m.Symlinks) > 0 {
 		for iNdEx := len(m.Symlinks) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Symlinks[iNdEx])
@@ -2592,6 +2601,10 @@ func (m *DiskSpec) SizeVT() (n int) {
 			l = len(s)
 			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.FirmwareVersion)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -4966,6 +4979,38 @@ func (m *DiskSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Symlinks = append(m.Symlinks, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FirmwareVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FirmwareVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/api/resource/definitions/hardware/hardware.pb.go
+++ b/pkg/machinery/api/resource/definitions/hardware/hardware.pb.go
@@ -483,6 +483,7 @@ type SystemInformationSpec struct {
 	Uuid          string                 `protobuf:"bytes,5,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	WakeUpType    string                 `protobuf:"bytes,6,opt,name=wake_up_type,json=wakeUpType,proto3" json:"wake_up_type,omitempty"`
 	SkuNumber     string                 `protobuf:"bytes,7,opt,name=sku_number,json=skuNumber,proto3" json:"sku_number,omitempty"`
+	BiosVersion   string                 `protobuf:"bytes,8,opt,name=bios_version,json=biosVersion,proto3" json:"bios_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -566,6 +567,13 @@ func (x *SystemInformationSpec) GetSkuNumber() string {
 	return ""
 }
 
+func (x *SystemInformationSpec) GetBiosVersion() string {
+	if x != nil {
+		return x.BiosVersion
+	}
+	return ""
+}
+
 var File_resource_definitions_hardware_hardware_proto protoreflect.FileDescriptor
 
 const file_resource_definitions_hardware_hardware_proto_rawDesc = "" +
@@ -614,7 +622,7 @@ const file_resource_definitions_hardware_hardware_proto_rawDesc = "" +
 	"core_count\x18\n" +
 	" \x01(\rR\tcoreCount\x12!\n" +
 	"\fcore_enabled\x18\v \x01(\rR\vcoreEnabled\x12!\n" +
-	"\fthread_count\x18\f \x01(\rR\vthreadCount\"\xf2\x01\n" +
+	"\fthread_count\x18\f \x01(\rR\vthreadCount\"\x95\x02\n" +
 	"\x15SystemInformationSpec\x12\"\n" +
 	"\fmanufacturer\x18\x01 \x01(\tR\fmanufacturer\x12!\n" +
 	"\fproduct_name\x18\x02 \x01(\tR\vproductName\x12\x18\n" +
@@ -624,7 +632,8 @@ const file_resource_definitions_hardware_hardware_proto_rawDesc = "" +
 	"\fwake_up_type\x18\x06 \x01(\tR\n" +
 	"wakeUpType\x12\x1d\n" +
 	"\n" +
-	"sku_number\x18\a \x01(\tR\tskuNumberBz\n" +
+	"sku_number\x18\a \x01(\tR\tskuNumber\x12!\n" +
+	"\fbios_version\x18\b \x01(\tR\vbiosVersionBz\n" +
 	"+dev.talos.api.resource.definitions.hardwareZKgithub.com/siderolabs/talos/pkg/machinery/api/resource/definitions/hardwareb\x06proto3"
 
 var (

--- a/pkg/machinery/api/resource/definitions/hardware/hardware_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/hardware/hardware_vtproto.pb.go
@@ -429,6 +429,13 @@ func (m *SystemInformationSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.BiosVersion) > 0 {
+		i -= len(m.BiosVersion)
+		copy(dAtA[i:], m.BiosVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BiosVersion)))
+		i--
+		dAtA[i] = 0x42
+	}
 	if len(m.SkuNumber) > 0 {
 		i -= len(m.SkuNumber)
 		copy(dAtA[i:], m.SkuNumber)
@@ -686,6 +693,10 @@ func (m *SystemInformationSpec) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.SkuNumber)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.BiosVersion)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -2152,6 +2163,38 @@ func (m *SystemInformationSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.SkuNumber = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BiosVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BiosVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/resources/block/disk.go
+++ b/pkg/machinery/resources/block/disk.go
@@ -34,15 +34,16 @@ type DiskSpec struct {
 	Readonly bool `yaml:"readonly" protobuf:"4"`
 	CDROM    bool `yaml:"cdrom" protobuf:"13"`
 
-	Model      string `yaml:"model,omitempty" protobuf:"5"`
-	Serial     string `yaml:"serial,omitempty" protobuf:"6"`
-	Modalias   string `yaml:"modalias,omitempty" protobuf:"7"`
-	WWID       string `yaml:"wwid,omitempty" protobuf:"8"`
-	UUID       string `yaml:"uuid,omitempty" protobuf:"17"`
-	BusPath    string `yaml:"bus_path,omitempty" protobuf:"9"`
-	SubSystem  string `yaml:"sub_system,omitempty" protobuf:"10"`
-	Transport  string `yaml:"transport,omitempty" protobuf:"11"`
-	Rotational bool   `yaml:"rotational,omitempty" protobuf:"12"`
+	Model           string `yaml:"model,omitempty" protobuf:"5"`
+	FirmwareVersion string `yaml:"firmware_version,omitempty" protobuf:"19"`
+	Serial          string `yaml:"serial,omitempty" protobuf:"6"`
+	Modalias        string `yaml:"modalias,omitempty" protobuf:"7"`
+	WWID            string `yaml:"wwid,omitempty" protobuf:"8"`
+	UUID            string `yaml:"uuid,omitempty" protobuf:"17"`
+	BusPath         string `yaml:"bus_path,omitempty" protobuf:"9"`
+	SubSystem       string `yaml:"sub_system,omitempty" protobuf:"10"`
+	Transport       string `yaml:"transport,omitempty" protobuf:"11"`
+	Rotational      bool   `yaml:"rotational,omitempty" protobuf:"12"`
 
 	// SecondaryDisks (if set) specifies the secondary disk IDs.
 	//

--- a/pkg/machinery/resources/hardware/system_information.go
+++ b/pkg/machinery/resources/hardware/system_information.go
@@ -29,6 +29,7 @@ type SystemInformationSpec struct {
 	Manufacturer string `yaml:"manufacturer,omitempty" protobuf:"1"`
 	ProductName  string `yaml:"productName,omitempty" protobuf:"2"`
 	Version      string `yaml:"version,omitempty" protobuf:"3"`
+	BIOSVersion  string `yaml:"biosVersion,omitempty" protobuf:"8"`
 	SerialNumber string `yaml:"serialnumber,omitempty" protobuf:"4"`
 	UUID         string `yaml:"uuid,omitempty" protobuf:"5"`
 	WakeUpType   string `yaml:"wakeUpType,omitempty" protobuf:"6"`

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -6342,6 +6342,7 @@ DiskSpec is the spec for Disks status.
 | secondary_disks | [string](#string) | repeated | SecondaryDisks (if set) specifies the secondary disk IDs.<br><br>E.g. if the blockdevice secondary is vda5, the secondary disk will be set as vda. This allows to map secondaries between disks ignoring the partitions. |
 | uuid | [string](#string) |  |  |
 | symlinks | [string](#string) | repeated |  |
+| firmware_version | [string](#string) |  |  |
 
 
 
@@ -7496,6 +7497,7 @@ SystemInformationSpec represents the system information obtained from smbios.
 | uuid | [string](#string) |  |  |
 | wake_up_type | [string](#string) |  |  |
 | sku_number | [string](#string) |  |  |
+| bios_version | [string](#string) |  |  |
 
 
 


### PR DESCRIPTION
Adds firmware-version fields to NVMe disks and surfaces the BIOS
version on the SystemInformation resource.

  block.DiskSpec.FirmwareVersion
    requires new go-blockdevice
    Transport == "nvme"; empty for other transports.

  hardware.SystemInformationSpec.BIOSVersion
    Sourced from SMBIOS (ctrl.SMBIOS.BIOSInformation.Version)