### PR TITLE
fix: stop the log persistence and close all files on shutdown

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/log_persistence.go
+++ b/internal/app/machined/pkg/controllers/runtime/log_persistence.go
@@ -31,6 +31,7 @@ type LogPersistenceController struct {
 	startup sync.Once
 	// RLocked by the log writers, Locked by volume handlers
 	canLog        sync.RWMutex
+	canLogLocked  bool // mirrors the state of canLog, used only in single-threaded context
 	files         *concurrent.HashTrieMap[string, *logfile.LogFile]
 	logMountPoint string
 }
@@ -87,12 +88,16 @@ func (ctrl *LogPersistenceController) startLogging(vms *block.VolumeMountStatus)
 	ctrl.logMountPoint = vms.TypedSpec().Target
 
 	ctrl.canLog.Unlock()
+	ctrl.canLogLocked = false
 }
 
 func (ctrl *LogPersistenceController) stopLogging() error {
 	// Stop all logging activities, close files
 	// after this call we should not hold /var/log
-	ctrl.canLog.Lock()
+	if !ctrl.canLogLocked {
+		ctrl.canLog.Lock()
+		ctrl.canLogLocked = true
+	}
 
 	for _, f := range ctrl.files.All() {
 		if err := f.Close(); err != nil {
@@ -113,6 +118,7 @@ func (ctrl *LogPersistenceController) Run(ctx context.Context, r controller.Runt
 		ctrl.files = concurrent.NewHashTrieMap[string, *logfile.LogFile]()
 		// Block writes until /var/log is ready
 		ctrl.canLog.Lock()
+		ctrl.canLogLocked = true
 
 		ctrl.V1Alpha1Logging.SetLineWriter(ctrl)
 	})
@@ -123,7 +129,7 @@ func (ctrl *LogPersistenceController) Run(ctx context.Context, r controller.Runt
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctrl.stopLogging()
 		case <-ticker.C:
 			for _, f := range ctrl.files.All() {
 				if err := f.Flush(); err != nil {

--- a/internal/app/machined/pkg/controllers/runtime/log_persistence_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/log_persistence_test.go
@@ -44,6 +44,15 @@ func (loggingMock) SetLineWriter(w runtime.LogWriter) {}
 
 func (loggingMock) RegisteredLogs() []string { return nil }
 
+func (suite *LogPersistenceSuite) TestNoEPHEMERAL() {
+	ctrl := &runtimectrl.LogPersistenceController{
+		V1Alpha1Logging: loggingMock{},
+	}
+
+	// don't mount the EPEMERAL volume, controller should still shutdown
+	suite.Require().NoError(suite.Runtime().RegisterController(ctrl))
+}
+
 func (suite *LogPersistenceSuite) TestDefault() {
 	ctrl := &runtimectrl.LogPersistenceController{
 		V1Alpha1Logging: loggingMock{},


### PR DESCRIPTION
If the controller-runtime is shutting down, and even if the volumes were not finalized, still close the log files and stop all log writers.

This fixes a problem with panic reboot and machined not being able to unmount `/var` in a clean way, as PID 1 still holds references to files in `/var/log/`.

The fix involves adding a variable which is only accessed in the controller goroutine to track whether the mutex was locked or not, so that we know if we have to lock it on stop or it's already locked.

This variable is not accessed concurrently (while the lock, as log writers acquire RLock over it from different goroutines).
