### PR TITLE
refactor: talosctl running tasks are now yellow

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -88,7 +88,7 @@ type healthReporter struct {
 }
 
 func (hr *healthReporter) Update(condition conditions.Condition) {
-	line := fmt.Sprintf("waiting for %s", condition)
+	line := fmt.Sprintf("waiting for %s", conditions.StatusLine(condition))
 
 	if line != hr.lastLine {
 		hr.srv.Send(&clusterapi.HealthCheckProgress{ //nolint:errcheck

--- a/pkg/cluster/check/check.go
+++ b/pkg/cluster/check/check.go
@@ -30,7 +30,7 @@ type ClusterCheck func(ClusterInfo) conditions.Condition
 
 // Reporter presents wait progress.
 //
-// It is supposed that reporter drops duplicate messages.
+// It is assumed that reporter drops duplicate messages.
 type Reporter interface {
 	Update(condition conditions.Condition)
 }
@@ -64,9 +64,6 @@ func Wait(ctx context.Context, cluster ClusterInfo, checks []ClusterCheck, repor
 			// report initial state
 			reporter.Update(condition)
 
-			// report last state
-			defer reporter.Update(condition)
-
 			for {
 				select {
 				case err = <-errCh:
@@ -76,6 +73,8 @@ func Wait(ctx context.Context, cluster ClusterInfo, checks []ClusterCheck, repor
 				}
 			}
 		}()
+
+		reporter.Update(condition)
 
 		if err != nil {
 			return err

--- a/pkg/cluster/check/check_test.go
+++ b/pkg/cluster/check/check_test.go
@@ -4,11 +4,227 @@
 
 package check_test
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/cluster/check"
+	"github.com/siderolabs/talos/pkg/conditions"
+)
+
+// staticCondition is a conditions.Condition whose String() and Wait() are fixed.
+type staticCondition struct {
+	str     string
+	waitErr error
+}
+
+func (c staticCondition) String() string { return c.str }
+
+func (c staticCondition) Wait(context.Context) error { return c.waitErr }
+
+// blockingCondition blocks until ctx is canceled, then returns ctx.Err().
+// It simulates the --wait-timeout scenario. started is closed once Wait enters,
+// so the test can cancel the context only after the condition is running.
+type blockingCondition struct {
+	str     string
+	started chan struct{}
+}
+
+func (c blockingCondition) String() string { return c.str }
+
+func (c blockingCondition) Wait(ctx context.Context) error {
+	close(c.started)
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+// captureReporter records every Update it receives.
+type captureReporter struct {
+	updates []string
+}
+
+func (r *captureReporter) Update(condition conditions.Condition) {
+	r.updates = append(r.updates, condition.String())
+}
+
+// captureReporter and *ConditionReporter must both satisfy the Reporter interface.
+var (
+	_ check.Reporter = (*captureReporter)(nil)
+	_ check.Reporter = (*check.ConditionReporter)(nil)
+)
+
+func TestWaitFailureReportsError(t *testing.T) {
+	rep := &captureReporter{}
+
+	wantErr := errors.New("boom")
+
+	err := check.Wait(
+		t.Context(),
+		nil,
+		[]check.ClusterCheck{
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "etcd to be healthy: boom", waitErr: wantErr}
+			},
+		},
+		rep,
+	)
+
+	require.ErrorIs(t, err, wantErr)
+
+	require.NotEmpty(t, rep.updates)
+	// The final update for a failed condition wraps it in failedCondition,
+	// so String() returns the underlying string.
+	assert.Equal(t, "etcd to be healthy: boom", rep.updates[len(rep.updates)-1])
+}
+
+func TestWaitFailureErrorCalledOnce(t *testing.T) {
+	rep := &captureReporter{}
+
+	wantErr := errors.New("boom")
+
+	require.ErrorIs(t, check.Wait(
+		t.Context(),
+		nil,
+		[]check.ClusterCheck{
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "etcd to be healthy: boom", waitErr: wantErr}
+			},
+		},
+		rep,
+	), wantErr)
+
+	// The final update for the failing check should be reported at least once.
+	// Count how many times the condition string appears in updates.
+	count := 0
+
+	for _, u := range rep.updates {
+		if strings.Contains(u, "etcd to be healthy: boom") {
+			count++
+		}
+	}
+
+	assert.GreaterOrEqual(t, count, 1, "failed condition must appear in updates at least once")
+}
+
+func TestWaitStopsAtFirstFailure(t *testing.T) {
+	rep := &captureReporter{}
+
+	errFirst := errors.New("first check failed")
+
+	err := check.Wait(
+		t.Context(),
+		nil,
+		[]check.ClusterCheck{
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "etcd to be healthy: first failed", waitErr: errFirst}
+			},
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "kubelet to be healthy: OK"}
+			},
+		},
+		rep,
+	)
+
+	require.ErrorIs(t, err, errFirst)
+
+	for _, u := range rep.updates {
+		assert.NotContains(t, u, "kubelet to be healthy",
+			"second check must not run after the first check fails")
+	}
+}
+
+func TestWaitContextCancellation(t *testing.T) {
+	rep := &captureReporter{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	started := make(chan struct{})
+
+	// Run Wait in a separate goroutine so we can cancel the context only after
+	// the condition has actually started (simulating --wait-timeout expiry
+	// mid-run rather than before the check begins).
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- check.Wait(
+			ctx,
+			nil,
+			[]check.ClusterCheck{
+				func(check.ClusterInfo) conditions.Condition {
+					return blockingCondition{
+						str:     "etcd to be healthy: context canceled",
+						started: started,
+					}
+				},
+			},
+			rep,
+		)
+	}()
+
+	<-started // condition is now blocking inside Wait
+	cancel()  // simulate timeout expiry
+
+	require.ErrorIs(t, <-errCh, context.Canceled)
+
+	assert.NotEmpty(t, rep.updates,
+		"timed-out/canceled condition must be reported via Update")
+}
+
+func TestWaitSuccessThenFailure(t *testing.T) {
+	rep := &captureReporter{}
+
+	errLast := errors.New("last check failed")
+
+	err := check.Wait(
+		t.Context(),
+		nil,
+		[]check.ClusterCheck{
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "etcd to be healthy: OK"}
+			},
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "kubelet to be healthy: OK"}
+			},
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "all nodes to report ready: failed", waitErr: errLast}
+			},
+		},
+		rep,
+	)
+
+	require.ErrorIs(t, err, errLast)
+
+	// First two checks reported via Update.
+	updateStr := strings.Join(rep.updates, " ")
+	assert.Contains(t, updateStr, "etcd to be healthy")
+	assert.Contains(t, updateStr, "kubelet to be healthy")
+
+	// The final update should be the failed condition.
+	assert.Contains(t, rep.updates[len(rep.updates)-1], "all nodes to report ready")
+}
+
+func TestWaitSuccessReportsUpdateOnly(t *testing.T) {
+	rep := &captureReporter{}
+
+	err := check.Wait(
+		t.Context(),
+		nil,
+		[]check.ClusterCheck{
+			func(check.ClusterInfo) conditions.Condition {
+				return staticCondition{str: "etcd to be healthy: OK"}
+			},
+		},
+		rep,
+	)
+
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, rep.updates)
 }

--- a/pkg/cluster/check/reporter.go
+++ b/pkg/cluster/check/reporter.go
@@ -30,8 +30,36 @@ func StderrReporter() *ConditionReporter {
 }
 
 func conditionToUpdate(condition conditions.Condition) reporter.Update {
-	line := strings.TrimSpace(fmt.Sprintf("waiting for %s", condition.String()))
+	line := strings.TrimSpace(fmt.Sprintf("waiting for %s", conditions.StatusLine(condition)))
 
+	if s, ok := condition.(conditions.Stateful); ok {
+		state, _ := s.State() //nolint:errcheck // we only care about the state for reporting
+
+		switch state {
+		case conditions.StateFailed:
+			return reporter.Update{
+				Message: line,
+				Status:  reporter.StatusError,
+			}
+		case conditions.StateSucceeded:
+			return reporter.Update{
+				Message: line,
+				Status:  reporter.StatusSucceeded,
+			}
+		case conditions.StateSkipped:
+			return reporter.Update{
+				Message: line,
+				Status:  reporter.StatusSkip,
+			}
+		case conditions.StateRunning:
+			return reporter.Update{
+				Message: line,
+				Status:  reporter.StatusRunning,
+			}
+		}
+	}
+
+	// Fallback for non-Stateful conditions (legacy suffix matching).
 	switch {
 	case strings.HasSuffix(line, "..."):
 		return reporter.Update{

--- a/pkg/cluster/check/reporter_internal_test.go
+++ b/pkg/cluster/check/reporter_internal_test.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package check
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/conditions"
+	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+// statefulCondition is a fake condition that implements Stateful.
+type statefulCondition struct {
+	description string
+	state       conditions.State
+	lastErr     error
+}
+
+func (c statefulCondition) String() string { return c.description }
+
+func (c statefulCondition) Wait(context.Context) error { return nil }
+
+func (c statefulCondition) State() (conditions.State, error) { return c.state, c.lastErr }
+
+// stringCondition is a non-Stateful fake (for testing the fallback path).
+type stringCondition string
+
+func (c stringCondition) String() string { return string(c) }
+
+func (c stringCondition) Wait(context.Context) error { return nil }
+
+func TestConditionToUpdate(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cond conditions.Condition
+		want reporter.Status
+	}{
+		{
+			name: "stateful: running (unpolled)",
+			cond: statefulCondition{description: "etcd to be healthy", state: conditions.StateRunning},
+			want: reporter.StatusRunning,
+		},
+		{
+			name: "stateful: running (transient error)",
+			cond: statefulCondition{description: "etcd to be healthy", state: conditions.StateRunning, lastErr: context.Canceled},
+			want: reporter.StatusRunning,
+		},
+		{
+			name: "stateful: succeeded",
+			cond: statefulCondition{description: "etcd to be healthy", state: conditions.StateSucceeded},
+			want: reporter.StatusSucceeded,
+		},
+		{
+			name: "stateful: skipped",
+			cond: statefulCondition{description: "etcd to be healthy", state: conditions.StateSkipped},
+			want: reporter.StatusSkip,
+		},
+		{
+			name: "stateful: failed",
+			cond: statefulCondition{description: "etcd to be healthy", state: conditions.StateFailed, lastErr: errors.New("connection refused")},
+			want: reporter.StatusError,
+		},
+		{
+			name: "non-Stateful fallback",
+			cond: stringCondition("etcd to be healthy: OK"),
+			want: reporter.StatusSucceeded,
+		},
+		{
+			name: "non-Stateful failed",
+			cond: stringCondition("etcd to be healthy"),
+			want: reporter.StatusError,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			update := conditionToUpdate(test.cond)
+
+			assert.Equal(t, test.want, update.Status)
+		})
+	}
+}

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -12,10 +12,66 @@ import (
 // OK is returned by the String method of the passed Condition.
 const OK = "OK"
 
+// State is the observable lifecycle state of a Condition.
+type State int
+
+const (
+	// StateRunning means the condition is not yet done; the last poll may have errored transiently.
+	StateRunning State = iota
+	// StateSucceeded means the condition's assertion returned nil.
+	StateSucceeded
+	// StateSkipped means the condition's assertion returned ErrSkipAssertion.
+	StateSkipped
+	// StateFailed means Wait returned non-nil; the condition will not be retried.
+	StateFailed
+)
+
 // Condition is a object which Wait()s for some condition to become true.
 //
 // Condition can describe itself via String() method.
 type Condition interface {
 	fmt.Stringer
 	Wait(ctx context.Context) error
+}
+
+// Stateful is an optional Condition extension exposing typed progress state,
+// so consumers render status without parsing String().
+type Stateful interface {
+	Condition
+	// State returns the current state and the last non-fatal poll error
+	// (nil unless running after a transient error).
+	State() (State, error)
+}
+
+// StatusLine returns the human-readable status line: the condition's description
+// decorated with its current state (": ...", ": OK", ": SKIP", or ": <error>").
+// Conditions that don't implement Stateful are returned unchanged.
+func StatusLine(c Condition) string {
+	s, ok := c.(Stateful)
+	if !ok {
+		return c.String()
+	}
+
+	state, lastErr := s.State()
+
+	switch state {
+	case StateSucceeded:
+		return c.String() + ": " + OK
+	case StateSkipped:
+		return c.String() + ": " + ErrSkipAssertion.Error()
+	case StateFailed:
+		if lastErr != nil {
+			return c.String() + ": " + lastErr.Error()
+		}
+
+		return c.String() + ": failed"
+	case StateRunning:
+		if lastErr != nil {
+			return c.String() + ": " + lastErr.Error()
+		}
+
+		return c.String() + ": ..."
+	}
+
+	return c.String()
 }

--- a/pkg/conditions/poll.go
+++ b/pkg/conditions/poll.go
@@ -7,7 +7,6 @@ package conditions
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
@@ -25,6 +24,7 @@ type pollingCondition struct {
 	lastErrMu  sync.Mutex
 	lastErr    error
 	lastErrSet bool
+	failed     bool
 
 	assertion   AssertionFunc
 	description string
@@ -32,21 +32,27 @@ type pollingCondition struct {
 }
 
 func (p *pollingCondition) String() string {
-	lastErr := "..."
+	return p.description
+}
 
+// State returns the current state and the last non-fatal poll error
+// (nil unless running after a transient error).
+func (p *pollingCondition) State() (State, error) {
 	p.lastErrMu.Lock()
+	defer p.lastErrMu.Unlock()
 
-	if p.lastErrSet {
-		if p.lastErr != nil {
-			lastErr = p.lastErr.Error()
-		} else {
-			lastErr = OK
-		}
+	switch {
+	case p.failed:
+		return StateFailed, p.lastErr
+	case !p.lastErrSet:
+		return StateRunning, nil
+	case p.lastErr == nil:
+		return StateSucceeded, nil
+	case errors.Is(p.lastErr, ErrSkipAssertion):
+		return StateSkipped, nil
+	default:
+		return StateRunning, p.lastErr
 	}
-
-	p.lastErrMu.Unlock()
-
-	return fmt.Sprintf("%s: %s", p.description, lastErr)
 }
 
 func (p *pollingCondition) Wait(ctx context.Context) error {
@@ -67,12 +73,16 @@ func (p *pollingCondition) Wait(ctx context.Context) error {
 
 			return err
 		}()
-		if err == nil || err == ErrSkipAssertion {
+		if err == nil || errors.Is(err, ErrSkipAssertion) {
 			return nil
 		}
 
 		select {
 		case <-ctx.Done():
+			p.lastErrMu.Lock()
+			p.failed = true
+			p.lastErrMu.Unlock()
+
 			return ctx.Err()
 		case <-ticker.C:
 		}

--- a/pkg/conditions/poll_test.go
+++ b/pkg/conditions/poll_test.go
@@ -35,7 +35,7 @@ func TestPollingCondition(t *testing.T) {
 
 		err := cond.Wait(t.Context())
 		assert.NoError(t, err)
-		assert.Equal(t, "Test condition: OK", cond.String())
+		assert.Equal(t, "Test condition", cond.String())
 		assert.Equal(t, 2, calls)
 	})
 
@@ -56,7 +56,7 @@ func TestPollingCondition(t *testing.T) {
 
 		err := cond.Wait(t.Context())
 		assert.NoError(t, err)
-		assert.Equal(t, "Test condition: SKIP", cond.String())
+		assert.Equal(t, "Test condition", cond.String())
 		assert.Equal(t, 2, calls)
 	})
 
@@ -76,7 +76,140 @@ func TestPollingCondition(t *testing.T) {
 
 		err := cond.Wait(ctx)
 		assert.Equal(t, context.DeadlineExceeded, err)
-		assert.Equal(t, "Test condition: failed", cond.String())
+		assert.Equal(t, "Test condition", cond.String())
 		assert.Equal(t, 2, calls)
+	})
+}
+
+func TestPollingConditionState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unpolled", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return nil
+		}, time.Millisecond)
+
+		state, err := cond.(conditions.Stateful).State()
+		assert.Equal(t, conditions.StateRunning, state)
+		assert.NoError(t, err)
+	})
+
+	t.Run("succeeded", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return nil
+		}, time.Millisecond)
+
+		err := cond.Wait(t.Context())
+		assert.NoError(t, err)
+
+		state, lastErr := cond.(conditions.Stateful).State()
+		assert.Equal(t, conditions.StateSucceeded, state)
+		assert.NoError(t, lastErr)
+	})
+
+	t.Run("skipped", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return conditions.ErrSkipAssertion
+		}, time.Millisecond)
+
+		err := cond.Wait(t.Context())
+		assert.NoError(t, err)
+
+		state, lastErr := cond.(conditions.Stateful).State()
+		assert.Equal(t, conditions.StateSkipped, state)
+		assert.NoError(t, lastErr)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		t.Parallel()
+
+		pollErr := errors.New("connection refused")
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return pollErr
+		}, time.Millisecond)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // cancel immediately so Wait exits after the first assertion attempt
+
+		err := cond.Wait(ctx)
+		assert.ErrorIs(t, err, context.Canceled)
+
+		state, lastErr := cond.(conditions.Stateful).State()
+		assert.Equal(t, conditions.StateFailed, state)
+		assert.Equal(t, pollErr, lastErr)
+	})
+}
+
+func TestDescribe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unpolled", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return nil
+		}, time.Millisecond)
+
+		assert.Equal(t, "Test: ...", conditions.StatusLine(cond))
+	})
+
+	t.Run("succeeded", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return nil
+		}, time.Millisecond)
+
+		err := cond.Wait(t.Context())
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Test: OK", conditions.StatusLine(cond))
+	})
+
+	t.Run("skipped", func(t *testing.T) {
+		t.Parallel()
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return conditions.ErrSkipAssertion
+		}, time.Millisecond)
+
+		err := cond.Wait(t.Context())
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Test: SKIP", conditions.StatusLine(cond))
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		t.Parallel()
+
+		pollErr := errors.New("connection refused")
+
+		cond := conditions.PollingCondition("Test", func(ctx context.Context) error {
+			return pollErr
+		}, time.Millisecond)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := cond.Wait(ctx)
+		assert.ErrorIs(t, err, context.Canceled)
+
+		assert.Equal(t, "Test: connection refused", conditions.StatusLine(cond))
+	})
+
+	t.Run("non-Stateful", func(t *testing.T) {
+		t.Parallel()
+
+		// A non-Stateful condition just returns its String() unchanged.
+		cond := conditions.WaitForFileToExist("test.txt")
+
+		assert.Equal(t, cond.String(), conditions.StatusLine(cond))
 	})
 }


### PR DESCRIPTION
## Work in progress

Until now, running tasks and transient errors were logged in red, which might be unnecessarily alarming for the end user.

This commit changes the color for running tasks/transient errors to be yellow. Non-transient, failed tasks are still reported as red.

To help visualize the change in UX:

### Before

"waiting" tasks representing transient errors and pending tasks were being reported in red.
<img width="1159" height="352" alt="Pasted image" src="https://github.com/user-attachments/assets/c5e0d634-96ba-42fb-ad38-9d33edfa535a" />
<img width="1159" height="352" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/d9d76f2e-da7e-442e-9348-cf0e7820d684" />

### After

"waiting" tasks are being reported in yellow.

<img width="821" height="269" alt="waiting" src="https://github.com/user-attachments/assets/3136777d-1d1b-4791-b504-5e750fbf00a7" />
<img width="821" height="269" alt="Pasted image" src="https://github.com/user-attachments/assets/f37914c0-710e-4337-b99e-35f11a0faa5c" />

Failed tasks (e.g. timeout) is still being reported in red (I forced a timeout by setting a short `--wait-timeout`):
<img width="821" height="269" alt="timeout" src="https://github.com/user-attachments/assets/40432718-41ca-44dd-a947-d45bd6f90d30" />
