### PR TITLE
feat: #10678 allow custom configuration for system volumes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4734,7 +4734,8 @@ jobs:
           QEMU_EXTRA_DISKS_TAGS: disk0
           USER_DISKS_MOUNTS: /var/mnt/extra,/var/mnt/p1,/var/mnt/p2
           WITH_CONFIG_PATCH: '@hack/test/patches/image-verification.yaml'
-          WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
+          WITH_CONFIG_PATCH_CONTROLPLANE: '@hack/test/patches/dedicated-system-volumes-controlplane.yaml'
+          WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml:@hack/test/patches/dedicated-system-volumes-worker.yaml'
           WITH_USER_DISK: "true"
         run: |
           sudo -E make e2e-qemu

--- a/.github/workflows/integration-qemu-triggered.yaml
+++ b/.github/workflows/integration-qemu-triggered.yaml
@@ -29,7 +29,8 @@ jobs:
             userDisksMounts: /var/mnt/extra,/var/mnt/p1,/var/mnt/p2
             variant: default
             withConfigPatch: '@hack/test/patches/image-verification.yaml'
-            withConfigPatchWorker: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
+            withConfigPatchControlPlane: '@hack/test/patches/dedicated-system-volumes-controlplane.yaml'
+            withConfigPatchWorker: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml:@hack/test/patches/dedicated-system-volumes-worker.yaml'
             withUserDisk: "true"
           - extraTestArgs: -talos.enforcing
             qemuExtraDisks: "3"
@@ -147,6 +148,7 @@ jobs:
           TAG_SUFFIX_IN: ${{ matrix.tagSuffixIn }}
           USER_DISKS_MOUNTS: ${{ matrix.userDisksMounts }}
           WITH_CONFIG_PATCH: ${{ matrix.withConfigPatch }}
+          WITH_CONFIG_PATCH_CONTROLPLANE: ${{ matrix.withConfigPatchControlPlane }}
           WITH_CONFIG_PATCH_WORKER: ${{ matrix.withConfigPatchWorker }}
           WITH_DISK_ENCRYPTION: ${{ matrix.withDiskEncryption }}
           WITH_ENFORCING: ${{ matrix.withEnforcing }}

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -458,7 +458,8 @@ spec:
             withUserDisk: "true"
             userDisksMounts: "/var/mnt/extra,/var/mnt/p1,/var/mnt/p2"
             withConfigPatch: "@hack/test/patches/image-verification.yaml"
-            withConfigPatchWorker: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml"
+            withConfigPatchWorker: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml:@hack/test/patches/dedicated-system-volumes-worker.yaml"
+            withConfigPatchControlPlane: "@hack/test/patches/dedicated-system-volumes-controlplane.yaml"
             qemuExtraDisks: "5"
             qemuExtraDisksDrivers: "virtiofs,ide,nvme"
             qemuExtraDiscsTags: "disk0"
@@ -533,6 +534,7 @@ spec:
             USER_DISKS_MOUNTS: ${{ matrix.userDisksMounts }}
             WITH_CONFIG_PATCH: ${{ matrix.withConfigPatch }}
             WITH_CONFIG_PATCH_WORKER: ${{ matrix.withConfigPatchWorker }}
+            WITH_CONFIG_PATCH_CONTROLPLANE: ${{ matrix.withConfigPatchControlPlane }}
             WITH_TALOS_VERSION: ${{ matrix.withTalosVersion }}
             QEMU_EXTRA_DISKS: ${{ matrix.qemuExtraDisks }}
             QEMU_EXTRA_DISKS_SIZE: "10240"

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
@@ -7,6 +7,7 @@ package makers_test
 import (
 	"testing"
 
+	sideronet "github.com/siderolabs/net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,7 +16,11 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/flags"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
@@ -122,4 +127,257 @@ func TestQemuMaker_Disks(t *testing.T) {
 			Serial:          "",
 		},
 	}, workerDisks)
+}
+
+func TestQemuMaker_DiskEncryption_StatePartition(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"uuid"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	blockCfg := block.NewVolumeConfigV1Alpha1()
+	blockCfg.MetaName = constants.StatePartitionLabel
+	blockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:   0,
+				KeyNodeID: &block.EncryptionKeyNodeID{},
+			},
+		},
+	}
+
+	ctr, err := container.New(blockCfg)
+	require.NoError(t, err)
+
+	assertConfigDefaultness(t, cOps, *m.Maker, nil, configpatcher.NewStrategicMergePatch(ctr))
+}
+
+func TestQemuMaker_DiskEncryption_EphemeralPartition(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptEphemeralPartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"uuid"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	blockCfg := block.NewVolumeConfigV1Alpha1()
+	blockCfg.MetaName = constants.EphemeralPartitionLabel
+	blockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:        0,
+				KeyNodeID:      &block.EncryptionKeyNodeID{},
+				KeyLockToSTATE: new(true),
+			},
+		},
+	}
+
+	ctr, err := container.New(blockCfg)
+	require.NoError(t, err)
+
+	assertConfigDefaultness(t, cOps, *m.Maker, nil, configpatcher.NewStrategicMergePatch(ctr))
+}
+
+func TestQemuMaker_DiskEncryption_BothPartitions(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.EncryptEphemeralPartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"uuid"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	// STATE partition patch (no KeyLockToSTATE)
+	stateBlockCfg := block.NewVolumeConfigV1Alpha1()
+	stateBlockCfg.MetaName = constants.StatePartitionLabel
+	stateBlockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:   0,
+				KeyNodeID: &block.EncryptionKeyNodeID{},
+			},
+		},
+	}
+
+	// EPHEMERAL partition patch (with KeyLockToSTATE)
+	ephemeralBlockCfg := block.NewVolumeConfigV1Alpha1()
+	ephemeralBlockCfg.MetaName = constants.EphemeralPartitionLabel
+	ephemeralBlockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:        0,
+				KeyNodeID:      &block.EncryptionKeyNodeID{},
+				KeyLockToSTATE: new(true),
+			},
+		},
+	}
+
+	stateCtr, err := container.New(stateBlockCfg)
+	require.NoError(t, err)
+
+	ephemeralCtr, err := container.New(ephemeralBlockCfg)
+	require.NoError(t, err)
+
+	assertConfigDefaultness(
+		t, cOps, *m.Maker, nil,
+		configpatcher.NewStrategicMergePatch(stateCtr),
+		configpatcher.NewStrategicMergePatch(ephemeralCtr),
+	)
+}
+
+func TestQemuMaker_DiskEncryption_KMSKeyType(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"kms"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	// Compute the expected bridge IP as done in getEncryptionKeys
+	bridgeIP, err := sideronet.NthIPInNetwork(m.Cidrs[0], 1)
+	require.NoError(t, err)
+
+	blockCfg := block.NewVolumeConfigV1Alpha1()
+	blockCfg.MetaName = constants.StatePartitionLabel
+	blockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot: 0,
+				KeyKMS: &block.EncryptionKeyKMS{
+					KMSEndpoint: "grpc://" + nethelpers.JoinHostPort(bridgeIP.String(), 4050),
+				},
+			},
+		},
+	}
+
+	ctr, err := container.New(blockCfg)
+	require.NoError(t, err)
+
+	assertConfigDefaultness(t, cOps, *m.Maker, nil, configpatcher.NewStrategicMergePatch(ctr))
+}
+
+func TestQemuMaker_DiskEncryption_MultipleKeyTypes(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"uuid", "tpm"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	blockCfg := block.NewVolumeConfigV1Alpha1()
+	blockCfg.MetaName = constants.StatePartitionLabel
+	blockCfg.EncryptionSpec = block.EncryptionSpec{
+		EncryptionProvider: blockres.EncryptionProviderLUKS2,
+		EncryptionKeys: []block.EncryptionKey{
+			{
+				KeySlot:   0,
+				KeyNodeID: &block.EncryptionKeyNodeID{},
+			},
+			{
+				KeySlot: 1,
+				KeyTPM: &block.EncryptionKeyTPM{
+					TPMCheckSecurebootStatusOnEnroll: new(true),
+				},
+			},
+		},
+	}
+
+	ctr, err := container.New(blockCfg)
+	require.NoError(t, err)
+
+	assertConfigDefaultness(t, cOps, *m.Maker, nil, configpatcher.NewStrategicMergePatch(ctr))
+}
+
+func TestQemuMaker_DiskEncryption_LegacyVersion(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	cOps.TalosVersion = "v1.6.0"
+
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"tpm"}
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	// For legacy version, the encryption config is applied to machine.systemDiskEncryption
+	// Verify the generated cluster config doesn't fail and includes the legacy encryption path
+	clusterCfgs, err := m.GetClusterConfigs()
+	require.NoError(t, err)
+
+	cfgBytes, err := clusterCfgs.ClusterRequest.Nodes[0].Config.EncodeBytes()
+	require.NoError(t, err)
+
+	cfgStr := string(cfgBytes)
+	// Legacy versions use systemDiskEncryption, not VolumeConfig
+	assert.Contains(t, cfgStr, "systemDiskEncryption")
+	assert.Contains(t, cfgStr, "provider: luks2")
+	assert.Contains(t, cfgStr, "tpm: {}")
+}
+
+func TestQemuMaker_DiskEncryption_ErrorUnknownKeyType(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = []string{"bogus"}
+
+	_, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown key type")
+}
+
+func TestQemuMaker_DiskEncryption_ErrorNoKeyTypes(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.EncryptStatePartition = true
+	qOps.DiskEncryptionKeyTypes = nil
+
+	_, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no disk encryption key types enabled")
 }

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -148,7 +148,7 @@ DHCPv4 search domains are now applied to the resolver configuration.
 DHCPv4 configuration now supports `ignoreRoutes` option to ignore routes provided by DHCPv4 servers.
 """
 
-[notes.EPHEMERAL]
+    [notes.EPHEMERAL]
         title = "noexec on EPHEMERAL (/var)"
         description = """\
 Talos 1.14 clusters now default the EPHEMERAL volume (`/var`) to `noexec` in addition to the existing `nosuid` and `nodev`
@@ -173,6 +173,27 @@ mount:
 > NOTE: Setting `secure: false` will also disable `nosuid` and `nodev`, which may have security implications. Use with caution.
 
 Longhorn v2 (SPDK data engine) runs the data plane inside the instance manager process and is not affected.
+"""
+
+    [notes.systemVolumes]
+        title = "Dedicated System Volumes"
+        description = """\
+The `ETCD`, `CRI`, `KUBELET` and `LOG` system volumes (`/var/lib/etcd`, `/var/lib/containerd`, `/var/lib/kubelet` and `/var/log`) can now be placed on dedicated partitions via a `VolumeConfig` document with `provisioning` set (optionally encrypted). By default they remain directories under the `EPHEMERAL` volume.
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: ETCD
+provisioning:
+  minSize: 1GB
+  maxSize: 2GB
+```
+
+The backing (directory vs. dedicated partition) is fixed at cluster creation: switching an already-provisioned node between the two is rejected.
+
+A dedicated partition has its own mount, so the `mount.secure` option (`nosuid`/`noexec`/`nodev`, enabled by default) can be set per volume; directory-backed volumes inherit the `EPHEMERAL` mount options.
+
+Note that with `ETCD` on a dedicated partition, etcd data no longer lives under `EPHEMERAL`. Resetting a control plane node with only the `EPHEMERAL` partition wiped will not clear etcd data; wipe the `ETCD` volume to reset etcd.
 """
 
     [notes.DoT]

--- a/hack/test/patches/dedicated-system-volumes-controlplane.yaml
+++ b/hack/test/patches/dedicated-system-volumes-controlplane.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: KUBELET
+provisioning:
+  minSize: 1GB
+  maxSize: 2GB
+mount:
+  # Just to test that nosuid,noexec,nodev are unset for this volume
+  secure: false
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: CRI
+provisioning:
+  minSize: 1GB
+  maxSize: 2GB
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: ETCD
+provisioning:
+  minSize: 1GB
+  maxSize: 2GB
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: LOG
+provisioning:
+  minSize: 1GB
+  maxSize: 1GB
+mount:
+  # This is also the default for all of the promotable system volumes, but let's set it explicitly for testing purposes
+  secure: true
+---

--- a/hack/test/patches/dedicated-system-volumes-worker.yaml
+++ b/hack/test/patches/dedicated-system-volumes-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: LOG
+provisioning:
+  minSize: 1GB
+  maxSize: 1GB
+mount:
+  secure: true
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: KUBELET
+provisioning:
+  minSize: 1GB
+  maxSize: 2GB
+mount:
+  secure: false
+---

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block/internal/volumes"
 	"github.com/siderolabs/talos/internal/pkg/partition"
 	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
@@ -42,6 +43,7 @@ func GetSystemVolumeTransformers(ctx context.Context,
 		metaVolumeTransformer,
 		GetStateVolumeTransformer(encryptionMeta, inContainer, isAgent),
 		GetEphemeralVolumeTransformer(inContainer),
+		GetPromotableSystemVolumesTransformer(inContainer),
 		StandardDirectoryVolumesTransformer,
 		GetOverlayVolumesTransformer(inContainer),
 	}
@@ -279,6 +281,140 @@ func manageStateConfigPresent(cfg configconfig.Config) func(vc *block.VolumeConf
 	}
 }
 
+// promotableVolumeDefinitions are the system volumes that default to a directory under the
+// EPHEMERAL volume, but can be placed on a dedicated partition via a VolumeConfig document at
+// cluster creation time.
+var promotableVolumeDefinitions = []struct {
+	ID           string
+	Path         string
+	Mode         os.FileMode
+	UID          int
+	GID          int
+	Recursive    bool
+	SELinuxLabel string
+}{
+	{
+		ID:           constants.EtcdDataVolumeID,
+		Path:         constants.EtcdDataPath,
+		SELinuxLabel: constants.EtcdDataSELinuxLabel,
+		Mode:         0o700,
+		UID:          constants.EtcdUserID,
+		GID:          constants.EtcdUserID,
+		Recursive:    true,
+	},
+	{
+		ID:           constants.CRIContainerdVolumeID,
+		Path:         constants.CRIContainerdDataPath,
+		SELinuxLabel: constants.CRIContainerdDataSELinuxLabel,
+		Mode:         0o000,
+	},
+	{
+		ID:           constants.KubeletDataVolumeID,
+		Path:         constants.KubeletDataPath,
+		SELinuxLabel: constants.KubeletDataSELinuxLabel,
+		Mode:         0o700,
+	},
+	{
+		ID:           constants.LogVolumeID,
+		Path:         constants.LogMountPoint,
+		SELinuxLabel: constants.LogSELinuxLabel,
+		Mode:         0o755,
+	},
+}
+
+// GetPromotableSystemVolumesTransformer returns the transformer for the promotable system volumes
+// (ETCD, CRI, KUBELET, LOG).
+//
+// By default each is provisioned as a directory under the EPHEMERAL volume (identical to the
+// legacy behavior). If a matching VolumeConfig with provisioning is present, the volume is instead
+// provisioned as a dedicated partition mounted at the same path.
+//
+// The chosen backing (directory vs. dedicated partition) is fixed at cluster creation: switching an
+// already-provisioned node between the two is rejected by VolumeConfig.RuntimeValidate, so this
+// transformer never has to migrate existing volume data.
+func GetPromotableSystemVolumesTransformer(inContainer bool) volumeConfigTransformer {
+	return func(cfg configconfig.Config) ([]VolumeResource, error) {
+		// skip if no config
+		if cfg == nil || cfg.Machine() == nil {
+			return nil, nil
+		}
+
+		resources := make([]VolumeResource, 0, len(promotableVolumeDefinitions))
+
+		for _, volume := range promotableVolumeDefinitions {
+			// the mount spec is the same whether the volume is a directory or a partition: it is
+			// always mounted at `volume.Path`, under its parent directory volume (e.g. /var/lib).
+			parentID := filepath.Dir(volume.Path)
+			// the /var mount point is provided by the EPHEMERAL volume, whose ID is not "/var".
+			if parentID == constants.EphemeralMountPoint {
+				parentID = constants.EphemeralPartitionLabel
+			}
+
+			mountSpec := block.MountSpec{
+				TargetPath:       filepath.Base(volume.Path),
+				ParentID:         parentID,
+				SelinuxLabel:     volume.SELinuxLabel,
+				FileMode:         volume.Mode,
+				UID:              volume.UID,
+				GID:              volume.GID,
+				RecursiveRelabel: volume.Recursive,
+			}
+
+			extraVolumeConfig, _ := cfg.Volumes().ByName(volume.ID)
+
+			var builder *Builder
+
+			if inContainer || !blockcfg.ProvisioningRequested(extraVolumeConfig.Provisioning()) {
+				// default: directory under EPHEMERAL (partitions cannot be provisioned in a container)
+				builder = NewBuilder().
+					WithType(block.VolumeTypeDirectory).
+					WithMount(mountSpec)
+			} else {
+				// placed on a dedicated partition
+				provisioning := extraVolumeConfig.Provisioning()
+
+				// a dedicated partition has its own mount, so honor the configured mount.secure
+				// (nosuid/noexec/nodev); a directory-backed volume inherits the EPHEMERAL mount.
+				mountSpec.Secure = extraVolumeConfig.Mount().Secure()
+
+				builder = NewBuilder().
+					WithType(block.VolumeTypePartition).
+					WithProvisioning(block.ProvisioningSpec{
+						Wave: block.WaveSystemDisk,
+						DiskSelector: block.DiskSelector{
+							Match: provisioning.DiskSelector().ValueOr(systemDiskMatch()),
+						},
+						PartitionSpec: block.PartitionSpec{
+							MinSize:         provisioning.MinSize().ValueOr(quirks.New("").PartitionSizes().EphemeralMinSize()),
+							MaxSize:         provisioning.MaxSize().ValueOrZero(),
+							RelativeMaxSize: provisioning.RelativeMaxSize().ValueOrZero(),
+							NegativeMaxSize: provisioning.MaxSizeNegative(),
+							Grow:            provisioning.Grow().ValueOr(false),
+							Label:           volume.ID,
+							TypeUUID:        partition.LinuxFilesystemData,
+						},
+						FilesystemSpec: block.FilesystemSpec{
+							Type:  block.FilesystemTypeXFS,
+							Label: volume.ID,
+						},
+					}).
+					WithMount(mountSpec).
+					WithLocator(labelVolumeMatch(volume.ID)).
+					WithTrim(cfg, extraVolumeConfig).
+					WithConvertEncryptionConfiguration(extraVolumeConfig.Encryption())
+			}
+
+			resources = append(resources, VolumeResource{
+				VolumeID:      volume.ID,
+				Label:         block.SystemVolumeLabel,
+				TransformFunc: builder.WriterFunc(),
+			})
+		}
+
+		return resources, nil
+	}
+}
+
 var standardVolumeDefinitions = []struct {
 	ID           string
 	Path         string
@@ -288,12 +424,8 @@ var standardVolumeDefinitions = []struct {
 	Recursive    bool
 	SELinuxLabel string
 }{
-	// /var/log
-	{
-		Path:         "/var/log",
-		Mode:         0o755,
-		SELinuxLabel: "system_u:object_r:var_log_t:s0",
-	},
+	// /var/log itself is a promotable system volume (LOG), handled by
+	// GetPromotableSystemVolumesTransformer; only its child directories are created here.
 	{
 		Path:         "/var/log/audit",
 		Mode:         0o700,
@@ -323,25 +455,9 @@ var standardVolumeDefinitions = []struct {
 		Mode:         0o700,
 		SELinuxLabel: constants.EphemeralSelinuxLabel,
 	},
-	{
-		ID:           constants.EtcdDataVolumeID,
-		Path:         constants.EtcdDataPath,
-		SELinuxLabel: constants.EtcdDataSELinuxLabel,
-		Mode:         0o700,
-		UID:          constants.EtcdUserID,
-		GID:          constants.EtcdUserID,
-		Recursive:    true,
-	},
-	{
-		Path:         "/var/lib/containerd",
-		Mode:         0o000,
-		SELinuxLabel: "system_u:object_r:containerd_state_t:s0",
-	},
-	{
-		Path:         "/var/lib/kubelet",
-		Mode:         0o700,
-		SELinuxLabel: "system_u:object_r:kubelet_state_t:s0",
-	},
+	// ETCD, CRI (containerd), KUBELET and LOG (/var/log) are "promotable" system volumes: by
+	// default they are directories under EPHEMERAL, but they can be promoted to a dedicated
+	// partition via a VolumeConfig document. They are handled by GetPromotableSystemVolumesTransformer.
 	{
 		Path:         "/var/lib/cni",
 		Mode:         0o700,
@@ -402,6 +518,13 @@ func StandardDirectoryVolumesTransformer(cfg configconfig.Config) ([]VolumeResou
 	parentIDs := map[string]string{
 		"/var":     constants.EphemeralPartitionLabel,
 		"/var/run": "/var/run",
+		// promotable system volumes are created by GetPromotableSystemVolumesTransformer, but
+		// their child directories (e.g. /var/lib/kubelet/seccomp) are created here, so their
+		// volume IDs must be known to resolve the parent mount.
+		constants.EtcdDataPath:          constants.EtcdDataVolumeID,
+		constants.CRIContainerdDataPath: constants.CRIContainerdVolumeID,
+		constants.KubeletDataPath:       constants.KubeletDataVolumeID,
+		constants.LogMountPoint:         constants.LogVolumeID,
 	}
 
 	for _, volume := range standardVolumeDefinitions {

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
@@ -47,7 +47,7 @@ func TestGetSystemVolumeTransformers(t *testing.T) {
 	encryptionMeta := runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(meta.StateEncryptionConfig))
 
 	transformers := volumeconfig.GetSystemVolumeTransformers(ctx, encryptionMeta, false, false)
-	require.Len(t, transformers, 5, "should return 5 transformers")
+	require.Len(t, transformers, 6, "should return 6 transformers")
 
 	var allResources []volumeconfig.VolumeResource //nolint:prealloc // this is a test
 
@@ -63,7 +63,7 @@ func TestGetSystemVolumeTransformers(t *testing.T) {
 		constants.StatePartitionLabel,
 		constants.EphemeralPartitionLabel,
 		"/var/run",
-		"/var/log",
+		constants.LogVolumeID,
 	} {
 		assert.Condition(t, func() bool {
 			for _, r := range allResources {
@@ -270,7 +270,7 @@ func TestStandardDirectoryVolumesTransformer(t *testing.T) {
 			name: "W/ config",
 			cfg:  &baseCfg,
 			checkFunc: func(t *testing.T, resources []volumeconfig.VolumeResource) {
-				require.Len(t, resources, 1+14) // +1 for /var/run symlink, +14 for standard directories
+				require.Len(t, resources, 1+10) // +1 for /var/run symlink, +10 for standard directories (ETCD/CRI/KUBELET/LOG are promotable, handled separately)
 
 				var varRunSymlinkResource *volumeconfig.VolumeResource
 
@@ -291,8 +291,8 @@ func TestStandardDirectoryVolumesTransformer(t *testing.T) {
 					assert.Equal(t, "/run", vc.TypedSpec().Symlink.SymlinkTargetPath)
 				})
 
-				// Check some standard directories
-				expectedPaths := []string{"/var/log", "/var/lib", constants.EtcdDataVolumeID}
+				// Check some standard directories (/var/log itself is promotable; its children remain here)
+				expectedPaths := []string{"/var/log/audit", "/var/lib", "/var/lib/cni"}
 				for _, expectedPath := range expectedPaths {
 					var found bool
 
@@ -325,6 +325,322 @@ func TestStandardDirectoryVolumesTransformer(t *testing.T) {
 			tc.checkFunc(t, resources)
 		})
 	}
+}
+
+func TestGetPromotableSystemVolumesTransformer(t *testing.T) {
+	t.Parallel()
+
+	findResource := func(t *testing.T, resources []volumeconfig.VolumeResource, volumeID string) volumeconfig.VolumeResource {
+		t.Helper()
+
+		for i := range resources {
+			if resources[i].VolumeID == volumeID {
+				return resources[i]
+			}
+		}
+
+		t.Fatalf("missing resource for %q", volumeID)
+
+		return volumeconfig.VolumeResource{}
+	}
+
+	t.Run("default is directory", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(container.NewV1Alpha1(&baseCfg))
+		require.NoError(t, err)
+		require.Len(t, resources, 4)
+
+		for _, volumeID := range []string{constants.EtcdDataVolumeID, constants.CRIContainerdVolumeID, constants.KubeletDataVolumeID, constants.LogVolumeID} {
+			r := findResource(t, resources, volumeID)
+
+			testTransformFunc(t, r.TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+				require.NoError(t, err)
+
+				assert.Equal(t, block.VolumeTypeDirectory, vc.TypedSpec().Type)
+				assert.Empty(t, vc.TypedSpec().Provisioning)
+			})
+		}
+	})
+
+	t.Run("promoted to partition via VolumeConfig", func(t *testing.T) {
+		t.Parallel()
+
+		etcdCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		etcdCfg.MetaName = constants.EtcdDataVolumeID
+		etcdCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		cfg, err := container.New(baseCfg.DeepCopy(), etcdCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		// ETCD promoted to a partition
+		testTransformFunc(t, findResource(t, resources, constants.EtcdDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypePartition, vc.TypedSpec().Type)
+			assert.Equal(t, block.WaveSystemDisk, vc.TypedSpec().Provisioning.Wave)
+			assert.Equal(t, constants.EtcdDataVolumeID, vc.TypedSpec().Provisioning.PartitionSpec.Label)
+			assert.EqualValues(t, 50*1024*1024*1024, vc.TypedSpec().Provisioning.PartitionSpec.MaxSize)
+
+			locator, err := vc.TypedSpec().Locator.Match.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, `volume.partition_label == "ETCD"`, string(locator))
+		})
+
+		// KUBELET stays a directory
+		testTransformFunc(t, findResource(t, resources, constants.KubeletDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypeDirectory, vc.TypedSpec().Type)
+		})
+	})
+
+	// promoteCfg builds a config that promotes a single volume via a maxSize provisioning request.
+	promoteCfg := func(t *testing.T, volumeID string) *container.Container {
+		t.Helper()
+
+		volCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		volCfg.MetaName = volumeID
+		volCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		cfg, err := container.New(baseCfg.DeepCopy(), volCfg)
+		require.NoError(t, err)
+
+		return cfg
+	}
+
+	// assertPromoted asserts that volumeID is provisioned as a dedicated partition.
+	assertPromoted := func(t *testing.T, resources []volumeconfig.VolumeResource, volumeID string) {
+		t.Helper()
+
+		testTransformFunc(t, findResource(t, resources, volumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypePartition, vc.TypedSpec().Type)
+			assert.Equal(t, block.WaveSystemDisk, vc.TypedSpec().Provisioning.Wave)
+			assert.Equal(t, volumeID, vc.TypedSpec().Provisioning.PartitionSpec.Label)
+			assert.Equal(t, block.FilesystemTypeXFS, vc.TypedSpec().Provisioning.FilesystemSpec.Type)
+
+			locator, err := vc.TypedSpec().Locator.Match.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, `volume.partition_label == "`+volumeID+`"`, string(locator))
+		})
+	}
+
+	assertDirectory := func(t *testing.T, resources []volumeconfig.VolumeResource, volumeID string) {
+		t.Helper()
+
+		testTransformFunc(t, findResource(t, resources, volumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypeDirectory, vc.TypedSpec().Type)
+		})
+	}
+
+	t.Run("promote CRI", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(promoteCfg(t, constants.CRIContainerdVolumeID))
+		require.NoError(t, err)
+
+		assertPromoted(t, resources, constants.CRIContainerdVolumeID)
+		assertDirectory(t, resources, constants.EtcdDataVolumeID)
+		assertDirectory(t, resources, constants.KubeletDataVolumeID)
+	})
+
+	t.Run("promote KUBELET", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(promoteCfg(t, constants.KubeletDataVolumeID))
+		require.NoError(t, err)
+
+		assertPromoted(t, resources, constants.KubeletDataVolumeID)
+		assertDirectory(t, resources, constants.EtcdDataVolumeID)
+		assertDirectory(t, resources, constants.CRIContainerdVolumeID)
+	})
+
+	t.Run("promote LOG", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(promoteCfg(t, constants.LogVolumeID))
+		require.NoError(t, err)
+
+		assertPromoted(t, resources, constants.LogVolumeID)
+		assertDirectory(t, resources, constants.EtcdDataVolumeID)
+		assertDirectory(t, resources, constants.CRIContainerdVolumeID)
+		assertDirectory(t, resources, constants.KubeletDataVolumeID)
+	})
+
+	t.Run("promote all four", func(t *testing.T) {
+		t.Parallel()
+
+		etcdCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		etcdCfg.MetaName = constants.EtcdDataVolumeID
+		etcdCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		criCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		criCfg.MetaName = constants.CRIContainerdVolumeID
+		criCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		kubeletCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		kubeletCfg.MetaName = constants.KubeletDataVolumeID
+		kubeletCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		logCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		logCfg.MetaName = constants.LogVolumeID
+		logCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		cfg, err := container.New(baseCfg.DeepCopy(), etcdCfg, criCfg, kubeletCfg, logCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		assertPromoted(t, resources, constants.EtcdDataVolumeID)
+		assertPromoted(t, resources, constants.CRIContainerdVolumeID)
+		assertPromoted(t, resources, constants.KubeletDataVolumeID)
+		assertPromoted(t, resources, constants.LogVolumeID)
+	})
+
+	t.Run("promoted mount is secure by default", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(promoteCfg(t, constants.LogVolumeID))
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.LogVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypePartition, vc.TypedSpec().Type)
+			assert.True(t, vc.TypedSpec().Mount.Secure, "promoted volume is secure by default (like EPHEMERAL)")
+		})
+	})
+
+	t.Run("promoted mount honors mount.secure=false", func(t *testing.T) {
+		t.Parallel()
+
+		secureOff := false
+		logCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		logCfg.MetaName = constants.LogVolumeID
+		logCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+		logCfg.MountSpec.MountSecure = &secureOff
+
+		cfg, err := container.New(baseCfg.DeepCopy(), logCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.LogVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypePartition, vc.TypedSpec().Type)
+			assert.False(t, vc.TypedSpec().Mount.Secure, "promoted LOG should honor mount.secure=false")
+		})
+	})
+
+	t.Run("custom diskSelector honored", func(t *testing.T) {
+		t.Parallel()
+
+		etcdCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		etcdCfg.MetaName = constants.EtcdDataVolumeID
+		etcdCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+		require.NoError(t, etcdCfg.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.transport == "nvme"`)))
+
+		cfg, err := container.New(baseCfg.DeepCopy(), etcdCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.EtcdDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			diskSelector, err := vc.TypedSpec().Provisioning.DiskSelector.Match.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, `disk.transport == "nvme"`, string(diskSelector))
+		})
+	})
+
+	t.Run("grow defaults to false", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(promoteCfg(t, constants.EtcdDataVolumeID))
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.EtcdDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			// unlike EPHEMERAL (grow defaults to true), promoted system volumes default to grow=false.
+			assert.False(t, vc.TypedSpec().Provisioning.PartitionSpec.Grow)
+		})
+	})
+
+	t.Run("encryption wired", func(t *testing.T) {
+		t.Parallel()
+
+		etcdCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		etcdCfg.MetaName = constants.EtcdDataVolumeID
+		etcdCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+		etcdCfg.EncryptionSpec.EncryptionProvider = block.EncryptionProviderLUKS2
+		etcdCfg.EncryptionSpec.EncryptionKeys = []blockcfg.EncryptionKey{
+			{
+				KeySlot: 0,
+				KeyStatic: &blockcfg.EncryptionKeyStatic{
+					KeyData: "topsecret",
+				},
+			},
+		}
+
+		cfg, err := container.New(baseCfg.DeepCopy(), etcdCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.EtcdDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypePartition, vc.TypedSpec().Type)
+			assert.NotEmpty(t, vc.TypedSpec().Encryption, "configured encryption must be wired into the promoted volume")
+			assert.Equal(t, block.EncryptionProviderLUKS2, vc.TypedSpec().Encryption.Provider)
+		})
+	})
+
+	t.Run("always directory in container", func(t *testing.T) {
+		t.Parallel()
+
+		etcdCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		etcdCfg.MetaName = constants.EtcdDataVolumeID
+		etcdCfg.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("50GiB")
+
+		cfg, err := container.New(baseCfg.DeepCopy(), etcdCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetPromotableSystemVolumesTransformer(true)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+
+		testTransformFunc(t, findResource(t, resources, constants.EtcdDataVolumeID).TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+
+			assert.Equal(t, block.VolumeTypeDirectory, vc.TypedSpec().Type)
+		})
+	})
 }
 
 func TestGetOverlayVolumesTransformer(t *testing.T) {

--- a/internal/app/machined/pkg/controllers/block/volume_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config_test.go
@@ -164,13 +164,13 @@ func (suite *VolumeConfigSuite) TestReconcileDefaults() {
 	})
 
 	ctest.AssertResources(suite, []resource.ID{
-		constants.LogMountPoint,
+		constants.LogVolumeID,
 		"/var/log/audit",
 		"/var/log/containers",
 		"/var/log/pods",
 		constants.EtcdDataVolumeID,
-		"/var/lib/containerd",
-		"/var/lib/kubelet",
+		constants.CRIContainerdVolumeID,
+		constants.KubeletDataVolumeID,
 		"/var/lib/cni",
 		constants.SeccompProfilesDirectory,
 		constants.KubernetesAuditLogDir,
@@ -334,6 +334,225 @@ func (suite *VolumeConfigSuite) TestReconcileExtraEPHEMERALConfig() {
 		asrt.EqualValues(2.5*1024*1024*1024*1024, r.TypedSpec().Provisioning.PartitionSpec.MaxSize)
 		asrt.EqualValues(quirks.New("").PartitionSizes().EphemeralMinSize(), r.TypedSpec().Provisioning.PartitionSpec.MinSize)
 
+		asrt.Equal(block.EncryptionProviderLUKS2, r.TypedSpec().Encryption.Provider)
+	})
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteETCD() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	ctr, err := container.New(
+		&v1alpha1.Config{
+			ConfigVersion: "v1alpha1",
+			MachineConfig: &v1alpha1.MachineConfig{},
+			ClusterConfig: &v1alpha1.ClusterConfig{
+				ControlPlane: &v1alpha1.ControlPlaneConfig{
+					Endpoint: &v1alpha1.Endpoint{
+						URL: u,
+					},
+				},
+			},
+		},
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName: constants.EtcdDataVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{
+				DiskSelectorSpec: blockcfg.DiskSelector{
+					Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.transport == "nvme"`, celenv.DiskLocator())),
+				},
+				ProvisioningMaxSize: blockcfg.MustSize("50GiB"),
+			},
+		},
+	)
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(ctr)
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), cfg))
+
+	// ETCD should now be provisioned as a dedicated partition instead of a directory
+	ctest.AssertResource(suite, constants.EtcdDataVolumeID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypePartition, r.TypedSpec().Type)
+		asrt.NotEmpty(r.TypedSpec().Provisioning)
+		asrt.Equal(block.WaveSystemDisk, r.TypedSpec().Provisioning.Wave)
+
+		locator, err := r.TypedSpec().Locator.Match.MarshalText()
+		asrt.NoError(err)
+		asrt.Equal(`volume.partition_label == "ETCD"`, string(locator))
+
+		diskSelector, err := r.TypedSpec().Provisioning.DiskSelector.Match.MarshalText()
+		asrt.NoError(err)
+		asrt.Equal(`disk.transport == "nvme"`, string(diskSelector))
+
+		asrt.Equal(constants.EtcdDataVolumeID, r.TypedSpec().Provisioning.PartitionSpec.Label)
+		asrt.EqualValues(50*1024*1024*1024, r.TypedSpec().Provisioning.PartitionSpec.MaxSize)
+
+		// mounted at the same path, under its parent directory volume (/var/lib)
+		asrt.Equal("etcd", r.TypedSpec().Mount.TargetPath)
+		asrt.Equal(filepath.Dir(constants.EtcdDataPath), r.TypedSpec().Mount.ParentID)
+		asrt.Equal(constants.EtcdDataSELinuxLabel, r.TypedSpec().Mount.SelinuxLabel)
+	})
+
+	// CRI, KUBELET and LOG remain directories (no VolumeConfig)
+	ctest.AssertResource(suite, constants.CRIContainerdVolumeID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypeDirectory, r.TypedSpec().Type)
+	})
+	ctest.AssertResource(suite, constants.KubeletDataVolumeID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypeDirectory, r.TypedSpec().Type)
+	})
+	ctest.AssertResource(suite, constants.LogVolumeID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypeDirectory, r.TypedSpec().Type)
+	})
+}
+
+// clusterEndpointConfig returns a minimal v1alpha1 config with a control plane endpoint,
+// which is the prerequisite for the system volume transformers to emit resources.
+func (suite *VolumeConfigSuite) clusterEndpointConfig() *v1alpha1.Config {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	return &v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+		},
+	}
+}
+
+// assertPromotedVolume returns an assertion that the volume is provisioned as a dedicated partition
+// mounted at the same path under its parent directory volume.
+func assertPromotedVolume(volumeID, path, selinuxLabel string) func(*block.VolumeConfig, *assert.Assertions) {
+	return func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypePartition, r.TypedSpec().Type)
+		asrt.NotEmpty(r.TypedSpec().Provisioning)
+		asrt.Equal(block.WaveSystemDisk, r.TypedSpec().Provisioning.Wave)
+		asrt.Equal(volumeID, r.TypedSpec().Provisioning.PartitionSpec.Label)
+
+		locator, err := r.TypedSpec().Locator.Match.MarshalText()
+		asrt.NoError(err)
+		asrt.Equal(`volume.partition_label == "`+volumeID+`"`, string(locator))
+
+		asrt.Equal(filepath.Base(path), r.TypedSpec().Mount.TargetPath)
+
+		// the /var mount point is provided by the EPHEMERAL volume, whose ID is not "/var".
+		expectedParentID := filepath.Dir(path)
+		if expectedParentID == constants.EphemeralMountPoint {
+			expectedParentID = constants.EphemeralPartitionLabel
+		}
+
+		asrt.Equal(expectedParentID, r.TypedSpec().Mount.ParentID)
+		asrt.Equal(selinuxLabel, r.TypedSpec().Mount.SelinuxLabel)
+	}
+}
+
+// reconcilePromoteSingle promotes a single system volume via maxSize provisioning and asserts that
+// it becomes a dedicated partition while the other promotable volumes remain directories.
+func (suite *VolumeConfigSuite) reconcilePromoteSingle(volumeID, path, selinuxLabel string, otherVolumeIDs ...string) {
+	ctr, err := container.New(
+		suite.clusterEndpointConfig(),
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName: volumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{
+				ProvisioningMaxSize: blockcfg.MustSize("50GiB"),
+			},
+		},
+	)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), config.NewMachineConfig(ctr)))
+
+	ctest.AssertResource(suite, volumeID, assertPromotedVolume(volumeID, path, selinuxLabel))
+
+	// the other promotable volumes remain directories (no VolumeConfig)
+	for _, otherID := range otherVolumeIDs {
+		ctest.AssertResource(suite, otherID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+			asrt.Equal(block.VolumeTypeDirectory, r.TypedSpec().Type)
+		})
+	}
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteCRI() {
+	suite.reconcilePromoteSingle(constants.CRIContainerdVolumeID, constants.CRIContainerdDataPath, constants.CRIContainerdDataSELinuxLabel,
+		constants.EtcdDataVolumeID, constants.KubeletDataVolumeID, constants.LogVolumeID)
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteKUBELET() {
+	suite.reconcilePromoteSingle(constants.KubeletDataVolumeID, constants.KubeletDataPath, constants.KubeletDataSELinuxLabel,
+		constants.EtcdDataVolumeID, constants.CRIContainerdVolumeID, constants.LogVolumeID)
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteLOG() {
+	suite.reconcilePromoteSingle(constants.LogVolumeID, constants.LogMountPoint, constants.LogSELinuxLabel,
+		constants.EtcdDataVolumeID, constants.CRIContainerdVolumeID, constants.KubeletDataVolumeID)
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteAllSystemVolumes() {
+	ctr, err := container.New(
+		suite.clusterEndpointConfig(),
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName:         constants.EtcdDataVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{ProvisioningMaxSize: blockcfg.MustSize("50GiB")},
+		},
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName:         constants.CRIContainerdVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{ProvisioningMaxSize: blockcfg.MustSize("50GiB")},
+		},
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName:         constants.KubeletDataVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{ProvisioningMaxSize: blockcfg.MustSize("50GiB")},
+		},
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName:         constants.LogVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{ProvisioningMaxSize: blockcfg.MustSize("50GiB")},
+		},
+	)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), config.NewMachineConfig(ctr)))
+
+	ctest.AssertResource(suite, constants.EtcdDataVolumeID,
+		assertPromotedVolume(constants.EtcdDataVolumeID, constants.EtcdDataPath, constants.EtcdDataSELinuxLabel))
+	ctest.AssertResource(suite, constants.CRIContainerdVolumeID,
+		assertPromotedVolume(constants.CRIContainerdVolumeID, constants.CRIContainerdDataPath, constants.CRIContainerdDataSELinuxLabel))
+	ctest.AssertResource(suite, constants.KubeletDataVolumeID,
+		assertPromotedVolume(constants.KubeletDataVolumeID, constants.KubeletDataPath, constants.KubeletDataSELinuxLabel))
+	ctest.AssertResource(suite, constants.LogVolumeID,
+		assertPromotedVolume(constants.LogVolumeID, constants.LogMountPoint, constants.LogSELinuxLabel))
+}
+
+func (suite *VolumeConfigSuite) TestReconcilePromoteETCDEncrypted() {
+	ctr, err := container.New(
+		suite.clusterEndpointConfig(),
+		&blockcfg.VolumeConfigV1Alpha1{
+			MetaName: constants.EtcdDataVolumeID,
+			ProvisioningSpec: blockcfg.ProvisioningSpec{
+				ProvisioningMaxSize: blockcfg.MustSize("50GiB"),
+			},
+			EncryptionSpec: blockcfg.EncryptionSpec{
+				EncryptionProvider: block.EncryptionProviderLUKS2,
+				EncryptionKeys: []blockcfg.EncryptionKey{
+					{
+						KeySlot: 0,
+						KeyStatic: &blockcfg.EncryptionKeyStatic{
+							KeyData: "topsecret",
+						},
+					},
+				},
+			},
+		},
+	)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), config.NewMachineConfig(ctr)))
+
+	// ETCD is promoted to an encrypted partition: the configured encryption must be wired through.
+	ctest.AssertResource(suite, constants.EtcdDataVolumeID, func(r *block.VolumeConfig, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumeTypePartition, r.TypedSpec().Type)
+		asrt.NotEmpty(r.TypedSpec().Encryption)
 		asrt.Equal(block.EncryptionProviderLUKS2, r.TypedSpec().Encryption.Provider)
 	})
 }

--- a/internal/app/machined/pkg/controllers/runtime/log_persistence.go
+++ b/internal/app/machined/pkg/controllers/runtime/log_persistence.go
@@ -164,7 +164,7 @@ func (ctrl *LogPersistenceController) Run(ctx context.Context, r controller.Runt
 			block.NewVolumeMountRequest(block.NamespaceName, requestID),
 			func(v *block.VolumeMountRequest) error {
 				v.TypedSpec().Requester = ctrl.Name()
-				v.TypedSpec().VolumeID = constants.LogMountPoint
+				v.TypedSpec().VolumeID = constants.LogVolumeID
 
 				return nil
 			},

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -232,6 +232,10 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 		MountEphemeralPartition,
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
+		"promotableVolumes",
+		MountPromotableSystemPartitions,
+	).AppendWhen(
+		r.State().Platform().Mode() != runtime.ModeContainer,
 		"userDisks",
 		pauseOnFailure(MountUserDisks, constants.FailurePauseTimeout),
 	).Append(
@@ -464,6 +468,9 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			"unmountBind",
 			UnmountSystemDiskBindMounts,
 		).Append(
+			"unmountPromotable",
+			UnmountPromotableSystemPartitions,
+		).Append(
 			"unmountSystem",
 			UnmountEphemeralPartition,
 		).Append(
@@ -511,6 +518,9 @@ func stopAllPhaselist(r runtime.Runtime, enableKexec bool) PhaseList {
 			"unmountBind",
 			UnmountSystemDiskBindMounts,
 		).Append(
+			"unmountPromotable",
+			UnmountPromotableSystemPartitions,
+		).Append(
 			"unmountSystem",
 			UnmountEphemeralPartition,
 		).Append(
@@ -547,6 +557,9 @@ func (*Sequencer) EmergencyVolumeCleanup(r runtime.Runtime) []runtime.Phase {
 		).Append(
 			"unmountBind",
 			UnmountSystemDiskBindMounts,
+		).Append(
+			"unmountPromotable",
+			UnmountPromotableSystemPartitions,
 		).Append(
 			"unmountSystem",
 			UnmountEphemeralPartition,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -60,7 +61,9 @@ import (
 	"github.com/siderolabs/talos/pkg/kernel/kspp"
 	"github.com/siderolabs/talos/pkg/kubernetes"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/block/blockhelpers"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	metamachinery "github.com/siderolabs/talos/pkg/machinery/meta"
@@ -684,6 +687,19 @@ func UnmountPodMounts(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 
 		rdr := bytes.NewReader(b)
 
+		// promotable system-volume partitions (ETCD/CRI/KUBELET/LOG) are COSI-managed and are
+		// unmounted by UnmountPromotableSystemPartitions after their consumers stop; skip the
+		// partition mountpoints themselves here (their pod/overlay submounts are still unmounted
+		// below) so a still-busy mount, e.g. /var/log held by syslogd, doesn't abort the sequence.
+		promotableMountpoints := map[string]struct{}{
+			constants.EtcdDataPath:          {},
+			constants.CRIContainerdDataPath: {},
+			constants.KubeletDataPath:       {},
+			constants.LogMountPoint:         {},
+		}
+
+		var mountpoints []string
+
 		scanner := bufio.NewScanner(rdr)
 		for scanner.Scan() {
 			fields := strings.Fields(scanner.Text())
@@ -693,20 +709,45 @@ func UnmountPodMounts(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 			}
 
 			mountpoint := fields[1]
-			if strings.HasPrefix(mountpoint, constants.EphemeralMountPoint+"/") {
-				logger.Printf("unmounting %s\n", mountpoint)
 
-				if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint, false, false); err != nil {
-					if errors.Is(err, syscall.EINVAL) {
-						log.Printf("ignoring unmount error %s: %v", mountpoint, err)
-					} else {
-						return fmt.Errorf("error unmounting %s: %w", mountpoint, err)
-					}
+			if _, isPromotable := promotableMountpoints[mountpoint]; isPromotable {
+				continue
+			}
+
+			if strings.HasPrefix(mountpoint, constants.EphemeralMountPoint+"/") {
+				mountpoints = append(mountpoints, mountpoint)
+			}
+		}
+
+		if err = scanner.Err(); err != nil {
+			return err
+		}
+
+		// Unmount the deepest paths first: pod/overlay submounts (e.g. under a dedicated
+		// /var/lib/kubelet or /var/lib/containerd system-volume partition) must be released before
+		// their parent mount, otherwise unmounting the dedicated mount point fails with EBUSY and
+		// leaves the EPHEMERAL teardown blocked.
+		slices.SortFunc(mountpoints, func(a, b string) int {
+			return strings.Count(b, "/") - strings.Count(a, "/")
+		})
+
+		var unmountErrors *multierror.Error
+
+		for _, mountpoint := range mountpoints {
+			logger.Printf("unmounting %s\n", mountpoint)
+
+			if err = mountv3.SafeUnmount(ctx, logger.Printf, mountpoint, false, false); err != nil {
+				if errors.Is(err, syscall.EINVAL) {
+					log.Printf("ignoring unmount error %s: %v", mountpoint, err)
+				} else {
+					// don't abort on a single busy mount: keep going so one failure doesn't leave
+					// the remaining (e.g. sibling or parent) mounts mounted.
+					unmountErrors = multierror.Append(unmountErrors, fmt.Errorf("error unmounting %s: %w", mountpoint, err))
 				}
 			}
 		}
 
-		return scanner.Err()
+		return unmountErrors.ErrorOrNil()
 	}, "unmountPodMounts"
 }
 
@@ -1426,6 +1467,75 @@ func UnmountEphemeralPartition(runtime.Sequence, any) (runtime.TaskExecutionFunc
 
 		return nil
 	}, "unmountEphemeralPartition"
+}
+
+// MountPromotableSystemPartitions mounts the promotable system-volume partitions (ETCD, CRI,
+// KUBELET, LOG) with a persistent, sequencer-owned mount request, so their mount lifetime is tied
+// to the machine lifecycle (like EPHEMERAL) rather than to the services that consume them.
+//
+// Without this, stopping the sole consuming service (e.g. `talosctl service kubelet restart`)
+// drops the last mount requester and the block controllers unmount the dedicated partition while
+// it is still in use (pod submounts under /var/lib/kubelet, log writers under /var/log), which
+// fails with EBUSY and leaves the service stuck waiting for the volume to be remounted.
+//
+// Only volumes provisioned onto a dedicated partition are mounted here; directory-backed
+// promotable volumes are plain directories under EPHEMERAL and need no persistent mount.
+func MountPromotableSystemPartitions(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+		for _, name := range configconfig.PromotableSystemVolumeNames {
+			vol, ok := r.Config().Volumes().ByName(name)
+			if !ok || !blockcfg.ProvisioningRequested(vol.Provisioning()) {
+				continue
+			}
+
+			mountRequest := blockres.NewVolumeMountRequest(blockres.NamespaceName, name)
+			mountRequest.TypedSpec().VolumeID = name
+			mountRequest.TypedSpec().Requester = "sequencer"
+			// honor the configured mount options; secure drives nosuid/noexec/nodev on the partition.
+			mountRequest.TypedSpec().Secure = vol.Mount().Secure()
+			mountRequest.TypedSpec().DisableAccessTime = vol.Mount().DisableAccessTime()
+
+			if err := r.State().V1Alpha2().Resources().Create(ctx, mountRequest); err != nil {
+				if state.IsConflictError(err) {
+					continue
+				}
+
+				return fmt.Errorf("failed to create %q mount request: %w", name, err)
+			}
+
+			if _, err := r.State().V1Alpha2().Resources().WatchFor(
+				ctx,
+				blockres.NewVolumeMountStatus(blockres.NamespaceName, name).Metadata(),
+				state.WithEventTypes(state.Created, state.Updated),
+			); err != nil {
+				return fmt.Errorf("failed to wait for %q to be mounted: %w", name, err)
+			}
+		}
+
+		return nil
+	}, "mountPromotableSystemPartitions"
+}
+
+// UnmountPromotableSystemPartitions destroys the persistent, sequencer-owned mount requests
+// created by MountPromotableSystemPartitions, releasing the sequencer's hold so the promotable
+// partitions can be unmounted by the block controllers before the EPHEMERAL partition they live
+// under is torn down.
+func UnmountPromotableSystemPartitions(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+		for _, name := range configconfig.PromotableSystemVolumeNames {
+			mountRequest := blockres.NewVolumeMountRequest(blockres.NamespaceName, name).Metadata()
+
+			if err := r.State().V1Alpha2().Resources().Destroy(ctx, mountRequest); err != nil {
+				if state.IsNotFoundError(err) {
+					continue
+				}
+
+				return fmt.Errorf("failed to destroy %q mount request: %w", name, err)
+			}
+		}
+
+		return nil
+	}, "unmountPromotableSystemPartitions"
 }
 
 // Install mounts or installs the system partitions.

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -106,7 +106,7 @@ func (c *CRI) Volumes(r runtime.Runtime) []string {
 	volumes := []string{
 		"/var/lib",
 		"/var/lib/cni",
-		"/var/lib/containerd",
+		constants.CRIContainerdVolumeID,
 		"/var/run",
 		"/var/run/lock",
 	}

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -117,8 +117,8 @@ func (k *Kubelet) DependsOn(runtime.Runtime) []string {
 func (k *Kubelet) Volumes(runtime.Runtime) []string {
 	return []string{
 		"/var/lib",
-		"/var/lib/kubelet",
-		constants.LogMountPoint,
+		constants.KubeletDataVolumeID,
+		constants.LogVolumeID,
 		"/var/log/audit",
 		"/var/log/containers",
 		"/var/log/pods",

--- a/internal/integration/api/etcd-recover.go
+++ b/internal/integration/api/etcd-recover.go
@@ -15,14 +15,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/go-retry/retry"
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
 // EtcdRecoverSuite ...
@@ -97,15 +100,36 @@ func (suite *EtcdRecoverSuite) TestSnapshotRecover() {
 
 	// wipe ephemeral partition on all control plane nodes, starting with the one that still has etcd running
 	for _, node := range controlPlaneNodes {
-		suite.ResetNode(suite.ctx, node, &machineapi.ResetRequest{
-			Reboot:   true,
-			Graceful: false,
-			SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
-				{
-					Label: constants.EphemeralPartitionLabel,
-					Wipe:  true,
-				},
+		partitionsToWipe := []*machineapi.ResetPartitionSpec{
+			{
+				Label: constants.EphemeralPartitionLabel,
+				Wipe:  true,
 			},
+		}
+
+		// The promotable system volumes (ETCD, CRI, KUBELET) default to directories under EPHEMERAL,
+		// but here they may be dedicated partitions. In the legacy directory layout wiping EPHEMERAL
+		// cleared all of them; once promoted to dedicated partitions it no longer does, so wipe each
+		// promotable volume that is a dedicated partition to keep parity. A directory-backed volume
+		// has no partition to wipe and the reset handler rejects an unlocated label, so skip it.
+		nodeCtx := client.WithNode(suite.ctx, node)
+
+		for _, volumeID := range config.PromotableSystemVolumeNames {
+			vs, err := safe.ReaderGetByID[*block.VolumeStatus](nodeCtx, suite.Client.COSI, volumeID)
+			if err != nil || vs.TypedSpec().Type != block.VolumeTypePartition {
+				continue
+			}
+
+			partitionsToWipe = append(partitionsToWipe, &machineapi.ResetPartitionSpec{
+				Label: volumeID,
+				Wipe:  true,
+			})
+		}
+
+		suite.ResetNode(suite.ctx, node, &machineapi.ResetRequest{
+			Reboot:                 true,
+			Graceful:               false,
+			SystemPartitionsToWipe: partitionsToWipe,
 		}, false)
 	}
 

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -8,18 +8,21 @@ package api
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/go-retry/retry"
+	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
@@ -124,16 +127,16 @@ func (suite *EtcdSuite) TestLeaveCluster() {
 		}
 	}
 
-	stream, err := suite.Client.MachineClient.List(nodeCtx, &machineapi.ListRequest{Root: constants.EtcdDataPath})
+	// LeaveCluster nukes the etcd data in place; /var/lib/etcd itself remains (it may be a
+	// dedicated volume mount point), so assert the data (member directory) is gone rather than
+	// the whole path.
+	stream, err := suite.Client.MachineClient.List(nodeCtx, &machineapi.ListRequest{Root: filepath.Join(constants.EtcdDataPath, "member")})
 	suite.Require().NoError(err)
 
 	_, err = stream.Recv()
 	suite.Require().Error(err)
-
-	suite.Assert().EqualError(
-		err,
-		"rpc error: code = Unknown desc = lstat /var/lib/etcd: no such file or directory",
-	)
+	suite.Require().Equal(client.StatusCode(err), codes.Unknown)
+	suite.Require().Contains(client.Status(err).Message(), "no such file or directory")
 
 	// NB: Reboot the node so that it can rejoin the etcd cluster. This allows us
 	// to check the cluster health and catch any issues in rejoining.
@@ -254,18 +257,24 @@ func (suite *EtcdSuite) TestRemoveMember() {
 		),
 	)
 
-	// NB: Reset the ephemeral the node so that it can rejoin the etcd cluster. This allows us
+	// Wipe etcd data so the removed node rejoins the cluster fresh. If ETCD is directory-backed it
+	// lives under EPHEMERAL (wipe EPHEMERAL); if it is a dedicated partition, wipe that partition
+	// directly and leave EPHEMERAL intact.
+	etcdVolumeStatus, err := safe.StateGetByID[*block.VolumeStatus](removeCtx, suite.Client.COSI, constants.EtcdDataVolumeID)
+	suite.Require().NoError(err)
+
+	partitionsToWipe := []*machineapi.ResetPartitionSpec{{Label: constants.EtcdDataVolumeID, Wipe: true}}
+	if etcdVolumeStatus.TypedSpec().Type == block.VolumeTypeDirectory {
+		partitionsToWipe = []*machineapi.ResetPartitionSpec{{Label: constants.EphemeralPartitionLabel, Wipe: true}}
+	}
+
+	// NB: Reset the node so that it can rejoin the etcd cluster. This allows us
 	// to check the cluster health and catch any issues in rejoining.
 	suite.AssertRebooted(
 		suite.ctx, nodeToRemove, func(nodeCtx context.Context) error {
 			_, err = suite.Client.MachineClient.Reset(nodeCtx, &machineapi.ResetRequest{
-				Reboot: true,
-				SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
-					{
-						Label: constants.EphemeralPartitionLabel,
-						Wipe:  true,
-					},
-				},
+				Reboot:                 true,
+				SystemPartitionsToWipe: partitionsToWipe,
 			})
 
 			return err

--- a/internal/integration/api/mounts.go
+++ b/internal/integration/api/mounts.go
@@ -14,9 +14,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
+
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
 // MountsSuite verifies mount flag policy on a running node.
@@ -151,6 +154,34 @@ var noexecExemptPrefixes = []string{
 	constants.ExtensionServiceRootfsPath, // /usr/local/lib/containers — extension service rootfs overlays (iscsid, etc.)
 }
 
+// promotableSystemVolumePathToID maps the mount point of each promotable system volume
+// (ETCD/CRI/KUBELET/LOG) to its volume ID. By default each is a directory under the EPHEMERAL
+// volume, but it can be provisioned onto a dedicated partition via a VolumeConfig document.
+var promotableSystemVolumePathToID = map[string]string{
+	constants.EtcdDataPath:          constants.EtcdDataVolumeID,
+	constants.CRIContainerdDataPath: constants.CRIContainerdVolumeID,
+	constants.KubeletDataPath:       constants.KubeletDataVolumeID,
+	constants.LogMountPoint:         constants.LogVolumeID,
+}
+
+// promotableSystemVolumePartition returns the volume ID (and true) when the mount is a promotable
+// system volume promoted onto a dedicated partition (mounted from a block device). Whether such a
+// mount carries the secure flags (nosuid/noexec/nodev) is governed by the volume's mount.secure
+// setting, so the caller asserts against that. When not promoted, the volume is a directory on
+// EPHEMERAL and does not appear as a separate mount, so the /var assertion enforces the policy.
+func promotableSystemVolumePartition(m mountInfo) (string, bool) {
+	volumeID, ok := promotableSystemVolumePathToID[m.mountPoint]
+	if !ok {
+		return "", false
+	}
+
+	if !strings.HasPrefix(m.source, "/dev/") {
+		return "", false
+	}
+
+	return volumeID, true
+}
+
 func noexecExempt(m mountInfo) bool {
 	if m.has("ro") {
 		return true
@@ -205,12 +236,33 @@ func (suite *MountsSuite) runPolicy(opt string, exempt func(mountInfo) bool, rat
 	}
 }
 
+//nolint:gocyclo
 func (suite *MountsSuite) checkOptOnNode(node, opt string, exempt func(mountInfo) bool, rationale string) {
 	mounts := suite.readMountInfo(node)
 
-	var violations []string
+	var (
+		violations []string // mounts that must carry opt but don't
+		unexpected []string // promoted promotable partitions that unexpectedly carry opt
+	)
 
 	for _, m := range mounts {
+		// a promotable system volume (ETCD/CRI/KUBELET/LOG) promoted onto a dedicated partition
+		// carries the secure flags (nosuid/noexec/nodev) only when its mount.secure is set, so
+		// assert the mount matches the configured value. When not promoted it is a directory on
+		// EPHEMERAL (not a separate mount) and the /var assertion below still enforces the policy.
+		if volumeID, promoted := promotableSystemVolumePartition(m); promoted {
+			entry := fmt.Sprintf("%s (fstype=%s, source=%s)", m.mountPoint, m.fsType, m.source)
+
+			switch secure := suite.promotableVolumeSecure(node, volumeID); {
+			case secure && !m.has(opt):
+				violations = append(violations, entry)
+			case !secure && m.has(opt):
+				unexpected = append(unexpected, entry)
+			}
+
+			continue
+		}
+
 		if workloadManaged(m) || exempt(m) {
 			continue
 		}
@@ -235,6 +287,23 @@ func (suite *MountsSuite) checkOptOnNode(node, opt string, exempt func(mountInfo
 		"mounts missing %s (policy: %s):\n  %s",
 		opt, rationale, strings.Join(violations, "\n  "),
 	)
+
+	suite.Assert().Empty(
+		unexpected,
+		"promoted promotable system-volume partitions carry %s despite mount.secure=false:\n  %s",
+		opt, strings.Join(unexpected, "\n  "),
+	)
+}
+
+// promotableVolumeSecure reports the effective mount.secure setting of a promotable system volume
+// on a node, read from its block.VolumeStatus.
+func (suite *MountsSuite) promotableVolumeSecure(node, volumeID string) bool {
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](nodeCtx, suite.Client.COSI, volumeID)
+	suite.Require().NoError(err)
+
+	return volumeStatus.TypedSpec().MountSpec.Secure
 }
 
 // readMountInfo fetches and parses /proc/self/mountinfo from a node.

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/internal/integration/base"
@@ -32,7 +33,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/cel"
 	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
 	"github.com/siderolabs/talos/pkg/machinery/client"
-	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
 	cricfg "github.com/siderolabs/talos/pkg/machinery/config/types/cri"
@@ -621,6 +624,165 @@ func (suite *VolumesSuite) TestUserVolumesPartition() {
 		func(dv *block.DiscoveredVolume, asrt *assert.Assertions) {
 			asrt.Empty(dv.TypedSpec().Name, "expected discovered volume %s to be wiped", dv.Metadata().ID())
 		})
+}
+
+// TestPromoteSystemVolumeRejected verifies that attempting to promote a promotable system volume
+// (ETCD/CRI/KUBELET/LOG) from a directory to a dedicated partition on an already-running node is
+// rejected by config validation. The backing of these volumes is fixed at cluster creation.
+func (suite *VolumesSuite) TestPromoteSystemVolumeRejected() {
+	if testing.Short() {
+		suite.T().Skip("skipping test in short mode.")
+	}
+
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping test for non-qemu provisioner")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	ctx := client.WithNode(suite.ctx, node)
+
+	userDisks := suite.UserDisks(suite.ctx, node)
+
+	if len(userDisks) < 1 {
+		suite.T().Skipf("skipping test, not enough user disks available on node %s: %q", node, userDisks)
+	}
+
+	disk, err := safe.StateGetByID[*block.Disk](ctx, suite.Client.COSI, filepath.Base(userDisks[0]))
+	suite.Require().NoError(err)
+
+	cfg, err := suite.ReadConfigFromNode(ctx)
+	suite.Require().NoError(err)
+
+	// Exercise every promotable system volume (ETCD/CRI/KUBELET/LOG). Which ones default to a
+	// directory under EPHEMERAL vs. a dedicated partition depends on the node's config patches, so
+	// only the directory-backed ones are candidates for a (rejected) promotion here.
+	for _, volumeID := range config.PromotableSystemVolumeNames {
+		suite.Run(volumeID, func() {
+			// Only a directory-backed volume can be (attempted to be) promoted; skip the ones that
+			// are already dedicated partitions.
+			vs, err := safe.ReaderGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, volumeID)
+			suite.Require().NoError(err)
+
+			if vs.TypedSpec().Type != block.VolumeTypeDirectory {
+				suite.T().Skipf("skipping, %s is not a directory on node %s", volumeID, node)
+			}
+
+			suite.T().Logf("attempting to promote %s volume on node %s with disk %s (expected to be rejected)", volumeID, node, userDisks[0])
+
+			doc := blockcfg.NewVolumeConfigV1Alpha1()
+			doc.MetaName = volumeID
+			doc.ProvisioningSpec.DiskSelectorSpec.Match = cel.MustExpression(
+				cel.ParseBooleanExpression(fmt.Sprintf("'%s' in disk.symlinks", disk.TypedSpec().Symlinks[0]), celenv.DiskLocator()),
+			)
+			doc.ProvisioningSpec.ProvisioningMinSize = blockcfg.MustByteSize("100MiB")
+			doc.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("2GiB")
+
+			docBytes, err := yaml.Marshal(doc)
+			suite.Require().NoError(err)
+
+			patch, err := configpatcher.LoadPatch(docBytes)
+			suite.Require().NoError(err)
+
+			patchedOut, err := configpatcher.Apply(configpatcher.WithConfig(cfg), []configpatcher.Patch{patch})
+			suite.Require().NoError(err)
+
+			patchedCfg, err := patchedOut.Config()
+			suite.Require().NoError(err)
+
+			cfgBytes, err := patchedCfg.Bytes()
+			suite.Require().NoError(err)
+
+			_, err = suite.Client.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
+				Data: cfgBytes,
+				Mode: machineapi.ApplyConfigurationRequest_AUTO,
+			})
+			suite.Require().Error(err, "promoting a system volume on a running node must be rejected")
+			suite.Require().Contains(err.Error(), "cannot be changed after creation",
+				"rejection error must reference the create-only constraint")
+
+			// The volume must still be a directory: the config was rejected, nothing changed.
+			vs, err = safe.ReaderGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, volumeID)
+			suite.Require().NoError(err)
+			suite.Require().Equal(block.VolumeTypeDirectory, vs.TypedSpec().Type,
+				"%s must remain a directory after the rejected apply", volumeID)
+		})
+	}
+}
+
+// TestDemoteSystemVolumeRejected verifies that attempting to demote a promotable system volume
+// (ETCD/CRI/KUBELET/LOG) from a dedicated partition back to a directory on an already-running node
+// is rejected by config validation. The backing of these volumes is fixed at cluster creation.
+//
+// On the QEMU integration cluster the control plane nodes provision these volumes as dedicated
+// partitions (via hack/test/patches/dedicated-system-volumes.yaml), so a control plane node is used.
+func (suite *VolumesSuite) TestDemoteSystemVolumeRejected() {
+	if testing.Short() {
+		suite.T().Skip("skipping test in short mode.")
+	}
+
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping test for non-qemu provisioner")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+
+	ctx := client.WithNode(suite.ctx, node)
+
+	cfg, err := suite.ReadConfigFromNode(ctx)
+	suite.Require().NoError(err)
+
+	// Exercise every promotable system volume (ETCD/CRI/KUBELET/LOG) provisioned as a dedicated
+	// partition on the control plane.
+	for _, volumeID := range config.PromotableSystemVolumeNames {
+		suite.Run(volumeID, func() {
+			// Verify the volume is currently a dedicated partition (the control plane default in this cluster).
+			vs, err := safe.ReaderGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, volumeID)
+			suite.Require().NoError(err)
+
+			if vs.TypedSpec().Type != block.VolumeTypePartition {
+				suite.T().Skipf("skipping, %s is not a dedicated partition on node %s", volumeID, node)
+			}
+
+			// Removing the VolumeConfig document requests the volume to revert to a directory, which
+			// is a forbidden migration off a dedicated partition.
+			remaining := xslices.Filter(cfg.Documents(), func(doc config.Document) bool {
+				if doc.Kind() != blockcfg.VolumeConfigKind {
+					return true
+				}
+
+				namedDoc, ok := doc.(config.NamedDocument)
+
+				return !ok || namedDoc.Name() != volumeID
+			})
+
+			if len(remaining) == len(cfg.Documents()) {
+				suite.T().Skipf("skipping, no %s VolumeConfig document present on node %s", volumeID, node)
+			}
+
+			suite.T().Logf("attempting to demote %s volume on node %s by removing its VolumeConfig (expected to be rejected)", volumeID, node)
+
+			ctr, err := container.New(remaining...)
+			suite.Require().NoError(err)
+
+			cfgBytes, err := ctr.Bytes()
+			suite.Require().NoError(err)
+
+			_, err = suite.Client.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
+				Data: cfgBytes,
+				Mode: machineapi.ApplyConfigurationRequest_AUTO,
+			})
+			suite.Require().Error(err, "demoting a system volume on a running node must be rejected")
+			suite.Require().Contains(err.Error(), "cannot be removed",
+				"rejection error must reference the create-only constraint")
+
+			// The volume must still be a partition: the config was rejected, nothing changed.
+			vs, err = safe.ReaderGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, volumeID)
+			suite.Require().NoError(err)
+			suite.Require().Equal(block.VolumeTypePartition, vs.TypedSpec().Type,
+				"%s must remain a dedicated partition after the rejected apply", volumeID)
+		})
+	}
 }
 
 // TestUserVolumeBTRFS verifies a user volume with BTRFS filesystem.
@@ -1937,8 +2099,8 @@ func (suite *VolumesSuite) TestImageCacheLocalEnabledWithoutCacheVolume() {
 	suite.assertImageCacheMountRequestsStable(ctx, mountRequestIDs, 10*time.Second)
 }
 
-func filterImageCacheConfigDocs(docs []configconfig.Document) []configconfig.Document {
-	result := make([]configconfig.Document, 0, len(docs))
+func filterImageCacheConfigDocs(docs []config.Document) []config.Document {
+	result := make([]config.Document, 0, len(docs))
 
 	for _, doc := range docs {
 		if doc.Kind() == cricfg.ImageCacheConfig {

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -609,15 +609,26 @@ func (apiSuite *APISuite) ResetNode(ctx context.Context, node string, resetSpec 
 	bootIDBefore, err := apiSuite.ReadBootID(nodeCtx)
 	apiSuite.Require().NoError(err)
 
-	// figure out if EPHEMERAL is going to be reset
-	ephemeralIsGoingToBeReset := false
+	// Figure out whether the KUBELET volume's backing storage is going to be wiped, which
+	// regenerates the kubelet PKI (and thus its serving cert). This happens on a full reset (the
+	// whole system disk is wiped), when the KUBELET partition is wiped directly, or when KUBELET is
+	// directory-backed (under EPHEMERAL) and EPHEMERAL is wiped. A dedicated KUBELET partition is
+	// independent of EPHEMERAL and survives an EPHEMERAL-only wipe, preserving the cert.
+	kubeletIsGoingToBeReset := false
 
 	if len(resetSpec.SystemPartitionsToWipe) == 0 && len(resetSpec.UserDisksToWipe) == 0 {
-		ephemeralIsGoingToBeReset = true
+		// full reset wipes the entire system disk, including the KUBELET volume
+		kubeletIsGoingToBeReset = true
 	} else {
 		for _, part := range resetSpec.SystemPartitionsToWipe {
-			if part.Label == constants.EphemeralPartitionLabel {
-				ephemeralIsGoingToBeReset = true
+			if part.Label == constants.KubeletDataVolumeID {
+				kubeletIsGoingToBeReset = true
+
+				break
+			}
+
+			if part.Label == constants.EphemeralPartitionLabel && apiSuite.kubeletVolumeIsDirectory(ctx, node) {
+				kubeletIsGoingToBeReset = true
 
 				break
 			}
@@ -685,12 +696,23 @@ waitLoop:
 		postReset, err := apiSuite.HashKubeletCert(ctx, node)
 		apiSuite.Require().NoError(err)
 
-		if ephemeralIsGoingToBeReset {
+		if kubeletIsGoingToBeReset {
 			apiSuite.Assert().NotEqual(preReset, postReset, "reset should lead to new kubelet cert being generated")
 		} else {
-			apiSuite.Assert().Equal(preReset, postReset, "ephemeral partition was not reset")
+			apiSuite.Assert().Equal(preReset, postReset, "kubelet cert should be unchanged (KUBELET volume was not wiped)")
 		}
 	}
+}
+
+// kubeletVolumeIsDirectory reports whether the KUBELET system volume is backed by a directory under
+// EPHEMERAL (vs. a dedicated partition) on the node.
+func (apiSuite *APISuite) kubeletVolumeIsDirectory(ctx context.Context, node string) bool {
+	nodeCtx := client.WithNode(ctx, node)
+
+	volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](nodeCtx, apiSuite.Client.COSI, constants.KubeletDataVolumeID)
+	apiSuite.Require().NoError(err)
+
+	return volumeStatus.TypedSpec().Type == block.VolumeTypeDirectory
 }
 
 // DumpLogs dumps a set of logs from the node.

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"math/rand/v2"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
@@ -151,6 +152,8 @@ func validateMemberHealth(ctx context.Context, memberURIs []string) (err error) 
 }
 
 // LeaveCluster removes the current member from the etcd cluster and nukes etcd data directory.
+//
+// nolint:gocyclo
 func (c *Client) LeaveCluster(ctx context.Context, st state.State) error {
 	memberID, err := GetLocalMemberID(ctx, st)
 	if err != nil {
@@ -187,9 +190,24 @@ func (c *Client) LeaveCluster(ctx context.Context, st state.State) error {
 		return fmt.Errorf("failed to stop etcd: %w", err)
 	}
 
-	// Once the member is removed, the data is no longer valid.
-	if err := os.RemoveAll(constants.EtcdDataPath); err != nil {
-		return fmt.Errorf("failed to remove %s: %w", constants.EtcdDataPath, err)
+	// Once the member is removed, the data is no longer valid. Remove the *contents* of the etcd
+	// data directory rather than the directory itself: /var/lib/etcd may be a dedicated volume
+	// mount point (promotable system volume), and unlinking a mount point fails with EBUSY.
+	entries, err := os.ReadDir(constants.EtcdDataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to read %s: %w", constants.EtcdDataPath, err)
+	}
+
+	for _, entry := range entries {
+		p := filepath.Join(constants.EtcdDataPath, entry.Name())
+
+		if err := os.RemoveAll(p); err != nil {
+			return fmt.Errorf("failed to remove %s: %w", p, err)
+		}
 	}
 
 	return nil

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -14,6 +14,16 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
+// PromotableSystemVolumeNames are the system volumes that default to a directory under the
+// EPHEMERAL volume but may instead be placed on a dedicated partition (via provisioning) at
+// cluster creation. The backing (directory vs. dedicated partition) is fixed at creation time.
+var PromotableSystemVolumeNames = []string{
+	constants.EtcdDataVolumeID,
+	constants.CRIContainerdVolumeID,
+	constants.KubeletDataVolumeID,
+	constants.LogVolumeID,
+}
+
 // VolumesConfig defines the interface to access volume configuration.
 type VolumesConfig interface {
 	// ByName returns a volume config configuration by name.

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -9,14 +9,17 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/validation"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
 // ValidateAsClient validates the config in the client context (outside of Talos).
@@ -144,7 +147,57 @@ func (container *Container) runtimeValidate(ctx context.Context, st state.State,
 		}
 	}
 
+	if err := container.runtimeValidateContainer(ctx, st); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
 	return warnings, multiErr.ErrorOrNil()
+}
+
+// runtimeValidateContainer validates the full configuration container in the runtime context.
+//
+// This is the runtime-context counterpart to validateContainer: it performs validation which only
+// makes sense for the whole configuration (vs. individual documents) and which requires runtime
+// state. In particular, it detects a promotable system volume (ETCD, CRI, KUBELET, LOG) whose backing
+// VolumeConfig document has been removed while the volume is still backed by a live dedicated
+// partition. The per-document VolumeConfig.RuntimeValidate cannot catch this because a removed
+// document is no longer part of the container.
+func (container *Container) runtimeValidateContainer(ctx context.Context, st state.State) error {
+	var errs *multierror.Error
+
+	volumes := container.Volumes()
+
+	for _, name := range configconfig.PromotableSystemVolumeNames {
+		if _, present := volumes.ByName(name); present {
+			// the document is still present: VolumeConfig.RuntimeValidate handles any backing conflict.
+			continue
+		}
+
+		volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](ctx, st, name)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				// the volume was never established (cluster creation / boot): nothing to conflict with.
+				continue
+			}
+
+			return err
+		}
+
+		// only compare against a settled volume; an in-flight volume is not yet established.
+		if volumeStatus.TypedSpec().Phase != block.VolumePhaseReady {
+			continue
+		}
+
+		if volumeStatus.TypedSpec().Type == block.VolumeTypePartition {
+			errs = multierror.Append(errs, fmt.Errorf(
+				"the %q system volume is backed by a dedicated partition and its VolumeConfig cannot be removed; "+
+					"migrating a system volume off a dedicated partition is not supported",
+				name,
+			))
+		}
+	}
+
+	return errs.ErrorOrNil()
 }
 
 // validateContainer validates the full configuration container.

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -5,10 +5,14 @@
 package container_test
 
 import (
+	"context"
 	"net/netip"
 	"net/url"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/xtesting/must"
 	"github.com/stretchr/testify/require"
@@ -362,6 +366,115 @@ func TestValidateContainer(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestRuntimeValidateSystemVolumeBacking(t *testing.T) {
+	t.Parallel()
+
+	const (
+		documentAbsent              = "absent"
+		documentWithoutProvisioning = "directory"
+		documentWithProvisioning    = "partition"
+	)
+
+	for _, test := range []struct {
+		name string
+
+		// document controls the KUBELET VolumeConfig document in the config:
+		// absent (removed), present without provisioning, or present with provisioning.
+		document string
+
+		// current volume to seed into the state (skipped if seedStatus is false).
+		seedStatus   bool
+		currentType  blockres.VolumeType
+		currentPhase blockres.VolumePhase
+
+		expectedErrorContains string
+	}{
+		{
+			name:         "removing config of a ready partition volume is rejected",
+			document:     documentAbsent,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseReady,
+
+			expectedErrorContains: `the "KUBELET" system volume is backed by a dedicated partition and its VolumeConfig cannot be removed; ` +
+				`migrating a system volume off a dedicated partition is not supported`,
+		},
+		{
+			name:         "removing config of a ready directory volume is allowed",
+			document:     documentAbsent,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypeDirectory,
+			currentPhase: blockres.VolumePhaseReady,
+		},
+		{
+			name:       "removing config with no established volume is allowed (cluster creation)",
+			document:   documentAbsent,
+			seedStatus: false,
+		},
+		{
+			name:         "removing config of an unsettled partition volume is allowed",
+			document:     documentAbsent,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseWaiting,
+		},
+		{
+			name:         "demoting via present config (drop provisioning) is still rejected by the per-document guard",
+			document:     documentWithoutProvisioning,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseReady,
+
+			expectedErrorContains: `the backing of the "KUBELET" system volume cannot be changed after creation (current: partition, requested: directory)`,
+		},
+		{
+			name:         "matching present partition config is allowed",
+			document:     documentWithProvisioning,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseReady,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			if test.seedStatus {
+				vs := blockres.NewVolumeStatus(blockres.NamespaceName, constants.KubeletDataVolumeID)
+				vs.TypedSpec().Type = test.currentType
+				vs.TypedSpec().Phase = test.currentPhase
+				require.NoError(t, st.Create(ctx, vs))
+			}
+
+			var documents []config.Document
+
+			if test.document != documentAbsent {
+				vc := block.NewVolumeConfigV1Alpha1()
+				vc.MetaName = constants.KubeletDataVolumeID
+
+				if test.document == documentWithProvisioning {
+					vc.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("5GB")
+				}
+
+				documents = append(documents, vc)
+			}
+
+			ctr, err := container.New(documents...)
+			require.NoError(t, err)
+
+			_, err = ctr.ValidateAtRuntime(ctx, st, validationMode{})
+
+			if test.expectedErrorContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedErrorContains)
 			}
 		})
 	}

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -796,7 +796,7 @@
         "apiVersion",
         "kind"
       ],
-      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\\n"
+      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`\\nsystem volumes are supported. The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes default to a\\ndirectory under `EPHEMERAL`, and can be placed on a dedicated partition by specifying\\n`provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be\\nchosen at cluster creation time: changing it on an already-provisioned node is not supported.\\n"
     },
     "block.VolumeDiscoverySpec": {
       "properties": {

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -832,7 +832,7 @@ func (VolumeConfigV1Alpha1) Doc() *encoder.Doc {
 	doc := &encoder.Doc{
 		Type:        "VolumeConfig",
 		Comments:    [3]string{"" /* encoder.HeadComment */, "VolumeConfig is a system volume configuration document." /* encoder.LineComment */, "" /* encoder.FootComment */},
-		Description: "VolumeConfig is a system volume configuration document.\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\n",
+		Description: "VolumeConfig is a system volume configuration document.\nNote: at the moment, only `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`\nsystem volumes are supported. The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes default to a\ndirectory under `EPHEMERAL`, and can be placed on a dedicated partition by specifying\n`provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be\nchosen at cluster creation time: changing it on an already-provisioned node is not supported.\n",
 		Fields: []encoder.Doc{
 			{
 				Type:   "Meta",

--- a/pkg/machinery/config/types/block/volume_config.go
+++ b/pkg/machinery/config/types/block/volume_config.go
@@ -7,10 +7,13 @@ package block
 //docgen:jsonschema
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
 
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-pointer"
 
@@ -45,6 +48,7 @@ var (
 	_ config.VolumeConfig                 = &VolumeConfigV1Alpha1{}
 	_ config.NamedDocument                = &VolumeConfigV1Alpha1{}
 	_ config.Validator                    = &VolumeConfigV1Alpha1{}
+	_ config.RuntimeValidator             = &VolumeConfigV1Alpha1{}
 	_ config.SecretDocument               = &VolumeConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &VolumeConfigV1Alpha1{}
 )
@@ -52,7 +56,11 @@ var (
 // VolumeConfigV1Alpha1 is a system volume configuration document.
 //
 //	description: |
-//	  Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.
+//	  Note: at the moment, only `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`
+//	  system volumes are supported. The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes default to a
+//	  directory under `EPHEMERAL`, and can be placed on a dedicated partition by specifying
+//	  `provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be
+//	  chosen at cluster creation time: changing it on an already-provisioned node is not supported.
 //	examples:
 //	  - value: exampleVolumeConfigEphemeralV1Alpha1()
 //	alias: VolumeConfig
@@ -199,6 +207,10 @@ func (s *VolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Op
 		constants.StatePartitionLabel,
 		constants.EphemeralPartitionLabel,
 		constants.ImageCachePartitionLabel,
+		constants.EtcdDataVolumeID,
+		constants.CRIContainerdVolumeID,
+		constants.KubeletDataVolumeID,
+		constants.LogVolumeID,
 	}
 
 	if slices.Index(allowedVolumes, s.MetaName) == -1 {
@@ -209,6 +221,36 @@ func (s *VolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Op
 		warnings         []string //nolint:prealloc
 		validationErrors error
 	)
+
+	validationErrors = errors.Join(validationErrors, s.validateVolumeConstraints())
+
+	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(false, true)
+	warnings = append(warnings, extraWarnings...)
+	validationErrors = errors.Join(validationErrors, extraErrors)
+
+	extraWarnings, extraErrors = s.EncryptionSpec.Validate()
+	warnings = append(warnings, extraWarnings...)
+	validationErrors = errors.Join(validationErrors, extraErrors)
+
+	if err := s.TrimSpec.Validate(); err != nil {
+		validationErrors = errors.Join(validationErrors, err)
+	}
+
+	return warnings, validationErrors
+}
+
+// mountNotAllowed returns an error if mount config is set for a volume that does not support it.
+func mountNotAllowed(name string, mount MountSpec) error {
+	if mount != (MountSpec{}) {
+		return fmt.Errorf("mount config is not allowed for the %q volume", name)
+	}
+
+	return nil
+}
+
+// validateVolumeConstraints validates the per-volume constraints on which config sections are allowed.
+func (s *VolumeConfigV1Alpha1) validateVolumeConstraints() error {
+	var validationErrors error
 
 	switch s.MetaName {
 	case constants.StatePartitionLabel:
@@ -224,28 +266,80 @@ func (s *VolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Op
 			}
 		}
 
-		if s.MountSpec != (MountSpec{}) {
-			validationErrors = errors.Join(validationErrors, fmt.Errorf("mount config is not allowed for the %q volume", s.MetaName))
-		}
+		validationErrors = errors.Join(validationErrors, mountNotAllowed(s.MetaName, s.MountSpec))
 	case constants.ImageCachePartitionLabel:
-		if s.MountSpec != (MountSpec{}) {
-			validationErrors = errors.Join(validationErrors, fmt.Errorf("mount config is not allowed for the %q volume", s.MetaName))
+		validationErrors = errors.Join(validationErrors, mountNotAllowed(s.MetaName, s.MountSpec))
+	case constants.EtcdDataVolumeID, constants.CRIContainerdVolumeID, constants.KubeletDataVolumeID, constants.LogVolumeID:
+		// these volumes default to a directory under EPHEMERAL and can be placed on a dedicated
+		// partition via provisioning (optionally encrypted). Mount config only takes effect on the
+		// dedicated-partition backing (a directory-backed volume inherits the EPHEMERAL mount), so
+		// it is allowed only together with provisioning.
+		if s.MountSpec != (MountSpec{}) && !ProvisioningRequested(s.Provisioning()) {
+			validationErrors = errors.Join(validationErrors, fmt.Errorf("mount config for the %q volume is only supported when it is provisioned onto a dedicated partition", s.MetaName))
 		}
 	}
 
-	extraWarnings, extraErrors := s.ProvisioningSpec.Validate(false, true)
-	warnings = append(warnings, extraWarnings...)
-	validationErrors = errors.Join(validationErrors, extraErrors)
+	return validationErrors
+}
 
-	extraWarnings, extraErrors = s.EncryptionSpec.Validate()
-	warnings = append(warnings, extraWarnings...)
-	validationErrors = errors.Join(validationErrors, extraErrors)
+// ProvisioningRequested reports whether provisioning is explicitly configured for a volume.
+//
+// For the promotable system volumes (ETCD, CRI, KUBELET, LOG) this is the opt-in signal to place the
+// volume on a dedicated partition instead of a directory under EPHEMERAL. The volume controller and
+// config validation share this predicate so they agree on what counts as a dedicated partition.
+func ProvisioningRequested(p config.VolumeProvisioningConfig) bool {
+	return p.DiskSelector().IsPresent() ||
+		p.Grow().IsPresent() ||
+		p.MinSize().IsPresent() ||
+		p.MaxSize().IsPresent()
+}
 
-	if err := s.TrimSpec.Validate(); err != nil {
-		validationErrors = errors.Join(validationErrors, err)
+// RuntimeValidate implements config.RuntimeValidator interface.
+//
+// For the promotable system volumes (ETCD, CRI, KUBELET, LOG) it enforces "create-only" semantics: the
+// backing of the volume — a directory under EPHEMERAL vs. a dedicated partition — is fixed at cluster
+// creation and cannot be changed on an already-provisioned node. Migrating an existing system volume
+// to or from a dedicated partition would orphan its on-disk state (and, for etcd, risk quorum), so it
+// is rejected here. Live migration may be supported later by a dedicated controller.
+//
+// The check compares the desired backing (partition if provisioning is requested, directory
+// otherwise) against the actual VolumeStatus. If the volume is not established yet (cluster creation
+// or boot, before the volume manager has processed it) there is nothing to conflict with, so it is
+// allowed.
+func (s *VolumeConfigV1Alpha1) RuntimeValidate(ctx context.Context, st state.State, _ validation.RuntimeMode, _ ...validation.Option) ([]string, error) {
+	if !slices.Contains(config.PromotableSystemVolumeNames, s.MetaName) {
+		return nil, nil
 	}
 
-	return warnings, validationErrors
+	desiredType := block.VolumeTypeDirectory
+	if ProvisioningRequested(s.ProvisioningSpec) {
+		desiredType = block.VolumeTypePartition
+	}
+
+	volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](ctx, st, s.MetaName)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			// the volume is not established yet (cluster creation / boot): nothing to conflict with.
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	// only compare against a settled volume; an in-flight volume is not yet established.
+	if volumeStatus.TypedSpec().Phase != block.VolumePhaseReady {
+		return nil, nil
+	}
+
+	if currentType := volumeStatus.TypedSpec().Type; currentType != desiredType {
+		return nil, fmt.Errorf(
+			"the backing of the %q system volume cannot be changed after creation (current: %s, requested: %s); "+
+				"migrating an existing system volume to or from a dedicated partition is not supported",
+			s.MetaName, currentType, desiredType,
+		)
+	}
+
+	return nil, nil
 }
 
 // Provisioning implements config.VolumeConfig interface.

--- a/pkg/machinery/config/types/block/volume_config_test.go
+++ b/pkg/machinery/config/types/block/volume_config_test.go
@@ -5,10 +5,14 @@
 package block_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -152,7 +156,7 @@ func TestVolumeConfigValidate(t *testing.T) {
 				return c
 			},
 
-			expectedErrors: "only [\"STATE\" \"EPHEMERAL\" \"IMAGECACHE\"] volumes are supported",
+			expectedErrors: "only [\"STATE\" \"EPHEMERAL\" \"IMAGECACHE\" \"ETCD\" \"CRI\" \"KUBELET\" \"LOG\"] volumes are supported",
 		},
 		{
 			name: "invalid disk selector",
@@ -303,6 +307,118 @@ func TestVolumeConfigValidate(t *testing.T) {
 			expectedErrors: "mount config is not allowed for the \"IMAGECACHE\" volume",
 		},
 		{
+			name: "mount spec for ETCD volume without provisioning",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EtcdDataVolumeID
+
+				c.MountSpec = block.MountSpec{
+					MountDisableAccessTime: new(true),
+				}
+
+				return c
+			},
+
+			expectedErrors: "mount config for the \"ETCD\" volume is only supported when it is provisioned onto a dedicated partition",
+		},
+		{
+			name: "mount spec for CRI volume without provisioning",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.CRIContainerdVolumeID
+
+				c.MountSpec = block.MountSpec{
+					MountDisableAccessTime: new(true),
+				}
+
+				return c
+			},
+
+			expectedErrors: "mount config for the \"CRI\" volume is only supported when it is provisioned onto a dedicated partition",
+		},
+		{
+			name: "mount spec for KUBELET volume without provisioning",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.KubeletDataVolumeID
+
+				c.MountSpec = block.MountSpec{
+					MountDisableAccessTime: new(true),
+				}
+
+				return c
+			},
+
+			expectedErrors: "mount config for the \"KUBELET\" volume is only supported when it is provisioned onto a dedicated partition",
+		},
+		{
+			name: "LOG promotion with secure mount is allowed",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.LogVolumeID
+
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("50GiB")
+				c.MountSpec = block.MountSpec{
+					MountSecure: new(true),
+				}
+
+				return c
+			},
+		},
+		{
+			name: "ETCD promotion provisioning is allowed",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EtcdDataVolumeID
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.transport == "nvme" && !system_disk`)))
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("50GiB")
+
+				return c
+			},
+		},
+		{
+			name: "ETCD promotion encryption is allowed",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EtcdDataVolumeID
+
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("50GiB")
+				c.EncryptionSpec.EncryptionProvider = blockres.EncryptionProviderLUKS2
+				c.EncryptionSpec.EncryptionKeys = []block.EncryptionKey{
+					{
+						KeySlot: 0,
+						KeyStatic: &block.EncryptionKeyStatic{
+							KeyData: "topsecret",
+						},
+					},
+				}
+
+				return c
+			},
+		},
+		{
+			name: "ETCD promotion trim is allowed",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EtcdDataVolumeID
+
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("50GiB")
+				c.TrimSpec = &block.TrimConfig{
+					TrimEnabled: new(true),
+				}
+
+				return c
+			},
+		},
+		{
 			name: "valid",
 
 			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
@@ -358,6 +474,114 @@ func TestVolumeConfigValidate(t *testing.T) {
 				require.Error(t, err)
 
 				assert.EqualError(t, err, test.expectedErrors)
+			}
+		})
+	}
+}
+
+func TestVolumeConfigRuntimeValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+
+		volumeID     string
+		provisioning bool
+
+		// current volume to seed into the state (skipped if seedStatus is false).
+		seedStatus   bool
+		currentType  blockres.VolumeType
+		currentPhase blockres.VolumePhase
+
+		expectedError string
+	}{
+		{
+			name:         "promote running directory volume is rejected",
+			volumeID:     constants.EtcdDataVolumeID,
+			provisioning: true,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypeDirectory,
+			currentPhase: blockres.VolumePhaseReady,
+
+			expectedError: `the backing of the "ETCD" system volume cannot be changed after creation (current: directory, requested: partition); ` +
+				`migrating an existing system volume to or from a dedicated partition is not supported`,
+		},
+		{
+			name:         "demote running partition volume is rejected",
+			volumeID:     constants.KubeletDataVolumeID,
+			provisioning: false,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseReady,
+
+			expectedError: `the backing of the "KUBELET" system volume cannot be changed after creation (current: partition, requested: directory); ` +
+				`migrating an existing system volume to or from a dedicated partition is not supported`,
+		},
+		{
+			name:         "matching partition is allowed",
+			volumeID:     constants.EtcdDataVolumeID,
+			provisioning: true,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypePartition,
+			currentPhase: blockres.VolumePhaseReady,
+		},
+		{
+			name:         "matching directory is allowed",
+			volumeID:     constants.CRIContainerdVolumeID,
+			provisioning: false,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypeDirectory,
+			currentPhase: blockres.VolumePhaseReady,
+		},
+		{
+			name:         "no established volume is allowed (cluster creation)",
+			volumeID:     constants.EtcdDataVolumeID,
+			provisioning: true,
+			seedStatus:   false,
+		},
+		{
+			name:         "unsettled volume is allowed",
+			volumeID:     constants.EtcdDataVolumeID,
+			provisioning: true,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypeDirectory,
+			currentPhase: blockres.VolumePhaseWaiting,
+		},
+		{
+			name:         "non-promotable volume is ignored",
+			volumeID:     constants.EphemeralPartitionLabel,
+			provisioning: true,
+			seedStatus:   true,
+			currentType:  blockres.VolumeTypeDirectory,
+			currentPhase: blockres.VolumePhaseReady,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			if test.seedStatus {
+				vs := blockres.NewVolumeStatus(blockres.NamespaceName, test.volumeID)
+				vs.TypedSpec().Type = test.currentType
+				vs.TypedSpec().Phase = test.currentPhase
+				require.NoError(t, st.Create(ctx, vs))
+			}
+
+			c := block.NewVolumeConfigV1Alpha1()
+			c.MetaName = test.volumeID
+
+			if test.provisioning {
+				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("50GiB")
+			}
+
+			_, err := c.RuntimeValidate(ctx, st, validationMode{})
+
+			if test.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.expectedError)
 			}
 		})
 	}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -474,6 +474,30 @@ const (
 	// EtcdUserID is the user ID for the etcd process.
 	EtcdUserID = 60
 
+	// CRIContainerdDataPath is the path where the CRI containerd stores its' state.
+	CRIContainerdDataPath = "/var/lib/containerd"
+
+	// CRIContainerdVolumeID is the ID of the CRI containerd data volume.
+	CRIContainerdVolumeID = "CRI"
+
+	// CRIContainerdDataSELinuxLabel is the SELinux label for the CRI containerd data directory.
+	CRIContainerdDataSELinuxLabel = "system_u:object_r:containerd_state_t:s0"
+
+	// KubeletDataPath is the path where the kubelet stores its' state.
+	KubeletDataPath = "/var/lib/kubelet"
+
+	// KubeletDataVolumeID is the ID of the kubelet data volume.
+	KubeletDataVolumeID = "KUBELET"
+
+	// KubeletDataSELinuxLabel is the SELinux label for the kubelet data directory.
+	KubeletDataSELinuxLabel = "system_u:object_r:kubelet_state_t:s0"
+
+	// LogVolumeID is the ID of the log data volume.
+	LogVolumeID = "LOG"
+
+	// LogSELinuxLabel is the SELinux label for the log directory.
+	LogSELinuxLabel = "system_u:object_r:var_log_t:s0"
+
 	// ConfigFilename is the filename of the saved config in STATE partition.
 	ConfigFilename = "config.yaml"
 
@@ -1361,7 +1385,7 @@ const (
 	// UserVolumeMountPoint is the path to the volume mount point for the user volumes.
 	UserVolumeMountPoint = "/var/mnt"
 
-	// LogMountPoint is the path to the logs mount point, and ID of the logs volume.
+	// LogMountPoint is the path to the logs mount point.
 	LogMountPoint = "/var/log"
 
 	// UserVolumePrefix is the prefix for the user volumes.

--- a/pkg/machinery/resources/block/block.go
+++ b/pkg/machinery/resources/block/block.go
@@ -87,7 +87,8 @@ func GetSystemDisk(ctx context.Context, st state.State) (*SystemDiskSpec, error)
 	return systemDisk.TypedSpec(), nil
 }
 
-// GetSystemDiskPaths returns the path(s) of system disk and STATE/EPHEMERAL partitions.
+// GetSystemDiskPaths returns the path(s) of system disk and STATE, EPHEMERAL,
+// CRI, KUBELET, and ETCD partitions (if not backed by EPHEMERAL).
 //
 // This is a legacy method to map old concept of system disk wipe into new volume subsystem.
 func GetSystemDiskPaths(ctx context.Context, st state.State) ([]string, error) {
@@ -104,7 +105,14 @@ func GetSystemDiskPaths(ctx context.Context, st state.State) ([]string, error) {
 	}
 
 	// fetch additional system volumes (which might be on the same or other disks)
-	for _, volumeID := range []string{constants.StatePartitionLabel, constants.EphemeralPartitionLabel} {
+	for _, volumeID := range []string{
+		constants.StatePartitionLabel,
+		constants.EphemeralPartitionLabel,
+		constants.EtcdDataVolumeID,
+		constants.KubeletDataVolumeID,
+		constants.CRIContainerdVolumeID,
+		constants.LogVolumeID,
+	} {
 		volumeStatus, err := safe.ReaderGetByID[*VolumeStatus](ctx, st, volumeID)
 		if err != nil {
 			if state.IsNotFoundError(err) {

--- a/pkg/machinery/resources/block/block_test.go
+++ b/pkg/machinery/resources/block/block_test.go
@@ -5,6 +5,7 @@
 package block_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/resource/meta"
@@ -13,7 +14,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
@@ -45,4 +48,145 @@ func TestRegisterResource(t *testing.T) {
 	} {
 		assert.NoError(t, resourceRegistry.Register(ctx, resource))
 	}
+}
+
+func TestGetSystemDisk(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		ctx := t.Context()
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		spec, err := block.GetSystemDisk(ctx, st)
+		require.NoError(t, err)
+		assert.Nil(t, spec)
+	})
+
+	t.Run("present", func(t *testing.T) {
+		ctx := t.Context()
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		createSystemDisk(ctx, t, st, "sda", "/dev/sda")
+
+		spec, err := block.GetSystemDisk(ctx, st)
+		require.NoError(t, err)
+		require.NotNil(t, spec)
+		assert.Equal(t, "sda", spec.DiskID)
+		assert.Equal(t, "/dev/sda", spec.DevPath)
+	})
+}
+
+func TestGetSystemDiskPaths(t *testing.T) {
+	// a directory-backed system volume (e.g. ETCD/KUBELET/CRI as a directory on EPHEMERAL)
+	// carries neither Location nor ParentLocation, so it must not contribute any disk path.
+	directoryVolume := func(id string) volumeSpec {
+		return volumeSpec{id: id, volumeType: block.VolumeTypeDirectory}
+	}
+
+	// a dedicated partition volume on its own disk carries the partition dev path in Location
+	// and the parent disk dev path in ParentLocation.
+	partitionVolume := func(id, location, parentLocation string) volumeSpec {
+		return volumeSpec{id: id, volumeType: block.VolumeTypePartition, location: location, parentLocation: parentLocation}
+	}
+
+	for _, test := range []struct {
+		name       string
+		systemDisk string // DevPath of the system disk, "" for none
+		volumes    []volumeSpec
+		expected   []string
+	}{
+		{
+			name:     "empty state",
+			expected: nil,
+		},
+		{
+			name:       "etcd/kubelet/cri/log as directories on ephemeral",
+			systemDisk: "/dev/sda",
+			volumes: []volumeSpec{
+				partitionVolume(constants.StatePartitionLabel, "/dev/sda2", "/dev/sda"),
+				partitionVolume(constants.EphemeralPartitionLabel, "/dev/sda3", "/dev/sda"),
+				directoryVolume(constants.EtcdDataVolumeID),
+				directoryVolume(constants.KubeletDataVolumeID),
+				directoryVolume(constants.CRIContainerdVolumeID),
+				directoryVolume(constants.LogVolumeID),
+			},
+			expected: []string{"/dev/sda"},
+		},
+		{
+			name:       "etcd/kubelet/cri/log on dedicated disks",
+			systemDisk: "/dev/sda",
+			volumes: []volumeSpec{
+				partitionVolume(constants.StatePartitionLabel, "/dev/sda2", "/dev/sda"),
+				partitionVolume(constants.EphemeralPartitionLabel, "/dev/sda3", "/dev/sda"),
+				partitionVolume(constants.EtcdDataVolumeID, "/dev/sdb1", "/dev/sdb"),
+				partitionVolume(constants.KubeletDataVolumeID, "/dev/sdc1", "/dev/sdc"),
+				partitionVolume(constants.CRIContainerdVolumeID, "/dev/sdd1", "/dev/sdd"),
+				partitionVolume(constants.LogVolumeID, "/dev/sde1", "/dev/sde"),
+			},
+			expected: []string{"/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde"},
+		},
+		{
+			name:       "volume without parent location falls back to location",
+			systemDisk: "/dev/sda",
+			volumes: []volumeSpec{
+				partitionVolume(constants.EphemeralPartitionLabel, "/dev/sda3", "/dev/sda"),
+				// no ParentLocation: whole-disk/external volume, Location is the disk itself.
+				{id: constants.EtcdDataVolumeID, volumeType: block.VolumeTypeDisk, location: "/dev/sdb"},
+			},
+			expected: []string{"/dev/sda", "/dev/sdb"},
+		},
+		{
+			name:       "dedicated volume on the system disk is not duplicated",
+			systemDisk: "/dev/sda",
+			volumes: []volumeSpec{
+				partitionVolume(constants.EphemeralPartitionLabel, "/dev/sda3", "/dev/sda"),
+				partitionVolume(constants.EtcdDataVolumeID, "/dev/sda4", "/dev/sda"),
+			},
+			expected: []string{"/dev/sda"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			if test.systemDisk != "" {
+				createSystemDisk(ctx, t, st, "system", test.systemDisk)
+			}
+
+			for _, vol := range test.volumes {
+				createVolumeStatus(ctx, t, st, vol)
+			}
+
+			paths, err := block.GetSystemDiskPaths(ctx, st)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, paths)
+		})
+	}
+}
+
+// volumeSpec describes a VolumeStatus to seed into the test state.
+type volumeSpec struct {
+	id             string
+	volumeType     block.VolumeType
+	location       string
+	parentLocation string
+}
+
+func createSystemDisk(ctx context.Context, t *testing.T, st state.State, diskID, devPath string) {
+	t.Helper()
+
+	systemDisk := block.NewSystemDisk(block.NamespaceName, block.SystemDiskID)
+	systemDisk.TypedSpec().DiskID = diskID
+	systemDisk.TypedSpec().DevPath = devPath
+
+	require.NoError(t, st.Create(ctx, systemDisk))
+}
+
+func createVolumeStatus(ctx context.Context, t *testing.T, st state.State, spec volumeSpec) {
+	t.Helper()
+
+	volumeStatus := block.NewVolumeStatus(block.NamespaceName, spec.id)
+	volumeStatus.TypedSpec().Type = spec.volumeType
+	volumeStatus.TypedSpec().Location = spec.location
+	volumeStatus.TypedSpec().ParentLocation = spec.parentLocation
+
+	require.NoError(t, st.Create(ctx, volumeStatus))
 }

--- a/website/content/v1.14/reference/configuration/block/volumeconfig.md
+++ b/website/content/v1.14/reference/configuration/block/volumeconfig.md
@@ -1,7 +1,11 @@
 ---
 description: |
     VolumeConfig is a system volume configuration document.
-    Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.
+    Note: at the moment, only `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`
+    system volumes are supported. The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes default to a
+    directory under `EPHEMERAL`, and can be placed on a dedicated partition by specifying
+    `provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be
+    chosen at cluster creation time: changing it on an already-provisioned node is not supported.
 title: VolumeConfig
 ---
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -796,7 +796,7 @@
         "apiVersion",
         "kind"
       ],
-      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL` and `IMAGECACHE` system volumes are supported.\\n"
+      "description": "VolumeConfig is a system volume configuration document.\\nNote: at the moment, only `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`\\nsystem volumes are supported. The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes default to a\\ndirectory under `EPHEMERAL`, and can be placed on a dedicated partition by specifying\\n`provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be\\nchosen at cluster creation time: changing it on an already-provisioned node is not supported.\\n"
     },
     "block.VolumeDiscoverySpec": {
       "properties": {


### PR DESCRIPTION
Resolves https://github.com/siderolabs/talos/issues/10678

Adds support for custom system volume configuration (etcd, cri, kubelet, logs).

With the following patch provided during cluster creation, for control plane nodes:
```sh
apiVersion: v1alpha1
kind: VolumeConfig
name: KUBELET
provisioning:
  minSize: 1GB
  maxSize: 5GB
```

The `KUBELET` volume gets provisioned on a separate XFS partition. Note that `ETCD` and `CRI` are still backed by `directory`, by default.
```sh
_out/talosctl-linux-amd64 get  -n 172.20.0.2 volumestatus                         15:38:49
NODE         NAMESPACE   TYPE           ID                                  VERSION   TYPE        PHASE   LOCATION    SIZE
172.20.0.2   runtime     VolumeStatus   /opt                                3         overlay     ready
172.20.0.2   runtime     VolumeStatus   /usr/libexec/kubernetes             3         overlay     ready
172.20.0.2   runtime     VolumeStatus   /var/lib                            2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/lib/cni                        2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/lib/kubelet/seccomp            2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/lib/kubelet/seccomp/profiles   2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/log                            2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/log/audit                      2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/log/audit/kube                 2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/log/containers                 2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/log/pods                       2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/mnt                            2         directory   ready
172.20.0.2   runtime     VolumeStatus   /var/run                            2         symlink     ready
172.20.0.2   runtime     VolumeStatus   /var/run/lock                       2         directory   ready
172.20.0.2   runtime     VolumeStatus   CRI                                 2         directory   ready
172.20.0.2   runtime     VolumeStatus   EPHEMERAL                           4         partition   ready   /dev/vda5   8.8 GB
172.20.0.2   runtime     VolumeStatus   ETCD                                4         directory   ready
172.20.0.2   runtime     VolumeStatus   KUBELET                             2         partition   ready   /dev/vda4   5.0 GB
172.20.0.2   runtime     VolumeStatus   META                                3         partition   ready   /dev/vda2   1.0 MB
172.20.0.2   runtime     VolumeStatus   STATE                               7         partition   ready   /dev/vda3   105 MB
```

Providing custom `VolumeConfigs` for `KUBELET`, `CRI`, and `ETCD` is allowed only during cluster creation. That is, system volumes already backed by `EPHEMERAL` cannot be converted into custom volumes, the opposite is disallowed as well.

For example, attempting to add `KUBELET` `VolumeConfig` for a cluster that has the kubelet data already backed by `EPHEMERAL`:
```sh
# Editing MachineConfigs.config.talos.dev/v1alpha1 at node 172.20.0.2
# 
# 1 error occurred:
# 	* 172.20.0.2: rpc error: code = InvalidArgument desc = 1 error occurred:
# 	* VolumeConfig/KUBELET: the backing of the "KUBELET" system volume cannot be changed after creation (current: directory, requested: partition); migrating an existing system volume to or from a dedicated partition is not supported
```

And conversely, the other way around:
```sh
# Editing MachineConfigs.config.talos.dev/v1alpha1 at node 172.20.0.2
# 
# 1 error occurred:
# 	* 172.20.0.2: rpc error: code = InvalidArgument desc = 1 error occurred:
# 	* the "KUBELET" system volume is backed by a dedicated partition and its VolumeConfig cannot be removed; migrating a system volume off a dedicated partition is not supported
```

This PR will be followed by a [docs](https://github.com/siderolabs/docs/) update.