### PR TITLE
feat: add ignoreRoutes to DHCPv4Config document

### DIFF
--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -138,6 +138,7 @@ message DHCP4OperatorSpec {
   uint32 route_metric = 1;
   bool skip_hostname_request = 2;
   ClientIdentifierSpec client_identifier = 3;
+  bool skip_routes = 4;
 }
 
 // DHCP6OperatorSpec describes DHCP6 operator options.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -131,9 +131,11 @@ List of changes:
 """
 
     [notes.dhcpsearchdomains]
-        title = "DHCP Search Domains"
+        title = "DHCP"
         description = """\
 DHCPv4 search domains are now applied to the resolver configuration.
+
+DHCPv4 configuration now supports `ignoreRoutes` option to ignore routes provided by DHCPv4 servers.
 """
 
 [notes.EPHEMERAL]

--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -35,6 +35,7 @@ type DHCP4 struct {
 	routeMetric         uint32
 	clientIdentifier    network.ClientIdentifierSpec
 	skipHostnameRequest bool
+	skipRoutes          bool
 	requestMTU          bool
 
 	lease *nclient4.Lease
@@ -56,6 +57,7 @@ func NewDHCP4(logger *zap.Logger, linkName string, config network.DHCP4OperatorS
 		linkName:            linkName,
 		routeMetric:         config.RouteMetric,
 		skipHostnameRequest: config.SkipHostnameRequest,
+		skipRoutes:          config.SkipRoutes,
 		clientIdentifier:    config.ClientIdentifier,
 		// <3 azure
 		// When including dhcp.OptionInterfaceMTU we don't get a dhcp offer back on azure.
@@ -305,7 +307,7 @@ func (d *DHCP4) TimeServerSpecs() []network.TimeServerSpecSpec {
 }
 
 func (d *DHCP4) parseNetworkConfigFromAck(ack *dhcpv4.DHCPv4, useHostname bool) {
-	specs := dhcpparse.ParseDHCP4Ack(ack, d.linkName, d.routeMetric, useHostname)
+	specs := dhcpparse.ParseDHCP4Ack(ack, d.linkName, d.routeMetric, useHostname, !d.skipRoutes)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4.go
@@ -39,11 +39,13 @@ type DHCP4AckSpecs struct {
 // ParseDHCP4Ack converts a DHCPv4 ACK packet into network configuration specs.
 //
 // It is a pure function (no I/O, no shared state) — `linkName` and
-// `routeMetric` come from the operator's configuration, and `useHostname`
-// controls whether the ACK's hostname/domain options are honored.
+// `routeMetric` come from the operator's configuration, `useHostname`
+// controls whether the ACK's hostname/domain options are honored, and
+// `useRoutes` controls whether the routes carried by the ACK (the default
+// gateway and classless static routes) are installed at all.
 //
 //nolint:gocyclo
-func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useHostname bool) DHCP4AckSpecs {
+func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useHostname bool, useRoutes bool) DHCP4AckSpecs {
 	var specs DHCP4AckSpecs
 
 	addr, _ := netipx.FromStdIPNet(&net.IPNet{
@@ -73,41 +75,76 @@ func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useH
 		}
 	}
 
-	// rfc3442:
-	//   If the DHCP server returns both a Classless Static Routes option and
-	//   a Router option, the DHCP client MUST ignore the Router option.
-	if len(ack.ClasslessStaticRoute()) > 0 {
-		// Track gateways for which we've already emitted an on-link route so
-		// we don't add duplicates when several classless routes share a gateway.
-		onLinkGateways := map[netip.Addr]struct{}{}
+	if useRoutes {
+		// rfc3442:
+		//   If the DHCP server returns both a Classless Static Routes option and
+		//   a Router option, the DHCP client MUST ignore the Router option.
+		if len(ack.ClasslessStaticRoute()) > 0 {
+			// Track gateways for which we've already emitted an on-link route so
+			// we don't add duplicates when several classless routes share a gateway.
+			onLinkGateways := map[netip.Addr]struct{}{}
 
-		for _, route := range ack.ClasslessStaticRoute() {
-			gw, _ := netipx.FromStdIP(route.Router)
-			dst, _ := netipx.FromStdIPNet(route.Dest)
+			for _, route := range ack.ClasslessStaticRoute() {
+				gw, _ := netipx.FromStdIP(route.Router)
+				dst, _ := netipx.FromStdIPNet(route.Dest)
 
-			specs.Routes = append(specs.Routes, network.RouteSpecSpec{
-				Family:      nethelpers.FamilyInet4,
-				Destination: dst,
-				Source:      addr.Addr(),
-				Gateway:     gw,
-				OutLinkName: linkName,
-				Table:       nethelpers.TableMain,
-				Priority:    routeMetric,
-				Scope:       nethelpers.ScopeGlobal,
-				Type:        nethelpers.TypeUnicast,
-				Protocol:    nethelpers.ProtocolBoot,
-				ConfigLayer: network.ConfigOperator,
-			})
+				specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+					Family:      nethelpers.FamilyInet4,
+					Destination: dst,
+					Source:      addr.Addr(),
+					Gateway:     gw,
+					OutLinkName: linkName,
+					Table:       nethelpers.TableMain,
+					Priority:    routeMetric,
+					Scope:       nethelpers.ScopeGlobal,
+					Type:        nethelpers.TypeUnicast,
+					Protocol:    nethelpers.ProtocolBoot,
+					ConfigLayer: network.ConfigOperator,
+				})
 
-			// If the gateway lives outside the lease's subnet, the kernel
-			// can't resolve it as on-link and refuses to install the route.
-			// AWS does this in IPv6-only subnets, handing out a 169.254.x.x/32
-			// lease with classless routes via 169.254.0.1. Add an explicit
-			// on-link route to the gateway so those routes can be installed.
-			if gw.IsValid() && !gw.IsUnspecified() && !addr.Contains(gw) {
-				if _, seen := onLinkGateways[gw]; !seen {
-					onLinkGateways[gw] = struct{}{}
+				// If the gateway lives outside the lease's subnet, the kernel
+				// can't resolve it as on-link and refuses to install the route.
+				// AWS does this in IPv6-only subnets, handing out a 169.254.x.x/32
+				// lease with classless routes via 169.254.0.1. Add an explicit
+				// on-link route to the gateway so those routes can be installed.
+				if gw.IsValid() && !gw.IsUnspecified() && !addr.Contains(gw) {
+					if _, seen := onLinkGateways[gw]; !seen {
+						onLinkGateways[gw] = struct{}{}
 
+						specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+							Family:      nethelpers.FamilyInet4,
+							Destination: netip.PrefixFrom(gw, gw.BitLen()),
+							Source:      addr.Addr(),
+							OutLinkName: linkName,
+							Table:       nethelpers.TableMain,
+							Priority:    routeMetric,
+							Scope:       nethelpers.ScopeLink,
+							Type:        nethelpers.TypeUnicast,
+							Protocol:    nethelpers.ProtocolBoot,
+							ConfigLayer: network.ConfigOperator,
+						})
+					}
+				}
+			}
+		} else {
+			for _, router := range ack.Router() {
+				gw, _ := netipx.FromStdIP(router)
+
+				specs.Routes = append(specs.Routes, network.RouteSpecSpec{
+					Family:      nethelpers.FamilyInet4,
+					Gateway:     gw,
+					Source:      addr.Addr(),
+					OutLinkName: linkName,
+					Table:       nethelpers.TableMain,
+					Priority:    routeMetric,
+					Scope:       nethelpers.ScopeGlobal,
+					Type:        nethelpers.TypeUnicast,
+					Protocol:    nethelpers.ProtocolBoot,
+					ConfigLayer: network.ConfigOperator,
+				})
+
+				if !addr.Contains(gw) {
+					// Add an interface route for the gateway if it's not in the same network
 					specs.Routes = append(specs.Routes, network.RouteSpecSpec{
 						Family:      nethelpers.FamilyInet4,
 						Destination: netip.PrefixFrom(gw, gw.BitLen()),
@@ -121,39 +158,6 @@ func ParseDHCP4Ack(ack *dhcpv4.DHCPv4, linkName string, routeMetric uint32, useH
 						ConfigLayer: network.ConfigOperator,
 					})
 				}
-			}
-		}
-	} else {
-		for _, router := range ack.Router() {
-			gw, _ := netipx.FromStdIP(router)
-
-			specs.Routes = append(specs.Routes, network.RouteSpecSpec{
-				Family:      nethelpers.FamilyInet4,
-				Gateway:     gw,
-				Source:      addr.Addr(),
-				OutLinkName: linkName,
-				Table:       nethelpers.TableMain,
-				Priority:    routeMetric,
-				Scope:       nethelpers.ScopeGlobal,
-				Type:        nethelpers.TypeUnicast,
-				Protocol:    nethelpers.ProtocolBoot,
-				ConfigLayer: network.ConfigOperator,
-			})
-
-			if !addr.Contains(gw) {
-				// Add an interface route for the gateway if it's not in the same network
-				specs.Routes = append(specs.Routes, network.RouteSpecSpec{
-					Family:      nethelpers.FamilyInet4,
-					Destination: netip.PrefixFrom(gw, gw.BitLen()),
-					Source:      addr.Addr(),
-					OutLinkName: linkName,
-					Table:       nethelpers.TableMain,
-					Priority:    routeMetric,
-					Scope:       nethelpers.ScopeLink,
-					Type:        nethelpers.TypeUnicast,
-					Protocol:    nethelpers.ProtocolBoot,
-					ConfigLayer: network.ConfigOperator,
-				})
 			}
 		}
 	}

--- a/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator/internal/dhcpparse/dhcp4_test.go
@@ -33,7 +33,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Addresses, 1)
 		assert.Equal(t, must.Value(netip.ParsePrefix("10.0.0.5/24"))(t), specs.Addresses[0].Address)
@@ -63,7 +63,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Routes, 2)
 		assert.Equal(t, must.Value(netip.ParseAddr("10.0.0.1"))(t), specs.Routes[0].Gateway)
@@ -86,7 +86,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			})),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		// Classless routes win, router option ignored — only the classless
 		// route is present (gateway is in the subnet, no helper needed).
@@ -118,7 +118,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			)),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		// 3 classless routes + 1 on-link helper for the shared gateway (deduped).
 		require.Len(t, specs.Routes, 4)
@@ -150,7 +150,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			})),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Routes, 1, "no helper for unspecified gateway")
 		assert.Equal(t, must.Value(netip.ParsePrefix("192.168.1.0/24"))(t), specs.Routes[0].Destination)
@@ -170,7 +170,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptGeneric(dhcpv4.OptionInterfaceMTU, []byte{0x05, 0xdc})), // 1500
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, true)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, true, true)
 
 		require.Len(t, specs.Links, 1)
 		assert.Equal(t, uint32(1500), specs.Links[0].MTU)
@@ -206,7 +206,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithDomainSearchList("corp.example.com", "example.com"),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Resolvers, 1)
 		assert.Equal(t, []string{"corp.example.com", "example.com"}, specs.Resolvers[0].SearchDomains)
@@ -222,7 +222,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Resolvers, 1)
 		assert.Equal(t, []string{"corp.example.com", "example.com"}, specs.Resolvers[0].SearchDomains)
@@ -237,7 +237,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Resolvers, 1)
 		assert.Equal(t, []string{"example.com", "corp.example.com"}, specs.Resolvers[0].SearchDomains)
@@ -253,7 +253,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptDomainName("example.com")),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Resolvers, 1)
 		assert.Empty(t, specs.Resolvers[0].NameServers)
@@ -271,7 +271,7 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptGeneric(dhcpv4.OptionDomainName, []byte("\x00\x00"))),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		require.Len(t, specs.Resolvers, 1)
 		assert.Empty(t, specs.Resolvers[0].SearchDomains)
@@ -285,8 +285,41 @@ func TestParseDHCP4Ack(t *testing.T) {
 			dhcpv4.WithOption(dhcpv4.OptHostName("myhost")),
 		))(t)
 
-		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false)
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, true)
 
 		assert.Empty(t, specs.Hostname)
+	})
+
+	t.Run("useRoutes=false suppresses the router-option default route", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptRouter(net.IPv4(10, 0, 0, 1))),
+			dhcpv4.WithOption(dhcpv4.OptDNS(net.IPv4(8, 8, 8, 8))),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, false)
+
+		assert.Empty(t, specs.Routes, "useRoutes=false drops the router-option route")
+		require.Len(t, specs.Addresses, 1, "the leased address is still configured")
+		require.Len(t, specs.Resolvers, 1, "only routes are dropped; DNS is still parsed")
+	})
+
+	t.Run("useRoutes=false suppresses classless static routes", func(t *testing.T) {
+		ack := must.Value(dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+			dhcpv4.WithYourIP(net.IPv4(10, 0, 0, 5)),
+			dhcpv4.WithNetmask(net.CIDRMask(24, 32)),
+			dhcpv4.WithOption(dhcpv4.OptClasslessStaticRoute(&dhcpv4.Route{
+				Dest:   &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
+				Router: net.IPv4(10, 0, 0, 254),
+			})),
+		))(t)
+
+		specs := dhcpparse.ParseDHCP4Ack(ack, linkName, routeMetric, false, false)
+
+		assert.Empty(t, specs.Routes, "useRoutes=false drops classless static routes too")
+		require.Len(t, specs.Addresses, 1, "the leased address is still configured")
 	})
 }

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -257,6 +257,7 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 					DHCP4: network.DHCP4OperatorSpec{
 						RouteMetric:         dhcp4.RouteMetric().ValueOr(network.DefaultRouteMetric),
 						SkipHostnameRequest: dhcp4.IgnoreHostname().ValueOrZero(),
+						SkipRoutes:          dhcp4.IgnoreRoutes().ValueOrZero(),
 						ClientIdentifier: network.ClientIdentifierSpec{
 							ClientIdentifier: dhcp4.ClientIdentifier(),
 							DUIDRawHex:       hex.EncodeToString(dhcp4.DUIDRaw().ValueOrZero()),

--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -386,6 +386,7 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationNewStyle() {
 	dhcp1 := networkcfg.NewDHCPv4ConfigV1Alpha1("eth0")
 	dhcp1.ConfigRouteMetric = 256
 	dhcp1.ConfigIgnoreHostname = new(true)
+	dhcp1.ConfigIgnoreRoutes = new(true)
 
 	dhcp2 := networkcfg.NewDHCPv6ConfigV1Alpha1("eth0")
 	dhcp2.ConfigRouteMetric = 512
@@ -417,12 +418,14 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationNewStyle() {
 				asrt.Equal("eth0", r.TypedSpec().LinkName)
 				asrt.EqualValues(256, r.TypedSpec().DHCP4.RouteMetric)
 				asrt.True(r.TypedSpec().DHCP4.SkipHostnameRequest)
+				asrt.True(r.TypedSpec().DHCP4.SkipRoutes)
 				asrt.Equal(nethelpers.ClientIdentifierMAC, r.TypedSpec().DHCP4.ClientIdentifier.ClientIdentifier)
 			case "configuration/dhcp4/eth23":
 				asrt.Equal(network.OperatorDHCP4, r.TypedSpec().Operator)
 				asrt.Equal("eth23", r.TypedSpec().LinkName)
 				asrt.EqualValues(network.DefaultRouteMetric, r.TypedSpec().DHCP4.RouteMetric)
 				asrt.False(r.TypedSpec().DHCP4.SkipHostnameRequest)
+				asrt.False(r.TypedSpec().DHCP4.SkipRoutes)
 				asrt.Equal(nethelpers.ClientIdentifierMAC, r.TypedSpec().DHCP4.ClientIdentifier.ClientIdentifier)
 			case "configuration/dhcp4/eth2":
 				asrt.Equal(network.OperatorDHCP4, r.TypedSpec().Operator)

--- a/pkg/machinery/api/resource/definitions/network/network.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network.pb.go
@@ -805,6 +805,7 @@ type DHCP4OperatorSpec struct {
 	RouteMetric         uint32                 `protobuf:"varint,1,opt,name=route_metric,json=routeMetric,proto3" json:"route_metric,omitempty"`
 	SkipHostnameRequest bool                   `protobuf:"varint,2,opt,name=skip_hostname_request,json=skipHostnameRequest,proto3" json:"skip_hostname_request,omitempty"`
 	ClientIdentifier    *ClientIdentifierSpec  `protobuf:"bytes,3,opt,name=client_identifier,json=clientIdentifier,proto3" json:"client_identifier,omitempty"`
+	SkipRoutes          bool                   `protobuf:"varint,4,opt,name=skip_routes,json=skipRoutes,proto3" json:"skip_routes,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -858,6 +859,13 @@ func (x *DHCP4OperatorSpec) GetClientIdentifier() *ClientIdentifierSpec {
 		return x.ClientIdentifier
 	}
 	return nil
+}
+
+func (x *DHCP4OperatorSpec) GetSkipRoutes() bool {
+	if x != nil {
+		return x.SkipRoutes
+	}
+	return false
 }
 
 // DHCP6OperatorSpec describes DHCP6 operator options.
@@ -5414,11 +5422,13 @@ const file_resource_definitions_network_network_proto_rawDesc = "" +
 	"\x14ClientIdentifierSpec\x12i\n" +
 	"\x11client_identifier\x18\x01 \x01(\x0e2<.talos.resource.definitions.enums.NethelpersClientIdentifierR\x10clientIdentifier\x12 \n" +
 	"\fduid_raw_hex\x18\x02 \x01(\tR\n" +
-	"duidRawHex\"\xd1\x01\n" +
+	"duidRawHex\"\xf2\x01\n" +
 	"\x11DHCP4OperatorSpec\x12!\n" +
 	"\froute_metric\x18\x01 \x01(\rR\vrouteMetric\x122\n" +
 	"\x15skip_hostname_request\x18\x02 \x01(\bR\x13skipHostnameRequest\x12e\n" +
-	"\x11client_identifier\x18\x03 \x01(\v28.talos.resource.definitions.network.ClientIdentifierSpecR\x10clientIdentifier\"\xd1\x01\n" +
+	"\x11client_identifier\x18\x03 \x01(\v28.talos.resource.definitions.network.ClientIdentifierSpecR\x10clientIdentifier\x12\x1f\n" +
+	"\vskip_routes\x18\x04 \x01(\bR\n" +
+	"skipRoutes\"\xd1\x01\n" +
 	"\x11DHCP6OperatorSpec\x12!\n" +
 	"\froute_metric\x18\x02 \x01(\rR\vrouteMetric\x122\n" +
 	"\x15skip_hostname_request\x18\x03 \x01(\bR\x13skipHostnameRequest\x12e\n" +

--- a/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
@@ -796,6 +796,16 @@ func (m *DHCP4OperatorSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.SkipRoutes {
+		i--
+		if m.SkipRoutes {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if m.ClientIdentifier != nil {
 		size, err := m.ClientIdentifier.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -5657,6 +5667,9 @@ func (m *DHCP4OperatorSpec) SizeVT() (n int) {
 		l = m.ClientIdentifier.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.SkipRoutes {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -9336,6 +9349,26 @@ func (m *DHCP4OperatorSpec) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipRoutes", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SkipRoutes = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/network.go
+++ b/pkg/machinery/config/config/network.go
@@ -200,6 +200,7 @@ type NetworkDHCPv4Config interface {
 	NetworkDHCPv4Config() // signal method
 	RouteMetric() optional.Optional[uint32]
 	IgnoreHostname() optional.Optional[bool]
+	IgnoreRoutes() optional.Optional[bool]
 	ClientIdentifier() nethelpers.ClientIdentifier
 	DUIDRaw() optional.Optional[nethelpers.HardwareAddr]
 }

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2980,6 +2980,13 @@
           "markdownDescription": "Ignore hostname received from the DHCP server.",
           "x-intellij-html-description": "\u003cp\u003eIgnore hostname received from the DHCP server.\u003c/p\u003e\n"
         },
+        "ignoreRoutes": {
+          "type": "boolean",
+          "title": "ignoreRoutes",
+          "description": "Ignore routes received from the DHCP server (the default gateway and classless static routes).\n\nThe connected route for the leased address is still configured.\n",
+          "markdownDescription": "Ignore routes received from the DHCP server (the default gateway and classless static routes).\n\nThe connected route for the leased address is still configured.",
+          "x-intellij-html-description": "\u003cp\u003eIgnore routes received from the DHCP server (the default gateway and classless static routes).\u003c/p\u003e\n\n\u003cp\u003eThe connected route for the leased address is still configured.\u003c/p\u003e\n"
+        },
         "clientIdentifier": {
           "enum": [
             "none",

--- a/pkg/machinery/config/types/network/deep_copy.generated.go
+++ b/pkg/machinery/config/types/network/deep_copy.generated.go
@@ -257,6 +257,10 @@ func (o *DHCPv4ConfigV1Alpha1) DeepCopy() *DHCPv4ConfigV1Alpha1 {
 		cp.ConfigIgnoreHostname = new(bool)
 		*cp.ConfigIgnoreHostname = *o.ConfigIgnoreHostname
 	}
+	if o.ConfigIgnoreRoutes != nil {
+		cp.ConfigIgnoreRoutes = new(bool)
+		*cp.ConfigIgnoreRoutes = *o.ConfigIgnoreRoutes
+	}
 	if o.ConfigClientIdentifier != nil {
 		cp.ConfigClientIdentifier = new(nethelpers.ClientIdentifier)
 		*cp.ConfigClientIdentifier = *o.ConfigClientIdentifier

--- a/pkg/machinery/config/types/network/dhcp4.go
+++ b/pkg/machinery/config/types/network/dhcp4.go
@@ -69,6 +69,11 @@ type DHCPv4ConfigV1Alpha1 struct {
 	//     Ignore hostname received from the DHCP server.
 	ConfigIgnoreHostname *bool `yaml:"ignoreHostname,omitempty"`
 	//   description: |
+	//     Ignore routes received from the DHCP server (the default gateway and classless static routes).
+	//
+	//     The connected route for the leased address is still configured.
+	ConfigIgnoreRoutes *bool `yaml:"ignoreRoutes,omitempty"`
+	//   description: |
 	//     Client identifier to use when communicating with DHCP servers.
 	//
 	//     Defaults to 'mac' if not set.
@@ -140,6 +145,15 @@ func (s *DHCPv4ConfigV1Alpha1) IgnoreHostname() optional.Optional[bool] {
 	}
 
 	return optional.Some(*s.ConfigIgnoreHostname)
+}
+
+// IgnoreRoutes returns whether to ignore routes from DHCP server.
+func (s *DHCPv4ConfigV1Alpha1) IgnoreRoutes() optional.Optional[bool] {
+	if s.ConfigIgnoreRoutes == nil {
+		return optional.None[bool]()
+	}
+
+	return optional.Some(*s.ConfigIgnoreRoutes)
 }
 
 // ClientIdentifier returns the client identifier.

--- a/pkg/machinery/config/types/network/dhcp4_test.go
+++ b/pkg/machinery/config/types/network/dhcp4_test.go
@@ -28,6 +28,7 @@ func TestDHCPv4ConfigMarshalStability(t *testing.T) {
 	cfg := network.NewDHCPv4ConfigV1Alpha1("enp0s3")
 	cfg.ConfigRouteMetric = 512
 	cfg.ConfigIgnoreHostname = new(true)
+	cfg.ConfigIgnoreRoutes = new(true)
 	cfg.ConfigClientIdentifier = new(nethelpers.ClientIdentifierDUID)
 	cfg.ConfigDUIDRaw = nethelpers.HardwareAddr{0x00, 0x01, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45}
 
@@ -56,6 +57,7 @@ func TestDHCPv4ConfigUnmarshal(t *testing.T) {
 		MetaName:               "enp0s3",
 		ConfigRouteMetric:      512,
 		ConfigIgnoreHostname:   new(true),
+		ConfigIgnoreRoutes:     new(true),
 		ConfigClientIdentifier: new(nethelpers.ClientIdentifierDUID),
 		ConfigDUIDRaw:          nethelpers.HardwareAddr{0x00, 0x01, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45},
 	}, docs[0])

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -587,6 +587,13 @@ func (DHCPv4ConfigV1Alpha1) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Ignore hostname received from the DHCP server." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
+				Name:        "ignoreRoutes",
+				Type:        "bool",
+				Note:        "",
+				Description: "Ignore routes received from the DHCP server (the default gateway and classless static routes).\n\nThe connected route for the leased address is still configured.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Ignore routes received from the DHCP server (the default gateway and classless static routes)." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "clientIdentifier",
 				Type:        "ClientIdentifier",
 				Note:        "",
@@ -611,7 +618,7 @@ func (DHCPv4ConfigV1Alpha1) Doc() *encoder.Doc {
 	doc.AddExample("", exampleDHCPv4ConfigV1Alpha1())
 
 	doc.Fields[1].AddExample("", "enp0s2")
-	doc.Fields[5].AddExample("", "00:01:00:01:23:45:67:89:ab:cd:ef:01:23:45")
+	doc.Fields[6].AddExample("", "00:01:00:01:23:45:67:89:ab:cd:ef:01:23:45")
 
 	return doc
 }

--- a/pkg/machinery/config/types/network/testdata/dhcpv4config.yaml
+++ b/pkg/machinery/config/types/network/testdata/dhcpv4config.yaml
@@ -3,5 +3,6 @@ kind: DHCPv4Config
 name: enp0s3
 routeMetric: 512
 ignoreHostname: true
+ignoreRoutes: true
 clientIdentifier: duid
 duidRaw: 00:01:00:01:23:45:67:89:ab:cd:ef:01:23:45

--- a/pkg/machinery/resources/network/network_test.go
+++ b/pkg/machinery/resources/network/network_test.go
@@ -95,6 +95,10 @@ func TestProtobufInterop(t *testing.T) {
 			res:  &network.NfTablesChain{},
 			spec: &networkpb.NfTablesChainSpec{},
 		},
+		{
+			res:  &network.OperatorSpec{},
+			spec: &networkpb.OperatorSpecSpec{},
+		},
 	} {
 		t.Run(test.res.ResourceDefinition().Type, func(t *testing.T) {
 			t.Parallel()
@@ -102,4 +106,22 @@ func TestProtobufInterop(t *testing.T) {
 			require.NoError(t, proto.ResourceSpecToProto(test.res, test.spec, protoenc.WithMarshalZeroFields()))
 		})
 	}
+}
+
+// TestOperatorSpecDHCP4SkipRoutesProtobuf is a regression test for the DHCP4
+// SkipRoutes field being dropped when an OperatorSpec crosses the resource API:
+// the field is present on the Go resource struct but must also exist in the
+// generated protobuf bindings, or it is silently lost on the wire.
+func TestOperatorSpecDHCP4SkipRoutesProtobuf(t *testing.T) {
+	t.Parallel()
+
+	res := network.NewOperatorSpec(network.NamespaceName, "test")
+	res.TypedSpec().Operator = network.OperatorDHCP4
+	res.TypedSpec().DHCP4.SkipRoutes = true
+
+	var spec networkpb.OperatorSpecSpec
+
+	require.NoError(t, proto.ResourceSpecToProto(res, &spec))
+
+	assert.True(t, spec.GetDhcp4().GetSkipRoutes(), "SkipRoutes must survive the resource->protobuf roundtrip")
 }

--- a/pkg/machinery/resources/network/operator_spec.go
+++ b/pkg/machinery/resources/network/operator_spec.go
@@ -60,6 +60,7 @@ type DHCP4OperatorSpec struct {
 	RouteMetric         uint32               `yaml:"routeMetric" protobuf:"1"`
 	SkipHostnameRequest bool                 `yaml:"skipHostnameRequest,omitempty" protobuf:"2"`
 	ClientIdentifier    ClientIdentifierSpec `yaml:"clientIdentifier,omitempty" protobuf:"3"`
+	SkipRoutes          bool                 `yaml:"skipRoutes,omitempty" protobuf:"4"`
 }
 
 // DHCP6OperatorSpec describes DHCP6 operator options.

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -9601,6 +9601,7 @@ DHCP4OperatorSpec describes DHCP4 operator options.
 | route_metric | [uint32](#uint32) |  |  |
 | skip_hostname_request | [bool](#bool) |  |  |
 | client_identifier | [ClientIdentifierSpec](#talos.resource.definitions.network.ClientIdentifierSpec) |  |  |
+| skip_routes | [bool](#bool) |  |  |
 
 
 

--- a/website/content/v1.14/reference/configuration/network/dhcpv4config.md
+++ b/website/content/v1.14/reference/configuration/network/dhcpv4config.md
@@ -31,6 +31,7 @@ name: enp0s2
 {{< /highlight >}}</details> | |
 |`routeMetric` |uint32 |An optional metric for the routes received from the DHCP server.<br><br>Lower values indicate higher priority.<br>Default value is 1024.  | |
 |`ignoreHostname` |bool |Ignore hostname received from the DHCP server.  | |
+|`ignoreRoutes` |bool |Ignore routes received from the DHCP server (the default gateway and classless static routes).<br><br>The connected route for the leased address is still configured.  | |
 |`clientIdentifier` |ClientIdentifier |Client identifier to use when communicating with DHCP servers.<br><br>Defaults to 'mac' if not set.  |`none`<br />`mac`<br />`duid`<br /> |
 |`duidRaw` |HardwareAddr |Raw value of the DUID to use as client identifier.<br><br>This field is only used if 'clientIdentifier' is set to 'duid'. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 duidRaw: 00:01:00:01:23:45:67:89:ab:cd:ef:01:23:45

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -2980,6 +2980,13 @@
           "markdownDescription": "Ignore hostname received from the DHCP server.",
           "x-intellij-html-description": "\u003cp\u003eIgnore hostname received from the DHCP server.\u003c/p\u003e\n"
         },
+        "ignoreRoutes": {
+          "type": "boolean",
+          "title": "ignoreRoutes",
+          "description": "Ignore routes received from the DHCP server (the default gateway and classless static routes).\n\nThe connected route for the leased address is still configured.\n",
+          "markdownDescription": "Ignore routes received from the DHCP server (the default gateway and classless static routes).\n\nThe connected route for the leased address is still configured.",
+          "x-intellij-html-description": "\u003cp\u003eIgnore routes received from the DHCP server (the default gateway and classless static routes).\u003c/p\u003e\n\n\u003cp\u003eThe connected route for the leased address is still configured.\u003c/p\u003e\n"
+        },
         "clientIdentifier": {
           "enum": [
             "none",


### PR DESCRIPTION
## What

Add an `ignoreRoutes` option to the new-style `DHCPv4Config` machine-config document. When set, the DHCPv4 operator uses the lease for addressing but installs none of the routes it carries: both the Router-option default gateway and any RFC 3442 classless static routes. The connected route for the leased address is still configured from the address itself, so the interface remains usable.

This mirrors the existing `ignoreHostname` field end to end (config document, operator spec, and `dhcpparse.ParseDHCP4Ack`). The behavior matches systemd-networkd's `UseRoutes=false`.

```yaml
apiVersion: v1alpha1
kind: DHCPv4Config
name: enp0s2
ignoreRoutes: true
```

## Why

Relates to #13708 and #13578.

On a dual-homed Linode node (a public NIC plus a VPC NIC), the VPC's DHCP server always serves a default gateway, even when that VPC has no internet egress. If Talos runs a DHCP4 operator on the VPC interface, it installs a competing default route that can win the race and black-hole the node's traffic. Today the only way to avoid this is to declare the interface statically with `dhcp: false`. `ignoreRoutes` lets the interface keep using DHCP for its address while declining the routes, which matters for dynamically provisioned nodes where a static per-node address is awkward.

I wrote up the investigation behind this in a comment on #13708: https://github.com/siderolabs/talos/issues/13708#issuecomment-4898228510 (it also may cover the independent dual-homed report in #13578).

## Scope

Kept deliberately small:

- New-style `DHCPv4Config` document only. I would be glad to add the same option to the v1alpha1 `dhcpOptions` and/or a DHCPv6 counterpart if that is preferred.
- No platform-driver changes.

## Testing

- `dhcpparse` unit tests for both suppression paths (the Router-option default gateway and RFC 3442 classless static routes); the existing tests continue to assert routes are produced when routes are not ignored.
- Config document marshal round-trip and JSON schema.
- Controller mapping test asserting `ignoreRoutes` maps to the operator spec's `SkipRoutes`.

## Live validation on hardware

Beyond the unit tests, I built a `v1.14.0-alpha.2` image with this change and validated it end to end on a real dual-homed Linode node — one public NIC (`eth0`) and one VPC NIC (`eth1`) whose DHCP server serves a default gateway with no internet egress. Same node, three configurations (`talosctl get routespecs` / `operatorspecs`):

**1. Address-only baseline** — VPC NIC static (`dhcp: false`), today's workaround. A single default route, via the public gateway:

```
RouteSpec     inet4/<public-gw>//100
OperatorSpec  dhcp4/eth0
```

**2. DHCP on the VPC NIC, no `ignoreRoutes`** — reproduces the problem. The VPC's DHCP-served default route is installed alongside the public one, so there are two default routes and the internet-less VPC gateway can win:

```
RouteSpec     inet4/<vpc-gw>//1024      # competing default route
RouteSpec     inet4/<public-gw>//100
OperatorSpec  dhcp4/eth0
OperatorSpec  dhcp4/eth1
```

**3. DHCP on the VPC NIC, `ignoreRoutes: true`** — the fix. The DHCP4 operator still runs on `eth1` and the interface still gets its lease address, but the DHCP-carried default route is not installed, so we are back to a single default route:

```
RouteSpec     inet4/<public-gw>//100    # vpc-gw route no longer installed
OperatorSpec  dhcp4/eth0
OperatorSpec  dhcp4/eth1                # still running
AddressStatus eth1/<vpc-addr>/24        # lease still acquired
```

The only difference between (2) and (3) is `ignoreRoutes: true`: the lease and the operator are unchanged, only the route install is suppressed.
