### PR TITLE
refactor: use ClientFactory for the action tracker

### DIFF
--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
@@ -52,63 +51,69 @@ var debugCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClientAndNodes(cmd.Context(), func(ctx context.Context, c *client.Client, nodes []string) error {
-			if len(nodes) != 1 {
-				return fmt.Errorf("expected exactly one node, got %v", nodes)
-			}
+		ctx := cmd.Context()
 
-			ctx = client.WithNode(ctx, nodes[0])
+		clientFactory, err := NewClientFactory(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-			rep := reporter.New()
+		defer clientFactory.Close() //nolint:errcheck
 
-			ctrdInstance, err := debugCmdFlags.containerdInstance()
+		ctx, c, node, err := clientFactory.BuildClientEnforceSingleNode(ctx, "debug")
+		if err != nil {
+			return err
+		}
+
+		rep := reporter.New()
+
+		ctrdInstance, err := debugCmdFlags.containerdInstance()
+		if err != nil {
+			return err
+		}
+
+		// verify if we are sending a tarball or pulling an image
+		_, err = os.Stat(args[0])
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat image argument: %w", err)
+		}
+
+		var imgName string
+
+		if err == nil {
+			imgName, err = imageImportInternal(ctx, c, ctrdInstance, node, args[0], rep)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to import image: %w", err)
 			}
-
-			// verify if we are sending a tarball or pulling an image
-			_, err = os.Stat(args[0])
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("failed to stat image argument: %w", err)
-			}
-
-			var imgName string
-
-			if err == nil {
-				imgName, err = imageImportInternal(ctx, c, ctrdInstance, nodes[0], args[0], rep)
-				if err != nil {
-					return fmt.Errorf("failed to import image: %w", err)
-				}
-			} else {
-				pullResult, err := imagePullInternal(ctx, c, ctrdInstance, nodes, args[0], rep)
-				if err != nil {
-					return fmt.Errorf("failed to pull image: %w", err)
-				}
-
-				imgName = pullResult[nodes[0]]
-			}
-
-			// no easy way to disable hooking up signal handling to the command context,
-			// so instead save this context and use a new one from here on out.
-			//
-			// new context so that SIGINT/similar won't immediately cancel streaming
-			// and instead allow us to forward the signal to the container
-			ctx = context.WithoutCancel(ctx)
-
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			runStream, err := c.DebugClient.ContainerRun(
-				ctx,
-				grpc.MaxCallRecvMsgSize(4*1024*1024), // 4 MiB
-				grpc.MaxCallSendMsgSize(4*1024*1024),
-			)
+		} else {
+			pullResult, err := imagePullInternal(ctx, clientFactory, ctrdInstance, args[0], rep)
 			if err != nil {
-				return fmt.Errorf("failed to create debug container stream: %w", err)
+				return fmt.Errorf("failed to pull image: %w", err)
 			}
 
-			return runContainer(ctx, rep, runStream, imgName, debugCmdFlags.args, ctrdInstance)
-		})
+			imgName = pullResult[node]
+		}
+
+		// no easy way to disable hooking up signal handling to the command context,
+		// so instead save this context and use a new one from here on out.
+		//
+		// new context so that SIGINT/similar won't immediately cancel streaming
+		// and instead allow us to forward the signal to the container
+		ctx = context.WithoutCancel(ctx)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		runStream, err := c.DebugClient.ContainerRun(
+			ctx,
+			grpc.MaxCallRecvMsgSize(4*1024*1024), // 4 MiB
+			grpc.MaxCallSendMsgSize(4*1024*1024),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create debug container stream: %w", err)
+		}
+
+		return runContainer(ctx, rep, runStream, imgName, debugCmdFlags.args, ctrdInstance)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/drain.go
+++ b/cmd/talosctl/cmd/talos/drain.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	drainpkg "github.com/siderolabs/talos/cmd/talosctl/cmd/talos/drain"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/kubeclient"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
-	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
@@ -30,8 +30,13 @@ type nodeUpdate struct {
 // and performs cordon + drain on all of them in parallel.
 //
 // It returns a map of talosIP -> k8sNodeName for use in the uncordon phase.
-// The context must NOT have "nodes" metadata set (use WithClientAndNodes).
-func drainNodes(ctx context.Context, c *client.Client, nodes []string, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
+func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
+	// For kubeconfig - build a random endpoint client (to go to the controlplane).
+	c, err := clientFactory.BuildRandomEndpointClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Fetch kubeconfig once - it is cluster-global, not node-specific.
 	clientset, err := kubeclient.FromTalosClient(ctx, c)
 	if err != nil {
@@ -42,7 +47,7 @@ func drainNodes(ctx context.Context, c *client.Client, nodes []string, drainTime
 	updateCh := make(chan nodeUpdate)
 
 	// k8sNames collects Talos IP -> K8s node name mappings produced by each goroutine.
-	k8sNames := make(map[string]string, len(nodes))
+	k8sNames := make(map[string]string, len(clientFactory.Nodes()))
 
 	var mapMux sync.Mutex // protects k8sNames map during writes
 
@@ -64,12 +69,14 @@ func drainNodes(ctx context.Context, c *client.Client, nodes []string, drainTime
 	}()
 
 	// Launch a goroutine per node.
-	for _, node := range nodes {
+	for _, node := range clientFactory.Nodes() {
 		eg.Go(func() error {
-			// Use client.WithNode for single-node COSI routing (avoids one-to-many proxy error).
-			nodeCtx := client.WithNode(ctx, node)
+			ctx, c, err := clientFactory.BuildClient(ctx, node)
+			if err != nil {
+				return fmt.Errorf("error building client for node %s: %w", node, err)
+			}
 
-			k8sNodeName, resolveErr := nodedrain.GetKubernetesNodeName(nodeCtx, c)
+			k8sNodeName, resolveErr := nodedrain.GetKubernetesNodeName(ctx, c)
 			if resolveErr != nil {
 				return fmt.Errorf("error resolving Kubernetes node name for %s: %w", node, resolveErr)
 			}
@@ -106,8 +113,13 @@ func drainNodes(ctx context.Context, c *client.Client, nodes []string, drainTime
 // then uncordons all of them in parallel.
 //
 // nodeNames maps talosIP -> k8sNodeName (produced by drainNodes).
-// The context must NOT have "nodes" metadata set (use WithClientAndNodes).
-func uncordonNodes(ctx context.Context, c *client.Client, nodeNames map[string]string, timeout time.Duration, rep *reporter.Reporter) error {
+func uncordonNodes(ctx context.Context, clientFactory *global.ClientFactory, nodeNames map[string]string, timeout time.Duration, rep *reporter.Reporter) error {
+	// For kubeconfig - build a random endpoint client (to go to the controlplane).
+	c, err := clientFactory.BuildRandomEndpointClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Fetch a fresh kubeconfig (the previous connection may be stale after reboot).
 	// The context has no "nodes" metadata (called from WithClientAndNodes), so the
 	// request routes to the endpoint which is a control-plane node by convention.

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/pull"
 	mgmthelpers "github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/artifacts"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services/registry"
 	"github.com/siderolabs/talos/pkg/flags"
@@ -116,73 +117,71 @@ var imageListCmd = &cobra.Command{
 }
 
 func imageList(ctx context.Context) error {
-	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		containerdInstance, err := imageCmdFlags.containerdInstance()
-		if err != nil {
-			return err
-		}
-
-		responseChan := multiplex.Streaming(
-			ctx, nodes,
-			func(ctx context.Context) (grpc.ServerStreamingClient[machine.ImageServiceListResponse], error) {
-				return c.ImageClient.List(ctx, &machine.ImageServiceListRequest{
-					Containerd: containerdInstance,
-				})
-			},
-		)
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		headerWritten := false
-
-		var errs error
-
-		for resp := range responseChan {
-			if resp.Err != nil {
-				if status.Code(resp.Err) == codes.Unimplemented {
-					// fallback to legacy API for older Talos
-					return imageListLegacy(ctx)
-				}
-
-				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-
-				continue
-			}
-
-			if !headerWritten {
-				headerWritten = true
-
-				fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tLABELS\tCREATED")
-			}
-
-			fmt.Fprintf(
-				w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				resp.Node,
-				resp.Payload.GetName(),
-				resp.Payload.GetDigest(),
-				humanize.Bytes(uint64(resp.Payload.GetSize())),
-				helpers.FormatLabels(resp.Payload.GetLabels()),
-				resp.Payload.GetCreatedAt().AsTime().Format(time.RFC3339),
-			)
-		}
-
-		return errors.Join(errs, w.Flush())
-	})
-}
-
-// imageListLegacy lists images using the legacy ImageList API.
-//
-// Note: remove me in Talos 1.15.
-func imageListLegacy(ctx context.Context) error {
-	clientFactory, err := NewClientFactory(ctx, &imageCmdFlags)
+	clientFactory, err := NewClientFactory(ctx, nil)
 	if err != nil {
 		return err
 	}
 
 	defer clientFactory.Close() //nolint:errcheck
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	containerdInstance, err := imageCmdFlags.containerdInstance()
+	if err != nil {
+		return err
+	}
+
+	responseChan := multiplex.StreamingViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (grpc.ServerStreamingClient[machine.ImageServiceListResponse], error) {
+			return c.ImageClient.List(ctx, &machine.ImageServiceListRequest{
+				Containerd: containerdInstance,
+			})
+		},
+	)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	headerWritten := false
+
+	var errs error
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			if status.Code(resp.Err) == codes.Unimplemented {
+				// fallback to legacy API for older Talos
+				return imageListLegacy(ctx, clientFactory)
+			}
+
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
+
+			continue
+		}
+
+		if !headerWritten {
+			headerWritten = true
+
+			fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tLABELS\tCREATED")
+		}
+
+		fmt.Fprintf(
+			w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			resp.Node,
+			resp.Payload.GetName(),
+			resp.Payload.GetDigest(),
+			humanize.Bytes(uint64(resp.Payload.GetSize())),
+			helpers.FormatLabels(resp.Payload.GetLabels()),
+			resp.Payload.GetCreatedAt().AsTime().Format(time.RFC3339),
+		)
+	}
+
+	return errors.Join(errs, w.Flush())
+}
+
+// imageListLegacy lists images using the legacy ImageList API.
+//
+// Note: remove me in Talos 1.15.
+func imageListLegacy(ctx context.Context, clientFactory *global.ClientFactory) error {
 	ns, err := imageCmdFlags.apiNamespace()
 	if err != nil {
 		return err
@@ -234,34 +233,38 @@ var imagePullCmd = &cobra.Command{
 
 // imagePull pulls an image using modern API and showing progress.
 func imagePull(ctx context.Context, imageRef string) error {
-	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
-		rep := reporter.New()
-
-		containerdInstance, err := imageCmdFlags.containerdInstance()
-		if err != nil {
-			return err
-		}
-
-		_, err = imagePullInternal(ctx, c, containerdInstance, nodes, imageRef, rep)
-
+	clientFactory, err := NewClientFactory(ctx, nil)
+	if err != nil {
 		return err
-	})
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	rep := reporter.New()
+
+	containerdInstance, err := imageCmdFlags.containerdInstance()
+	if err != nil {
+		return err
+	}
+
+	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, imageRef, rep)
+
+	return err
 }
 
 func imagePullInternal(
 	ctx context.Context,
-	c *client.Client,
+	clientFactory *global.ClientFactory,
 	containerdInstance *common.ContainerdInstance,
-	nodes []string,
 	imageRef string,
 	rep *reporter.Reporter,
 ) (map[string]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	streamCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	responseChan := multiplex.Streaming(
-		ctx, nodes,
-		func(ctx context.Context) (grpc.ServerStreamingClient[machine.ImageServicePullResponse], error) {
+	responseChan := multiplex.StreamingViaFactory(
+		streamCtx, clientFactory,
+		func(ctx context.Context, c *client.Client) (grpc.ServerStreamingClient[machine.ImageServicePullResponse], error) {
 			return c.ImageClient.Pull(ctx, &machine.ImageServicePullRequest{
 				Containerd: containerdInstance,
 				ImageRef:   imageRef,
@@ -375,8 +378,6 @@ func imageImportInternal(
 
 	defer in.Close() //nolint:errcheck
 
-	ctx = client.WithNode(ctx, node)
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -458,35 +459,40 @@ var imageRemoveCmd = &cobra.Command{
 
 // imageRemove removes an image using modern API.
 func imageRemove(ctx context.Context, imageRef string) error {
-	return WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-		containerdInstance, err := imageCmdFlags.containerdInstance()
-		if err != nil {
-			return err
+	clientFactory, err := NewClientFactory(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	containerdInstance, err := imageCmdFlags.containerdInstance()
+	if err != nil {
+		return err
+	}
+
+	responseChan := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*emptypb.Empty, error) {
+			return c.ImageClient.Remove(ctx, &machine.ImageServiceRemoveRequest{
+				Containerd: containerdInstance,
+				ImageRef:   imageRef,
+			})
+		},
+	)
+
+	var errs error
+
+	for resp := range responseChan {
+		if resp.Err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
 		}
+	}
 
-		responseChan := multiplex.Unary(
-			ctx, nodes,
-			func(ctx context.Context) (*emptypb.Empty, error) {
-				return c.ImageClient.Remove(ctx, &machine.ImageServiceRemoveRequest{
-					Containerd: containerdInstance,
-					ImageRef:   imageRef,
-				})
-			},
-		)
-
-		var errs error
-
-		for resp := range responseChan {
-			if resp.Err != nil {
-				errs = errors.Join(errs, fmt.Errorf("error from node %s: %w", resp.Node, resp.Err))
-			}
-		}
-
-		return errs
-	})
+	return errs
 }
 
 var imageK8sBundleCmdFlags = struct {

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
 	"github.com/siderolabs/talos/pkg/flags"
@@ -59,46 +60,40 @@ var rebootCmd = &cobra.Command{
 }
 
 func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
+	clientFactory, err := NewClientFactory(ctx, &rebootCmdFlags, action.GRPCDialOptions()...)
+	if err != nil {
+		return err
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
 	rep := reporter.New(
 		reporter.WithOutputMode(rebootCmdFlags.progress.Value()),
 	)
 
 	if !rebootCmdFlags.drain {
-		return rebootInternal(ctx, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
+		return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 	}
 
-	var nodeNames map[string]string
-
-	if err := WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
-		var drainErr error
-
-		nodeNames, drainErr = drainNodes(ctx, c, nodes, rebootCmdFlags.drainTimeout, rep)
-
-		return drainErr
-	}); err != nil {
-		return err
+	nodeNames, err := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rep)
+	if err != nil {
+		return fmt.Errorf("error draining nodes: %w", err)
 	}
 
 	defer func() {
-		if uncordonErr := WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, _ []string) error {
-			return uncordonNodes(ctx, c, nodeNames, rebootCmdFlags.timeout, rep)
-		}); uncordonErr != nil {
+		if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, rebootCmdFlags.timeout, rep); uncordonErr != nil {
 			retErr = errors.Join(retErr, uncordonErr)
 		}
 	}()
 
-	return rebootInternal(ctx, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
+	return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 }
 
-func rebootInternal(ctx context.Context, wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode) error {
+func rebootInternal(
+	ctx context.Context, clientFactory *global.ClientFactory,
+	wait, debug bool, timeout time.Duration, rep *reporter.Reporter, opts ...client.RebootMode,
+) error {
 	if !wait {
-		clientFactory, err := NewClientFactory(ctx, &rebootCmdFlags)
-		if err != nil {
-			return err
-		}
-
-		defer clientFactory.Close() //nolint:errcheck
-
 		if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
 			return err
 		}
@@ -122,7 +117,7 @@ func rebootInternal(ctx context.Context, wait, debug bool, timeout time.Duration
 	}
 
 	return action.NewTracker(
-		&GlobalArgs,
+		clientFactory,
 		action.MachineReadyEventFn,
 		rebootGetActorID(opts...),
 		action.WithPostCheck(action.BootIDChangedPostCheckFn),

--- a/cmd/talosctl/cmd/talos/reset.go
+++ b/cmd/talosctl/cmd/talos/reset.go
@@ -92,16 +92,16 @@ var resetCmd = &cobra.Command{
 
 		resetRequest := buildResetRequest()
 
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &resetCmdFlags, action.GRPCDialOptions()...)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
 		if !resetCmdFlags.wait {
-			ctx := cmd.Context()
-
-			clientFactory, err := NewClientFactory(ctx, &resetCmdFlags)
-			if err != nil {
-				return err
-			}
-
-			defer clientFactory.Close() //nolint:errcheck
-
 			if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ var resetCmd = &cobra.Command{
 		}
 
 		return action.NewTracker(
-			&GlobalArgs,
+			clientFactory,
 			action.StopAllServicesEventFn,
 			actionFn,
 			action.WithPostCheck(postCheckFn),

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -55,14 +55,9 @@ const pathAutoCompleteLimit = 500
 // column widths while responses are still arriving.
 const outputFlushInterval = 500 * time.Millisecond
 
-// WithClientAndNodes builds upon WithClientNoNodes to pass a list of nodes via command function.
-func WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
-	return GlobalArgs.WithClientAndNodes(ctx, action, dialOptions...)
-}
-
 // NewClientFactory creates a new ClientFactory.
-func NewClientFactory(ctx context.Context, flags any) (*global.ClientFactory, error) {
-	return global.NewClientFactory(ctx, &GlobalArgs, flags)
+func NewClientFactory(ctx context.Context, flags any, dialOptions ...grpc.DialOption) (*global.ClientFactory, error) {
+	return global.NewClientFactory(ctx, &GlobalArgs, flags, dialOptions...)
 }
 
 // Commands is a list of commands published by the package.

--- a/cmd/talosctl/cmd/talos/shutdown.go
+++ b/cmd/talosctl/cmd/talos/shutdown.go
@@ -38,16 +38,16 @@ var shutdownCmd = &cobra.Command{
 			client.WithShutdownForce(shutdownCmdFlags.force),
 		}
 
+		ctx := cmd.Context()
+
+		clientFactory, err := NewClientFactory(ctx, &shutdownCmdFlags, action.GRPCDialOptions()...)
+		if err != nil {
+			return err
+		}
+
+		defer clientFactory.Close() //nolint:errcheck
+
 		if !shutdownCmdFlags.wait {
-			ctx := cmd.Context()
-
-			clientFactory, err := NewClientFactory(ctx, &shutdownCmdFlags)
-			if err != nil {
-				return err
-			}
-
-			defer clientFactory.Close() //nolint:errcheck
-
 			if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
 				return err
 			}
@@ -71,12 +71,12 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		return action.NewTracker(
-			&GlobalArgs,
+			clientFactory,
 			action.StopAllServicesEventFn,
 			shutdownGetActorID,
 			action.WithDebug(shutdownCmdFlags.debug),
 			action.WithTimeout(shutdownCmdFlags.timeout),
-		).Run(cmd.Context())
+		).Run(ctx)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -74,7 +74,14 @@ var upgradeCmd = &cobra.Command{
 }
 
 func upgradeRun(ctx context.Context) error {
-	return WithClientAndNodes(ctx, upgradeViaLifecycleService)
+	clientFactory, err := NewClientFactory(ctx, &upgradeCmdFlags, action.GRPCDialOptions()...)
+	if err != nil {
+		return err
+	}
+
+	defer clientFactory.Close() //nolint:errcheck
+
+	return upgradeViaLifecycleService(ctx, clientFactory)
 }
 
 var talosUpgradeAPIVersionRange = semver.MustParseRange(">1.13.0-alpha.2 <2.0.0")
@@ -83,7 +90,7 @@ var talosUpgradeAPIVersionRange = semver.MustParseRange(">1.13.0-alpha.2 <2.0.0"
 // If the server returns codes.Unimplemented, it falls back to the legacy MachineService.Upgrade.
 //
 //nolint:gocyclo
-func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []string) (retErr error) {
+func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.ClientFactory) (retErr error) {
 	if upgradeCmdFlags.debug {
 		upgradeCmdFlags.wait = true
 	}
@@ -91,7 +98,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 	if upgradeCmdFlags.legacy {
 		cli.Warning("Forcing use of legacy upgrade method. This flag is deprecated and will be removed in Talos 1.18.")
 
-		return upgradeLegacy(ctx)
+		return upgradeLegacy(ctx, clientFactory)
 	}
 
 	opts := []client.RebootMode{
@@ -107,28 +114,25 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		reporter.WithOutputMode(upgradeCmdFlags.progress.Value()),
 	)
 
-	err = WithClientAndNodes(ctx, func(ctx context.Context, c *client.Client, nodes []string) error {
-		return helpers.TalosVersionCheck(ctx, c, talosUpgradeAPIVersionRange, nodes)
-	})
-	if err != nil {
+	if err = helpers.TalosVersionCheck(ctx, clientFactory, talosUpgradeAPIVersionRange); err != nil {
 		if xerrors.TagIs[helpers.VersionOutsideRangeError](err) {
 			rep.Report(reporter.Update{
 				Status:  reporter.StatusError,
 				Message: "New upgrade API is not available, falling back to legacy",
 			})
 
-			return upgradeLegacy(ctx)
+			return upgradeLegacy(ctx, clientFactory)
 		}
 
 		return fmt.Errorf("error checking Talos version compatibility: %w", err)
 	}
 
-	_, err = imagePullInternal(ctx, c, containerdInstance, nodes, upgradeCmdFlags.upgradeImage, rep)
+	_, err = imagePullInternal(ctx, clientFactory, containerdInstance, upgradeCmdFlags.upgradeImage, rep)
 	if err != nil {
 		return fmt.Errorf("error pulling upgrade image: %w", err)
 	}
 
-	_, err = upgradeInternal(ctx, c, containerdInstance, nodes, upgradeCmdFlags.upgradeImage, rep)
+	_, err = upgradeInternal(ctx, clientFactory, containerdInstance, upgradeCmdFlags.upgradeImage, rep)
 	if err != nil {
 		return fmt.Errorf("error during upgrade: %w", err)
 	}
@@ -136,7 +140,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 	var nodeNames map[string]string
 
 	if upgradeCmdFlags.drain {
-		nodeNames, err = drainNodes(ctx, c, nodes, upgradeCmdFlags.drainTimeout, rep)
+		nodeNames, err = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, rep)
 		if err != nil {
 			return err
 		}
@@ -148,13 +152,13 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 		}
 
 		if len(nodeNames) > 0 {
-			if uncordonErr := uncordonNodes(ctx, c, nodeNames, upgradeCmdFlags.timeout, rep); uncordonErr != nil {
+			if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, upgradeCmdFlags.timeout, rep); uncordonErr != nil {
 				retErr = errors.Join(retErr, uncordonErr)
 			}
 		}
 	}()
 
-	err = rebootInternal(ctx, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
+	err = rebootInternal(ctx, clientFactory, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
 	if err != nil {
 		return fmt.Errorf("error during upgrade: %w", err)
 	}
@@ -162,7 +166,7 @@ func upgradeViaLifecycleService(ctx context.Context, c *client.Client, nodes []s
 	return nil
 }
 
-func upgradeInternal(ctx context.Context, c *client.Client, containerdInstance *common.ContainerdInstance, nodes []string, imageRef string, rep *reporter.Reporter) (map[string]int32, error) {
+func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, containerdInstance *common.ContainerdInstance, imageRef string, rep *reporter.Reporter) (map[string]int32, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -173,9 +177,9 @@ func upgradeInternal(ctx context.Context, c *client.Client, containerdInstance *
 
 	finishedUpgrades := map[string]int32{}
 
-	responseChan := multiplex.Streaming(
-		ctx, nodes,
-		func(ctx context.Context) (grpc.ServerStreamingClient[machine.LifecycleServiceUpgradeResponse], error) {
+	responseChan := multiplex.StreamingViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (grpc.ServerStreamingClient[machine.LifecycleServiceUpgradeResponse], error) {
 			return c.LifecycleClient.Upgrade(ctx, &machine.LifecycleServiceUpgradeRequest{
 				Containerd: containerdInstance,
 				Source: &machine.InstallArtifactsSource{
@@ -235,7 +239,7 @@ func upgradeInternal(ctx context.Context, c *client.Client, containerdInstance *
 // upgradeLegacy dispatches to the legacy upgrade path, respecting --wait.
 //
 // Note: remove me in Talos 1.18.
-func upgradeLegacy(ctx context.Context) error {
+func upgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory) error {
 	rebootModeStr := strings.ToUpper(upgradeCmdFlags.rebootMode.String())
 
 	rebootMode, ok := machine.UpgradeRequest_RebootMode_value[rebootModeStr]
@@ -256,7 +260,7 @@ func upgradeLegacy(ctx context.Context) error {
 	}
 
 	return action.NewTracker(
-		&GlobalArgs,
+		clientFactory,
 		action.MachineReadyEventFn,
 		func(ctx context.Context, c *client.Client) (string, error) {
 			return upgradeGetActorID(ctx, c, opts)

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
@@ -75,6 +76,21 @@ var (
 	}
 )
 
+// GRPCDialOptions returns the gRPC dial options for the tracker.
+func GRPCDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithConnectParams(grpc.ConnectParams{
+			// disable grpc backoff
+			Backoff:           backoff.Config{},
+			MinConnectTimeout: 20 * time.Second,
+		}),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    10 * time.Second,
+			Timeout: 5 * time.Second,
+		}),
+	}
+}
+
 type nodeUpdate struct {
 	node   string
 	update reporter.Update
@@ -91,7 +107,7 @@ type Tracker struct {
 	timeout                  time.Duration
 	isTerminal               bool
 	debug                    bool
-	clientExecutor           ClientExecutor
+	clientExecutor           ClientFactory
 }
 
 // TrackerOption is the functional option for the Tracker.
@@ -136,7 +152,7 @@ func WithTerminalOverride(isTerminal bool) TrackerOption {
 
 // NewTracker creates a new Tracker.
 func NewTracker(
-	clientExecutor ClientExecutor,
+	clientFactory ClientFactory,
 	expectedEventFn func(event client.EventResult) bool,
 	actionFn func(ctx context.Context, c *client.Client) (string, error),
 	opts ...TrackerOption,
@@ -144,11 +160,11 @@ func NewTracker(
 	tracker := Tracker{
 		expectedEventFn:          expectedEventFn,
 		actionFn:                 actionFn,
-		nodeToLatestStatusUpdate: make(map[string]reporter.Update, len(clientExecutor.NodeList())),
+		nodeToLatestStatusUpdate: make(map[string]reporter.Update, len(clientFactory.Nodes())),
 		reporter:                 reporter.New(),
 		reportCh:                 make(chan nodeUpdate),
 		isTerminal:               isatty.IsTerminal(os.Stderr.Fd()),
-		clientExecutor:           clientExecutor,
+		clientExecutor:           clientFactory,
 	}
 
 	for _, option := range opts {
@@ -158,10 +174,10 @@ func NewTracker(
 	return &tracker
 }
 
-// ClientExecutor is the interface for the client executor.
-type ClientExecutor interface {
-	WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error
-	NodeList() []string
+// ClientFactory is the interface for the client factory.
+type ClientFactory interface {
+	BuildClient(ctx context.Context, node string) (context.Context, *client.Client, error)
+	Nodes() []string
 }
 
 // Run executes the action on nodes and tracks its progress by watching events with retries.
@@ -173,79 +189,77 @@ func (a *Tracker) Run(ctx context.Context) error {
 
 	var eg errgroup.Group
 
-	err := a.clientExecutor.WithClientNoNodes(ctx, func(ctx context.Context, c *client.Client) error {
-		ctx, cancel := context.WithTimeout(ctx, a.timeout)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(ctx, a.timeout)
+	defer cancel()
 
-		// TODO: refactor this with Tracker refactor to use client factory
-		// if err := helpers.ClientVersionCheck(ctx, c, a.clientExecutor.NodeList()); err != nil {
-		// 	return err
-		// }
+	if err := helpers.ClientVersionCheck(ctx, a.clientExecutor); err != nil {
+		return err
+	}
 
-		eg.Go(func() error {
-			return a.runReporter(ctx)
-		})
+	eg.Go(func() error {
+		return a.runReporter(ctx)
+	})
 
-		// Reporter is started, it will print the errors if there is any.
-		// So from here on we can suppress the command error to be printed to avoid it being printed twice.
-		common.SuppressErrors = true
+	// Reporter is started, it will print the errors if there is any.
+	// So from here on we can suppress the command error to be printed to avoid it being printed twice.
+	common.SuppressErrors = true
 
-		var trackEg errgroup.Group
+	var trackEg errgroup.Group
 
-		for _, node := range a.clientExecutor.NodeList() {
-			var (
-				dmesg *circular.Buffer
-				err   error
-			)
+	for _, node := range a.clientExecutor.Nodes() {
+		var (
+			dmesg *circular.Buffer
+			err   error
+		)
 
-			if a.debug {
-				dmesg, err = circular.NewBuffer()
-				if err != nil {
-					return err
-				}
+		if a.debug {
+			dmesg, err = circular.NewBuffer()
+			if err != nil {
+				return err
 			}
-
-			tracker := nodeTracker{
-				ctx:     client.WithNode(ctx, node),
-				node:    node,
-				tracker: a,
-				dmesg:   dmesg,
-				cli:     c,
-			}
-
-			if a.debug {
-				eg.Go(tracker.tailDebugLogs)
-			}
-
-			trackEg.Go(func() error {
-				trackErr := tracker.run()
-				if trackErr != nil {
-					if a.debug {
-						failedNodesToDmesgs.Set(node, dmesg.GetReader())
-					}
-
-					tracker.update(reporter.Update{
-						Message: trackErr.Error(),
-						Status:  reporter.StatusError,
-					})
-				}
-
-				return trackErr
-			})
 		}
 
-		return trackEg.Wait()
-	}, grpc.WithConnectParams(grpc.ConnectParams{
-		// disable grpc backoff
-		Backoff:           backoff.Config{},
-		MinConnectTimeout: 20 * time.Second,
-	}), grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time:    10 * time.Second,
-		Timeout: 5 * time.Second,
-	}))
+		nodeCtx, c, err := a.clientExecutor.BuildClient(ctx, node)
+		if err != nil {
+			return fmt.Errorf("failed to build client for node %s: %w", node, err)
+		}
+
+		tracker := nodeTracker{
+			ctx:     nodeCtx,
+			node:    node,
+			tracker: a,
+			dmesg:   dmesg,
+			cli:     c,
+		}
+
+		if a.debug {
+			eg.Go(tracker.tailDebugLogs)
+		}
+
+		trackEg.Go(func() error {
+			trackErr := tracker.run()
+			if trackErr != nil {
+				if a.debug {
+					failedNodesToDmesgs.Set(node, dmesg.GetReader())
+				}
+
+				tracker.update(reporter.Update{
+					Message: trackErr.Error(),
+					Status:  reporter.StatusError,
+				})
+			}
+
+			return trackErr
+		})
+	}
+
+	err := trackEg.Wait()
 	if errors.Is(err, context.Canceled) {
 		err = nil
 	}
+
+	// stop the reporter
+	cancel()
 
 	eg.Wait() //nolint:errcheck
 

--- a/cmd/talosctl/pkg/talos/global/client.go
+++ b/cmd/talosctl/pkg/talos/global/client.go
@@ -6,12 +6,7 @@
 package global
 
 import (
-	"context"
 	"errors"
-
-	"google.golang.org/grpc"
-
-	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
 // ErrConfigContext is returned when config context cannot be resolved.
@@ -25,47 +20,4 @@ type Args struct {
 	Nodes           []string
 	Endpoints       []string
 	SideroV1KeysDir string
-}
-
-// NodeList returns the list of nodes to run the command against.
-//
-// Deprecated: returns wrong information.
-func (args *Args) NodeList() []string {
-	return args.Nodes
-}
-
-// WithClientNoNodes wraps common code to initialize Talos client and provide cancellable context.
-//
-// WithClientNoNodes doesn't set any node information on the request context.
-func (args *Args) WithClientNoNodes(ctx context.Context, action func(context.Context, *client.Client) error, dialOptions ...grpc.DialOption) error {
-	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
-	if err != nil {
-		return err
-	}
-
-	defer factory.Close() //nolint:errcheck
-
-	_, c, err := factory.BuildClient(ctx, "")
-	if err != nil {
-		return err
-	}
-
-	return action(ctx, c)
-}
-
-// WithClientAndNodes builds upon WithClientNoNodes to provide a list of nodes to the function.
-func (args *Args) WithClientAndNodes(ctx context.Context, action func(context.Context, *client.Client, []string) error, dialOptions ...grpc.DialOption) error {
-	factory, err := NewClientFactory(ctx, args, nil, dialOptions...)
-	if err != nil {
-		return err
-	}
-
-	defer factory.Close() //nolint:errcheck
-
-	_, c, err := factory.BuildClient(ctx, "")
-	if err != nil {
-		return err
-	}
-
-	return action(ctx, c, factory.Nodes())
 }

--- a/cmd/talosctl/pkg/talos/global/factory.go
+++ b/cmd/talosctl/pkg/talos/global/factory.go
@@ -58,9 +58,6 @@ func NewClientFactory(ctx context.Context, args *Args, flags any, dialOptions ..
 
 		factory.nodes = configContext.Nodes
 		factory.client = c
-
-		// TODO: this is a temporary hack, remove it once global tracker refactoring is done
-		args.Nodes = factory.nodes
 	}
 
 	if len(factory.nodes) < 1 {

--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -14,38 +14,26 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/xerrors"
 
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 )
 
-// CheckErrors goes through the returned message list and checks if any messages have errors set.
-//
-//nolint:staticcheck // to be refactored next
-func CheckErrors[T interface{ GetMetadata() *common.Metadata }](messages ...T) error {
-	var err error
-
-	for _, msg := range messages {
-		md := msg.GetMetadata()
-		if md != nil && md.Error != "" {
-			err = AppendErrors(err, errors.New(md.Error))
-		}
-	}
-
-	return err
+// ClientFactory is the interface for the client factory.
+type ClientFactory interface {
+	BuildClient(ctx context.Context, node string) (context.Context, *client.Client, error)
+	Nodes() []string
 }
 
 // VersionOutsideRangeError is returned when a node is running a Talos version that is outside the desired range.
 type VersionOutsideRangeError struct{}
 
 // TalosVersionCheck verifies that all nodes are running the desired Talos version.
-func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Range, nodes []string) error {
-	respCh := multiplex.Unary(
-		ctx, nodes,
-		func(ctx context.Context) (*machine.VersionResponse, error) {
+func TalosVersionCheck(ctx context.Context, clientFactory ClientFactory, desired semver.Range) error {
+	respCh := multiplex.UnaryViaFactory(
+		ctx, clientFactory,
+		func(ctx context.Context, c *client.Client) (*machine.VersionResponse, error) {
 			return c.Version(ctx)
 		},
 	)
@@ -77,7 +65,7 @@ func TalosVersionCheck(ctx context.Context, c *client.Client, desired semver.Ran
 }
 
 // ClientVersionCheck verifies that client is not outdated vs. Talos version.
-func ClientVersionCheck(ctx context.Context, clientFactory *global.ClientFactory) error {
+func ClientVersionCheck(ctx context.Context, clientFactory ClientFactory) error {
 	respCh := multiplex.UnaryViaFactory(
 		ctx, clientFactory,
 		func(ctx context.Context, c *client.Client) (*machine.VersionResponse, error) {
@@ -121,38 +109,4 @@ func ClientVersionCheck(ctx context.Context, clientFactory *global.ClientFactory
 	}
 
 	return errs
-}
-
-// ClientVersionCheckLegacy verifies that client is not outdated vs. Talos version.
-//
-// Deprecated: this function relies on client.WithNodes behavior which is deprecated; use ClientVersionCheck instead.
-func ClientVersionCheckLegacy(ctx context.Context, c *client.Client) error {
-	// ignore the error, as we are only interested in the nodes which respond
-	serverVersions, _ := c.Version(ctx) //nolint:errcheck
-
-	clientVersion, err := semver.ParseTolerant(version.NewVersion().Tag)
-	if err != nil {
-		return fmt.Errorf("error parsing client version: %w", err)
-	}
-
-	var warnings []string
-
-	for _, msg := range serverVersions.GetMessages() {
-		node := msg.GetMetadata().GetHostname() //nolint:staticcheck // to be refactored next
-
-		serverVersion, err := semver.ParseTolerant(msg.GetVersion().Tag)
-		if err != nil {
-			return fmt.Errorf("%s: error parsing server version: %w", node, err)
-		}
-
-		if serverVersion.Compare(clientVersion) < 0 {
-			warnings = append(warnings, fmt.Sprintf("%s: server version %s is older than client version %s", node, serverVersion, clientVersion))
-		}
-	}
-
-	if warnings != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: %s\n", strings.Join(warnings, ", "))
-	}
-
-	return nil
 }

--- a/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
+++ b/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,10 +49,10 @@ type Options struct {
 // The context must target a single node (via client.WithNode) because COSI
 // State/Get does not support one-to-many proxying.
 func GetKubernetesNodeName(ctx context.Context, c *client.Client) (string, error) {
-	nodenameRes, err := safe.StateGet[*k8s.Nodename](
+	nodenameRes, err := safe.StateGetByID[*k8s.Nodename](
 		ctx,
 		c.COSI,
-		resource.NewMetadata(k8s.NamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined),
+		k8s.NodenameID,
 	)
 	if err != nil {
 		return "", fmt.Errorf("error getting Kubernetes node name from Talos API: %w", err)

--- a/pkg/cluster/crashdump.go
+++ b/pkg/cluster/crashdump.go
@@ -80,7 +80,7 @@ func Crashdump(ctx context.Context, cluster provision.Cluster, logWriter io.Writ
 }
 
 func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset, error) {
-	kubeconfig, err := c.Kubeconfig(client.ClearNode(ctx))
+	kubeconfig, err := c.Kubeconfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machinery/client/context.go
+++ b/pkg/machinery/client/context.go
@@ -26,18 +26,6 @@ func WithNodes(ctx context.Context, nodes ...string) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
-// ClearNode removes any node metadata from the context, so that the request will be processed by the endpoint as usual.
-func ClearNode(ctx context.Context) context.Context {
-	md, _ := metadata.FromOutgoingContext(ctx)
-
-	// overwrite any previous nodes in the context metadata with new value
-	md = md.Copy()
-	md.Delete("node")
-	md.Delete("nodes")
-
-	return metadata.NewOutgoingContext(ctx, md)
-}
-
 // WithNode wraps the context with metadata to send request to a single node.
 //
 // Request will be proxied by the endpoint to the specified node without any further processing.

--- a/pkg/machinery/client/multiplex/stream.go
+++ b/pkg/machinery/client/multiplex/stream.go
@@ -78,7 +78,7 @@ func Streaming[ResponseT any](ctx context.Context, nodes []string, initiate func
 
 // StreamingViaFactory is a helper which performs streaming multiplexing using a ClientFactory to create clients for each node.
 func StreamingViaFactory[ResponseT any](
-	ctx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (grpc.ServerStreamingClient[ResponseT], error),
+	origCtx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (grpc.ServerStreamingClient[ResponseT], error),
 ) <-chan Response[*ResponseT] {
 	responseCh := make(chan Response[*ResponseT])
 
@@ -86,10 +86,10 @@ func StreamingViaFactory[ResponseT any](
 
 	for _, node := range factory.Nodes() {
 		wg.Go(func() {
-			ctx, client, err := factory.BuildClient(ctx, node)
+			ctx, client, err := factory.BuildClient(origCtx, node)
 			if err != nil {
 				channel.SendWithContext(
-					ctx, responseCh,
+					origCtx, responseCh,
 					Response[*ResponseT]{
 						Node: node,
 						Err:  err,

--- a/pkg/machinery/client/multiplex/unary.go
+++ b/pkg/machinery/client/multiplex/unary.go
@@ -53,17 +53,17 @@ func Unary[ResponseT any](ctx context.Context, nodes []string, initiate func(con
 }
 
 // UnaryViaFactory is a helper which performs unary multiplexing using a ClientFactory to create clients for each node.
-func UnaryViaFactory[ResponseT any](ctx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (ResponseT, error)) <-chan Response[ResponseT] {
+func UnaryViaFactory[ResponseT any](origCtx context.Context, factory ClientFactory, initiate func(context.Context, *client.Client) (ResponseT, error)) <-chan Response[ResponseT] {
 	responseCh := make(chan Response[ResponseT])
 
 	var wg sync.WaitGroup
 
 	for _, node := range factory.Nodes() {
 		wg.Go(func() {
-			ctx, client, err := factory.BuildClient(ctx, node)
+			ctx, client, err := factory.BuildClient(origCtx, node)
 			if err != nil {
 				channel.SendWithContext(
-					ctx, responseCh,
+					origCtx, responseCh,
 					Response[ResponseT]{
 						Node: node,
 						Err:  err,

--- a/pkg/machinery/formatters/formatters.go
+++ b/pkg/machinery/formatters/formatters.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/emicklei/dot"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/inspect"
@@ -88,15 +87,6 @@ func RenderGraph(ctx context.Context, c *client.Client, resp *inspect.Controller
 	if withResources {
 		resources := map[string][]resource.Resource{}
 
-		md, _ := metadata.FromOutgoingContext(ctx)
-		nodes := md["nodes"]
-
-		nodeCtx := ctx
-
-		if len(nodes) > 0 {
-			nodeCtx = client.WithNode(ctx, nodes[0])
-		}
-
 		for _, msg := range resp.GetMessages() {
 			for _, edge := range msg.GetEdges() {
 				resourceType := resourceTypeID(edge)
@@ -107,12 +97,12 @@ func RenderGraph(ctx context.Context, c *client.Client, resp *inspect.Controller
 
 				namespace := edge.GetResourceNamespace()
 
-				rd, err := c.ResolveResourceKind(nodeCtx, &namespace, edge.GetResourceType())
+				rd, err := c.ResolveResourceKind(ctx, &namespace, edge.GetResourceType())
 				if err != nil {
 					return err
 				}
 
-				items, err := c.COSI.List(nodeCtx, resource.NewMetadata(namespace, rd.TypedSpec().Type, "", resource.VersionUndefined))
+				items, err := c.COSI.List(ctx, resource.NewMetadata(namespace, rd.TypedSpec().Type, "", resource.VersionUndefined))
 				if err != nil {
 					// ignore errors here
 					continue


### PR DESCRIPTION
The interface used previously was _almost_ like factory, but adapt to it fully.

Drop all the remaining legacy code that was around waiting for the last steps of refactoring.

Fixes #13490
