### PR TITLE
refactor: simplify trustd/apid rootfs setup

### DIFF
--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -180,6 +180,7 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 	// Set the mounts.
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
+		{Type: "bind", Destination: "/apid", Source: "/sbin/init", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: filepath.Dir(constants.MachineSocketPath), Source: filepath.Dir(constants.MachineSocketPath), Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: filepath.Dir(constants.APIRuntimeSocketPath), Source: filepath.Dir(constants.APIRuntimeSocketPath), Options: []string{"rbind", "rw"}},
 	}

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -168,6 +168,7 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	// Set the mounts.
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: filepath.Dir(constants.TrustdRuntimeSocketPath), Source: filepath.Dir(constants.TrustdRuntimeSocketPath), Options: []string{"rbind", "ro"}},
+		{Type: "bind", Destination: "/trustd", Source: "/sbin/init", Options: []string{"bind", "ro"}},
 	}
 
 	mounts = bindMountContainerMarker(mounts)

--- a/internal/app/machined/pkg/system/services/utils.go
+++ b/internal/app/machined/pkg/system/services/utils.go
@@ -12,7 +12,6 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/siderolabs/talos/internal/pkg/containermode"
-	mount "github.com/siderolabs/talos/internal/pkg/mount/v3"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -22,16 +21,6 @@ func prepareRootfs(id string) error {
 
 	if err := os.MkdirAll(rootfsPath, 0o711); err != nil { // rwx--x--x, non-root programs should be able to follow path
 		return fmt.Errorf("failed to create rootfs %q: %w", rootfsPath, err)
-	}
-
-	executablePath := filepath.Join(rootfsPath, id)
-
-	if err := os.WriteFile(executablePath, nil, 0o555); err != nil { // r-xr-xr-x, non-root programs should be able to execute & read
-		return fmt.Errorf("failed to create empty executable %q: %w", executablePath, err)
-	}
-
-	if err := mount.BindReadonly("/sbin/init", executablePath); err != nil {
-		return fmt.Errorf("failed to create bind mount for %q: %w", executablePath, err)
 	}
 
 	return nil


### PR DESCRIPTION
These services run from an empty rootfs, and instead of bind-mounting `/sbin/init` (multi-service binary) into it outside of container startup flow, simply use a container mount to bind the binary into the initially empty rootfs.
