### PR TITLE
fix: revert coredns to 1.14.2

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -24,6 +24,7 @@ containerd: 2.3.2
 etcd: 3.7.0-rc.0-0
 Flannel: v0.28.5
 runc: 1.5.0-rc.3
+CoreDNS: 1.14.2
 
 Talos is built with Go 1.26.4.
 """

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -402,7 +402,7 @@ const (
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
 	// renovate: datasource=docker depName=registry.k8s.io/coredns/coredns
-	DefaultCoreDNSVersion = "v1.14.3"
+	DefaultCoreDNSVersion = "v1.14.2"
 
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -2491,7 +2491,7 @@ talosctl image k8s-bundle [flags]
 ### Options
 
 ```
-      --coredns-version semver                 CoreDNS semantic version (default v1.14.3)
+      --coredns-version semver                 CoreDNS semantic version (default v1.14.2)
       --etcd-version semver                    ETCD semantic version (default v3.7.0-rc.0-0)
       --flannel-version semver                 Flannel CNI semantic version (default v0.28.5)
   -h, --help                                   help for k8s-bundle

--- a/website/content/v1.14/reference/configuration/v1alpha1/config.md
+++ b/website/content/v1.14/reference/configuration/v1alpha1/config.md
@@ -984,7 +984,7 @@ etcd:
 {{< /highlight >}}</details> | |
 |`coreDNS` |<a href="#Config.cluster.coreDNS">CoreDNS</a> |Core DNS specific configuration options. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 coreDNS:
-    image: registry.k8s.io/coredns/coredns:v1.14.3 # The `image` field is an override to the default coredns image.
+    image: registry.k8s.io/coredns/coredns:v1.14.2 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}</details> | |
 |`externalCloudProvider` |<a href="#Config.cluster.externalCloudProvider">ExternalCloudProviderConfig</a> |External cloud provider configuration. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 externalCloudProvider:
@@ -1492,7 +1492,7 @@ CoreDNS represents the CoreDNS config values.
 {{< highlight yaml >}}
 cluster:
     coreDNS:
-        image: registry.k8s.io/coredns/coredns:v1.14.3 # The `image` field is an override to the default coredns image.
+        image: registry.k8s.io/coredns/coredns:v1.14.2 # The `image` field is an override to the default coredns image.
 {{< /highlight >}}
 
 


### PR DESCRIPTION
1.14.3 builds are amd64-only, which is breaking for any other arch.

```sh
crane manifest registry.k8s.io/coredns/coredns:v1.14.3
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 3070,
      "digest": "sha256:f713ee04ec58ad6a470c729494da71cd5351fb3367cfe8fefc1951287a6706de"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 84728,
         "digest": "sha256:03c9b64681eef07f903b45cfbe5c064db1f1c7f682863b895104ac2680a271a7"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 12579,
         "digest": "sha256:2e4cf50eeb92ac3a7afe75e15d96a26dee99449f86b46c75b5d95f4418a5bca0"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 458603,
         "digest": "sha256:56ce5a7a0a8cc3aded9e8cab00fd85f0a1c50376aa9f2318c4e66beb03eadf8f"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 28389,
         "digest": "sha256:e1089d61b200106053b1717881bf0c1c47551478f01569d9224d33cccf3e4692"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 75,
         "digest": "sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 193,
         "digest": "sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 130,
         "digest": "sha256:d82bc7a76a838c9a4a6025192429c2fed58f73742ef1fb9c8bb7b995fc3b7213"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 168,
         "digest": "sha256:68e4cd60e60fed4486d5b4b40b079e57781e828d93d80a7411e8760dcccfbbf7"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 84,
         "digest": "sha256:0783a66ae7492bb16937c7723c534e431404aa3ebbdcaaed65d264a95a266b9e"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 358,
         "digest": "sha256:efae86a3fb38e05e6e2584bc2f48534a0d82f8d9e9a4163d04885d5c65423105"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 320,
         "digest": "sha256:6b72b81ed96620b324f40ade069bbd3fcee69d62182bb03681c3976b6909eec4"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 130874,
         "digest": "sha256:6cdd517ba90571b01009637268b5fddb4e3eea409bb6dae0bf40ed8ad9e33ef4"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 22818466,
         "digest": "sha256:0fbc275577b733d68d947732e2e23b70b7c08d4781c9b7e11a5095e5bd319367"
      }
   ]
}%
```
```sh
crane manifest registry.k8s.io/coredns/coredns:v1.14.2
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3023,
         "digest": "sha256:fd5079792b93909db3adefa91e41c3995455013394f0197c7346786ae19079fc",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3023,
         "digest": "sha256:708fd09134ad7b4785e6fbdd80cdced62f6d3546a810741e4c0a8a1973d1a6f5",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3023,
         "digest": "sha256:3c5a66ca0d50fbd3ddb862857ce2a01a9d74dd409aea4b1fde83a9c68c598754",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3023,
         "digest": "sha256:a3ef9c7f0d60c65643b5269c12dc78176d328926cab649e6d780d6540dcb1982",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:b70e85931b8519f163fac5e4bba2b90157e25b34318491c04502e840c7a2552e",
         "platform": {
            "architecture": "riscv64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3023,
         "digest": "sha256:d605b1d48772a7b4bcf7325b55af4a0731652b3b0fd30afe3baa41bf522b2ae2",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}%
```