### PR TITLE
fix: provide cooldown period for the QoS trigger

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/internal/oom/oom_test.go
@@ -825,7 +825,7 @@ func TestEvaluateTrigger(t *testing.T) {
 			name: "cgroup-true-cool",
 			dir:  "./testdata/trigger-true",
 			ctx: map[string]any{
-				"time_since_trigger": 3 * time.Second,
+				"time_since_trigger": 6 * time.Second,
 			},
 			triggerExpr: triggerExpr1,
 			expect:      true,

--- a/pkg/machinery/config/types/runtime/oom.go
+++ b/pkg/machinery/config/types/runtime/oom.go
@@ -151,7 +151,7 @@ func (s *OOMV1Alpha1) Validate(validation.RuntimeMode, ...validation.Option) ([]
 
 // TriggerExpression returns the OOM trigger expression.
 func (s *OOMV1Alpha1) TriggerExpression() cel.Expression {
-	if s.OOMCgroupRankingExpression.IsZero() {
+	if s.OOMTriggerExpression.IsZero() {
 		return config.DefaultOOMConfig{}.TriggerExpression()
 	}
 

--- a/pkg/machinery/config/types/runtime/testdata/oom.yaml
+++ b/pkg/machinery/config/types/runtime/testdata/oom.yaml
@@ -2,7 +2,7 @@ apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: |-
     multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
-    multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 ||
-    memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
+    multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 &&
+    time_since_trigger > duration("5s") || memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))'
 sampleInterval: 100ms

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1353,7 +1353,7 @@ const (
 
 	// DefaultOOMTriggerExpression is the default CEL expression used to determine whether to trigger OOM.
 	DefaultOOMTriggerExpression = `(multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
-	     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0) ||
+	     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 && time_since_trigger > duration("5s")) ||
 		(memory_full_avg10 > 75.0 && time_since_trigger > duration("10s"))`
 
 	// DefaultOOMCgroupRankingExpression is the default CEL expression used to rank cgroups for OOM killer.

--- a/website/content/v1.14/reference/configuration/runtime/oomconfig.md
+++ b/website/content/v1.14/reference/configuration/runtime/oomconfig.md
@@ -18,8 +18,8 @@ apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: |- # This expression defines when to trigger OOM action.
     multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
-    multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 ||
-    memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
+    multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 &&
+    time_since_trigger > duration("5s") || memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))' # This expression defines how to rank cgroups for OOM handler.
 sampleInterval: 100ms # How often should the trigger expression be evaluated.
 {{< /highlight >}}


### PR DESCRIPTION
Fixes #13622

The trigger expression was missing cooldown periof for the QoS trigger, only for the second trigger part (on overall PSI value), which might trigger a storm of kills - the controller wakes up every 500ms, if the trigger expression is still true, perform a kill, and the cycle repeats.

The shim process should be reaped by CRI/containerd/kubelet: when the workload exists, the shims sends TaskExit event which should be processed by the full CRI chain, cleaning up the container/pod which will clean up the shims as well.

If we kill too fast, containerd/kubelet stack can't keep up, creating even more PSI from "leftover" shims.
