### PR TITLE
feat: grab support bundle via client factory

### DIFF
--- a/cmd/talosctl/cmd/talos/dmesg.go
+++ b/cmd/talosctl/cmd/talos/dmesg.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var dmesgCmdFlags struct {
+	global.InsecureFlags
+
 	follow bool
 	tail   bool
 }
@@ -66,4 +69,5 @@ func init() {
 	addCommand(dmesgCmd)
 	dmesgCmd.Flags().BoolVarP(&dmesgCmdFlags.follow, "follow", "f", false, "specify if the kernel log should be streamed")
 	dmesgCmd.Flags().BoolVarP(&dmesgCmdFlags.tail, "tail", "", false, "specify if only new messages should be sent (makes sense only when combined with --follow)")
+	dmesgCmdFlags.InsecureFlags.AddFlags(dmesgCmd)
 }

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -14,12 +14,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
 var memoryCmdFlags struct {
+	global.InsecureFlags
+
 	verbose bool
 }
 
@@ -170,5 +173,6 @@ func renderVerbose(responseChan <-chan multiplex.Response[*machineapi.MemoryResp
 
 func init() {
 	memoryCmd.Flags().BoolVarP(&memoryCmdFlags.verbose, "verbose", "v", false, "display extended memory statistics")
+	memoryCmdFlags.InsecureFlags.AddFlags(memoryCmd)
 	addCommand(memoryCmd)
 }

--- a/cmd/talosctl/cmd/talos/service.go
+++ b/cmd/talosctl/cmd/talos/service.go
@@ -21,6 +21,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 )
 
+var serviceCmdFlags struct {
+	global.InsecureFlags
+}
+
 // serviceCmd represents the service command.
 var serviceCmd = &cobra.Command{
 	Use:     "service [<id> [start|stop|restart|status]]",
@@ -54,7 +58,7 @@ With actions 'start', 'stop', 'restart', service state is updated respectively.`
 
 		ctx := cmd.Context()
 
-		clientFactory, err := NewClientFactory(ctx, nil)
+		clientFactory, err := NewClientFactory(ctx, &serviceCmdFlags)
 		if err != nil {
 			return err
 		}
@@ -281,4 +285,5 @@ func (svc serviceInfoWrapper) healthStatus() string {
 
 func init() {
 	addCommand(serviceCmd)
+	serviceCmdFlags.InsecureFlags.AddFlags(serviceCmd)
 }

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -34,6 +34,8 @@ import (
 )
 
 var supportCmdFlags struct {
+	global.InsecureFlags
+
 	output                        string
 	numWorkers                    int
 	verbose                       bool
@@ -169,6 +171,8 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 }
 
 func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progress, clientFactory *global.ClientFactory) error {
+	var errs error
+
 	nodeCtx, c, err := clientFactory.BuildClientFirstNode(ctx)
 	if err != nil {
 		return err
@@ -176,13 +180,13 @@ func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progr
 
 	clientset, err := getKubernetesClient(nodeCtx, c)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create kubernetes client %s\n", err)
+		errs = errors.Join(errs, fmt.Errorf("failed to create kubernetes client: %w", err))
 	}
 
 	opts := []bundle.Option{
 		bundle.WithArchiveOutput(dest),
 		bundle.WithKubernetesClient(clientset),
-		bundle.WithTalosClient(c),
+		bundle.WithTalosClientProvider(clientFactory.BuildClient),
 		bundle.WithNodes(clientFactory.Nodes()...),
 		bundle.WithNumWorkers(supportCmdFlags.numWorkers),
 		bundle.WithProgressChan(progress),
@@ -196,10 +200,10 @@ func collectData(ctx context.Context, dest io.Writer, progress chan bundle.Progr
 
 	collectors, err := collectors.GetForOptions(ctx, options)
 	if err != nil {
-		return err
+		errs = errors.Join(errs, fmt.Errorf("failed to create collectors: %w", err))
 	}
 
-	return support.CreateSupportBundle(ctx, options, collectors...)
+	return errors.Join(errs, support.CreateSupportBundle(ctx, options, collectors...))
 }
 
 func getKubernetesClient(ctx context.Context, c *client.Client) (*k8s.Clientset, error) {
@@ -445,4 +449,5 @@ func init() {
 		&supportCmdFlags.encryptionNoDefaultRecipients, "encryption-no-default-recipients", false,
 		"do not encrypt to the default recipients, only to the ones provided via --encryption-recipients",
 	)
+	supportCmdFlags.InsecureFlags.AddFlags(supportCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-smbios v0.3.4
 	github.com/siderolabs/go-tail v0.1.1
-	github.com/siderolabs/go-talos-support v0.2.2
+	github.com/siderolabs/go-talos-support v0.3.0
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/siderolabs/kms-client v0.2.0
 	github.com/siderolabs/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ github.com/siderolabs/go-smbios v0.3.4 h1:3HvW8lf+kw+HnC67XzdCH8WhkDeX+K9W4VmV54
 github.com/siderolabs/go-smbios v0.3.4/go.mod h1:lNA6mNOsqhDQcE7HnAtATOa8F9CU8Q69M5wyNUSU0Co=
 github.com/siderolabs/go-tail v0.1.1 h1:3XeJgd97OHyFAIE7nQEMcRhOfnv7DvXbu0BRKbtT6u8=
 github.com/siderolabs/go-tail v0.1.1/go.mod h1:IihAL39acadXHfb5fEAOKK2DaDFIrG2+VD3b2H/ziZ0=
-github.com/siderolabs/go-talos-support v0.2.2 h1:5urNuBSZdWrJhScWrjuaxf9xXmJFWTdx5YJO/iP3fko=
-github.com/siderolabs/go-talos-support v0.2.2/go.mod h1:IB9sOkhUgjGJFuuBs+TZVdjgG01ly8/Ku9SOshINvSU=
+github.com/siderolabs/go-talos-support v0.3.0 h1:8+JErCZAc2jRTtSJKkW1xFJxetX/b5m/YesMgVnz2v4=
+github.com/siderolabs/go-talos-support v0.3.0/go.mod h1:IB9sOkhUgjGJFuuBs+TZVdjgG01ly8/Ku9SOshINvSU=
 github.com/siderolabs/grpc-proxy v0.5.2 h1:o34tS02IxbX3qeXe0MM99zE2XhfWHuvdBtSWWRD9HNI=
 github.com/siderolabs/grpc-proxy v0.5.2/go.mod h1:ygf+gqFxWdymAXuP4qMHTa+j6SvasdcFg3XkhpvUvDw=
 github.com/siderolabs/kms-client v0.2.0 h1:8RniCStUI75RTZO8qkhHOSVOnEU1AvvsKqJ7FqW/8NA=

--- a/pkg/cluster/crashdump.go
+++ b/pkg/cluster/crashdump.go
@@ -51,7 +51,9 @@ func Crashdump(ctx context.Context, cluster provision.Cluster, logWriter io.Writ
 
 	opts := []bundle.Option{
 		bundle.WithArchiveOutput(supportFile),
-		bundle.WithTalosClient(c),
+		bundle.WithTalosClientProvider(func(ctx context.Context, node string) (context.Context, *client.Client, error) {
+			return client.WithNode(ctx, node), c, nil
+		}),
 		bundle.WithNodes(nodes...),
 		bundle.WithNumWorkers(4),
 		bundle.WithLogOutput(io.Discard),

--- a/pkg/machinery/formatters/formatters.go
+++ b/pkg/machinery/formatters/formatters.go
@@ -9,66 +9,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
-	"slices"
-	"strings"
-	"text/tabwriter"
-	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/emicklei/dot"
-	"google.golang.org/grpc/peer"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/inspect"
-	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
-
-// RenderMounts renders mounts output.
-//
-// Deprecated: use [RenderMountsStream] which handles multi-node responses via [multiplex.Unary].
-func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *peer.Peer) error {
-	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
-	parts := []string{"FILESYSTEM", "SIZE(GB)", "USED(GB)", "AVAILABLE(GB)", "PERCENT USED", "MOUNTED ON"}
-
-	var defaultNode string
-
-	if remotePeer != nil {
-		parts = append([]string{"NODE"}, parts...)
-		defaultNode = client.AddrFromPeer(remotePeer)
-	}
-
-	fmt.Fprintln(w, strings.Join(parts, "\t"))
-
-	for _, msg := range resp.Messages {
-		for _, r := range msg.Stats {
-			percentAvailable := 100.0 - 100.0*(float64(r.Available)/float64(r.Size))
-
-			if math.IsNaN(percentAvailable) {
-				continue
-			}
-
-			node := defaultNode
-
-			if msg.Metadata != nil {
-				node = msg.Metadata.Hostname //nolint:staticcheck // deprecated path, kept for backwards compatibility
-			}
-
-			format := "%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n"
-			args := []any{r.Filesystem, float64(r.Size) * 1e-9, float64(r.Size-r.Available) * 1e-9, float64(r.Available) * 1e-9, percentAvailable, r.MountedOn}
-
-			if defaultNode != "" {
-				format = "%s\t" + format
-
-				args = slices.Insert(args, 0, any(node))
-			}
-
-			fmt.Fprintf(w, format, args...)
-		}
-	}
-
-	return w.Flush()
-}
 
 // RenderGraph renders inspect controller runtime graph.
 //
@@ -194,86 +141,4 @@ func RenderGraph(ctx context.Context, c *client.Client, resp *inspect.Controller
 	graph.Write(output)
 
 	return nil
-}
-
-// RenderServicesInfo writes human readable service information to the io.Writer.
-//
-// Deprecated: this relies on the legacy per-message node metadata; new code should
-// format the node explicitly from the multiplexed response (see the `service` command).
-func RenderServicesInfo(services []client.ServiceInfo, output io.Writer, defaultNode string, withNodeInfo bool) error {
-	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
-
-	node := defaultNode
-
-	for _, s := range services {
-		if s.Metadata != nil {
-			node = s.Metadata.Hostname //nolint:staticcheck // to be refactored next
-		}
-
-		if withNodeInfo {
-			fmt.Fprintf(w, "NODE\t%s\n", node)
-		}
-
-		svc := ServiceInfoWrapper{s.Service}
-		fmt.Fprintf(w, "ID\t%s\n", svc.Id)
-		fmt.Fprintf(w, "STATE\t%s\n", svc.State)
-		fmt.Fprintf(w, "HEALTH\t%s\n", svc.HealthStatus())
-
-		if svc.Health.LastMessage != "" {
-			fmt.Fprintf(w, "LAST HEALTH MESSAGE\t%s\n", svc.Health.LastMessage)
-		}
-
-		label := "EVENTS"
-
-		for i := range svc.Events.Events {
-			event := svc.Events.Events[len(svc.Events.Events)-1-i]
-
-			ts := event.Ts.AsTime()
-			fmt.Fprintf(w, "%s\t[%s]: %s (%s ago)\n", label, event.State, event.Msg, time.Since(ts).Round(time.Second))
-			label = ""
-		}
-	}
-
-	return w.Flush()
-}
-
-// ServiceInfoWrapper helper that allows generating rich service information.
-//
-// Deprecated: new code should format service information from the multiplexed
-// response with the node attached explicitly (see the `service` command).
-type ServiceInfoWrapper struct {
-	*machine.ServiceInfo
-}
-
-// LastUpdated derive last updated time from events stream.
-func (svc ServiceInfoWrapper) LastUpdated() string {
-	if len(svc.Events.Events) == 0 {
-		return ""
-	}
-
-	ts := svc.Events.Events[len(svc.Events.Events)-1].Ts.AsTime()
-
-	return time.Since(ts).Round(time.Second).String()
-}
-
-// LastEvent return last service event.
-func (svc ServiceInfoWrapper) LastEvent() string {
-	if len(svc.Events.Events) == 0 {
-		return "<none>"
-	}
-
-	return svc.Events.Events[len(svc.Events.Events)-1].Msg
-}
-
-// HealthStatus service health status.
-func (svc ServiceInfoWrapper) HealthStatus() string {
-	if svc.Health.Unknown {
-		return "?"
-	}
-
-	if svc.Health.Healthy {
-		return "OK"
-	}
-
-	return "Fail"
 }

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -1338,11 +1338,13 @@ talosctl dmesg [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -f, --follow                     specify if the kernel log should be streamed
   -h, --help                       help for dmesg
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --tail                       specify if only new messages should be sent (makes sense only when combined with --follow)
@@ -2858,10 +2860,12 @@ talosctl memory [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for memory
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -3336,10 +3340,12 @@ talosctl service [<id> [start|stop|restart|status]] [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for service
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -3441,12 +3447,14 @@ talosctl support [flags]
 ### Options
 
 ```
+      --cert-fingerprint strings            list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string                      cluster to connect to if a proxy endpoint is used
       --context string                      context to be used in command
       --encryption-no-default-recipients    do not encrypt to the default recipients, only to the ones provided via --encryption-recipients
       --encryption-recipients stringArray   additional age recipients (SSH or age public keys) to encrypt the support bundle to (can be specified multiple times)
   -e, --endpoints strings                   override default endpoints in Talos configuration
   -h, --help                                help for support
+  -i, --insecure                            use the insecure (encrypted with no auth) maintenance service
       --no-encryption                       do not encrypt the support bundle (output is written as-is)
   -n, --nodes strings                       target the specified nodes
   -w, --num-workers int                     number of workers per node (default 1)


### PR DESCRIPTION
Fixes #13491

Fixes #13488

Use new `go-talos-support` bundle library, pass the client factory as the client provider.

Aggregate and properly report partial failures.

Also, while I'm at it - implement insecure mode for dmesg, memory and service (list) commands. Support bundle can be gathered in maintenance mode now as well.

See https://github.com/siderolabs/go-talos-support/pull/17
