### PR TITLE
test: fix rook-ceph tests

### DIFF
--- a/internal/integration/k8s/constants.go
+++ b/internal/integration/k8s/constants.go
@@ -11,6 +11,11 @@ const (
 	// RookCephHelmChartVersion is the version of the Rook Ceph Helm chart to use.
 	// renovate: datasource=helm versioning=helm depName=rook-ceph registryUrl=https://charts.rook.io/release
 	RookCephHelmChartVersion = "v1.20.1"
+	// CephCSIDriversHelmChartVersion is the version of the Ceph-CSI drivers Helm chart to use.
+	// Starting with Rook v1.20 the CSI drivers are no longer deployed by the operator chart and
+	// have to be installed separately via the ceph-csi-drivers chart.
+	// renovate: datasource=helm versioning=helm depName=ceph-csi-drivers registryUrl=https://ceph.github.io/ceph-csi-operator
+	CephCSIDriversHelmChartVersion = "v1.0.1"
 	// LongHornHelmChartVersion is the version of the Longhorn Helm chart to use.
 	// renovate: datasource=helm versioning=helm depName=longhorn registryUrl=https://charts.longhorn.io
 	LongHornHelmChartVersion = "1.12.0"

--- a/internal/integration/k8s/rook.go
+++ b/internal/integration/k8s/rook.go
@@ -17,6 +17,9 @@ import (
 //go:embed testdata/rook-ceph-cluster-values.yaml
 var rookCephClusterValues []byte
 
+//go:embed testdata/ceph-csi-drivers-values.yaml
+var cephCSIDriversValues []byte
+
 // RookSuite tests deploying Rook.
 type RookSuite struct {
 	base.K8sSuite
@@ -55,6 +58,21 @@ func (suite *RookSuite) TestDeploy() {
 		nil,
 	); err != nil {
 		suite.T().Fatalf("failed to install Rook chart: %v", err)
+	}
+
+	// Starting with Rook v1.20 the CSI drivers are no longer deployed by the operator chart;
+	// they have to be installed separately via the ceph-csi-drivers chart, after the operator
+	// (which provides the ceph-csi-operator and its CRDs) and before the cluster chart.
+	if err := suite.HelmInstall(
+		ctx,
+		"rook-ceph",
+		"https://ceph.github.io/ceph-csi-operator",
+		CephCSIDriversHelmChartVersion,
+		"ceph-csi-drivers",
+		"ceph-csi-drivers",
+		cephCSIDriversValues,
+	); err != nil {
+		suite.T().Fatalf("failed to install Ceph-CSI drivers chart: %v", err)
 	}
 
 	if err := suite.HelmInstall(

--- a/internal/integration/k8s/testdata/ceph-csi-drivers-values.yaml
+++ b/internal/integration/k8s/testdata/ceph-csi-drivers-values.yaml
@@ -1,0 +1,23 @@
+operatorConfig:
+  namespace: rook-ceph
+  driverSpecDefaults:
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    nodePlugin:
+      priorityClassName: system-node-critical
+    controllerPlugin:
+      priorityClassName: system-cluster-critical
+
+drivers:
+  rbd:
+    enabled: true
+    name: rook-ceph.rbd.csi.ceph.com
+  cephfs:
+    enabled: true
+    name: rook-ceph.cephfs.csi.ceph.com
+  nfs:
+    enabled: false
+    name: rook-ceph.nfs.csi.ceph.com
+  nvmeof:
+    enabled: false
+    name: rook-ceph.nvmeof.csi.ceph.com


### PR DESCRIPTION
We need to install an additional chart now to enable CSI drivers.
