### PR TITLE
fix: shutdown/reboot via usermode helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -807,6 +807,9 @@ RUN <<END
     # some extensions like qemu-guest agent will call '/sbin/shutdown'
     ln /rootfs/usr/bin/init /rootfs/usr/bin/shutdown
     chmod +x /rootfs/usr/bin/shutdown
+    # the orderly_reboot call by the kernel (e.g. hyper-v restart request) will call '/sbin/reboot'
+    ln /rootfs/usr/bin/init /rootfs/usr/bin/reboot
+    chmod +x /rootfs/usr/bin/reboot
     ln /rootfs/usr/bin/init /rootfs/usr/bin/dashboard
     chmod +x /rootfs/usr/bin/dashboard
 END
@@ -898,6 +901,9 @@ RUN <<END
     # some extensions like qemu-guest agent will call '/sbin/shutdown'
     ln /rootfs/usr/bin/init /rootfs/usr/bin/shutdown
     chmod +x /rootfs/usr/bin/shutdown
+    # the orderly_reboot call by the kernel (e.g. hyper-v restart request) will call '/sbin/reboot'
+    ln /rootfs/usr/bin/init /rootfs/usr/bin/reboot
+    chmod +x /rootfs/usr/bin/reboot
     ln /rootfs/usr/bin/init /rootfs/usr/bin/dashboard
     chmod +x /rootfs/usr/bin/dashboard
 END

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -338,7 +338,17 @@ func main() {
 
 		return
 	// Azure uses the hv_utils kernel module to shutdown the node in hyper-v by calling perform_shutdown which will call orderly_poweroff which will call /sbin/poweroff.
-	case "poweroff", "shutdown":
+	// Hyper-V restart requests call orderly_reboot which will call /sbin/reboot.
+	case "poweroff", "shutdown", "reboot":
+		// These are invoked by the kernel usermode helper (and machined is the static
+		// usermode helper), which has no console, so set up kmsg logging to make the
+		// invocation and its result visible in `talosctl dmesg`.
+		if !containermode.InContainer() {
+			kmsg.SetupLogger(nil, filepath.Base(os.Args[0]), nil) //nolint:errcheck // best effort logging to kmsg
+		}
+
+		log.Printf("usermode helper invoked as %q (args %v)", os.Args[0], os.Args[1:])
+
 		poweroff.Main(os.Args)
 
 		return

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -24,6 +24,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/health"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/goroutine"
+	"github.com/siderolabs/talos/internal/pkg/miniprocfs"
 	"github.com/siderolabs/talos/internal/pkg/selinux"
 	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/grpc/factory"
@@ -167,8 +168,20 @@ func (s *machinedService) Main(ctx context.Context, _ runtime.Runtime, logWriter
 		Logger:        log.New(logWriter, "machined/authz/authorizer ", log.Flags()).Printf,
 	}
 
+	// machined's own identity, used to recognize the kernel static usermode helper
+	// (e.g. `/sbin/poweroff` -> machined), which re-executes this same binary in this
+	// same mount namespace.
+	selfMountNamespace, _ := miniprocfs.ReadMountNamespace(int32(os.Getpid()))
+	selfExeDev, selfExeIno, _ := miniprocfs.ReadExeIdentity(int32(os.Getpid()))
+
 	pidAuthorizer := &unix.Authorizer{
-		Resources: s.c.Runtime().State().V1Alpha2().Resources(),
+		Resources:          s.c.Runtime().State().V1Alpha2().Resources(),
+		SelfMountNamespace: selfMountNamespace,
+		SelfExeDev:         selfExeDev,
+		SelfExeIno:         selfExeIno,
+		// the usermode helper only ever calls Shutdown/Reboot, both of which accept Admin/Operator;
+		// poweroff.Main requests role.Admin and the authorizer intersects requested with allowed.
+		UsermodeHelperRoles: role.MakeSet(role.Admin, role.Operator),
 		AllowedServices: []unix.AllowedService{
 			{
 				// normal network API access

--- a/internal/app/poweroff/main.go
+++ b/internal/app/poweroff/main.go
@@ -7,6 +7,7 @@ package poweroff
 import (
 	"context"
 	"log"
+	"path/filepath"
 	"slices"
 
 	"google.golang.org/grpc"
@@ -34,7 +35,7 @@ func Main(args []string) {
 	ctx := context.Background()
 
 	md := metadata.Pairs()
-	authz.SetMetadata(md, role.MakeSet(role.Admin))
+	authz.SetMetadata(md, role.MakeSet(role.Operator))
 	adminCtx := metadata.NewOutgoingContext(ctx, md)
 
 	client, err := client.New(
@@ -48,22 +49,42 @@ func Main(args []string) {
 		log.Fatalf("error while creating machinery client: %s", err)
 	}
 
-	switch ActionFromArgs(args) {
+	action := ActionFromArgs(args)
+
+	log.Printf("helper: action %q", action)
+
+	switch action {
 	case Shutdown:
 		err = client.Shutdown(adminCtx)
 		if err != nil {
 			log.Fatalf("error while sending shutdown command: %s", err)
 		}
+
+		log.Printf("shutdown command sent")
 	case Reboot:
 		err = client.Reboot(adminCtx)
 		if err != nil {
 			log.Fatalf("error while sending reboot command: %s", err)
 		}
+
+		log.Printf("reboot command sent")
 	}
 }
 
 // ActionFromArgs returns the action to be performed based on the arguments.
+//
+// The default action is derived from the basename the binary was invoked as
+// (e.g. the kernel usermode helper calls `/sbin/reboot` for orderly_reboot and
+// `/sbin/poweroff` for orderly_poweroff), and can be overridden by explicit flags.
+//
+//nolint:gocyclo
 func ActionFromArgs(args []string) Action {
+	action := Shutdown
+
+	if len(args) > 0 && filepath.Base(args[0]) == "reboot" {
+		action = Reboot
+	}
+
 	if len(args) > 1 {
 		if slices.ContainsFunc(args[1:], func(s string) bool {
 			return s == "--halt" || s == "-H" || s == "--poweroff" || s == "-P" || s == "-p"
@@ -78,5 +99,5 @@ func ActionFromArgs(args []string) Action {
 		}
 	}
 
-	return Shutdown
+	return action
 }

--- a/internal/app/poweroff/poweroff_test.go
+++ b/internal/app/poweroff/poweroff_test.go
@@ -88,6 +88,26 @@ func TestParseArgs(t *testing.T) {
 			args:   []string{"poweroff", "--reboot"},
 			action: poweroff.Reboot,
 		},
+		{
+			name:   "reboot no args",
+			args:   []string{"reboot"},
+			action: poweroff.Reboot,
+		},
+		{
+			name:   "reboot full path",
+			args:   []string{"/sbin/reboot"},
+			action: poweroff.Reboot,
+		},
+		{
+			name:   "reboot with poweroff",
+			args:   []string{"reboot", "-p"},
+			action: poweroff.Shutdown,
+		},
+		{
+			name:   "reboot with poweroff long",
+			args:   []string{"reboot", "--poweroff"},
+			action: poweroff.Shutdown,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/miniprocfs/exe_linux.go
+++ b/internal/pkg/miniprocfs/exe_linux.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+package miniprocfs
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+// ReadExeIdentity returns the device and inode of the executable backing the process.
+//
+// It stats /proc/<pid>/exe, which follows the magic symlink to the real backing file, so the
+// returned identity is stable regardless of the path (or hardlink name) used to exec it.
+func ReadExeIdentity(pid int32) (dev, ino uint64, ok bool) {
+	fi, err := os.Stat("/proc/" + strconv.Itoa(int(pid)) + "/exe")
+	if err != nil {
+		return 0, 0, false
+	}
+
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+
+	return st.Dev, st.Ino, true
+}

--- a/internal/pkg/miniprocfs/exe_other.go
+++ b/internal/pkg/miniprocfs/exe_other.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+
+package miniprocfs
+
+// ReadExeIdentity is not supported on non-Linux platforms.
+func ReadExeIdentity(int32) (dev, ino uint64, ok bool) {
+	return 0, 0, false
+}

--- a/internal/pkg/selinux/policy/file_contexts
+++ b/internal/pkg/selinux/policy/file_contexts
@@ -24,6 +24,7 @@
 /lib/modules	system_u:object_r:module_t:s0
 /usr/bin/runc	system_u:object_r:containerd_exec_t:s0
 /usr/bin/init	--	system_u:object_r:init_exec_t:s0
+/usr/bin/reboot	system_u:object_r:init_exec_t:s0
 /usr/bin/udevadm	--	system_u:object_r:udev_exec_t:s0
 /usr/bin/poweroff	system_u:object_r:init_exec_t:s0
 /usr/bin/shutdown	system_u:object_r:init_exec_t:s0

--- a/internal/pkg/selinux/policy/selinux/services/machined.cil
+++ b/internal/pkg/selinux/policy/selinux/services/machined.cil
@@ -2,6 +2,7 @@
 (call system_f (init_exec_t))
 (context init_exec_t (system_u object_r init_exec_t (systemLow systemLow)))
 (filecon "/usr/bin/init" file init_exec_t)
+(filecon "/usr/bin/reboot" any init_exec_t)
 (filecon "/usr/bin/poweroff" any init_exec_t)
 (filecon "/usr/bin/shutdown" any init_exec_t)
 (filecon "/usr/bin/dashboard" any init_exec_t)

--- a/pkg/grpc/middleware/auth/unix/authorizer.go
+++ b/pkg/grpc/middleware/auth/unix/authorizer.go
@@ -50,6 +50,19 @@ type Authorizer struct {
 	// AllowedServices is a list of globs matching service names allowed to connect.
 	AllowedServices []AllowedService
 
+	// SelfMountNamespace, SelfExeDev and SelfExeIno describe the identity of the process running
+	// the authorizer (mount namespace and executable device/inode).
+	//
+	// They are used to recognize the kernel static usermode helper, which re-executes this same
+	// binary in this same mount namespace (e.g. `/sbin/poweroff` -> machined). When SelfExeIno is
+	// zero the check is disabled.
+	SelfMountNamespace string
+	SelfExeDev         uint64
+	SelfExeIno         uint64
+
+	// UsermodeHelperRoles is the role set granted to a recognized usermode helper.
+	UsermodeHelperRoles role.Set
+
 	// Logger.
 	Logger func(format string, v ...any)
 }
@@ -72,10 +85,28 @@ func (a *Authorizer) matchService(servicePID *runtime.ServicePID, pid int32, mou
 	return role.Set{}, false
 }
 
-// authorize returns error if the calling process is not authorized (doesn't have a valid PID) to call the given gRPC method.
+// matchUsermodeHelper reports whether the peer is the kernel static usermode helper: this same
+// binary (same executable inode), re-executed by the kernel in this same mount namespace as root.
+//
+// This is intended to distinguish the kernel usermode helper from typical containerized processes:
+// peers in a different mount namespace and/or running a different executable inode won't match.
+func (a *Authorizer) matchUsermodeHelper(creds PeerCredentials) bool {
+	if a.SelfExeIno == 0 {
+		// not configured -> disabled
+		return false
+	}
+
+	return creds.UID == 0 &&
+		creds.ExeDev == a.SelfExeDev && creds.ExeIno == a.SelfExeIno &&
+		creds.MountNamespace != "" && creds.MountNamespace == a.SelfMountNamespace
+}
+
+// Authorize returns the role set allowed for the calling process based on Unix peer credentials.
+//
+// It returns ErrNotAuthorized when the peer PID/mount namespace cannot be mapped to an allowed service (or usermode helper).
 //
 //nolint:gocyclo
-func (a *Authorizer) authorize(ctx context.Context) (role.Set, error) {
+func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	peerCreds, ok := GetPeerCredentials(ctx)
 	if !ok {
 		a.logf("no peer credentials found in context")
@@ -103,6 +134,15 @@ func (a *Authorizer) authorize(ctx context.Context) (role.Set, error) {
 
 			return allowedRoles, nil
 		}
+	}
+
+	// recognize the kernel static usermode helper (e.g. /sbin/poweroff -> machined): it re-executes
+	// this same binary in this same mount namespace, but has an ephemeral PID that never appears as
+	// a service PID, so it would otherwise fall through to the watch below and time out.
+	if a.matchUsermodeHelper(peerCreds) {
+		a.logf("authorized usermode helper (PID %d) with roles %s", pid, a.UsermodeHelperRoles.Strings())
+
+		return a.UsermodeHelperRoles, nil
 	}
 
 	// perform a watch to wait for the PID to appear in the state, as it might not be there yet if the service is just starting
@@ -144,7 +184,7 @@ func (a *Authorizer) authorize(ctx context.Context) (role.Set, error) {
 // UnaryInterceptor returns grpc UnaryServerInterceptor.
 func (a *Authorizer) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		allowedRoles, err := a.authorize(ctx)
+		allowedRoles, err := a.Authorize(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +202,7 @@ func (a *Authorizer) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := stream.Context()
 
-		allowedRoles, err := a.authorize(ctx)
+		allowedRoles, err := a.Authorize(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/grpc/middleware/auth/unix/authorizer_test.go
+++ b/pkg/grpc/middleware/auth/unix/authorizer_test.go
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package unix_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/peer"
+
+	"github.com/siderolabs/talos/pkg/grpc/middleware/auth/unix"
+	"github.com/siderolabs/talos/pkg/machinery/role"
+)
+
+const (
+	selfMountNamespace = "mnt:[4026531840]"
+	selfExeDev         = uint64(42)
+	selfExeIno         = uint64(1000)
+)
+
+func newUsermodeHelperAuthorizer(t *testing.T) *unix.Authorizer {
+	t.Helper()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	return &unix.Authorizer{
+		Resources:           st,
+		SelfMountNamespace:  selfMountNamespace,
+		SelfExeDev:          selfExeDev,
+		SelfExeIno:          selfExeIno,
+		UsermodeHelperRoles: role.MakeSet(role.Admin, role.Operator),
+	}
+}
+
+func ctxWithCreds(parent context.Context, creds unix.PeerCredentials) context.Context {
+	return peer.NewContext(parent, &peer.Peer{AuthInfo: creds})
+}
+
+func TestAuthorizerUsermodeHelper(t *testing.T) {
+	t.Parallel()
+
+	a := newUsermodeHelperAuthorizer(t)
+
+	// the kernel usermode helper: this same binary (exe dev/ino), same mount namespace, UID 0.
+	ctx := ctxWithCreds(context.Background(), unix.PeerCredentials{
+		PID:            12345,
+		UID:            0,
+		MountNamespace: selfMountNamespace,
+		ExeDev:         selfExeDev,
+		ExeIno:         selfExeIno,
+	})
+
+	roles, err := a.Authorize(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, roles.Includes(role.Admin))
+	assert.True(t, roles.Includes(role.Operator))
+}
+
+func TestAuthorizerUsermodeHelperRejected(t *testing.T) {
+	t.Parallel()
+
+	for name, creds := range map[string]unix.PeerCredentials{
+		"wrong exe inode": {
+			PID: 12345, UID: 0, MountNamespace: selfMountNamespace, ExeDev: selfExeDev, ExeIno: selfExeIno + 1,
+		},
+		"wrong exe device": {
+			PID: 12345, UID: 0, MountNamespace: selfMountNamespace, ExeDev: selfExeDev + 1, ExeIno: selfExeIno,
+		},
+		"wrong mount namespace": {
+			PID: 12345, UID: 0, MountNamespace: "mnt:[4026531999]", ExeDev: selfExeDev, ExeIno: selfExeIno,
+		},
+		"empty mount namespace": {
+			PID: 12345, UID: 0, MountNamespace: "", ExeDev: selfExeDev, ExeIno: selfExeIno,
+		},
+		"non-root uid": {
+			PID: 12345, UID: 1000, MountNamespace: selfMountNamespace, ExeDev: selfExeDev, ExeIno: selfExeIno,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			a := newUsermodeHelperAuthorizer(t)
+
+			// bound the fallback watch so the deny path returns promptly instead of waiting PIDTimeout.
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			_, err := a.Authorize(ctxWithCreds(ctx, creds))
+			assert.ErrorIs(t, err, unix.ErrNotAuthorized)
+		})
+	}
+}
+
+func TestAuthorizerUsermodeHelperDisabled(t *testing.T) {
+	t.Parallel()
+
+	// without SelfExeIno configured (as in apid/trustd authorizers) the check is disabled,
+	// even for otherwise-matching credentials.
+	a := &unix.Authorizer{
+		Resources:           state.WrapCore(namespaced.NewState(inmem.Build)),
+		UsermodeHelperRoles: role.MakeSet(role.Admin, role.Operator),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err := a.Authorize(ctxWithCreds(ctx, unix.PeerCredentials{
+		PID:            12345,
+		UID:            0,
+		MountNamespace: selfMountNamespace,
+		ExeDev:         selfExeDev,
+		ExeIno:         selfExeIno,
+	}))
+	assert.ErrorIs(t, err, unix.ErrNotAuthorized)
+}

--- a/pkg/grpc/middleware/auth/unix/context.go
+++ b/pkg/grpc/middleware/auth/unix/context.go
@@ -18,6 +18,11 @@ type PeerCredentials struct {
 	UID            uint32
 	GID            uint32
 	MountNamespace string
+	// ExeDev and ExeIno identify the executable backing the peer process
+	// (device and inode of /proc/<pid>/exe), used to recognize machined's own
+	// binary re-executed as a kernel usermode helper.
+	ExeDev uint64
+	ExeIno uint64
 }
 
 // AuthType implements credentials.AuthInfo.

--- a/pkg/grpc/middleware/auth/unix/creds_linux.go
+++ b/pkg/grpc/middleware/auth/unix/creds_linux.go
@@ -61,11 +61,17 @@ func (unixCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthIn
 
 	mountNamespace, _ := miniprocfs.ReadMountNamespace(ucred.Pid)
 
+	// capture the peer executable identity while the peer is still connected (blocked on the RPC),
+	// so we can recognize machined's own binary re-executed as a kernel usermode helper.
+	exeDev, exeIno, _ := miniprocfs.ReadExeIdentity(ucred.Pid)
+
 	return rawConn, PeerCredentials{
 		PID:            ucred.Pid,
 		UID:            ucred.Uid,
 		GID:            ucred.Gid,
 		MountNamespace: mountNamespace,
+		ExeDev:         exeDev,
+		ExeIno:         exeIno,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #13692

The core issue was the authz check introduced in 1.13: machined denies connection over the machined socket which don't come from registered services PIDs.

So shutdown worked when /sbin/poweroff was called via qemu-guest-agent, as this is a system extensions service.

Usermode helpers are not the same - Talos machined has no way to know about them ahead of time, so they need to be checked separately - instead we check the caller process exe inode (executable), UID and mount namespace, if it matches machined, we allow the call through.

While we are at it, implement /sbin/reboot mirroring /sbin/shutdown - this is what hv_utils might invoke as well.

The test plan:

1. Usermode helper (works):

```
echo /sbin/poweroff > /proc/sys/kernel/modprobe
ip link add vrf0 type vrf # triggers modprobe, but actually shuts down
```

2. Direct execution (denied):

```
nsenter -t 1 -m /sbin/reboot
```
