### PR TITLE
chore: v1alpha1 validation accesses Discovery through the `ClusterConfig` struct

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -259,7 +259,7 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 	}
 
 	if kcfg := c.NetworkKubeSpanConfig(); kcfg != nil && kcfg.Enabled() {
-		if !c.Cluster().Discovery().Enabled() {
+		if !c.ClusterConfig.Discovery().Enabled() {
 			result = multierror.Append(result, errors.New(".cluster.discovery should be enabled when .machine.network.kubespan is enabled"))
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/siderolabs/talos/pull/13562

We still need to keep the `Discovery()` func in the `ClusterConfig` interface, since the [cluster config controller needs it](https://github.com/siderolabs/talos/blob/020de3f514d59960906e0e7747e1df4501843355/internal/app/machined/pkg/controllers/cluster/config.go#L97-L98). However, we can keep things a bit more tidy in the [v1alpha1 validation](https://github.com/siderolabs/talos/blob/020de3f514d59960906e0e7747e1df4501843355/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go#L262-L263), since it doesn't need to to reference the config throught the `ClusterConfig` interface.
