### PR TITLE
fix: stop follow reader on renamed files

### DIFF
--- a/pkg/follow/follow.go
+++ b/pkg/follow/follow.go
@@ -162,7 +162,7 @@ func (r *Reader) notify() {
 				case r.notifyCh <- nil:
 				default:
 				}
-			case fsnotify.Remove:
+			case fsnotify.Remove, fsnotify.Rename:
 				select {
 				case r.notifyCh <- errors.New("file was removed while watching"):
 				case <-r.ctx.Done():

--- a/pkg/follow/follow_test.go
+++ b/pkg/follow/follow_test.go
@@ -222,6 +222,33 @@ func (suite *FollowSuite) TestDeleted() {
 	suite.Require().Equal([]byte("abcdefghijklmno"), <-combinedCh)
 }
 
+func (suite *FollowSuite) TestRenamed() {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	// pass sizeHint as 15+1 to make code read beyond the end and encounter file renamed
+	combinedCh := suite.readAll(ctx, "file was removed while watching", 16, time.Second)
+
+	time.Sleep(150 * time.Millisecond)
+
+	//nolint:errcheck
+	suite.writer.WriteString("abc")
+	//nolint:errcheck
+	suite.writer.WriteString("def")
+	//nolint:errcheck
+	suite.writer.WriteString("ghi")
+	//nolint:errcheck
+	suite.writer.WriteString("jkl")
+	//nolint:errcheck
+	suite.writer.WriteString("mno")
+	time.Sleep(150 * time.Millisecond)
+
+	// chunker should terminate when file is renamed away
+	suite.Require().NoError(os.Rename(suite.writer.Name(), suite.writer.Name()+".old"))
+
+	suite.Require().Equal([]byte("abcdefghijklmno"), <-combinedCh)
+}
+
 func (suite *FollowSuite) TestReadWrite() {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()


### PR DESCRIPTION
## What? (description)

Handle `fsnotify.Rename` the same way as `fsnotify.Remove` in `pkg/follow`.
Added a regression test for the renamed-file case too.

## Why? (reasoning)

Talos rotates log files with `os.Rename`, so this is a real path, not just a lab repro.
Before this, a follow reader could just sit there til the context timed out after the watched path got renamed away. Kinda meh for log streaming.
After this change it returns `file was removed while watching` right away, same as the remove case.

Repro:
1. Open a file with `follow.NewReader`.
2. Read past the current EOF.
3. Rename the file.
4. Before this fix, the read waits til ctx timeout and ends as `unexpected EOF`.
5. After this fix, it returns `file was removed while watching` right away.

## Acceptance

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
