### PR TITLE
test: fix some test flakiness

### DIFF
--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -658,6 +658,8 @@ func (k8sSuite *K8sSuite) LogPodLogs(ctx context.Context, namespace, podName str
 	readCloser, err := req.Stream(ctx)
 	if err != nil {
 		k8sSuite.T().Logf("failed to get pod logs: %s", err)
+
+		return
 	}
 
 	defer readCloser.Close() //nolint:errcheck

--- a/internal/integration/k8s/tink.go
+++ b/internal/integration/k8s/tink.go
@@ -61,6 +61,8 @@ const (
 )
 
 // TestDeploy verifies that tink can be deployed with a single control-plane node.
+//
+//nolint:gocyclo
 func (suite *TinkSuite) TestDeploy() {
 	if testing.Short() {
 		suite.T().Skip("skipping in short mode")
@@ -227,6 +229,13 @@ func (suite *TinkSuite) TestDeploy() {
 		suite.LogPodLogs(ctx, namespace, ss+"-0")
 		suite.T().Fatalf("failed to bootstrap Talos-in-Kubernetes")
 	}
+
+	suite.T().Cleanup(func() {
+		// dump the TinK pod logs if the test failed, to help with debugging
+		if suite.T().Failed() {
+			suite.LogPodLogs(suite.T().Context(), namespace, ss+"-0")
+		}
+	})
 
 	clusterAccess := &tinkClusterAccess{
 		KubernetesClient: cluster.KubernetesClient{

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -379,7 +379,6 @@ func launchVM(config *LaunchConfig) error {
 				"-kernel", config.UKIPath,
 				"-append", config.KernelArgs,
 			)
-			sdStubExtraCmdline += config.sdStubExtraCmdlineConfig
 		case config.KernelImagePath != "":
 			args = append(
 				args,
@@ -387,8 +386,16 @@ func launchVM(config *LaunchConfig) error {
 				"-initrd", config.InitrdPath,
 				"-append", config.KernelArgs,
 			)
-			sdStubExtraCmdline += config.sdStubExtraCmdlineConfig
 		}
+	}
+
+	if (config.UKIPath != "" || config.KernelImagePath != "") && config.USBPath == "" && config.ISOPath == "" {
+		// inject talos.config= into the boot, even if the disk is bootable,
+		// as the tests might wipe just STATE partition relying on Talos being able to
+		// re-download the config on boot
+		//
+		// but, don't activate this on USB/ISO boot options
+		sdStubExtraCmdline += config.sdStubExtraCmdlineConfig
 	}
 
 	if !config.SkipInjectingExtraCmdline {


### PR DESCRIPTION
In QEMU provisioner, append `talos.config=` even if the disk is bootable
- it breaks the test which resets the STATE partition only if it happens after a "regular" reboot.

Show the TinK pod logs if the test fails (trying to catch the issue).
