### PR TITLE
fix: kubelet stuck restarting

### DIFF
--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -255,6 +255,12 @@ func (svcrunner *ServiceRunner) Run(notifyChannels ...chan<- struct{}) error {
 
 	if condition != nil {
 		if err := svcrunner.waitFor(ctx, condition); err != nil {
+			// a canceled context here means the service was shut down before it
+			// started running; treat it as a clean stop (mirrors run(), see below)
+			if ctx.Err() != nil {
+				return nil
+			}
+
 			return fmt.Errorf("condition failed: %w", err)
 		}
 	}
@@ -262,6 +268,11 @@ func (svcrunner *ServiceRunner) Run(notifyChannels ...chan<- struct{}) error {
 	svcrunner.UpdateState(ctx, events.StatePreparing, "Running pre state")
 
 	if err := svcrunner.service.PreFunc(ctx, svcrunner.runtime); err != nil {
+		// see above: a canceled context means the service was shut down
+		if ctx.Err() != nil {
+			return nil
+		}
+
 		return fmt.Errorf("failed to run pre stage: %w", err)
 	}
 

--- a/internal/app/machined/pkg/system/service_runner_test.go
+++ b/internal/app/machined/pkg/system/service_runner_test.go
@@ -330,7 +330,8 @@ func (suite *ServiceRunnerSuite) TestAbortOnCondition() {
 
 	sr.Shutdown()
 
-	suite.Assert().EqualError(<-errCh, "condition failed: context canceled")
+	// a shutdown while waiting on the condition is a clean stop, not a failure
+	suite.Assert().NoError(<-errCh)
 
 	suite.assertStateSequence([]events.ServiceState{
 		events.StateStarting,

--- a/internal/app/machined/pkg/system/system_test.go
+++ b/internal/app/machined/pkg/system/system_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/logging"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/system/events"
 )
 
 var (
@@ -90,6 +92,42 @@ func (suite *SystemServicesSuite) TestStopWithRevDeps() {
 	}
 
 	system.Services(nil).Shutdown(context.TODO())
+}
+
+func serviceState(id string) string {
+	for _, svcRunner := range system.Services(nil).List() {
+		if proto := svcRunner.AsProto(); proto.Id == id {
+			return proto.State
+		}
+	}
+
+	return ""
+}
+
+// TestStopDuringCondition verifies that stopping a service while it is still
+// waiting on its start condition is treated as a clean stop, and doesn't leave
+// the service stuck in the Failed state (regression test).
+func (suite *SystemServicesSuite) TestStopDuringCondition() {
+	cond := NewMockCondition("test condition")
+
+	system.Services(newRuntime(suite.T())).LoadAndStart(
+		&MockService{name: "stopcond", condition: cond},
+	)
+
+	// wait until the service is waiting on the condition
+	suite.Require().NoError(retry.Constant(time.Minute, retry.WithUnits(10*time.Millisecond)).Retry(func() error {
+		if state := serviceState("stopcond"); state != events.StateWaiting.String() {
+			return retry.ExpectedErrorf("service should be waiting, got %q", state)
+		}
+
+		return nil
+	}))
+
+	// stopping the service while it waits on the condition should be a clean
+	// stop, not a failure (it used to stick in StateFailed)
+	suite.Require().NoError(system.Services(nil).Stop(context.Background(), "stopcond"))
+
+	suite.Assert().Equal(events.StateFinished.String(), serviceState("stopcond"))
 }
 
 func TestSystemServicesSuite(t *testing.T) {


### PR DESCRIPTION
The bug shows up in the logs like:

```
waiting for kubelet to be healthy: 1 error occurred:
    * 172.20.1.4: service "kubelet" not in expected state "Running": current state [Failed] Condition failed: context canceled
```

Under rapid restarts, if the restart comes while the kubelet is in the condition/pre phase, the service runner treated context cancelation as a fatal event, preventing further restarts.

Ignore context canceled events properly.
