### PR TITLE
feat: #13272 add default probes for kube-apiserver

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -291,10 +291,8 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 	}
 
 	builder := argsbuilder.Args{
-		"admission-control-config-file": {filepath.Join(constants.KubernetesAPIServerConfigDir, "admission-control-config.yaml")},
-		"allow-privileged":              {"true"},
-		// Do not accept anonymous requests by default. Otherwise the kube-apiserver will set the request's group to system:unauthenticated exposing endpoints like /version etc.
-		"anonymous-auth":                     {"false"},
+		"admission-control-config-file":      {filepath.Join(constants.KubernetesAPIServerConfigDir, "admission-control-config.yaml")},
+		"allow-privileged":                   {"true"},
 		"api-audiences":                      {cfg.ControlPlaneEndpoint},
 		"bind-address":                       {"0.0.0.0"},
 		"client-ca-file":                     {filepath.Join(constants.KubernetesAPIServerSecretsDir, "ca.crt")},
@@ -348,6 +346,13 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 
 	handleKubeAPIServerAuthorizationFlags(k8sVersion, builder, extraArgs)
 
+	// Anonymous requests are not accepted by default, otherwise the kube-apiserver would set the request's
+	// group to system:unauthenticated, exposing endpoints like /version etc. Anonymous access is instead
+	// restricted to the health endpoints only (via the authentication config file), so the kubelet HTTP
+	// liveness probe can reach /livez without credentials while every other endpoint keeps rejecting anonymous
+	// requests.
+	useAuthenticationConfig := HandleKubeAPIServerAnonymousAuthFlags(builder, extraArgs)
+
 	mergePolicies := argsbuilder.MergePolicies{
 		"enable-admission-plugins": argsbuilder.MergeAdditive,
 		"feature-gates":            argsbuilder.MergeAdditive,
@@ -370,6 +375,7 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"tls-min-version":                  argsbuilder.MergeDenied,
 		"tls-private-key-file":             argsbuilder.MergeDenied,
 		"authorization-config":             argsbuilder.MergeDenied,
+		"authentication-config":            argsbuilder.MergeDenied,
 	}
 
 	if err := builder.Merge(extraArgs, argsbuilder.WithMergePolicies(mergePolicies)); err != nil {
@@ -386,6 +392,62 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 	env := envVars(cfg.EnvironmentVariables)
 	if goGCEnv := k8stemplates.GoGCEnvFromResources(resources); goGCEnv.Name != "" {
 		env = append(env, goGCEnv)
+	}
+
+	// The probes are unauthenticated requests, so they can only be used when anonymous access to the health
+	// endpoints is allowed via the authentication config file, otherwise they would be rejected with a 401.
+	var (
+		startupProbe   *v1.Probe
+		livenessProbe  *v1.Probe
+		readinessProbe *v1.Probe
+	)
+
+	if useAuthenticationConfig {
+		// Probe configuration follows kubeadm defaults.
+		startupProbe = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path:   "/livez",
+					Host:   "localhost",
+					Port:   intstr.FromInt(cfg.LocalPort),
+					Scheme: v1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      15,
+			FailureThreshold:    24,
+		}
+
+		readinessProbe = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path:   "/readyz",
+					Host:   "localhost",
+					Port:   intstr.FromInt(cfg.LocalPort),
+					Scheme: v1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 0,
+			PeriodSeconds:       1,
+			TimeoutSeconds:      15,
+			FailureThreshold:    3,
+		}
+
+		livenessProbe = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path:   "/livez",
+					Host:   "localhost",
+					Port:   intstr.FromInt(cfg.LocalPort),
+					Scheme: v1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      15,
+			FailureThreshold:    8,
+		}
 	}
 
 	return k8s.APIServerID, safe.WriterModify(ctx, r, k8s.NewStaticPod(k8s.NamespaceName, k8s.APIServerID), func(r *k8s.StaticPod) error {
@@ -450,7 +512,10 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 								ReadOnly:  false,
 							},
 						}, volumeMounts(cfg.ExtraVolumes)...),
-						Resources: resources,
+						StartupProbe:   startupProbe,
+						LivenessProbe:  livenessProbe,
+						ReadinessProbe: readinessProbe,
+						Resources:      resources,
 						SecurityContext: &v1.SecurityContext{
 							AllowPrivilegeEscalation: new(false),
 							Capabilities: &v1.Capabilities{
@@ -785,7 +850,7 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 	})
 }
 
-func kubeAPIServerExtraArgsHasAuthorizationWebhooFlags(extraArgs map[string][]string) bool {
+func kubeAPIServerExtraArgsHasAuthorizationWebhookFlags(extraArgs map[string][]string) bool {
 	return slices.ContainsFunc(maps.Keys(extraArgs), func(arg string) bool {
 		return strings.HasPrefix(arg, "authorization-webhook-")
 	})
@@ -807,7 +872,7 @@ func handleKubeAPIServerAuthorizationFlags(kubeVersion compatibility.Version, ar
 	}
 
 	// 2. user has set `authorization-webhook-*` flags, we'll just merge our default `authorization-mode` flag
-	if kubeAPIServerExtraArgsHasAuthorizationWebhooFlags(extraArgs) {
+	if kubeAPIServerExtraArgsHasAuthorizationWebhookFlags(extraArgs) {
 		argBuilder.Set("authorization-mode", argsbuilder.Value{"Node,RBAC"})
 
 		return
@@ -828,4 +893,31 @@ func handleKubeAPIServerAuthorizationFlags(kubeVersion compatibility.Version, ar
 	}
 
 	argBuilder.Set("authorization-config", argsbuilder.Value{filepath.Join(constants.KubernetesAPIServerConfigDir, "authorization-config.yaml")})
+}
+
+// KubeAPIServerExtraArgsConflictWithAuthenticationConfig returns true if user-provided extra args conflict with
+// the structured authentication config file, which is mutually exclusive with the --anonymous-auth and --oidc-* flags.
+func KubeAPIServerExtraArgsConflictWithAuthenticationConfig(extraArgs map[string][]string) bool {
+	return slices.ContainsFunc(maps.Keys(extraArgs), func(arg string) bool {
+		return arg == "anonymous-auth" || arg == "authentication-config" || strings.HasPrefix(arg, "oidc-")
+	})
+}
+
+// HandleKubeAPIServerAnonymousAuthFlags configures anonymous authentication for the kube-apiserver.
+//
+// It returns true if anonymous auth is managed via the structured authentication config file
+// (--authentication-config), which restricts anonymous access to the health endpoints only. Otherwise anonymous
+// auth is fully disabled via --anonymous-auth=false and the caller must not rely on unauthenticated probes.
+func HandleKubeAPIServerAnonymousAuthFlags(argBuilder argsbuilder.Args, extraArgs map[string][]string) bool {
+	// --authentication-config is mutually exclusive with the --anonymous-auth and --oidc-* flags, so when the
+	// user provides any of those via extra args, fall back to fully disabling anonymous auth.
+	if KubeAPIServerExtraArgsConflictWithAuthenticationConfig(extraArgs) {
+		argBuilder.Set("anonymous-auth", argsbuilder.Value{"false"})
+
+		return false
+	}
+
+	argBuilder.Set("authentication-config", argsbuilder.Value{filepath.Join(constants.KubernetesAPIServerConfigDir, "authentication-config.yaml")})
+
+	return true
 }

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates"
+	"github.com/siderolabs/talos/pkg/argsbuilder"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
@@ -61,7 +62,33 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileDefaults() {
 			suite.Require().NoError(err)
 
 			if staticPod.Metadata().ID() == k8s.APIServerID {
-				asrt.Contains(pod.Spec.Containers[0].Command, "--tls-min-version=VersionTLS13")
+				container := pod.Spec.Containers[0]
+
+				asrt.Contains(container.Command, "--tls-min-version=VersionTLS13")
+
+				// the default (latest) kube-apiserver version supports configurable anonymous auth endpoints,
+				// so anonymous access is restricted to the health endpoints via the authentication config file
+				// and the unauthenticated probes are wired up.
+				asrt.Contains(container.Command, "--authentication-config="+filepath.Join(constants.KubernetesAPIServerConfigDir, "authentication-config.yaml"))
+
+				for _, command := range container.Command {
+					asrt.NotContains(command, "--anonymous-auth")
+				}
+
+				if asrt.NotNil(container.StartupProbe) {
+					asrt.Equal("/livez", container.StartupProbe.HTTPGet.Path)
+					asrt.Equal(v1.URISchemeHTTPS, container.StartupProbe.HTTPGet.Scheme)
+				}
+
+				if asrt.NotNil(container.LivenessProbe) {
+					asrt.Equal("/livez", container.LivenessProbe.HTTPGet.Path)
+					asrt.Equal(v1.URISchemeHTTPS, container.LivenessProbe.HTTPGet.Scheme)
+				}
+
+				if asrt.NotNil(container.ReadinessProbe) {
+					asrt.Equal("/readyz", container.ReadinessProbe.HTTPGet.Path)
+					asrt.Equal(v1.URISchemeHTTPS, container.ReadinessProbe.HTTPGet.Scheme)
+				}
 			}
 		},
 	)
@@ -286,6 +313,28 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraArgsK8s() {
 			},
 		},
 		{
+			k8sVersion: "v1.32.0",
+			args: map[string]k8s.ArgValues{
+				"bind-address": {Values: []string{"127.0.0.1"}},
+			},
+			expected: map[string][]string{
+				"bind-address":          {"127.0.0.1"},
+				"authentication-config": {filepath.Join(constants.KubernetesAPIServerConfigDir, "authentication-config.yaml")},
+			},
+		},
+		{
+			k8sVersion: "v1.32.0", // user provided oidc-* flags conflict with the authentication config file, fall back to anonymous-auth=false
+			args: map[string]k8s.ArgValues{
+				"bind-address":    {Values: []string{"127.0.0.1"}},
+				"oidc-issuer-url": {Values: []string{"https://example.com"}},
+			},
+			expected: map[string][]string{
+				"bind-address":    {"127.0.0.1"},
+				"anonymous-auth":  {"false"},
+				"oidc-issuer-url": {"https://example.com"},
+			},
+		},
+		{
 			args: map[string]k8s.ArgValues{
 				"proxy-client-key-file": {Values: []string{"front-proxy-client.key"}},
 			},
@@ -357,6 +406,87 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraArgsK8s() {
 			for k, v := range test.expected {
 				assertArg(k, v)
 			}
+		})
+	}
+}
+
+func (suite *ControlPlaneStaticPodSuite) TestReconcileAPIServerProbes() {
+	configStatus := k8s.NewConfigStatus(k8s.ControlPlaneNamespaceName, k8s.ConfigStatusStaticPodID)
+	secretStatus := k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID)
+	configAPIServer := k8s.NewAPIServerConfig()
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), configStatus))
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), secretStatus))
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), configAPIServer))
+
+	tests := []struct {
+		name         string
+		args         map[string]k8s.ArgValues
+		expectProbes bool
+	}{
+		{
+			// anonymous access is restricted to the health endpoints via the authentication config file, so the
+			// unauthenticated probes can reach them and are wired up.
+			name:         "default",
+			expectProbes: true,
+		},
+		{
+			// user provided oidc-* flags conflict with the authentication config file, anonymous auth is fully
+			// disabled, so the unauthenticated probes would be rejected and are not wired up.
+			name: "conflicting oidc args",
+			args: map[string]k8s.ArgValues{
+				"oidc-issuer-url": {Values: []string{"https://example.com"}},
+			},
+			expectProbes: false,
+		},
+		{
+			// user explicitly set anonymous-auth, which conflicts with the authentication config file, so the
+			// probes are not wired up.
+			name: "conflicting anonymous-auth arg",
+			args: map[string]k8s.ArgValues{
+				"anonymous-auth": {Values: []string{"true"}},
+			},
+			expectProbes: false,
+		},
+	}
+
+	for _, test := range tests {
+		suite.Run(test.name, func() {
+			configAPIServer.TypedSpec().ExtraArgs = test.args
+
+			suite.Require().NoError(suite.State().Update(suite.Ctx(), configAPIServer))
+
+			rtestutils.AssertResource(suite.Ctx(), suite.T(), suite.State(), k8s.APIServerID, func(staticPod *k8s.StaticPod, assert *assert.Assertions) {
+				apiServerPod, err := k8sadapter.StaticPod(staticPod).Pod()
+				suite.Require().NoError(err)
+
+				assert.NotEmpty(apiServerPod.Spec.Containers)
+
+				container := apiServerPod.Spec.Containers[0]
+
+				if !test.expectProbes {
+					assert.Nil(container.StartupProbe)
+					assert.Nil(container.LivenessProbe)
+					assert.Nil(container.ReadinessProbe)
+
+					return
+				}
+
+				if assert.NotNil(container.StartupProbe) {
+					assert.Equal("/livez", container.StartupProbe.HTTPGet.Path)
+					assert.Equal(v1.URISchemeHTTPS, container.StartupProbe.HTTPGet.Scheme)
+				}
+
+				if assert.NotNil(container.LivenessProbe) {
+					assert.Equal("/livez", container.LivenessProbe.HTTPGet.Path)
+					assert.Equal(v1.URISchemeHTTPS, container.LivenessProbe.HTTPGet.Scheme)
+				}
+
+				if assert.NotNil(container.ReadinessProbe) {
+					assert.Equal("/readyz", container.ReadinessProbe.HTTPGet.Path)
+					assert.Equal(v1.URISchemeHTTPS, container.ReadinessProbe.HTTPGet.Scheme)
+				}
+			})
 		})
 	}
 }
@@ -622,5 +752,82 @@ func TestControlPlaneStaticPodSuite(t *testing.T) {
 				suite.Require().NoError(suite.State().Destroy(suite.Ctx(), v1alpha1.NewService("etcd").Metadata()))
 			},
 		},
+	})
+}
+
+func TestKubeAPIServerExtraArgsConflictWithAuthenticationConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name             string
+		extraArgs        map[string][]string
+		conflictExpected bool
+	}{
+		{
+			name:             "empty",
+			extraArgs:        nil,
+			conflictExpected: false,
+		},
+		{
+			name:             "unrelated args",
+			extraArgs:        map[string][]string{"bind-address": {"127.0.0.1"}, "authorization-mode": {"Webhook"}},
+			conflictExpected: false,
+		},
+		{
+			name:             "anonymous-auth",
+			extraArgs:        map[string][]string{"anonymous-auth": {"true"}},
+			conflictExpected: true,
+		},
+		{
+			name:             "authentication-config",
+			extraArgs:        map[string][]string{"authentication-config": {"/etc/foo.yaml"}},
+			conflictExpected: true,
+		},
+		{
+			name:             "oidc-issuer-url",
+			extraArgs:        map[string][]string{"oidc-issuer-url": {"https://example.com"}},
+			conflictExpected: true,
+		},
+		{
+			name:             "oidc-client-id alongside unrelated args",
+			extraArgs:        map[string][]string{"bind-address": {"127.0.0.1"}, "oidc-client-id": {"talos"}},
+			conflictExpected: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.conflictExpected, k8sctrl.KubeAPIServerExtraArgsConflictWithAuthenticationConfig(test.extraArgs))
+		})
+	}
+}
+
+func TestHandleKubeAPIServerAnonymousAuthFlags(t *testing.T) {
+	t.Parallel()
+
+	authenticationConfigPath := filepath.Join(constants.KubernetesAPIServerConfigDir, "authentication-config.yaml")
+
+	t.Run("no conflict uses authentication config", func(t *testing.T) {
+		t.Parallel()
+
+		builder := argsbuilder.Args{}
+
+		useAuthenticationConfig := k8sctrl.HandleKubeAPIServerAnonymousAuthFlags(builder, map[string][]string{"bind-address": {"127.0.0.1"}})
+
+		assert.True(t, useAuthenticationConfig)
+		assert.Equal(t, argsbuilder.Value{authenticationConfigPath}, builder.Get("authentication-config"))
+		assert.False(t, builder.Contains("anonymous-auth"))
+	})
+
+	t.Run("conflicting args disable anonymous auth", func(t *testing.T) {
+		t.Parallel()
+
+		builder := argsbuilder.Args{}
+
+		useAuthenticationConfig := k8sctrl.HandleKubeAPIServerAnonymousAuthFlags(builder, map[string][]string{"oidc-issuer-url": {"https://example.com"}})
+
+		assert.False(t, useAuthenticationConfig)
+		assert.Equal(t, argsbuilder.Value{"false"}, builder.Get("anonymous-auth"))
+		assert.False(t, builder.Contains("authentication-config"))
 	})
 }

--- a/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 
 	"github.com/siderolabs/talos/internal/pkg/selinux"
@@ -136,6 +137,27 @@ func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r control
 			f        func() (runtime.Object, error)
 		}
 
+		apiServerConfigFiles := []configFile{
+			{
+				filename: "admission-control-config.yaml",
+				f:        admissionControlConfig(admissionConfig),
+			},
+			{
+				filename: "auditpolicy.yaml",
+				f:        auditPolicyConfig(auditConfig),
+			},
+			{
+				filename: "authorization-config.yaml",
+				f:        authorizationConfig(authorizerConfig, kubeAPIServerVersion),
+			},
+			// Anonymous access is restricted to the health endpoints only via the authentication config file
+			// (see ControlPlaneStaticPodController).
+			{
+				filename: "authentication-config.yaml",
+				f:        authenticationConfig(),
+			},
+		}
+
 		serializer := k8sjson.NewSerializerWithOptions(
 			k8sjson.DefaultMetaFactory, nil, nil,
 			k8sjson.SerializerOptions{
@@ -159,20 +181,7 @@ func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r control
 				selinuxLabel: constants.KubernetesAPIServerConfigDirSELinuxLabel,
 				uid:          constants.KubernetesAPIServerRunUser,
 				gid:          constants.KubernetesAPIServerRunGroup,
-				configs: []configFile{
-					{
-						filename: "admission-control-config.yaml",
-						f:        admissionControlConfig(admissionConfig),
-					},
-					{
-						filename: "auditpolicy.yaml",
-						f:        auditPolicyConfig(auditConfig),
-					},
-					{
-						filename: "authorization-config.yaml",
-						f:        authorizationConfig(authorizerConfig, kubeAPIServerVersion),
-					},
-				},
+				configs:      apiServerConfigFiles,
 			},
 			{
 				name:         "kube-scheduler",
@@ -311,5 +320,30 @@ func authorizationConfig(spec *k8s.AuthorizationConfigSpec, kubeAPIServerVersion
 		}
 
 		return &cfg, nil
+	}
+}
+
+// authenticationConfig renders the kube-apiserver authentication configuration.
+//
+// It enables anonymous authentication only for the health endpoints, so unauthenticated probes can reach them
+// while every other endpoint keeps rejecting anonymous requests.
+func authenticationConfig() func() (runtime.Object, error) {
+	return func() (runtime.Object, error) {
+		cfg := &apiserverv1beta1.AuthenticationConfiguration{
+			JWT: []apiserverv1beta1.JWTAuthenticator{},
+			Anonymous: &apiserverv1beta1.AnonymousAuthConfig{
+				Enabled: true,
+				Conditions: []apiserverv1beta1.AnonymousAuthCondition{
+					{Path: "/livez"},
+					{Path: "/readyz"},
+					{Path: "/healthz"},
+				},
+			},
+		}
+
+		cfg.APIVersion = "apiserver.config.k8s.io/v1beta1"
+		cfg.Kind = "AuthenticationConfiguration"
+
+		return cfg, nil
 	}
 }


### PR DESCRIPTION
Resolves: https://github.com/siderolabs/talos/issues/13272

Adds default, non-configurable probes to kube-apiserver.

Probe periods, timeouts, failure thresholds follow what kubeadm does out of the box ([1](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/staticpod/utils.go#L256-L279), [2](https://github.com/kubernetes/kubernetes/blob/2f5e22e8bb66836f767715d99a83662250968bf5/cmd/kubeadm/app/phases/controlplane/manifests.go?plain=1#L67-L69)). The key difference is that Talos disables kube-apiserver [anonymous auth](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests), which we work around with [anonymous auth configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration). Kubeadm doesn't have this problem, as it never disables anonymous auth.

The `AnonymousAuthConfigurableEndpoints` feature gate is introduced as alpha with Kubernetes v1.31 (disabled by default), and beta with v1.32 (enabled by default) (see [feature gate docs](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features)). However, since as the time of writing the oldest version we support is v1.32, this feature does not handle feature compatibility concerns that would otherwise arise with <v1.32 (feature absent or disabled by default).

One caveat is that OIDC and configurable auth are mutually exclusive ([src](https://github.com/kubernetes/kubernetes/blob/9e570c4124691bd0d765e780d0225655f99a905e/pkg/kubeapiserver/options/authentication.go#L863-L866)). Therefore, if OIDC is enabled (e.g. via `extraArgs`):
- we cannot enable configurable auth, and therefore we cannot configure kube-apiserver probes - otherwise they would always get HTTP 401 responses.
- we disable anonymous auth altogether (current approach).

As tested locally, the kube-apiserver Pods are rendered with default probes:

```yaml
apiVersion: v1
kind: Pod
metadata:
# ...
  name: kube-apiserver-talos-default-controlplane-1
  namespace: kube-system
# ...
    image: registry.k8s.io/kube-apiserver:v1.36.1
    imagePullPolicy: IfNotPresent
    livenessProbe:
      failureThreshold: 8
      httpGet:
        host: localhost
        path: /livez
        port: 6443
        scheme: HTTPS
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 15
    name: kube-apiserver
    readinessProbe:
      failureThreshold: 3
      httpGet:
        host: localhost
        path: /readyz
        port: 6443
        scheme: HTTPS
      periodSeconds: 1
      successThreshold: 1
      timeoutSeconds: 15
# ...
    startupProbe:
      failureThreshold: 24
      httpGet:
        host: localhost
        path: /livez
        port: 6443
        scheme: HTTPS
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 15
# ...
```
