### PR TITLE
fix(talosctl): add scrolling to dashboard footer node list

### DIFF
--- a/internal/pkg/dashboard/components/footer.go
+++ b/internal/pkg/dashboard/components/footer.go
@@ -34,6 +34,10 @@ type Footer struct {
 	selectedScreen string
 	paused         bool
 
+	// lastWidth is the inner width captured during the last Draw, used so the
+	// event setters can re-render the windowed node list outside of a draw.
+	lastWidth int
+
 	hitRegions []hitRegion
 
 	// NodeClick is called when a node label is clicked. May be nil.
@@ -103,38 +107,69 @@ func NewFooter(screenKeyToName map[string]string, nodes []string) *Footer {
 		return action, event
 	})
 
-	widget.refresh()
-
 	return widget
+}
+
+// Draw renders the footer, windowing the node list to the available width so
+// the selected node and the screen tabs always stay visible.
+func (widget *Footer) Draw(screen tcell.Screen) {
+	// The parent Grid sets the rect before Draw, so the inner width is known here.
+	_, _, width, _ := widget.GetInnerRect() //nolint:dogsled
+
+	widget.Render(width)
+	widget.TextView.Draw(screen)
 }
 
 // OnNodeSelect implements the NodeSelectListener interface.
 func (widget *Footer) OnNodeSelect(node string) {
 	widget.selectedNode = node
 
-	widget.refresh()
+	widget.Render(widget.lastWidth)
 }
 
 // SelectScreen refreshes the footer with the tabs and screens data.
 func (widget *Footer) SelectScreen(screen string) {
 	widget.selectedScreen = screen
 
-	widget.refresh()
+	widget.Render(widget.lastWidth)
 }
 
 // SetPaused refreshes the footer with the new paused state.
 func (widget *Footer) SetPaused(paused bool) {
 	widget.paused = paused
 
-	widget.refresh()
+	widget.Render(widget.lastWidth)
 }
 
-// refresh rebuilds the footer text and updates hit regions for mouse click detection.
+// Visible widths of the fixed footer separators and indicators.
+const (
+	nodeSepWidth    = 3 // " | " between nodes
+	nodesEndWidth   = 6 // "] --- " between the nodes and screens sections
+	screenSepWidth  = 5 // " --- " between screens
+	leftArrowWidth  = 2 // "‹ " overflow indicator
+	rightArrowWidth = 2 // " ›" overflow indicator
+)
+
+// Render rebuilds the footer text and the mouse-click hit regions for the given
+// inner width.
 //
 // The footer format is: [node1 | node2 | node3] --- [F1: Screen1] --- [Screen2] --- ...
 // where the selected node/screen is highlighted in red.
-// Hit regions track the x-offset ranges of each node and screen label.
-func (widget *Footer) refresh() {
+//
+// The screens section (and the PAUSED indicator) is always rendered in full;
+// the node list gets the remaining width and is windowed around the selected
+// node so it stays visible. "‹"/"›" indicators are shown when nodes are hidden
+// to the left/right. Hit regions track the x-offset ranges of each visible node
+// and screen label.
+//
+//nolint:gocyclo
+func (widget *Footer) Render(width int) {
+	if width <= 0 {
+		return
+	}
+
+	widget.lastWidth = width
+
 	var sb strings.Builder
 
 	x := 0
@@ -147,23 +182,48 @@ func (widget *Footer) refresh() {
 		x += visibleWidth
 	}
 
+	// The screens section is always shown in full; reserve its width up front so
+	// the node window can take the rest. The leading "] --- " is part of it.
+	screensWidth := nodesEndWidth + widget.screensWidth()
+
+	// Budget for the windowed node list, excluding the opening "[" and the
+	// reserved screens section.
+	nodeBudget := max(width-1-screensWidth, 0)
+
+	start, end := widget.nodeWindow(nodeBudget)
+
 	// Opening bracket wrapping the nodes section.
 	write("[", 1)
 
-	for i, node := range widget.nodes {
-		if i > 0 {
-			write(" | ", 3)
+	if start > 0 {
+		write("‹ ", leftArrowWidth)
+	}
+
+	for i := start; i < end; i++ {
+		if i > start {
+			write(" | ", nodeSepWidth)
 		}
 
-		displayName := node
-		if displayName == "" {
-			displayName = "(local)"
+		displayName := widget.displayName(i)
+
+		// If a single node still does not fit, truncate it so the screens stay visible.
+		if end-start == 1 {
+			avail := nodeBudget
+			if start > 0 {
+				avail -= leftArrowWidth
+			}
+
+			if end < len(widget.nodes) {
+				avail -= rightArrowWidth
+			}
+
+			displayName = truncateName(displayName, avail)
 		}
 
 		startX := x
 		nameLen := len([]rune(displayName))
 
-		if node == widget.selectedNode {
+		if widget.nodes[i] == widget.selectedNode {
 			write(fmt.Sprintf("[red]%s[-]", displayName), nameLen)
 		} else {
 			write(displayName, nameLen)
@@ -172,19 +232,20 @@ func (widget *Footer) refresh() {
 		widget.hitRegions = append(widget.hitRegions, hitRegion{
 			startX: startX,
 			endX:   x,
-			node:   node,
+			node:   widget.nodes[i],
 		})
 	}
 
+	if end < len(widget.nodes) {
+		write(" ›", rightArrowWidth)
+	}
+
 	// Closing bracket and separator between nodes and screens.
-	write("] --- ", 6)
+	write("] --- ", nodesEndWidth)
 
-	screenKeys := maps.Keys(widget.screenKeyToName)
-	slices.Sort(screenKeys)
-
-	for i, screenKey := range screenKeys {
+	for i, screenKey := range widget.sortedScreenKeys() {
 		if i > 0 {
-			write(" --- ", 5)
+			write(" --- ", screenSepWidth)
 		}
 
 		screenName := widget.screenKeyToName[screenKey]
@@ -207,9 +268,143 @@ func (widget *Footer) refresh() {
 
 	if widget.paused {
 		// [[yellow]PAUSED[-]] renders as [PAUSED] — no click region needed.
-		write(" --- ", 5)
+		write(" --- ", screenSepWidth)
 		write("[[yellow]PAUSED[-]]", 8)
 	}
 
 	widget.SetText(sb.String())
+}
+
+// sortedScreenKeys returns the screen keys in stable order.
+func (widget *Footer) sortedScreenKeys() []string {
+	screenKeys := maps.Keys(widget.screenKeyToName)
+	slices.Sort(screenKeys)
+
+	return screenKeys
+}
+
+// screensWidth returns the visible width of the screens section (without the
+// leading "] --- " joiner) including the PAUSED indicator when paused.
+func (widget *Footer) screensWidth() int {
+	w := 0
+
+	for i, screenKey := range widget.sortedScreenKeys() {
+		if i > 0 {
+			w += screenSepWidth
+		}
+
+		screenName := widget.screenKeyToName[screenKey]
+
+		if screenName == widget.selectedScreen {
+			w += len([]rune(screenName)) + 2
+		} else {
+			w += len(screenKey) + len([]rune(screenName)) + 4
+		}
+	}
+
+	if widget.paused {
+		w += screenSepWidth + 8
+	}
+
+	return w
+}
+
+// displayName returns the label shown for the node at index i.
+func (widget *Footer) displayName(i int) string {
+	if widget.nodes[i] == "" {
+		return "(local)"
+	}
+
+	return widget.nodes[i]
+}
+
+// nodeWidth returns the visible width of the node label at index i.
+func (widget *Footer) nodeWidth(i int) int {
+	return len([]rune(widget.displayName(i)))
+}
+
+// nodeWindow returns the [start, end) range of nodes to render so the selected
+// node stays visible within budget, leaving room for the "‹"/"›" overflow
+// indicators when nodes are hidden.
+//
+//nolint:gocyclo
+func (widget *Footer) nodeWindow(budget int) (int, int) {
+	if len(widget.nodes) == 0 || budget == 0 {
+		return 0, 0
+	}
+
+	sel := 0
+
+	for i, node := range widget.nodes {
+		if node == widget.selectedNode {
+			sel = i
+
+			break
+		}
+	}
+
+	// windowWidth is the visible width of [start, end) including the overflow
+	// indicators that would be shown for any hidden nodes.
+	windowWidth := func(start, end int) int {
+		total := 0
+
+		for i := start; i < end; i++ {
+			if i > start {
+				total += nodeSepWidth
+			}
+
+			total += widget.nodeWidth(i)
+		}
+
+		if start > 0 {
+			total += leftArrowWidth
+		}
+
+		if end < len(widget.nodes) {
+			total += rightArrowWidth
+		}
+
+		return total
+	}
+
+	start, end := sel, sel+1
+
+	// Greedily grow the window, alternating right then left, while it fits.
+	for {
+		grew := false
+
+		if end < len(widget.nodes) && windowWidth(start, end+1) <= budget {
+			end++
+			grew = true
+		}
+
+		if start > 0 && windowWidth(start-1, end) <= budget {
+			start--
+			grew = true
+		}
+
+		if !grew {
+			break
+		}
+	}
+
+	return start, end
+}
+
+// truncateName shortens s to at most max visible runes, appending "…" when cut.
+func truncateName(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+
+	r := []rune(s)
+	if len(r) <= maxWidth {
+		return s
+	}
+
+	if maxWidth == 1 {
+		return "…"
+	}
+
+	return string(r[:maxWidth-1]) + "…"
 }

--- a/internal/pkg/dashboard/components/footer_test.go
+++ b/internal/pkg/dashboard/components/footer_test.go
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/siderolabs/talos/internal/pkg/dashboard/components"
+)
+
+func testFooter(nodes []string) *components.Footer {
+	f := components.NewFooter(map[string]string{"F1": "Summary", "F2": "Monitor"}, nodes)
+	f.SelectScreen("Summary")
+
+	return f
+}
+
+func manyNodes(n int) []string {
+	nodes := make([]string, n)
+	for i := range nodes {
+		nodes[i] = "10.0.0." + string(rune('0'+i%10)) + strings.Repeat("x", i/10)
+	}
+
+	return nodes
+}
+
+func TestFooterRenderFitsAllNodes(t *testing.T) {
+	nodes := manyNodes(12)
+	f := testFooter(nodes)
+	f.OnNodeSelect(nodes[0])
+
+	// Plenty of width: everything fits, no overflow indicators.
+	f.Render(400)
+
+	text := f.GetText(true)
+
+	for _, node := range nodes {
+		if !strings.Contains(text, node) {
+			t.Errorf("expected all nodes visible, missing %q in %q", node, text)
+		}
+	}
+
+	if strings.ContainsAny(text, "‹›") {
+		t.Errorf("did not expect overflow indicators when everything fits: %q", text)
+	}
+
+	if !strings.Contains(text, "Monitor") {
+		t.Errorf("expected screen tabs visible: %q", text)
+	}
+}
+
+func TestFooterRenderWindowsAroundSelected(t *testing.T) {
+	nodes := manyNodes(12)
+	f := testFooter(nodes)
+
+	// First node selected in a narrow terminal: window starts at the left, so a
+	// right indicator must appear but not a left one, and the selected node and
+	// the screen tabs must remain visible.
+	f.OnNodeSelect(nodes[0])
+	f.Render(80)
+
+	text := f.GetText(true)
+
+	if !strings.Contains(text, nodes[0]) {
+		t.Errorf("expected selected node %q visible: %q", nodes[0], text)
+	}
+
+	if !strings.Contains(text, "›") {
+		t.Errorf("expected right overflow indicator: %q", text)
+	}
+
+	if strings.Contains(text, "‹") {
+		t.Errorf("did not expect left overflow indicator at the start: %q", text)
+	}
+
+	if !strings.Contains(text, "Monitor") {
+		t.Errorf("expected screen tabs always visible: %q", text)
+	}
+
+	// Last node selected: the window scrolls right, so a left indicator appears
+	// but not a right one, and the selected node stays visible.
+	last := nodes[len(nodes)-1]
+	f.OnNodeSelect(last)
+	f.Render(80)
+
+	text = f.GetText(true)
+
+	if !strings.Contains(text, last) {
+		t.Errorf("expected selected last node %q visible: %q", last, text)
+	}
+
+	if !strings.Contains(text, "‹") {
+		t.Errorf("expected left overflow indicator after scrolling right: %q", text)
+	}
+
+	if strings.Contains(text, "›") {
+		t.Errorf("did not expect right overflow indicator at the end: %q", text)
+	}
+
+	if !strings.Contains(text, "Monitor") {
+		t.Errorf("expected screen tabs always visible: %q", text)
+	}
+}
+
+func TestFooterRenderTruncatesSingleNode(t *testing.T) {
+	nodes := []string{"a-very-long-node-name-that-cannot-fit-in-a-narrow-terminal"}
+	f := testFooter(nodes)
+	f.OnNodeSelect(nodes[0])
+
+	f.Render(60)
+
+	text := f.GetText(true)
+
+	if !strings.Contains(text, "…") {
+		t.Errorf("expected the long node name to be truncated with an ellipsis: %q", text)
+	}
+
+	if !strings.Contains(text, "Monitor") {
+		t.Errorf("expected screen tabs to stay visible: %q", text)
+	}
+}


### PR DESCRIPTION
In `talosctl dashboard`, with a big enough cluster, the node list in the footer gets cut off on the right side, so the user needs to blindly select nodes via the cursor keys. This commit fixes this problem by adding horizontal scrolling for the node/ip list in the footer.

<img width="6838" height="3472" alt="Screenshot_20260606_174127" src="https://github.com/user-attachments/assets/efbb3746-c17c-42b2-ad7f-d901e9f1d7a4" />


# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

In the `talosctl dashboard` TUI: Add horizontal scrolling for the IP/node list in the footer.

## Why? (reasoning)

With enough nodes in the cluster the IP/node list gets cut off on the right side. This is an annoying TUI bug as this list is the only way to select a node.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable) - not applicable
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
