### PR TITLE
feat: drop apply config method reboot

### DIFF
--- a/api/common/common.proto
+++ b/api/common/common.proto
@@ -60,13 +60,14 @@ message Error {
 message Metadata {
   // Multi-node proxying is deprecated.
   option deprecated = true;
+  option (remove_deprecated_message) = "v2.0";
   // hostname of the server response comes from (injected by proxy)
-  string hostname = 1 [deprecated = true];
+  string hostname = 1 [deprecated = true, (remove_deprecated_field) = "v2.0"];
   // error is set if request failed to the upstream (rest of response is
   // undefined)
-  string error = 2 [deprecated = true];
+  string error = 2 [deprecated = true, (remove_deprecated_field) = "v2.0"];
   // error as gRPC Status
-  google.rpc.Status status = 3 [deprecated = true];
+  google.rpc.Status status = 3 [deprecated = true, (remove_deprecated_field) = "v2.0"];
 }
 
 message Data {

--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -126,7 +126,7 @@ service MachineService {
 // node.
 message ApplyConfigurationRequest {
   enum Mode {
-    REBOOT = 0;
+    REBOOT = 0 [deprecated = true, (common.remove_deprecated_enum_value) = "v2.0"]; // Deprecated: use AUTO or NO_REBOOT instead
     AUTO = 1;
     NO_REBOOT = 2;
     STAGED = 3;

--- a/cmd/talosctl/pkg/talos/helpers/mode.go
+++ b/cmd/talosctl/pkg/talos/helpers/mode.go
@@ -24,15 +24,13 @@ type Mode struct {
 }
 
 func (m Mode) String() string {
-	switch m.Mode {
+	switch m.Mode { //nolint:exhaustive
 	case machine.ApplyConfigurationRequest_TRY:
 		return modeTry
 	case machine.ApplyConfigurationRequest_AUTO:
 		return modeAuto
 	case machine.ApplyConfigurationRequest_NO_REBOOT:
 		return modeNoReboot
-	case machine.ApplyConfigurationRequest_REBOOT:
-		return modeReboot
 	case machine.ApplyConfigurationRequest_STAGED:
 		return modeStaged
 	default:
@@ -63,7 +61,6 @@ func (m *Mode) Type() string {
 const (
 	modeAuto     = "auto"
 	modeNoReboot = "no-reboot"
-	modeReboot   = "reboot"
 	modeStaged   = "staged"
 	modeTry      = "try"
 )
@@ -73,7 +70,6 @@ func AddModeFlags(mode *Mode, command *cobra.Command) {
 	modes := map[string]machine.ApplyConfigurationRequest_Mode{
 		modeAuto:     machine.ApplyConfigurationRequest_AUTO,
 		modeNoReboot: machine.ApplyConfigurationRequest_NO_REBOOT,
-		modeReboot:   machine.ApplyConfigurationRequest_REBOOT,
 		modeStaged:   machine.ApplyConfigurationRequest_STAGED,
 		modeTry:      machine.ApplyConfigurationRequest_TRY,
 	}

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -256,6 +256,13 @@ List of changes:
 - Deprecated `.machine.sysfs` in the v1alpha1 config; use the `SysfsConfig` document for sysfs configuration.
 """
 
+    [notes.apply_config]
+        title = "Apply Configuration Modes"
+        description = """\
+The '--mode=reboot' option has been removed from the `talosctl apply-config` command; by default, configuration is applied without a reboot.
+Most configuration changes don't require a reboot; the documentation lists the changes that do.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/apid/pkg/backend/apid_test.go
+++ b/internal/app/apid/pkg/backend/apid_test.go
@@ -329,11 +329,6 @@ func testEnum(t *testing.T, enum protoreflect.EnumDescriptor, currentVersion *co
 }
 
 func testMessage(t *testing.T, message protoreflect.MessageDescriptor, currentVersion *config.VersionContract) {
-	// skip explicitly common.Metadata, which is legacy & deprecated, but not scheduled to be removed
-	if message.FullName() == "common.Metadata" {
-		return
-	}
-
 	testDeprecated(t, message, currentVersion)
 
 	fields := message.Fields()

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -129,8 +128,7 @@ type Server struct {
 
 	server *grpc.Server
 
-	applyConfigMu       sync.Mutex
-	applyConfigRebooted atomic.Bool
+	applyConfigMu sync.Mutex
 }
 
 func (s *Server) checkSupported(feature runtime.ModeCapability) error {
@@ -187,10 +185,6 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 	}
 	defer s.applyConfigMu.Unlock()
 
-	if s.applyConfigRebooted.Load() {
-		return nil, status.Error(codes.FailedPrecondition, "configuration was already applied and node is rebooting, cannot apply more configuration changes until next reboot")
-	}
-
 	roles := authz.GetRoles(ctx)
 	inMaintenance := !s.Controller.Runtime().ConfigCompleteForBoot()
 
@@ -199,8 +193,8 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 	}
 
 	mode := in.Mode.String()
-	modeDetails := "Applied configuration with a reboot"
-	modeErr := ""
+
+	var modeDetails string
 
 	if in.Mode != machine.ApplyConfigurationRequest_TRY {
 		s.Controller.Runtime().CancelConfigRollbackTimeout()
@@ -218,6 +212,14 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		return nil, status.Error(codes.InvalidArgument, "the applied machine configuration doesn't contain v1alpha1 config, did you mean to patch the machine config instead?")
 	}
 
+	if in.Mode == machine.ApplyConfigurationRequest_REBOOT { //nolint:staticcheck // backwards compatibility
+		if inMaintenance {
+			in.Mode = machine.ApplyConfigurationRequest_NO_REBOOT
+		} else {
+			return nil, status.Error(codes.Unimplemented, "the REBOOT mode is not supported, please use AUTO or NO_REBOOT modes instead")
+		}
+	}
+
 	validationMode := modeWrapper{
 		Mode:      s.Controller.Runtime().State().Platform().Mode(),
 		installed: s.Controller.Runtime().State().Machine().Installed(),
@@ -228,37 +230,25 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	if inMaintenance && in.Mode == machine.ApplyConfigurationRequest_REBOOT {
-		in.Mode = machine.ApplyConfigurationRequest_NO_REBOOT
-	}
-
 	//nolint:exhaustive
 	switch in.Mode {
+	// --mode=auto
+	case machine.ApplyConfigurationRequest_AUTO:
+		in.Mode = machine.ApplyConfigurationRequest_NO_REBOOT
+		mode = fmt.Sprintf("%s(%s)", mode, in.Mode)
+
+		fallthrough
 	// --mode=try
 	case machine.ApplyConfigurationRequest_TRY:
 		fallthrough
 	// --mode=no-reboot
 	case machine.ApplyConfigurationRequest_NO_REBOOT:
-		if err = s.Controller.Runtime().CanApplyImmediate(cfgProvider); err != nil && !inMaintenance {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
-
 		modeDetails = "Applied configuration without a reboot"
 	// --mode=staged
 	case machine.ApplyConfigurationRequest_STAGED:
 		modeDetails = "Staged configuration to be applied after the next reboot"
-	// --mode=auto detect actual update mode
-	case machine.ApplyConfigurationRequest_AUTO:
-		if err = s.Controller.Runtime().CanApplyImmediate(cfgProvider); err != nil && !inMaintenance {
-			in.Mode = machine.ApplyConfigurationRequest_REBOOT
-			modeDetails = "Applied configuration with a reboot"
-			modeErr = ": " + err.Error()
-		} else {
-			in.Mode = machine.ApplyConfigurationRequest_NO_REBOOT
-			modeDetails = "Applied configuration without a reboot"
-		}
-
-		mode = fmt.Sprintf("%s(%s)", mode, in.Mode)
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "incorrect mode '%s' specified for the apply config call", in.Mode.String())
 	}
 
 	if in.DryRun {
@@ -313,23 +303,6 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		if err := s.Controller.Runtime().SetPersistedConfig(cfgProvider); err != nil {
 			return nil, err
 		}
-	// --mode=reboot
-	case machine.ApplyConfigurationRequest_REBOOT:
-		if err := s.Controller.Runtime().SetPersistedConfig(cfgProvider); err != nil {
-			return nil, err
-		}
-
-		s.applyConfigRebooted.Store(true)
-
-		go func() {
-			if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, nil, runtime.WithTakeover()); err != nil {
-				if !runtime.IsRebootError(err) {
-					log.Println("apply configuration failed:", err)
-				}
-			}
-		}()
-	default:
-		return nil, fmt.Errorf("incorrect mode '%s' specified for the apply config call", in.Mode.String())
 	}
 
 	return &machine.ApplyConfigurationResponse{
@@ -337,7 +310,7 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 			{
 				Mode:        in.Mode,
 				Warnings:    warnings,
-				ModeDetails: modeDetails + modeErr,
+				ModeDetails: modeDetails,
 			},
 		},
 	}, nil

--- a/internal/app/machined/pkg/runtime/runtime.go
+++ b/internal/app/machined/pkg/runtime/runtime.go
@@ -21,7 +21,6 @@ type Runtime interface { //nolint:interfacebloat
 	CancelConfigRollbackTimeout()
 	SetConfig(config.Provider) error
 	SetPersistedConfig(config.Provider) error
-	CanApplyImmediate(config.Provider) error
 	State() State
 	Events() EventStream
 	Logging() LoggingManager

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -6,10 +6,8 @@ package v1alpha1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
-	"reflect"
 	"sync"
 	"time"
 
@@ -20,8 +18,6 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services"
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
-	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	machineconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -124,96 +120,6 @@ func (r *Runtime) SetConfig(cfg config.Provider) error {
 // SetPersistedConfig implements the Runtime interface.
 func (r *Runtime) SetPersistedConfig(cfg config.Provider) error {
 	return r.s.V1Alpha2().SetConfig(context.TODO(), machineconfig.PersistentID, cfg)
-}
-
-// CanApplyImmediate implements the Runtime interface.
-func (r *Runtime) CanApplyImmediate(cfg config.Provider) error {
-	cfgProv := r.configProvider()
-	if cfgProv == nil {
-		return errors.New("no current config")
-	}
-
-	currentConfig := cfgProv.RawV1Alpha1()
-	if currentConfig == nil {
-		return errors.New("current config is not v1alpha1")
-	}
-
-	newConfig := cfg.RawV1Alpha1()
-	if newConfig == nil {
-		return errors.New("new config is not v1alpha1")
-	}
-
-	// copy the config as we're going to modify it
-	newConfig = newConfig.DeepCopy()
-
-	// the config changes allowed to be applied immediately are:
-	// * .debug
-	// * .cluster
-	// * .machine.ca
-	// * .machine.acceptedCAs
-	// * .machine.time
-	// * .machine.certCANs
-	// * .machine.install
-	// * .machine.network
-	// * .machine.sysfs
-	// * .machine.sysctls
-	// * .machine.logging
-	// * .machine.controlplane
-	// * .machine.kubelet
-	// * .machine.kernel
-	// * .machine.registries (note that auth is not applied immediately, containerd limitation)
-	// * .machine.pods
-	// * .machine.seccompProfiles
-	// * .machine.nodeAnnotations
-	// * .machine.nodeLabels
-	// * .machine.nodeTaints
-	// * .machine.features.kubernetesTalosAPIAccess
-	// * .machine.features.kubePrism
-	// * .machine.features.hostDNS
-	// * .machine.features.imageCache
-	// * .machine.features.nodeAddressSortAlgorithm
-	newConfig.ConfigDebug = currentConfig.ConfigDebug
-	newConfig.ClusterConfig = currentConfig.ClusterConfig
-
-	if newConfig.MachineConfig != nil && currentConfig.MachineConfig != nil {
-		newConfig.MachineConfig.MachineCA = currentConfig.MachineConfig.MachineCA
-		newConfig.MachineConfig.MachineAcceptedCAs = currentConfig.MachineConfig.MachineAcceptedCAs
-		newConfig.MachineConfig.MachineTime = currentConfig.MachineConfig.MachineTime //nolint:staticcheck
-		newConfig.MachineConfig.MachineCertSANs = currentConfig.MachineConfig.MachineCertSANs
-		newConfig.MachineConfig.MachineInstall = currentConfig.MachineConfig.MachineInstall
-		newConfig.MachineConfig.MachineNetwork = currentConfig.MachineConfig.MachineNetwork //nolint:staticcheck
-		newConfig.MachineConfig.MachineSysfs = currentConfig.MachineConfig.MachineSysfs     //nolint:staticcheck
-		newConfig.MachineConfig.MachineSysctls = currentConfig.MachineConfig.MachineSysctls //nolint:staticcheck
-		newConfig.MachineConfig.MachineLogging = currentConfig.MachineConfig.MachineLogging
-		newConfig.MachineConfig.MachineControlPlane = currentConfig.MachineConfig.MachineControlPlane //nolint:staticcheck
-		newConfig.MachineConfig.MachineKubelet = currentConfig.MachineConfig.MachineKubelet
-		newConfig.MachineConfig.MachineKernel = currentConfig.MachineConfig.MachineKernel
-		newConfig.MachineConfig.MachineRegistries = currentConfig.MachineConfig.MachineRegistries //nolint:staticcheck // backwards compatibility
-		newConfig.MachineConfig.MachinePods = currentConfig.MachineConfig.MachinePods
-		newConfig.MachineConfig.MachineSeccompProfiles = currentConfig.MachineConfig.MachineSeccompProfiles
-		newConfig.MachineConfig.MachineNodeAnnotations = currentConfig.MachineConfig.MachineNodeAnnotations
-		newConfig.MachineConfig.MachineNodeLabels = currentConfig.MachineConfig.MachineNodeLabels
-		newConfig.MachineConfig.MachineNodeTaints = currentConfig.MachineConfig.MachineNodeTaints
-
-		if newConfig.MachineConfig.MachineFeatures != nil && currentConfig.MachineConfig.MachineFeatures != nil {
-			newConfig.MachineConfig.MachineFeatures.KubernetesTalosAPIAccessConfig = currentConfig.MachineConfig.MachineFeatures.KubernetesTalosAPIAccessConfig
-			newConfig.MachineConfig.MachineFeatures.KubePrismSupport = currentConfig.MachineConfig.MachineFeatures.KubePrismSupport
-			newConfig.MachineConfig.MachineFeatures.HostDNSSupport = currentConfig.MachineConfig.MachineFeatures.HostDNSSupport       //nolint:staticcheck // backwards compatibility
-			newConfig.MachineConfig.MachineFeatures.ImageCacheSupport = currentConfig.MachineConfig.MachineFeatures.ImageCacheSupport //nolint:staticcheck // backwards compatibility
-			newConfig.MachineConfig.MachineFeatures.FeatureNodeAddressSortAlgorithm = currentConfig.MachineConfig.MachineFeatures.FeatureNodeAddressSortAlgorithm
-		}
-	}
-
-	if !reflect.DeepEqual(currentConfig, newConfig) {
-		diff, err := configdiff.DiffConfigs(container.NewV1Alpha1(currentConfig), container.NewV1Alpha1(newConfig))
-		if err != nil {
-			return fmt.Errorf("error calculating diff: %w", err)
-		}
-
-		return fmt.Errorf("this config change can't be applied in immediate mode\ndiff:\n%s", diff)
-	}
-
-	return nil
 }
 
 // State implements the Runtime interface.

--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -9,7 +9,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"os"
 	"slices"
@@ -144,19 +143,17 @@ func (suite *ApplyConfigSuite) TestApply() {
 	cfgDataOut, err := cont.Bytes()
 	suite.Require().NoErrorf(err, "failed to marshal config for node %q", node)
 
+	_, err = suite.Client.ApplyConfiguration(
+		nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Data: cfgDataOut,
+			Mode: machineapi.ApplyConfigurationRequest_AUTO,
+		},
+	)
+	suite.Require().NoErrorf(err, "failed to apply configuration (node %q): %s", node, err)
+
 	suite.AssertRebooted(
 		suite.ctx, node, func(nodeCtx context.Context) error {
-			_, err = suite.Client.ApplyConfiguration(
-				nodeCtx, &machineapi.ApplyConfigurationRequest{
-					Data: cfgDataOut,
-					Mode: machineapi.ApplyConfigurationRequest_REBOOT,
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to apply configuration (node %q): %w", node, err)
-			}
-
-			return nil
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, assertRebootedRebootTimeout,
 		suite.CleanupFailedPods,
 	)
@@ -253,17 +250,17 @@ func (suite *ApplyConfigSuite) TestApplyNoOpCRIPatch() {
 		)
 	})
 
+	_, err = suite.Client.ApplyConfiguration(
+		nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Data: cfgDataOut,
+			Mode: machineapi.ApplyConfigurationRequest_AUTO,
+		},
+	)
+	suite.Require().NoErrorf(err, "failed to apply configuration (node %q)", node)
+
 	suite.AssertRebooted(
 		suite.ctx, node, func(nodeCtx context.Context) error {
-			_, err = suite.Client.ApplyConfiguration(
-				nodeCtx, &machineapi.ApplyConfigurationRequest{
-					Data: cfgDataOut,
-					Mode: machineapi.ApplyConfigurationRequest_REBOOT,
-				},
-			)
-			suite.Assert().NoErrorf(err, "failed to apply configuration (node %q)", node)
-
-			return nil
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, assertRebootedRebootTimeout,
 		suite.CleanupFailedPods,
 	)
@@ -281,17 +278,17 @@ func (suite *ApplyConfigSuite) TestApplyNoOpCRIPatch() {
 		})
 	})
 
+	_, err = suite.Client.ApplyConfiguration(
+		nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Data: cfgDataOut,
+			Mode: machineapi.ApplyConfigurationRequest_AUTO,
+		},
+	)
+	suite.Require().NoErrorf(err, "failed to apply configuration (node %q)", node)
+
 	suite.AssertRebooted(
 		suite.ctx, node, func(nodeCtx context.Context) error {
-			_, err = suite.Client.ApplyConfiguration(
-				nodeCtx, &machineapi.ApplyConfigurationRequest{
-					Data: cfgDataOut,
-					Mode: machineapi.ApplyConfigurationRequest_REBOOT,
-				},
-			)
-			suite.Assert().NoErrorf(err, "failed to apply configuration (node %q)", node)
-
-			return nil
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, assertRebootedRebootTimeout,
 		suite.CleanupFailedPods,
 	)

--- a/internal/integration/api/common.go
+++ b/internal/integration/api/common.go
@@ -248,30 +248,31 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 	suite.Require().NoError(err)
 
 	nodeName := k8sNode.Name
+	nodeCtx := client.WithNode(suite.ctx, node)
 
 	suite.T().Logf("adjusting base OCI specs on %s/%s", node, nodeName)
 
-	suite.AssertRebooted(
-		suite.ctx, node, func(nodeCtx context.Context) error {
-			suite.PatchMachineConfig(nodeCtx, &v1alpha1.Config{
-				MachineConfig: &v1alpha1.MachineConfig{
-					MachineBaseRuntimeSpecOverrides: meta.Unstructured{
-						Object: map[string]any{
-							"process": map[string]any{
-								"rlimits": []map[string]any{
-									{
-										"type": "RLIMIT_NOFILE",
-										"hard": 1024,
-										"soft": 1024,
-									},
-								},
+	suite.PatchMachineConfig(nodeCtx, &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineBaseRuntimeSpecOverrides: meta.Unstructured{
+				Object: map[string]any{
+					"process": map[string]any{
+						"rlimits": []map[string]any{
+							{
+								"type": "RLIMIT_NOFILE",
+								"hard": 1024,
+								"soft": 1024,
 							},
 						},
 					},
 				},
-			})
+			},
+		},
+	})
 
-			return nil
+	suite.AssertRebooted(
+		suite.ctx, node, func(nodeCtx context.Context) error {
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, assertRebootedRebootTimeout,
 		suite.CleanupFailedPods,
 	)
@@ -300,17 +301,17 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 	suite.Assert().NoError(ociUlimits1PodDef.Delete(suite.ctx))
 
 	// revert the patch
+	suite.PatchMachineConfig(nodeCtx, map[string]any{
+		"machine": map[string]any{
+			"baseRuntimeSpecOverrides": map[string]any{
+				"$patch": "delete",
+			},
+		},
+	})
+
 	suite.AssertRebooted(
 		suite.ctx, node, func(nodeCtx context.Context) error {
-			suite.PatchMachineConfig(nodeCtx, map[string]any{
-				"machine": map[string]any{
-					"baseRuntimeSpecOverrides": map[string]any{
-						"$patch": "delete",
-					},
-				},
-			})
-
-			return nil
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
 		}, assertRebootedRebootTimeout,
 		suite.CleanupFailedPods,
 	)

--- a/pkg/machinery/api/common/common.pb.go
+++ b/pkg/machinery/api/common/common.pb.go
@@ -982,11 +982,15 @@ const file_common_common_proto_rawDesc = "" +
 	"\x05Error\x12 \n" +
 	"\x04code\x18\x01 \x01(\x0e2\f.common.CodeR\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12.\n" +
-	"\adetails\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\adetails\"x\n" +
-	"\bMetadata\x12\x1e\n" +
-	"\bhostname\x18\x01 \x01(\tB\x02\x18\x01R\bhostname\x12\x18\n" +
-	"\x05error\x18\x02 \x01(\tB\x02\x18\x01R\x05error\x12.\n" +
-	"\x06status\x18\x03 \x01(\v2\x12.google.rpc.StatusB\x02\x18\x01R\x06status:\x02\x18\x01\"J\n" +
+	"\adetails\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\adetails\"\x98\x01\n" +
+	"\bMetadata\x12&\n" +
+	"\bhostname\x18\x01 \x01(\tB\n" +
+	"\xea\xbb-\x04v2.0\x18\x01R\bhostname\x12 \n" +
+	"\x05error\x18\x02 \x01(\tB\n" +
+	"\xea\xbb-\x04v2.0\x18\x01R\x05error\x126\n" +
+	"\x06status\x18\x03 \x01(\v2\x12.google.rpc.StatusB\n" +
+	"\xea\xbb-\x04v2.0\x18\x01R\x06status:\n" +
+	"\xea\xbb-\x04v2.0\x18\x01\"J\n" +
 	"\x04Data\x12,\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x10.common.MetadataR\bmetadata\x12\x14\n" +
 	"\x05bytes\x18\x02 \x01(\fR\x05bytes\"8\n" +

--- a/pkg/machinery/api/machine/machine.pb.go
+++ b/pkg/machinery/api/machine/machine.pb.go
@@ -31,7 +31,8 @@ const (
 type ApplyConfigurationRequest_Mode int32
 
 const (
-	ApplyConfigurationRequest_REBOOT    ApplyConfigurationRequest_Mode = 0
+	// Deprecated: Marked as deprecated in machine/machine.proto.
+	ApplyConfigurationRequest_REBOOT    ApplyConfigurationRequest_Mode = 0 // Deprecated: use AUTO or NO_REBOOT instead
 	ApplyConfigurationRequest_AUTO      ApplyConfigurationRequest_Mode = 1
 	ApplyConfigurationRequest_NO_REBOOT ApplyConfigurationRequest_Mode = 2
 	ApplyConfigurationRequest_STAGED    ApplyConfigurationRequest_Mode = 3
@@ -11631,15 +11632,15 @@ var File_machine_machine_proto protoreflect.FileDescriptor
 
 const file_machine_machine_proto_rawDesc = "" +
 	"\n" +
-	"\x15machine/machine.proto\x12\amachine\x1a\x13common/common.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8c\x02\n" +
+	"\x15machine/machine.proto\x12\amachine\x1a\x13common/common.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x98\x02\n" +
 	"\x19ApplyConfigurationRequest\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12;\n" +
 	"\x04mode\x18\x04 \x01(\x0e2'.machine.ApplyConfigurationRequest.ModeR\x04mode\x12\x17\n" +
 	"\adry_run\x18\x05 \x01(\bR\x06dryRun\x12C\n" +
-	"\x10try_mode_timeout\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x0etryModeTimeout\"@\n" +
-	"\x04Mode\x12\n" +
-	"\n" +
-	"\x06REBOOT\x10\x00\x12\b\n" +
+	"\x10try_mode_timeout\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x0etryModeTimeout\"L\n" +
+	"\x04Mode\x12\x16\n" +
+	"\x06REBOOT\x10\x00\x1a\n" +
+	"\xea\xbb-\x04v2.0\b\x01\x12\b\n" +
 	"\x04AUTO\x10\x01\x12\r\n" +
 	"\tNO_REBOOT\x10\x02\x12\n" +
 	"\n" +

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -4751,7 +4751,7 @@ rpc upgrade
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| REBOOT | 0 |  |
+| REBOOT | 0 | Deprecated: use AUTO or NO_REBOOT instead |
 | AUTO | 1 |  |
 | NO_REBOOT | 2 |  |
 | STAGED | 3 |  |

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -16,20 +16,20 @@ talosctl apply-config [flags]
 ### Options
 
 ```
-      --cert-fingerprint strings                    list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
-  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
-  -p, --config-patch stringArray                    the list of config patches to apply to the local config file before sending it to the node
-      --context string                              context to be used in command
-      --dry-run                                     check how the config change will be applied in dry-run mode
-  -e, --endpoints strings                           override default endpoints in Talos configuration
-  -f, --file string                                 the filename of the updated configuration
-  -h, --help                                        help for apply-config
-  -i, --insecure                                    use the insecure (encrypted with no auth) maintenance service
-  -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
-  -n, --nodes strings                               target the specified nodes
-      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
-      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
-      --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
+      --cert-fingerprint strings            list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
+  -c, --cluster string                      cluster to connect to if a proxy endpoint is used
+  -p, --config-patch stringArray            the list of config patches to apply to the local config file before sending it to the node
+      --context string                      context to be used in command
+      --dry-run                             check how the config change will be applied in dry-run mode
+  -e, --endpoints strings                   override default endpoints in Talos configuration
+  -f, --file string                         the filename of the updated configuration
+  -h, --help                                help for apply-config
+  -i, --insecure                            use the insecure (encrypted with no auth) maintenance service
+  -m, --mode auto, no-reboot, staged, try   apply config mode (default auto)
+  -n, --nodes strings                       target the specified nodes
+      --siderov1-keys-dir string            the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                  the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
+      --timeout duration                    the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
 ### SEE ALSO
@@ -1443,17 +1443,17 @@ talosctl edit machineconfig [flags]
 ### Options
 
 ```
-  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
-      --context string                              context to be used in command
-      --dry-run                                     do not apply the change after editing and print the change summary instead
-  -e, --endpoints strings                           override default endpoints in Talos configuration
-  -h, --help                                        help for edit
-  -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
-      --namespace string                            resource namespace (default is to use default namespace per resource)
-  -n, --nodes strings                               target the specified nodes
-      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
-      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
-      --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
+  -c, --cluster string                      cluster to connect to if a proxy endpoint is used
+      --context string                      context to be used in command
+      --dry-run                             do not apply the change after editing and print the change summary instead
+  -e, --endpoints strings                   override default endpoints in Talos configuration
+  -h, --help                                help for edit
+  -m, --mode auto, no-reboot, staged, try   apply config mode (default auto)
+      --namespace string                    resource namespace (default is to use default namespace per resource)
+  -n, --nodes strings                       target the specified nodes
+      --siderov1-keys-dir string            the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                  the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
+      --timeout duration                    the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
 ### SEE ALSO
@@ -3107,19 +3107,19 @@ talosctl patch machineconfig [flags]
 ### Options
 
 ```
-  -c, --cluster string                              cluster to connect to if a proxy endpoint is used
-      --context string                              context to be used in command
-      --dry-run                                     print the change summary and patch preview without applying the changes
-  -e, --endpoints strings                           override default endpoints in Talos configuration
-  -h, --help                                        help for patch
-  -m, --mode auto, no-reboot, reboot, staged, try   apply config mode (default auto)
-      --namespace string                            resource namespace (default is to use default namespace per resource)
-  -n, --nodes strings                               target the specified nodes
-  -p, --patch stringArray                           the patch to be applied to the resource file, use @file to read a patch from file.
-      --patch-file string                           a file containing a patch to be applied to the resource.
-      --siderov1-keys-dir string                    the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
-      --talosconfig string                          the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
-      --timeout duration                            the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
+  -c, --cluster string                      cluster to connect to if a proxy endpoint is used
+      --context string                      context to be used in command
+      --dry-run                             print the change summary and patch preview without applying the changes
+  -e, --endpoints strings                   override default endpoints in Talos configuration
+  -h, --help                                help for patch
+  -m, --mode auto, no-reboot, staged, try   apply config mode (default auto)
+      --namespace string                    resource namespace (default is to use default namespace per resource)
+  -n, --nodes strings                       target the specified nodes
+  -p, --patch stringArray                   the patch to be applied to the resource file, use @file to read a patch from file.
+      --patch-file string                   a file containing a patch to be applied to the resource.
+      --siderov1-keys-dir string            the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
+      --talosconfig string                  the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
+      --timeout duration                    the config will be rolled back after specified timeout (if try mode is selected) (default 1m0s)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Reasons:

* most of the changes are applied without reboot
* the reboot check is already inconsistent - sometimes reboot is required, but it is not properly detected
* eventually all configuration documents can be applied without a reboot
* reboot coupled with apply config doesn't allow to do graceful reboot with cordon/drain etc.

An apply config followed by a proper reboot is a better flow than automatic reboot triggered without details.
