### PR TITLE
docs: update KubeSpanConfig desc to match DiscoveryServiceConfig

### DIFF
--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -3305,9 +3305,9 @@
         "enabled": {
           "type": "boolean",
           "title": "enabled",
-          "description": "Enable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.\n",
-          "markdownDescription": "Enable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.",
-          "x-intellij-html-description": "\u003cp\u003eEnable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.\u003c/p\u003e\n"
+          "description": "Enable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.\n",
+          "markdownDescription": "Enable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.",
+          "x-intellij-html-description": "\u003cp\u003eEnable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.\u003c/p\u003e\n"
         },
         "advertiseKubernetesNetworks": {
           "type": "boolean",

--- a/pkg/machinery/config/types/network/kubespan.go
+++ b/pkg/machinery/config/types/network/kubespan.go
@@ -58,7 +58,7 @@ type KubeSpanConfigV1Alpha1 struct {
 
 	//   description: |
 	//     Enable the KubeSpan feature.
-	//     Cluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.
+	//     Requires cluster discovery to be enabled through a DiscoveryServiceConfig document.
 	//   schema:
 	//     type: boolean
 	ConfigEnabled *bool `yaml:"enabled,omitempty"`

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -1059,7 +1059,7 @@ func (KubeSpanConfigV1Alpha1) Doc() *encoder.Doc {
 				Name:        "enabled",
 				Type:        "bool",
 				Note:        "",
-				Description: "Enable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.",
+				Description: "Enable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Enable the KubeSpan feature." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{

--- a/website/content/v1.14/reference/configuration/network/kubespanconfig.md
+++ b/website/content/v1.14/reference/configuration/network/kubespanconfig.md
@@ -36,7 +36,7 @@ filters:
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`enabled` |bool |Enable the KubeSpan feature.<br>Cluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.  | |
+|`enabled` |bool |Enable the KubeSpan feature.<br>Requires cluster discovery to be enabled through a DiscoveryServiceConfig document.  | |
 |`advertiseKubernetesNetworks` |bool |Control whether Kubernetes pod CIDRs are announced over KubeSpan from the node.<br>If disabled, CNI handles pod-to-pod traffic encapsulation.<br>If enabled, KubeSpan takes over pod-to-pod traffic directly.  | |
 |`allowDownPeerBypass` |bool |Skip sending traffic via KubeSpan if the peer connection state is not up.<br>This provides configurable choice between connectivity and security.  | |
 |`harvestExtraEndpoints` |bool |KubeSpan can collect and publish extra endpoints for each member of the cluster<br>based on Wireguard endpoint information for each peer.<br>Disabled by default. Do not enable with high peer counts (>50).  | |

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -3305,9 +3305,9 @@
         "enabled": {
           "type": "boolean",
           "title": "enabled",
-          "description": "Enable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.\n",
-          "markdownDescription": "Enable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.",
-          "x-intellij-html-description": "\u003cp\u003eEnable the KubeSpan feature.\nCluster discovery should be enabled with cluster.discovery.enabled for KubeSpan to be enabled.\u003c/p\u003e\n"
+          "description": "Enable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.\n",
+          "markdownDescription": "Enable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.",
+          "x-intellij-html-description": "\u003cp\u003eEnable the KubeSpan feature.\nRequires cluster discovery to be enabled through a DiscoveryServiceConfig document.\u003c/p\u003e\n"
         },
         "advertiseKubernetesNetworks": {
           "type": "boolean",


### PR DESCRIPTION
Now directs the user to use DiscoveryServiceConfig.

Needed for https://github.com/siderolabs/docs/pull/606