### PR TITLE
chore: fix lint error in test

### DIFF
--- a/tools/sbom-builder/main_test.go
+++ b/tools/sbom-builder/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	v2_3 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"github.com/stretchr/testify/assert"
 )
 
 // skipIfFIPS skips tests that exercise documentUUID, which derives a UUIDv5 via
@@ -63,9 +64,7 @@ func TestAddOSPackage_AddsSiblingWithRefs(t *testing.T) {
 	)
 
 	osPkg := findPackage(doc, "Package-os-talos")
-	if osPkg == nil {
-		t.Fatalf("expected Package-os-talos to be added, got: %v", packageIDs(doc))
-	}
+	assert.NotNil(t, "expected Package-os-talos to be added, got: %v", packageIDs(doc))
 
 	if osPkg.PrimaryPackagePurpose != "OPERATING-SYSTEM" {
 		t.Errorf("PrimaryPackagePurpose = %q, want OPERATING-SYSTEM", osPkg.PrimaryPackagePurpose)


### PR DESCRIPTION
fix staticcheck possible nil pointer dereference

```
#31 4.306 tools/sbom-builder/main_test.go:66:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
#31 4.306 	if osPkg == nil {
#31 4.306 	   ^
#31 4.306 tools/sbom-builder/main_test.go:70:11: SA5011: possible nil pointer dereference (staticcheck)
#31 4.306 	if osPkg.PrimaryPackagePurpose != "OPERATING-SYSTEM" {
#31 4.306 	         ^
#31 4.306 tools/sbom-builder/main_test.go:104:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
#31 4.306 	if goPkg == nil {
#31 4.306 	   ^
#31 4.306 tools/sbom-builder/main_test.go:108:11: SA5011: possible nil pointer dereference (staticcheck)
#31 4.306 	if goPkg.PackageName != "github.com/siderolabs/talos" {
#31 4.306 	         ^
#31 4.306 4 issues:

```
