### PR TITLE
fix: `cli.md` codeblocks

### DIFF
--- a/cmd/talosctl/cmd/docs.go
+++ b/cmd/talosctl/cmd/docs.go
@@ -178,6 +178,80 @@ var docsCmd = &cobra.Command{
 	},
 }
 
+// isListMarker checks if a line starts with a markdown list marker.
+func isListMarker(line string) bool {
+	trimmed := strings.TrimSpace(line)
+
+	return strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "+ ")
+}
+
+// processIndentedBlock handles a block of consecutive tab-indented lines.
+func processIndentedBlock(lines []string, i *int, result *[]string) {
+	var indentedLines []string
+	for *i < len(lines) && strings.HasPrefix(lines[*i], "\t") {
+		indentedLines = append(indentedLines, strings.TrimPrefix(lines[*i], "\t"))
+		*i++
+	}
+
+	if len(indentedLines) == 0 {
+		return
+	}
+
+	if isListMarker(indentedLines[0]) {
+		for _, l := range indentedLines {
+			*result = append(*result, "\t"+l)
+		}
+	} else {
+		*result = append(*result, "```")
+		*result = append(*result, indentedLines...)
+		*result = append(*result, "```")
+	}
+}
+
+// ConvertIndentedCodeBlocks converts tab-indented lines to fenced code blocks.
+// This handles Cobra's built-in completion commands which use tab-indented lines
+// in their Long descriptions instead of fenced code blocks.
+func ConvertIndentedCodeBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+
+	var result []string
+
+	inCodeBlock := false
+	i := 0
+
+	for i < len(lines) {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeBlock = !inCodeBlock
+
+			result = append(result, line)
+			i++
+
+			continue
+		}
+
+		if inCodeBlock {
+			result = append(result, line)
+			i++
+
+			continue
+		}
+
+		if strings.HasPrefix(line, "\t") {
+			processIndentedBlock(lines, &i, &result)
+
+			continue
+		}
+
+		result = append(result, line)
+		i++
+	}
+
+	return strings.Join(result, "\n")
+}
+
 // GenMarkdownReference is the same as GenMarkdownTree, but
 // with custom filePrepender and linkHandler.
 //
@@ -205,6 +279,8 @@ func GenMarkdownReference(cmd *cobra.Command, w io.Writer, linkHandler func(stri
 	if cmd.Name() == "create" && cmd.Parent() != nil && cmd.Parent().Name() == "cluster" {
 		return nil
 	}
+
+	cmd.Long = ConvertIndentedCodeBlocks(cmd.Long)
 
 	return doc.GenMarkdownCustom(cmd, w, linkHandler)
 }

--- a/cmd/talosctl/cmd/docs_test.go
+++ b/cmd/talosctl/cmd/docs_test.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/talos/cmd/talosctl/cmd"
+)
+
+func TestConvertIndentedCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single line no indent",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "single tab-indented line",
+			input:    "Line 1\n\tcode line\nLine 3",
+			expected: "Line 1\n```\ncode line\n```\nLine 3",
+		},
+		{
+			name:     "multiple consecutive tab-indented lines",
+			input:    "Intro\n\tline 1\n\tline 2\n\tline 3\nAfter",
+			expected: "Intro\n```\nline 1\nline 2\nline 3\n```\nAfter",
+		},
+		{
+			name:     "multiple groups of indented lines",
+			input:    "First group:\n\tcode 1\n\tcode 2\nMiddle\n\tcode 3\n\tcode 4\nEnd",
+			expected: "First group:\n```\ncode 1\ncode 2\n```\nMiddle\n```\ncode 3\ncode 4\n```\nEnd",
+		},
+		{
+			name:     "already fenced code block untouched",
+			input:    "Intro\n```\n\tcode in fence\n\tmore code\n```\nAfter",
+			expected: "Intro\n```\n\tcode in fence\n\tmore code\n```\nAfter",
+		},
+		{
+			name:     "indented lines with fenced block nearby",
+			input:    "Section 1:\n\tindented\nSection 2:\n```\nfenced\n```\nSection 3:\n\tmore indented",
+			expected: "Section 1:\n```\nindented\n```\nSection 2:\n```\nfenced\n```\nSection 3:\n```\nmore indented\n```",
+		},
+		{
+			name:     "fenced block with language specifier",
+			input:    "Example:\n```yaml\n\tkey: value\n```\nAfter:\n\tindented",
+			expected: "Example:\n```yaml\n\tkey: value\n```\nAfter:\n```\nindented\n```",
+		},
+		{
+			name:     "tabs at varying positions (only leading tabs count)",
+			input:    "Text\n\tindent\n  spaces\nMore\n\tanother\ttab",
+			expected: "Text\n```\nindent\n```\n  spaces\nMore\n```\nanother\ttab\n```",
+		},
+		{
+			name:     "real-world cobra completion example",
+			input:    "To load completions in your current shell session:\n\n\tsource <(talosctl completion bash)\n\nTo load completions for every new session:",
+			expected: "To load completions in your current shell session:\n\n```\nsource <(talosctl completion bash)\n```\n\nTo load completions for every new session:",
+		},
+		{
+			name:     "multiple fenced code blocks",
+			input:    "First:\n```\ncode1\n```\nSecond:\n```\ncode2\n```\nThird:\n\tindented",
+			expected: "First:\n```\ncode1\n```\nSecond:\n```\ncode2\n```\nThird:\n```\nindented\n```",
+		},
+		{
+			name:     "toggle between fenced and indented",
+			input:    "\tfenced toggle 1\n```\nin fence\n```\n\tfenced toggle 2",
+			expected: "```\nfenced toggle 1\n```\n```\nin fence\n```\n```\nfenced toggle 2\n```",
+		},
+		{
+			name:     "whitespace-only lines between indented groups",
+			input:    "Start\n\tcode1\n\nMiddle\n\tcode2\nEnd",
+			expected: "Start\n```\ncode1\n```\n\nMiddle\n```\ncode2\n```\nEnd",
+		},
+		{
+			name:     "preserve line with spaces only",
+			input:    "Text\n\tindented\n   \nMore",
+			expected: "Text\n```\nindented\n```\n   \nMore",
+		},
+		{
+			name:     "mixed tabs and spaces in continuation",
+			input:    "Start:\n\tline with tab\n  \t  line with mixed spacing\nEnd",
+			expected: "Start:\n```\nline with tab\n```\n  \t  line with mixed spacing\nEnd",
+		},
+		{
+			name:     "tab-indented list items not wrapped",
+			input:    "Items:\n\t- Item 1\n\t- Item 2\n\t- Item 3\nAfter",
+			expected: "Items:\n\t- Item 1\n\t- Item 2\n\t- Item 3\nAfter",
+		},
+		{
+			name:     "tab-indented mixed list with different markers",
+			input:    "Items:\n\t- First\n\t* Second\n\t+ Third\nAfter",
+			expected: "Items:\n\t- First\n\t* Second\n\t+ Third\nAfter",
+		},
+		{
+			name:     "tab-indented non-list code wrapped",
+			input:    "Code:\n\techo hello\n\techo world\nAfter",
+			expected: "Code:\n```\necho hello\necho world\n```\nAfter",
+		},
+		{
+			name:     "list with continuation paragraph",
+			input:    "My list:\n\t- AAA\n\t\n\t  AAA continuation\nAfter",
+			expected: "My list:\n\t- AAA\n\t\n\t  AAA continuation\nAfter",
+		},
+		{
+			name:     "list with multiple items and continuations",
+			input:    "Items:\n\t- Item 1\n\t\n\t  Continuation\n\t- Item 2\nAfter",
+			expected: "Items:\n\t- Item 1\n\t\n\t  Continuation\n\t- Item 2\nAfter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cmd.ConvertIndentedCodeBlocks(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertIndentedCodeBlocks() mismatch\nInput:\n%q\nExpected:\n%q\nGot:\n%q", tt.input, tt.expected, result)
+			}
+		})
+	}
+}

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -714,17 +714,23 @@ If it is not installed already, you can install it via your OS's package manager
 
 To load completions in your current shell session:
 
-	source <(talosctl completion bash)
+```
+source <(talosctl completion bash)
+```
 
 To load completions for every new session, execute once:
 
 #### Linux:
 
-	talosctl completion bash > /etc/bash_completion.d/talosctl
+```
+talosctl completion bash > /etc/bash_completion.d/talosctl
+```
 
 #### macOS:
 
-	talosctl completion bash > $(brew --prefix)/etc/bash_completion.d/talosctl
+```
+talosctl completion bash > $(brew --prefix)/etc/bash_completion.d/talosctl
+```
 
 You will need to start a new shell for this setup to take effect.
 
@@ -754,11 +760,15 @@ Generate the autocompletion script for the fish shell.
 
 To load completions in your current shell session:
 
-	talosctl completion fish | source
+```
+talosctl completion fish | source
+```
 
 To load completions for every new session, execute once:
 
-	talosctl completion fish > ~/.config/fish/completions/talosctl.fish
+```
+talosctl completion fish > ~/.config/fish/completions/talosctl.fish
+```
 
 You will need to start a new shell for this setup to take effect.
 
@@ -788,7 +798,9 @@ Generate the autocompletion script for powershell.
 
 To load completions in your current shell session:
 
-	talosctl completion powershell | Out-String | Invoke-Expression
+```
+talosctl completion powershell | Out-String | Invoke-Expression
+```
 
 To load completions for every new session, add the output of the above command
 to your powershell profile.
@@ -820,21 +832,29 @@ Generate the autocompletion script for the zsh shell.
 If shell completion is not already enabled in your environment you will need
 to enable it.  You can execute the following once:
 
-	echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
 
 To load completions in your current shell session:
 
-	source <(talosctl completion zsh)
+```
+source <(talosctl completion zsh)
+```
 
 To load completions for every new session, execute once:
 
 #### Linux:
 
-	talosctl completion zsh > "${fpath[1]}/_talosctl"
+```
+talosctl completion zsh > "${fpath[1]}/_talosctl"
+```
 
 #### macOS:
 
-	talosctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_talosctl
+```
+talosctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_talosctl
+```
 
 You will need to start a new shell for this setup to take effect.
 


### PR DESCRIPTION
https://github.com/siderolabs/talos/pull/13073 introduced a regression to codeblock fencing (\`\`\`), breaking downstream static site generation in siderolabs/docs. This commit fixes the generation logic to fence code snippets.
