### PR TITLE
feat: support proxy-url in talosconfig context

### DIFF
--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -125,6 +125,44 @@ var configNodeCmd = &cobra.Command{
 	},
 }
 
+// configProxyURLCmd represents the `config proxy-url` command.
+var configProxyURLCmd = &cobra.Command{
+	Use:   "proxy-url [url]",
+	Short: "Set the proxy URL for the current context",
+	Long: `Set the proxy URL for the current context.
+
+Supported schemes: socks5, http, https.
+Use "direct" to explicitly bypass any proxy, including environment variable proxies.
+Pass an empty string to clear the proxy URL.
+Omit the argument to display the current proxy URL.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := openConfigAndContext("")
+		if err != nil {
+			return err
+		}
+
+		ctxData, err := getContextData(c)
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			cmd.Println(ctxData.ProxyURL)
+
+			return nil
+		}
+
+		ctxData.ProxyURL = strings.TrimSpace(args[0])
+
+		if err := c.Save(GlobalArgs.Talosconfig); err != nil {
+			return fmt.Errorf("error writing config: %w", err)
+		}
+
+		return nil
+	},
+}
+
 // configContextCmd represents the `config context` command.
 var configContextCmd = &cobra.Command{
 	Use:     "context <context>",
@@ -612,6 +650,7 @@ func init() {
 	configCmd.AddCommand(
 		configEndpointCmd,
 		configNodeCmd,
+		configProxyURLCmd,
 		configContextCmd,
 		configAddCmd,
 		configRemoveCmd,

--- a/cmd/talosctl/cmd/talos/config_test.go
+++ b/cmd/talosctl/cmd/talos/config_test.go
@@ -5,6 +5,10 @@
 package talos //nolint:testpackage // to test unexported function
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -101,4 +105,61 @@ Certificate expires: 10 years from now (2031-07-03)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestConfigProxyURLCmd(t *testing.T) {
+	const talosconfigYAML = `
+context: test
+contexts:
+  test:
+    endpoints:
+      - 192.168.1.1:50000
+`
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "talosconfig")
+
+	require.NoError(t, os.WriteFile(cfgPath, []byte(talosconfigYAML), 0o600))
+
+	origCfg := GlobalArgs.Talosconfig
+	GlobalArgs.Talosconfig = cfgPath
+
+	t.Cleanup(func() { GlobalArgs.Talosconfig = origCfg })
+
+	t.Run("GetEmpty", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		origOut := configProxyURLCmd.OutOrStdout()
+		configProxyURLCmd.SetOut(&buf)
+		t.Cleanup(func() { configProxyURLCmd.SetOut(origOut) })
+
+		require.NoError(t, configProxyURLCmd.RunE(configProxyURLCmd, nil))
+		assert.Equal(t, "\n", buf.String())
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		require.NoError(t, configProxyURLCmd.RunE(configProxyURLCmd, []string{"socks5://localhost:1080"}))
+
+		cfg, err := clientconfig.Open(cfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "socks5://localhost:1080", cfg.Contexts["test"].ProxyURL)
+	})
+
+	t.Run("GetAfterSet", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		configProxyURLCmd.SetOut(&buf)
+		t.Cleanup(func() { configProxyURLCmd.SetOut(nil) })
+
+		require.NoError(t, configProxyURLCmd.RunE(configProxyURLCmd, nil))
+		assert.Equal(t, fmt.Sprintf("%s\n", "socks5://localhost:1080"), buf.String())
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		require.NoError(t, configProxyURLCmd.RunE(configProxyURLCmd, []string{""}))
+
+		cfg, err := clientconfig.Open(cfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "", cfg.Contexts["test"].ProxyURL)
+	})
 }

--- a/internal/integration/api/proxy-url.go
+++ b/internal/integration/api/proxy-url.go
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_api
+
+package api
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+)
+
+// ProxyURLSuite verifies that proxy-url in a talosconfig context routes
+// talosctl→API connections through the specified proxy.
+type ProxyURLSuite struct {
+	base.APISuite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+}
+
+// SuiteName ...
+func (suite *ProxyURLSuite) SuiteName() string {
+	return "api.ProxyURLSuite"
+}
+
+// SetupTest ...
+func (suite *ProxyURLSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 2*time.Minute)
+}
+
+// TearDownTest ...
+func (suite *ProxyURLSuite) TearDownTest() {
+	if suite.ctxCancel != nil {
+		suite.ctxCancel()
+	}
+}
+
+// TestProxyURL verifies that setting proxy-url on a talosconfig context causes
+// outgoing API connections to be routed through the proxy.
+func (suite *ProxyURLSuite) TestProxyURL() {
+	var connectCount atomic.Int32
+
+	ln, err := (&net.ListenConfig{}).Listen(suite.ctx, "tcp", "127.0.0.1:0")
+	suite.Require().NoError(err)
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodConnect {
+				http.Error(w, "only CONNECT supported", http.StatusMethodNotAllowed)
+
+				return
+			}
+
+			connectCount.Add(1)
+
+			dialCtx, dialCancel := context.WithTimeout(r.Context(), 10*time.Second)
+			defer dialCancel()
+
+			dst, dialErr := (&net.Dialer{}).DialContext(dialCtx, "tcp", r.Host)
+			if dialErr != nil {
+				http.Error(w, dialErr.Error(), http.StatusServiceUnavailable)
+
+				return
+			}
+
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				dst.Close() //nolint:errcheck
+
+				http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+
+				return
+			}
+
+			src, _, hijackErr := hijacker.Hijack()
+			if hijackErr != nil {
+				dst.Close() //nolint:errcheck
+
+				http.Error(w, hijackErr.Error(), http.StatusServiceUnavailable)
+
+				return
+			}
+
+			src.Write([]byte("HTTP/1.0 200 Connection established\r\n\r\n")) //nolint:errcheck
+
+			done := make(chan struct{}, 2)
+
+			go func() { io.Copy(dst, src); done <- struct{}{} }() //nolint:errcheck
+			go func() { io.Copy(src, dst); done <- struct{}{} }() //nolint:errcheck
+
+			<-done
+
+			dst.Close() //nolint:errcheck
+			src.Close() //nolint:errcheck
+		}),
+	}
+
+	go srv.Serve(ln) //nolint:errcheck
+
+	defer srv.Close() //nolint:errcheck
+
+	proxyAddr := "http://" + ln.Addr().String()
+
+	currentCtx := suite.Talosconfig.Contexts[suite.Talosconfig.Context]
+	suite.Require().NotNil(currentCtx)
+
+	ctxWithProxy := *currentCtx
+	ctxWithProxy.ProxyURL = proxyAddr
+
+	node := suite.RandomDiscoveredNodeInternalIP()
+
+	c, err := client.New(suite.ctx,
+		client.WithConfigContext(&ctxWithProxy),
+		client.WithEndpoints(node),
+	)
+	suite.Require().NoError(err)
+
+	defer c.Close() //nolint:errcheck
+
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	_, err = c.Version(nodeCtx)
+	suite.Require().NoError(err)
+
+	suite.Assert().Positive(connectCount.Load(), "expected at least one CONNECT tunneling request through the proxy")
+}
+
+func init() {
+	allSuites = append(allSuites, new(ProxyURLSuite))
+}

--- a/pkg/machinery/client/config/config.go
+++ b/pkg/machinery/client/config/config.go
@@ -58,6 +58,7 @@ type Context struct {
 	Key              string   `yaml:"key,omitempty"`
 	Auth             Auth     `yaml:"auth,omitempty"`
 	Cluster          string   `yaml:"cluster,omitempty"`
+	ProxyURL         string   `yaml:"proxy-url,omitempty"`
 }
 
 // Auth may hold credentials for an authentication method such as Basic Auth.

--- a/pkg/machinery/client/config/config_test.go
+++ b/pkg/machinery/client/config/config_test.go
@@ -5,12 +5,65 @@
 package config_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 )
+
+func TestProxyURLRoundTrip(t *testing.T) {
+	yaml := `
+context: test
+contexts:
+  test:
+    endpoints:
+      - 192.168.1.1:50000
+    proxy-url: socks5://localhost:1080
+`
+
+	cfg, err := clientconfig.FromString(yaml)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	ctx := cfg.Contexts["test"]
+	if ctx == nil {
+		t.Fatal("context 'test' not found")
+	}
+
+	if ctx.ProxyURL != "socks5://localhost:1080" {
+		t.Fatalf("expected proxy-url %q, got %q", "socks5://localhost:1080", ctx.ProxyURL)
+	}
+
+	// Round-trip through marshal/unmarshal
+	b, err := cfg.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	cfg2, err := clientconfig.FromBytes(b)
+	if err != nil {
+		t.Fatalf("unexpected parse error after marshal: %v", err)
+	}
+
+	if cfg2.Contexts["test"].ProxyURL != "socks5://localhost:1080" {
+		t.Fatalf("proxy-url not preserved after round-trip: got %q", cfg2.Contexts["test"].ProxyURL)
+	}
+
+	// Empty proxy-url must be omitted from YAML output
+	ctx.ProxyURL = ""
+
+	b, err = cfg.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	if strings.Contains(string(b), "proxy-url") {
+		t.Fatalf("proxy-url should be absent from YAML when empty, got:\n%s", b)
+	}
+}
 
 func TestConfigMerge(t *testing.T) {
 	context1 := &clientconfig.Context{}

--- a/pkg/machinery/client/connection.go
+++ b/pkg/machinery/client/connection.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	"github.com/siderolabs/talos/pkg/machinery/client/dialer"
 	"github.com/siderolabs/talos/pkg/machinery/client/resolver"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/version"
@@ -75,6 +76,10 @@ func (c *Client) getConn(opts ...grpc.DialOption) (*grpcConnectionWrapper, error
 
 	if err := c.resolveConfigContext(); err != nil {
 		return nil, fmt.Errorf("failed to resolve configuration context: %w", err)
+	}
+
+	if proxyURL := c.options.configContext.ProxyURL; proxyURL != "" {
+		dialOpts = append(dialOpts, grpc.WithContextDialer(dialer.ForProxyURL(proxyURL)))
 	}
 
 	basicAuth := c.options.configContext.Auth.Basic

--- a/pkg/machinery/client/dialer/dialer_test.go
+++ b/pkg/machinery/client/dialer/dialer_test.go
@@ -29,3 +29,45 @@ func TestDynamicProxyDialer_SOCKS5(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDialerForProxyURL_SOCKS5(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := dialer.ForProxyURL("socks5://localhost:12345")(ctx, "example.com:443")
+	if err == nil {
+		t.Fatal("expected a SOCKS5 connection error, but no error received")
+	}
+
+	if _, ok := err.(net.Error); !ok {
+		t.Fatalf("unexpected error type %T: %v", err, err)
+	}
+}
+
+func TestDialerForProxyURL_Direct(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := dialer.ForProxyURL("direct")(ctx, "127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected a connection error, but no error received")
+	}
+
+	if _, ok := err.(net.Error); !ok {
+		t.Fatalf("unexpected error type %T: %v", err, err)
+	}
+}
+
+func TestDialerForProxyURL_InvalidScheme(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := dialer.ForProxyURL("ftp://proxy.example.com:21")(ctx, "example.com:443")
+	if err == nil {
+		t.Fatal("expected an error for unsupported scheme, but no error received")
+	}
+
+	if _, ok := err.(net.Error); ok {
+		t.Fatalf("expected a non-net.Error for unsupported scheme, got: %v", err)
+	}
+}

--- a/pkg/machinery/client/dialer/proxy.go
+++ b/pkg/machinery/client/dialer/proxy.go
@@ -90,6 +90,10 @@ func DynamicProxyDialerWithTLSConfig(tlsConfigFunc func() *tls.Config) func(ctx 
 				return nil, err
 			}
 
+			if cd, ok := socks5Dialer.(proxy.ContextDialer); ok {
+				return cd.DialContext(ctx, "tcp", addr)
+			}
+
 			return socks5Dialer.Dial("tcp", addr)
 		}
 
@@ -123,6 +127,57 @@ func mapAddress(address string) (*url.URL, error) {
 	}
 
 	return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
+}
+
+// ForProxyURL returns a context dialer that routes connections through the given proxy URL.
+// Use "direct" to explicitly bypass any proxy (including env vars).
+// Supported schemes: socks5, http, https.
+func ForProxyURL(rawURL string) func(ctx context.Context, addr string) (net.Conn, error) {
+	if rawURL == "direct" {
+		return func(ctx context.Context, addr string) (net.Conn, error) {
+			return NetDialerWithTCPKeepalive().DialContext(ctx, "tcp", addr)
+		}
+	}
+
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		proxyURL, err := url.Parse(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL: %w", err)
+		}
+
+		switch proxyURL.Scheme {
+		case "socks5":
+			socks5Dialer, err := proxySocksFromURL(proxyURL)
+			if err != nil {
+				return nil, err
+			}
+
+			if cd, ok := socks5Dialer.(proxy.ContextDialer); ok {
+				return cd.DialContext(ctx, "tcp", addr)
+			}
+
+			return socks5Dialer.Dial("tcp", addr)
+		case "http":
+			conn, err := NetDialerWithTCPKeepalive().DialContext(ctx, "tcp", proxyURL.Host)
+			if err != nil {
+				return nil, err
+			}
+
+			return doHTTPConnectHandshake(ctx, conn, addr, proxyURL, grpcUA)
+		case "https":
+			conn, err := (&tls.Dialer{
+				NetDialer: NetDialerWithTCPKeepalive(),
+				Config:    &tls.Config{},
+			}).DialContext(ctx, "tcp", proxyURL.Host)
+			if err != nil {
+				return nil, err
+			}
+
+			return doHTTPConnectHandshake(ctx, conn, addr, proxyURL, grpcUA)
+		default:
+			return nil, fmt.Errorf("unsupported proxy scheme %q", proxyURL.Scheme)
+		}
+	}
 }
 
 // To read a response from a net.Conn, http.ReadResponse() takes a bufio.Reader.

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -1040,6 +1040,44 @@ talosctl config node <endpoint>... [flags]
 
 * [talosctl config](#talosctl-config)	 - Manage the client configuration file (talosconfig)
 
+## talosctl config proxy-url
+
+Set the proxy URL for the current context
+
+### Synopsis
+
+Set the proxy URL for the current context.
+
+Supported schemes: socks5, http, https.
+Use "direct" to explicitly bypass any proxy, including environment variable proxies.
+Pass an empty string to clear the proxy URL.
+Omit the argument to display the current proxy URL.
+
+```
+talosctl config proxy-url [url] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for proxy-url
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --cluster string             cluster to connect to if a proxy endpoint is used
+      --context string             context to be used in command
+  -e, --endpoints strings          override default endpoints in Talos configuration
+  -n, --nodes strings              target the specified nodes
+      --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
+```
+
+### SEE ALSO
+
+* [talosctl config](#talosctl-config)	 - Manage the client configuration file (talosconfig)
+
 ## talosctl config remove
 
 Remove contexts
@@ -1098,6 +1136,7 @@ Manage the client configuration file (talosconfig)
 * [talosctl config merge](#talosctl-config-merge)	 - Merge additional contexts from another client configuration file
 * [talosctl config new](#talosctl-config-new)	 - Generate a new client configuration file
 * [talosctl config node](#talosctl-config-node)	 - Set the node(s) for the current context
+* [talosctl config proxy-url](#talosctl-config-proxy-url)	 - Set the proxy URL for the current context
 * [talosctl config remove](#talosctl-config-remove)	 - Remove contexts
 
 ## talosctl conformance kubernetes


### PR DESCRIPTION
## What? (description)

Add a `proxy-url` field to the talosconfig `Context`, mirroring kubectl's `clusters[].cluster.proxy-url` in kubeconfig. When set, connections to the Talos API are routed through the specified proxy without requiring `HTTPS_PROXY` environment variables.

Also adds a `talosctl config proxy-url [url]` subcommand to get/set the field from the CLI, consistent with the existing `config endpoint` and `config node` commands.

Supported schemes: `socks5`, `http`, `https`. Use `"direct"` to explicitly bypass any proxy (including env var proxies) for a specific context.

**Example:**
```yaml
context: home-lab
contexts:
  home-lab:
    endpoints: [192.168.1.10:50000]
    proxy-url: socks5://localhost:1080
    ca: ...
```

```sh
talosctl config proxy-url socks5://localhost:1080  # set
talosctl config proxy-url                          # get
talosctl config proxy-url ""                       # clear
```

## Why? (reasoning)

Users who cannot reach the Talos API directly (e.g. behind a bastion host via SSH SOCKS5 tunnel) currently must set `HTTPS_PROXY` as an environment variable for every shell session. This is inconvenient and not composable when managing multiple clusters with different proxy requirements.

kubectl solves this with per-cluster `proxy-url` in kubeconfig. This PR brings the same ergonomics to talosctl.

Closes #11665

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
