### PR TITLE
fix: relax LUKS header validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/siderolabs/discovery-client v0.1.15
 	github.com/siderolabs/gen v0.8.6
 	github.com/siderolabs/go-adv v1.0.0
-	github.com/siderolabs/go-blockdevice/v2 v2.0.29
+	github.com/siderolabs/go-blockdevice/v2 v2.0.30
 	github.com/siderolabs/go-circular v0.2.3
 	github.com/siderolabs/go-cmd v0.2.0
 	github.com/siderolabs/go-copy v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -803,8 +803,8 @@ github.com/siderolabs/go-adv v1.0.0 h1:ZWXnoGq1GKeEIkLSR4o6oKcayFsowZkJsWcyQqwPk
 github.com/siderolabs/go-adv v1.0.0/go.mod h1:nR6YwduJv56mZI1D3ow1Zok5lwefiM94hS0o1d6KmNc=
 github.com/siderolabs/go-api-signature v0.3.12 h1:i1X+kPh9fzo+lEjtEplZSbtq1p21vKv4FCWJcB/ozvk=
 github.com/siderolabs/go-api-signature v0.3.12/go.mod h1:dPLiXohup4qHX7KUgF/wwOE3lRU5uAr3ssEomNxiyxY=
-github.com/siderolabs/go-blockdevice/v2 v2.0.29 h1:CNg9gEsW+YGjmKZ4RPrk0ToTvHVPdB5o6pOeaFCGtKM=
-github.com/siderolabs/go-blockdevice/v2 v2.0.29/go.mod h1:tvBizVxJtZ+uIuZQnDBRKXImcm4bpr1y1Sa0CjH27vQ=
+github.com/siderolabs/go-blockdevice/v2 v2.0.30 h1:+U7GvHypsQ+LyEqo64LDsvCU59JEnv2vb8nvt1KBgFk=
+github.com/siderolabs/go-blockdevice/v2 v2.0.30/go.mod h1:tvBizVxJtZ+uIuZQnDBRKXImcm4bpr1y1Sa0CjH27vQ=
 github.com/siderolabs/go-circular v0.2.3 h1:GKkA1Tw79kEFGtWdl7WTxEUTbwtklITeiRT0V1McHrA=
 github.com/siderolabs/go-circular v0.2.3/go.mod h1:YBN/q9YpQphUYnBtBgPsngauSHj1TEZfgQZWZVjk1WE=
 github.com/siderolabs/go-cmd v0.2.0 h1:fZ0jbQzZg4bFLmJzNEDZM/RlebZsfHOo2k+PCJ6g7y4=


### PR DESCRIPTION
Pull in go-blockdevice with a fix.

See https://github.com/siderolabs/go-blockdevice/issues/156
