### PR TITLE
fix: improve security of scheduler/controller-manager

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/controller-manager.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/controller-manager.go
@@ -75,13 +75,13 @@ func ControllerManagerPod(configResource *k8s.ControllerManagerConfig, secretsVe
 						},
 						env...,
 					),
-					VolumeMounts: append([]v1.VolumeMount{
+					VolumeMounts: append(append([]v1.VolumeMount{
 						{
 							Name:      "secrets",
 							MountPath: constants.KubernetesControllerManagerSecretsDir,
 							ReadOnly:  true,
 						},
-					}, VolumeMounts(cfg.ExtraVolumes)...),
+					}, EphemeralWritableMounts()...), VolumeMounts(cfg.ExtraVolumes)...),
 					StartupProbe: &v1.Probe{
 						ProbeHandler: v1.ProbeHandler{
 							HTTPGet: &v1.HTTPGetAction{
@@ -94,6 +94,7 @@ func ControllerManagerPod(configResource *k8s.ControllerManagerConfig, secretsVe
 						// Give 60 seconds for the container to start up
 						PeriodSeconds:                 5,
 						FailureThreshold:              12,
+						TimeoutSeconds:                15,
 						TerminationGracePeriodSeconds: nil,
 					},
 					LivenessProbe: &v1.Probe{
@@ -110,6 +111,7 @@ func ControllerManagerPod(configResource *k8s.ControllerManagerConfig, secretsVe
 					Resources: resources,
 					SecurityContext: &v1.SecurityContext{
 						AllowPrivilegeEscalation: new(false),
+						ReadOnlyRootFilesystem:   new(true),
 						Capabilities: &v1.Capabilities{
 							Drop: []v1.Capability{"ALL"},
 						},
@@ -125,7 +127,7 @@ func ControllerManagerPod(configResource *k8s.ControllerManagerConfig, secretsVe
 				RunAsUser:    new(int64(constants.KubernetesControllerManagerRunUser)),
 				RunAsGroup:   new(int64(constants.KubernetesControllerManagerRunGroup)),
 			},
-			Volumes: append([]v1.Volume{
+			Volumes: append(append([]v1.Volume{
 				{
 					Name: "secrets",
 					VolumeSource: v1.VolumeSource{
@@ -134,7 +136,7 @@ func ControllerManagerPod(configResource *k8s.ControllerManagerConfig, secretsVe
 						},
 					},
 				},
-			}, Volumes(cfg.ExtraVolumes)...),
+			}, EphemeralWritableVolumes()...), Volumes(cfg.ExtraVolumes)...),
 		},
 	}, nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/scheduler.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/scheduler.go
@@ -43,6 +43,7 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 				Scheme: v1.URISchemeHTTPS,
 			},
 		},
+		TimeoutSeconds: 15,
 	}
 
 	readinessProbe := &v1.Probe{
@@ -54,6 +55,7 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 				Scheme: v1.URISchemeHTTPS,
 			},
 		},
+		TimeoutSeconds: 15,
 	}
 
 	startupProbe := &v1.Probe{
@@ -65,6 +67,10 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 				Scheme: v1.URISchemeHTTPS,
 			},
 		},
+		// Give 60 seconds for the container to start up
+		PeriodSeconds:    5,
+		FailureThreshold: 12,
+		TimeoutSeconds:   15,
 	}
 
 	return &v1.Pod{
@@ -110,7 +116,7 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 						},
 						env...,
 					),
-					VolumeMounts: append([]v1.VolumeMount{
+					VolumeMounts: append(append([]v1.VolumeMount{
 						{
 							Name:      "secrets",
 							MountPath: constants.KubernetesSchedulerSecretsDir,
@@ -121,13 +127,14 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 							MountPath: constants.KubernetesSchedulerConfigDir,
 							ReadOnly:  true,
 						},
-					}, VolumeMounts(cfg.ExtraVolumes)...),
+					}, EphemeralWritableMounts()...), VolumeMounts(cfg.ExtraVolumes)...),
 					StartupProbe:   startupProbe,
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,
 					Resources:      resources,
 					SecurityContext: &v1.SecurityContext{
 						AllowPrivilegeEscalation: new(false),
+						ReadOnlyRootFilesystem:   new(true),
 						Capabilities: &v1.Capabilities{
 							Drop: []v1.Capability{"ALL"},
 						},
@@ -143,7 +150,7 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 				RunAsUser:    new(int64(constants.KubernetesSchedulerRunUser)),
 				RunAsGroup:   new(int64(constants.KubernetesSchedulerRunGroup)),
 			},
-			Volumes: append([]v1.Volume{
+			Volumes: append(append([]v1.Volume{
 				{
 					Name: "secrets",
 					VolumeSource: v1.VolumeSource{
@@ -160,7 +167,7 @@ func SchedulerPod(configResource *k8s.SchedulerConfig, secretsVersion string) (r
 						},
 					},
 				},
-			}, Volumes(cfg.ExtraVolumes)...),
+			}, EphemeralWritableVolumes()...), Volumes(cfg.ExtraVolumes)...),
 		},
 	}, nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/controller-manager.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/controller-manager.yaml
@@ -50,6 +50,7 @@ spec:
       capabilities:
         drop:
         - ALL
+      readOnlyRootFilesystem: true
       seccompProfile:
         type: RuntimeDefault
     startupProbe:
@@ -60,10 +61,15 @@ spec:
         port: 10257
         scheme: HTTPS
       periodSeconds: 5
+      timeoutSeconds: 15
     volumeMounts:
     - mountPath: /system/secrets/kubernetes/kube-controller-manager
       name: secrets
       readOnly: true
+    - mountPath: /tmp
+      name: tmp
+    - mountPath: /var/run/kubernetes
+      name: run
   hostNetwork: true
   priority: 2000000000
   priorityClassName: system-cluster-critical
@@ -75,4 +81,10 @@ spec:
   - hostPath:
       path: /system/secrets/kubernetes/kube-controller-manager
     name: secrets
+  - emptyDir:
+      medium: Memory
+    name: tmp
+  - emptyDir:
+      medium: Memory
+    name: run
 status: {}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/scheduler.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/scheduler.yaml
@@ -40,6 +40,7 @@ spec:
         path: /livez
         port: 10259
         scheme: HTTPS
+      timeoutSeconds: 15
     name: kube-scheduler
     readinessProbe:
       httpGet:
@@ -47,6 +48,7 @@ spec:
         path: /readyz
         port: 10259
         scheme: HTTPS
+      timeoutSeconds: 15
     resources:
       requests:
         cpu: 50m
@@ -56,14 +58,18 @@ spec:
       capabilities:
         drop:
         - ALL
+      readOnlyRootFilesystem: true
       seccompProfile:
         type: RuntimeDefault
     startupProbe:
+      failureThreshold: 12
       httpGet:
         host: localhost
         path: /livez
         port: 10259
         scheme: HTTPS
+      periodSeconds: 5
+      timeoutSeconds: 15
     volumeMounts:
     - mountPath: /system/secrets/kubernetes/kube-scheduler
       name: secrets
@@ -71,6 +77,10 @@ spec:
     - mountPath: /system/config/kubernetes/kube-scheduler
       name: config
       readOnly: true
+    - mountPath: /tmp
+      name: tmp
+    - mountPath: /var/run/kubernetes
+      name: run
   hostNetwork: true
   priority: 2000000000
   priorityClassName: system-cluster-critical
@@ -85,4 +95,10 @@ spec:
   - hostPath:
       path: /system/config/kubernetes/kube-scheduler
     name: config
+  - emptyDir:
+      medium: Memory
+    name: tmp
+  - emptyDir:
+      medium: Memory
+    name: run
 status: {}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/volumes.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/volumes.go
@@ -22,6 +22,46 @@ func VolumeMounts(volumes []k8s.ExtraVolume) []v1.VolumeMount {
 	})
 }
 
+// EphemeralWritableMounts returns the volume mounts for the scratch directories that
+// control plane components need to write to even when running with a read-only root
+// filesystem: self-signed serving certificates land in /var/run/kubernetes (the default
+// --cert-dir), and the Go runtime and the binaries use /tmp for temporary files.
+func EphemeralWritableMounts() []v1.VolumeMount {
+	return []v1.VolumeMount{
+		{
+			Name:      "tmp",
+			MountPath: "/tmp",
+		},
+		{
+			Name:      "run",
+			MountPath: "/var/run/kubernetes",
+		},
+	}
+}
+
+// EphemeralWritableVolumes returns the tmpfs-backed emptyDir volumes that back
+// EphemeralWritableMounts.
+func EphemeralWritableVolumes() []v1.Volume {
+	return []v1.Volume{
+		{
+			Name: "tmp",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium: v1.StorageMediumMemory,
+				},
+			},
+		},
+		{
+			Name: "run",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium: v1.StorageMediumMemory,
+				},
+			},
+		},
+	}
+}
+
 // Volumes translates definition into K8s volume specs.
 func Volumes(volumes []k8s.ExtraVolume) []v1.Volume {
 	return xslices.Map(volumes, func(vol k8s.ExtraVolume) v1.Volume {


### PR DESCRIPTION
Provide correct defaults for the probe settings.

Use read only filesystem for the container images, and provide explicit
tmpfs volumes for the writeable parts.
