### PR TITLE
test: skip fstrim default schedule on cloud tests

### DIFF
--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -1779,6 +1779,12 @@ func (suite *VolumesSuite) TestZswapStatus() {
 
 // TestFSTrimDefaultSchedule verifies that the default schedule for filesystem trimming is applied.
 func (suite *VolumesSuite) TestFSTrimDefaultSchedule() {
+	// TODO: we can remove this skip clause once TF provider in contrib is updated
+	// to Talos 1.14 machinery.
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping test for non-qemu provisioner")
+	}
+
 	for _, node := range suite.DiscoverNodeInternalIPs(suite.ctx) {
 		suite.Run(node, func() {
 			ctx := client.WithNode(suite.ctx, node)

--- a/internal/integration/cli/patch.go
+++ b/internal/integration/cli/patch.go
@@ -29,11 +29,11 @@ func (suite *PatchSuite) SuiteName() string {
 func (suite *PatchSuite) TestSuccess() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
 
-	// this should be a no-op patch to verify that the command runs, but it should not change the config
 	patch := map[string]any{
 		"apiVersion": "v1alpha1",
-		"kind":       "KubeSchedulerConfig",
-		"image":      fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, constants.DefaultKubernetesVersion),
+		"kind":       "WatchdogTimerConfig",
+		"device":     "/dev/watchdog33",
+		"timeout":    "2m0s",
 	}
 
 	data, err := json.Marshal(patch)
@@ -46,6 +46,21 @@ func (suite *PatchSuite) TestSuccess() {
 	)
 	suite.RunCLI(
 		[]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot", "--dry-run"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+	)
+
+	removePatch := map[string]any{
+		"apiVersion": "v1alpha1",
+		"kind":       "WatchdogTimerConfig",
+		"$patch":     "delete",
+	}
+
+	data, err = json.Marshal(removePatch)
+	suite.Require().NoError(err)
+
+	suite.RunCLI(
+		[]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot"},
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 	)


### PR DESCRIPTION
The TF provider is not up to date with Talos 1.14 machinery, so it doesn't generate the default fstrim schedule failing the test.

Skip the test for now outside of QEMU.
