### PR TITLE
fix: data race in manifest sync

### DIFF
--- a/internal/app/machined/pkg/adapters/k8s/manifest.go
+++ b/internal/app/machined/pkg/adapters/k8s/manifest.go
@@ -116,8 +116,12 @@ func (a manifest) SetYAML(yamlBytes []byte) error {
 }
 
 // Objects returns list of unstructured object.
+//
+// The returned objects are deep copies, so callers may mutate them freely without
+// racing with concurrent readers of the resource spec (e.g. the COSI state server
+// marshaling the resource for an API List/Get).
 func (a manifest) Objects() []*unstructured.Unstructured {
 	return xslices.Map(a.Manifest.TypedSpec().Items, func(item k8s.SingleManifest) *unstructured.Unstructured {
-		return &unstructured.Unstructured{Object: item.Object}
+		return (&unstructured.Unstructured{Object: item.Object}).DeepCopy()
 	})
 }

--- a/internal/app/machined/pkg/adapters/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/adapters/k8s/manifest_test.go
@@ -52,6 +52,25 @@ rules:
 	assert.Equal(t, adapter.Objects()[0].GetKind(), "Policy")
 }
 
+func TestManifestObjectsAreCopies(t *testing.T) {
+	manifest := k8s.NewManifest(k8s.ControlPlaneNamespaceName, "test")
+	adapter := k8sadapter.Manifest(manifest)
+
+	require.NoError(t, adapter.SetYAML([]byte(strings.TrimSpace(`
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+`))))
+
+	// mutating an object returned by Objects() must not affect the resource spec,
+	// otherwise the controller races with concurrent readers (e.g. the COSI state
+	// server marshaling the resource for an API List/Get).
+	adapter.Objects()[0].SetNamespace("mutated")
+
+	assert.Empty(t, adapter.Objects()[0].GetNamespace())
+}
+
 //go:embed testdata/list.yaml
 var listManifest []byte
 

--- a/pkg/imager/filemap/filemap.go
+++ b/pkg/imager/filemap/filemap.go
@@ -150,7 +150,11 @@ func Layer(filemap []File) (v1.Layer, error) {
 	slices.SortFunc(filemap, func(a, b File) int { return cmp.Compare(a.ImagePath, b.ImagePath) })
 
 	// Return a new copy of the buffer each time it's opened.
+	//
+	// WithCompressedCaching memoizes the compressed bytes after the first read, so the gzip
+	// pipeline is spun up exactly once instead of being re-created for each digest/diffID/write
+	// access.
 	return tarball.LayerFromOpener(func() (io.ReadCloser, error) {
 		return Build(filemap), nil
-	}, tarball.WithMediaType(types.OCILayer))
+	}, tarball.WithMediaType(types.OCILayer), tarball.WithCompressedCaching)
 }

--- a/pkg/imager/filemap/filemap_test.go
+++ b/pkg/imager/filemap/filemap_test.go
@@ -5,11 +5,13 @@
 package filemap_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/imager/filemap"
 )
@@ -68,4 +70,39 @@ func TestFileMap(t *testing.T) {
 		},
 		artifacts,
 	)
+}
+
+// TestLayer exercises the digest, diffID and compressed-read paths the way go-containerregistry
+// does when building and writing an image. Run with -race, it guards against re-introducing
+// repeated compression of the layer (each compression spins up a streaming gzip goroutine, and
+// the GC-reused flate buffers across those goroutines trip the race detector).
+func TestLayer(t *testing.T) {
+	tempDir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "a/b"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a/b/file"), []byte("hello world"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a/executable"), []byte("payload"), 0o755))
+
+	artifacts, err := filemap.Walk(tempDir, "")
+	require.NoError(t, err)
+
+	layer, err := filemap.Layer(artifacts)
+	require.NoError(t, err)
+
+	_, err = layer.Digest()
+	require.NoError(t, err)
+
+	_, err = layer.DiffID()
+	require.NoError(t, err)
+
+	// read the compressed stream multiple times, mirroring digest + tarball write
+	for range 3 {
+		rc, err := layer.Compressed()
+		require.NoError(t, err)
+
+		_, err = io.Copy(io.Discard, rc)
+		require.NoError(t, err)
+
+		require.NoError(t, rc.Close())
+	}
 }


### PR DESCRIPTION
On the same map, concurrently:

- Write (controller goroutine): ManifestApplyController.apply() → obj.SetNamespace() at manifest_apply.go:327 / :304.
- Read (gRPC COSI state server): State.List → protoenc.Marshal → structpb.NewStruct marshaling the k8s.Manifest resource for an API call.

The root cause is that manifest.Objects() in adapters/k8s/manifest.go wrapped the shared spec map by reference, and apply() mutated it in place — racing with anything serving k8s.Manifest over the API.

Found via qemu-race integration test.
