### PR TITLE
fix: honor FailurePauseTimeout when pausing before reboot

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1921,7 +1921,7 @@ func pauseOnFailure(callback func(runtime.Sequence, any) (runtime.TaskExecutionF
 			if err != nil {
 				logger.Printf("%s failed, rebooting in %.0f minutes. You can use talosctl apply-config or talosctl edit mc to fix the issues, error:\n%s", name, timeout.Minutes(), err)
 
-				timer := time.NewTimer(time.Minute * 5)
+				timer := time.NewTimer(timeout)
 				defer timer.Stop()
 
 				select {


### PR DESCRIPTION
## What

`pauseOnFailure` (used for `MountUserDisks` and `WriteUserFiles` in the boot sequence) is passed `FailurePauseTimeout` (35m) and logs "rebooting in 35 minutes", but the actual timer is hardcoded to `time.Minute * 5`. The pause that is supposed to give the operator time to fix the machine config with `talosctl apply-config` / `talosctl edit mc` actually ends after 5 minutes — 30 minutes earlier than advertised.

The `timeout` parameter has only ever been used for the log message, never for the timer, since the function was introduced in 27af5d41.

## Change

Use the `timeout` parameter for the timer, so the pause matches both the `FailurePauseTimeout` constant and the operator-facing message. Removes the magic number.

## Behavioral impact

The reboot pause on a recoverable sequencer failure changes from 5 to 35 minutes — the value the constant and the message already advertise. If 5 minutes is the intended pause, the constant and message should be lowered instead; happy to flip the fix if maintainers prefer that.

Found while debugging a bare-metal Talos bootstrap on Cozystack (CNCF).
