### PR TITLE
fix: align documented image cache partition label

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -796,7 +796,7 @@
         "apiVersion",
         "kind"
       ],
-      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.\\n"
+      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\\n"
     },
     "block.VolumeDiscoverySpec": {
       "properties": {

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -832,7 +832,7 @@ func (VolumeConfigV1Alpha1) Doc() *encoder.Doc {
 	doc := &encoder.Doc{
 		Type:        "VolumeConfig",
 		Comments:    [3]string{"" /* encoder.HeadComment */, "VolumeConfig is a system volume configuration document." /* encoder.LineComment */, "" /* encoder.FootComment */},
-		Description: "VolumeConfig is a system volume configuration document.\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.\n",
+		Description: "VolumeConfig is a system volume configuration document.\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\n",
 		Fields: []encoder.Doc{
 			{
 				Type:   "Meta",

--- a/pkg/machinery/config/types/block/volume_config.go
+++ b/pkg/machinery/config/types/block/volume_config.go
@@ -52,7 +52,7 @@ var (
 // VolumeConfigV1Alpha1 is a system volume configuration document.
 //
 //	description: |
-//	  Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.
+//	  Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.
 //	examples:
 //	  - value: exampleVolumeConfigEphemeralV1Alpha1()
 //	alias: VolumeConfig

--- a/website/content/v1.14/reference/configuration/block/volumeconfig.md
+++ b/website/content/v1.14/reference/configuration/block/volumeconfig.md
@@ -1,7 +1,7 @@
 ---
 description: |
     VolumeConfig is a system volume configuration document.
-    Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.
+    Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.
 title: VolumeConfig
 ---
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -796,7 +796,7 @@
         "apiVersion",
         "kind"
       ],
-      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.\\n"
+      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\\n"
     },
     "block.VolumeDiscoverySpec": {
       "properties": {


### PR DESCRIPTION
The actual one is "IMAGECACHE", not "IMAGE-CACHE". See [constants.go#L1293](https://github.com/siderolabs/talos/blob/6d03b3f611de4ca06a6ee0587b91f8957e1e867f/pkg/machinery/constants/constants.go#L1293) for reference.