### PR TITLE
fix: align flannel MTU with kubespan to avoid permanent fragmentation

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -80,6 +80,11 @@ message BootstrapManifestsConfigSpec {
   bool flannel_kube_network_policies_enabled = 19;
   string flannel_kube_network_policies_image = 20;
   string cni_name = 21;
+  uint32 flannel_backend_mtu = 22;
+  string flannel_backend_type = 23;
+  uint32 flannel_backend_port = 24;
+  Resources flannel_resources = 25;
+  google.protobuf.Struct flannel_backend_extra_config = 26;
 }
 
 // ConfigStatusSpec describes status of rendered secrets.

--- a/internal/app/machined/pkg/controllers/cluster/config.go
+++ b/internal/app/machined/pkg/controllers/cluster/config.go
@@ -22,7 +22,7 @@ import (
 // ConfigController watches v1alpha1.Config, updates discovery config.
 type ConfigController = transform.Controller[*config.MachineConfig, *cluster.Config]
 
-// NewConfigController instanciates the config controller.
+// NewConfigController instantiates the config controller.
 func NewConfigController() *ConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *cluster.Config]{

--- a/internal/app/machined/pkg/controllers/cluster/info.go
+++ b/internal/app/machined/pkg/controllers/cluster/info.go
@@ -19,7 +19,7 @@ import (
 // InfoController looks up control plane infos.
 type InfoController = transform.Controller[*config.MachineConfig, *cluster.Info]
 
-// NewInfoController instanciates the cluster info controller.
+// NewInfoController instantiates the cluster info controller.
 func NewInfoController() *InfoController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *cluster.Info]{

--- a/internal/app/machined/pkg/controllers/etcd/config.go
+++ b/internal/app/machined/pkg/controllers/etcd/config.go
@@ -19,7 +19,7 @@ import (
 // ConfigController watches v1alpha1.Config, updates etcd config.
 type ConfigController = transform.Controller[*config.MachineConfig, *etcd.Config]
 
-// NewConfigController instanciates the config controller.
+// NewConfigController instantiates the config controller.
 //
 //nolint:gocyclo
 func NewConfigController() *ConfigController {

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -65,7 +65,7 @@ func controlplaneMapFunc[Output generic.ResourceWithRD](output Output, extraChec
 // ControlPlaneAdmissionControlController manages k8s.AdmissionControlConfig based on configuration.
 type ControlPlaneAdmissionControlController = transform.Controller[*config.MachineConfig, *k8s.AdmissionControlConfig]
 
-// NewControlPlaneAdmissionControlController instanciates the controller.
+// NewControlPlaneAdmissionControlController instantiates the controller.
 func NewControlPlaneAdmissionControlController() *ControlPlaneAdmissionControlController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.AdmissionControlConfig]{
@@ -95,7 +95,7 @@ func NewControlPlaneAdmissionControlController() *ControlPlaneAdmissionControlCo
 // ControlPlaneAuditPolicyController manages k8s.AuditPolicyConfig based on configuration.
 type ControlPlaneAuditPolicyController = transform.Controller[*config.MachineConfig, *k8s.AuditPolicyConfig]
 
-// NewControlPlaneAuditPolicyController instanciates the controller.
+// NewControlPlaneAuditPolicyController instantiates the controller.
 func NewControlPlaneAuditPolicyController() *ControlPlaneAuditPolicyController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.AuditPolicyConfig]{
@@ -115,7 +115,7 @@ func NewControlPlaneAuditPolicyController() *ControlPlaneAuditPolicyController {
 // ControlPlaneAuthorizationController manages k8s.AuthorizationConfig based on configuration.
 type ControlPlaneAuthorizationController = transform.Controller[*config.MachineConfig, *k8s.AuthorizationConfig]
 
-// NewControlPlaneAuthorizationController instanciates the controller.
+// NewControlPlaneAuthorizationController instantiates the controller.
 func NewControlPlaneAuthorizationController() *ControlPlaneAuthorizationController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.AuthorizationConfig]{
@@ -177,7 +177,7 @@ func NewControlPlaneAuthorizationController() *ControlPlaneAuthorizationControll
 // ControlPlaneAPIServerController manages k8s.APIServerConfig based on configuration.
 type ControlPlaneAPIServerController = transform.Controller[*config.MachineConfig, *k8s.APIServerConfig]
 
-// NewControlPlaneAPIServerController instanciates the controller.
+// NewControlPlaneAPIServerController instantiates the controller.
 func NewControlPlaneAPIServerController() *ControlPlaneAPIServerController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.APIServerConfig]{
@@ -229,7 +229,7 @@ func NewControlPlaneAPIServerController() *ControlPlaneAPIServerController {
 // ControlPlaneControllerManagerController manages k8s.ControllerManagerConfig based on configuration.
 type ControlPlaneControllerManagerController = transform.Controller[*config.MachineConfig, *k8s.ControllerManagerConfig]
 
-// NewControlPlaneControllerManagerController instanciates the controller.
+// NewControlPlaneControllerManagerController instantiates the controller.
 func NewControlPlaneControllerManagerController() *ControlPlaneControllerManagerController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.ControllerManagerConfig]{
@@ -279,7 +279,7 @@ func NewControlPlaneControllerManagerController() *ControlPlaneControllerManager
 // ControlPlaneSchedulerController manages k8s.SchedulerConfig based on configuration.
 type ControlPlaneSchedulerController = transform.Controller[*config.MachineConfig, *k8s.SchedulerConfig]
 
-// NewControlPlaneSchedulerController instanciates the controller.
+// NewControlPlaneSchedulerController instantiates the controller.
 func NewControlPlaneSchedulerController() *ControlPlaneSchedulerController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.SchedulerConfig]{
@@ -318,7 +318,9 @@ func NewControlPlaneSchedulerController() *ControlPlaneSchedulerController {
 // ControlPlaneBootstrapManifestsController manages k8s.BootstrapManifestsConfig based on configuration.
 type ControlPlaneBootstrapManifestsController = transform.Controller[*config.MachineConfig, *k8s.BootstrapManifestsConfig]
 
-// NewControlPlaneBootstrapManifestsController instanciates the controller.
+// NewControlPlaneBootstrapManifestsController instantiates the controller.
+//
+//nolint:gocyclo
 func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifestsController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.BootstrapManifestsConfig]{
@@ -389,6 +391,21 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 				if k8sFlannelCNIConfig := cfgProvider.K8sFlannelCNIConfig(); k8sFlannelCNIConfig != nil {
 					res.TypedSpec().FlannelEnabled = true
 					res.TypedSpec().FlannelImage = images.Flannel.String()
+					res.TypedSpec().FlannelBackendType = k8sFlannelCNIConfig.BackendType()
+					res.TypedSpec().FlannelBackendPort = k8sFlannelCNIConfig.BackendPort().ValueOrZero()
+
+					configuredMTU := k8sFlannelCNIConfig.BackendMTU()
+
+					// default Flannel MTU to KubeSpan MTU if KubeSpan is enabled
+					if !configuredMTU.IsPresent() {
+						if kubespanConfig := cfgProvider.NetworkKubeSpanConfig(); kubespanConfig != nil && kubespanConfig.Enabled() {
+							configuredMTU = optional.Some(kubespanConfig.MTU())
+						}
+					}
+
+					res.TypedSpec().FlannelBackendMTU = configuredMTU.ValueOrZero()
+					res.TypedSpec().FlannelBackendExtraConfig = k8sFlannelCNIConfig.BackendExtraConfig()
+					res.TypedSpec().FlannelResources = convertResources(k8sFlannelCNIConfig.Resources())
 					res.TypedSpec().FlannelExtraArgs = k8sFlannelCNIConfig.ExtraArgs()
 					res.TypedSpec().FlannelKubeServiceHost = flannelKubeServiceHost
 					res.TypedSpec().FlannelKubeServicePort = flannelKubeServicePort
@@ -398,6 +415,11 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 				} else {
 					res.TypedSpec().FlannelEnabled = false
 					res.TypedSpec().FlannelImage = ""
+					res.TypedSpec().FlannelBackendType = ""
+					res.TypedSpec().FlannelBackendPort = 0
+					res.TypedSpec().FlannelBackendMTU = 0
+					res.TypedSpec().FlannelBackendExtraConfig = nil
+					res.TypedSpec().FlannelResources = k8s.Resources{}
 					res.TypedSpec().FlannelExtraArgs = nil
 					res.TypedSpec().FlannelKubeServiceHost = ""
 					res.TypedSpec().FlannelKubeServicePort = ""
@@ -423,7 +445,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 // ControlPlaneExtraManifestsController manages k8s.ExtraManifestsConfig based on configuration.
 type ControlPlaneExtraManifestsController = transform.Controller[*config.MachineConfig, *k8s.ExtraManifestsConfig]
 
-// NewControlPlaneExtraManifestsController instanciates the controller.
+// NewControlPlaneExtraManifestsController instantiates the controller.
 func NewControlPlaneExtraManifestsController() *ControlPlaneExtraManifestsController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.ExtraManifestsConfig]{

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -22,11 +22,11 @@ import (
 	"github.com/siderolabs/go-kubernetes/kubernetes/compatibility"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	k8sadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/k8s"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates"
 	"github.com/siderolabs/talos/pkg/argsbuilder"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -36,9 +36,6 @@ import (
 
 // systemCriticalPriority is copied from scheduling.SystemCriticalPriority in Kubernetes internals.
 const systemCriticalPriority int32 = 2000000000
-
-// GoGCMemLimitPercentage set the percentage of memorylimit to use for the golang garbage collection target limit.
-const GoGCMemLimitPercentage = 95
 
 // ControlPlaneStaticPodController manages k8s.StaticPod based on control plane configuration.
 type ControlPlaneStaticPodController struct{}
@@ -282,67 +279,6 @@ func envVars(environment map[string]string) []v1.EnvVar {
 	})
 }
 
-func resources(resourcesConfig k8s.Resources, defaultCPU, defaultMemory string) (v1.ResourceRequirements, error) {
-	resources := v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    apiresource.MustParse(defaultCPU),
-			v1.ResourceMemory: apiresource.MustParse(defaultMemory),
-		},
-		Limits: v1.ResourceList{},
-	}
-
-	if cpu := resourcesConfig.Requests[string(v1.ResourceCPU)]; cpu != "" {
-		parsedCPU, err := apiresource.ParseQuantity(cpu)
-		if err != nil {
-			return v1.ResourceRequirements{}, fmt.Errorf("error parsing CPU request: %w", err)
-		}
-
-		resources.Requests[v1.ResourceCPU] = parsedCPU
-	}
-
-	if memory := resourcesConfig.Requests[string(v1.ResourceMemory)]; memory != "" {
-		parsedMemory, err := apiresource.ParseQuantity(memory)
-		if err != nil {
-			return v1.ResourceRequirements{}, fmt.Errorf("error parsing memory request: %w", err)
-		}
-
-		resources.Requests[v1.ResourceMemory] = parsedMemory
-	}
-
-	if cpu := resourcesConfig.Limits[string(v1.ResourceCPU)]; cpu != "" {
-		parsedCPU, err := apiresource.ParseQuantity(cpu)
-		if err != nil {
-			return v1.ResourceRequirements{}, fmt.Errorf("error parsing CPU limit: %w", err)
-		}
-
-		resources.Limits[v1.ResourceCPU] = parsedCPU
-	}
-
-	if memory := resourcesConfig.Limits[string(v1.ResourceMemory)]; memory != "" {
-		parsedMemory, err := apiresource.ParseQuantity(memory)
-		if err != nil {
-			return v1.ResourceRequirements{}, fmt.Errorf("error parsing memory limit: %w", err)
-		}
-
-		resources.Limits[v1.ResourceMemory] = parsedMemory
-	}
-
-	return resources, nil
-}
-
-func goGCEnvFromResources(resources v1.ResourceRequirements) (envVar v1.EnvVar) {
-	memoryLimit := resources.Limits[v1.ResourceMemory]
-	if memoryLimit.Value() > 0 {
-		gcMemLimit := memoryLimit.Value() * GoGCMemLimitPercentage / 100
-		envVar = v1.EnvVar{
-			Name:  "GOMEMLIMIT",
-			Value: strconv.FormatInt(gcMemLimit, 10),
-		}
-	}
-
-	return envVar
-}
-
 func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context, r controller.Runtime, _ *zap.Logger,
 	configResource resource.Resource, secretsVersion, configVersion string,
 ) (string, error) {
@@ -442,13 +378,13 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 
 	args = append(args, builder.Args()...)
 
-	resources, err := resources(cfg.Resources, "200m", "512Mi")
+	resources, err := k8stemplates.Resources(cfg.Resources, "200m", "512Mi")
 	if err != nil {
 		return "", err
 	}
 
 	env := envVars(cfg.EnvironmentVariables)
-	if goGCEnv := goGCEnvFromResources(resources); goGCEnv.Name != "" {
+	if goGCEnv := k8stemplates.GoGCEnvFromResources(resources); goGCEnv.Name != "" {
 		env = append(env, goGCEnv)
 	}
 
@@ -576,13 +512,13 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 		return "", nil
 	}
 
-	resources, err := resources(cfg.Resources, "50m", "256Mi")
+	resources, err := k8stemplates.Resources(cfg.Resources, "50m", "256Mi")
 	if err != nil {
 		return "", err
 	}
 
 	env := envVars(cfg.EnvironmentVariables)
-	if goGCEnv := goGCEnvFromResources(resources); goGCEnv.Name != "" {
+	if goGCEnv := k8stemplates.GoGCEnvFromResources(resources); goGCEnv.Name != "" {
 		env = append(env, goGCEnv)
 	}
 
@@ -704,13 +640,13 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 		return "", nil
 	}
 
-	resources, err := resources(cfg.Resources, "10m", "64Mi")
+	resources, err := k8stemplates.Resources(cfg.Resources, "10m", "64Mi")
 	if err != nil {
 		return "", err
 	}
 
 	env := envVars(cfg.EnvironmentVariables)
-	if goGCEnv := goGCEnvFromResources(resources); goGCEnv.Name != "" {
+	if goGCEnv := k8stemplates.GoGCEnvFromResources(resources); goGCEnv.Name != "" {
 		env = append(env, goGCEnv)
 	}
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -22,6 +22,7 @@ import (
 	k8sadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/k8s"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
@@ -564,7 +565,7 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileStaticPodResources() {
 			},
 			expectedEnv: v1.EnvVar{
 				Name:  "GOMEMLIMIT",
-				Value: strconv.FormatInt(1024*1024*1024*k8sctrl.GoGCMemLimitPercentage/100, 10),
+				Value: strconv.FormatInt(1024*1024*1024*k8stemplates.GoGCMemLimitPercentage/100, 10),
 			},
 		},
 	}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
@@ -7,6 +7,7 @@ package k8stemplates
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -139,20 +140,28 @@ func FlannelConfigMapTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 	}
 
 	var netConf struct {
-		Network        string `json:"Network,omitempty"`
-		IPv6Network    string `json:"IPv6Network,omitempty"`
-		EnableIPv6     *bool  `json:"EnableIPv6,omitempty"`
-		EnableIPv4     *bool  `json:"EnableIPv4,omitempty"`
-		EnableNFTables *bool  `json:"EnableNFTables,omitempty"`
-		Backend        struct {
-			Type string `json:"Type"`
-			Port int    `json:"Port"`
-		} `json:"Backend"`
+		Network        string         `json:"Network,omitempty"`
+		IPv6Network    string         `json:"IPv6Network,omitempty"`
+		EnableIPv6     *bool          `json:"EnableIPv6,omitempty"`
+		EnableIPv4     *bool          `json:"EnableIPv4,omitempty"`
+		EnableNFTables *bool          `json:"EnableNFTables,omitempty"`
+		Backend        map[string]any `json:"Backend"`
 	}
 
 	netConf.EnableNFTables = new(true)
-	netConf.Backend.Type = "vxlan"
-	netConf.Backend.Port = 4789
+	netConf.Backend = make(map[string]any)
+	netConf.Backend["Type"] = spec.FlannelBackendType
+
+	if spec.FlannelBackendPort != 0 {
+		netConf.Backend["Port"] = spec.FlannelBackendPort
+	}
+
+	if spec.FlannelBackendMTU != 0 {
+		netConf.Backend["MTU"] = spec.FlannelBackendMTU
+	}
+
+	// merge in user overrides
+	maps.Copy(netConf.Backend, spec.FlannelBackendExtraConfig)
 
 	hasIPv4 := false
 
@@ -197,7 +206,7 @@ func FlannelConfigMapTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 
 // FlannelDaemonSetTemplate returns the template of the DaemonSet
 // for the flannel CNI plugin.
-func FlannelDaemonSetTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Object {
+func FlannelDaemonSetTemplate(spec *k8s.BootstrapManifestsConfigSpec) (runtime.Object, error) {
 	envVars := []corev1.EnvVar{
 		{
 			Name: "POD_NAME",
@@ -256,42 +265,49 @@ func FlannelDaemonSetTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 		})
 	}
 
-	containers := []corev1.Container{
-		{
-			Name:    "kube-flannel",
-			Image:   spec.FlannelImage,
-			Command: []string{"/opt/bin/flanneld"},
-			Args: slices.Concat(
-				[]string{
-					"--ip-masq",
-					"--kube-subnet-mgr",
-				},
-				spec.FlannelExtraArgs,
-			),
-			Env: envVars,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
-				},
+	flanneldContainer := corev1.Container{
+		Name:    "kube-flannel",
+		Image:   spec.FlannelImage,
+		Command: []string{"/opt/bin/flanneld"},
+		Args: slices.Concat(
+			[]string{
+				"--ip-masq",
+				"--kube-subnet-mgr",
 			},
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
-				},
-				Privileged: new(false),
+			spec.FlannelExtraArgs,
+		),
+		Env: envVars,
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "run",
-					MountPath: "/run/flannel",
-				},
-				{
-					Name:      "flannel-cfg",
-					MountPath: "/etc/kube-flannel/",
-				},
+			Privileged: new(false),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "run",
+				MountPath: "/run/flannel",
+			},
+			{
+				Name:      "flannel-cfg",
+				MountPath: "/etc/kube-flannel/",
 			},
 		},
+	}
+
+	var err error
+
+	flanneldContainer.Resources, err = Resources(spec.FlannelResources, "100m", "50Mi")
+	if err != nil {
+		return nil, fmt.Errorf("invalid flannel resource requirements: %w", err)
+	}
+
+	if gcEnv := GoGCEnvFromResources(flanneldContainer.Resources); gcEnv.Name != "" {
+		flanneldContainer.Env = append(flanneldContainer.Env, gcEnv)
+	}
+
+	containers := []corev1.Container{
+		flanneldContainer,
 	}
 
 	if spec.FlannelKubeNetworkPoliciesEnabled {
@@ -404,5 +420,5 @@ func FlannelDaemonSetTemplate(spec *k8s.BootstrapManifestsConfigSpec) runtime.Ob
 				},
 			},
 		},
-	}
+	}, nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 )
@@ -235,7 +236,9 @@ func TestTemplates(t *testing.T) {
 			name: "flannel-configmap-v4",
 			obj: func() runtime.Object {
 				return k8stemplates.FlannelConfigMapTemplate(&k8s.BootstrapManifestsConfigSpec{
-					PodCIDRs: []string{"10.96.0.0/12"},
+					PodCIDRs:           []string{"10.96.0.0/12"},
+					FlannelBackendType: constants.FlannelDefaultBackend,
+					FlannelBackendPort: constants.FlannelDefaultBackendPort,
 				})
 			},
 		},
@@ -243,7 +246,9 @@ func TestTemplates(t *testing.T) {
 			name: "flannel-configmap-v6",
 			obj: func() runtime.Object {
 				return k8stemplates.FlannelConfigMapTemplate(&k8s.BootstrapManifestsConfigSpec{
-					PodCIDRs: []string{"fd00::/112"},
+					PodCIDRs:           []string{"fd00::/112"},
+					FlannelBackendType: constants.FlannelDefaultBackend,
+					FlannelBackendPort: constants.FlannelDefaultBackendPort,
 				})
 			},
 		},
@@ -251,28 +256,60 @@ func TestTemplates(t *testing.T) {
 			name: "flannel-configmap-dual",
 			obj: func() runtime.Object {
 				return k8stemplates.FlannelConfigMapTemplate(&k8s.BootstrapManifestsConfigSpec{
-					PodCIDRs: []string{"10.96.0.0/12", "fd00::/112"},
+					PodCIDRs:           []string{"10.96.0.0/12", "fd00::/112"},
+					FlannelBackendType: constants.FlannelDefaultBackend,
+					FlannelBackendPort: constants.FlannelDefaultBackendPort,
+					FlannelBackendExtraConfig: map[string]any{
+						"VNI": 4096,
+					},
+				})
+			},
+		},
+		{
+			name: "flannel-configmap-with-mtu",
+			obj: func() runtime.Object {
+				return k8stemplates.FlannelConfigMapTemplate(&k8s.BootstrapManifestsConfigSpec{
+					PodCIDRs:           []string{"10.96.0.0/12"},
+					FlannelBackendType: constants.FlannelDefaultBackend,
+					FlannelBackendPort: constants.FlannelDefaultBackendPort,
+					FlannelBackendMTU:  1420,
 				})
 			},
 		},
 		{
 			name: "flannel-daemonset",
 			obj: func() runtime.Object {
-				return k8stemplates.FlannelDaemonSetTemplate(&k8s.BootstrapManifestsConfigSpec{
+				spec, err := k8stemplates.FlannelDaemonSetTemplate(&k8s.BootstrapManifestsConfigSpec{
 					FlannelImage:     "quay.io/coreos/flannel:v0.14.0",
 					FlannelExtraArgs: []string{"--foo=bar"},
 				})
+				require.NoError(t, err)
+
+				return spec
 			},
 		},
 		{
 			name: "flannel-daemonset-with-network-policies",
 			obj: func() runtime.Object {
-				return k8stemplates.FlannelDaemonSetTemplate(&k8s.BootstrapManifestsConfigSpec{
-					FlannelImage:                      "quay.io/coreos/flannel:v0.14.0",
-					FlannelExtraArgs:                  []string{"--foo=bar"},
+				spec, err := k8stemplates.FlannelDaemonSetTemplate(&k8s.BootstrapManifestsConfigSpec{
+					FlannelImage:     "quay.io/coreos/flannel:v0.14.0",
+					FlannelExtraArgs: []string{"--foo=bar"},
+					FlannelResources: k8s.Resources{
+						Requests: map[string]string{
+							"cpu":    "100m",
+							"memory": "50Mi",
+						},
+						Limits: map[string]string{
+							"cpu":    "200m",
+							"memory": "100Mi",
+						},
+					},
 					FlannelKubeNetworkPoliciesEnabled: true,
 					FlannelKubeNetworkPoliciesImage:   "registry.k8s.io/networking/kube-network-policies:v0.7.0",
 				})
+				require.NoError(t, err)
+
+				return spec
 			},
 		},
 	} {

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/resources.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/resources.go
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8stemplates
+
+import (
+	"fmt"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+)
+
+// Resources returns Kubernetes resource requirements based on the provided configuration and defaults.
+func Resources(resourcesConfig k8s.Resources, defaultCPU, defaultMemory string) (v1.ResourceRequirements, error) {
+	resources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    apiresource.MustParse(defaultCPU),
+			v1.ResourceMemory: apiresource.MustParse(defaultMemory),
+		},
+		Limits: v1.ResourceList{},
+	}
+
+	if cpu := resourcesConfig.Requests[string(v1.ResourceCPU)]; cpu != "" {
+		parsedCPU, err := apiresource.ParseQuantity(cpu)
+		if err != nil {
+			return v1.ResourceRequirements{}, fmt.Errorf("error parsing CPU request: %w", err)
+		}
+
+		resources.Requests[v1.ResourceCPU] = parsedCPU
+	}
+
+	if memory := resourcesConfig.Requests[string(v1.ResourceMemory)]; memory != "" {
+		parsedMemory, err := apiresource.ParseQuantity(memory)
+		if err != nil {
+			return v1.ResourceRequirements{}, fmt.Errorf("error parsing memory request: %w", err)
+		}
+
+		resources.Requests[v1.ResourceMemory] = parsedMemory
+	}
+
+	if cpu := resourcesConfig.Limits[string(v1.ResourceCPU)]; cpu != "" {
+		parsedCPU, err := apiresource.ParseQuantity(cpu)
+		if err != nil {
+			return v1.ResourceRequirements{}, fmt.Errorf("error parsing CPU limit: %w", err)
+		}
+
+		resources.Limits[v1.ResourceCPU] = parsedCPU
+	}
+
+	if memory := resourcesConfig.Limits[string(v1.ResourceMemory)]; memory != "" {
+		parsedMemory, err := apiresource.ParseQuantity(memory)
+		if err != nil {
+			return v1.ResourceRequirements{}, fmt.Errorf("error parsing memory limit: %w", err)
+		}
+
+		resources.Limits[v1.ResourceMemory] = parsedMemory
+	}
+
+	return resources, nil
+}
+
+// GoGCMemLimitPercentage sets the percentage of memorylimit to use for the golang garbage collection target limit.
+const GoGCMemLimitPercentage = 95
+
+// GoGCEnvFromResources returns an environment variable for Go's garbage collection target limit
+// based on the provided resource requirements.
+func GoGCEnvFromResources(resources v1.ResourceRequirements) (envVar v1.EnvVar) {
+	memoryLimit := resources.Limits[v1.ResourceMemory]
+	if memoryLimit.Value() > 0 {
+		gcMemLimit := memoryLimit.Value() * GoGCMemLimitPercentage / 100
+		envVar = v1.EnvVar{
+			Name:  "GOMEMLIMIT",
+			Value: strconv.FormatInt(gcMemLimit, 10),
+		}
+	}
+
+	return envVar
+}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-dual.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-dual.yaml
@@ -27,8 +27,9 @@ data:
       "EnableIPv6": true,
       "EnableNFTables": true,
       "Backend": {
+        "Port": 4789,
         "Type": "vxlan",
-        "Port": 4789
+        "VNI": 4096
       }
     }
 kind: ConfigMap

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v6.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-v6.yaml
@@ -27,8 +27,8 @@ data:
       "EnableIPv4": false,
       "EnableNFTables": true,
       "Backend": {
-        "Type": "vxlan",
-        "Port": 4789
+        "Port": 4789,
+        "Type": "vxlan"
       }
     }
 kind: ConfigMap

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-with-mtu.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-configmap-with-mtu.yaml
@@ -25,6 +25,7 @@ data:
       "Network": "10.96.0.0/12",
       "EnableNFTables": true,
       "Backend": {
+        "MTU": 1420,
         "Port": 4789,
         "Type": "vxlan"
       }

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-daemonset-with-network-policies.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-daemonset-with-network-policies.yaml
@@ -46,9 +46,14 @@ spec:
           value: "5000"
         - name: CONT_WHEN_CACHE_NOT_READY
           value: "false"
+        - name: GOMEMLIMIT
+          value: "99614720"
         image: quay.io/coreos/flannel:v0.14.0
         name: kube-flannel
         resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config.go
@@ -24,7 +24,7 @@ import (
 // KubeletConfigController renders kubelet configuration based on machine config.
 type KubeletConfigController = transform.Controller[*config.MachineConfig, *k8s.KubeletConfig]
 
-// NewKubeletConfigController instanciates the config controller.
+// NewKubeletConfigController instantiates the config controller.
 func NewKubeletConfigController() *KubeletConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.KubeletConfig]{

--- a/internal/app/machined/pkg/controllers/k8s/kubeprism_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubeprism_config.go
@@ -23,7 +23,7 @@ import (
 // KubePrismConfigController creates config for KubePrism.
 type KubePrismConfigController = transform.Controller[*config.MachineConfig, *k8s.KubePrismConfig]
 
-// NewKubePrismConfigController instanciates the controller.
+// NewKubePrismConfigController instantiates the controller.
 func NewKubePrismConfigController() *KubePrismConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *k8s.KubePrismConfig]{

--- a/internal/app/machined/pkg/controllers/k8s/kubeprism_endpoints.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubeprism_endpoints.go
@@ -22,7 +22,7 @@ import (
 // KubePrismEndpointsController creates a list of API server endpoints.
 type KubePrismEndpointsController = transform.Controller[*config.MachineConfig, *k8s.KubePrismEndpoints]
 
-// NewKubePrismEndpointsController instanciates the controller.
+// NewKubePrismEndpointsController instantiates the controller.
 //
 //nolint:gocyclo
 func NewKubePrismEndpointsController() *KubePrismEndpointsController {

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -6,6 +6,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -148,6 +149,14 @@ type renderedManifest struct {
 }
 
 func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scrt *secrets.KubernetesRootSpec) ([]renderedManifest, error) {
+	var errs error
+
+	aggregateManifestError := func(obj runtime.Object, err error) runtime.Object {
+		errs = errors.Join(errs, err)
+
+		return obj
+	}
+
 	manifests := []renderedManifest{
 		{
 			"00-kubelet-bootstrapping-token",
@@ -220,7 +229,7 @@ func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scr
 					k8stemplates.FlannelClusterRoleBindingTemplate(),
 					k8stemplates.FlannelServiceAccountTemplate(),
 					k8stemplates.FlannelConfigMapTemplate(&cfg),
-					k8stemplates.FlannelDaemonSetTemplate(&cfg),
+					aggregateManifestError(k8stemplates.FlannelDaemonSetTemplate(&cfg)),
 				},
 			},
 		)
@@ -241,7 +250,7 @@ func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scr
 	}
 
 	if cfg.PodSecurityPolicyEnabled {
-		return nil, fmt.Errorf("pod security policies are not supported anymore, please remove the flag from the configuration")
+		errs = errors.Join(errs, errors.New("pod security policies are not supported anymore, please remove the flag from the configuration"))
 	}
 
 	if cfg.TalosAPIServiceEnabled {
@@ -256,7 +265,7 @@ func (ctrl *ManifestController) render(cfg k8s.BootstrapManifestsConfigSpec, scr
 		)
 	}
 
-	return manifests, nil
+	return manifests, errs
 }
 
 //nolint:dupl

--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
@@ -21,7 +21,7 @@ import (
 // NodeIPConfigController configures k8s.NodeIP based on machine config.
 type NodeIPConfigController = transform.Controller[*config.MachineConfig, *k8s.NodeIPConfig]
 
-// NewNodeIPConfigController instanciates the controller.
+// NewNodeIPConfigController instantiates the controller.
 //
 //nolint:gocyclo
 func NewNodeIPConfigController() *NodeIPConfigController {

--- a/internal/app/machined/pkg/controllers/kubeaccess/config.go
+++ b/internal/app/machined/pkg/controllers/kubeaccess/config.go
@@ -19,7 +19,7 @@ import (
 // ConfigController watches v1alpha1.Config, updates Talos API access config.
 type ConfigController = transform.Controller[*config.MachineConfig, *kubeaccess.Config]
 
-// NewConfigController instanciates the config controller.
+// NewConfigController instantiates the config controller.
 func NewConfigController() *ConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *kubeaccess.Config]{

--- a/internal/app/machined/pkg/controllers/kubespan/config.go
+++ b/internal/app/machined/pkg/controllers/kubespan/config.go
@@ -19,7 +19,7 @@ import (
 // ConfigController watches v1alpha1.Config, updates KubeSpan config.
 type ConfigController = transform.Controller[*config.MachineConfig, *kubespan.Config]
 
-// NewConfigController instanciates the config controller.
+// NewConfigController instantiates the config controller.
 func NewConfigController() *ConfigController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *kubespan.Config]{

--- a/internal/app/machined/pkg/controllers/secrets/kubelet.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubelet.go
@@ -23,7 +23,7 @@ import (
 // KubeletController manages secrets.Kubelet based on configuration.
 type KubeletController = transform.Controller[*config.MachineConfig, *secrets.Kubelet]
 
-// NewKubeletController instanciates the controller.
+// NewKubeletController instantiates the controller.
 func NewKubeletController() *KubeletController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *secrets.Kubelet]{

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -45,7 +45,7 @@ func rootMapFunc[Output generic.ResourceWithRD](output Output, requireControlPla
 // RootEtcdController manages secrets.EtcdRoot based on configuration.
 type RootEtcdController = transform.Controller[*config.MachineConfig, *secrets.EtcdRoot]
 
-// NewRootEtcdController instanciates the controller.
+// NewRootEtcdController instantiates the controller.
 func NewRootEtcdController() *RootEtcdController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *secrets.EtcdRoot]{
@@ -70,7 +70,7 @@ func NewRootEtcdController() *RootEtcdController {
 // RootKubernetesController manages secrets.KubernetesRoot based on configuration.
 type RootKubernetesController = transform.Controller[*config.MachineConfig, *secrets.KubernetesRoot]
 
-// NewRootKubernetesController instanciates the controller.
+// NewRootKubernetesController instantiates the controller.
 func NewRootKubernetesController() *RootKubernetesController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *secrets.KubernetesRoot]{
@@ -157,7 +157,7 @@ func NewRootKubernetesController() *RootKubernetesController {
 // RootOSController manages secrets.OSRoot based on configuration.
 type RootOSController = transform.Controller[*config.MachineConfig, *secrets.OSRoot]
 
-// NewRootOSController instanciates the controller.
+// NewRootOSController instantiates the controller.
 func NewRootOSController() *RootOSController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *secrets.OSRoot]{

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -476,6 +476,11 @@ type BootstrapManifestsConfigSpec struct {
 	FlannelKubeNetworkPoliciesEnabled bool                   `protobuf:"varint,19,opt,name=flannel_kube_network_policies_enabled,json=flannelKubeNetworkPoliciesEnabled,proto3" json:"flannel_kube_network_policies_enabled,omitempty"`
 	FlannelKubeNetworkPoliciesImage   string                 `protobuf:"bytes,20,opt,name=flannel_kube_network_policies_image,json=flannelKubeNetworkPoliciesImage,proto3" json:"flannel_kube_network_policies_image,omitempty"`
 	CniName                           string                 `protobuf:"bytes,21,opt,name=cni_name,json=cniName,proto3" json:"cni_name,omitempty"`
+	FlannelBackendMtu                 uint32                 `protobuf:"varint,22,opt,name=flannel_backend_mtu,json=flannelBackendMtu,proto3" json:"flannel_backend_mtu,omitempty"`
+	FlannelBackendType                string                 `protobuf:"bytes,23,opt,name=flannel_backend_type,json=flannelBackendType,proto3" json:"flannel_backend_type,omitempty"`
+	FlannelBackendPort                uint32                 `protobuf:"varint,24,opt,name=flannel_backend_port,json=flannelBackendPort,proto3" json:"flannel_backend_port,omitempty"`
+	FlannelResources                  *Resources             `protobuf:"bytes,25,opt,name=flannel_resources,json=flannelResources,proto3" json:"flannel_resources,omitempty"`
+	FlannelBackendExtraConfig         *structpb.Struct       `protobuf:"bytes,26,opt,name=flannel_backend_extra_config,json=flannelBackendExtraConfig,proto3" json:"flannel_backend_extra_config,omitempty"`
 	unknownFields                     protoimpl.UnknownFields
 	sizeCache                         protoimpl.SizeCache
 }
@@ -648,6 +653,41 @@ func (x *BootstrapManifestsConfigSpec) GetCniName() string {
 		return x.CniName
 	}
 	return ""
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelBackendMtu() uint32 {
+	if x != nil {
+		return x.FlannelBackendMtu
+	}
+	return 0
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelBackendType() string {
+	if x != nil {
+		return x.FlannelBackendType
+	}
+	return ""
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelBackendPort() uint32 {
+	if x != nil {
+		return x.FlannelBackendPort
+	}
+	return 0
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelResources() *Resources {
+	if x != nil {
+		return x.FlannelResources
+	}
+	return nil
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelBackendExtraConfig() *structpb.Struct {
+	if x != nil {
+		return x.FlannelBackendExtraConfig
+	}
+	return nil
 }
 
 // ConfigStatusSpec describes status of rendered secrets.
@@ -2531,7 +2571,7 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\awebhook\x18\x03 \x01(\v2\x17.google.protobuf.StructR\awebhook\"\x85\x01\n" +
 	"\x17AuthorizationConfigSpec\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12T\n" +
-	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xa8\a\n" +
+	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xee\t\n" +
 	"\x1cBootstrapManifestsConfigSpec\x12\x16\n" +
 	"\x06server\x18\x01 \x01(\tR\x06server\x12%\n" +
 	"\x0ecluster_domain\x18\x02 \x01(\tR\rclusterDomain\x12\x1c\n" +
@@ -2556,7 +2596,12 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\x19flannel_kube_service_port\x18\x12 \x01(\tR\x16flannelKubeServicePort\x12P\n" +
 	"%flannel_kube_network_policies_enabled\x18\x13 \x01(\bR!flannelKubeNetworkPoliciesEnabled\x12L\n" +
 	"#flannel_kube_network_policies_image\x18\x14 \x01(\tR\x1fflannelKubeNetworkPoliciesImage\x12\x19\n" +
-	"\bcni_name\x18\x15 \x01(\tR\acniName\"B\n" +
+	"\bcni_name\x18\x15 \x01(\tR\acniName\x12.\n" +
+	"\x13flannel_backend_mtu\x18\x16 \x01(\rR\x11flannelBackendMtu\x120\n" +
+	"\x14flannel_backend_type\x18\x17 \x01(\tR\x12flannelBackendType\x120\n" +
+	"\x14flannel_backend_port\x18\x18 \x01(\rR\x12flannelBackendPort\x12V\n" +
+	"\x11flannel_resources\x18\x19 \x01(\v2).talos.resource.definitions.k8s.ResourcesR\x10flannelResources\x12X\n" +
+	"\x1cflannel_backend_extra_config\x18\x1a \x01(\v2\x17.google.protobuf.StructR\x19flannelBackendExtraConfig\"B\n" +
 	"\x10ConfigStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\"\x91\x06\n" +
@@ -2801,46 +2846,48 @@ var file_resource_definitions_k8s_k8s_proto_depIdxs = []int32{
 	50, // 6: talos.resource.definitions.k8s.AuditPolicyConfigSpec.config:type_name -> google.protobuf.Struct
 	50, // 7: talos.resource.definitions.k8s.AuthorizationAuthorizersSpec.webhook:type_name -> google.protobuf.Struct
 	5,  // 8: talos.resource.definitions.k8s.AuthorizationConfigSpec.config:type_name -> talos.resource.definitions.k8s.AuthorizationAuthorizersSpec
-	14, // 9: talos.resource.definitions.k8s.ControllerManagerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
-	40, // 10: talos.resource.definitions.k8s.ControllerManagerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.ControllerManagerConfigSpec.EnvironmentVariablesEntry
-	31, // 11: talos.resource.definitions.k8s.ControllerManagerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
-	41, // 12: talos.resource.definitions.k8s.ControllerManagerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry
-	51, // 13: talos.resource.definitions.k8s.EndpointSpec.addresses:type_name -> common.NetIP
-	42, // 14: talos.resource.definitions.k8s.ExtraManifest.extra_headers:type_name -> talos.resource.definitions.k8s.ExtraManifest.ExtraHeadersEntry
-	12, // 15: talos.resource.definitions.k8s.ExtraManifestsConfigSpec.extra_manifests:type_name -> talos.resource.definitions.k8s.ExtraManifest
-	16, // 16: talos.resource.definitions.k8s.KubePrismConfigSpec.endpoints:type_name -> talos.resource.definitions.k8s.KubePrismEndpoint
-	16, // 17: talos.resource.definitions.k8s.KubePrismEndpointsSpec.endpoints:type_name -> talos.resource.definitions.k8s.KubePrismEndpoint
-	52, // 18: talos.resource.definitions.k8s.KubeletConfigSpec.extra_mounts:type_name -> talos.resource.definitions.proto.Mount
-	50, // 19: talos.resource.definitions.k8s.KubeletConfigSpec.extra_config:type_name -> google.protobuf.Struct
-	50, // 20: talos.resource.definitions.k8s.KubeletConfigSpec.credential_provider_config:type_name -> google.protobuf.Struct
-	43, // 21: talos.resource.definitions.k8s.KubeletConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry
-	52, // 22: talos.resource.definitions.k8s.KubeletSpecSpec.extra_mounts:type_name -> talos.resource.definitions.proto.Mount
-	50, // 23: talos.resource.definitions.k8s.KubeletSpecSpec.config:type_name -> google.protobuf.Struct
-	50, // 24: talos.resource.definitions.k8s.KubeletSpecSpec.credential_provider_config:type_name -> google.protobuf.Struct
-	34, // 25: talos.resource.definitions.k8s.ManifestSpec.items:type_name -> talos.resource.definitions.k8s.SingleManifest
-	51, // 26: talos.resource.definitions.k8s.NodeIPSpec.addresses:type_name -> common.NetIP
-	44, // 27: talos.resource.definitions.k8s.NodeStatusSpec.labels:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.LabelsEntry
-	45, // 28: talos.resource.definitions.k8s.NodeStatusSpec.annotations:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntry
-	53, // 29: talos.resource.definitions.k8s.NodeStatusSpec.pod_cid_rs:type_name -> common.NetIPPrefix
-	46, // 30: talos.resource.definitions.k8s.Resources.requests:type_name -> talos.resource.definitions.k8s.Resources.RequestsEntry
-	47, // 31: talos.resource.definitions.k8s.Resources.limits:type_name -> talos.resource.definitions.k8s.Resources.LimitsEntry
-	14, // 32: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
-	48, // 33: talos.resource.definitions.k8s.SchedulerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.EnvironmentVariablesEntry
-	31, // 34: talos.resource.definitions.k8s.SchedulerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
-	50, // 35: talos.resource.definitions.k8s.SchedulerConfigSpec.config:type_name -> google.protobuf.Struct
-	49, // 36: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry
-	50, // 37: talos.resource.definitions.k8s.SingleManifest.object:type_name -> google.protobuf.Struct
-	50, // 38: talos.resource.definitions.k8s.StaticPodSpec.pod:type_name -> google.protobuf.Struct
-	50, // 39: talos.resource.definitions.k8s.StaticPodStatusSpec.pod_status:type_name -> google.protobuf.Struct
-	3,  // 40: talos.resource.definitions.k8s.APIServerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 41: talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 42: talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	3,  // 43: talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
-	44, // [44:44] is the sub-list for method output_type
-	44, // [44:44] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	31, // 9: talos.resource.definitions.k8s.BootstrapManifestsConfigSpec.flannel_resources:type_name -> talos.resource.definitions.k8s.Resources
+	50, // 10: talos.resource.definitions.k8s.BootstrapManifestsConfigSpec.flannel_backend_extra_config:type_name -> google.protobuf.Struct
+	14, // 11: talos.resource.definitions.k8s.ControllerManagerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
+	40, // 12: talos.resource.definitions.k8s.ControllerManagerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.ControllerManagerConfigSpec.EnvironmentVariablesEntry
+	31, // 13: talos.resource.definitions.k8s.ControllerManagerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
+	41, // 14: talos.resource.definitions.k8s.ControllerManagerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry
+	51, // 15: talos.resource.definitions.k8s.EndpointSpec.addresses:type_name -> common.NetIP
+	42, // 16: talos.resource.definitions.k8s.ExtraManifest.extra_headers:type_name -> talos.resource.definitions.k8s.ExtraManifest.ExtraHeadersEntry
+	12, // 17: talos.resource.definitions.k8s.ExtraManifestsConfigSpec.extra_manifests:type_name -> talos.resource.definitions.k8s.ExtraManifest
+	16, // 18: talos.resource.definitions.k8s.KubePrismConfigSpec.endpoints:type_name -> talos.resource.definitions.k8s.KubePrismEndpoint
+	16, // 19: talos.resource.definitions.k8s.KubePrismEndpointsSpec.endpoints:type_name -> talos.resource.definitions.k8s.KubePrismEndpoint
+	52, // 20: talos.resource.definitions.k8s.KubeletConfigSpec.extra_mounts:type_name -> talos.resource.definitions.proto.Mount
+	50, // 21: talos.resource.definitions.k8s.KubeletConfigSpec.extra_config:type_name -> google.protobuf.Struct
+	50, // 22: talos.resource.definitions.k8s.KubeletConfigSpec.credential_provider_config:type_name -> google.protobuf.Struct
+	43, // 23: talos.resource.definitions.k8s.KubeletConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry
+	52, // 24: talos.resource.definitions.k8s.KubeletSpecSpec.extra_mounts:type_name -> talos.resource.definitions.proto.Mount
+	50, // 25: talos.resource.definitions.k8s.KubeletSpecSpec.config:type_name -> google.protobuf.Struct
+	50, // 26: talos.resource.definitions.k8s.KubeletSpecSpec.credential_provider_config:type_name -> google.protobuf.Struct
+	34, // 27: talos.resource.definitions.k8s.ManifestSpec.items:type_name -> talos.resource.definitions.k8s.SingleManifest
+	51, // 28: talos.resource.definitions.k8s.NodeIPSpec.addresses:type_name -> common.NetIP
+	44, // 29: talos.resource.definitions.k8s.NodeStatusSpec.labels:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.LabelsEntry
+	45, // 30: talos.resource.definitions.k8s.NodeStatusSpec.annotations:type_name -> talos.resource.definitions.k8s.NodeStatusSpec.AnnotationsEntry
+	53, // 31: talos.resource.definitions.k8s.NodeStatusSpec.pod_cid_rs:type_name -> common.NetIPPrefix
+	46, // 32: talos.resource.definitions.k8s.Resources.requests:type_name -> talos.resource.definitions.k8s.Resources.RequestsEntry
+	47, // 33: talos.resource.definitions.k8s.Resources.limits:type_name -> talos.resource.definitions.k8s.Resources.LimitsEntry
+	14, // 34: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_volumes:type_name -> talos.resource.definitions.k8s.ExtraVolume
+	48, // 35: talos.resource.definitions.k8s.SchedulerConfigSpec.environment_variables:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.EnvironmentVariablesEntry
+	31, // 36: talos.resource.definitions.k8s.SchedulerConfigSpec.resources:type_name -> talos.resource.definitions.k8s.Resources
+	50, // 37: talos.resource.definitions.k8s.SchedulerConfigSpec.config:type_name -> google.protobuf.Struct
+	49, // 38: talos.resource.definitions.k8s.SchedulerConfigSpec.extra_args:type_name -> talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry
+	50, // 39: talos.resource.definitions.k8s.SingleManifest.object:type_name -> google.protobuf.Struct
+	50, // 40: talos.resource.definitions.k8s.StaticPodSpec.pod:type_name -> google.protobuf.Struct
+	50, // 41: talos.resource.definitions.k8s.StaticPodStatusSpec.pod_status:type_name -> google.protobuf.Struct
+	3,  // 42: talos.resource.definitions.k8s.APIServerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 43: talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 44: talos.resource.definitions.k8s.KubeletConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	3,  // 45: talos.resource.definitions.k8s.SchedulerConfigSpec.ExtraArgsEntry.value:type_name -> talos.resource.definitions.k8s.ArgValues
+	46, // [46:46] is the sub-list for method output_type
+	46, // [46:46] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_resource_definitions_k8s_k8s_proto_init() }

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -491,6 +491,53 @@ func (m *BootstrapManifestsConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.FlannelBackendExtraConfig != nil {
+		size, err := (*structpb.Struct)(m.FlannelBackendExtraConfig).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.FlannelResources != nil {
+		size, err := m.FlannelResources.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
+	}
+	if m.FlannelBackendPort != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FlannelBackendPort))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc0
+	}
+	if len(m.FlannelBackendType) > 0 {
+		i -= len(m.FlannelBackendType)
+		copy(dAtA[i:], m.FlannelBackendType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.FlannelBackendType)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xba
+	}
+	if m.FlannelBackendMtu != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FlannelBackendMtu))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
 	if len(m.CniName) > 0 {
 		i -= len(m.CniName)
 		copy(dAtA[i:], m.CniName)
@@ -2894,6 +2941,24 @@ func (m *BootstrapManifestsConfigSpec) SizeVT() (n int) {
 	}
 	l = len(m.CniName)
 	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FlannelBackendMtu != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.FlannelBackendMtu))
+	}
+	l = len(m.FlannelBackendType)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FlannelBackendPort != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.FlannelBackendPort))
+	}
+	if m.FlannelResources != nil {
+		l = m.FlannelResources.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FlannelBackendExtraConfig != nil {
+		l = (*structpb.Struct)(m.FlannelBackendExtraConfig).SizeVT()
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -5500,6 +5565,148 @@ func (m *BootstrapManifestsConfigSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.CniName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 22:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelBackendMtu", wireType)
+			}
+			m.FlannelBackendMtu = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FlannelBackendMtu |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelBackendType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FlannelBackendType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 24:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelBackendPort", wireType)
+			}
+			m.FlannelBackendPort = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FlannelBackendPort |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 25:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelResources", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FlannelResources == nil {
+				m.FlannelResources = &Resources{}
+			}
+			if err := m.FlannelResources.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 26:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelBackendExtraConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FlannelBackendExtraConfig == nil {
+				m.FlannelBackendExtraConfig = &structpb1.Struct{}
+			}
+			if err := (*structpb.Struct)(m.FlannelBackendExtraConfig).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/config/config/k8s.go
+++ b/pkg/machinery/config/config/k8s.go
@@ -4,7 +4,11 @@
 
 package config
 
-import "net/netip"
+import (
+	"net/netip"
+
+	"github.com/siderolabs/gen/optional"
+)
 
 // K8sControllerManagerConfig defines configuration options for the kube-controller-manager static pod.
 type K8sControllerManagerConfig interface {
@@ -44,6 +48,11 @@ type K8sNetworkConfig interface {
 
 // K8sFlannelCNIConfig defines the configuration options for the Flannel CNI in Kubernetes.
 type K8sFlannelCNIConfig interface {
+	BackendType() string
+	BackendPort() optional.Optional[uint16]
+	BackendMTU() optional.Optional[uint32]
+	BackendExtraConfig() map[string]any
+	Resources() Resources
 	ExtraArgs() []string
 	KubeNetworkPoliciesEnabled() bool
 }

--- a/pkg/machinery/config/generate/kubernetes.go
+++ b/pkg/machinery/config/generate/kubernetes.go
@@ -25,6 +25,8 @@ func (in *Input) generateKubernetesControlplaneConfigs() []config.Document {
 
 	if in.Options.CNICustomURL == "" {
 		flannelConfig = k8s.NewKubeFlannelCNIConfigV1Alpha1()
+		flannelConfig.FlannelBackendType = constants.FlannelDefaultBackend
+		flannelConfig.FlannelBackendPort = constants.FlannelDefaultBackendPort
 	}
 
 	etcdEncryptionConfig := k8s.NewKubeEtcdEncryptionConfigV1Alpha1()

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -1304,6 +1304,41 @@
           "markdownDescription": "kind is the kind of the resource.",
           "x-intellij-html-description": "\u003cp\u003ekind is the kind of the resource.\u003c/p\u003e\n"
         },
+        "backendType": {
+          "type": "string",
+          "title": "backendType",
+          "description": "Type of the Flannel backend to use.\n\nSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is “vxlan”.\n",
+          "markdownDescription": "Type of the Flannel backend to use.\n\nSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is \"vxlan\".",
+          "x-intellij-html-description": "\u003cp\u003eType of the Flannel backend to use.\u003c/p\u003e\n\n\u003cp\u003eSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is \u0026ldquo;vxlan\u0026rdquo;.\u003c/p\u003e\n"
+        },
+        "backendPort": {
+          "type": "integer",
+          "title": "backendPort",
+          "description": "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\n\nThe default value in generated machine configuration is 4789.\n",
+          "markdownDescription": "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\n\nThe default value in generated machine configuration is 4789.",
+          "x-intellij-html-description": "\u003cp\u003eUDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\u003c/p\u003e\n\n\u003cp\u003eThe default value in generated machine configuration is 4789.\u003c/p\u003e\n"
+        },
+        "backendMTU": {
+          "type": "integer",
+          "title": "backendMTU",
+          "description": "Transport MTU to be used for the pod network.\n\nFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.\n",
+          "markdownDescription": "Transport MTU to be used for the pod network.\n\nFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.",
+          "x-intellij-html-description": "\u003cp\u003eTransport MTU to be used for the pod network.\u003c/p\u003e\n\n\u003cp\u003eFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.\u003c/p\u003e\n"
+        },
+        "backendExtraConfig": {
+          "type": "object",
+          "title": "backendExtraConfig",
+          "description": "Extra configuration for Flannel backend.\n\nThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration ‘Backend’ section as-is.\n",
+          "markdownDescription": "Extra configuration for Flannel backend.\n\nThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration 'Backend' section as-is.",
+          "x-intellij-html-description": "\u003cp\u003eExtra configuration for Flannel backend.\u003c/p\u003e\n\n\u003cp\u003eThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration \u0026lsquo;Backend\u0026rsquo; section as-is.\u003c/p\u003e\n"
+        },
+        "resources": {
+          "type": "object",
+          "title": "resources",
+          "description": "Resources configuration for Flannel main container.\n",
+          "markdownDescription": "Resources configuration for Flannel main container.",
+          "x-intellij-html-description": "\u003cp\u003eResources configuration for Flannel main container.\u003c/p\u003e\n"
+        },
         "extraArgs": {
           "items": {
             "type": "string"

--- a/pkg/machinery/config/types/k8s/deep_copy.generated.go
+++ b/pkg/machinery/config/types/k8s/deep_copy.generated.go
@@ -53,6 +53,18 @@ func (o *KubeEtcdEncryptionConfigV1Alpha1) DeepCopy() *KubeEtcdEncryptionConfigV
 // DeepCopy generates a deep copy of *KubeFlannelCNIConfigV1Alpha1.
 func (o *KubeFlannelCNIConfigV1Alpha1) DeepCopy() *KubeFlannelCNIConfigV1Alpha1 {
 	var cp KubeFlannelCNIConfigV1Alpha1 = *o
+	{
+		retV := o.FlannelBackendExtraConfig.DeepCopy()
+		cp.FlannelBackendExtraConfig = *retV
+	}
+	{
+		retV := o.FlannelResources.Requests.DeepCopy()
+		cp.FlannelResources.Requests = *retV
+	}
+	{
+		retV := o.FlannelResources.Limits.DeepCopy()
+		cp.FlannelResources.Limits = *retV
+	}
 	if o.FlannelExtraArgs != nil {
 		cp.FlannelExtraArgs = make([]string, len(o.FlannelExtraArgs))
 		copy(cp.FlannelExtraArgs, o.FlannelExtraArgs)

--- a/pkg/machinery/config/types/k8s/flannel.go
+++ b/pkg/machinery/config/types/k8s/flannel.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"errors"
 
+	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-pointer"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -15,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/config/validation"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 //docgen:jsonschema
@@ -51,6 +53,38 @@ type KubeFlannelCNIConfigV1Alpha1 struct {
 	meta.Meta `yaml:",inline"`
 
 	//   description: |
+	//     Type of the Flannel backend to use.
+	//
+	//     See Flannel documentation for supported backend types.
+	//     The default value in generated machine configuration is "vxlan".
+	FlannelBackendType string `yaml:"backendType"`
+	//   description: |
+	//     UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).
+	//
+	//     The default value in generated machine configuration is 4789.
+	FlannelBackendPort uint16 `yaml:"backendPort,omitempty"`
+	//   description: |
+	//     Transport MTU to be used for the pod network.
+	//
+	//     Flannel will subtract encapsulation overhead from this MTU to calculate
+	//     the MTU of the pod interface.
+	//     If not set, the default is auto-detection of MTU by Flannel.
+	//     If KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.
+	FlannelBackendMTU uint32 `yaml:"backendMTU,omitempty"`
+	//   description: |
+	//     Extra configuration for Flannel backend.
+	//
+	//     The content of this field depends on the backend type used.
+	//     The value of this field will be patched into Flannel configuration 'Backend' section as-is.
+	//   schema:
+	//     type: object
+	FlannelBackendExtraConfig meta.Unstructured `yaml:"backendExtraConfig,omitempty"`
+	//   description: |
+	//     Resources configuration for Flannel main container.
+	//   schema:
+	//     type: object
+	FlannelResources ResourcesConfig `yaml:"resources,omitempty"`
+	//   description: |
 	//     Extra arguments for 'flanneld'.
 	//   examples:
 	//     - value: >
@@ -75,6 +109,9 @@ func NewKubeFlannelCNIConfigV1Alpha1() *KubeFlannelCNIConfigV1Alpha1 {
 
 func exampleKubeFlannelCNIConfigV1Alpha1() *KubeFlannelCNIConfigV1Alpha1 {
 	cfg := NewKubeFlannelCNIConfigV1Alpha1()
+	cfg.FlannelBackendType = constants.FlannelDefaultBackend
+	cfg.FlannelBackendPort = constants.FlannelDefaultBackendPort
+	cfg.FlannelBackendMTU = 1420
 	cfg.FlannelExtraArgs = []string{"--iface-can-reach=192.168.1.1"}
 	cfg.FlannelKubeNetworkPoliciesEnabled = new(true)
 
@@ -93,7 +130,13 @@ func (s *KubeFlannelCNIConfigV1Alpha1) Validate(_ validation.RuntimeMode, _ ...v
 		warnings []string
 	)
 
-	// more validation will be added here eventually
+	if s.FlannelBackendType == "" {
+		errs = errors.Join(errs, errors.New("flannel backend type must be specified"))
+	}
+
+	extraErrs := s.FlannelResources.Validate()
+
+	errs = errors.Join(errs, extraErrs)
 
 	return warnings, errs
 }
@@ -105,6 +148,39 @@ func (s *KubeFlannelCNIConfigV1Alpha1) V1Alpha1ConflictValidate(v1alpha1Cfg *v1a
 	}
 
 	return nil
+}
+
+// BackendType implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) BackendType() string {
+	return s.FlannelBackendType
+}
+
+// BackendPort implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) BackendPort() optional.Optional[uint16] {
+	if s.FlannelBackendPort == 0 {
+		return optional.None[uint16]()
+	}
+
+	return optional.Some(s.FlannelBackendPort)
+}
+
+// BackendMTU implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) BackendMTU() optional.Optional[uint32] {
+	if s.FlannelBackendMTU == 0 {
+		return optional.None[uint32]()
+	}
+
+	return optional.Some(s.FlannelBackendMTU)
+}
+
+// BackendExtraConfig implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) BackendExtraConfig() map[string]any {
+	return s.FlannelBackendExtraConfig.Object
+}
+
+// Resources implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) Resources() config.Resources {
+	return s.FlannelResources
 }
 
 // ExtraArgs implements config.K8sFlannelCNIConfig interface.

--- a/pkg/machinery/config/types/k8s/flannel_test.go
+++ b/pkg/machinery/config/types/k8s/flannel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 //go:embed testdata/flannelconfig.yaml
@@ -25,6 +26,9 @@ func TestKubeFlannelCNIConfigMarshalStability(t *testing.T) {
 	t.Parallel()
 
 	cfg := k8s.NewKubeFlannelCNIConfigV1Alpha1()
+	cfg.FlannelBackendType = constants.FlannelDefaultBackend
+	cfg.FlannelBackendPort = constants.FlannelDefaultBackendPort
+	cfg.FlannelBackendMTU = 1420
 	cfg.FlannelExtraArgs = []string{"--iface-can-reach=10.0.0.1"}
 	cfg.FlannelKubeNetworkPoliciesEnabled = new(true)
 
@@ -50,6 +54,9 @@ func TestKubeFlannelCNIConfigUnmarshal(t *testing.T) {
 			MetaAPIVersion: "v1alpha1",
 			MetaKind:       k8s.KubeFlannelCNIConfig,
 		},
+		FlannelBackendType:                constants.FlannelDefaultBackend,
+		FlannelBackendPort:                constants.FlannelDefaultBackendPort,
+		FlannelBackendMTU:                 1420,
 		FlannelExtraArgs:                  []string{"--iface-can-reach=10.0.0.1"},
 		FlannelKubeNetworkPoliciesEnabled: new(true),
 	}, docs[0])
@@ -68,6 +75,36 @@ func TestKubeFlannelCNIConfigValidate(t *testing.T) {
 		{
 			name: "empty",
 			cfg:  k8s.NewKubeFlannelCNIConfigV1Alpha1,
+
+			expectedError: "flannel backend type must be specified",
+		},
+		{
+			name: "invalid resources",
+			cfg: func() *k8s.KubeFlannelCNIConfigV1Alpha1 {
+				cfg := k8s.NewKubeFlannelCNIConfigV1Alpha1()
+				cfg.FlannelBackendType = constants.FlannelDefaultBackend
+				cfg.FlannelResources = k8s.ResourcesConfig{
+					Requests: meta.Unstructured{
+						Object: map[string]any{
+							"invalid": "1",
+						},
+					},
+				}
+
+				return cfg
+			},
+
+			expectedError: "unsupported pod resource \"invalid\"",
+		},
+		{
+			name: "valid config",
+			cfg: func() *k8s.KubeFlannelCNIConfigV1Alpha1 {
+				cfg := k8s.NewKubeFlannelCNIConfigV1Alpha1()
+				cfg.FlannelBackendType = constants.FlannelDefaultBackend
+				cfg.FlannelBackendPort = constants.FlannelDefaultBackendPort
+
+				return cfg
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/machinery/config/types/k8s/k8s_doc.go
+++ b/pkg/machinery/config/types/k8s/k8s_doc.go
@@ -21,6 +21,10 @@ func (ResourcesConfig) Doc() *encoder.Doc {
 				FieldName: "resources",
 			},
 			{
+				TypeName:  "KubeFlannelCNIConfigV1Alpha1",
+				FieldName: "resources",
+			},
+			{
 				TypeName:  "KubeSchedulerConfigV1Alpha1",
 				FieldName: "resources",
 			},
@@ -138,6 +142,41 @@ func (KubeFlannelCNIConfigV1Alpha1) Doc() *encoder.Doc {
 				Inline: true,
 			},
 			{
+				Name:        "backendType",
+				Type:        "string",
+				Note:        "",
+				Description: "Type of the Flannel backend to use.\n\nSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is \"vxlan\".",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Type of the Flannel backend to use." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "backendPort",
+				Type:        "uint16",
+				Note:        "",
+				Description: "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\n\nThe default value in generated machine configuration is 4789.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation)." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "backendMTU",
+				Type:        "uint32",
+				Note:        "",
+				Description: "Transport MTU to be used for the pod network.\n\nFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Transport MTU to be used for the pod network." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "backendExtraConfig",
+				Type:        "Unstructured",
+				Note:        "",
+				Description: "Extra configuration for Flannel backend.\n\nThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration 'Backend' section as-is.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Extra configuration for Flannel backend." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "resources",
+				Type:        "ResourcesConfig",
+				Note:        "",
+				Description: "Resources configuration for Flannel main container.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Resources configuration for Flannel main container." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "extraArgs",
 				Type:        "[]string",
 				Note:        "",
@@ -156,7 +195,7 @@ func (KubeFlannelCNIConfigV1Alpha1) Doc() *encoder.Doc {
 
 	doc.AddExample("", exampleKubeFlannelCNIConfigV1Alpha1())
 
-	doc.Fields[1].AddExample("", []string{"--iface-can-reach=192.168.1.1"})
+	doc.Fields[6].AddExample("", []string{"--iface-can-reach=192.168.1.1"})
 
 	return doc
 }

--- a/pkg/machinery/config/types/k8s/testdata/flannelconfig.yaml
+++ b/pkg/machinery/config/types/k8s/testdata/flannelconfig.yaml
@@ -1,5 +1,8 @@
 apiVersion: v1alpha1
 kind: KubeFlannelCNIConfig
+backendType: vxlan
+backendPort: 4789
+backendMTU: 1420
 extraArgs:
     - --iface-can-reach=10.0.0.1
 kubeNetworkPoliciesEnabled: true

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
@@ -115,3 +115,5 @@ config: {}
 ---
 apiVersion: v1alpha1
 kind: KubeFlannelCNIConfig
+backendType: vxlan
+backendPort: 4789

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
@@ -5,9 +5,11 @@
 package v1alpha1
 
 import (
+	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-pointer"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 // Name implements the config.CNI interface.
@@ -29,12 +31,37 @@ func (c *CNIConfig) Flannel() config.K8sFlannelCNIConfig {
 	return c.CNIFlannel
 }
 
-// ExtraArgs implements the config.FlannelCNI interface.
+// BackendType implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) BackendType() string {
+	return constants.FlannelDefaultBackend
+}
+
+// BackendPort implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) BackendPort() optional.Optional[uint16] {
+	return optional.Some[uint16](constants.FlannelDefaultBackendPort)
+}
+
+// BackendMTU implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) BackendMTU() optional.Optional[uint32] {
+	return optional.None[uint32]()
+}
+
+// BackendExtraConfig implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) BackendExtraConfig() map[string]any {
+	return nil
+}
+
+// Resources implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) Resources() config.Resources {
+	return &ResourcesConfig{}
+}
+
+// ExtraArgs implements the config.K8sFlannelCNIConfig interface.
 func (c *FlannelCNIConfig) ExtraArgs() []string {
 	return c.FlanneldExtraArgs
 }
 
-// KubeNetworkPoliciesEnabled implements the config.FlannelCNI interface.
+// KubeNetworkPoliciesEnabled implements the config.K8sFlannelCNIConfig interface.
 func (c *FlannelCNIConfig) KubeNetworkPoliciesEnabled() bool {
 	return pointer.SafeDeref(c.FlannelKubeNetworkPoliciesEnabled)
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1194,6 +1194,12 @@ const (
 	// renovate: datasource=github-releases depName=flannel-io/flannel
 	FlannelVersion = "v0.28.5"
 
+	// FlannelDefaultBackend is the default backend for flannel.
+	FlannelDefaultBackend = "vxlan"
+
+	// FlannelDefaultBackendPort is the default port for flannel vxlan backend.
+	FlannelDefaultBackendPort = 4789
+
 	// KubeNetworkPoliciesVersion is the version of kube-network-policies when network policies are enabled for flannel.
 	//
 	// renovate: datasource=docker depName=registry.k8s.io/networking/kube-network-policies

--- a/pkg/machinery/resources/k8s/deep_copy.generated.go
+++ b/pkg/machinery/resources/k8s/deep_copy.generated.go
@@ -122,6 +122,24 @@ func (o BootstrapManifestsConfigSpec) DeepCopy() BootstrapManifestsConfigSpec {
 		cp.FlannelExtraArgs = make([]string, len(o.FlannelExtraArgs))
 		copy(cp.FlannelExtraArgs, o.FlannelExtraArgs)
 	}
+	if o.FlannelBackendExtraConfig != nil {
+		cp.FlannelBackendExtraConfig = make(map[string]any, len(o.FlannelBackendExtraConfig))
+		for k2, v2 := range o.FlannelBackendExtraConfig {
+			cp.FlannelBackendExtraConfig[k2] = v2
+		}
+	}
+	if o.FlannelResources.Requests != nil {
+		cp.FlannelResources.Requests = make(map[string]string, len(o.FlannelResources.Requests))
+		for k3, v3 := range o.FlannelResources.Requests {
+			cp.FlannelResources.Requests[k3] = v3
+		}
+	}
+	if o.FlannelResources.Limits != nil {
+		cp.FlannelResources.Limits = make(map[string]string, len(o.FlannelResources.Limits))
+		for k3, v3 := range o.FlannelResources.Limits {
+			cp.FlannelResources.Limits[k3] = v3
+		}
+	}
 	return cp
 }
 

--- a/pkg/machinery/resources/k8s/manifests_config.go
+++ b/pkg/machinery/resources/k8s/manifests_config.go
@@ -42,13 +42,18 @@ type BootstrapManifestsConfigSpec struct {
 	DNSServiceIP   string `yaml:"dnsServiceIP" protobuf:"9"`
 	DNSServiceIPv6 string `yaml:"dnsServiceIPv6" protobuf:"10"`
 
-	FlannelEnabled                    bool     `yaml:"flannelEnabled" protobuf:"11"`
-	FlannelImage                      string   `yaml:"flannelImage" protobuf:"12"`
-	FlannelExtraArgs                  []string `yaml:"flannelExtraArgs" protobuf:"16"`
-	FlannelKubeServiceHost            string   `yaml:"flannelKubeServiceHost" protobuf:"17"`
-	FlannelKubeServicePort            string   `yaml:"flannelKubeServicePort" protobuf:"18"`
-	FlannelKubeNetworkPoliciesEnabled bool     `yaml:"flannelKubeNetworkPoliciesEnabled" protobuf:"19"`
-	FlannelKubeNetworkPoliciesImage   string   `yaml:"flannelKubeNetworkPoliciesImage" protobuf:"20"`
+	FlannelEnabled                    bool           `yaml:"flannelEnabled" protobuf:"11"`
+	FlannelImage                      string         `yaml:"flannelImage" protobuf:"12"`
+	FlannelExtraArgs                  []string       `yaml:"flannelExtraArgs" protobuf:"16"`
+	FlannelKubeServiceHost            string         `yaml:"flannelKubeServiceHost" protobuf:"17"`
+	FlannelKubeServicePort            string         `yaml:"flannelKubeServicePort" protobuf:"18"`
+	FlannelKubeNetworkPoliciesEnabled bool           `yaml:"flannelKubeNetworkPoliciesEnabled" protobuf:"19"`
+	FlannelKubeNetworkPoliciesImage   string         `yaml:"flannelKubeNetworkPoliciesImage" protobuf:"20"`
+	FlannelBackendType                string         `yaml:"flannelBackendType" protobuf:"23"`
+	FlannelBackendPort                uint16         `yaml:"flannelBackendPort" protobuf:"24"`
+	FlannelBackendMTU                 uint32         `yaml:"flannelBackendMTU" protobuf:"22"`
+	FlannelBackendExtraConfig         map[string]any `yaml:"flannelBackendExtraConfig" protobuf:"26"`
+	FlannelResources                  Resources      `yaml:"flannelResources" protobuf:"25"`
 
 	PodSecurityPolicyEnabled bool `yaml:"podSecurityPolicyEnabled" protobuf:"14"`
 

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -7752,6 +7752,11 @@ BootstrapManifestsConfigSpec is configuration for bootstrap manifests.
 | flannel_kube_network_policies_enabled | [bool](#bool) |  |  |
 | flannel_kube_network_policies_image | [string](#string) |  |  |
 | cni_name | [string](#string) |  |  |
+| flannel_backend_mtu | [uint32](#uint32) |  |  |
+| flannel_backend_type | [string](#string) |  |  |
+| flannel_backend_port | [uint32](#uint32) |  |  |
+| flannel_resources | [Resources](#talos.resource.definitions.k8s.Resources) |  |  |
+| flannel_backend_extra_config | [google.protobuf.Struct](#google.protobuf.Struct) |  |  |
 
 
 

--- a/website/content/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig.md
+++ b/website/content/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig.md
@@ -16,6 +16,9 @@ title: KubeFlannelCNIConfig
 {{< highlight yaml >}}
 apiVersion: v1alpha1
 kind: KubeFlannelCNIConfig
+backendType: vxlan # Type of the Flannel backend to use.
+backendPort: 4789 # UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).
+backendMTU: 1420 # Transport MTU to be used for the pod network.
 # Extra arguments for 'flanneld'.
 extraArgs:
     - --iface-can-reach=192.168.1.1
@@ -25,11 +28,41 @@ kubeNetworkPoliciesEnabled: true # Deploys kube-network-policies along with Flan
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
+|`backendType` |string |Type of the Flannel backend to use.<br><br>See Flannel documentation for supported backend types.<br>The default value in generated machine configuration is "vxlan".  | |
+|`backendPort` |uint16 |UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).<br><br>The default value in generated machine configuration is 4789.  | |
+|`backendMTU` |uint32 |Transport MTU to be used for the pod network.<br><br>Flannel will subtract encapsulation overhead from this MTU to calculate<br>the MTU of the pod interface.<br>If not set, the default is auto-detection of MTU by Flannel.<br>If KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.  | |
+|`backendExtraConfig` |Unstructured |Extra configuration for Flannel backend.<br><br>The content of this field depends on the backend type used.<br>The value of this field will be patched into Flannel configuration 'Backend' section as-is.  | |
+|`resources` |<a href="#KubeFlannelCNIConfig.resources">ResourcesConfig</a> |Resources configuration for Flannel main container.  | |
 |`extraArgs` |[]string |Extra arguments for 'flanneld'. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 extraArgs:
     - --iface-can-reach=192.168.1.1
 {{< /highlight >}}</details> | |
 |`kubeNetworkPoliciesEnabled` |bool |Deploys kube-network-policies along with Flannel.<br><br>This enables Kubernetes Network Policies support in the cluster.  | |
+
+
+
+
+## resources {#KubeFlannelCNIConfig.resources}
+
+ResourcesConfig represents the pod resources.
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`requests` |Unstructured |Requests configures the reserved cpu/memory resources. <details><summary>Show example(s)</summary>resources requests.:{{< highlight yaml >}}
+requests:
+    cpu: 1
+    memory: 1Gi
+{{< /highlight >}}</details> | |
+|`limits` |Unstructured |Limits configures the maximum cpu/memory limits a pod can use. <details><summary>Show example(s)</summary>resources limits.:{{< highlight yaml >}}
+limits:
+    cpu: 2
+    memory: 2500Mi
+{{< /highlight >}}</details> | |
+
+
 
 
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -1304,6 +1304,41 @@
           "markdownDescription": "kind is the kind of the resource.",
           "x-intellij-html-description": "\u003cp\u003ekind is the kind of the resource.\u003c/p\u003e\n"
         },
+        "backendType": {
+          "type": "string",
+          "title": "backendType",
+          "description": "Type of the Flannel backend to use.\n\nSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is “vxlan”.\n",
+          "markdownDescription": "Type of the Flannel backend to use.\n\nSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is \"vxlan\".",
+          "x-intellij-html-description": "\u003cp\u003eType of the Flannel backend to use.\u003c/p\u003e\n\n\u003cp\u003eSee Flannel documentation for supported backend types.\nThe default value in generated machine configuration is \u0026ldquo;vxlan\u0026rdquo;.\u003c/p\u003e\n"
+        },
+        "backendPort": {
+          "type": "integer",
+          "title": "backendPort",
+          "description": "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\n\nThe default value in generated machine configuration is 4789.\n",
+          "markdownDescription": "UDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\n\nThe default value in generated machine configuration is 4789.",
+          "x-intellij-html-description": "\u003cp\u003eUDP port used by Flannel for encapsulating traffic (if the backend type requires encapsulation).\u003c/p\u003e\n\n\u003cp\u003eThe default value in generated machine configuration is 4789.\u003c/p\u003e\n"
+        },
+        "backendMTU": {
+          "type": "integer",
+          "title": "backendMTU",
+          "description": "Transport MTU to be used for the pod network.\n\nFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.\n",
+          "markdownDescription": "Transport MTU to be used for the pod network.\n\nFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.",
+          "x-intellij-html-description": "\u003cp\u003eTransport MTU to be used for the pod network.\u003c/p\u003e\n\n\u003cp\u003eFlannel will subtract encapsulation overhead from this MTU to calculate\nthe MTU of the pod interface.\nIf not set, the default is auto-detection of MTU by Flannel.\nIf KubeSpan is enabled, and the value is not set, defaults to KubeSpan MTU.\u003c/p\u003e\n"
+        },
+        "backendExtraConfig": {
+          "type": "object",
+          "title": "backendExtraConfig",
+          "description": "Extra configuration for Flannel backend.\n\nThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration ‘Backend’ section as-is.\n",
+          "markdownDescription": "Extra configuration for Flannel backend.\n\nThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration 'Backend' section as-is.",
+          "x-intellij-html-description": "\u003cp\u003eExtra configuration for Flannel backend.\u003c/p\u003e\n\n\u003cp\u003eThe content of this field depends on the backend type used.\nThe value of this field will be patched into Flannel configuration \u0026lsquo;Backend\u0026rsquo; section as-is.\u003c/p\u003e\n"
+        },
+        "resources": {
+          "type": "object",
+          "title": "resources",
+          "description": "Resources configuration for Flannel main container.\n",
+          "markdownDescription": "Resources configuration for Flannel main container.",
+          "x-intellij-html-description": "\u003cp\u003eResources configuration for Flannel main container.\u003c/p\u003e\n"
+        },
         "extraArgs": {
           "items": {
             "type": "string"


### PR DESCRIPTION
When kubespan is enabled, flannel auto-detects its underlay MTU from the host's primary interface (typically 1500) and creates flannel.1 at MTU 1450 (= 1500 - 50 VXLAN overhead). Encapsulated VXLAN packets are then routed through kubespan's WireGuard tunnel (default MTU 1420), forcing permanent fragmentation and degraded throughput.

Fix it in two parts:

* Render `Backend.MTU` in flannel's net-conf.json from a new `backendMTU` field. Counter-intuitively, flannel's `Backend.MTU` represents the *underlay* transport MTU, not the resulting flannel.1 MTU — flannel internally subtracts the VXLAN overhead when creating the device. See: https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan

* In ControlPlaneBootstrapManifestsController, default `Backend.MTU` to the kubespan link MTU when kubespan is enabled and the field is unset. Explicit user override always wins.

With the default kubespan MTU of 1420, flannel.1 ends up at 1370, so encapsulated VXLAN traffic fits within the WireGuard MTU without fragmentation. When kubespan is disabled and the field is unset, behavior is unchanged: `Backend.MTU` is omitted from net-conf.json and flannel auto-detects from the external interface as before.

Refactor Flannel config to support more fields and overrides natively for better customization.

Fixes #13457
