### PR TITLE
feat: add --no-reboot flag to upgrade cmd

### DIFF
--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -39,6 +39,7 @@ var upgradeCmdFlags = struct {
 	imageCmdFlagsType
 
 	upgradeImage string
+	noReboot     bool
 	rebootMode   flags.PflagExtended[machine.RebootRequest_Mode]
 	progress     flags.PflagExtended[reporter.OutputMode]
 
@@ -93,6 +94,10 @@ var talosUpgradeAPIVersionRange = semver.MustParseRange(">1.13.0-alpha.2 <2.0.0"
 func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.ClientFactory) (retErr error) {
 	if upgradeCmdFlags.debug {
 		upgradeCmdFlags.wait = true
+	}
+
+	if upgradeCmdFlags.noReboot {
+		upgradeCmdFlags.drain = false
 	}
 
 	if upgradeCmdFlags.legacy {
@@ -158,9 +163,11 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 		}
 	}()
 
-	err = rebootInternal(ctx, clientFactory, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
-	if err != nil {
-		return fmt.Errorf("error during upgrade: %w", err)
+	if !upgradeCmdFlags.noReboot {
+		err = rebootInternal(ctx, clientFactory, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)
+		if err != nil {
+			return fmt.Errorf("error during upgrade: %w", err)
+		}
 	}
 
 	return nil
@@ -364,6 +371,7 @@ func init() {
 		),
 	)
 	upgradeCmd.Flags().Var(upgradeCmdFlags.progress, "progress", fmt.Sprintf("output mode for upgrade progress. Values: %v", upgradeCmdFlags.progress.Options()))
+	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.noReboot, "no-reboot", false, "do not reboot the node after upgrade (skip reboot and drain)")
 	upgradeCmd.Flags().BoolVar(&upgradeCmdFlags.drain, "drain", true, "drain the Kubernetes node before rebooting (cordon + evict pods)")
 	upgradeCmd.Flags().DurationVar(&upgradeCmdFlags.drainTimeout, "drain-timeout", nodedrain.DefaultDrainTimeout, "timeout for draining the Kubernetes node")
 

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -3653,6 +3653,7 @@ talosctl upgrade [flags]
   -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-alpha.2")
       --legacy                     force use of legacy upgrade method
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
+      --no-reboot                  do not reboot the node after upgrade (skip reboot and drain)
   -n, --nodes strings              target the specified nodes
       --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")
   -m, --reboot-mode string         select the reboot mode during upgrade. Mode "powercycle" bypasses kexec. Values: [default force powercycle] (default "default")


### PR DESCRIPTION
Allows deferring reboot after upgrade, skipping drain too since
node stays up. Docs regenerated.

Fixes https://github.com/siderolabs/talos/issues/13721

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
