### PR TITLE
fix: shutdown in e2e-docker-short

### DIFF
--- a/pkg/provision/providers/docker/node.go
+++ b/pkg/provision/providers/docker/node.go
@@ -26,6 +26,10 @@ import (
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
+// nodeStopTimeoutSeconds is how long to wait for a node container to gracefully shut
+// down (machined shutdown sequence) before Docker forcibly SIGKILLs it.
+const nodeStopTimeoutSeconds = 30
+
 type portMap struct {
 	exposedPorts network.PortSet
 	portBindings network.PortMap
@@ -267,6 +271,13 @@ func (p *provisioner) destroyNodes(ctx context.Context, clusterName string, opti
 	for _, ctr := range containers {
 		go func(ctr container.Summary) {
 			fmt.Fprintln(options.LogWriter, "destroying node", ctr.Names[0][1:])
+
+			// Give Talos a chance to gracefully shut down: SIGTERM triggers the shutdown
+			// sequence inside machined (stop services, kill children, unmount), which
+			// tears down the nested container runtimes and mounts in order.
+			if _, err := p.client.ContainerStop(ctx, ctr.ID, client.ContainerStopOptions{Timeout: new(nodeStopTimeoutSeconds)}); err != nil {
+				fmt.Fprintf(options.LogWriter, "error stopping node %s (continuing with force remove): %s\n", ctr.Names[0][1:], err)
+			}
 
 			_, err := p.client.ContainerRemove(ctx, ctr.ID, client.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
 


### PR DESCRIPTION
Containers now receive SIGTERM to allow machined shutdown sequence to
complete (stop services, kill children, unmount) before force removal.
Prevents tearing down nested container runtimes and mounts abruptly,
which can leave stale state or cause unclean unmounts.

30s timeout matches typical shutdown duration.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
