### PR TITLE
fix: use a forked version of secure-io/siv-go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -214,6 +214,7 @@ linters:
         - github.com/mdlayher/kobject
         - golang.zx2c4.com/wireguard/wgctrl
         - github.com/mdlayher/ethtool
+        - github.com/secure-io/siv-go
       replace-local: true
       exclude-forbidden: false
       retract-allow-no-explanation: false

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ replace (
 	// see https://github.com/mdlayher/kobject/pull/5
 	github.com/mdlayher/kobject => github.com/smira/kobject v0.0.0-20240304111826-49c8d4613389
 
+	// replace to disable assembly implementation (see https://github.com/beevik/nts/issues/1#issuecomment-4879122150)
+	github.com/secure-io/siv-go => github.com/smira/siv-go v0.0.0-20260706144621-2093d2730928
+
 	// Use nested module.
 	github.com/siderolabs/talos/pkg/machinery => ./pkg/machinery
 

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,6 @@ github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgm
 github.com/sassoftware/relic/v7 v7.6.2/go.mod h1:kjmP0IBVkJZ6gXeAu35/KCEfca//+PKM6vTAsyDPY+k=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 h1:ObX9hZmK+VmijreZO/8x9pQ8/P/ToHD/bdSb4Eg4tUo=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36/go.mod h1:LEsDu4BubxK7/cWhtlQWfuxwL4rf/2UEpxXz1o1EMtM=
-github.com/secure-io/siv-go v0.0.0-20180922214919-5ff40651e2c4 h1:zOjq+1/uLzn/Xo40stbvjIY/yehG0+mfmlsiEmc0xmQ=
-github.com/secure-io/siv-go v0.0.0-20180922214919-5ff40651e2c4/go.mod h1:aI+8yClBW+1uovkHw6HM01YXnYB8vohtB9C83wzx34E=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0 h1:iuCR9kcMFD4QurdKrGvPLoKZLv9YvwPYVr0473BdtFs=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0/go.mod h1:+PMOTjUGwHj2vcZ+TFKlb1tXRbrdWE1LYDT5i9JC80Q=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
@@ -862,6 +860,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/smira/kobject v0.0.0-20240304111826-49c8d4613389 h1:f/5NRv5IGZxbjBhc5MnlbNmyuXBPxvekhBAUzyKWyLY=
 github.com/smira/kobject v0.0.0-20240304111826-49c8d4613389/go.mod h1:+SexPO1ZvdbbWUdUnyXEWv3+4NwHZjKhxOmQqHY4Pqc=
+github.com/smira/siv-go v0.0.0-20260706144621-2093d2730928 h1:jLGRk/3hqXLnAjFhChWXFLc+uUbKeyQIvCBciG/CsPs=
+github.com/smira/siv-go v0.0.0-20260706144621-2093d2730928/go.mod h1:aI+8yClBW+1uovkHw6HM01YXnYB8vohtB9C83wzx34E=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=


### PR DESCRIPTION
The issue goes via NTP/NTS library which uses secure-io/siv-go to for AES-GCM-SIV which is not in the Go standard library.

This seems to cause a random crash like:

```
unexpected fault address 0x0
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x80 addr=0x0 pc=0x521854f]

goroutine 1208 gp=0xc00248c960 m=6 mp=0xc000269008 [running]:
runtime.throw({0x6ee2c62?, 0xc00163a870?})
	/go/src/runtime/panic.go:1229 +0x48 fp=0xc0023dccd0 sp=0xc0023dcca0 pc=0x499388
runtime.sigpanic()
	/go/src/runtime/signal_unix.go:945 +0x285 fp=0xc0023dcd30 sp=0xc0023dccd0 pc=0x49c3e5
github.com/secure-io/siv-go.aesGcmXORKeyStream({0xc001991320, 0x88, 0x88}, {0xc001a90068, 0x88, 0x1f98}, {0xc0006b6f50, 0x10, 0x10}, {0xc00163a870, ...}, ...)
	/.cache/mod/github.com/secure-io/siv-go@v0.0.0-20180922214919-5ff40651e2c4/aes_gcm_amd64.s:67 +0x60f fp=0xc0023dcd38 sp=0xc0023dcd30 pc=0x521854f
github.com/secure-io/siv-go.(*aesGcmSivAsm).open(0xc001f61cc8, {0xc001991320, 0x88, 0x88}, {0xc0006b6ee0, 0xc, 0x10}, {0xc001a90068, 0x98, 0x1f98}, ...)
	/.cache/mod/github.com/secure-io/siv-go@v0.0.0-20180922214919-5ff40651e2c4/aes_gcm_amd64.go:67 +0x311 fp=0xc0023dce38 sp=0xc0023dcd38 pc=0x5213131
github.com/secure-io/siv-go.(*aesGcmSiv).Open(0xc002b48980, {0x0, 0x0, 0x0}, {0xc0006b6ee0, 0xc, 0x10}, {0xc001a90068, 0x98, 0x1f98}, ...)
	/.cache/mod/github.com/secure-io/siv-go@v0.0.0-20180922214919-5ff40651e2c4/aes_gcm.go:58 +0x223 fp=0xc0023dcef0 sp=0xc0023dce38 pc=0x5212543
github.com/beevik/nts.(*Session).processResponse(0xc001d78900, {0xc001a90000, 0x100, 0x2000})
	/.cache/mod/github.com/beevik/nts@v0.3.0/session.go:320 +0x7a2 fp=0xc0023dd0a0 sp=0xc0023dcef0 pc=0x521efe2
github.com/beevik/nts.privateWrapper.ProcessResponse({0x71fdea0?}, {0xc001a90000, 0x100, 0x2000})
	/.cache/mod/github.com/beevik/nts@v0.3.0/session.go:206 +0x45 fp=0xc0023dd0e8 sp=0xc0023dd0a0 pc=0x521e005
github.com/beevik/ntp.getTime({0xc0024fc3c0, 0x13}, 0xc0023ad900)
	/.cache/mod/github.com/beevik/ntp@v1.5.0/ntp.go:607 +0x149e fp=0xc0023dd370 sp=0xc0023dd0e8 pc=0x52098be
github.com/beevik/ntp.QueryWithOptions({0xc0024fc3c0, 0x13}, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, {0x0, 0x0}, ...}, ...})
	/.cache/mod/github.com/beevik/ntp@v1.5.0/ntp.go:447 +0xd3 fp=0xc0023dd3d0 sp=0xc0023dd370 pc=0x5208333
github.com/beevik/nts.(*Session).QueryWithOptions(0xc001d78900, 0xc0023dd548)
	/.cache/mod/github.com/beevik/nts@v0.3.0/session.go:178 +0x285 fp=0xc0023dd530 sp=0xc0023dd3d0 pc=0x521dca5
github.com/beevik/nts.(*Session).Query(0xc001d78900)
	/.cache/mod/github.com/beevik/nts@v0.3.0/session.go:171 +0x9e fp=0xc0023dd5e8 sp=0xc0023dd530 pc=0x521d9be
github.com/siderolabs/talos/internal/pkg/ntp.(*Syncer).queryNTS(0xc0007ad400, {0x6f29b30, 0x13})
	/src/internal/pkg/ntp/ntp.go:474 +0x1dd fp=0xc0023dd9d8 sp=0xc0023dd5e8 pc=0x5224a1d
github.com/siderolabs/talos/internal/pkg/ntp.(*Syncer).queryServer(0xc0007ad400, {0x6f29b30, 0x13})
	/src/internal/pkg/ntp/ntp.go:379 +0x85 fp=0xc0023dda20 sp=0xc0023dd9d8 pc=0x5223565
github.com/siderolabs/talos/internal/pkg/ntp.(*Syncer).query(0xc0007ad400, {0x724bce0, 0xc002e4c780})
	/src/internal/pkg/ntp/ntp.go:308 +0x554 fp=0xc0023ddc50 sp=0xc0023dda20 pc=0x5222474
github.com/siderolabs/talos/internal/pkg/ntp.(*Syncer).Run(0xc0007ad400, {0x724bce0, 0xc002e4c780})
	/src/internal/pkg/ntp/ntp.go:200 +0x2a8 fp=0xc0023ddf68 sp=0xc0023ddc50 pc=0x5221448
github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time.(*SyncController).Run.func5()
	/src/internal/app/machined/pkg/controllers/time/sync.go:285 +0x73 fp=0xc0023ddfb0 sp=0xc0023ddf68 pc=0x5e326d3
sync.(*WaitGroup).Go.func1()
	/go/src/sync/waitgroup.go:258 +0x4a fp=0xc0023ddfe0 sp=0xc0023ddfb0 pc=0x4b75aa
runtime.goexit({})
	/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0xc0023ddfe8 sp=0xc0023ddfe0 pc=0x4a1e41
created by sync.(*WaitGroup).Go in goroutine 666
	/go/src/sync/waitgroup.go:238 +0x73
```

The stacktrace matches exactly https://github.com/beevik/nts/issues/1#issuecomment-4879122150

Use the forked siv-go which drops the assembly path (uses Go native implementation). It should have no real performance impact, as NTS is not doing heavy cryptography.

The fork has only one commit diff: https://github.com/smira/siv-go/commit/2093d2730928acd95563baa349e9bf0daef76385
