### PR TITLE
chore: add lefthook.yml

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,29 @@
+commit-msg:
+  parallel: false
+  commands:
+    conformance:
+      run: make conformance
+pre-commit:
+  jobs:
+    - name: fix
+      group:
+        parallel: false
+        jobs:
+          - name: generate
+            run: make generate
+            stage_fixed: true
+          - name: docs
+            run: make docs
+            stage_fixed: true
+          - name: fmt
+            run: make fmt
+            stage_fixed: true
+          - name: lint-fmt
+            run: make lint-fmt
+            stage_fixed: true
+    - name: lint
+      group:
+        parallel: false
+        jobs:
+          - name: lint
+            run: make lint


### PR DESCRIPTION
See https://github.com/siderolabs/kres/pull/674 for more context on why the lefthook.yml in Talos is not generated by kres.
