### PR TITLE
fix: make LVM reconciliation robust and idempotent

### DIFF
--- a/internal/app/lvmd/lvmd.go
+++ b/internal/app/lvmd/lvmd.go
@@ -77,6 +77,10 @@ func lvmStatus(err error) error {
 		return status.Error(codes.NotFound, lvm.ErrNotFound.Error())
 	case errors.Is(err, lvm.ErrInUse):
 		return status.Error(codes.FailedPrecondition, lvm.ErrInUse.Error())
+	case errors.Is(err, lvm.ErrDevicePartitioned):
+		return status.Error(codes.FailedPrecondition, lvm.ErrDevicePartitioned.Error())
+	case errors.Is(err, lvm.ErrExists):
+		return status.Error(codes.AlreadyExists, lvm.ErrExists.Error())
 	case errors.Is(err, lvm.ErrNotEmpty):
 		return status.Error(codes.FailedPrecondition, lvm.ErrNotEmpty.Error())
 	case errors.Is(err, lvm.ErrOpen):

--- a/internal/app/machined/pkg/controllers/storage/lvm_logical_volume_reconcile.go
+++ b/internal/app/machined/pkg/controllers/storage/lvm_logical_volume_reconcile.go
@@ -21,6 +21,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/storage"
 )
 
+// msgTooFewPVs is surfaced as an LVMValidationError when a VG does not have
+// enough physical volumes for the requested RAID layout.
+const msgTooFewPVs = "volume group has too few physical volumes for the requested layout"
+
 // parseSizeBytes parses an LVM raw byte-size column, returning 0 when the value
 // is empty or unparseable (treated as "unknown", which never triggers a grow).
 func parseSizeBytes(raw string) uint64 {
@@ -247,14 +251,14 @@ func (ctrl *LVMLogicalVolumeReconcileController) reconcileLV(
 	mirrors, stripes, ok := resolveRAIDParams(spec, pvCount)
 	if !ok {
 		logger.Warn(
-			"skipping logical volume: volume group has too few physical volumes for the requested layout",
+			"skipping logical volume: too few physical volumes for the requested layout",
 			zap.String("vg", spec.VGName),
 			zap.String("lv", spec.Name),
 			zap.Stringer("type", spec.Type),
 			zap.Int("pv_count", pvCount),
 		)
 
-		return "", nil
+		return msgTooFewPVs, nil
 	}
 
 	logger.Info(
@@ -276,6 +280,11 @@ func (ctrl *LVMLogicalVolumeReconcileController) reconcileLV(
 		if errors.Is(err, exec.ErrNotFound) {
 			logger.Warn("lvm binary not found; skipping LVM provisioning")
 
+			return "", nil
+		}
+
+		// Idempotent: the LV may already exist (status scan lag).
+		if errors.Is(err, lvm.ErrExists) {
 			return "", nil
 		}
 

--- a/internal/app/machined/pkg/controllers/storage/lvm_logical_volume_reconcile_test.go
+++ b/internal/app/machined/pkg/controllers/storage/lvm_logical_volume_reconcile_test.go
@@ -296,7 +296,10 @@ func (suite *LVMLogicalVolumeReconcileSuite) TestRaid0SkipsWhenTooFewPVs() {
 	suite.createPVStatus("sda1", "/dev/sda1", "vg-pool")
 	suite.createRAIDLVSpec("vg-pool", "lv-stripe", storageres.LVMLogicalVolumeTypeRAID0, 0, 2)
 
-	time.Sleep(250 * time.Millisecond)
+	// No lvcreate, and the too-few-PVs condition is surfaced as a validation error.
+	ctest.AssertResource(suite, "vg-pool/lv-stripe", func(e *storageres.LVMValidationError, asrt *assert.Assertions) {
+		asrt.Contains(e.TypedSpec().Message, "too few physical volumes")
+	})
 
 	suite.Assert().Zero(suite.provisioner.count())
 }

--- a/internal/app/machined/pkg/controllers/storage/lvm_physical_volume_spec.go
+++ b/internal/app/machined/pkg/controllers/storage/lvm_physical_volume_spec.go
@@ -180,6 +180,19 @@ func (ctrl *LVMPhysicalVolumeSpecController) matchVolumesToVG(
 			continue
 		}
 
+		// A partitioned whole disk can't be a PV; its partitions are matched
+		// separately. Skip it so the reconciler doesn't try pvcreate on a
+		// device that lvm rejects ("device is partitioned").
+		if vol.partitioned {
+			logger.Debug(
+				"skipping partitioned disk as PV candidate; its partitions are preferred",
+				zap.String("device", vol.devPath),
+				zap.String("vg", doc.Name()),
+			)
+
+			continue
+		}
+
 		if prev, ok := claimedBy[vol.devPath]; ok && prev != doc.Name() {
 			conflicts[doc.Name()] = fmt.Sprintf("device %q already claimed by volume group %q", vol.devPath, prev)
 
@@ -243,8 +256,9 @@ func (ctrl *LVMPhysicalVolumeSpecController) writeValidationError(ctx context.Co
 
 // volumeProto is a discovered volume prepared for CEL selector evaluation.
 type volumeProto struct {
-	devPath    string
-	celContext map[string]any
+	devPath     string
+	celContext  map[string]any
+	partitioned bool
 }
 
 // buildVolumeProtos lists discovered volumes and prepares the CEL evaluation
@@ -254,6 +268,8 @@ type volumeProto struct {
 // evaluate to false against them rather than spanning the disk and all its
 // partitions. Partitions are therefore selectable only via `volume.*`
 // predicates (e.g. volume.partition_label), matching the documented contract.
+//
+//nolint:gocyclo
 func buildVolumeProtos(ctx context.Context, r controller.Runtime) ([]volumeProto, error) {
 	disks, err := safe.ReaderListAll[*block.Disk](ctx, r)
 	if err != nil {
@@ -277,6 +293,16 @@ func buildVolumeProtos(ctx context.Context, r controller.Runtime) ([]volumeProto
 		return nil, fmt.Errorf("list discovered volumes: %w", err)
 	}
 
+	// Devices that are parents of at least one partition. A partitioned
+	// whole disk cannot back a PV directly.
+	hasPartitions := map[string]struct{}{}
+
+	for v := range volumes.All() {
+		if parent := v.TypedSpec().ParentDevPath; parent != "" {
+			hasPartitions[parent] = struct{}{}
+		}
+	}
+
 	out := make([]volumeProto, 0, volumes.Len())
 
 	for v := range volumes.All() {
@@ -294,11 +320,14 @@ func buildVolumeProtos(ctx context.Context, r controller.Runtime) ([]volumeProto
 		// and disks without a Disk resource get an empty DiskSpec so disk-level
 		// predicates evaluate false instead of erroring on an unbound variable.
 		disk := &blockpb.DiskSpec{}
+		partitioned := false
 
 		if spec.ParentDevPath == "" {
 			if d, ok := diskByDevPath[spec.DevPath]; ok {
 				disk = d
 			}
+
+			_, partitioned = hasPartitions[spec.DevPath]
 		}
 
 		celCtx := map[string]any{
@@ -306,7 +335,7 @@ func buildVolumeProtos(ctx context.Context, r controller.Runtime) ([]volumeProto
 			"disk":   disk,
 		}
 
-		out = append(out, volumeProto{devPath: spec.DevPath, celContext: celCtx})
+		out = append(out, volumeProto{devPath: spec.DevPath, celContext: celCtx, partitioned: partitioned})
 	}
 
 	// Stable order for deterministic downstream iteration.

--- a/internal/app/machined/pkg/controllers/storage/lvm_physical_volume_spec_test.go
+++ b/internal/app/machined/pkg/controllers/storage/lvm_physical_volume_spec_test.go
@@ -103,11 +103,38 @@ func (suite *LVMPhysicalVolumeSpecSuite) TestSelectsPartitionsByLabelPrefix() {
 	ctest.AssertNoResource[*storageres.LVMPhysicalVolumeSpec](suite, "vdb")
 }
 
+func (suite *LVMPhysicalVolumeSpecSuite) TestSkipsPartitionedDisk() {
+	// A whole disk that carries partitions cannot be a PV; pvcreate rejects it.
+	// The selector matches the whole disk (by transport) and a raw-volume
+	// partition (by label); only the partition must yield a PV spec.
+	createDisk(&suite.DefaultSuite, "vdb", "/dev/vdb", "virtio")
+	createPartition(&suite.DefaultSuite, "vdb1", "/dev/vdb1", "/dev/vdb", "r-data0")
+	// A whole, unpartitioned disk that should still be used directly.
+	createDisk(&suite.DefaultSuite, "vdd", "/dev/vdd", "virtio")
+
+	applyMachineConfig(&suite.DefaultSuite,
+		newVGDoc("vg-pool", `disk.transport == "virtio" || volume.partition_label.startsWith("r-data")`),
+	)
+
+	ctest.AssertResources(
+		suite,
+		[]string{"vdb1", "vdd"},
+		func(pv *storageres.LVMPhysicalVolumeSpec, asrt *assert.Assertions) {
+			asrt.Equal("vg-pool", pv.TypedSpec().VGName)
+		},
+	)
+
+	// The partitioned whole disk must not become a PV.
+	ctest.AssertNoResource[*storageres.LVMPhysicalVolumeSpec](suite, "vdb")
+}
+
 func (suite *LVMPhysicalVolumeSpecSuite) TestDiskSelectorMatchesWholeDiskOnly() {
 	// A disk-level predicate matches only the whole disk, never its partitions:
 	// partitions get an empty disk in the CEL context so disk.* evaluates false.
+	// vdb is whole and unpartitioned; vdc carries a partition vdc1.
 	createDisk(&suite.DefaultSuite, "vdb", "/dev/vdb", "virtio")
-	createPartition(&suite.DefaultSuite, "vdb1", "/dev/vdb1", "/dev/vdb", "r-lvmpv0")
+	createDisk(&suite.DefaultSuite, "vdc", "/dev/vdc", "virtio")
+	createPartition(&suite.DefaultSuite, "vdc1", "/dev/vdc1", "/dev/vdc", "r-lvmpv0")
 
 	applyMachineConfig(&suite.DefaultSuite, newVGDoc("vg-pool", `disk.dev_path == "/dev/vdb"`))
 
@@ -115,8 +142,8 @@ func (suite *LVMPhysicalVolumeSpecSuite) TestDiskSelectorMatchesWholeDiskOnly() 
 		asrt.Equal("vg-pool", pv.TypedSpec().VGName)
 	})
 
-	// The partition must not be claimed by a disk-level selector.
-	ctest.AssertNoResource[*storageres.LVMPhysicalVolumeSpec](suite, "vdb1")
+	// A partition is never claimed by a disk-level selector.
+	ctest.AssertNoResource[*storageres.LVMPhysicalVolumeSpec](suite, "vdc1")
 }
 
 func (suite *LVMPhysicalVolumeSpecSuite) TestOverlappingVGsSurfaceValidationError() {

--- a/internal/app/machined/pkg/controllers/storage/lvm_volume_group_reconcile.go
+++ b/internal/app/machined/pkg/controllers/storage/lvm_volume_group_reconcile.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	machineruntime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/pkg/lvm"
 	"github.com/siderolabs/talos/pkg/machinery/resources/storage"
 )
 
@@ -133,6 +134,8 @@ func (ctrl *LVMVolumeGroupReconcileController) Run(ctx context.Context, r contro
 }
 
 // reconcileVG converges one VG.
+//
+//nolint:gocyclo
 func (ctrl *LVMVolumeGroupReconcileController) reconcileVG(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -158,6 +161,11 @@ func (ctrl *LVMVolumeGroupReconcileController) reconcileVG(
 				return nil
 			}
 
+			// Idempotent: the device may already be a PV (status scan lag).
+			if errors.Is(err, lvm.ErrExists) {
+				continue
+			}
+
 			return fmt.Errorf("pvcreate %q: %w", device, err)
 		}
 	}
@@ -171,7 +179,7 @@ func (ctrl *LVMVolumeGroupReconcileController) reconcileVG(
 			zap.Strings("devices", spec.PhysicalVolumes),
 		)
 
-		if err := ctrl.LVM.VGCreate(ctx, spec.Name, spec.PhysicalVolumes...); err != nil {
+		if err := ctrl.LVM.VGCreate(ctx, spec.Name, spec.PhysicalVolumes...); err != nil && !errors.Is(err, lvm.ErrExists) {
 			return fmt.Errorf("vgcreate %q: %w", spec.Name, err)
 		}
 
@@ -189,7 +197,7 @@ func (ctrl *LVMVolumeGroupReconcileController) reconcileVG(
 		zap.Strings("devices", missing),
 	)
 
-	if err := ctrl.LVM.VGExtend(ctx, spec.Name, missing...); err != nil {
+	if err := ctrl.LVM.VGExtend(ctx, spec.Name, missing...); err != nil && !errors.Is(err, lvm.ErrExists) {
 		return fmt.Errorf("vgextend %q: %w", spec.Name, err)
 	}
 

--- a/internal/pkg/lvm/errors.go
+++ b/internal/pkg/lvm/errors.go
@@ -39,6 +39,14 @@ var (
 	// ErrInUse is returned when a PV is still claimed by a VG, or an LV
 	// has active holders / a mounted filesystem.
 	ErrInUse = errors.New("lvm: resource in use")
+	// ErrDevicePartitioned is returned when pvcreate is asked to initialize a
+	// whole disk that carries a partition table. The disk's partitions should
+	// be used as PVs instead.
+	ErrDevicePartitioned = errors.New("lvm: device is partitioned")
+	// ErrExists is returned when a create operation targets an object that
+	// already exists (VG/LV already present, device already a PV). Callers
+	// reconciling towards desired state can treat this as success.
+	ErrExists = errors.New("lvm: resource already exists")
 	// ErrNotEmpty is returned when a VG still contains logical volumes.
 	ErrNotEmpty = errors.New("lvm: resource not empty")
 	// ErrOpen is returned when the LV is open (mounted, snapshot origin,
@@ -73,6 +81,21 @@ var (
 	// vgreduce: "Physical volume \"%s\" still in use"
 	//   lib/metadata/vg.c:724
 	pvInUseRE = regexp.MustCompile(`(is used by VG|still in use)`)
+
+	// pvcreate against a whole disk with a partition table:
+	//   "Cannot use %s: device is partitioned"
+	//   reason string: lib/cache/lvmcache.c (DEV_FILTERED_PARTITIONED branch)
+	//   flag set by:   lib/filters/filter-partitioned.c
+	devicePartitionedRE = regexp.MustCompile(`device is partitioned`)
+
+	// create-against-existing family (idempotent from a reconciler's view).
+	// Verified against the lvm2 source tree:
+	//   "A volume group called %s already exists."                       tools/vgcreate.c:93
+	//   "Logical volume %s already exists in Volume group %s."           tools/lvcreate.c:1585
+	//   "Physical volume '%s' is already in volume group '%s'"           tools/toollib.c:5177, lib/metadata/metadata.c:334
+	//   "Can't initialize PV '%s' without -ff."                          tools/toollib.c:5173
+	//   "Can't initialize physical volume \"%s\" of volume group ...     tools/toollib.c:5175
+	alreadyExistsRE = regexp.MustCompile(`(already exists|is already in volume group|Can't initialize (physical volume|PV) )`)
 
 	// lvremove path (lib/activate/activate.c:982,1006):
 	//   "Logical volume %s contains a filesystem in use."
@@ -163,6 +186,10 @@ func sentinelFor(exit *cmd.ExitError) error {
 // or nil if no narrow pattern fits.
 func matchStderr(out []byte) error {
 	switch {
+	case alreadyExistsRE.Match(out):
+		return ErrExists
+	case devicePartitionedRE.Match(out):
+		return ErrDevicePartitioned
 	case vgNotEmptyRE.Match(out):
 		return ErrNotEmpty
 	case pvInUseRE.Match(out):

--- a/internal/pkg/lvm/errors_internal_test.go
+++ b/internal/pkg/lvm/errors_internal_test.go
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package lvm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMatchStderr(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		out  string
+		want error
+	}{
+		{
+			name: "device partitioned",
+			out:  "  Cannot use /dev/vda: device is partitioned",
+			want: ErrDevicePartitioned,
+		},
+		{
+			name: "vg already exists",
+			out:  "  A volume group called vg-pool already exists.",
+			want: ErrExists,
+		},
+		{
+			name: "lv already exists",
+			out:  "  Logical volume lv-data already exists in Volume group vg-pool.",
+			want: ErrExists,
+		},
+		{
+			name: "pv already in vg",
+			out:  "  Physical volume '/dev/sda1' is already in volume group 'vg-pool'",
+			want: ErrExists,
+		},
+		{
+			name: "pv already initialized",
+			out:  "  Can't initialize PV '/dev/sda1' without -ff.",
+			want: ErrExists,
+		},
+		{
+			name: "vg not empty",
+			out:  `Volume group "vg0" still contains 2 logical volume(s)`,
+			want: ErrNotEmpty,
+		},
+		{
+			name: "pv in use",
+			out:  "PV /dev/sda1 is used by VG vg0 so please use vgreduce first.",
+			want: ErrInUse,
+		},
+		{
+			name: "not found",
+			out:  `Volume group "vg0" not found`,
+			want: ErrNotFound,
+		},
+		{
+			name: "unmatched",
+			out:  "some other failure",
+			want: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := matchStderr([]byte(test.out))
+			if !errors.Is(got, test.want) {
+				t.Fatalf("matchStderr(%q) = %v, want %v", test.out, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
pvcreate on a partitioned whole disk fails, and a selector that matched
both a disk and its partitions tried to use both. The PV spec controller
now skips a partitioned whole disk so only its partitions are offered as
PVs.

pvcreate/vgcreate/vgextend/lvcreate are treated as idempotent: an
"already exists" / "already in volume group" / "Can't initialize ...
without -ff" result (the on-disk state lagging the status scan) is
classified as ErrExists and accepted instead of looping forever. lvmd
maps it to AlreadyExists.

A "device is partitioned" failure is classified as ErrDevicePartitioned
(FailedPrecondition) instead of an opaque command error.

A RAID logical volume whose VG has too few PVs for the requested
mirrors/stripes previously skipped silently; it now surfaces an
LVMValidationError so the condition is observable.
