### PR TITLE
refactor: config generation uses multi-doc sysctlconfig

### DIFF
--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -224,3 +224,8 @@ func (contract *VersionContract) MultidocKubernetesConfigSupported() bool {
 func (contract *VersionContract) FilesystemTrimEnabledByDefault() bool {
 	return contract.Greater(TalosVersion1_13)
 }
+
+// MultidocSysctlConfigSupported returns true if version of Talos should use multi-doc Sysctl config.
+func (contract *VersionContract) MultidocSysctlConfigSupported() bool {
+	return contract.Greater(TalosVersion1_13)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -75,6 +75,7 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.HostDNSMultidocConfig())
 	assert.True(t, contract.MultidocKubernetesConfigSupported())
 	assert.True(t, contract.FilesystemTrimEnabledByDefault())
+	assert.True(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_14(t *testing.T) {
@@ -108,6 +109,7 @@ func TestContract1_14(t *testing.T) {
 	assert.True(t, contract.HostDNSMultidocConfig())
 	assert.True(t, contract.MultidocKubernetesConfigSupported())
 	assert.True(t, contract.FilesystemTrimEnabledByDefault())
+	assert.True(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_13(t *testing.T) {
@@ -141,6 +143,7 @@ func TestContract1_13(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_12(t *testing.T) {
@@ -174,6 +177,7 @@ func TestContract1_12(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_11(t *testing.T) {
@@ -207,6 +211,7 @@ func TestContract1_11(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_10(t *testing.T) {
@@ -240,6 +245,7 @@ func TestContract1_10(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_9(t *testing.T) {
@@ -273,6 +279,7 @@ func TestContract1_9(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_8(t *testing.T) {
@@ -306,6 +313,7 @@ func TestContract1_8(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_7(t *testing.T) {
@@ -339,6 +347,7 @@ func TestContract1_7(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_6(t *testing.T) {
@@ -372,6 +381,7 @@ func TestContract1_6(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_5(t *testing.T) {
@@ -405,6 +415,7 @@ func TestContract1_5(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_4(t *testing.T) {
@@ -438,6 +449,7 @@ func TestContract1_4(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_3(t *testing.T) {
@@ -471,6 +483,7 @@ func TestContract1_3(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_2(t *testing.T) {
@@ -504,6 +517,7 @@ func TestContract1_2(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_1(t *testing.T) {
@@ -537,6 +551,7 @@ func TestContract1_1(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }
 
 func TestContract1_0(t *testing.T) {
@@ -570,4 +585,5 @@ func TestContract1_0(t *testing.T) {
 	assert.False(t, contract.HostDNSMultidocConfig())
 	assert.False(t, contract.MultidocKubernetesConfigSupported())
 	assert.False(t, contract.FilesystemTrimEnabledByDefault())
+	assert.False(t, contract.MultidocSysctlConfigSupported())
 }

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime"
 	v1alpha1 "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -39,8 +40,11 @@ func (in *Input) init() ([]config.Document, error) {
 			InstallExtraKernelArgs: in.Options.InstallExtraKernelArgs,
 		},
 		MachineDisks:    in.Options.MachineDisks,
-		MachineSysctls:  in.Options.Sysctls, //nolint:staticcheck // legacy configuration
 		MachineFeatures: &v1alpha1.FeaturesConfig{},
+	}
+
+	if !in.Options.VersionContract.MultidocSysctlConfigSupported() {
+		machine.MachineSysctls = in.Options.Sysctls //nolint:staticcheck // legacy configuration
 	}
 
 	if in.Options.VersionContract.GrubUseUKICmdlineDefault() {
@@ -237,6 +241,13 @@ func (in *Input) init() ([]config.Document, error) {
 		}
 
 		documents = append(documents, resolverConfig)
+	}
+
+	if len(in.Options.Sysctls) > 0 && in.Options.VersionContract.MultidocSysctlConfigSupported() {
+		sysctlConfig := runtime.NewSysctlConfigV1Alpha1()
+		sysctlConfig.Params = in.Options.Sysctls
+
+		documents = append(documents, sysctlConfig)
 	}
 
 	documents = append(documents, in.generateBlockConfigs()...)

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime"
 	v1alpha1 "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -40,8 +41,11 @@ func (in *Input) worker() ([]config.Document, error) {
 			InstallExtraKernelArgs: in.Options.InstallExtraKernelArgs,
 		},
 		MachineDisks:    in.Options.MachineDisks,
-		MachineSysctls:  in.Options.Sysctls, //nolint:staticcheck // legacy configuration
 		MachineFeatures: &v1alpha1.FeaturesConfig{},
+	}
+
+	if !in.Options.VersionContract.MultidocSysctlConfigSupported() {
+		machine.MachineSysctls = in.Options.Sysctls //nolint:staticcheck // legacy configuration
 	}
 
 	if in.Options.VersionContract.GrubUseUKICmdlineDefault() {
@@ -161,6 +165,13 @@ func (in *Input) worker() ([]config.Document, error) {
 		}
 
 		documents = append(documents, resolverConfig)
+	}
+
+	if len(in.Options.Sysctls) > 0 && in.Options.VersionContract.MultidocSysctlConfigSupported() {
+		sysctlConfig := runtime.NewSysctlConfigV1Alpha1()
+		sysctlConfig.Params = in.Options.Sysctls
+
+		documents = append(documents, sysctlConfig)
 	}
 
 	documents = append(documents, in.generateBlockConfigs()...)

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
@@ -27,8 +27,6 @@ machine:
             - bar=baz
         wipe: false
         grubUseUKICmdline: true
-    sysctls:
-        foo: bar
     features:
         diskQuotaSupport: true
         kubePrism:
@@ -98,6 +96,11 @@ kind: ResolverConfig
 hostDNS:
     enabled: true
     forwardKubeDNSToHost: true
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+    foo: bar
 ---
 apiVersion: v1alpha1
 kind: FilesystemTrimConfig

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-worker.yaml
@@ -27,8 +27,6 @@ machine:
             - bar=baz
         wipe: false
         grubUseUKICmdline: true
-    sysctls:
-        foo: bar
     features:
         diskQuotaSupport: true
         kubePrism:
@@ -56,6 +54,11 @@ kind: ResolverConfig
 hostDNS:
     enabled: true
     forwardKubeDNSToHost: true
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+    foo: bar
 ---
 apiVersion: v1alpha1
 kind: FilesystemTrimConfig


### PR DESCRIPTION
Adds SysctlConfig version contract, updates config generation to use the multi-doc SysctlConfig if supported.

No equivalent changes for SysfsConfig, as it's not used in config generation at the moment.