### PR TITLE
fix: correct the link alias condition

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_alias_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_alias_spec.go
@@ -109,8 +109,13 @@ func (ctrl *LinkAliasSpecController) Run(ctx context.Context, r controller.Runti
 				continue
 			}
 
-			if link.Attributes.Info != nil || nethelpers.LinkType(link.Type) != nethelpers.LinkEther {
-				// skip non-physical links
+			if nethelpers.LinkType(link.Type) != nethelpers.LinkEther {
+				// skip non-physical links: physical links have type==ether && kind == ""
+				continue
+			}
+
+			if linkKind := pointer.SafeDeref(link.Attributes.Info).Kind; linkKind != "" {
+				// skip non-physical links, check for kind
 				continue
 			}
 


### PR DESCRIPTION
A link in the kernel might have attributes.info set, but the kind might be still empty. We want an empty kind, but we don't care about other attributes.

This is true specifically for the physical links which are part of the bond.

Fixes #13519
