### PR TITLE
feat: delegate drain ops to go-kubernetes/nodedrain

### DIFF
--- a/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
+++ b/cmd/talosctl/pkg/talos/nodedrain/nodedrain.go
@@ -9,15 +9,11 @@ package nodedrain
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/siderolabs/go-kubernetes/kubernetes/nodedrain"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubectl/pkg/drain"
 
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -27,9 +23,6 @@ import (
 const (
 	// DefaultDrainTimeout is the default maximum time to wait for the node to be drained.
 	DefaultDrainTimeout = 5 * time.Minute
-
-	// nodeReadyPollInterval is how often to poll for node readiness.
-	nodeReadyPollInterval = 5 * time.Second
 )
 
 // ReportFunc is a callback for reporting drain progress updates.
@@ -65,64 +58,17 @@ func GetKubernetesNodeName(ctx context.Context, c *client.Client) (string, error
 // all pods. It uses the kubectl drain library for proper PDB handling, eviction
 // API support, and pod filtering.
 func CordonAndDrain(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts Options, report ReportFunc) error {
-	timeout := opts.DrainTimeout
-	if timeout == 0 {
-		timeout = DefaultDrainTimeout
-	}
-
-	drainCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	node, err := clientset.CoreV1().Nodes().Get(drainCtx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error getting node %q: %w", nodeName, err)
-	}
-
-	// Set up the drain helper with sensible defaults covering 90% of cases.
-	drainer := &drain.Helper{
-		Ctx:                 drainCtx,
-		Client:              clientset,
-		Force:               true, // handle unmanaged pods
-		GracePeriodSeconds:  -1,   // use pod's own terminationGracePeriodSeconds
-		IgnoreAllDaemonSets: true, // DaemonSet pods are re-created by the DS controller
-		DeleteEmptyDirData:  true, // node is rebooting, local data is lost anyway
-		Timeout:             timeout,
-		Out:                 io.Discard,
-		ErrOut:              io.Discard,
-		OnPodDeletionOrEvictionStarted: func(pod *corev1.Pod, usingEviction bool) {
-			action := "deleting"
-			if usingEviction {
-				action = "evicting"
-			}
-
-			report(reporter.Update{
-				Message: fmt.Sprintf("%s: %s pod %s/%s", nodeName, action, pod.Namespace, pod.Name),
-				Status:  reporter.StatusRunning,
-			})
-		},
-		OnPodDeletionOrEvictionFinished: func(pod *corev1.Pod, usingEviction bool, err error) {
-			if err != nil {
-				report(reporter.Update{
-					Message: fmt.Sprintf("%s: failed to evict pod %s/%s: %v", nodeName, pod.Namespace, pod.Name, err),
-					Status:  reporter.StatusError,
-				})
-
-				return
-			}
-
-			report(reporter.Update{
-				Message: fmt.Sprintf("%s: evicted pod %s/%s", nodeName, pod.Namespace, pod.Name),
-				Status:  reporter.StatusRunning,
-			})
-		},
-	}
-
 	report(reporter.Update{
 		Message: fmt.Sprintf("%s: cordoning node", nodeName),
 		Status:  reporter.StatusRunning,
 	})
 
-	if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {
+	if err := nodedrain.Cordon(ctx, clientset, nodeName); err != nil {
+		report(reporter.Update{
+			Message: fmt.Sprintf("%s: error cordoning node: %v", nodeName, err),
+			Status:  reporter.StatusError,
+		})
+
 		return fmt.Errorf("error cordoning node %q: %w", nodeName, err)
 	}
 
@@ -136,7 +82,22 @@ func CordonAndDrain(ctx context.Context, clientset kubernetes.Interface, nodeNam
 		Status:  reporter.StatusRunning,
 	})
 
-	if err := drain.RunNodeDrain(drainer, nodeName); err != nil {
+	dopts := nodedrain.DrainOptions{
+		Timeout: opts.DrainTimeout,
+		Progress: func(s string) {
+			report(reporter.Update{
+				Message: fmt.Sprintf("%s: %s", nodeName, s),
+				Status:  reporter.StatusRunning,
+			})
+		},
+	}
+
+	if err := nodedrain.Drain(ctx, clientset, nodeName, dopts); err != nil {
+		report(reporter.Update{
+			Message: fmt.Sprintf("%s: error cordoning node: %v", nodeName, err),
+			Status:  reporter.StatusError,
+		})
+
 		return fmt.Errorf("error draining node %q: %w", nodeName, err)
 	}
 
@@ -151,41 +112,22 @@ func CordonAndDrain(ctx context.Context, clientset kubernetes.Interface, nodeNam
 // WaitForNodeReady polls the Kubernetes API until the node reports a Ready condition
 // with status True.
 func WaitForNodeReady(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(ctx, nodeReadyPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		if err != nil {
-			// Transient errors are expected while the node is rebooting.
-			return false, nil //nolint:nilerr
-		}
-
-		for _, cond := range node.Status.Conditions {
-			if cond.Type == corev1.NodeReady {
-				return cond.Status == corev1.ConditionTrue, nil
-			}
-		}
-
-		return false, nil
-	})
+	return nodedrain.WaitForNodeReady(ctx, clientset, nodeName, timeout)
 }
 
 // Uncordon marks the Kubernetes node as schedulable again.
 func Uncordon(ctx context.Context, clientset kubernetes.Interface, nodeName string, report ReportFunc) error {
-	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error getting node %q for uncordon: %w", nodeName, err)
-	}
-
-	drainer := &drain.Helper{
-		Ctx:    ctx,
-		Client: clientset,
-	}
-
 	report(reporter.Update{
 		Message: fmt.Sprintf("%s: uncordoning node", nodeName),
 		Status:  reporter.StatusRunning,
 	})
 
-	if err := drain.RunCordonOrUncordon(drainer, node, false); err != nil {
+	if err := nodedrain.Uncordon(ctx, clientset, nodeName); err != nil {
+		report(reporter.Update{
+			Message: fmt.Sprintf("%s: error uncordoning node: %v", nodeName, err),
+			Status:  reporter.StatusError,
+		})
+
 		return fmt.Errorf("error uncordoning node %q: %w", nodeName, err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/siderolabs/go-debug v0.6.2
 	github.com/siderolabs/go-kmsg v0.1.6
 	github.com/siderolabs/go-kubeconfig v0.1.2
-	github.com/siderolabs/go-kubernetes v0.2.39
+	github.com/siderolabs/go-kubernetes v0.2.40
 	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pcidb v0.3.3
 	github.com/siderolabs/go-pointer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -812,8 +812,8 @@ github.com/siderolabs/go-kmsg v0.1.6 h1:ZrJPExUnJubqiNA7T8RUi/ySvJsnIen+bdiY+pea
 github.com/siderolabs/go-kmsg v0.1.6/go.mod h1:fryspKc1f6nMIOK5YbUPutz2v2rdBTBeLqW/ci9BDfk=
 github.com/siderolabs/go-kubeconfig v0.1.2 h1:0D0v3lXUKon+A2qRFwOnc9m4qSB+e+5WDmvGjiJPH8Y=
 github.com/siderolabs/go-kubeconfig v0.1.2/go.mod h1:FMl17PHjjAJjdeUTMN+gBzGH0lhsCbj2IX9/HNMpMh0=
-github.com/siderolabs/go-kubernetes v0.2.39 h1:NhCKsFwwXNDDYD7PPLycP7VVJwaZmXum8kEQoA65yDA=
-github.com/siderolabs/go-kubernetes v0.2.39/go.mod h1:4DBVXLASGnJIhbDRJNl9DayYohYLu3VhQ1cpY/Gj2nw=
+github.com/siderolabs/go-kubernetes v0.2.40 h1:558ZJoX47B/FoSdDqk+gfJZTMtqT78e/+bBPnEOi7jk=
+github.com/siderolabs/go-kubernetes v0.2.40/go.mod h1:yXYk/2N9okLCq+SZCm2x32LtGcs0HcRislWQMyaodWA=
 github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
 github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pcidb v0.3.3 h1:Cxng3j6gUrWCh1tHlt524A4cC+dyRU+3j1AWQM6ULPc=


### PR DESCRIPTION
Extract inline kubectl drain logic into shared go-kubernetes library so
it can be reused across upgrades and reboots without duplicating PDB
handling, eviction, and pod-filtering code.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
