### PR TITLE
fix: ensure consistent manifest apply order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/siderolabs/go-debug v0.6.2
 	github.com/siderolabs/go-kmsg v0.1.6
 	github.com/siderolabs/go-kubeconfig v0.1.2
-	github.com/siderolabs/go-kubernetes v0.2.38
+	github.com/siderolabs/go-kubernetes v0.2.39
 	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pcidb v0.3.3
 	github.com/siderolabs/go-pointer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/siderolabs/go-kmsg v0.1.6 h1:ZrJPExUnJubqiNA7T8RUi/ySvJsnIen+bdiY+pea
 github.com/siderolabs/go-kmsg v0.1.6/go.mod h1:fryspKc1f6nMIOK5YbUPutz2v2rdBTBeLqW/ci9BDfk=
 github.com/siderolabs/go-kubeconfig v0.1.2 h1:0D0v3lXUKon+A2qRFwOnc9m4qSB+e+5WDmvGjiJPH8Y=
 github.com/siderolabs/go-kubeconfig v0.1.2/go.mod h1:FMl17PHjjAJjdeUTMN+gBzGH0lhsCbj2IX9/HNMpMh0=
-github.com/siderolabs/go-kubernetes v0.2.38 h1:HzBHnSE0zA/7eXpqRnfDYS94F5KO9QMW6tOqIQ33O2Y=
-github.com/siderolabs/go-kubernetes v0.2.38/go.mod h1:4DBVXLASGnJIhbDRJNl9DayYohYLu3VhQ1cpY/Gj2nw=
+github.com/siderolabs/go-kubernetes v0.2.39 h1:NhCKsFwwXNDDYD7PPLycP7VVJwaZmXum8kEQoA65yDA=
+github.com/siderolabs/go-kubernetes v0.2.39/go.mod h1:4DBVXLASGnJIhbDRJNl9DayYohYLu3VhQ1cpY/Gj2nw=
 github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
 github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pcidb v0.3.3 h1:Cxng3j6gUrWCh1tHlt524A4cC+dyRU+3j1AWQM6ULPc=

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
@@ -530,6 +531,13 @@ func syncManifestsSSA(ctx context.Context, objects []*unstructured.Unstructured,
 		WaitTimeout:     options.ReconcileTimeout,
 		NoPrune:         options.NoPrune,
 		Force:           options.ForceManifests,
+		CustomStageKinds: map[schema.GroupKind]struct{}{
+			// perform sync for configmaps/secrets before e.g. deployments/daemonsets,
+			// as there is a common pattern of linking them via a label/annotation checksum,
+			// to ensure that the dependent resources are reconciled after the configmap/secret is updated.
+			schema.ParseGroupKind("ConfigMap"): {},
+			schema.ParseGroupKind("Secret"):    {},
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("error applying manifests: %w", err)


### PR DESCRIPTION
Fist, pull in a fix from go-kubernetes to show apply order in the exact order manifests were applied.

Second, in the sync code, promote configmaps and secrets to the third (custom) stage, before other resources, but after other cluster-wide resources.
