### PR TITLE
fix: do not block volume lifecycle teardown on failed user volumes

### DIFF
--- a/internal/app/machined/pkg/controllers/block/volume_manager.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager.go
@@ -453,7 +453,9 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 			}
 
 			// when closing, ignore META volume, we want it to stay longer, so no problem if is not closed yet
-			allClosed = allClosed && (volumeStatus.TypedSpec().Phase == block.VolumePhaseClosed || vc.Metadata().ID() == constants.MetaPartitionLabel)
+			allClosed = allClosed && (volumeStatus.TypedSpec().Phase == block.VolumePhaseClosed ||
+				vc.Metadata().ID() == constants.MetaPartitionLabel ||
+				isFailedUserVolumeProvisioning(volumeLifecycleTearingDown, vc, volumeStatus))
 
 			if shouldCloseVolume && volumeStatus.TypedSpec().Phase == block.VolumePhaseClosed {
 				if volumeParentStatus != nil {
@@ -496,6 +498,54 @@ func (ctrl *VolumeManagerController) Run(ctx context.Context, r controller.Runti
 				return fmt.Errorf("error removing finalizer from volume lifecycle: %w", err)
 			}
 		}
+	}
+}
+
+// userConfiguredVolumeLabels are the labels for volumes provisioned from user machine
+// configuration (as opposed to system volumes). A failing allocation of any of these
+// must not block a global volume lifecycle teardown (e.g. reset/reboot/upgrade).
+var userConfiguredVolumeLabels = []string{
+	block.UserVolumeLabel,
+	block.RawVolumeLabel,
+	block.ExistingVolumeLabel,
+	block.SwapVolumeLabel,
+}
+
+// isFailedUserVolumeProvisioning reports whether a volume is a user-configured volume
+// whose provisioning failed before it was ever provisioned/mounted, during a global
+// volume lifecycle teardown. Such volumes have nothing to close (no mount, no open
+// crypto device), so they should not hold up the teardown - otherwise a user volume
+// referencing a non-existent disk blocks reset until the teardown times out.
+func isFailedUserVolumeProvisioning(volumeLifecycleTearingDown bool, volumeConfig *block.VolumeConfig, volumeStatus *block.VolumeStatus) bool {
+	if !volumeLifecycleTearingDown || volumeStatus.TypedSpec().Phase != block.VolumePhaseFailed {
+		return false
+	}
+
+	isUserConfigured := false
+
+	for _, label := range userConfiguredVolumeLabels {
+		if _, ok := volumeConfig.Metadata().Labels().Raw()[label]; ok {
+			isUserConfigured = true
+
+			break
+		}
+	}
+
+	if !isUserConfigured {
+		return false
+	}
+
+	switch volumeStatus.TypedSpec().PreFailPhase {
+	case block.VolumePhaseWaiting, block.VolumePhaseMissing, block.VolumePhaseLocated,
+		block.VolumePhaseProvisioned, block.VolumePhaseFailed, block.VolumePhaseClosed:
+		// never opened a device or a mount, so there is nothing to close: safe to skip
+		return true
+	case block.VolumePhaseReady, block.VolumePhasePrepared:
+		// volume was decrypted and/or mounted, it needs a real close - must not skip
+		return false
+	default:
+		// unknown/new phase: stay strict and keep blocking the teardown
+		return false
 	}
 }
 

--- a/internal/app/machined/pkg/controllers/block/volume_manager_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager_test.go
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package block_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	blockctrls "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
+	"github.com/siderolabs/talos/pkg/machinery/cel"
+	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+type VolumeManagerSuite struct {
+	ctest.DefaultSuite
+}
+
+func TestVolumeManagerSuite(t *testing.T) {
+	suite.Run(t, &VolumeManagerSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 30 * time.Second,
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(&blockctrls.VolumeManagerController{}))
+			},
+		},
+	})
+}
+
+// setupFailingVolume creates a VolumeLifecycle and a volume config that references a
+// non-existent disk (so it can never be provisioned), waits for the volume to end up
+// in the Failed phase, and pins a finalizer on its status to simulate a consumer that
+// is never cleaned up. It returns the created VolumeLifecycle.
+func (suite *VolumeManagerSuite) setupFailingVolume(id string, labels ...string) *block.VolumeLifecycle {
+	ctx := suite.Ctx()
+
+	// devices are ready
+	devicesStatus := runtimeres.NewDevicesStatus(runtimeres.NamespaceName, runtimeres.DevicesID)
+	devicesStatus.TypedSpec().Ready = true
+	suite.Require().NoError(suite.State().Create(ctx, devicesStatus))
+
+	// volume lifecycle exists (controller ceases all ops without it)
+	lifecycle := block.NewVolumeLifecycle(block.NamespaceName, block.VolumeLifecycleID)
+	suite.Require().NoError(suite.State().Create(ctx, lifecycle))
+
+	// volume referencing a non-existent disk
+	vc := block.NewVolumeConfig(block.NamespaceName, id)
+	for _, label := range labels {
+		vc.Metadata().Labels().Set(label, "")
+	}
+
+	vc.TypedSpec().Type = block.VolumeTypePartition
+	vc.TypedSpec().Provisioning = block.ProvisioningSpec{
+		Wave: block.WaveUserVolumes,
+		DiskSelector: block.DiskSelector{
+			Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.dev_path == "/dev/does-not-exist"`, celenv.DiskLocator())),
+		},
+		PartitionSpec: block.PartitionSpec{
+			MinSize: 1024 * 1024,
+		},
+	}
+	vc.TypedSpec().Locator = block.LocatorSpec{
+		Match: cel.MustExpression(cel.ParseBooleanExpression(`volume.partition_label == "`+id+`"`, celenv.VolumeLocator())),
+	}
+	suite.Require().NoError(suite.State().Create(ctx, vc))
+
+	// the controller writes a DiscoveryRefreshRequest once devices become ready;
+	// mirror it back as a DiscoveryRefreshStatus so devicesReady becomes true.
+	suite.Assert().Eventually(func() bool {
+		req, err := safe.StateGetByID[*block.DiscoveryRefreshRequest](ctx, suite.State(), block.RefreshID)
+		if err != nil {
+			return false
+		}
+
+		st := block.NewDiscoveryRefreshStatus(block.NamespaceName, block.RefreshID)
+		st.TypedSpec().Request = req.TypedSpec().Request
+
+		if err := suite.State().Create(ctx, st); err != nil {
+			// already created - update
+			existing, gerr := safe.StateGetByID[*block.DiscoveryRefreshStatus](ctx, suite.State(), block.RefreshID)
+			if gerr != nil {
+				return false
+			}
+
+			existing.TypedSpec().Request = req.TypedSpec().Request
+			suite.Require().NoError(suite.State().Update(ctx, existing))
+		}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// the volume should end up Failed (no disk matched selector)
+	ctest.AssertResource(suite, id, func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+		asrt.Equal(block.VolumePhaseFailed, vs.TypedSpec().Phase)
+	})
+
+	// pin a finalizer on the failing volume status to simulate a consumer that is
+	// never cleaned up, so the volume cannot be closed the usual way.
+	suite.AddFinalizer(block.NewVolumeStatus(block.NamespaceName, id).Metadata(), "test")
+	ctest.AssertResource(suite, id, func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+		asrt.True(vs.Metadata().Finalizers().Has("test"))
+	})
+
+	return lifecycle
+}
+
+// assertFailingVolumeDoesNotBlockReset sets up a failing volume with the given label,
+// tears down the VolumeLifecycle (as reset does), and asserts the controller releases
+// its lifecycle finalizer so the teardown can complete.
+func (suite *VolumeManagerSuite) assertFailingVolumeDoesNotBlockReset(label string) {
+	lifecycle := suite.setupFailingVolume("v-bad", label)
+
+	// simulate reset: tear down the VolumeLifecycle
+	_, err := suite.State().Teardown(suite.Ctx(), lifecycle.Metadata())
+	suite.Require().NoError(err)
+
+	// the controller must remove its finalizer so TeardownVolumeLifecycle can
+	// proceed; otherwise reset is blocked by the failing volume.
+	ctest.AssertResource(suite, block.VolumeLifecycleID, func(lc *block.VolumeLifecycle, asrt *assert.Assertions) {
+		asrt.True(lc.Metadata().Finalizers().Empty(), "finalizers: %v", lc.Metadata().Finalizers())
+	})
+}
+
+// A user-configured volume whose allocation fails (references a non-existent disk) must
+// not hold up a global volume lifecycle teardown (reset/reboot/upgrade), even if its
+// status still has a finalizer. This applies to every user-configured volume kind.
+
+func (suite *VolumeManagerSuite) TestFailingUserVolumeDoesNotBlockReset() {
+	suite.assertFailingVolumeDoesNotBlockReset(block.UserVolumeLabel)
+}
+
+func (suite *VolumeManagerSuite) TestFailingRawVolumeDoesNotBlockReset() {
+	suite.assertFailingVolumeDoesNotBlockReset(block.RawVolumeLabel)
+}
+
+func (suite *VolumeManagerSuite) TestFailingExistingVolumeDoesNotBlockReset() {
+	suite.assertFailingVolumeDoesNotBlockReset(block.ExistingVolumeLabel)
+}
+
+func (suite *VolumeManagerSuite) TestFailingSwapVolumeDoesNotBlockReset() {
+	suite.assertFailingVolumeDoesNotBlockReset(block.SwapVolumeLabel)
+}
+
+// TestFailingSystemVolumeStillBlocks verifies the fix is scoped to user-configured
+// volumes: a failing system volume with a lingering finalizer must still hold the
+// lifecycle teardown (it may need a real close/unmount), so the finalizer stays.
+func (suite *VolumeManagerSuite) TestFailingSystemVolumeStillBlocks() {
+	lifecycle := suite.setupFailingVolume("s-bad", block.SystemVolumeLabel)
+
+	_, err := suite.State().Teardown(suite.Ctx(), lifecycle.Metadata())
+	suite.Require().NoError(err)
+
+	// lifecycle finalizer must NOT be removed while the system volume is not closed
+	suite.Assert().Never(func() bool {
+		lc, err := safe.StateGetByID[*block.VolumeLifecycle](suite.Ctx(), suite.State(), block.VolumeLifecycleID)
+		if err != nil {
+			return false
+		}
+
+		return lc.Metadata().Phase() == resource.PhaseTearingDown && lc.Metadata().Finalizers().Empty()
+	}, 2*time.Second, 200*time.Millisecond)
+}

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -9,18 +9,26 @@ package api
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/siderolabs/go-retry/retry"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/cel"
+	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
 // RebootSuite ...
@@ -284,6 +292,54 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 		// NB: using `ctx` here to have client talking to init node by default
 		suite.AssertClusterHealthy(suite.ctx)
 	}
+}
+
+// TestRebootWithFailingUserVolume verifies that a user volume whose allocation fails
+// (it references a disk that does not exist) does not block the reboot sequence.
+//
+// The reboot sequence tears down the volume lifecycle; a failing user volume that is
+// never provisioned must not hold that teardown up, otherwise the node fails to reboot.
+func (suite *RebootSuite) TestRebootWithFailingUserVolume() {
+	if !suite.Capabilities().SupportsReboot {
+		suite.T().Skip("cluster doesn't support reboots")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	volumeID := fmt.Sprintf("badvol%04x", rand.Int31())
+	userVolumeID := constants.UserVolumePrefix + volumeID
+
+	suite.T().Logf("creating a failing user volume %q on node %s", volumeID, node)
+
+	doc := blockcfg.NewUserVolumeConfigV1Alpha1()
+	doc.MetaName = volumeID
+	// selector references a disk that does not exist, so the volume can never be allocated
+	doc.ProvisioningSpec.DiskSelectorSpec.Match = cel.MustExpression(
+		cel.ParseBooleanExpression(`disk.dev_path == "/dev/does-not-exist"`, celenv.DiskLocator()),
+	)
+	doc.ProvisioningSpec.ProvisioningMinSize = blockcfg.MustByteSize("100MiB")
+	doc.ProvisioningSpec.ProvisioningMaxSize = blockcfg.MustSize("1GiB")
+
+	suite.PatchMachineConfig(nodeCtx, doc)
+	defer suite.RemoveMachineConfigDocumentsByName(nodeCtx, blockcfg.UserVolumeConfigKind, volumeID)
+
+	// the user volume should fail to allocate (no disk matched the selector)
+	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{userVolumeID},
+		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
+			asrt.Equal(block.VolumePhaseFailed, vs.TypedSpec().Phase)
+		},
+	)
+
+	// reboot must complete despite the failing user volume
+	suite.AssertRebooted(
+		suite.ctx, node, func(nodeCtx context.Context) error {
+			return base.IgnoreGRPCUnavailable(suite.Client.Reboot(nodeCtx))
+		}, 10*time.Minute,
+		suite.CleanupFailedPods,
+	)
+
+	suite.WaitForBootDone(suite.ctx)
 }
 
 func init() {


### PR DESCRIPTION
A user volume referencing a non-existent disk can never allocate and
stays in VolumePhaseFailed with a lingering finalizer. Global lifecycle
teardown (reset/reboot/upgrade) waited for it to reach Closed, which
never happened, so TeardownVolumeLifecycle hung for its full 5-minute
timeout instead of completing.

Treat a failed user-configured volume (User/Raw/Existing/Swap) that
never reached Ready/Prepared as closed for teardown purposes, since it
has nothing to unmount or decrypt. System volumes are unaffected.

Adds unit coverage in volume_manager_test.go and an integration case
in RebootSuite verifying reboot completes despite a failing user
volume.

Fixes https://github.com/siderolabs/talos/issues/13733

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
