### PR TITLE
feat(talosctl): wait for volume detach before reboot on upgrade

### DIFF
--- a/cmd/talosctl/cmd/talos/drain.go
+++ b/cmd/talosctl/cmd/talos/drain.go
@@ -30,7 +30,10 @@ type nodeUpdate struct {
 // and performs cordon + drain on all of them in parallel.
 //
 // It returns a map of talosIP -> k8sNodeName for use in the uncordon phase.
-func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
+//
+// When waitForVolumeDetach is set, each node also waits (up to volumeDetachTimeout)
+// for its CSI VolumeAttachments to clear after draining; best-effort, never fatal.
+func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainTimeout time.Duration, waitForVolumeDetach bool, volumeDetachTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
 	// For kubeconfig - build a random endpoint client (to go to the controlplane).
 	c, err := clientFactory.BuildRandomEndpointClient(ctx)
 	if err != nil {
@@ -90,9 +93,23 @@ func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainT
 				updateCh <- nodeUpdate{node: k8sNodeName, update: upd}
 			}
 
-			return nodedrain.CordonAndDrain(ctx, clientset, k8sNodeName, nodedrain.Options{
+			if drainErr := nodedrain.CordonAndDrain(ctx, clientset, k8sNodeName, nodedrain.Options{
 				DrainTimeout: drainTimeout,
-			}, reportFn)
+			}, reportFn); drainErr != nil {
+				return drainErr
+			}
+
+			if waitForVolumeDetach {
+				// Best-effort: a slow or stuck CSI detach must not block the reboot.
+				if detachErr := nodedrain.WaitForVolumeDetach(ctx, clientset, k8sNodeName, volumeDetachTimeout, reportFn); detachErr != nil {
+					reportFn(reporter.Update{
+						Message: fmt.Sprintf("%s: proceeding despite volume detach wait: %v", k8sNodeName, detachErr),
+						Status:  reporter.StatusError,
+					})
+				}
+			}
+
+			return nil
 		})
 	}
 

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -27,10 +27,12 @@ import (
 var rebootCmdFlags = struct {
 	trackableActionCmdFlags
 
-	progress     flags.PflagExtended[reporter.OutputMode]
-	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
-	drain        bool
-	drainTimeout time.Duration
+	progress            flags.PflagExtended[reporter.OutputMode]
+	rebootMode          flags.PflagExtended[machine.RebootRequest_Mode]
+	drain               bool
+	drainTimeout        time.Duration
+	waitForVolumeDetach bool
+	volumeDetachTimeout time.Duration
 }{
 	rebootMode: flags.ProtoEnum(machine.RebootRequest_DEFAULT, machine.RebootRequest_Mode_value, machine.RebootRequest_Mode_name),
 	progress:   reporter.NewOutputModeFlag(),
@@ -75,7 +77,7 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 		return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 	}
 
-	nodeNames, err := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rep)
+	nodeNames, err := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rebootCmdFlags.waitForVolumeDetach, rebootCmdFlags.volumeDetachTimeout, rep)
 	if err != nil {
 		return fmt.Errorf("error draining nodes: %w", err)
 	}
@@ -154,6 +156,8 @@ func init() {
 	)
 	rebootCmd.Flags().BoolVar(&rebootCmdFlags.drain, "drain", false, "drain the Kubernetes node before rebooting (cordon + evict pods)")
 	rebootCmd.Flags().DurationVar(&rebootCmdFlags.drainTimeout, "drain-timeout", nodedrain.DefaultDrainTimeout, "timeout for draining the Kubernetes node")
+	rebootCmd.Flags().BoolVar(&rebootCmdFlags.waitForVolumeDetach, "wait-for-volume-detach", true, "after draining, wait for the node's CSI volumes to detach before rebooting (best-effort; requires --drain)")
+	rebootCmd.Flags().DurationVar(&rebootCmdFlags.volumeDetachTimeout, "volume-detach-timeout", nodedrain.DefaultVolumeDetachTimeout, "timeout for waiting for the node's CSI volumes to detach")
 	rebootCmdFlags.addTrackActionFlags(rebootCmd)
 	addCommand(rebootCmd)
 }

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -42,8 +42,10 @@ var upgradeCmdFlags = struct {
 	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
 	progress     flags.PflagExtended[reporter.OutputMode]
 
-	drain        bool
-	drainTimeout time.Duration
+	drain               bool
+	drainTimeout        time.Duration
+	waitForVolumeDetach bool
+	volumeDetachTimeout time.Duration
 
 	legacy   bool
 	force    bool // Deprecated: only used for legacy upgrade path, to be removed in Talos 1.18.
@@ -140,7 +142,7 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 	var nodeNames map[string]string
 
 	if upgradeCmdFlags.drain {
-		nodeNames, err = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, rep)
+		nodeNames, err = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, upgradeCmdFlags.waitForVolumeDetach, upgradeCmdFlags.volumeDetachTimeout, rep)
 		if err != nil {
 			return err
 		}
@@ -366,6 +368,8 @@ func init() {
 	upgradeCmd.Flags().Var(upgradeCmdFlags.progress, "progress", fmt.Sprintf("output mode for upgrade progress. Values: %v", upgradeCmdFlags.progress.Options()))
 	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.drain, "drain", true, "drain the Kubernetes node before rebooting (cordon + evict pods)")
 	upgradeCmd.Flags().DurationVar(&upgradeCmdFlags.drainTimeout, "drain-timeout", nodedrain.DefaultDrainTimeout, "timeout for draining the Kubernetes node")
+	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.waitForVolumeDetach, "wait-for-volume-detach", true, "after draining, wait for the node's CSI volumes to detach before rebooting (best-effort; requires --drain)")
+	upgradeCmd.Flags().DurationVar(&upgradeCmdFlags.volumeDetachTimeout, "volume-detach-timeout", nodedrain.DefaultVolumeDetachTimeout, "timeout for waiting for the node's CSI volumes to detach")
 
 	// Mark legacy-only flags as deprecated. These are only used when falling back
 	// to the legacy MachineService.Upgrade unary API for older Talos versions.

--- a/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
+++ b/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
@@ -28,8 +28,15 @@ const (
 	// DefaultDrainTimeout is the default maximum time to wait for the node to be drained.
 	DefaultDrainTimeout = 5 * time.Minute
 
+	// DefaultVolumeDetachTimeout is the default maximum time to wait for the node's
+	// CSI volumes to detach after draining, before rebooting.
+	DefaultVolumeDetachTimeout = 5 * time.Minute
+
 	// nodeReadyPollInterval is how often to poll for node readiness.
 	nodeReadyPollInterval = 5 * time.Second
+
+	// volumeDetachPollInterval is how often to poll for VolumeAttachment teardown.
+	volumeDetachPollInterval = 2 * time.Second
 )
 
 // ReportFunc is a callback for reporting drain progress updates.
@@ -146,6 +153,54 @@ func CordonAndDrain(ctx context.Context, clientset kubernetes.Interface, nodeNam
 	})
 
 	return nil
+}
+
+// WaitForVolumeDetach polls the Kubernetes API until no VolumeAttachment references
+// the node, or the timeout elapses. A drain evicts pods but does not wait for their
+// volumes to be unmounted and detached; rebooting before that completes can orphan a
+// mount and surface as a Multi-Attach error when the pod reschedules elsewhere.
+// Best-effort: callers should warn and proceed on error rather than block the reboot.
+func WaitForVolumeDetach(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout time.Duration, report ReportFunc) error {
+	if timeout == 0 {
+		timeout = DefaultVolumeDetachTimeout
+	}
+
+	report(reporter.Update{
+		Message: fmt.Sprintf("%s: waiting for volumes to detach", nodeName),
+		Status:  reporter.StatusRunning,
+	})
+
+	return wait.PollUntilContextTimeout(ctx, volumeDetachPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		vaList, err := clientset.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			// Transient errors are expected; keep polling until the timeout.
+			return false, nil //nolint:nilerr
+		}
+
+		remaining := 0
+
+		for _, va := range vaList.Items {
+			if va.Spec.NodeName == nodeName {
+				remaining++
+			}
+		}
+
+		if remaining > 0 {
+			report(reporter.Update{
+				Message: fmt.Sprintf("%s: waiting for %d volume(s) to detach", nodeName, remaining),
+				Status:  reporter.StatusRunning,
+			})
+
+			return false, nil
+		}
+
+		report(reporter.Update{
+			Message: fmt.Sprintf("%s: volumes detached", nodeName),
+			Status:  reporter.StatusSucceeded,
+		})
+
+		return true, nil
+	})
 }
 
 // WaitForNodeReady polls the Kubernetes API until the node reports a Ready condition

--- a/cmd/talosctl/pkg/talos/nodedrain/nodedrain_test.go
+++ b/cmd/talosctl/pkg/talos/nodedrain/nodedrain_test.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nodedrain_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+func volumeAttachment(name, nodeName string) *storagev1.VolumeAttachment {
+	pvName := "pv-" + name
+
+	return &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: storagev1.VolumeAttachmentSpec{
+			NodeName: nodeName,
+			Attacher: "csi.example.com",
+			Source:   storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvName},
+		},
+	}
+}
+
+func TestWaitForVolumeDetach(t *testing.T) {
+	const nodeName = "node-1"
+
+	for _, test := range []struct {
+		name    string
+		objects []*storagev1.VolumeAttachment
+		timeout time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "no attachments",
+			timeout: time.Second,
+		},
+		{
+			name:    "attachment on another node is ignored",
+			objects: []*storagev1.VolumeAttachment{volumeAttachment("va-other", "node-2")},
+			timeout: time.Second,
+		},
+		{
+			name:    "attachment on the node times out",
+			objects: []*storagev1.VolumeAttachment{volumeAttachment("va-1", nodeName)},
+			timeout: 100 * time.Millisecond,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(test.objects))
+			for _, va := range test.objects {
+				objects = append(objects, va)
+			}
+
+			clientset := fake.NewClientset(objects...)
+
+			err := nodedrain.WaitForVolumeDetach(context.Background(), clientset, nodeName, test.timeout, func(reporter.Update) {})
+			if (err != nil) != test.wantErr {
+				t.Fatalf("WaitForVolumeDetach() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION


# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

talosctl upgrade and reboot drain the node before rebooting, but the drain only waits for pods to be evicted, not for their CSI volumes to be unmounted and detached.

This adds a post-drain wait for the node's VolumeAttachments to clear before reboot, via two new flags on both commands:

  - --wait-for-volume-detach (default true, requires --drain)
  - --volume-detach-timeout (default 5m)

Best-effort: a timeout is reported but does not block the reboot. Implemented as nodedrain.WaitForVolumeDetach, called per-node from drainNodes after CordonAndDrain.

## Why? (reasoning)
Volume teardown (kubelet unmount + attach-detach controller detach) continues after a pod is evicted. A kexec reboot can outrun it, orphaning the mount and pinning the volume in the node's volumesInUse. That blocks detach, so the volume can't  reattach elsewhere and the rescheduled pod hits a Multi-Attach error until the mount is manually cleared. Waiting for VolumeAttachments to clear before reboot closes the race.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
