### PR TITLE
test: assert dm transport for device-mapper disks

### DIFF
--- a/internal/app/machined/pkg/controllers/storage/md_monitor.go
+++ b/internal/app/machined/pkg/controllers/storage/md_monitor.go
@@ -27,7 +27,7 @@ const mdMonitorRestartBackoff = 30 * time.Second
 
 // MDMonitor is the mdadm monitor subset used by MDMonitorController.
 type MDMonitor interface {
-	Monitor(ctx context.Context, onEvent func(string, error)) error
+	Monitor(ctx context.Context, onEvent func(string)) error
 }
 
 // MDMonitorController runs mdadm monitor and emits MD refresh requests for each event.
@@ -99,11 +99,7 @@ func (ctrl *MDMonitorController) Run(ctx context.Context, r controller.Runtime, 
 }
 
 func (ctrl *MDMonitorController) runMonitor(ctx context.Context, r controller.Writer, logger *zap.Logger) error {
-	return ctrl.MD.Monitor(ctx, func(event string, err error) {
-		if err != nil {
-			logger.Warn("MD monitor error", zap.Error(err))
-		}
-
+	return ctrl.MD.Monitor(ctx, func(event string) {
 		if !strings.Contains(event, " event detected ") {
 			logger.Info("MD monitor message", zap.String("message", event))
 

--- a/internal/app/machined/pkg/controllers/storage/md_monitor_test.go
+++ b/internal/app/machined/pkg/controllers/storage/md_monitor_test.go
@@ -23,9 +23,9 @@ type fakeMDMonitor struct {
 	events []string
 }
 
-func (f *fakeMDMonitor) Monitor(ctx context.Context, onEvent func(string, error)) error {
+func (f *fakeMDMonitor) Monitor(ctx context.Context, onEvent func(string)) error {
 	for _, e := range f.events {
-		onEvent(e, nil)
+		onEvent(e)
 	}
 
 	<-ctx.Done()

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -179,9 +179,13 @@ func (suite *VolumesSuite) TestDisks() {
 
 				if suite.Cluster != nil {
 					// running on our own provider, transport should be always detected
-					if disk.TypedSpec().BusPath == "/virtual" {
+					switch {
+					case strings.HasPrefix(disk.Metadata().ID(), "dm-"):
+						// device-mapper disks report a "dm" transport
+						suite.Assert().Equal("dm", disk.TypedSpec().Transport, "disk: %s", disk.Metadata().ID())
+					case disk.TypedSpec().BusPath == "/virtual":
 						suite.Assert().Empty(disk.TypedSpec().Transport, "disk: %s", disk.Metadata().ID())
-					} else {
+					default:
 						suite.Assert().NotEmpty(disk.TypedSpec().Transport, "disk: %s", disk.Metadata().ID())
 					}
 				}

--- a/internal/pkg/md/array_test.go
+++ b/internal/pkg/md/array_test.go
@@ -88,9 +88,7 @@ printf 'mdadm: RebuildFinished event detected on md device /dev/md0\n'
 
 	var events []string
 
-	require.NoError(t, m.Monitor(context.Background(), func(event string, err error) {
-		assert.NoError(t, err)
-
+	require.NoError(t, m.Monitor(context.Background(), func(event string) {
 		events = append(events, event)
 	}))
 
@@ -116,9 +114,14 @@ exit 1
 	m, err := New(WithMdadmPath(script))
 	require.NoError(t, err)
 
-	err = m.Monitor(context.Background(), func(string, error) {})
+	// the "no array" condition must surface only via the return value; the
+	// callback must not fire for it, otherwise it gets logged as a warning on
+	// every restart.
+	called := false
+	err = m.Monitor(context.Background(), func(string) { called = true })
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNotFound))
+	assert.False(t, called, "callback must not fire for the no-array condition")
 }
 
 func TestCommandArguments(t *testing.T) {

--- a/internal/pkg/md/md.go
+++ b/internal/pkg/md/md.go
@@ -62,26 +62,31 @@ func (md *MD) run(ctx context.Context, args ...string) (string, error) {
 // EventCallback is a thread-safe callback for handling events of type T.
 type EventCallback[T any] struct {
 	mu      sync.Mutex
-	onEvent func(T, error)
+	onEvent func(T)
 }
 
 // NewEventCallback creates a new EventCallback for handling events of type T.
-func NewEventCallback[T any](onEvent func(T, error)) *EventCallback[T] {
+func NewEventCallback[T any](onEvent func(T)) *EventCallback[T] {
 	return &EventCallback[T]{
 		onEvent: onEvent,
 	}
 }
 
 // Emit calls the onEvent callback with the provided event of type T.
-func (ec *EventCallback[T]) Emit(event T, err error) {
+func (ec *EventCallback[T]) Emit(event T) {
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
 
-	ec.onEvent(event, err)
+	ec.onEvent(event)
 }
 
 // Monitor runs mdadm monitor and calls onEvent for each emitted event line.
-func (md *MD) Monitor(ctx context.Context, onEvent func(string, error)) error {
+//
+// onEvent receives only stdout event lines. Errors are not delivered through the
+// callback: stderr is buffered and classified via the process exit, so the
+// terminal "no array" condition surfaces once, as the (quiet) ErrNotFound return
+// value, rather than also being logged as a warning per restart.
+func (md *MD) Monitor(ctx context.Context, onEvent func(string)) error {
 	var stderr bytes.Buffer
 
 	ec := NewEventCallback(onEvent)
@@ -91,12 +96,11 @@ func (md *MD) Monitor(ctx context.Context, onEvent func(string, error)) error {
 		md.mdadm,
 		[]string{"--monitor", "--scan", "--mail=talos@local"},
 		cmd.WithStdout(newLineWriter(func(s string) {
-			ec.Emit(s, nil)
+			ec.Emit(s)
 		})),
 		cmd.WithStderr(newLineWriter(func(s string) {
 			stderr.WriteString(s)
 			stderr.WriteByte('\n')
-			ec.Emit("", errors.New(s))
 		})),
 	)
 	if err != nil {


### PR DESCRIPTION
Device-mapper disks (dm-*) report transport "dm", not empty or
generic non-empty. Prior check lumped them with "/virtual" bus
disks, causing false assertions on real clusters.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
