### PR TITLE
chore: speed up lefthook with globs

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,21 +6,33 @@ pre-commit:
         jobs:
           - name: generate
             run: make generate
+            glob:
+              - "pkg/**"
+              - "api/**"
+              - "hack/boilerplate.txt"
             env:
               USERNAME: siderolabs
             stage_fixed: true
           - name: docs
             run: make docs
+            glob:
+              - "cmd/talosctl/**"
+              - "pkg/machinery/config/**"
             env:
               USERNAME: siderolabs
             stage_fixed: true
           - name: fmt
             run: make fmt
+            glob:
+              - "api/**/*.proto"
+              - "pkg/provision/api/**/*.proto"
             env:
               USERNAME: siderolabs
             stage_fixed: true
           - name: lint-fmt
             run: make lint-fmt
+            glob:
+              - "**/*.go"
             env:
               USERNAME: siderolabs
             stage_fixed: true
@@ -30,6 +42,15 @@ pre-commit:
         jobs:
           - name: lint
             run: make lint
+            glob:
+              - "**/*.go"
+              - "**/*.proto"
+              - "**/*.md"
+              - "go.mod"
+              - "go.sum"
+              - "pkg/machinery/go.mod"
+              - "pkg/machinery/go.sum"
+              - ".golangci.yml"
             env:
               USERNAME: siderolabs
 post-commit:


### PR DESCRIPTION
Currently we run all jobs every single time, which for Talos is fairly time consuming. It's best to skip the jobs that do not relate to the currently staged changes.

Here the change is straightforward, as we maintain the `Makefile` and `lefthook.yml` by hand. I'll try to reflect this back into Kres `CompileLefthook` callables.