### PR TITLE
feat: add imager flag to set the SecureBoot key enrollment mode

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -51,6 +51,7 @@ var cmdFlags struct {
 	SecurebootIncludeWellKnownCerts bool
 	SecurebootSignerAddress         string
 	PCRSignerAddress                string
+	SecurebootEnrollKeys            string
 }
 
 // rootCmd represents the base command when called without any subcommands.
@@ -205,6 +206,10 @@ var rootCmd = &cobra.Command{
 				prof.Input.SecureBoot.PCRSigner.SignerAddress = cmdFlags.PCRSignerAddress
 			}
 
+			if err := applySDBootEnrollKeys(cmdFlags.SecurebootEnrollKeys, &prof.Output); err != nil {
+				return err
+			}
+
 			if cmdFlags.EmbeddedConfigPath != "" {
 				data, err := os.ReadFile(cmdFlags.EmbeddedConfigPath)
 				if err != nil {
@@ -241,6 +246,36 @@ var rootCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// applySDBootEnrollKeys applies the --secureboot-enroll-keys flag value to the output profile.
+//
+// The value is set on both the image and ISO options so it applies regardless of the base
+// profile's output kind; the unused options struct is ignored downstream. An empty value is
+// a no-op, leaving the base profile's default (if-safe) in place.
+func applySDBootEnrollKeys(value string, output *profile.Output) error {
+	if value == "" {
+		return nil
+	}
+
+	enrollKeys, err := profile.SDBootEnrollKeysString(value)
+	if err != nil {
+		return xerrors.NewTaggedf[profile.InvalidInputTag]("invalid --secureboot-enroll-keys value: %w", err)
+	}
+
+	if output.ImageOptions == nil {
+		output.ImageOptions = &profile.ImageOptions{}
+	}
+
+	output.ImageOptions.SDBootEnrollKeys = enrollKeys
+
+	if output.ISOOptions == nil {
+		output.ISOOptions = &profile.ISOOptions{}
+	}
+
+	output.ISOOptions.SDBootEnrollKeys = enrollKeys
+
+	return nil
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -285,5 +320,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(
 		&cmdFlags.PCRSignerAddress, "pcr-signer-address", "",
 		"gRPC unix:// address of a PCR signer service",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&cmdFlags.SecurebootEnrollKeys, "secureboot-enroll-keys", "",
+		fmt.Sprintf(
+			"how systemd-boot enrolls SecureBoot keys on first boot (loader.conf secure-boot-enroll), one of: %s. "+
+				"Defaults to if-safe (auto-enrolls only in a VM); use force for unattended bare-metal enrollment when the firmware is in setup mode",
+			strings.Join(profile.SDBootEnrollKeysStrings(), ", "),
+		),
 	)
 }

--- a/cmd/installer/cmd/imager/root_test.go
+++ b/cmd/installer/cmd/imager/root_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/pkg/imager/profile"
 	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -43,4 +44,46 @@ func TestExecuteInvalidProfileStdin(t *testing.T) {
 	err = execute()
 	require.Error(t, err)
 	require.Equal(t, constants.ExitInvalidInput, installerexitcode.Resolve(err))
+}
+
+func TestApplySDBootEnrollKeys(t *testing.T) {
+	t.Run("empty is a no-op", func(t *testing.T) {
+		var output profile.Output
+
+		require.NoError(t, applySDBootEnrollKeys("", &output))
+		require.Nil(t, output.ImageOptions)
+		require.Nil(t, output.ISOOptions)
+	})
+
+	t.Run("force sets both image and ISO options", func(t *testing.T) {
+		var output profile.Output
+
+		require.NoError(t, applySDBootEnrollKeys("force", &output))
+		require.NotNil(t, output.ImageOptions)
+		require.Equal(t, profile.SDBootEnrollKeysForce, output.ImageOptions.SDBootEnrollKeys)
+		require.NotNil(t, output.ISOOptions)
+		require.Equal(t, profile.SDBootEnrollKeysForce, output.ISOOptions.SDBootEnrollKeys)
+	})
+
+	t.Run("preserves existing image options", func(t *testing.T) {
+		output := profile.Output{
+			ImageOptions: &profile.ImageOptions{
+				DiskSize:   1234,
+				DiskFormat: profile.DiskFormatRaw,
+			},
+		}
+
+		require.NoError(t, applySDBootEnrollKeys("force", &output))
+		require.Equal(t, int64(1234), output.ImageOptions.DiskSize)
+		require.Equal(t, profile.DiskFormatRaw, output.ImageOptions.DiskFormat)
+		require.Equal(t, profile.SDBootEnrollKeysForce, output.ImageOptions.SDBootEnrollKeys)
+	})
+
+	t.Run("invalid value is rejected as invalid input", func(t *testing.T) {
+		var output profile.Output
+
+		err := applySDBootEnrollKeys("bogus", &output)
+		require.Error(t, err)
+		require.Equal(t, constants.ExitInvalidInput, installerexitcode.Resolve(err))
+	})
 }

--- a/pkg/imager/profile/profile_test.go
+++ b/pkg/imager/profile/profile_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/imager/profile"
+	"github.com/siderolabs/talos/pkg/machinery/config/merge"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 )
 
@@ -94,4 +95,40 @@ func TestFillDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSDBootEnrollKeysMergePreservesImageOptions ensures that the override profile built by the
+// imager's --secureboot-enroll-keys flag (carrying only the enroll mode) merges onto a base
+// profile without wiping the other image options such as disk size and format.
+func TestSDBootEnrollKeysMergePreservesImageOptions(t *testing.T) {
+	t.Parallel()
+
+	base := profile.Default["secureboot-metal"].DeepCopy()
+
+	require.NotNil(t, base.Output.ImageOptions)
+
+	origDiskSize := base.Output.ImageOptions.DiskSize
+	origDiskFormat := base.Output.ImageOptions.DiskFormat
+
+	require.NotZero(t, origDiskSize, "precondition: secureboot-metal base profile should have a non-zero disk size")
+
+	// Mirror what the imager CLI builds: an override carrying only the enroll mode on both
+	// image and ISO options.
+	override := profile.Profile{
+		Output: profile.Output{
+			ImageOptions: &profile.ImageOptions{SDBootEnrollKeys: profile.SDBootEnrollKeysForce},
+			ISOOptions:   &profile.ISOOptions{SDBootEnrollKeys: profile.SDBootEnrollKeysForce},
+		},
+	}
+
+	require.NoError(t, merge.Merge(&base, &override))
+
+	// The enroll mode is applied...
+	require.Equal(t, profile.SDBootEnrollKeysForce, base.Output.ImageOptions.SDBootEnrollKeys)
+	require.NotNil(t, base.Output.ISOOptions)
+	require.Equal(t, profile.SDBootEnrollKeysForce, base.Output.ISOOptions.SDBootEnrollKeys)
+
+	// ...without clobbering the other image options inherited from the base profile.
+	require.Equal(t, origDiskSize, base.Output.ImageOptions.DiskSize)
+	require.Equal(t, origDiskFormat, base.Output.ImageOptions.DiskFormat)
 }


### PR DESCRIPTION
## What? (description)

Add a `--secureboot-enroll-keys` flag to the `imager` command, mapping to the existing `sdBootEnrollKeys` profile field (`off` / `manual` / `if-safe` / `force`) for both the disk-image and ISO outputs. The value is written to systemd-boot's `loader.conf` as `secure-boot-enroll`.

The default is unchanged (`if-safe`); the flag is purely additive. Previously this field could only be set by hand-writing a raw imager profile YAML.

## Why? (reasoning)

`if-safe` auto-enrolls SecureBoot keys only inside a VM, so on bare-metal the keys are never enrolled unattended. Network provisioning flows with no console operator (PXE, Tinkerbell, Metal³, …) need `force`, which enrolls once while the UEFI firmware is in setup mode (sd-boot's setup-mode gate prevents it from ever overwriting an already-enrolled platform key).

Discussed in https://github.com/siderolabs/talos/discussions/12568 — @smira confirmed adding a flag (and exposing it in Image Factory later); @frezbo confirmed the imager already supports the value via the profile.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable) — tracked via discussion #12568
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`) — N/A, imager flags are not part of generated docs
- [x] you ran unit-tests (`make unit-tests`)