### PR TITLE
fix: decode extraArgs list values correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/siderolabs/crypto v0.6.5
 	github.com/siderolabs/discovery-api v0.1.8
 	github.com/siderolabs/discovery-client v0.1.15
-	github.com/siderolabs/gen v0.8.6
+	github.com/siderolabs/gen v0.8.7
 	github.com/siderolabs/go-adv v1.0.0
 	github.com/siderolabs/go-blockdevice/v2 v2.0.31
 	github.com/siderolabs/go-circular v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -791,8 +791,9 @@ github.com/siderolabs/discovery-client v0.1.15 h1:XN2nm2U/RUtevZtKZnwYAOE+Z68VpW
 github.com/siderolabs/discovery-client v0.1.15/go.mod h1:iUpFYp40CNTnqshG7d2r9zjMruLEaT0sb49rZzVSXVA=
 github.com/siderolabs/ethtool v0.6.0-sidero h1:0LVd+VWgwGo1d5DEJiJSY+rW3R6P5Sp1qHKKqMahDJI=
 github.com/siderolabs/ethtool v0.6.0-sidero/go.mod h1:pZdvfpIRgnKmcS2kDJSqE9AjyPEQORZ3O3tKsJzkcwA=
-github.com/siderolabs/gen v0.8.6 h1:pE6shuqov3L+5rEcAUJ/kY6iJofimljQw5G95P8a5c4=
 github.com/siderolabs/gen v0.8.6/go.mod h1:J9IbusbES2W6QWjtSHpDV9iPGZHc978h1+KJ4oQRspQ=
+github.com/siderolabs/gen v0.8.7 h1:Nu31kL0ln/facRHBfNX7zcB7w9VZ9tifXKsP4lUtWHw=
+github.com/siderolabs/gen v0.8.7/go.mod h1:J9IbusbES2W6QWjtSHpDV9iPGZHc978h1+KJ4oQRspQ=
 github.com/siderolabs/go-adv v1.0.0 h1:ZWXnoGq1GKeEIkLSR4o6oKcayFsowZkJsWcyQqwPk6c=
 github.com/siderolabs/go-adv v1.0.0/go.mod h1:nR6YwduJv56mZI1D3ow1Zok5lwefiM94hS0o1d6KmNc=
 github.com/siderolabs/go-api-signature v0.3.13 h1:1u3vOWpn4PJJcQZCQXXXxeZk+HcoRdXCpvojE3q5Q9k=

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader/internal/decoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/internal/registry"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 )
@@ -303,6 +304,28 @@ pods:
 `),
 			expected:    nil,
 			expectedErr: "",
+		},
+		{
+			name: "kube apiserver extra args list value",
+			source: []byte(`---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+extraArgs:
+  service-account-issuer:
+    - https://OLD-ENDPOINT:6443
+    - https://NEW-ENDPOINT:6443
+`),
+			expected: []config.Document{
+				&k8s.KubeAPIServerConfigV1Alpha1{
+					Meta: meta.Meta{
+						MetaAPIVersion: "v1alpha1",
+						MetaKind:       "KubeAPIServerConfig",
+					},
+					PodArgs: meta.Args{
+						"service-account-issuer": meta.NewArgValue("", []string{"https://OLD-ENDPOINT:6443", "https://NEW-ENDPOINT:6443"}),
+					},
+				},
+			},
 		},
 		{
 			name: "omit empty test",


### PR DESCRIPTION
siderolabs/gen v0.8.7 includes the list-value
fix from https://github.com/siderolabs/gen/pull/33. Bump to unblock multi-value
extraArgs in KubeAPIServerConfig decoder.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
