### PR TITLE
chore: enrich the SBOM with Go module licenses

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/sbom_item.go
+++ b/internal/app/machined/pkg/controllers/runtime/sbom_item.go
@@ -120,10 +120,11 @@ type spdxDocument struct {
 }
 
 type spdxPackage struct {
-	Name         string            `json:"name"`
-	Version      string            `json:"versionInfo"`
-	License      string            `json:"licenseDeclared"`
-	ExternalRefs []spdxExternalRef `json:"externalRefs"`
+	Name             string            `json:"name"`
+	Version          string            `json:"versionInfo"`
+	LicenseDeclared  string            `json:"licenseDeclared"`
+	LicenseConcluded string            `json:"licenseConcluded"`
+	ExternalRefs     []spdxExternalRef `json:"externalRefs"`
 }
 
 type spdxExternalRef struct {
@@ -152,23 +153,7 @@ func (ctrl *SBOMItemController) processSPDXFile(ctx context.Context, r controlle
 
 		if err := safe.WriterModify(ctx, r, runtimeres.NewSBOMItemSpec(runtimeres.NamespaceName, pkg.Name),
 			func(item *runtimeres.SBOMItem) error {
-				item.TypedSpec().Name = pkg.Name
-				item.TypedSpec().Version = pkg.Version
-
-				if pkg.License != "NOASSERTION" {
-					item.TypedSpec().License = pkg.License
-				}
-
-				for _, ref := range pkg.ExternalRefs {
-					switch ref.Type {
-					case "cpe23Type":
-						item.TypedSpec().CPEs = append(item.TypedSpec().CPEs, ref.Locator)
-					case "purl":
-						item.TypedSpec().PURLs = append(item.TypedSpec().PURLs, ref.Locator)
-					}
-				}
-
-				item.TypedSpec().Extension = isExtension
+				updateSBOMItem(item, pkg, isExtension)
 
 				return nil
 			}); err != nil {
@@ -177,4 +162,27 @@ func (ctrl *SBOMItemController) processSPDXFile(ctx context.Context, r controlle
 	}
 
 	return nil
+}
+
+// updateSBOMItem populates an SBOMItem resource from a parsed SPDX package.
+func updateSBOMItem(item *runtimeres.SBOMItem, pkg spdxPackage, isExtension bool) {
+	item.TypedSpec().Name = pkg.Name
+	item.TypedSpec().Version = pkg.Version
+
+	if pkg.LicenseConcluded != "NOASSERTION" {
+		item.TypedSpec().License = pkg.LicenseConcluded
+	} else if pkg.LicenseDeclared != "NOASSERTION" {
+		item.TypedSpec().License = pkg.LicenseDeclared
+	}
+
+	for _, ref := range pkg.ExternalRefs {
+		switch ref.Type {
+		case "cpe23Type":
+			item.TypedSpec().CPEs = append(item.TypedSpec().CPEs, ref.Locator)
+		case "purl":
+			item.TypedSpec().PURLs = append(item.TypedSpec().PURLs, ref.Locator)
+		}
+	}
+
+	item.TypedSpec().Extension = isExtension
 }

--- a/tools/sbom-builder/go.mod
+++ b/tools/sbom-builder/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spdx/tools-golang v0.5.7
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/mod v0.36.0
 	modernc.org/sqlite v1.52.0
 )
 
@@ -259,7 +260,6 @@ require (
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/tools/sbom-builder/main.go
+++ b/tools/sbom-builder/main.go
@@ -31,7 +31,13 @@
 //     (https://github.com/anchore/syft/blob/v1.44.0/syft/format/common/spdxhelpers/to_syft_model.go#L128),
 //     so any externalRefs on it never reach the vulnerability matcher.
 //
-//  2. Provide deterministic output (RFC3339 CreationInfo.Created derived from
+//  2. Enrich the Go-module packages syft catalogs: per-module license
+//     discovery is enabled against the local module cache (GOMODCACHE), and
+//     each go-module package gets its PackageDownloadLocation (module proxy
+//     zip) and PackageHomePage (pkg.go.dev) filled in, both derived from the
+//     module path and version. syft leaves these as NOASSERTION otherwise.
+//
+//  3. Provide deterministic output (RFC3339 CreationInfo.Created derived from
 //     SOURCE_DATE_EPOCH, plus a UUIDv5 documentNamespace hashed from a stable
 //     digest of the cataloged packages). This replaces the prior fork-only
 //     env vars while https://github.com/anchore/syft/pull/3932 remains open.
@@ -54,11 +60,14 @@ import (
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/format/common/spdxhelpers"
+	"github.com/anchore/syft/syft/pkg/cataloger/golang"
 	"github.com/anchore/syft/syft/source"
 	"github.com/google/uuid"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	v2_3 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"golang.org/x/mod/module"
 	_ "modernc.org/sqlite" // pulled in by syft catalogers; harmless if unused
 )
 
@@ -110,10 +119,20 @@ func run(sourceDir, sourceName, sourceVersion, cpeVendor, cpeProduct string, sou
 	}
 	defer src.Close() //nolint:errcheck
 
+	// Enable the Go cataloger's per-module license discovery from the local
+	// module cache. syft's default mod-cache dir is derived from GOPATH, but the
+	// Talos build sets GOMODCACHE explicitly (e.g. /.cache/mod), so point the
+	// cataloger at GOMODCACHE when it is set. The cache is fully populated by the
+	// preceding `go mod download`, so this stays offline and reproducible.
+	goCfg := golang.DefaultCatalogerConfig().
+		WithSearchLocalModCacheLicenses(true).
+		WithLocalModCacheDir(os.Getenv("GOMODCACHE"))
+
 	cfg := syft.DefaultCreateSBOMConfig().
 		WithCatalogerSelection(
 			cataloging.NewSelectionRequest().WithExpression("+sbom-cataloger,go"),
-		)
+		).
+		WithPackagesConfig(pkgcataloging.DefaultConfig().WithGolangConfig(goCfg))
 
 	sbomDoc, err := syft.CreateSBOM(ctx, src, cfg)
 	if err != nil {
@@ -128,6 +147,8 @@ func run(sourceDir, sourceName, sourceVersion, cpeVendor, cpeProduct string, sou
 		cpeRef(cpeVendor, cpeProduct, cpeVersion),
 	)
 	addGoModulePackage(doc, sourceVersion)
+
+	enrichGoModuleURLs(doc)
 
 	applyDeterminism(doc, normalizedName, sourceDateEpoch)
 
@@ -310,6 +331,80 @@ func addGoModulePackage(doc *v2_3.Document, version string) {
 			break
 		}
 	}
+}
+
+const goProxyBaseURL = "https://proxy.golang.org"
+
+// enrichGoModuleURLs fills in PackageDownloadLocation and PackageHomePage for
+// every Go-module package syft cataloged. syft leaves both as NOASSERTION for
+// go-module packages, but they are fully derivable from the module path and
+// version:
+//
+//   - PackageDownloadLocation: the module proxy zip
+//     (https://proxy.golang.org/<escaped-path>/@v/<escaped-version>.zip), the
+//     canonical, content-addressed artifact for the module version.
+//   - PackageHomePage: the pkg.go.dev landing page
+//     (https://pkg.go.dev/<path>@<version>), the human-facing entry point.
+//
+// A package is treated as a Go module when it carries a `pkg:golang/...` purl
+// externalRef. The module path is taken from PackageName (syft sets it to the
+// module path) rather than parsed back out of the purl, so we avoid the
+// purl-escaping round-trip; the proxy escaping is applied here via
+// golang.org/x/mod/module.
+//
+// Only empty/NOASSERTION/NONE fields are filled, so identifiers already set by
+// addOSPackage/addGoModulePackage (e.g. the GitHub release URL on the talos
+// module) are preserved. Packages without a resolvable module version — local
+// `replace` targets and the synthetic stdlib package, which has no dot-bearing
+// module domain — are skipped, since neither the proxy nor pkg.go.dev can
+// address them.
+func enrichGoModuleURLs(doc *v2_3.Document) {
+	for _, p := range doc.Packages {
+		if !isGoModulePackage(p) {
+			continue
+		}
+
+		modulePath := p.PackageName
+		version := p.PackageVersion
+
+		// Need a module-domain path (contains a dot) and a concrete version to
+		// build either URL; local replaces and stdlib have neither.
+		if version == "" || !strings.Contains(modulePath, ".") {
+			continue
+		}
+
+		if isUnsetLocation(p.PackageDownloadLocation) {
+			if escPath, err := module.EscapePath(modulePath); err == nil {
+				if escVer, err := module.EscapeVersion(version); err == nil {
+					p.PackageDownloadLocation = fmt.Sprintf(
+						"%s/%s/@v/%s.zip", goProxyBaseURL, escPath, escVer,
+					)
+				}
+			}
+		}
+
+		if p.PackageHomePage == "" {
+			p.PackageHomePage = fmt.Sprintf("https://pkg.go.dev/%s@%s", modulePath, version)
+		}
+	}
+}
+
+// isGoModulePackage reports whether the SPDX package carries a `pkg:golang/...`
+// purl externalRef, syft's marker for a Go-module package.
+func isGoModulePackage(p *v2_3.Package) bool {
+	for _, ref := range p.PackageExternalReferences {
+		if ref.RefType == "purl" && strings.HasPrefix(ref.Locator, "pkg:golang/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnsetLocation reports whether an SPDX download-location field carries no
+// real value (empty, NOASSERTION, or NONE) and so is safe to fill in.
+func isUnsetLocation(loc string) bool {
+	return loc == "" || loc == "NOASSERTION" || loc == "NONE"
 }
 
 // applyDeterminism overwrites creationInfo.created and documentNamespace with

--- a/tools/sbom-builder/main_test.go
+++ b/tools/sbom-builder/main_test.go
@@ -261,6 +261,82 @@ func TestDocumentUUID_DistinguishesContent(t *testing.T) {
 	}
 }
 
+func TestEnrichGoModuleURLs(t *testing.T) {
+	goRef := func(locator string) *v2_3.PackageExternalReference {
+		return &v2_3.PackageExternalReference{Category: "PACKAGE-MANAGER", RefType: "purl", Locator: locator}
+	}
+
+	doc := &v2_3.Document{Packages: []*v2_3.Package{
+		// plain go module: both URLs get filled in
+		{
+			PackageSPDXIdentifier:     "P-mod",
+			PackageName:               "github.com/foo/Bar",
+			PackageVersion:            "v1.2.3",
+			PackageDownloadLocation:   "NOASSERTION",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{goRef("pkg:golang/github.com/foo/Bar@v1.2.3")},
+		},
+		// existing download location is preserved; only homepage is added
+		{
+			PackageSPDXIdentifier:     "P-talos",
+			PackageName:               "github.com/siderolabs/talos",
+			PackageVersion:            "v1.13.3",
+			PackageDownloadLocation:   "https://github.com/siderolabs/talos/releases/tag/v1.13.3",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{goRef("pkg:golang/github.com/siderolabs/talos@v1.13.3")},
+		},
+		// stdlib: no module domain, left untouched
+		{
+			PackageSPDXIdentifier:     "P-std",
+			PackageName:               "stdlib",
+			PackageVersion:            "go1.26.4",
+			PackageDownloadLocation:   "NOASSERTION",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{goRef("pkg:golang/stdlib@go1.26.4")},
+		},
+		// local replace target: no version, left untouched
+		{
+			PackageSPDXIdentifier:     "P-local",
+			PackageName:               "github.com/foo/local",
+			PackageVersion:            "",
+			PackageDownloadLocation:   "NOASSERTION",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{goRef("pkg:golang/github.com/foo/local")},
+		},
+		// non-go package: untouched
+		{
+			PackageSPDXIdentifier:   "P-other",
+			PackageName:             "libfoo",
+			PackageVersion:          "1.0",
+			PackageDownloadLocation: "NOASSERTION",
+		},
+	}}
+
+	enrichGoModuleURLs(doc)
+
+	mod := findPackage(doc, "P-mod")
+	// uppercase Bar must be proxy-escaped to !bar
+	if want := "https://proxy.golang.org/github.com/foo/!bar/@v/v1.2.3.zip"; mod.PackageDownloadLocation != want {
+		t.Errorf("download location = %q, want %q", mod.PackageDownloadLocation, want)
+	}
+
+	if want := "https://pkg.go.dev/github.com/foo/Bar@v1.2.3"; mod.PackageHomePage != want {
+		t.Errorf("homepage = %q, want %q", mod.PackageHomePage, want)
+	}
+
+	talos := findPackage(doc, "P-talos")
+	if want := "https://github.com/siderolabs/talos/releases/tag/v1.13.3"; talos.PackageDownloadLocation != want {
+		t.Errorf("existing download location overwritten: got %q", talos.PackageDownloadLocation)
+	}
+
+	if want := "https://pkg.go.dev/github.com/siderolabs/talos@v1.13.3"; talos.PackageHomePage != want {
+		t.Errorf("talos homepage = %q, want %q", talos.PackageHomePage, want)
+	}
+
+	for _, id := range []common.ElementID{"P-std", "P-local", "P-other"} {
+		p := findPackage(doc, id)
+		if p.PackageDownloadLocation != "NOASSERTION" || p.PackageHomePage != "" {
+			t.Errorf("%s should be untouched, got download=%q homepage=%q", id, p.PackageDownloadLocation, p.PackageHomePage)
+		}
+	}
+}
+
 // helpers
 
 func newDoc() *v2_3.Document {


### PR DESCRIPTION
Also populate homepage based on pkg.go.dev.

Show licenses via resource items more reliably.
