### PR TITLE
feat: talosctl improvements

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -161,8 +161,9 @@ func (m *Qemu) AddExtraGenOps() error {
 		}
 	}
 
-	// disable kexec, if bootloader is disabled
-	if !m.EOps.BootloaderEnabled {
+	// disable kexec, if bootloader is disabled, and
+	// also disable kexec on arm64 due to https://github.com/siderolabs/talos/issues/12393
+	if !m.EOps.BootloaderEnabled || m.EOps.TargetArch == "arm64" {
 		m.GenOps = slices.Concat(m.GenOps, []generate.Option{
 			generate.WithSysctls(map[string]string{
 				"kernel.kexec_load_disabled": "1",

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -201,7 +201,6 @@ func GetQemu() Qemu {
 		PreallocateDisks:  false,
 		BootloaderEnabled: true,
 		UefiEnabled:       true,
-		Nameservers:       defaultNameservers,
 		DiskBlockSize:     512,
 		TargetArch:        runtime.GOARCH,
 		CniBinPath:        []string{filepath.Join(clustercmd.DefaultCNIDir, "bin")},

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_linux.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_linux.go
@@ -1,9 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-//go:build linux
-
-package clusterops
-
-var defaultNameservers = []string{}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_other.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options_other.go
@@ -1,9 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-//go:build !linux
-
-package clusterops
-
-var defaultNameservers = []string{"8.8.8.8", "1.1.1.1", "2001:4860:4860::8888", "2606:4700:4700::1111"}

--- a/cmd/talosctl/cmd/mgmt/cluster/logs.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/logs.go
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/logtail"
+	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers"
+)
+
+var logsCmdFlags struct {
+	follow bool
+}
+
+// logsCmd streams QEMU console logs for a cluster's machines.
+var logsCmd = &cobra.Command{
+	Use:   "logs [machine]",
+	Short: "Stream QEMU console logs for cluster machines",
+	Long: `Streams QEMU console logs (the per-machine <machine>.log files).
+
+With no machine argument, every machine in the cluster is tailed, each line
+prefixed with its machine name.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		machine := ""
+		if len(args) == 1 {
+			machine = args[0]
+		}
+
+		return localClusterLogs(cmd.Context(), machine)
+	},
+}
+
+// localClusterLogs tails the local state directory's console log files.
+func localClusterLogs(ctx context.Context, machine string) error {
+	machines := []string{machine}
+
+	// A specific machine was requested — skip the per-line prefix.
+	prefix := machine == ""
+
+	if machine == "" {
+		state, err := provision.ReadState(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+		if err != nil {
+			return fmt.Errorf("failed to read cluster state: %w", err)
+		}
+
+		provisioner, err := providers.Factory(ctx, state.ProvisionerName)
+		if err != nil {
+			return err
+		}
+
+		defer provisioner.Close() //nolint:errcheck
+
+		cluster, err := provisioner.Reflect(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+		if err != nil {
+			return err
+		}
+
+		machines = nil
+
+		for _, node := range cluster.Info().Nodes {
+			machines = append(machines, node.Name)
+		}
+	}
+
+	if len(machines) == 0 {
+		return errors.New("no machines to tail")
+	}
+
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, m := range machines {
+		wg.Add(1)
+
+		go func(machine string) {
+			defer wg.Done()
+
+			path := filepath.Join(PersistentFlags.StateDir, PersistentFlags.ClusterName, machine+".log")
+			tailLocalLog(ctx, path, machine, logsCmdFlags.follow, prefix, &mu)
+		}(m)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+// tailLocalLog tails a single console log file to stdout via the shared
+// logtail helper (tail -F). With prefix set, lines are tagged with the
+// machine name. Writes are serialized through mu so concurrent tailers
+// don't interleave mid-line.
+func tailLocalLog(ctx context.Context, path, machine string, follow, prefix bool, mu *sync.Mutex) {
+	logtail.Tail(ctx, path, follow, func(line []byte) bool {
+		mu.Lock()
+
+		if prefix {
+			fmt.Fprintf(os.Stdout, "[%s] %s\n", machine, line)
+		} else {
+			fmt.Fprintf(os.Stdout, "%s\n", line)
+		}
+
+		mu.Unlock()
+
+		return true
+	})
+}
+
+func init() {
+	logsCmd.Flags().BoolVarP(&logsCmdFlags.follow, "follow", "f", false, "keep streaming new output (tail -F)")
+	Cmd.AddCommand(logsCmd)
+}

--- a/cmd/talosctl/cmd/mgmt/cluster/reboot.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/reboot.go
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers"
+)
+
+var rebootCmdFlags struct {
+	nodes []string
+}
+
+// rebootCmd represents the cluster reboot command.
+var rebootCmd = &cobra.Command{
+	Use:   "reboot",
+	Short: "Forcefully reboots cluster nodes",
+	Long: `Forcefully reboots cluster nodes by restarting the underlying VMs.
+
+By default all nodes are rebooted; pass --node (repeatable) to reboot only specific
+nodes, matched by name or IP address. Only QEMU-based clusters are supported.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return reboot(cmd.Context())
+	},
+}
+
+func reboot(ctx context.Context) error {
+	state, err := provision.ReadState(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster state: %w", err)
+	}
+
+	provisioner, err := providers.Factory(ctx, state.ProvisionerName)
+	if err != nil {
+		return err
+	}
+
+	defer provisioner.Close() //nolint:errcheck
+
+	rebooter, ok := provisioner.(provision.RebootProvisioner)
+	if !ok {
+		return fmt.Errorf("provisioner %q does not support rebooting nodes", state.ProvisionerName)
+	}
+
+	cluster, err := provisioner.Reflect(ctx, PersistentFlags.ClusterName, PersistentFlags.StateDir)
+	if err != nil {
+		return err
+	}
+
+	nodes, err := selectRebootNodes(cluster.Info().Nodes, rebootCmdFlags.nodes)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes {
+		fmt.Printf("rebooting node %q\n", node.Name)
+
+		if err := rebooter.RebootNode(ctx, cluster, node); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// selectRebootNodes returns the nodes matching the given filters (by name or IP).
+// An empty filter list selects all nodes.
+func selectRebootNodes(all []provision.NodeInfo, filters []string) ([]provision.NodeInfo, error) {
+	if len(filters) == 0 {
+		return all, nil
+	}
+
+	selected := make([]provision.NodeInfo, 0, len(filters))
+
+	for _, filter := range filters {
+		idx := slices.IndexFunc(all, func(node provision.NodeInfo) bool {
+			return node.Name == filter || slices.ContainsFunc(node.IPs, func(ip netip.Addr) bool {
+				return ip.String() == filter
+			})
+		})
+
+		if idx < 0 {
+			return nil, fmt.Errorf("no node found matching %q", filter)
+		}
+
+		selected = append(selected, all[idx])
+	}
+
+	return selected, nil
+}
+
+func init() {
+	rebootCmd.Flags().StringSliceVarP(&rebootCmdFlags.nodes, "node", "n", nil, "node name or IP to reboot, can be repeated (default: all nodes)")
+
+	Cmd.AddCommand(rebootCmd)
+}

--- a/cmd/talosctl/pkg/logtail/logtail.go
+++ b/cmd/talosctl/pkg/logtail/logtail.go
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package logtail streams complete lines of a file with `tail -F`
+// semantics: while following, it reopens the file when it is recreated
+// (new inode) or truncated.
+package logtail
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// pollInterval is how often a followed file is re-checked once EOF is hit.
+const pollInterval = 500 * time.Millisecond
+
+// EmitFunc receives one complete log line (trailing newline stripped).
+// Returning false stops the tail.
+type EmitFunc func(line []byte) bool
+
+// waitForFile polls until the file at path can be opened, returning the open
+// handle. It returns ctx.Err() if the context is canceled while waiting.
+func waitForFile(ctx context.Context, path string) (*os.File, error) {
+	for {
+		if f, err := os.Open(path); err == nil {
+			return f, nil
+		}
+
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// Tail streams lines of the file at path to emit. With follow, it keeps
+// polling for new output until ctx is done, reopening the file if it is
+// recreated or truncated — i.e. `tail -F` behavior.
+//
+// nolint:gocyclo
+func Tail(ctx context.Context, path string, follow bool, emit EmitFunc) {
+	f, err := os.Open(path)
+	if err != nil {
+		if !follow {
+			emit(fmt.Appendf(nil, "(console log unavailable: %v)", err))
+
+			return
+		}
+
+		// tail -F: the file may not exist yet (e.g. right after cluster start),
+		// so wait for it to appear instead of giving up.
+		if f, err = waitForFile(ctx, path); err != nil {
+			return
+		}
+	}
+
+	defer func() { f.Close() }() // nolint:errcheck
+
+	var (
+		partial []byte
+		offset  int64
+	)
+
+	buf := make([]byte, 8192)
+
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			offset += int64(n)
+			partial = append(partial, buf[:n]...)
+
+			for {
+				idx := bytes.IndexByte(partial, '\n')
+				if idx < 0 {
+					break
+				}
+
+				if !emit(bytes.TrimRight(partial[:idx], "\r")) {
+					return
+				}
+
+				partial = append([]byte(nil), partial[idx+1:]...)
+			}
+		}
+
+		switch {
+		case readErr == io.EOF && !follow:
+			if len(partial) > 0 {
+				emit(partial)
+			}
+
+			return
+		case readErr == io.EOF:
+			select {
+			case <-time.After(pollInterval):
+			case <-ctx.Done():
+				return
+			}
+
+			// tail -F: reopen if the file was recreated or truncated.
+			if nf, rotated := reopenIfRotated(f, path, offset); rotated {
+				f = nf
+				offset = 0
+				partial = nil
+			}
+		case readErr != nil:
+			return
+		}
+	}
+}
+
+// reopenIfRotated returns a fresh handle (and true) when the file at path
+// was recreated (new inode) or truncated below offset; otherwise the
+// original handle and false.
+func reopenIfRotated(f *os.File, path string, offset int64) (*os.File, bool) {
+	pathInfo, err := os.Stat(path)
+	if err != nil {
+		// Gone for the moment — keep waiting on the current handle.
+		return f, false
+	}
+
+	if curInfo, err := f.Stat(); err == nil && os.SameFile(pathInfo, curInfo) {
+		if pathInfo.Size() >= offset {
+			return f, false // same file, not truncated
+		}
+
+		// Truncated in place — rewind to the start.
+		if _, err := f.Seek(0, io.SeekStart); err == nil {
+			return f, true
+		}
+
+		return f, false
+	}
+
+	// Recreated with a new inode — reopen.
+	nf, err := os.Open(path)
+	if err != nil {
+		return f, false
+	}
+
+	defer func() { f.Close() }() // nolint:errcheck
+
+	return nf, true
+}

--- a/pkg/provision/providers/qemu/reboot.go
+++ b/pkg/provision/providers/qemu/reboot.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/siderolabs/talos/pkg/provision"
+)
+
+// RebootNode forcefully reboots a single cluster node via the QEMU monitor.
+//
+// Sending "q" (quit) to the node's monitor socket makes the QEMU process exit; the per-node
+// launcher (see Launch) then restarts the VM while it is still powered on, resulting in a cold
+// reboot. This mirrors the manual `echo q | socat - unix-connect:<node>.monitor` workflow.
+func (p *provisioner) RebootNode(_ context.Context, cluster provision.Cluster, node provision.NodeInfo) error {
+	statePath, err := cluster.StatePath()
+	if err != nil {
+		return err
+	}
+
+	monitorPath := filepath.Join(statePath, fmt.Sprintf("%s.monitor", node.Name))
+
+	if err := sendMonitorCommand(monitorPath, "q"); err != nil {
+		return fmt.Errorf("failed to reboot node %q: %w", node.Name, err)
+	}
+
+	return nil
+}

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -36,3 +36,10 @@ type Provisioner interface {
 
 	UserDiskName(index int) string
 }
+
+// RebootProvisioner is an optional interface implemented by provisioners that support
+// forcefully rebooting individual cluster nodes.
+type RebootProvisioner interface {
+	// RebootNode forcefully reboots a single cluster node.
+	RebootNode(ctx context.Context, cluster Cluster, node NodeInfo) error
+}

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -576,6 +576,39 @@ talosctl cluster destroy [flags]
 
 * [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
 
+## talosctl cluster logs
+
+Stream QEMU console logs for cluster machines
+
+### Synopsis
+
+Streams QEMU console logs (the per-machine <machine>.log files).
+
+With no machine argument, every machine in the cluster is tailed, each line
+prefixed with its machine name.
+
+```
+talosctl cluster logs [machine] [flags]
+```
+
+### Options
+
+```
+  -f, --follow   keep streaming new output (tail -F)
+  -h, --help     help for logs
+```
+
+### Options inherited from parent commands
+
+```
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
+```
+
+### SEE ALSO
+
+* [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
+
 ## talosctl cluster reboot
 
 Forcefully reboots cluster nodes
@@ -595,7 +628,7 @@ talosctl cluster reboot [flags]
 
 ```
   -h, --help           help for reboot
-      --node strings   node name or IP to reboot, can be repeated (default: all nodes)
+  -n, --node strings   node name or IP to reboot, can be repeated (default: all nodes)
 ```
 
 ### Options inherited from parent commands
@@ -652,6 +685,7 @@ A collection of commands for managing local docker-based or QEMU-based clusters
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl cluster create](#talosctl-cluster-create)	 - Create a local Talos cluster.
 * [talosctl cluster destroy](#talosctl-cluster-destroy)	 - Destroys a local Talos kubernetes cluster
+* [talosctl cluster logs](#talosctl-cluster-logs)	 - Stream QEMU console logs for cluster machines
 * [talosctl cluster reboot](#talosctl-cluster-reboot)	 - Forcefully reboots cluster nodes
 * [talosctl cluster show](#talosctl-cluster-show)	 - Shows info about a local provisioned kubernetes cluster
 

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -576,6 +576,39 @@ talosctl cluster destroy [flags]
 
 * [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
 
+## talosctl cluster reboot
+
+Forcefully reboots cluster nodes
+
+### Synopsis
+
+Forcefully reboots cluster nodes by restarting the underlying VMs.
+
+By default all nodes are rebooted; pass --node (repeatable) to reboot only specific
+nodes, matched by name or IP address. Only QEMU-based clusters are supported.
+
+```
+talosctl cluster reboot [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for reboot
+      --node strings   node name or IP to reboot, can be repeated (default: all nodes)
+```
+
+### Options inherited from parent commands
+
+```
+      --name string    the name of the cluster (default "talos-default")
+      --state string   directory path to store cluster state (default "/home/user/.talos/clusters")
+```
+
+### SEE ALSO
+
+* [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or QEMU-based clusters
+
 ## talosctl cluster show
 
 Shows info about a local provisioned kubernetes cluster
@@ -619,6 +652,7 @@ A collection of commands for managing local docker-based or QEMU-based clusters
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl cluster create](#talosctl-cluster-create)	 - Create a local Talos cluster.
 * [talosctl cluster destroy](#talosctl-cluster-destroy)	 - Destroys a local Talos kubernetes cluster
+* [talosctl cluster reboot](#talosctl-cluster-reboot)	 - Forcefully reboots cluster nodes
 * [talosctl cluster show](#talosctl-cluster-show)	 - Shows info about a local provisioned kubernetes cluster
 
 ## talosctl completion bash


### PR DESCRIPTION
This brings in three changes across three commits:

* [disable kexec for cluster create on arm64](https://github.com/siderolabs/talos/commit/80d5460596fc339dfc61bae8a0163eb8b8b82562)
* [feat(talosctl): use gateway dns for cluster](https://github.com/siderolabs/talos/commit/8c8099c98c93bc58f27ff4325a18ef2b92408ddf) @Orzelius might want to take a look

 This fixes issues that i have to explicitly set --nameservers on mac when i want to use tailscale domain names that are otherwise directly resolvable on host 

* [feat(talosctl): support rebooting cluster nodes](https://github.com/siderolabs/talos/commit/29fbf81d66f8a6cdb4df3fa2d2669c30ac1f41d7)
* [feat(talosctl): implement cluster logs](https://github.com/siderolabs/talos/commit/c82305a03447cee1718f9c108ecccd2375443ed7)