### PR TITLE
fix: bump number of open files for etcd

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -229,6 +229,11 @@ func (e *Etcd) Runner(r runtime.Runtime) (runner.Runner, error) {
 				oci.WithHostNamespace(specs.NetworkNamespace),
 				oci.WithMounts(mounts),
 				oci.WithUIDGID(constants.EtcdUserID, constants.EtcdUserID),
+				oci.WithRlimit(&specs.POSIXRlimit{
+					Type: "RLIMIT_NOFILE",
+					Hard: uint64(10240),
+					Soft: uint64(10240),
+				}),
 			),
 			runner.WithOOMScoreAdj(-998),
 		),


### PR DESCRIPTION
The default OCI spec contains a limit of 1024.

See https://github.com/kubernetes/kubernetes/issues/111622
