### PR TITLE
feat: #13526 KubeNetworkConfig supports node CIDR configuration

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -116,6 +116,8 @@ message ControllerManagerConfigSpec {
   Resources resources = 9;
   map<string, ArgValues> extra_args = 10;
   repeated string args = 11;
+  int64 node_cidr_mask_size_i_pv4 = 12;
+  int64 node_cidr_mask_size_i_pv6 = 13;
 }
 
 // EndpointSpec describes a list of endpoints to connect to.

--- a/cmd/talosctl/pkg/logtail/logtail.go
+++ b/cmd/talosctl/pkg/logtail/logtail.go
@@ -43,7 +43,7 @@ func waitForFile(ctx context.Context, path string) (*os.File, error) {
 // polling for new output until ctx is done, reopening the file if it is
 // recreated or truncated — i.e. `tail -F` behavior.
 //
-// nolint:gocyclo
+//nolint:gocyclo
 func Tail(ctx context.Context, path string, follow bool, emit EmitFunc) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -60,7 +60,7 @@ func Tail(ctx context.Context, path string, follow bool, emit EmitFunc) {
 		}
 	}
 
-	defer func() { f.Close() }() // nolint:errcheck
+	defer func() { f.Close() }() //nolint:errcheck
 
 	var (
 		partial []byte
@@ -144,7 +144,7 @@ func reopenIfRotated(f *os.File, path string, offset int64) (*os.File, bool) {
 		return f, false
 	}
 
-	defer func() { f.Close() }() // nolint:errcheck
+	defer func() { f.Close() }() //nolint:errcheck
 
 	return nf, true
 }

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -127,6 +127,7 @@ List of changes:
 - Deprecated `.cluster.proxy` in the v1alpha1 config; use the `KubeProxyConfig` document for kube-proxy configuration.
 - Deprecated `.cluster.network` in the v1alpha1 config; use the `KubeNetworkConfig` document for Kubernetes network configuration; Flannel can be configured using the `KubeFlannelCNIConfig` document.
 - Deprecated `.cluster.coreDNS` in the v1alpha1 config; use the `KubeCoreDNSConfig` document for CoreDNS configuration.
+- Added `nodeCIDRMaskSizeIPv4` (default `24`) and `nodeCIDRMaskSizeIPv6` (default `64`) settings to the `KubeNetworkConfig` document to control the per-node pod CIDR mask size and validate the pod and service subnet sizes.
 """
 
     [notes.dhcpsearchdomains]

--- a/internal/app/debug/debug.go
+++ b/internal/app/debug/debug.go
@@ -110,7 +110,7 @@ func (s *Service) ContainerRun(srv grpc.BidiStreamingServer[machine.DebugContain
 	}
 
 	defer func() {
-		cg.Delete() // nolint: errcheck
+		cg.Delete() //nolint: errcheck
 	}()
 
 	ctr, err := createDebugContainer(ctx, c8dClient, containerID, img, spec, cgroupPath)

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -320,6 +320,8 @@ func NewControlPlaneControllerManagerController() *ControlPlaneControllerManager
 					ExtraVolumes:         convertVolumes(controllerManagerConfig.ExtraVolumes()),
 					EnvironmentVariables: controllerManagerConfig.Env(),
 					Resources:            convertResources(controllerManagerConfig.Resources()),
+					NodeCIDRMaskSizeIPv4: machineConfig.Config().K8sNetworkConfig().NodeCIDRMaskSizeIPv4(),
+					NodeCIDRMaskSizeIPv6: machineConfig.Config().K8sNetworkConfig().NodeCIDRMaskSizeIPv6(),
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -228,6 +229,8 @@ func handleKubeAPIServerAuthorizationFlags(argBuilder argsbuilder.Args, extraArg
 type ControlPlaneControllerManagerFinalController = transform.Controller[*k8s.ControllerManagerConfig, *k8s.ControllerManagerConfig]
 
 // NewControlPlaneControllerManagerFinalController instantiates the controller.
+//
+//nolint:gocyclo
 func NewControlPlaneControllerManagerFinalController() *ControlPlaneControllerManagerFinalController {
 	return transform.NewController(
 		transform.Settings[*k8s.ControllerManagerConfig, *k8s.ControllerManagerConfig]{
@@ -283,6 +286,34 @@ func NewControlPlaneControllerManagerFinalController() *ControlPlaneControllerMa
 
 				if in.TypedSpec().CloudProvider != "" && !k8sVersion.CloudProviderFlagRemoved() {
 					builder.Set("cloud-provider", argsbuilder.Value{in.TypedSpec().CloudProvider})
+				}
+
+				// emit the per-node pod CIDR mask size only for the address families actually present in the
+				// cluster CIDRs (pod CIDRs): kube-controller-manager rejects a per-family flag when that family is absent.
+				//
+				// This is not mentioned in the configuration reference, grep `--node-cidr-mask-size` at
+				// https://github.com/kubernetes/kubernetes/blob/16e45f3b5e6a76a1ac741550e3a65980eea783c2/CHANGELOG/CHANGELOG-1.23.md#L2387-L2390
+				var hasIPv4, hasIPv6 bool
+
+				for _, podCIDR := range in.TypedSpec().PodCIDRs {
+					prefix, err := netip.ParsePrefix(podCIDR)
+					if err != nil {
+						return fmt.Errorf("failed to parse pod CIDR %q: %w", podCIDR, err)
+					}
+
+					if prefix.Addr().Is6() {
+						hasIPv6 = true
+					} else {
+						hasIPv4 = true
+					}
+				}
+
+				if hasIPv4 {
+					builder.Set("node-cidr-mask-size-ipv4", argsbuilder.Value{strconv.Itoa(in.TypedSpec().NodeCIDRMaskSizeIPv4)})
+				}
+
+				if hasIPv6 {
+					builder.Set("node-cidr-mask-size-ipv6", argsbuilder.Value{strconv.Itoa(in.TypedSpec().NodeCIDRMaskSizeIPv6)})
 				}
 
 				mergePolicies := argsbuilder.MergePolicies{

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
@@ -305,10 +305,11 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 		{
 			name: "enabled produces canonical args",
 			input: k8s.ControllerManagerConfigSpec{
-				Enabled:      true,
-				Image:        imagePostRemoval,
-				PodCIDRs:     []string{"10.244.0.0/16"},
-				ServiceCIDRs: []string{"10.96.0.0/12"},
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				PodCIDRs:             []string{"10.244.0.0/16"},
+				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				NodeCIDRMaskSizeIPv4: 24,
 			},
 			expected: k8s.ControllerManagerConfigSpec{
 				Enabled: true,
@@ -327,6 +328,7 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 					"--controllers=*",
 					"--kubeconfig=" + kubeconfigPath,
 					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=24",
 					"--profiling=false",
 					"--root-ca-file=" + caCrtPath,
 					"--service-account-private-key-file=" + saKeyPath,
@@ -338,13 +340,88 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 			},
 		},
 		{
+			name: "custom IPv4 node CIDR mask size flows through",
+			input: k8s.ControllerManagerConfigSpec{
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				PodCIDRs:             []string{"10.244.0.0/16"},
+				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				NodeCIDRMaskSizeIPv4: 25,
+			},
+			expected: k8s.ControllerManagerConfigSpec{
+				Enabled: true,
+				Image:   imagePostRemoval,
+				Args: []string{
+					"/usr/local/bin/kube-controller-manager",
+					"--use-service-account-credentials",
+					"--allocate-node-cidrs=true",
+					"--authentication-kubeconfig=" + kubeconfigPath,
+					"--authorization-kubeconfig=" + kubeconfigPath,
+					"--bind-address=127.0.0.1",
+					"--cluster-cidr=10.244.0.0/16",
+					"--cluster-signing-cert-file=" + caCrtPath,
+					"--cluster-signing-key-file=" + caKeyPath,
+					"--configure-cloud-routes=false",
+					"--controllers=*",
+					"--kubeconfig=" + kubeconfigPath,
+					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=25",
+					"--profiling=false",
+					"--root-ca-file=" + caCrtPath,
+					"--service-account-private-key-file=" + saKeyPath,
+					"--service-cluster-ip-range=10.96.0.0/12",
+					"--terminated-pod-gc-threshold=100",
+					"--tls-min-version=VersionTLS13",
+					"--use-service-account-credentials=true",
+				},
+			},
+		},
+		{
+			name: "IPv6-only emits only the IPv6 node CIDR mask size",
+			input: k8s.ControllerManagerConfigSpec{
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				PodCIDRs:             []string{"fd00::/64"},
+				ServiceCIDRs:         []string{"fd00:1::/108"},
+				NodeCIDRMaskSizeIPv6: 64,
+			},
+			expected: k8s.ControllerManagerConfigSpec{
+				Enabled: true,
+				Image:   imagePostRemoval,
+				Args: []string{
+					"/usr/local/bin/kube-controller-manager",
+					"--use-service-account-credentials",
+					"--allocate-node-cidrs=true",
+					"--authentication-kubeconfig=" + kubeconfigPath,
+					"--authorization-kubeconfig=" + kubeconfigPath,
+					"--bind-address=127.0.0.1",
+					"--cluster-cidr=fd00::/64",
+					"--cluster-signing-cert-file=" + caCrtPath,
+					"--cluster-signing-key-file=" + caKeyPath,
+					"--configure-cloud-routes=false",
+					"--controllers=*",
+					"--kubeconfig=" + kubeconfigPath,
+					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv6=64",
+					"--profiling=false",
+					"--root-ca-file=" + caCrtPath,
+					"--service-account-private-key-file=" + saKeyPath,
+					"--service-cluster-ip-range=fd00:1::/108",
+					"--terminated-pod-gc-threshold=100",
+					"--tls-min-version=VersionTLS13",
+					"--use-service-account-credentials=true",
+				},
+			},
+		},
+		{
 			name: "cloud provider keeps --cloud-provider on k8s < 1.33",
 			input: k8s.ControllerManagerConfigSpec{
-				Enabled:       true,
-				Image:         imagePreRemoval,
-				CloudProvider: "external",
-				PodCIDRs:      []string{"10.244.0.0/16"},
-				ServiceCIDRs:  []string{"10.96.0.0/12"},
+				Enabled:              true,
+				Image:                imagePreRemoval,
+				CloudProvider:        "external",
+				PodCIDRs:             []string{"10.244.0.0/16"},
+				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				NodeCIDRMaskSizeIPv4: 24,
 			},
 			expected: k8s.ControllerManagerConfigSpec{
 				Enabled: true,
@@ -364,6 +441,7 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 					"--controllers=*",
 					"--kubeconfig=" + kubeconfigPath,
 					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=24",
 					"--profiling=false",
 					"--root-ca-file=" + caCrtPath,
 					"--service-account-private-key-file=" + saKeyPath,
@@ -377,11 +455,12 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 		{
 			name: "cloud provider dropped on k8s >= 1.33",
 			input: k8s.ControllerManagerConfigSpec{
-				Enabled:       true,
-				Image:         imagePostRemoval,
-				CloudProvider: "external",
-				PodCIDRs:      []string{"10.244.0.0/16"},
-				ServiceCIDRs:  []string{"10.96.0.0/12"},
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				CloudProvider:        "external",
+				PodCIDRs:             []string{"10.244.0.0/16"},
+				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				NodeCIDRMaskSizeIPv4: 24,
 			},
 			expected: k8s.ControllerManagerConfigSpec{
 				Enabled: true,
@@ -400,6 +479,7 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 					"--controllers=*",
 					"--kubeconfig=" + kubeconfigPath,
 					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=24",
 					"--profiling=false",
 					"--root-ca-file=" + caCrtPath,
 					"--service-account-private-key-file=" + saKeyPath,
@@ -413,10 +493,12 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 		{
 			name: "multiple pod and service CIDRs joined; extra controllers merged additively",
 			input: k8s.ControllerManagerConfigSpec{
-				Enabled:      true,
-				Image:        imagePostRemoval,
-				PodCIDRs:     []string{"10.244.0.0/16", "fd00::/64"},
-				ServiceCIDRs: []string{"10.96.0.0/12", "fd00:1::/108"},
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				PodCIDRs:             []string{"10.244.0.0/16", "fd00::/64"},
+				ServiceCIDRs:         []string{"10.96.0.0/12", "fd00:1::/108"},
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 64,
 				ExtraArgs: map[string]k8s.ArgValues{
 					"controllers": {Values: []string{"-bootstrapsigner", "-tokencleaner"}},
 					"v":           {Values: []string{"4"}},
@@ -439,6 +521,8 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 					"--controllers=*,-bootstrapsigner,-tokencleaner",
 					"--kubeconfig=" + kubeconfigPath,
 					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=24",
+					"--node-cidr-mask-size-ipv6=64",
 					"--profiling=false",
 					"--root-ca-file=" + caCrtPath,
 					"--service-account-private-key-file=" + saKeyPath,
@@ -453,10 +537,11 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 		{
 			name: "extra args override defaults; pass-through fields preserved",
 			input: k8s.ControllerManagerConfigSpec{
-				Enabled:      true,
-				Image:        imagePostRemoval,
-				PodCIDRs:     []string{"10.244.0.0/16"},
-				ServiceCIDRs: []string{"10.96.0.0/12"},
+				Enabled:              true,
+				Image:                imagePostRemoval,
+				PodCIDRs:             []string{"10.244.0.0/16"},
+				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				NodeCIDRMaskSizeIPv4: 24,
 				ExtraArgs: map[string]k8s.ArgValues{
 					"bind-address":                {Values: []string{"0.0.0.0"}},
 					"terminated-pod-gc-threshold": {Values: []string{"50"}},
@@ -499,6 +584,7 @@ func (suite *ControlPlaneControllerManagerFinalSuite) TestTransform() {
 					"--controllers=*",
 					"--kubeconfig=" + kubeconfigPath,
 					"--leader-elect=true",
+					"--node-cidr-mask-size-ipv4=24",
 					"--profiling=false",
 					"--root-ca-file=" + caCrtPath,
 					"--service-account-private-key-file=" + saKeyPath,
@@ -565,7 +651,7 @@ func setK8sRoot(suite *ControlPlaneAPIServerFinalSuite, spec secrets.KubernetesR
 	}
 }
 
-// nolint:gocyclo
+//nolint:gocyclo
 func (suite *ControlPlaneAPIServerFinalSuite) TestTransform() {
 	secretsDir := constants.KubernetesAPIServerSecretsDir
 	configDir := constants.KubernetesAPIServerConfigDir

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
@@ -67,10 +67,10 @@ func (suite *K8sControlPlaneSuite) TestReconcileDefaults() {
 
 	cn := k8scfg.NewKubeNetworkConfigV1Alpha1()
 	cn.NetworkPodSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 	}
 	cn.NetworkServiceSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 	}
 
 	ctr, err := container.New(v1alpha1Cfg, cn)
@@ -436,8 +436,8 @@ func (suite *K8sControlPlaneSuite) TestReconcileIPv6() {
 						},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						PodSubnet:     []string{constants.DefaultIPv6PodNet},
-						ServiceSubnet: []string{constants.DefaultIPv6ServiceNet},
+						PodSubnet:     []string{constants.DefaultIPv6PodCIDR},
+						ServiceSubnet: []string{constants.DefaultIPv6ServiceCIDR},
 					},
 				},
 			},
@@ -473,8 +473,8 @@ func (suite *K8sControlPlaneSuite) TestReconcileDualStack() {
 						},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						PodSubnet:     []string{constants.DefaultIPv4PodNet, constants.DefaultIPv6PodNet},
-						ServiceSubnet: []string{constants.DefaultIPv4ServiceNet, constants.DefaultIPv6ServiceNet},
+						PodSubnet:     []string{constants.DefaultIPv4PodCIDR, constants.DefaultIPv6PodCIDR},
+						ServiceSubnet: []string{constants.DefaultIPv4ServiceCIDR, constants.DefaultIPv6ServiceCIDR},
 					},
 				},
 			},

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
@@ -141,7 +141,7 @@ func (suite *KubeletConfigSuite) TestReconcileDefaults() {
 						},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						ServiceSubnet: []string{constants.DefaultIPv4ServiceNet},
+						ServiceSubnet: []string{constants.DefaultIPv4ServiceCIDR},
 					},
 				},
 			},

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -31,12 +31,12 @@ var defaultManifestSpec = k8s.BootstrapManifestsConfigSpec{
 	Server:        "127.0.0.1",
 	ClusterDomain: "cluster.",
 
-	PodCIDRs: []string{constants.DefaultIPv4PodNet},
+	PodCIDRs: []string{constants.DefaultIPv4PodCIDR},
 
 	ProxyEnabled: true,
 	ProxyImage:   "foo/bar",
 	ProxyArgs: []string{
-		fmt.Sprintf("--cluster-cidr=%s", constants.DefaultIPv4PodNet),
+		fmt.Sprintf("--cluster-cidr=%s", constants.DefaultIPv4PodCIDR),
 		"--hostname-override=$(NODE_NAME)",
 		"--kubeconfig=/etc/kubernetes/kubeconfig",
 		"--proxy-mode=iptables",
@@ -142,7 +142,7 @@ func (suite *ManifestSuite) TestReconcileIPv6() {
 
 	manifestConfig := k8s.NewBootstrapManifestsConfig()
 	spec := defaultManifestSpec
-	spec.PodCIDRs = []string{constants.DefaultIPv6PodNet}
+	spec.PodCIDRs = []string{constants.DefaultIPv6PodCIDR}
 	spec.DNSServiceIP = ""
 	spec.DNSServiceIPv6 = "fc00:db8:10::10"
 	*manifestConfig.TypedSpec() = spec
@@ -191,7 +191,7 @@ func (suite *ManifestSuite) TestReconcileIPv6() {
 		v, _, _ := unstructured.NestedString(configmap.Object, "data", "net-conf.json") //nolint:errcheck
 		asrt.Contains(v, `"EnableIPv4": false`)
 		asrt.Contains(v, `"EnableIPv6": true`)
-		asrt.Contains(v, fmt.Sprintf(`"IPv6Network": "%s"`, constants.DefaultIPv6PodNet))
+		asrt.Contains(v, fmt.Sprintf(`"IPv6Network": "%s"`, constants.DefaultIPv6PodCIDR))
 	})
 }
 

--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
@@ -66,8 +66,8 @@ func (suite *NodeIPConfigSuite) TestReconcileWithSubnets() {
 						},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						ServiceSubnet: []string{constants.DefaultIPv4ServiceNet},
-						PodSubnet:     []string{constants.DefaultIPv4PodNet},
+						ServiceSubnet: []string{constants.DefaultIPv4ServiceCIDR},
+						PodSubnet:     []string{constants.DefaultIPv4PodCIDR},
 					},
 				},
 			},
@@ -101,8 +101,8 @@ func (suite *NodeIPConfigSuite) TestReconcileWithNewVIPs() {
 				},
 			},
 			ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-				ServiceSubnet: []string{constants.DefaultIPv4ServiceNet},
-				PodSubnet:     []string{constants.DefaultIPv4PodNet},
+				ServiceSubnet: []string{constants.DefaultIPv4ServiceCIDR},
+				PodSubnet:     []string{constants.DefaultIPv4PodCIDR},
 			},
 		},
 	}
@@ -144,8 +144,8 @@ func (suite *NodeIPConfigSuite) TestReconcileDefaults() {
 						},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						ServiceSubnet: []string{constants.DefaultIPv4ServiceNet, constants.DefaultIPv6ServiceNet},
-						PodSubnet:     []string{constants.DefaultIPv4PodNet, constants.DefaultIPv6PodNet},
+						ServiceSubnet: []string{constants.DefaultIPv4ServiceCIDR, constants.DefaultIPv6ServiceCIDR},
+						PodSubnet:     []string{constants.DefaultIPv4PodCIDR, constants.DefaultIPv6PodCIDR},
 					},
 				},
 			},

--- a/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
@@ -62,7 +62,7 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigEnabled() {
 						Endpoint: &v1alpha1.Endpoint{URL: u},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						PodSubnet: []string{constants.DefaultIPv4PodNet},
+						PodSubnet: []string{constants.DefaultIPv4PodCIDR},
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv4() {
 						Endpoint: &v1alpha1.Endpoint{URL: u},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						PodSubnet: []string{constants.DefaultIPv4PodNet, constants.DefaultIPv6PodNet},
+						PodSubnet: []string{constants.DefaultIPv4PodCIDR, constants.DefaultIPv6PodCIDR},
 					},
 				},
 			},
@@ -184,7 +184,7 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv6Only() {
 						Endpoint: &v1alpha1.Endpoint{URL: u},
 					},
 					ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-						PodSubnet: []string{constants.DefaultIPv6PodNet},
+						PodSubnet: []string{constants.DefaultIPv6PodCIDR},
 					},
 				},
 			},
@@ -226,7 +226,7 @@ func (suite *HostDNSConfigSuite) TestResolverConfigDocument() {
 		MachineConfig: &v1alpha1.MachineConfig{},
 		ClusterConfig: &v1alpha1.ClusterConfig{
 			ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
-				PodSubnet: []string{constants.DefaultIPv4PodNet},
+				PodSubnet: []string{constants.DefaultIPv4PodCIDR},
 			},
 		},
 	}

--- a/internal/integration/api/kube-network-config.go
+++ b/internal/integration/api/kube-network-config.go
@@ -1,0 +1,210 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_api
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	k8sres "github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+)
+
+// podCIDRFamilies reports which IP families are present among the cluster's pod CIDRs.
+func podCIDRFamilies(netCfg configconfig.K8sNetworkConfig) (hasIPv4, hasIPv6 bool) {
+	for _, podCIDR := range netCfg.PodCIDRs() {
+		if podCIDR.Addr().Is6() {
+			hasIPv6 = true
+		} else {
+			hasIPv4 = true
+		}
+	}
+
+	return hasIPv4, hasIPv6
+}
+
+// KubeNetworkConfigSuite verifies the KubeNetworkConfig node CIDR mask size settings
+// are wired end-to-end into the kube-controller-manager arguments.
+type KubeNetworkConfigSuite struct {
+	base.APISuite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+}
+
+// SuiteName ...
+func (suite *KubeNetworkConfigSuite) SuiteName() string {
+	return "api.KubeNetworkConfigSuite"
+}
+
+// SetupTest ...
+func (suite *KubeNetworkConfigSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+}
+
+// TearDownTest ...
+func (suite *KubeNetworkConfigSuite) TearDownTest() {
+	if suite.ctxCancel != nil {
+		suite.ctxCancel()
+	}
+}
+
+// TestNodeCIDRMaskSize applies a KubeNetworkConfig node CIDR mask size for each address family
+// present in the cluster's pod CIDRs and asserts the value flows through to the rendered
+// kube-controller-manager arguments, then reverts to the defaults.
+//
+// The test handles both legacy (.machine.cluster.network) and multidoc (KubeNetworkConfig) clusters
+// by reading the effective config, building a complete KubeNetworkConfig document, atomically
+// clearing the legacy field if present, and restoring the original config in cleanup.
+func (suite *KubeNetworkConfigSuite) TestNodeCIDRMaskSize() {
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping if cluster is not qemu")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	suite.T().Logf("testing on node %q", node)
+
+	// Read the current config to restore it at the end
+	originalProvider, err := suite.ReadConfigFromNode(nodeCtx)
+	suite.Require().NoErrorf(err, "failed to read existing config from node %q", node)
+
+	originalCfgBytes, err := originalProvider.Bytes()
+	suite.Require().NoErrorf(err, "failed to marshal original config for node %q", node)
+
+	// Restore original config when the test finishes
+	defer func() {
+		if err := suite.restoreConfig(nodeCtx, originalCfgBytes); err != nil {
+			suite.T().Logf("failed to restore original config: %v", err)
+		}
+	}()
+
+	netCfg := originalProvider.K8sNetworkConfig()
+	suite.Require().NotNil(netCfg, "cluster has no K8sNetworkConfig")
+
+	hasIPv4, hasIPv6 := podCIDRFamilies(netCfg)
+	suite.Require().True(hasIPv4 || hasIPv6, "cluster has no pod CIDRs")
+
+	const (
+		customIPv4MaskSize = 25
+		customIPv6MaskSize = 72
+	)
+
+	// Apply custom (non-default) node CIDR mask sizes for the families present, and assert they
+	// reach the rendered kube-controller-manager arguments.
+	suite.applyNodeCIDRMaskSizes(nodeCtx, originalProvider, netCfg, customIPv4MaskSize, customIPv6MaskSize)
+	suite.assertControllerManagerArgs(nodeCtx, netCfg, customIPv4MaskSize, customIPv6MaskSize)
+
+	// Revert to the defaults and assert they take effect again.
+	suite.applyNodeCIDRMaskSizes(nodeCtx, originalProvider, netCfg, constants.DefaultNodeCIDRMaskSizeIPv4, constants.DefaultNodeCIDRMaskSizeIPv6)
+	suite.assertControllerManagerArgs(nodeCtx, netCfg, constants.DefaultNodeCIDRMaskSizeIPv4, constants.DefaultNodeCIDRMaskSizeIPv6)
+}
+
+// applyNodeCIDRMaskSizes builds a complete KubeNetworkConfig document with the given mask sizes,
+// clears the legacy v1alpha1 .cluster.network field if present, and applies both in a single request.
+func (suite *KubeNetworkConfigSuite) applyNodeCIDRMaskSizes(
+	nodeCtx context.Context,
+	provider config.Provider,
+	netCfg configconfig.K8sNetworkConfig,
+	ipv4MaskSize int,
+	ipv6MaskSize int,
+) {
+	kubeNetCfg := k8s.NewKubeNetworkConfigV1Alpha1()
+	kubeNetCfg.NetworkDNSDomain = netCfg.DNSDomain()
+	kubeNetCfg.NetworkPodSubnets = xslices.Map(netCfg.PodCIDRs(), func(p netip.Prefix) meta.Prefix {
+		return meta.Prefix{Prefix: p}
+	})
+	kubeNetCfg.NetworkServiceSubnets = xslices.Map(netCfg.ServiceCIDRs(), func(p netip.Prefix) meta.Prefix {
+		return meta.Prefix{Prefix: p}
+	})
+	kubeNetCfg.NetworkNodeCIDRMaskSizeIPv4 = ipv4MaskSize
+	kubeNetCfg.NetworkNodeCIDRMaskSizeIPv6 = ipv6MaskSize
+
+	// Clear the legacy v1alpha1 field if present
+	patched, err := provider.PatchV1Alpha1(func(cfg *v1alpha1.Config) error {
+		if cfg.ClusterConfig != nil {
+			cfg.ClusterConfig.ClusterNetwork = nil //nolint:staticcheck // intentionally clearing legacy field
+		}
+
+		return nil
+	})
+	suite.Require().NoError(err, "failed to patch v1alpha1 config")
+
+	// Drop any pre-existing KubeNetworkConfig document (multi-doc clusters ship one by
+	// default) so it doesn't collide with the one we just built.
+	existingDocs := slices.DeleteFunc(patched.Documents(), func(d configconfig.Document) bool {
+		return d.Kind() == k8s.KubeNetworkConfig
+	})
+
+	// Build the final config with both the legacy-field clear and the new document
+	cont, err := container.New(slices.Concat(existingDocs, []configconfig.Document{kubeNetCfg})...)
+	suite.Require().NoError(err, "failed to build config container")
+
+	cfgDataOut, err := cont.Bytes()
+	suite.Require().NoError(err, "failed to marshal config")
+
+	_, err = suite.Client.ApplyConfiguration(
+		nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Data: cfgDataOut,
+			Mode: machineapi.ApplyConfigurationRequest_AUTO,
+		},
+	)
+	suite.Require().NoError(err, "failed to apply configuration")
+}
+
+// assertControllerManagerArgs waits for the rendered kube-controller-manager arguments to contain
+// the expected per-family node CIDR mask size flags.
+func (suite *KubeNetworkConfigSuite) assertControllerManagerArgs(nodeCtx context.Context, netCfg configconfig.K8sNetworkConfig, ipv4MaskSize int, ipv6MaskSize int) {
+	hasIPv4, hasIPv6 := podCIDRFamilies(netCfg)
+
+	rtestutils.AssertResource(
+		nodeCtx, suite.T(), suite.Client.COSI, k8sres.FinalControllerManagerConfigID,
+		func(cfg *k8sres.ControllerManagerConfig, asrt *assert.Assertions) {
+			if hasIPv4 {
+				asrt.Contains(cfg.TypedSpec().Args, fmt.Sprintf("--node-cidr-mask-size-ipv4=%d", ipv4MaskSize))
+			}
+
+			if hasIPv6 {
+				asrt.Contains(cfg.TypedSpec().Args, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", ipv6MaskSize))
+			}
+		},
+	)
+}
+
+// restoreConfig applies the original configuration back to the node.
+func (suite *KubeNetworkConfigSuite) restoreConfig(nodeCtx context.Context, originalCfgBytes []byte) error {
+	_, err := suite.Client.ApplyConfiguration(
+		nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Data: originalCfgBytes,
+			Mode: machineapi.ApplyConfigurationRequest_AUTO,
+		},
+	)
+
+	return err
+}
+
+func init() {
+	allSuites = append(allSuites, new(KubeNetworkConfigSuite))
+}

--- a/internal/pkg/efivarfs/devicepath_test.go
+++ b/internal/pkg/efivarfs/devicepath_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/siderolabs/talos/internal/pkg/efivarfs"
 )
 
-// nolint:gocyclo
+//nolint:gocyclo
 func TestMarshalExamples(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -849,6 +849,8 @@ type ControllerManagerConfigSpec struct {
 	Resources            *Resources             `protobuf:"bytes,9,opt,name=resources,proto3" json:"resources,omitempty"`
 	ExtraArgs            map[string]*ArgValues  `protobuf:"bytes,10,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Args                 []string               `protobuf:"bytes,11,rep,name=args,proto3" json:"args,omitempty"`
+	NodeCidrMaskSizeIPv4 int64                  `protobuf:"varint,12,opt,name=node_cidr_mask_size_i_pv4,json=nodeCidrMaskSizeIPv4,proto3" json:"node_cidr_mask_size_i_pv4,omitempty"`
+	NodeCidrMaskSizeIPv6 int64                  `protobuf:"varint,13,opt,name=node_cidr_mask_size_i_pv6,json=nodeCidrMaskSizeIPv6,proto3" json:"node_cidr_mask_size_i_pv6,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -951,6 +953,20 @@ func (x *ControllerManagerConfigSpec) GetArgs() []string {
 		return x.Args
 	}
 	return nil
+}
+
+func (x *ControllerManagerConfigSpec) GetNodeCidrMaskSizeIPv4() int64 {
+	if x != nil {
+		return x.NodeCidrMaskSizeIPv4
+	}
+	return 0
+}
+
+func (x *ControllerManagerConfigSpec) GetNodeCidrMaskSizeIPv6() int64 {
+	if x != nil {
+		return x.NodeCidrMaskSizeIPv6
+	}
+	return 0
 }
 
 // EndpointSpec describes a list of endpoints to connect to.
@@ -2705,7 +2721,7 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\x15proxy_config_checksum\x18\x1d \x01(\tR\x13proxyConfigChecksum\"B\n" +
 	"\x10ConfigStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion\"\x91\x06\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"\x83\a\n" +
 	"\x1bControllerManagerConfigSpec\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12%\n" +
@@ -2719,7 +2735,9 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\n" +
 	"extra_args\x18\n" +
 	" \x03(\v2J.talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntryR\textraArgs\x12\x12\n" +
-	"\x04args\x18\v \x03(\tR\x04args\x1aG\n" +
+	"\x04args\x18\v \x03(\tR\x04args\x127\n" +
+	"\x19node_cidr_mask_size_i_pv4\x18\f \x01(\x03R\x14nodeCidrMaskSizeIPv4\x127\n" +
+	"\x19node_cidr_mask_size_i_pv6\x18\r \x01(\x03R\x14nodeCidrMaskSizeIPv6\x1aG\n" +
 	"\x19EnvironmentVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ag\n" +

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -904,6 +904,16 @@ func (m *ControllerManagerConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.NodeCidrMaskSizeIPv6 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NodeCidrMaskSizeIPv6))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.NodeCidrMaskSizeIPv4 != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.NodeCidrMaskSizeIPv4))
+		i--
+		dAtA[i] = 0x60
+	}
 	if len(m.Args) > 0 {
 		for iNdEx := len(m.Args) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Args[iNdEx])
@@ -3192,6 +3202,12 @@ func (m *ControllerManagerConfigSpec) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.NodeCidrMaskSizeIPv4 != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.NodeCidrMaskSizeIPv4))
+	}
+	if m.NodeCidrMaskSizeIPv6 != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.NodeCidrMaskSizeIPv6))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6776,6 +6792,44 @@ func (m *ControllerManagerConfigSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Args = append(m.Args, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeCidrMaskSizeIPv4", wireType)
+			}
+			m.NodeCidrMaskSizeIPv4 = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NodeCidrMaskSizeIPv4 |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeCidrMaskSizeIPv6", wireType)
+			}
+			m.NodeCidrMaskSizeIPv6 = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NodeCidrMaskSizeIPv6 |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/k8s.go
+++ b/pkg/machinery/config/config/k8s.go
@@ -100,6 +100,8 @@ type K8sNetworkConfig interface {
 	PodCIDRs() []netip.Prefix
 	ServiceCIDRs() []netip.Prefix
 	DNSDomain() string
+	NodeCIDRMaskSizeIPv4() int
+	NodeCIDRMaskSizeIPv6() int
 }
 
 // K8sFlannelCNIConfig defines the configuration options for the Flannel CNI in Kubernetes.

--- a/pkg/machinery/config/generate/generate.go
+++ b/pkg/machinery/config/generate/generate.go
@@ -71,11 +71,11 @@ func NewInput(clustername, endpoint, kubernetesVersion string, opts ...Option) (
 	var podNet, serviceNet string
 
 	if addr, addrErr := netip.ParseAddr(endpoint); addrErr == nil && addr.Is6() {
-		podNet = constants.DefaultIPv6PodNet
-		serviceNet = constants.DefaultIPv6ServiceNet
+		podNet = constants.DefaultIPv6PodCIDR
+		serviceNet = constants.DefaultIPv6ServiceCIDR
 	} else {
-		podNet = constants.DefaultIPv4PodNet
-		serviceNet = constants.DefaultIPv4ServiceNet
+		podNet = constants.DefaultIPv4PodCIDR
+		serviceNet = constants.DefaultIPv4ServiceCIDR
 	}
 
 	if input.Options.SecretsBundle == nil {

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2076,6 +2076,24 @@
           "description": "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.\n",
           "markdownDescription": "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.",
           "x-intellij-html-description": "\u003cp\u003eThe service subnet (CIDR), this can be a single value or two values for dual-stack clusters.\u003c/p\u003e\n"
+        },
+        "nodeCIDRMaskSizeIPv4": {
+          "type": "integer",
+          "maximum": 32,
+          "minimum": 1,
+          "title": "nodeCIDRMaskSizeIPv4",
+          "description": "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is 24.\nMust be between 1 and 32.\n",
+          "markdownDescription": "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is `24`.\nMust be between 1 and 32.",
+          "x-intellij-html-description": "\u003cp\u003eThe IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is \u003ccode\u003e24\u003c/code\u003e.\nMust be between 1 and 32.\u003c/p\u003e\n"
+        },
+        "nodeCIDRMaskSizeIPv6": {
+          "type": "integer",
+          "maximum": 128,
+          "minimum": 1,
+          "title": "nodeCIDRMaskSizeIPv6",
+          "description": "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is 64.\nMust be between 1 and 128.\n",
+          "markdownDescription": "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is `64`.\nMust be between 1 and 128.",
+          "x-intellij-html-description": "\u003cp\u003eThe IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is \u003ccode\u003e64\u003c/code\u003e.\nMust be between 1 and 128.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/k8s/k8s_doc.go
+++ b/pkg/machinery/config/types/k8s/k8s_doc.go
@@ -534,6 +534,20 @@ func (KubeNetworkConfigV1Alpha1) Doc() *encoder.Doc {
 				Description: "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "nodeCIDRMaskSizeIPv4",
+				Type:        "int",
+				Note:        "",
+				Description: "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is `24`.\nMust be between 1 and 32.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
+				Name:        "nodeCIDRMaskSizeIPv6",
+				Type:        "int",
+				Note:        "",
+				Description: "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is `64`.\nMust be between 1 and 128.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/pkg/machinery/config/types/k8s/network.go
+++ b/pkg/machinery/config/types/k8s/network.go
@@ -25,6 +25,12 @@ import (
 // KubeNetworkConfig defines the KubeNetworkConfig configuration name.
 const KubeNetworkConfig = "KubeNetworkConfig"
 
+// minSubnetHostBits defines the minimum number of bits identifying hosts in a subnet.
+// For example:
+// - For a IPv4 subnet prefix /28, the host identifier bit length is 32 - 28 = 4 bits.
+// - For a IPv6 subnet prefix /124, the host identifier bit length is 128 - 124 = 4 bits.
+const minSubnetHostBits = 4
+
 func init() {
 	registry.Register(KubeNetworkConfig, func(version string) config.Document {
 		switch version {
@@ -77,6 +83,26 @@ type KubeNetworkConfigV1Alpha1 struct {
 	//       pattern: ^[0-9a-f.:]+/\d{1,3}$
 	//   schemaRequired: true
 	NetworkServiceSubnets []meta.Prefix `yaml:"serviceSubnets" merge:"replace"`
+	//   description: |
+	//     The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.
+	//     The default is `24`.
+	//     Must be between 1 and 32.
+	//   schema:
+	//     type: integer
+	//     minimum: 1
+	//     maximum: 32
+	//   schemaRequired: false
+	NetworkNodeCIDRMaskSizeIPv4 int `yaml:"nodeCIDRMaskSizeIPv4,omitempty"`
+	//   description: |
+	//     The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.
+	//     The default is `64`.
+	//     Must be between 1 and 128.
+	//   schema:
+	//     type: integer
+	//     minimum: 1
+	//     maximum: 128
+	//   schemaRequired: false
+	NetworkNodeCIDRMaskSizeIPv6 int `yaml:"nodeCIDRMaskSizeIPv6,omitempty"`
 }
 
 // NewKubeNetworkConfigV1Alpha1 creates a new KubeNetworkConfig config document.
@@ -93,10 +119,10 @@ func exampleKubeNetworkConfig1V1Alpha1() *KubeNetworkConfigV1Alpha1 {
 	cfg := NewKubeNetworkConfigV1Alpha1()
 	cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 	cfg.NetworkPodSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 	}
 	cfg.NetworkServiceSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 	}
 
 	return cfg
@@ -106,10 +132,10 @@ func exampleKubeNetworkConfig2V1Alpha1() *KubeNetworkConfigV1Alpha1 {
 	cfg := NewKubeNetworkConfigV1Alpha1()
 	cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 	cfg.NetworkPodSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
 	}
 	cfg.NetworkServiceSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
 	}
 
 	return cfg
@@ -119,12 +145,12 @@ func exampleKubeNetworkConfig3V1Alpha1() *KubeNetworkConfigV1Alpha1 {
 	cfg := NewKubeNetworkConfigV1Alpha1()
 	cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 	cfg.NetworkPodSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
 	}
 	cfg.NetworkServiceSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
 	}
 
 	return cfg
@@ -136,60 +162,28 @@ func (s *KubeNetworkConfigV1Alpha1) Clone() config.Document {
 }
 
 // Validate implements config.Validator interface.
-//
-//nolint:gocyclo
 func (s *KubeNetworkConfigV1Alpha1) Validate(_ validation.RuntimeMode, _ ...validation.Option) ([]string, error) {
 	var (
 		errs     error
 		warnings []string
 	)
 
-	validateSubnets := func(subnets []meta.Prefix, minSize int) error {
-		if len(subnets) == 0 {
-			return errors.New("at least one subnets must be specified")
-		}
+	nodeMaskIPv4Valid := s.isValidNodeCIDRMaskSizeIPv4()
+	nodeMaskIPv6Valid := s.isValidNodeCIDRMaskSizeIPv6()
 
-		if len(subnets) > 2 {
-			return errors.New("at most two subnets can be specified for dual-stack clusters")
-		}
-
-		var numberIPv4, numberIPv6 int
-
-		for _, subnet := range subnets {
-			if !subnet.Prefix.IsValid() {
-				return fmt.Errorf("invalid subnet: %s", subnet.Prefix)
-			}
-
-			if subnet.Prefix.Masked() != subnet.Prefix {
-				return fmt.Errorf("invalid subnet: %s is not a valid CIDR", subnet.Prefix)
-			}
-
-			if subnet.Prefix.Addr().Is4() {
-				numberIPv4++
-			} else {
-				numberIPv6++
-			}
-
-			size := subnet.Prefix.Addr().BitLen() - subnet.Prefix.Bits()
-
-			// more validations to come later, we need to define node CIDR size setting
-			if size < minSize {
-				return fmt.Errorf("invalid subnet: %s is too small, it must be at least /%d IPs", subnet.Prefix, minSize)
-			}
-		}
-
-		if numberIPv4 > 1 || numberIPv6 > 1 {
-			return errors.New("at most one IPv4 and one IPv6 subnet can be specified for dual-stack clusters")
-		}
-
-		return nil
+	if !nodeMaskIPv4Valid {
+		errs = errors.Join(errs, fmt.Errorf("nodeCIDRMaskSizeIPv4 must be between 1 and 32"))
 	}
 
-	if err := validateSubnets(s.NetworkPodSubnets, 4); err != nil {
+	if !nodeMaskIPv6Valid {
+		errs = errors.Join(errs, fmt.Errorf("nodeCIDRMaskSizeIPv6 must be between 1 and 128"))
+	}
+
+	if err := validateSubnets(s.NetworkPodSubnets, s.validatePodSubnetSize(nodeMaskIPv4Valid, nodeMaskIPv6Valid)); err != nil {
 		errs = errors.Join(errs, errors.New("pod subnets: "+err.Error()))
 	}
 
-	if err := validateSubnets(s.NetworkServiceSubnets, 4); err != nil {
+	if err := validateSubnets(s.NetworkServiceSubnets, s.validateServiceSubnetSize); err != nil {
 		errs = errors.Join(errs, errors.New("service subnets: "+err.Error()))
 	}
 
@@ -200,10 +194,128 @@ func (s *KubeNetworkConfigV1Alpha1) Validate(_ validation.RuntimeMode, _ ...vali
 	return warnings, errs
 }
 
+func (s *KubeNetworkConfigV1Alpha1) isValidNodeCIDRMaskSizeIPv4() bool {
+	return s.NetworkNodeCIDRMaskSizeIPv4 == 0 ||
+		(s.NetworkNodeCIDRMaskSizeIPv4 >= 1 && s.NetworkNodeCIDRMaskSizeIPv4 <= 32)
+}
+
+func (s *KubeNetworkConfigV1Alpha1) isValidNodeCIDRMaskSizeIPv6() bool {
+	return s.NetworkNodeCIDRMaskSizeIPv6 == 0 ||
+		(s.NetworkNodeCIDRMaskSizeIPv6 >= 1 && s.NetworkNodeCIDRMaskSizeIPv6 <= 128)
+}
+
+func (s *KubeNetworkConfigV1Alpha1) validatePodSubnetSize(nodeMaskIPv4Valid, nodeMaskIPv6Valid bool) func(netip.Prefix) error {
+	return func(podSubnet netip.Prefix) error {
+		perNodePodMaskSize := s.NodeCIDRMaskSizeIPv4()
+		isPerNodePodCIDRValid := nodeMaskIPv4Valid
+
+		if podSubnet.Addr().Is6() {
+			perNodePodMaskSize = s.NodeCIDRMaskSizeIPv6()
+			isPerNodePodCIDRValid = nodeMaskIPv6Valid
+		}
+
+		if !isPerNodePodCIDRValid {
+			return nil
+		}
+
+		// Note that the mask size is inversely proportional to the number of hosts in the subnet.
+		if podSubnet.Bits() > perNodePodMaskSize {
+			return fmt.Errorf(
+				"invalid subnet: %s is smaller than the per-node pod CIDR mask size /%d",
+				podSubnet,
+				perNodePodMaskSize,
+			)
+		}
+
+		if perNodePodMaskSize-podSubnet.Bits() > constants.PodSubnetNodeMaskMaxDiff {
+			return fmt.Errorf(
+				"invalid subnet: %s is too large for the per-node pod CIDR mask size /%d, the difference must be at most %d bits",
+				podSubnet,
+				perNodePodMaskSize,
+				constants.PodSubnetNodeMaskMaxDiff,
+			)
+		}
+
+		return nil
+	}
+}
+
+func (s *KubeNetworkConfigV1Alpha1) validateServiceSubnetSize(serviceSubnet netip.Prefix) error {
+	if hostBits := serviceSubnet.Addr().BitLen() - serviceSubnet.Bits(); hostBits > constants.MaxHostBitsForServiceSubnet {
+		return fmt.Errorf(
+			"invalid subnet: %s is too large, it must be at least /%d (at most %d host identifier bits)",
+			serviceSubnet,
+			serviceSubnet.Addr().BitLen()-constants.MaxHostBitsForServiceSubnet,
+			constants.MaxHostBitsForServiceSubnet,
+		)
+	}
+
+	return nil
+}
+
+// validateSubnets validates the given subnets and checks their sizes using the provided checkSize function.
+func validateSubnets(subnets []meta.Prefix, checkSize func(netip.Prefix) error) error {
+	if len(subnets) == 0 {
+		return errors.New("at least one subnet must be specified")
+	}
+
+	if len(subnets) > 2 {
+		return errors.New("at most two subnets can be specified for dual-stack clusters")
+	}
+
+	var countIPv4, countIPv6 int
+
+	for _, subnet := range subnets {
+		isIPv4, err := validateSubnet(subnet, checkSize)
+		if err != nil {
+			return err
+		}
+
+		if isIPv4 {
+			countIPv4++
+		} else {
+			countIPv6++
+		}
+	}
+
+	if countIPv4 > 1 || countIPv6 > 1 {
+		return errors.New("at most one IPv4 and one IPv6 subnet can be specified for dual-stack clusters")
+	}
+
+	return nil
+}
+
+// validateSubnet validates a single subnet and reports whether it is an IPv4 subnet.
+func validateSubnet(subnet meta.Prefix, checkSize func(netip.Prefix) error) (bool, error) {
+	if !subnet.Prefix.IsValid() {
+		return false, fmt.Errorf("invalid subnet: %s", subnet.Prefix)
+	}
+
+	if subnet.Prefix.Masked() != subnet.Prefix {
+		return false, fmt.Errorf("invalid subnet: %s is not a valid CIDR", subnet.Prefix)
+	}
+
+	hostBits := subnet.Prefix.Addr().BitLen() - subnet.Prefix.Bits()
+
+	if hostBits < minSubnetHostBits {
+		return false, fmt.Errorf(
+			"invalid subnet: /%d is too small, it must be larger than /%d",
+			subnet.Prefix.Bits(),
+			subnet.Prefix.Bits()-minSubnetHostBits,
+		)
+	}
+
+	if err := checkSize(subnet.Prefix); err != nil {
+		return false, err
+	}
+
+	return subnet.Prefix.Addr().Is4(), nil
+}
+
 // V1Alpha1ConflictValidate implements container.V1Alpha1ConflictValidator interface.
 func (s *KubeNetworkConfigV1Alpha1) V1Alpha1ConflictValidate(v1alpha1Cfg *v1alpha1.Config) error {
 	if v1alpha1Cfg.ClusterConfig != nil && v1alpha1Cfg.ClusterConfig.ClusterNetwork != nil { //nolint:staticcheck // legacy access
-		return errors.New("cluster network config in v1alpha1 config (.machine.cluster.network) can't be used with KubeNetworkConfig document, please remove it to avoid conflicts")
+		return errors.New("cluster network config is already set in the v1alpha1 config (.machine.cluster.network). Please remove it and use only the new KubeNetworkConfig document to avoid conflicts")
 	}
 
 	return nil
@@ -230,4 +342,22 @@ func (s *KubeNetworkConfigV1Alpha1) DNSDomain() string {
 	}
 
 	return s.NetworkDNSDomain
+}
+
+// NodeCIDRMaskSizeIPv4 returns the IPv4 per-node pod CIDR mask size, falling back to the default.
+func (s *KubeNetworkConfigV1Alpha1) NodeCIDRMaskSizeIPv4() int {
+	if s.NetworkNodeCIDRMaskSizeIPv4 == 0 {
+		return constants.DefaultNodeCIDRMaskSizeIPv4
+	}
+
+	return s.NetworkNodeCIDRMaskSizeIPv4
+}
+
+// NodeCIDRMaskSizeIPv6 returns the IPv6 per-node pod CIDR mask size, falling back to the default.
+func (s *KubeNetworkConfigV1Alpha1) NodeCIDRMaskSizeIPv6() int {
+	if s.NetworkNodeCIDRMaskSizeIPv6 == 0 {
+		return constants.DefaultNodeCIDRMaskSizeIPv6
+	}
+
+	return s.NetworkNodeCIDRMaskSizeIPv6
 }

--- a/pkg/machinery/config/types/k8s/network_test.go
+++ b/pkg/machinery/config/types/k8s/network_test.go
@@ -29,10 +29,10 @@ func TestKubeNetworkConfigMarshalStability(t *testing.T) {
 	cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 	cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 	cfg.NetworkPodSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 	}
 	cfg.NetworkServiceSubnets = []meta.Prefix{
-		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 	}
 
 	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
@@ -59,10 +59,10 @@ func TestKubeNetworkConfigUnmarshal(t *testing.T) {
 		},
 		NetworkDNSDomain: constants.DefaultDNSDomain,
 		NetworkPodSubnets: []meta.Prefix{
-			{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+			{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 		},
 		NetworkServiceSubnets: []meta.Prefix{
-			{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+			{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 		},
 	}, docs[0])
 }
@@ -81,7 +81,7 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 			name: "empty",
 			cfg:  k8s.NewKubeNetworkConfigV1Alpha1,
 
-			expectedError: "pod subnets: at least one subnets must be specified\nservice subnets: at least one subnets must be specified",
+			expectedError: "pod subnets: at least one subnet must be specified\nservice subnets: at least one subnet must be specified",
 		},
 		{
 			name: "double v4",
@@ -89,12 +89,12 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 				cfg.NetworkPodSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 				}
 
 				return cfg
@@ -109,11 +109,11 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 				cfg.NetworkPodSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 				}
 
 				return cfg
@@ -130,7 +130,7 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 					{Prefix: netip.MustParsePrefix("192.168.1.1/24")},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 				}
 
 				return cfg
@@ -144,10 +144,10 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 				cfg.NetworkPodSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
 				}
 
 				return cfg
@@ -159,10 +159,10 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 				cfg.NetworkPodSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
 				}
 
 				return cfg
@@ -174,13 +174,291 @@ func TestKubeNetworkConfigValidate(t *testing.T) {
 				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
 				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
 				cfg.NetworkPodSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodNet)},
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
 				}
 				cfg.NetworkServiceSubnets = []meta.Prefix{
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceNet)},
-					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceNet)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
 				}
+
+				return cfg
+			},
+		},
+		{
+			name: "service subnet too large",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("10.0.0.0/10")},
+				}
+
+				return cfg
+			},
+
+			expectedError: "service subnets: invalid subnet: 10.0.0.0/10 is too large, it must be at least /12 (at most 20 host identifier bits)",
+		},
+		{
+			name: "pod subnet too large for node mask v4",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("2.0.0.0/7")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+
+				return cfg
+			},
+
+			expectedError: "pod subnets: invalid subnet: 2.0.0.0/7 is too large for the per-node pod CIDR mask size /24, the difference must be at most 16 bits",
+		},
+		{
+			name: "pod subnet too large for node mask v6",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("fc00:db8::/40")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+
+				return cfg
+			},
+
+			expectedError: "pod subnets: invalid subnet: fc00:db8::/40 is too large for the per-node pod CIDR mask size /64, the difference must be at most 16 bits",
+		},
+		{
+			name: "pod subnet smaller than node mask",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("10.244.0.0/28")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+
+				return cfg
+			},
+
+			expectedError: "pod subnets: invalid subnet: 10.244.0.0/28 is smaller than the per-node pod CIDR mask size /24",
+		},
+		{
+			name: "custom node mask makes pod subnet valid",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("2.0.0.0/7")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = 20
+
+				return cfg
+			},
+		},
+		{
+			name: "custom node mask makes pod subnet invalid v6",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 80
+
+				return cfg
+			},
+
+			expectedError: "pod subnets: invalid subnet: fc00:db8:10::/56 is too large for the per-node pod CIDR mask size /80, the difference must be at most 16 bits",
+		},
+		{
+			name: "node mask ipv4 negative",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = -1
+
+				return cfg
+			},
+
+			expectedError: "nodeCIDRMaskSizeIPv4 must be between 1 and 32",
+		},
+		{
+			name: "node mask ipv4 too large",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = 33
+
+				return cfg
+			},
+
+			expectedError: "nodeCIDRMaskSizeIPv4 must be between 1 and 32",
+		},
+		{
+			name: "node mask ipv6 negative",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = -5
+
+				return cfg
+			},
+
+			expectedError: "nodeCIDRMaskSizeIPv6 must be between 1 and 128",
+		},
+		{
+			name: "node mask ipv6 too large",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 129
+
+				return cfg
+			},
+
+			expectedError: "nodeCIDRMaskSizeIPv6 must be between 1 and 128",
+		},
+		{
+			name: "node mask ipv4 and ipv6 both out of range",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = -1
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 200
+
+				return cfg
+			},
+
+			expectedError: "nodeCIDRMaskSizeIPv4 must be between 1 and 32\nnodeCIDRMaskSizeIPv6 must be between 1 and 128",
+		},
+		{
+			name: "node mask ipv4 boundary valid at 1",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("0.0.0.0/1")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = 1
+
+				return cfg
+			},
+		},
+		{
+			name: "node mask ipv4 boundary valid at 32",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = 32
+
+				return cfg
+			},
+		},
+		{
+			name: "node mask ipv6 boundary valid at 1",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("::/1")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 1
+
+				return cfg
+			},
+		},
+		{
+			name: "node mask ipv6 boundary valid at 128",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix("fc00:db8:10::/120")},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 128
+
+				return cfg
+			},
+		},
+		{
+			name: "node mask ipv4 and ipv6 explicitly unset",
+			cfg: func() *k8s.KubeNetworkConfigV1Alpha1 {
+				cfg := k8s.NewKubeNetworkConfigV1Alpha1()
+				cfg.NetworkDNSDomain = constants.DefaultDNSDomain
+				cfg.NetworkPodSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6PodCIDR)},
+				}
+				cfg.NetworkServiceSubnets = []meta.Prefix{
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+					{Prefix: netip.MustParsePrefix(constants.DefaultIPv6ServiceCIDR)},
+				}
+				cfg.NetworkNodeCIDRMaskSizeIPv4 = 0
+				cfg.NetworkNodeCIDRMaskSizeIPv6 = 0
 
 				return cfg
 			},
@@ -224,7 +502,7 @@ func TestKubeNetworkConfigV1Alpha1Validate(t *testing.T) {
 				},
 			},
 
-			expectedError: "cluster network config in v1alpha1 config (.machine.cluster.network) can't be used with KubeNetworkConfig document, please remove it to avoid conflicts",
+			expectedError: "cluster network config is already set in the v1alpha1 config (.machine.cluster.network). Please remove it and use only the new KubeNetworkConfig document to avoid conflicts",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -203,7 +203,7 @@ func (c *ClusterConfig) PodCIDRs() []netip.Prefix {
 	case c.ClusterNetwork == nil:
 		fallthrough
 	case len(c.ClusterNetwork.PodSubnet) == 0:
-		subnets = []string{constants.DefaultIPv4PodNet}
+		subnets = []string{constants.DefaultIPv4PodCIDR}
 	default:
 		subnets = c.ClusterNetwork.PodSubnet
 	}
@@ -223,7 +223,7 @@ func (c *ClusterConfig) ServiceCIDRs() []netip.Prefix {
 	case c.ClusterNetwork == nil:
 		fallthrough
 	case len(c.ClusterNetwork.ServiceSubnet) == 0:
-		subnets = []string{constants.DefaultIPv4ServiceNet}
+		subnets = []string{constants.DefaultIPv4ServiceCIDR}
 	default:
 		subnets = c.ClusterNetwork.ServiceSubnet
 	}
@@ -242,6 +242,20 @@ func (c *ClusterConfig) DNSDomain() string {
 	}
 
 	return c.ClusterNetwork.DNSDomain
+}
+
+// NodeCIDRMaskSizeIPv4 implements the config.K8sNetworkConfig interface.
+//
+// The legacy v1alpha1 config has no per-node CIDR mask size setting, so the default is always used.
+func (c *ClusterConfig) NodeCIDRMaskSizeIPv4() int {
+	return constants.DefaultNodeCIDRMaskSizeIPv4
+}
+
+// NodeCIDRMaskSizeIPv6 implements the config.K8sNetworkConfig interface.
+//
+// The legacy v1alpha1 config has no per-node CIDR mask size setting, so the default is always used.
+func (c *ClusterConfig) NodeCIDRMaskSizeIPv6() int {
+	return constants.DefaultNodeCIDRMaskSizeIPv6
 }
 
 // Discovery implements the config.Cluster interface.

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -907,17 +907,34 @@ const (
 	// CNISELinuxLabel is the SELinux label to be set for CNI configuration overlay mount.
 	CNISELinuxLabel = "system_u:object_r:cni_conf_t:s0"
 
-	// DefaultIPv4PodNet is the IPv4 network to be used for kubernetes Pods.
-	DefaultIPv4PodNet = "10.244.0.0/16"
+	// DefaultIPv4PodCIDR is the IPv4 network to be used for kubernetes Pods.
+	DefaultIPv4PodCIDR = "10.244.0.0/16"
 
-	// DefaultIPv4ServiceNet is the IPv4 network to be used for kubernetes Services.
-	DefaultIPv4ServiceNet = "10.96.0.0/12"
+	// DefaultIPv4ServiceCIDR is the IPv4 network to be used for kubernetes Services.
+	DefaultIPv4ServiceCIDR = "10.96.0.0/12"
 
-	// DefaultIPv6PodNet is the IPv6 network to be used for kubernetes Pods.
-	DefaultIPv6PodNet = "fc00:db8:10::/56"
+	// DefaultIPv6PodCIDR is the IPv6 network to be used for kubernetes Pods.
+	DefaultIPv6PodCIDR = "fc00:db8:10::/56"
 
-	// DefaultIPv6ServiceNet is the IPv6 network to be used for kubernetes Services.
-	DefaultIPv6ServiceNet = "fc00:db8:20::/112"
+	// DefaultIPv6ServiceCIDR is the IPv6 network to be used for kubernetes Services.
+	DefaultIPv6ServiceCIDR = "fc00:db8:20::/112"
+
+	// MaxHostBitsForServiceSubnet is the maximum number of host bits allowed in a service subnet
+	// (i.e. the service subnet may hold at most 2^MaxHostBitsForServiceSubnet addresses).
+	MaxHostBitsForServiceSubnet = 20
+
+	// PodSubnetNodeMaskMaxDiff is the maximum allowed difference between the per-node pod CIDR mask
+	// size and the pod subnet mask size.
+	//
+	// It bounds the size of the per-node pod CIDR allocation bitmap, which is kept uncompressed in
+	// memory; https://github.com/kubernetes/kubernetes/issues/44918
+	PodSubnetNodeMaskMaxDiff = 16
+
+	// DefaultNodeCIDRMaskSizeIPv4 is the default IPv4 per-node pod CIDR mask size.
+	DefaultNodeCIDRMaskSizeIPv4 = 24
+
+	// DefaultNodeCIDRMaskSizeIPv6 is the default IPv6 per-node pod CIDR mask size.
+	DefaultNodeCIDRMaskSizeIPv6 = 64
 
 	// DefaultDNSDomain is the default DNS domain.
 	DefaultDNSDomain = "cluster.local"

--- a/pkg/machinery/resources/k8s/controllermanager_config.go
+++ b/pkg/machinery/resources/k8s/controllermanager_config.go
@@ -40,6 +40,8 @@ type ControllerManagerConfigSpec struct {
 	ExtraVolumes         []ExtraVolume        `yaml:"extraVolumes" protobuf:"7"`
 	EnvironmentVariables map[string]string    `yaml:"environmentVariables" protobuf:"8"`
 	Resources            Resources            `yaml:"resources" protobuf:"9"`
+	NodeCIDRMaskSizeIPv4 int                  `yaml:"nodeCIDRMaskSizeIPv4" protobuf:"12"`
+	NodeCIDRMaskSizeIPv6 int                  `yaml:"nodeCIDRMaskSizeIPv6" protobuf:"13"`
 }
 
 // NewControllerManagerConfig returns new ControllerManagerConfig resource.

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -8019,6 +8019,8 @@ ControllerManagerConfigSpec is configuration for kube-controller-manager.
 | resources | [Resources](#talos.resource.definitions.k8s.Resources) |  |  |
 | extra_args | [ControllerManagerConfigSpec.ExtraArgsEntry](#talos.resource.definitions.k8s.ControllerManagerConfigSpec.ExtraArgsEntry) | repeated |  |
 | args | [string](#string) | repeated |  |
+| node_cidr_mask_size_i_pv4 | [int64](#int64) |  |  |
+| node_cidr_mask_size_i_pv6 | [int64](#int64) |  |  |
 
 
 

--- a/website/content/v1.14/reference/configuration/kubernetes/kubenetworkconfig.md
+++ b/website/content/v1.14/reference/configuration/kubernetes/kubenetworkconfig.md
@@ -57,6 +57,8 @@ serviceSubnets:
 |`dnsDomain` |string |The domain used by Kubernetes DNS.<br>The default is `cluster.local`  | |
 |`podSubnets` |[]Prefix |The pod subnet (CIDR), this can be a single value or two values for dual-stack clusters.  | |
 |`serviceSubnets` |[]Prefix |The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.  | |
+|`nodeCIDRMaskSizeIPv4` |int |The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.<br>The default is `24`.<br>Must be between 1 and 32.  | |
+|`nodeCIDRMaskSizeIPv6` |int |The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.<br>The default is `64`.<br>Must be between 1 and 128.  | |
 
 
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -2076,6 +2076,24 @@
           "description": "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.\n",
           "markdownDescription": "The service subnet (CIDR), this can be a single value or two values for dual-stack clusters.",
           "x-intellij-html-description": "\u003cp\u003eThe service subnet (CIDR), this can be a single value or two values for dual-stack clusters.\u003c/p\u003e\n"
+        },
+        "nodeCIDRMaskSizeIPv4": {
+          "type": "integer",
+          "maximum": 32,
+          "minimum": 1,
+          "title": "nodeCIDRMaskSizeIPv4",
+          "description": "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is 24.\nMust be between 1 and 32.\n",
+          "markdownDescription": "The IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is `24`.\nMust be between 1 and 32.",
+          "x-intellij-html-description": "\u003cp\u003eThe IPv4 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv4 pod subnet.\nThe default is \u003ccode\u003e24\u003c/code\u003e.\nMust be between 1 and 32.\u003c/p\u003e\n"
+        },
+        "nodeCIDRMaskSizeIPv6": {
+          "type": "integer",
+          "maximum": 128,
+          "minimum": 1,
+          "title": "nodeCIDRMaskSizeIPv6",
+          "description": "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is 64.\nMust be between 1 and 128.\n",
+          "markdownDescription": "The IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is `64`.\nMust be between 1 and 128.",
+          "x-intellij-html-description": "\u003cp\u003eThe IPv6 per-node pod CIDR mask size, i.e. the size of the pod CIDR allocated to each node, from the IPv6 pod subnet.\nThe default is \u003ccode\u003e64\u003c/code\u003e.\nMust be between 1 and 128.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Resolves #13526

Adds node CIDR size setting configuration (and validation) to the KubeNetworkConfig document.  


