### PR TITLE
fix: increment time epoch on wall-clock jump when time sync is disabled

### DIFF
--- a/internal/app/machined/pkg/controllers/time/internal/clock/export_test.go
+++ b/internal/app/machined/pkg/controllers/time/internal/clock/export_test.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package clock
+
+import "time"
+
+// SetWallClock is used in test to simulate jumps.
+func (d *WallClockJumpDetector) SetWallClock(t time.Time) {
+	d.lastWallClock = wallClockOnly(t)
+}

--- a/internal/app/machined/pkg/controllers/time/internal/clock/jump.go
+++ b/internal/app/machined/pkg/controllers/time/internal/clock/jump.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package clock provides clock-related privimites, e.g. jump detection.
+package clock
+
+import (
+	"context"
+	"time"
+
+	"github.com/siderolabs/gen/channel"
+)
+
+// DefaultJumpDetectionInterval is the default interval for wall-clock jump detection.
+const DefaultJumpDetectionInterval = time.Minute
+
+// WallClockJumpDetector detects wall-clock jumps by comparing elapsed time of wall clock and monotonic clock.
+type WallClockJumpDetector struct {
+	lastWallClock      time.Time
+	lastMonotonicClock time.Time
+	interval           time.Duration
+	threshold          time.Duration
+}
+
+// NewWallClockJumpDetector creates a new WallClockJumpDetector.
+func NewWallClockJumpDetector(interval, threshold time.Duration) *WallClockJumpDetector {
+	now := time.Now()
+
+	return &WallClockJumpDetector{
+		lastWallClock:      wallClockOnly(now),
+		lastMonotonicClock: now,
+		interval:           interval,
+		threshold:          threshold,
+	}
+}
+
+// Run starts the jump detector loop.
+func (d *WallClockJumpDetector) Run(ctx context.Context) <-chan struct{} {
+	jumpCh := make(chan struct{}, 1)
+
+	go func() {
+		ticker := time.NewTicker(d.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			now := time.Now()
+
+			wallClockElapsed := wallClockOnly(now).Sub(d.lastWallClock)
+			monotonicElapsed := now.Sub(d.lastMonotonicClock)
+
+			if (wallClockElapsed - monotonicElapsed).Abs() > d.threshold {
+				if !channel.SendWithContext(ctx, jumpCh, struct{}{}) {
+					return
+				}
+
+				// remember new clock readings
+				d.lastWallClock = wallClockOnly(now)
+				d.lastMonotonicClock = now
+			}
+		}
+	}()
+
+	return jumpCh
+}
+
+func wallClockOnly(now time.Time) time.Time {
+	// Round(0) strips the monotonic clock reading so Sub compares wall-clock time.
+	return now.Round(0)
+}

--- a/internal/app/machined/pkg/controllers/time/internal/clock/jump_test.go
+++ b/internal/app/machined/pkg/controllers/time/internal/clock/jump_test.go
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package clock_test
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time/internal/clock"
+)
+
+func TestWallClockJumpDetectorNoJump(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		jumpDetector := clock.NewWallClockJumpDetector(100*time.Millisecond, 200*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		jumpCh := jumpDetector.Run(ctx)
+
+		synctest.Wait()
+
+		// run a cycle without a jump
+		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-jumpCh:
+			t.Fatal("no jump expected")
+		default:
+		}
+	})
+}
+
+func TestWallClockJumpDetectorJump(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		jumpDetector := clock.NewWallClockJumpDetector(100*time.Millisecond, 200*time.Millisecond)
+
+		// Simulate a jump by offsetting the stored wall-clock baseline before the
+		// detector goroutine starts. Doing it before Run starts the goroutine means
+		// the `go` statement provides the happens-before edge, so there's no data
+		// race on the baseline (which the detector goroutine reads and updates).
+		jumpDetector.SetWallClock(time.Now().Add(time.Second))
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		jumpCh := jumpDetector.Run(ctx)
+
+		// run a cycle with a jump
+		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-jumpCh:
+			// Jump detected as expected.
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("expected to detect a wall clock jump, but did not")
+		}
+
+		// now, as the jump was already detected, it should not be reported anymore
+		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-jumpCh:
+			t.Fatal("no jump expected")
+		default:
+		}
+	})
+}

--- a/internal/app/machined/pkg/controllers/time/sync.go
+++ b/internal/app/machined/pkg/controllers/time/sync.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time/internal/clock"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/pkg/ntp"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -27,8 +28,9 @@ import (
 
 // SyncController manages v1alpha1.TimeSync based on configuration and NTP sync process.
 type SyncController struct {
-	V1Alpha1Mode v1alpha1runtime.Mode
-	NewNTPSyncer NewNTPSyncerFunc
+	V1Alpha1Mode         v1alpha1runtime.Mode
+	NewNTPSyncer         NewNTPSyncerFunc
+	NewClockJumpDetector NewClockJumpDetectorFunc
 
 	bootTime stdtime.Time
 }
@@ -64,6 +66,14 @@ type NTPSyncer interface {
 // NewNTPSyncerFunc function allows to replace ntp.Syncer with the mock.
 type NewNTPSyncerFunc func(*zap.Logger, []string, bool) NTPSyncer
 
+// ClockJumpDetector detects wall clock jumps, interface for mocking.
+type ClockJumpDetector interface {
+	Run(ctx context.Context) <-chan struct{}
+}
+
+// NewClockJumpDetectorFunc function allows to replace clock jump detector with the mock.
+type NewClockJumpDetectorFunc func(interval, threshold stdtime.Duration) ClockJumpDetector
+
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo,cyclop
@@ -75,6 +85,12 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 	if ctrl.NewNTPSyncer == nil {
 		ctrl.NewNTPSyncer = func(logger *zap.Logger, timeServers []string, useNTS bool) NTPSyncer {
 			return ntp.NewSyncer(logger, timeServers, useNTS)
+		}
+	}
+
+	if ctrl.NewClockJumpDetector == nil {
+		ctrl.NewClockJumpDetector = func(interval, threshold stdtime.Duration) ClockJumpDetector {
+			return clock.NewWallClockJumpDetector(interval, threshold)
 		}
 	}
 
@@ -115,6 +131,9 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 		timeSyncTimeoutCh    <-chan stdtime.Time
 	)
 
+	wallClockJumpDetector := ctrl.NewClockJumpDetector(clock.DefaultJumpDetectionInterval, ntp.EpochLimit)
+	wallClockJumpCh := wallClockJumpDetector.Run(ctx)
+
 	defer func() {
 		if syncer != nil {
 			syncCtxCancel()
@@ -128,6 +147,8 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 	}()
 
 	for {
+		var wallClockJumpDetected bool
+
 		select {
 		case <-ctx.Done():
 			return nil
@@ -140,6 +161,8 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 		case <-timeSyncTimeoutCh:
 			timeSynced = true
 			timeSyncTimeoutTimer = nil
+		case <-wallClockJumpCh:
+			wallClockJumpDetected = true
 		}
 
 		timeServersStatus, err := safe.ReaderGet[*network.TimeServerStatus](
@@ -180,6 +203,15 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 			}
 
 			syncTimeout = cfg.Config().NetworkTimeSyncConfig().BootTimeout()
+		}
+
+		if wallClockJumpDetected && syncDisabled {
+			epoch++
+
+			logger.Info(
+				"detected wall-clock jump while time synchronization is disabled, incrementing time epoch",
+				zap.Duration("threshold", ntp.EpochLimit),
+			)
 		}
 
 		if !timeSynced {

--- a/internal/app/machined/pkg/controllers/time/sync_wall_clock_jump_test.go
+++ b/internal/app/machined/pkg/controllers/time/sync_wall_clock_jump_test.go
@@ -1,0 +1,186 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package time_test
+
+import (
+	"context"
+	"testing"
+	stdtime "time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	timeresource "github.com/siderolabs/talos/pkg/machinery/resources/time"
+)
+
+type SyncWallClockJumpSuite struct {
+	ctest.DefaultSuite
+
+	detector *fakeClockJumpDetector
+	syncer   *noopSyncer
+}
+
+func (suite *SyncWallClockJumpSuite) TestDetectedJumpIncrementsEpochWhenSyncDisabled() {
+	suite.registerSyncControllerWithMode(runtime.ModeContainer)
+	suite.createDefaultTimeServers()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        0,
+		SyncDisabled: true,
+	})
+
+	suite.detector.enqueueJump()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        1,
+		SyncDisabled: true,
+	})
+}
+
+func (suite *SyncWallClockJumpSuite) TestDetectedJumpIsRetainedUntilInputsAreAvailable() {
+	suite.registerSyncControllerWithMode(runtime.ModeContainer)
+	timeServers := suite.createDefaultTimeServers()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        0,
+		SyncDisabled: true,
+	})
+
+	suite.Destroy(timeServers)
+
+	suite.detector.enqueueJump()
+
+	suite.createDefaultTimeServers()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        1,
+		SyncDisabled: true,
+	})
+}
+
+func (suite *SyncWallClockJumpSuite) TestDetectorNoEpochChange() {
+	suite.registerSyncControllerWithMode(runtime.ModeMetal)
+	suite.createDefaultTimeServers()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       false,
+		Epoch:        0,
+		SyncDisabled: false,
+	})
+
+	suite.syncer.sendSynced()
+	suite.detector.enqueueJump()
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        0,
+		SyncDisabled: false,
+	})
+}
+
+func (suite *SyncWallClockJumpSuite) registerSyncControllerWithMode(mode runtime.Mode) {
+	suite.detector = newFakeClockJumpDetector()
+	suite.syncer = newNoopSyncer()
+
+	suite.Require().NoError(suite.Runtime().RegisterController(&time.SyncController{
+		V1Alpha1Mode: mode,
+		NewNTPSyncer: func(*zap.Logger, []string, bool) time.NTPSyncer {
+			return suite.syncer
+		},
+		NewClockJumpDetector: func(stdtime.Duration, stdtime.Duration) time.ClockJumpDetector {
+			return suite.detector
+		},
+	}))
+}
+
+func (suite *SyncWallClockJumpSuite) createDefaultTimeServers() *network.TimeServerStatus {
+	timeServers := network.NewTimeServerStatus(network.NamespaceName, network.TimeServerID)
+	timeServers.TypedSpec().NTPServers = []string{constants.DefaultNTPServer}
+
+	suite.Create(timeServers)
+
+	return timeServers
+}
+
+func (suite *SyncWallClockJumpSuite) assertTimeStatus(spec timeresource.StatusSpec) {
+	ctest.AssertResource(suite, timeresource.StatusID, func(r *timeresource.Status, asrt *assert.Assertions) {
+		asrt.Equal(spec, *r.TypedSpec())
+	})
+}
+
+func TestSyncWallClockJumpSuite(t *testing.T) {
+	t.Parallel()
+
+	testSuite := &SyncWallClockJumpSuite{}
+	testSuite.DefaultSuite = ctest.DefaultSuite{
+		Timeout: 10 * stdtime.Second,
+		AfterSetup: func(s *ctest.DefaultSuite) {
+			deviceStatus := runtimeres.NewDevicesStatus(runtimeres.NamespaceName, runtimeres.DevicesID)
+			deviceStatus.TypedSpec().Ready = true
+			s.Create(deviceStatus)
+		},
+	}
+
+	suite.Run(t, testSuite)
+}
+
+type fakeClockJumpDetector struct {
+	jumps chan struct{}
+}
+
+func newFakeClockJumpDetector() *fakeClockJumpDetector {
+	return &fakeClockJumpDetector{
+		jumps: make(chan struct{}),
+	}
+}
+
+func (detector *fakeClockJumpDetector) Run(context.Context) <-chan struct{} {
+	return detector.jumps
+}
+
+func (detector *fakeClockJumpDetector) enqueueJump() {
+	detector.jumps <- struct{}{}
+}
+
+type noopSyncer struct {
+	syncedCh chan struct{}
+	epochCh  chan struct{}
+}
+
+func newNoopSyncer() *noopSyncer {
+	return &noopSyncer{
+		syncedCh: make(chan struct{}),
+		epochCh:  make(chan struct{}),
+	}
+}
+
+func (syncer *noopSyncer) Run(ctx context.Context) {
+	<-ctx.Done()
+}
+
+func (syncer *noopSyncer) Synced() <-chan struct{} {
+	return syncer.syncedCh
+}
+
+func (syncer *noopSyncer) sendSynced() {
+	syncer.syncedCh <- struct{}{}
+}
+
+func (syncer *noopSyncer) EpochChange() <-chan struct{} {
+	return syncer.epochCh
+}
+
+func (syncer *noopSyncer) SetTimeServers([]string) {}


### PR DESCRIPTION
# Pull Request

## What? (description)

This PR adds lightweight **wall-clock jump detection** to `time.SyncController` for cases where active time synchronization is disabled (most notably in `PLATFORM=container`).

When `syncDisabled` is true, the controller now runs a small periodic check (default interval: 1 minute) that compares **wall-clock elapsed time** against **monotonic elapsed time**. If the absolute difference exceeds the existing `ntp.EpochLimit` threshold (15 minutes), it increments `time.Status.Epoch` and logs the event.

Key implementation details:

- `wallClockJumpDetector` strips the monotonic clock reading via `time.Now().Round(0)` so that `Sub` compares true wall-clock deltas
- The detector is **only** instantiated when `syncDisabled == true`; it is stopped and reset immediately when sync becomes enabled
- If a jump is detected while controller inputs are temporarily unavailable, the pending jump is retained and applied once the next reconcile cycle completes
- No new machine configuration options are introduced. No certificate lifetimes or refresh intervals are changed

Added test coverage:

- `TestWallClockJumpDetector`: unit tests for the detector math (forward jump, backward jump, below-threshold, equal-to-threshold).
- `TestSyncWallClockJumpSuite`: integration tests verifying that:
  - a detected jump increments `Epoch` when sync is disabled
  - pending jumps survive temporary input unavailability
  - the detector stops cleanly when sync is re-enabled

## Why? (reasoning)

Talos internal service certificates (Talos API server, `trustd`, maintenance service) are short-lived (`24h`) and refreshed by controllers that already depend on `time.Status`:

```go
// time status isn't fetched, but the fact that it is in dependencies means
// that certs will be regenerated on time sync/jump
```

On normal platforms, an NTP syncer detects large clock discontinuities and bumps `time.Status.Epoch`, which triggers certificate regeneration. In container mode, however, Talos forcibly disables NTP:

```go
if ctrl.V1Alpha1Mode == ModeContainer {
    syncDisabled = true
}
```

Because of this, after a host sleep / VM pause (e.g. Docker Desktop on macOS), the wall clock can jump forward by hours, but `time.Status.Epoch` never changes. The certificate controllers therefore never receive a reconcile trigger, and `apid` continues to serve an expired certificate until enough **active** runtime passes for the next monotonic refresh ticker to fire. In practice this means `talosctl` and any tooling that relies on the Talos API fails immediately after resume.

Rather than increasing certificate lifetimes (which weakens security posture) or adding new configuration knobs, this PR restores the **intended semantics** of `time.Status.Epoch`: signal large wall-clock discontinuities so that downstream controllers (including certificate controllers) can react promptly. This makes the container provisioner behavior consistent with the architectural contract already present in the codebase.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`) <- but I am not a member of `siderolabs` GitHub org
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`) <- full suite has failed (unrelated things), my tests passed via `make unit-tests TESTPKGS=github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time`

> See `make help` for a description of the available targets.
