### PR TITLE
test: increase resource inmem buffer to stabilize the tests

### DIFF
--- a/internal/app/machined/pkg/controllers/ctest/ctest.go
+++ b/internal/app/machined/pkg/controllers/ctest/ctest.go
@@ -50,7 +50,13 @@ func (suite *DefaultSuite) SetupTest() {
 
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), suite.Timeout)
 
-	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+	suite.state = state.WrapCore(namespaced.NewState(
+		func(ns resource.Namespace) state.CoreState {
+			return inmem.NewStateWithOptions(
+				inmem.WithHistoryMaxCapacity(1000),
+			)(ns)
+		},
+	))
 
 	var err error
 


### PR DESCRIPTION
This is only for controller unit-tests, which create a inmem resource state for the test, but with high concurrency they might end up with a buffer overrun. The default size was 100 items, bumped it to 1000.
