### PR TITLE
feat: set user-agent for Kubernetes client

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/siderolabs/talos/pkg/httpdefaults"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
@@ -62,6 +63,8 @@ func NewClientFromKubeletKubeconfig() (*Client, error) {
 		Timeout:   15 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext
+
+	config.UserAgent = httpdefaults.UserAgent()
 
 	return NewForConfig(config)
 }
@@ -101,6 +104,8 @@ func NewForConfig(config *restclient.Config) (*Client, error) {
 	if err := loadPKIIntoVariable(&config.TLSClientConfig.KeyData, &config.TLSClientConfig.KeyFile); err != nil {
 		return nil, fmt.Errorf("failed to load client key: %w", err)
 	}
+
+	config.UserAgent = httpdefaults.UserAgent()
 
 	// now, initialize the client using the standard method
 	client, err := taloskubernetes.NewForConfig(config)


### PR DESCRIPTION
Fixes https://github.com/siderolabs/go-kubernetes/issues/65

This is how it looks now in the audit log:

```json
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Metadata",
  "auditID": "e7da32e7-30a5-467f-a9c8-6c240de1f596",
  "stage": "RequestReceived",
  "requestURI": "/api/v1/nodes/talos-default-controlplane-2?timeout=30s",
  "verb": "get",
  "user": {
    "username": "admin",
    "groups": [
      "system:masters",
      "system:authenticated"
    ],
    "extra": {
      "authentication.kubernetes.io/credential-id": [
        "X509SHA256=696bd138dac53304ee1c94ad6c75c4fef5d38cc7c95c4c679d45c70bd0bc18aa"
      ]
    }
  },
  "sourceIPs": [
    "172.20.0.1"
  ],
  "userAgent": "Talos/v1.14.0-alpha.2-8-gba926c6ce-dirty",
  "objectRef": {
    "resource": "nodes",
    "name": "talos-default-controlplane-2",
    "apiVersion": "v1"
  },
  "requestReceivedTimestamp": "2026-06-29T08:22:24.995217Z",
  "stageTimestamp": "2026-06-29T08:22:24.995217Z"
}
```
