### PR TITLE
ci: verify go.mod tidiness in generate target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -400,7 +400,29 @@ FROM scratch AS microsoft-db-keys
 COPY --link --from=microsoft-secureboot-database /DB/Certificates/MicCor*.der /db/
 COPY --link --from=microsoft-secureboot-database /DB/Certificates/microsoft*.der /db/
 
+# The base target provides a container that can be used to build all Talos
+# assets.
+
+FROM build-go AS base
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./internal ./internal
+COPY --link --from=embed / ./
+RUN --mount=type=cache,target=/.cache,id=talos/.cache go list all >/dev/null
+WORKDIR /src/pkg/machinery
+RUN --mount=type=cache,target=/.cache,id=talos/.cache go list all >/dev/null
+RUN --mount=type=cache,target=/.cache,id=talos/.cache go generate -v ./version
+WORKDIR /src
+
+FROM base AS go-mod-tidy
+RUN --mount=type=cache,target=/.cache,id=talos/.cache go mod tidy
+WORKDIR /src/pkg/machinery
+RUN --mount=type=cache,target=/.cache,id=talos/.cache go mod tidy
+WORKDIR /src
+
 FROM --platform=${BUILDPLATFORM} scratch AS generate
+COPY --link --from=go-mod-tidy /src/go.mod /src/go.sum /
+COPY --link --from=go-mod-tidy /src/pkg/machinery/go.mod /src/pkg/machinery/go.sum /pkg/machinery/
 COPY --link --from=proto-format-build /src/api /api/
 COPY --link --from=generate-build-clean /api/resource/definitions/ /api/resource/definitions/
 COPY --link --from=generate-build-clean /api/machinery /pkg/machinery/
@@ -420,19 +442,6 @@ COPY --link --from=pkg-ca-certificates /etc/ssl/certs/ca-certificates /internal/
 COPY --link --from=microsoft-key-keys / /internal/pkg/secureboot/database/certs/
 COPY --link --from=microsoft-db-keys / /internal/pkg/secureboot/database/certs/
 
-# The base target provides a container that can be used to build all Talos
-# assets.
-
-FROM build-go AS base
-COPY ./cmd ./cmd
-COPY ./pkg ./pkg
-COPY ./internal ./internal
-COPY --link --from=embed / ./
-RUN --mount=type=cache,target=/.cache,id=talos/.cache go list all >/dev/null
-WORKDIR /src/pkg/machinery
-RUN --mount=type=cache,target=/.cache,id=talos/.cache go list all >/dev/null
-RUN --mount=type=cache,target=/.cache,id=talos/.cache go generate -v ./version
-WORKDIR /src
 
 # The vulncheck target runs the vulnerability check tool.
 


### PR DESCRIPTION
Run `go mod tidy` on root and machinery modules during the
generate flow and emit the results. CI `make check-dirty`
then fails on any go.mod/go.sum drift.

Ref. https://github.com/siderolabs/talos/issues/13554

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
