### PR TITLE
feat: implement controlplane only config validation

### DIFF
--- a/pkg/machinery/config/container/container.go
+++ b/pkg/machinery/config/container/container.go
@@ -25,6 +25,14 @@ type V1Alpha1ConflictValidator interface {
 	V1Alpha1ConflictValidate(*v1alpha1.Config) error
 }
 
+// ControlplaneOnlyConfig is the interface implemented by config documents which are only applicable to controlplane nodes.
+//
+// Such documents will not be allowed for machines which do not have a machine type, or the machine type is not controlplane/init.
+type ControlplaneOnlyConfig interface {
+	config.Document
+	ControlplaneOnlyDocument()
+}
+
 // Container wraps all configuration documents into a single container.
 type Container struct {
 	v1alpha1Config *v1alpha1.Config
@@ -137,6 +145,19 @@ func (container *Container) PatchV1Alpha1(patcher func(*v1alpha1.Config) error) 
 
 	return PatchDocument(container, func(c *v1alpha1.Config) error {
 		return patcher(c)
+	})
+}
+
+// Has checks if the container has a document of the given kind.
+//
+// This method only works for new multi-doc config documents, and does not check for v1alpha1.Config.
+func (container *Container) Has(kind string) bool {
+	return slices.ContainsFunc(container.documents, func(d config.Document) bool {
+		if _, ok := d.(selector); ok {
+			return false
+		}
+
+		return d.Kind() == kind
 	})
 }
 

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
+	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
@@ -214,11 +215,28 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 		}
 	}
 
-	// worker specific checks
-	if container.Machine() != nil && container.Machine().Type() == machine.TypeWorker {
-		if container.K8sEtcdEncryptionConfig() != nil {
-			errs = multierror.Append(errs, fmt.Errorf("etcd encryption config is not supported for worker machines"))
-		}
+	// machine type specific checks
+	var machineType machine.Type
+
+	if container.Machine() != nil {
+		machineType = container.Machine().Type()
+	}
+
+	controlplaneDocs := findMatchingDocs[ControlplaneOnlyConfig](container.documents)
+
+	if len(controlplaneDocs) > 0 && !machineType.IsControlPlane() {
+		kinds := xslices.Map(controlplaneDocs, func(d ControlplaneOnlyConfig) string {
+			return d.Kind()
+		})
+		slices.Sort(kinds)
+		kinds = slices.Compact(kinds)
+
+		errs = multierror.Append(errs,
+			fmt.Errorf(
+				"the following document kinds are only allowed on control plane machines: %v",
+				kinds,
+			),
+		)
 	}
 
 	return errs

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
@@ -270,6 +271,13 @@ func TestValidateContainer(t *testing.T) {
 		},
 	}
 
+	kubeEtcdEncryptionConfig := k8s.NewKubeEtcdEncryptionConfigV1Alpha1()
+	kubeEtcdEncryptionConfig.Config = meta.Unstructured{
+		Object: map[string]any{
+			"some": "thing",
+		},
+	}
+
 	for _, tt := range []struct {
 		name        string
 		documents   []config.Document
@@ -328,6 +336,18 @@ func TestValidateContainer(t *testing.T) {
 		{
 			name:      "DoT with hostDNS",
 			documents: []config.Document{resolverConfigDoT, v1alpha1CfgHostDNS},
+		},
+		{
+			name:      "controlplane doc only",
+			documents: []config.Document{kubeEtcdEncryptionConfig},
+
+			expectedError: "1 error occurred:\n\t* the following document kinds are only allowed on control plane machines: [KubeEtcdEncryptionConfig]\n\n",
+		},
+		{
+			name:      "controlplane doc with v1alpha1 worker",
+			documents: []config.Document{v1alpha1Cfg, kubeEtcdEncryptionConfig},
+
+			expectedError: "1 error occurred:\n\t* the following document kinds are only allowed on control plane machines: [KubeEtcdEncryptionConfig]\n\n",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/machinery/config/generate/rotatepatcher/kubernetes.go
+++ b/pkg/machinery/config/generate/rotatepatcher/kubernetes.go
@@ -24,7 +24,7 @@ type PatcherFunc func(config.Provider) (config.Provider, error)
 func K8sAddAcceptedCA(caCrt []byte) PatcherFunc {
 	return func(in config.Provider) (config.Provider, error) {
 		// detect version contract, and act accordingly
-		multidoc := hasDocument(k8s.KubeAPIServerCAConfig, in)
+		multidoc := in.Has(k8s.KubeAPIServerCAConfig)
 
 		if !multidoc {
 			return in.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
@@ -60,7 +60,7 @@ func K8sAddAcceptedCA(caCrt []byte) PatcherFunc {
 func K8sDeleteAcceptedCA(caCrt []byte) PatcherFunc {
 	return func(in config.Provider) (config.Provider, error) {
 		// detect version contract, and act accordingly
-		multidoc := hasDocument(k8s.KubeAPIServerCAConfig, in)
+		multidoc := in.Has(k8s.KubeAPIServerCAConfig)
 
 		if !multidoc {
 			return in.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
@@ -99,7 +99,7 @@ func K8sDeleteAcceptedCA(caCrt []byte) PatcherFunc {
 func K8sSetCA(newCA *x509.PEMEncodedCertificateAndKey) PatcherFunc {
 	return func(in config.Provider) (config.Provider, error) {
 		// detect version contract, and act accordingly
-		multidoc := hasDocument(k8s.KubeAPIServerCAConfig, in)
+		multidoc := in.Has(k8s.KubeAPIServerCAConfig)
 		machineType := in.Machine().Type()
 
 		if !multidoc {

--- a/pkg/machinery/config/generate/rotatepatcher/rotatepatcher.go
+++ b/pkg/machinery/config/generate/rotatepatcher/rotatepatcher.go
@@ -4,15 +4,3 @@
 
 // Package rotatepatcher provides a config patcher which modifies machine configuration to rotate PKI.
 package rotatepatcher
-
-import "github.com/siderolabs/talos/pkg/machinery/config"
-
-func hasDocument(kind string, cfg config.Container) bool {
-	for _, doc := range cfg.Documents() {
-		if doc.Kind() == kind {
-			return true
-		}
-	}
-
-	return false
-}

--- a/pkg/machinery/config/generate/stdpatches/guess.go
+++ b/pkg/machinery/config/generate/stdpatches/guess.go
@@ -16,7 +16,7 @@ func GuessVersionContractKubelet(cfg config.Container) *config.VersionContract {
 
 // GuessVersionContractKubeAPIServer attempts to guess the version contract for kube-apiserver configuration based on the provided machine configuration.
 func GuessVersionContractKubeAPIServer(cfg config.Container) *config.VersionContract {
-	if hasDocument(k8s.KubeAPIServerConfig, cfg) {
+	if cfg.Has(k8s.KubeAPIServerConfig) {
 		return config.TalosVersionCurrent
 	}
 
@@ -26,7 +26,7 @@ func GuessVersionContractKubeAPIServer(cfg config.Container) *config.VersionCont
 
 // GuessVersionContractKubeControllerManager attempts to guess the version contract for kube-controller-manager configuration based on the provided machine configuration.
 func GuessVersionContractKubeControllerManager(cfg config.Container) *config.VersionContract {
-	if hasDocument(k8s.KubeControllerManagerConfig, cfg) {
+	if cfg.Has(k8s.KubeControllerManagerConfig) {
 		return config.TalosVersionCurrent
 	}
 
@@ -36,7 +36,7 @@ func GuessVersionContractKubeControllerManager(cfg config.Container) *config.Ver
 
 // GuessVersionContractKubeScheduler attempts to guess the version contract for kube-scheduler configuration based on the provided machine configuration.
 func GuessVersionContractKubeScheduler(cfg config.Container) *config.VersionContract {
-	if hasDocument(k8s.KubeSchedulerConfig, cfg) {
+	if cfg.Has(k8s.KubeSchedulerConfig) {
 		return config.TalosVersionCurrent
 	}
 
@@ -46,20 +46,10 @@ func GuessVersionContractKubeScheduler(cfg config.Container) *config.VersionCont
 
 // GuessVersionContractKubeProxy attempts to guess the version contract for kube-proxy configuration based on the provided machine configuration.
 func GuessVersionContractKubeProxy(cfg config.Container) *config.VersionContract {
-	if hasDocument(k8s.KubeProxyConfig, cfg) {
+	if cfg.Has(k8s.KubeProxyConfig) {
 		return config.TalosVersionCurrent
 	}
 
 	// the last before multi-doc k8s config
 	return config.TalosVersion1_13
-}
-
-func hasDocument(kind string, cfg config.Container) bool {
-	for _, doc := range cfg.Documents() {
-		if doc.Kind() == kind {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -61,6 +61,11 @@ type Container interface {
 	//
 	// Documents should be not be modified.
 	Documents() []config.Document
+
+	// Has checks if the container has a config document of the given kind.
+	//
+	// This method doesn't support legacy v1alpha1 config.
+	Has(kind string) bool
 }
 
 // Provider defines the configuration consumption interface combining access and encoding/decoding.

--- a/pkg/machinery/config/types/k8s/admission_control.go
+++ b/pkg/machinery/config/types/k8s/admission_control.go
@@ -37,6 +37,7 @@ var (
 	_ config.NamedDocument                   = &KubeAdmissionControlConfigV1Alpha1{}
 	_ config.Validator                       = &KubeAdmissionControlConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator    = &KubeAdmissionControlConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig       = &KubeAdmissionControlConfigV1Alpha1{}
 )
 
 // KubeAdmissionControlConfigV1Alpha1 configures kube-apiserver admission control plugins.
@@ -142,3 +143,6 @@ func (s *KubeAdmissionControlConfigV1Alpha1) K8sAdmissionControlPluginConfigSign
 func (s *KubeAdmissionControlConfigV1Alpha1) Configuration() map[string]any {
 	return s.PluginConfig.Object
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAdmissionControlConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/aggregator_ca.go
+++ b/pkg/machinery/config/types/k8s/aggregator_ca.go
@@ -42,6 +42,7 @@ var (
 	_ config.Validator                    = &KubeAggregatorCAConfigV1Alpha1{}
 	_ config.SecretDocument               = &KubeAggregatorCAConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeAggregatorCAConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeAggregatorCAConfigV1Alpha1{}
 )
 
 // KubeAggregatorCAConfigV1Alpha1 configures Kubernetes API aggregator accepted CAs.
@@ -169,3 +170,6 @@ func (s *KubeAggregatorCAConfigV1Alpha1) Redact(replacement string) {
 		s.AggregatorIssuingCA.Key = replacement
 	}
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAggregatorCAConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/apiserver.go
+++ b/pkg/machinery/config/types/k8s/apiserver.go
@@ -43,6 +43,7 @@ var (
 	_ config.K8sAPIServerConfig           = &KubeAPIServerConfigV1Alpha1{}
 	_ config.Validator                    = &KubeAPIServerConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeAPIServerConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeAPIServerConfigV1Alpha1{}
 )
 
 // KubeAPIServerConfigV1Alpha1 configures kube-apiserver controlplane static pod.
@@ -293,3 +294,6 @@ func (s *KubeAPIServerConfigV1Alpha1) APIPort() int {
 func (s *KubeAPIServerConfigV1Alpha1) InjectDefaultAuthorizers() bool {
 	return false
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAPIServerConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/audit_policy.go
+++ b/pkg/machinery/config/types/k8s/audit_policy.go
@@ -34,6 +34,7 @@ func init() {
 var (
 	_ config.K8sAuditPolicyConfig         = &KubeAuditPolicyConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeAuditPolicyConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeAuditPolicyConfigV1Alpha1{}
 )
 
 // KubeAuditPolicyConfigV1Alpha1 configures kube-apiserver audit policy.
@@ -107,3 +108,6 @@ func (s *KubeAuditPolicyConfigV1Alpha1) K8sAuditPolicyConfigSignal() {}
 func (s *KubeAuditPolicyConfigV1Alpha1) Configuration() map[string]any {
 	return s.AuditConfig.Object
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAuditPolicyConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/authentication.go
+++ b/pkg/machinery/config/types/k8s/authentication.go
@@ -6,6 +6,7 @@ package k8s
 
 import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/internal/registry"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 )
@@ -28,7 +29,8 @@ func init() {
 
 // Check interfaces.
 var (
-	_ config.K8sAuthenticationConfig = &KubeAuthenticationConfigV1Alpha1{}
+	_ config.K8sAuthenticationConfig   = &KubeAuthenticationConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig = &KubeAuthenticationConfigV1Alpha1{}
 )
 
 // KubeAuthenticationConfigV1Alpha1 configures kube-apiserver authentication.
@@ -100,3 +102,6 @@ func (s *KubeAuthenticationConfigV1Alpha1) K8sAuthenticationConfigSignal() {}
 func (s *KubeAuthenticationConfigV1Alpha1) Configuration() map[string]any {
 	return s.AuthConfig.Object
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAuthenticationConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/authorization.go
+++ b/pkg/machinery/config/types/k8s/authorization.go
@@ -39,6 +39,7 @@ var (
 	_ config.NamedDocument                = &KubeAuthorizerConfigV1Alpha1{}
 	_ config.Validator                    = &KubeAuthorizerConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeAuthorizerConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeAuthorizerConfigV1Alpha1{}
 )
 
 // KubeAuthorizerConfigV1Alpha1 configures kube-apiserver authorization by configuring a specific authorization plugin.
@@ -216,3 +217,6 @@ func (s *KubeAuthorizerConfigV1Alpha1) Type() string {
 func (s *KubeAuthorizerConfigV1Alpha1) Webhook() map[string]any {
 	return s.AuthorizerWebhook.Object
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeAuthorizerConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/controller_manager.go
+++ b/pkg/machinery/config/types/k8s/controller_manager.go
@@ -39,6 +39,7 @@ var (
 	_ config.K8sControllerManagerConfig   = &KubeControllerManagerConfigV1Alpha1{}
 	_ config.Validator                    = &KubeControllerManagerConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeControllerManagerConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeControllerManagerConfigV1Alpha1{}
 )
 
 // KubeControllerManagerConfigV1Alpha1 configures kube-controller-manager controlplane static pod.
@@ -196,3 +197,6 @@ func (s *KubeControllerManagerConfigV1Alpha1) Resources() config.Resources {
 func (s *KubeControllerManagerConfigV1Alpha1) ExtraVolumes() []config.VolumeMount {
 	return nil
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeControllerManagerConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/coredns.go
+++ b/pkg/machinery/config/types/k8s/coredns.go
@@ -35,6 +35,7 @@ func init() {
 var (
 	_ config.K8sCoreDNSConfig             = &KubeCoreDNSConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeCoreDNSConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeCoreDNSConfigV1Alpha1{}
 )
 
 // KubeCoreDNSConfigV1Alpha1 configures CoreDNS deployment.
@@ -110,3 +111,6 @@ func (s *KubeCoreDNSConfigV1Alpha1) Image() string {
 
 	return s.PodImage
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeCoreDNSConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/etcd_encryption.go
+++ b/pkg/machinery/config/types/k8s/etcd_encryption.go
@@ -37,6 +37,7 @@ var (
 	_ config.SecretDocument               = &KubeEtcdEncryptionConfigV1Alpha1{}
 	_ config.Validator                    = &KubeEtcdEncryptionConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeEtcdEncryptionConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeEtcdEncryptionConfigV1Alpha1{}
 )
 
 // KubeEtcdEncryptionConfigV1Alpha1 configures kube-apiserver etcd encryption rules.
@@ -158,3 +159,6 @@ func (s *KubeEtcdEncryptionConfigV1Alpha1) V1Alpha1ConflictValidate(v1alpha1Cfg 
 func (s *KubeEtcdEncryptionConfigV1Alpha1) EtcdEncryptionConfig() map[string]any {
 	return s.Config.Object
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeEtcdEncryptionConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/flannel.go
+++ b/pkg/machinery/config/types/k8s/flannel.go
@@ -40,6 +40,7 @@ var (
 	_ config.K8sFlannelCNIConfig          = &KubeFlannelCNIConfigV1Alpha1{}
 	_ config.Validator                    = &KubeFlannelCNIConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeFlannelCNIConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeFlannelCNIConfigV1Alpha1{}
 )
 
 // KubeFlannelCNIConfigV1Alpha1 deploys Flannel CNI to the cluster.
@@ -192,3 +193,6 @@ func (s *KubeFlannelCNIConfigV1Alpha1) ExtraArgs() []string {
 func (s *KubeFlannelCNIConfigV1Alpha1) KubeNetworkPoliciesEnabled() bool {
 	return pointer.SafeDeref(s.FlannelKubeNetworkPoliciesEnabled)
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/proxy.go
+++ b/pkg/machinery/config/types/k8s/proxy.go
@@ -39,6 +39,7 @@ var (
 	_ config.K8sProxyConfig               = &KubeProxyConfigV1Alpha1{}
 	_ config.Validator                    = &KubeProxyConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeProxyConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeProxyConfigV1Alpha1{}
 )
 
 // KubeProxyConfigV1Alpha1 deploys Flannel CNI to the cluster.
@@ -232,3 +233,6 @@ func (s *KubeProxyConfigV1Alpha1) Config() map[string]any {
 func (s *KubeProxyConfigV1Alpha1) UseConfigFile() bool {
 	return true
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeProxyConfigV1Alpha1) ControlplaneOnlyDocument() {}

--- a/pkg/machinery/config/types/k8s/scheduler.go
+++ b/pkg/machinery/config/types/k8s/scheduler.go
@@ -39,6 +39,7 @@ var (
 	_ config.K8sSchedulerConfig           = &KubeSchedulerConfigV1Alpha1{}
 	_ config.Validator                    = &KubeSchedulerConfigV1Alpha1{}
 	_ container.V1Alpha1ConflictValidator = &KubeSchedulerConfigV1Alpha1{}
+	_ container.ControlplaneOnlyConfig    = &KubeSchedulerConfigV1Alpha1{}
 )
 
 // KubeSchedulerConfigV1Alpha1 configures kube-scheduler controlplane static pod.
@@ -230,3 +231,6 @@ func (s *KubeSchedulerConfigV1Alpha1) Config() map[string]any {
 func (s *KubeSchedulerConfigV1Alpha1) ExtraVolumes() []config.VolumeMount {
 	return nil
 }
+
+// ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.
+func (s *KubeSchedulerConfigV1Alpha1) ControlplaneOnlyDocument() {}


### PR DESCRIPTION
Allow to validate for some config documents which should not be on non-controlplane nodes.

Also refactor `hasDocument` helpers into native `Has()` method.
