### PR TITLE
fix: print link status changes

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -229,6 +229,8 @@ func (ctrl *LinkStatusController) reconcile(
 		if err = safe.WriterModify(ctx, r, network.NewLinkStatus(network.NamespaceName, link.Attributes.Name), func(r *network.LinkStatus) error {
 			status := r.TypedSpec()
 
+			prevUp := status.LinkState
+
 			status.Alias = pointer.SafeDeref(link.Attributes.Alias)
 			status.AltNames = slices.Clone(link.Attributes.AltNames)
 			status.Index = link.Index
@@ -260,6 +262,10 @@ func (ctrl *LinkStatusController) reconcile(
 				status.LinkState = ethState.Link
 			} else {
 				status.LinkState = false
+			}
+
+			if prevUp != status.LinkState && status.Physical() {
+				logger.Info("link state changed", zap.String("link", link.Attributes.Name), zap.Bool("up", status.LinkState))
 			}
 
 			if ethInfo != nil {

--- a/pkg/cluster/crashdump.go
+++ b/pkg/cluster/crashdump.go
@@ -69,9 +69,13 @@ func Crashdump(ctx context.Context, cluster provision.Cluster, logWriter io.Writ
 
 	collectors, err := collectors.GetForOptions(ctx, options)
 	if err != nil {
-		fmt.Fprintf(logWriter, "error creating crashdump collector options: %s\n", err)
+		if len(collectors) == 0 {
+			fmt.Fprintf(logWriter, "error creating crashdump collectors: %s\n", err)
 
-		return
+			return
+		}
+
+		fmt.Fprintf(logWriter, "warning: error (ignored) creating some crashdump collectors: %s\n", err)
 	}
 
 	if err := support.CreateSupportBundle(ctx, options, collectors...); err != nil {


### PR DESCRIPTION
Also generate crash dump via support bundle even if some collectors failed to build, e.g. if one node is down, other nodes can still be accessed.

Link status changes should be useful on their own, but this change should help to debug stuck Talos/no networking in the encrypted-vip pipeline.
