### PR TITLE
fix: flaky serviceaccount suite test

### DIFF
--- a/internal/integration/api/serviceaccount.go
+++ b/internal/integration/api/serviceaccount.go
@@ -64,7 +64,7 @@ func (suite *ServiceAccountSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 5*time.Minute)
 
-	suite.ClearConnectionRefused(suite.ctx, suite.DiscoverNodeInternalIPsByType(suite.ctx, machine.TypeWorker)...)
+	suite.ClearConnectionRefused(suite.ctx, suite.DiscoverNodeInternalIPs(suite.ctx)...)
 	suite.AssertClusterHealthy(suite.ctx)
 }
 
@@ -85,10 +85,14 @@ func (suite *ServiceAccountSuite) TestValid() {
 	_, err = suite.getCRD()
 	suite.Assert().NoError(err)
 
-	sa, err := suite.createServiceAccount("kube-system", name, []string{"os:reader"})
-	suite.Assert().NoError(err)
+	// Best-effort cleanup in case a previous run left this SA behind.
+	suite.DeleteResource(suite.ctx, serviceAccountGVR, "kube-system", name)                          //nolint:errcheck
+	suite.EnsureResourceIsDeleted(suite.ctx, 30*time.Second, serviceAccountGVR, "kube-system", name) //nolint:errcheck
 
-	defer suite.DeleteResource(suite.ctx, serviceAccountGVR, "default", name) //nolint:errcheck
+	sa, err := suite.createServiceAccount("kube-system", name, []string{"os:reader"})
+	suite.Require().NoError(err)
+
+	defer suite.DeleteResource(suite.ctx, serviceAccountGVR, "kube-system", name) //nolint:errcheck
 
 	err = suite.WaitForEventExists(suite.ctx, "kube-system", func(event eventsv1.Event) bool {
 		return event.Regarding.UID == sa.GetUID() &&
@@ -114,16 +118,16 @@ func (suite *ServiceAccountSuite) TestValid() {
 
 	node := suite.RandomDiscoveredNodeInternalIP()
 
-	_, err = suite.creteTestJob("kube-system", name, name, node)
+	_, err = suite.createTestJob("kube-system", name, name, node)
 	suite.Assert().NoError(err)
+
+	defer func() {
+		suite.DeleteResource(suite.ctx, jobGVR, "kube-system", name) //nolint:errcheck
+
+		suite.Assert().NoError(suite.EnsureResourceIsDeleted(suite.ctx, 30*time.Second, jobGVR, "kube-system", name)) //nolint:errcheck
+	}()
 
 	err = suite.waitForJobReady(2*time.Minute, "kube-system", name)
-	suite.Assert().NoError(err)
-
-	err = suite.DeleteResource(suite.ctx, jobGVR, "kube-system", name)
-	suite.Require().NoError(err)
-
-	err = suite.EnsureResourceIsDeleted(suite.ctx, 30*time.Second, jobGVR, "kube-system", name)
 	suite.Assert().NoError(err)
 
 	err = suite.DeleteResource(suite.ctx, serviceAccountGVR, "kube-system", name)
@@ -247,7 +251,7 @@ func (suite *ServiceAccountSuite) createServiceAccount(ns string, name string, r
 	}, metav1.CreateOptions{})
 }
 
-func (suite *ServiceAccountSuite) creteTestJob(ns, name, serviceAccount, node string) (*unstructured.Unstructured, error) {
+func (suite *ServiceAccountSuite) createTestJob(ns, name, serviceAccount, node string) (*unstructured.Unstructured, error) {
 	return suite.DynamicClient.Resource(jobGVR).Namespace(ns).Create(suite.ctx, &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", jobGVR.Group, jobGVR.Version),


### PR DESCRIPTION
We were not clearing connection refused for the controlplane nodes which might have been due to side effect of other tests, in our case this was due to the rotateca tests. Now explicitly clear the error for both workers and controlplane nodes.