### PR TITLE
test: apid tls provider

### DIFF
--- a/internal/app/apid/pkg/provider/provider_test.go
+++ b/internal/app/apid/pkg/provider/provider_test.go
@@ -2,27 +2,50 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package provider
+package provider_test
 
 import (
+	"context"
 	stdlibtls "crypto/tls"
 	"testing"
+	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/siderolabs/talos/internal/app/apid/pkg/provider"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 )
 
-type CertificateProviderSuite struct {
+type TLSConfigSuite struct {
 	suite.Suite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+
+	resources state.State
 }
 
-func TestCertificateProviderSuite(t *testing.T) {
-	suite.Run(t, new(CertificateProviderSuite))
+func TestTLSConfigSuite(t *testing.T) {
+	suite.Run(t, new(TLSConfigSuite))
 }
 
-func (suite *CertificateProviderSuite) newAPICerts(withClient bool) (*secrets.API, []byte) {
+func (suite *TLSConfigSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(suite.T().Context(), 10*time.Second)
+	suite.resources = state.WrapCore(namespaced.NewState(inmem.Build))
+}
+
+func (suite *TLSConfigSuite) TearDownTest() {
+	suite.ctxCancel()
+}
+
+// newAPICerts builds a secrets.API resource with a fresh CA and server cert.
+// When withClient is true, a client cert is included as well.
+func (suite *TLSConfigSuite) newAPICerts(withClient bool) *secrets.API {
 	ca, err := x509.NewSelfSignedCertificateAuthority()
 	suite.Require().NoError(err)
 
@@ -40,189 +63,144 @@ func (suite *CertificateProviderSuite) newAPICerts(withClient bool) (*secrets.AP
 		api.TypedSpec().Client = x509.NewCertificateAndKeyFromKeyPair(clientCrt)
 	}
 
-	return api, ca.CrtPEM
+	return api
 }
 
-func (suite *CertificateProviderSuite) TestUpdate() {
-	api, caPEM := suite.newAPICerts(true)
+// newTLSConfig seeds the state with API certs and returns a ready TLSConfig.
+func (suite *TLSConfigSuite) newTLSConfig(withClient, skipClientCertVerify bool) *provider.TLSConfig {
+	suite.Require().NoError(suite.resources.Create(suite.ctx, suite.newAPICerts(withClient)))
 
-	p := &certificateProvider{}
-	suite.Require().NoError(p.Update(api))
-
-	suite.True(p.HasClientCertificate())
-
-	caBytes, err := p.GetCA()
+	cfg, err := provider.NewTLSConfig(suite.ctx, suite.resources, skipClientCertVerify)
 	suite.Require().NoError(err)
-	suite.Equal(caPEM, caBytes)
 
-	pool, err := p.GetCACertPool()
-	suite.Require().NoError(err)
-	suite.NotNil(pool)
-
-	serverCert, err := p.GetCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotNil(serverCert)
-
-	clientCert, err := p.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotNil(clientCert)
+	return cfg
 }
 
-func (suite *CertificateProviderSuite) TestUpdateNoClient() {
-	api, _ := suite.newAPICerts(false)
-
-	p := &certificateProvider{}
-	suite.Require().NoError(p.Update(api))
-
-	suite.False(p.HasClientCertificate())
-
-	clientCert, err := p.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-	suite.Nil(clientCert)
-
-	serverCert, err := p.GetCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotNil(serverCert)
-}
-
-func (suite *CertificateProviderSuite) TestUpdateInvalidServerKeyPair() {
-	api, _ := suite.newAPICerts(true)
-	api.TypedSpec().Server.Key = []byte("not-a-key")
-
-	p := &certificateProvider{}
-	suite.Error(p.Update(api))
-}
-
-func (suite *CertificateProviderSuite) TestUpdateInvalidClientKeyPair() {
-	api, _ := suite.newAPICerts(true)
-	api.TypedSpec().Client.Key = []byte("not-a-key")
-
-	p := &certificateProvider{}
-	suite.Error(p.Update(api))
-}
-
-func (suite *CertificateProviderSuite) TestUpdateInvalidCA() {
-	api, _ := suite.newAPICerts(true)
-	api.TypedSpec().AcceptedCAs = []*x509.PEMEncodedCertificate{
-		{Crt: []byte("not-a-cert")},
-	}
-
-	p := &certificateProvider{}
-	suite.Error(p.Update(api))
-}
-
-func (suite *CertificateProviderSuite) TestUpdateEmptyCA() {
-	api, _ := suite.newAPICerts(true)
-	api.TypedSpec().AcceptedCAs = nil
-
-	p := &certificateProvider{}
-	suite.Require().NoError(p.Update(api))
-
-	caBytes, err := p.GetCA()
-	suite.Require().NoError(err)
-	suite.Empty(caBytes)
-}
-
-func (suite *CertificateProviderSuite) TestUpdateClearsClient() {
-	p := &certificateProvider{}
-
-	apiWithClient, _ := suite.newAPICerts(true)
-	suite.Require().NoError(p.Update(apiWithClient))
-	suite.True(p.HasClientCertificate())
-
-	apiWithoutClient, _ := suite.newAPICerts(false)
-	suite.Require().NoError(p.Update(apiWithoutClient))
-	suite.False(p.HasClientCertificate())
-
-	clientCert, err := p.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-	suite.Nil(clientCert)
-}
-
-func (suite *CertificateProviderSuite) TestUpdateRotation() {
-	p := &certificateProvider{}
-
-	api1, _ := suite.newAPICerts(true)
-	suite.Require().NoError(p.Update(api1))
-
-	server1, err := p.GetCertificate(nil)
+// updateAPI applies mutate to the current secrets.API resource in state.
+func (suite *TLSConfigSuite) updateAPI(mutate func(*secrets.API)) {
+	r, err := suite.resources.Get(suite.ctx, resource.NewMetadata(secrets.NamespaceName, secrets.APIType, secrets.APIID, resource.VersionUndefined))
 	suite.Require().NoError(err)
 
-	client1, err := p.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-
-	api2, _ := suite.newAPICerts(true)
-	suite.Require().NoError(p.Update(api2))
-
-	server2, err := p.GetCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotEqual(server1.Certificate[0], server2.Certificate[0])
-
-	client2, err := p.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotEqual(client1.Certificate[0], client2.Certificate[0])
+	api := r.(*secrets.API).DeepCopy().(*secrets.API) //nolint:forcetypeassert
+	mutate(api)
+	suite.Require().NoError(suite.resources.Update(suite.ctx, api))
 }
 
-func (suite *CertificateProviderSuite) newTLSConfig(withClient, skipClientCertVerify bool) *TLSConfig {
-	api, _ := suite.newAPICerts(withClient)
-
-	p := &certificateProvider{}
-	suite.Require().NoError(p.Update(api))
-
-	return &TLSConfig{
-		certificateProvider:  p,
-		skipClientCertVerify: skipClientCertVerify,
-	}
-}
-
-func (suite *CertificateProviderSuite) TestServerConfigMutual() {
+// TestServerConfigMutual checks mutual TLS client auth when skipClientCertVerify is false.
+func (suite *TLSConfigSuite) TestServerConfigMutual() {
 	cfg := suite.newTLSConfig(true, false)
 
 	serverTLS, err := cfg.ServerConfig()
 	suite.Require().NoError(err)
-	suite.Require().NotNil(serverTLS)
-
 	suite.Equal(stdlibtls.RequireAndVerifyClientCert, serverTLS.ClientAuth)
-	suite.NotNil(serverTLS.GetCertificate)
-	suite.NotNil(serverTLS.GetConfigForClient)
 
 	serverCert, err := serverTLS.GetCertificate(nil)
 	suite.Require().NoError(err)
 	suite.NotNil(serverCert)
 }
 
-func (suite *CertificateProviderSuite) TestServerConfigServerOnly() {
+// TestServerConfigServerOnly checks server-only TLS when skipClientCertVerify is true.
+func (suite *TLSConfigSuite) TestServerConfigServerOnly() {
 	cfg := suite.newTLSConfig(true, true)
 
 	serverTLS, err := cfg.ServerConfig()
 	suite.Require().NoError(err)
-	suite.Require().NotNil(serverTLS)
-
 	suite.Equal(stdlibtls.NoClientCert, serverTLS.ClientAuth)
-	suite.NotNil(serverTLS.GetCertificate)
-
-	serverCert, err := serverTLS.GetCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotNil(serverCert)
 }
 
-func (suite *CertificateProviderSuite) TestClientConfigWithClient() {
+// TestClientConfigWithClient checks ClientConfig when a client cert is present.
+func (suite *TLSConfigSuite) TestClientConfigWithClient() {
 	cfg := suite.newTLSConfig(true, false)
 
 	clientTLS, err := cfg.ClientConfig()
 	suite.Require().NoError(err)
 	suite.Require().NotNil(clientTLS)
 
-	suite.NotNil(clientTLS.GetClientCertificate)
-	suite.NotNil(clientTLS.RootCAs)
-
 	clientCert, err := clientTLS.GetClientCertificate(nil)
 	suite.Require().NoError(err)
 	suite.NotNil(clientCert)
 }
 
-func (suite *CertificateProviderSuite) TestClientConfigWithoutClient() {
+// TestClientConfigWithoutClient checks that ClientConfig is nil without a client cert.
+func (suite *TLSConfigSuite) TestClientConfigWithoutClient() {
 	cfg := suite.newTLSConfig(false, false)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Nil(clientTLS)
+}
+
+// TestWatchRotation checks that Watch reloads server and client certs on API updates.
+func (suite *TLSConfigSuite) TestWatchRotation() {
+	cfg := suite.newTLSConfig(true, false)
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+
+	server1, err := serverTLS.GetCertificate(nil)
+	suite.Require().NoError(err)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+
+	client1, err := clientTLS.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+
+	updated := make(chan struct{}, 1)
+
+	go func() {
+		_ = cfg.Watch(suite.ctx, func() {
+			select {
+			case updated <- struct{}{}:
+			default:
+			}
+		})
+	}()
+
+	next := suite.newAPICerts(true)
+	suite.updateAPI(func(api *secrets.API) {
+		*api.TypedSpec() = *next.TypedSpec()
+	})
+
+	select {
+	case <-updated:
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out waiting for watch update")
+	}
+
+	server2, err := serverTLS.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotEqual(server1.Certificate[0], server2.Certificate[0])
+
+	client2, err := clientTLS.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotEqual(client1.Certificate[0], client2.Certificate[0])
+}
+
+// TestWatchClearsClient checks that removing the client cert makes ClientConfig nil.
+func (suite *TLSConfigSuite) TestWatchClearsClient() {
+	cfg := suite.newTLSConfig(true, false)
+
+	updated := make(chan struct{}, 1)
+
+	go func() {
+		_ = cfg.Watch(suite.ctx, func() {
+			select {
+			case updated <- struct{}{}:
+			default:
+			}
+		})
+	}()
+
+	suite.updateAPI(func(api *secrets.API) {
+		api.TypedSpec().Client = nil
+	})
+
+	select {
+	case <-updated:
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out waiting for watch update")
+	}
 
 	clientTLS, err := cfg.ClientConfig()
 	suite.Require().NoError(err)

--- a/internal/app/apid/pkg/provider/provider_test.go
+++ b/internal/app/apid/pkg/provider/provider_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
@@ -78,10 +78,9 @@ func (suite *TLSConfigSuite) newTLSConfig(withClient, skipClientCertVerify bool)
 
 // updateAPI applies mutate to the current secrets.API resource in state.
 func (suite *TLSConfigSuite) updateAPI(mutate func(*secrets.API)) {
-	r, err := suite.resources.Get(suite.ctx, resource.NewMetadata(secrets.NamespaceName, secrets.APIType, secrets.APIID, resource.VersionUndefined))
+	api, err := safe.StateGetResource(suite.ctx, suite.resources, secrets.NewAPI())
 	suite.Require().NoError(err)
 
-	api := r.(*secrets.API).DeepCopy().(*secrets.API) //nolint:forcetypeassert
 	mutate(api)
 	suite.Require().NoError(suite.resources.Update(suite.ctx, api))
 }
@@ -108,21 +107,9 @@ func (suite *TLSConfigSuite) TestServerConfigServerOnly() {
 	suite.Equal(stdlibtls.NoClientCert, serverTLS.ClientAuth)
 }
 
-// TestClientConfigWithClient checks ClientConfig when a client cert is present.
-func (suite *TLSConfigSuite) TestClientConfigWithClient() {
-	cfg := suite.newTLSConfig(true, false)
-
-	clientTLS, err := cfg.ClientConfig()
-	suite.Require().NoError(err)
-	suite.Require().NotNil(clientTLS)
-
-	clientCert, err := clientTLS.GetClientCertificate(nil)
-	suite.Require().NoError(err)
-	suite.NotNil(clientCert)
-}
-
 // TestClientConfigWithoutClient checks that ClientConfig is nil without a client cert.
 func (suite *TLSConfigSuite) TestClientConfigWithoutClient() {
+	// no client cert, and no client cert verification
 	cfg := suite.newTLSConfig(false, false)
 
 	clientTLS, err := cfg.ClientConfig()
@@ -157,21 +144,26 @@ func (suite *TLSConfigSuite) TestWatchRotation() {
 		})
 	}()
 
+	// Refreshing the secrets.API object with a new one.
+	// It updates the keys and certs as well.
 	next := suite.newAPICerts(true)
 	suite.updateAPI(func(api *secrets.API) {
 		*api.TypedSpec() = *next.TypedSpec()
 	})
 
 	select {
+	// We block until changes land on the channel.
 	case <-updated:
 	case <-suite.ctx.Done():
 		suite.Require().Fail("timed out waiting for watch update")
 	}
 
+	// Compare the server cert with the old server cert.
 	server2, err := serverTLS.GetCertificate(nil)
 	suite.Require().NoError(err)
 	suite.NotEqual(server1.Certificate[0], server2.Certificate[0])
 
+	// Compare the client cert with the old client cert.
 	client2, err := clientTLS.GetClientCertificate(nil)
 	suite.Require().NoError(err)
 	suite.NotEqual(client1.Certificate[0], client2.Certificate[0])
@@ -197,6 +189,7 @@ func (suite *TLSConfigSuite) TestWatchClearsClient() {
 	})
 
 	select {
+	// We block until changes land on the channel.
 	case <-updated:
 	case <-suite.ctx.Done():
 		suite.Require().Fail("timed out waiting for watch update")

--- a/internal/app/apid/pkg/provider/provider_test.go
+++ b/internal/app/apid/pkg/provider/provider_test.go
@@ -2,13 +2,229 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package provider_test
+package provider
 
-import "testing"
+import (
+	stdlibtls "crypto/tls"
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/siderolabs/crypto/x509"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
+)
+
+type CertificateProviderSuite struct {
+	suite.Suite
+}
+
+func TestCertificateProviderSuite(t *testing.T) {
+	suite.Run(t, new(CertificateProviderSuite))
+}
+
+func (suite *CertificateProviderSuite) newAPICerts(withClient bool) (*secrets.API, []byte) {
+	ca, err := x509.NewSelfSignedCertificateAuthority()
+	suite.Require().NoError(err)
+
+	serverCrt, err := x509.NewKeyPair(ca)
+	suite.Require().NoError(err)
+
+	api := secrets.NewAPI()
+	api.TypedSpec().Server = x509.NewCertificateAndKeyFromKeyPair(serverCrt)
+	api.TypedSpec().AcceptedCAs = []*x509.PEMEncodedCertificate{{Crt: ca.CrtPEM}}
+
+	if withClient {
+		clientCrt, err := x509.NewKeyPair(ca)
+		suite.Require().NoError(err)
+
+		api.TypedSpec().Client = x509.NewCertificateAndKeyFromKeyPair(clientCrt)
+	}
+
+	return api, ca.CrtPEM
+}
+
+func (suite *CertificateProviderSuite) TestUpdate() {
+	api, caPEM := suite.newAPICerts(true)
+
+	p := &certificateProvider{}
+	suite.Require().NoError(p.Update(api))
+
+	suite.True(p.HasClientCertificate())
+
+	caBytes, err := p.GetCA()
+	suite.Require().NoError(err)
+	suite.Equal(caPEM, caBytes)
+
+	pool, err := p.GetCACertPool()
+	suite.Require().NoError(err)
+	suite.NotNil(pool)
+
+	serverCert, err := p.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(serverCert)
+
+	clientCert, err := p.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(clientCert)
+}
+
+func (suite *CertificateProviderSuite) TestUpdateNoClient() {
+	api, _ := suite.newAPICerts(false)
+
+	p := &certificateProvider{}
+	suite.Require().NoError(p.Update(api))
+
+	suite.False(p.HasClientCertificate())
+
+	clientCert, err := p.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.Nil(clientCert)
+
+	serverCert, err := p.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(serverCert)
+}
+
+func (suite *CertificateProviderSuite) TestUpdateInvalidServerKeyPair() {
+	api, _ := suite.newAPICerts(true)
+	api.TypedSpec().Server.Key = []byte("not-a-key")
+
+	p := &certificateProvider{}
+	suite.Error(p.Update(api))
+}
+
+func (suite *CertificateProviderSuite) TestUpdateInvalidClientKeyPair() {
+	api, _ := suite.newAPICerts(true)
+	api.TypedSpec().Client.Key = []byte("not-a-key")
+
+	p := &certificateProvider{}
+	suite.Error(p.Update(api))
+}
+
+func (suite *CertificateProviderSuite) TestUpdateInvalidCA() {
+	api, _ := suite.newAPICerts(true)
+	api.TypedSpec().AcceptedCAs = []*x509.PEMEncodedCertificate{
+		{Crt: []byte("not-a-cert")},
+	}
+
+	p := &certificateProvider{}
+	suite.Error(p.Update(api))
+}
+
+func (suite *CertificateProviderSuite) TestUpdateEmptyCA() {
+	api, _ := suite.newAPICerts(true)
+	api.TypedSpec().AcceptedCAs = nil
+
+	p := &certificateProvider{}
+	suite.Require().NoError(p.Update(api))
+
+	caBytes, err := p.GetCA()
+	suite.Require().NoError(err)
+	suite.Empty(caBytes)
+}
+
+func (suite *CertificateProviderSuite) TestUpdateClearsClient() {
+	p := &certificateProvider{}
+
+	apiWithClient, _ := suite.newAPICerts(true)
+	suite.Require().NoError(p.Update(apiWithClient))
+	suite.True(p.HasClientCertificate())
+
+	apiWithoutClient, _ := suite.newAPICerts(false)
+	suite.Require().NoError(p.Update(apiWithoutClient))
+	suite.False(p.HasClientCertificate())
+
+	clientCert, err := p.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.Nil(clientCert)
+}
+
+func (suite *CertificateProviderSuite) TestUpdateRotation() {
+	p := &certificateProvider{}
+
+	api1, _ := suite.newAPICerts(true)
+	suite.Require().NoError(p.Update(api1))
+
+	server1, err := p.GetCertificate(nil)
+	suite.Require().NoError(err)
+
+	client1, err := p.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+
+	api2, _ := suite.newAPICerts(true)
+	suite.Require().NoError(p.Update(api2))
+
+	server2, err := p.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotEqual(server1.Certificate[0], server2.Certificate[0])
+
+	client2, err := p.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotEqual(client1.Certificate[0], client2.Certificate[0])
+}
+
+func (suite *CertificateProviderSuite) newTLSConfig(withClient, skipClientCertVerify bool) *TLSConfig {
+	api, _ := suite.newAPICerts(withClient)
+
+	p := &certificateProvider{}
+	suite.Require().NoError(p.Update(api))
+
+	return &TLSConfig{
+		certificateProvider:  p,
+		skipClientCertVerify: skipClientCertVerify,
+	}
+}
+
+func (suite *CertificateProviderSuite) TestServerConfigMutual() {
+	cfg := suite.newTLSConfig(true, false)
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(serverTLS)
+
+	suite.Equal(stdlibtls.RequireAndVerifyClientCert, serverTLS.ClientAuth)
+	suite.NotNil(serverTLS.GetCertificate)
+	suite.NotNil(serverTLS.GetConfigForClient)
+
+	serverCert, err := serverTLS.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(serverCert)
+}
+
+func (suite *CertificateProviderSuite) TestServerConfigServerOnly() {
+	cfg := suite.newTLSConfig(true, true)
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(serverTLS)
+
+	suite.Equal(stdlibtls.NoClientCert, serverTLS.ClientAuth)
+	suite.NotNil(serverTLS.GetCertificate)
+
+	serverCert, err := serverTLS.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(serverCert)
+}
+
+func (suite *CertificateProviderSuite) TestClientConfigWithClient() {
+	cfg := suite.newTLSConfig(true, false)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(clientTLS)
+
+	suite.NotNil(clientTLS.GetClientCertificate)
+	suite.NotNil(clientTLS.RootCAs)
+
+	clientCert, err := clientTLS.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.NotNil(clientCert)
+}
+
+func (suite *CertificateProviderSuite) TestClientConfigWithoutClient() {
+	cfg := suite.newTLSConfig(false, false)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Nil(clientTLS)
 }

--- a/internal/app/apid/pkg/provider/provider_test.go
+++ b/internal/app/apid/pkg/provider/provider_test.go
@@ -4,11 +4,401 @@
 
 package provider_test
 
-import "testing"
+import (
+	"context"
+	stdlibtls "crypto/tls"
+	stdx509 "crypto/x509"
+	"encoding/pem"
+	"slices"
+	"testing"
+	"time"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/crypto/x509"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/talos/internal/app/apid/pkg/provider"
+	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
+)
+
+// Named arguments for the helpers below: both parameters are booleans, so spelling
+// them out at the call site keeps the cases readable.
+const (
+	withClientCert    = true
+	withoutClientCert = false
+
+	verifyClientCert     = false
+	skipClientCertVerify = true
+)
+
+// watch tracks a TLSConfig.Watch running in the background.
+type watch struct {
+	updated chan struct{}
+	errCh   chan error
+	joined  bool
+}
+
+type TLSConfigSuite struct {
+	suite.Suite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+
+	resources state.State
+	watches   []*watch
+}
+
+func TestTLSConfigSuite(t *testing.T) {
+	suite.Run(t, new(TLSConfigSuite))
+}
+
+func (suite *TLSConfigSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(suite.T().Context(), 10*time.Second)
+	suite.resources = state.WrapCore(namespaced.NewState(inmem.Build))
+	suite.watches = nil
+}
+
+func (suite *TLSConfigSuite) TearDownTest() {
+	suite.ctxCancel()
+
+	// Watch returns nil once the context is canceled, and it should not outlive the test.
+	for _, w := range suite.watches {
+		if w.joined {
+			continue
+		}
+
+		select {
+		case err := <-w.errCh:
+			suite.NoError(err, "watch should return nil once the context is canceled")
+		case <-time.After(10 * time.Second):
+			suite.Fail("watch goroutine didn't stop after the context was canceled")
+		}
+	}
+}
+
+// newAPICerts builds a secrets.API resource with a fresh CA and server cert.
+// When withClient is true, a client cert is included as well.
+func (suite *TLSConfigSuite) newAPICerts(withClient bool) *secrets.API {
+	ca, err := x509.NewSelfSignedCertificateAuthority()
+	suite.Require().NoError(err)
+
+	serverCrt, err := x509.NewKeyPair(ca)
+	suite.Require().NoError(err)
+
+	api := secrets.NewAPI()
+	api.TypedSpec().Server = x509.NewCertificateAndKeyFromKeyPair(serverCrt)
+	api.TypedSpec().AcceptedCAs = []*x509.PEMEncodedCertificate{{Crt: ca.CrtPEM}}
+
+	if withClient {
+		clientCrt, err := x509.NewKeyPair(ca)
+		suite.Require().NoError(err)
+
+		api.TypedSpec().Client = x509.NewCertificateAndKeyFromKeyPair(clientCrt)
+	}
+
+	return api
+}
+
+// newTLSConfig seeds the state with the given API certs and returns a ready TLSConfig.
+func (suite *TLSConfigSuite) newTLSConfig(api *secrets.API, skipClientCertVerify bool) *provider.TLSConfig {
+	suite.Require().NoError(suite.resources.Create(suite.ctx, api))
+
+	cfg, err := provider.NewTLSConfig(suite.ctx, suite.resources, skipClientCertVerify)
+	suite.Require().NoError(err)
+
+	return cfg
+}
+
+// updateAPI applies mutate to the current secrets.API resource in state.
+func (suite *TLSConfigSuite) updateAPI(mutate func(*secrets.API)) {
+	api, err := safe.StateGetResource(suite.ctx, suite.resources, secrets.NewAPI())
+	suite.Require().NoError(err)
+
+	mutate(api)
+	suite.Require().NoError(suite.resources.Update(suite.ctx, api))
+}
+
+// startWatch runs TLSConfig.Watch in the background; the returned watch is joined in TearDownTest.
+func (suite *TLSConfigSuite) startWatch(cfg *provider.TLSConfig) *watch {
+	w := &watch{
+		updated: make(chan struct{}, 1),
+		errCh:   make(chan error, 1),
+	}
+
+	suite.watches = append(suite.watches, w)
+
+	go func() {
+		w.errCh <- cfg.Watch(suite.ctx, func() {
+			select {
+			case w.updated <- struct{}{}:
+			default:
+			}
+		})
+	}()
+
+	return w
+}
+
+// waitUpdate blocks until the watch reports an update; if the watch returns first, its
+// error is reported instead of letting the test hit the context timeout.
+func (suite *TLSConfigSuite) waitUpdate(w *watch) {
+	select {
+	case <-w.updated:
+	case err := <-w.errCh:
+		w.joined = true
+
+		suite.Require().NoError(err, "watch returned before the update landed")
+		suite.Require().Fail("watch returned before the update landed")
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out waiting for watch update")
+	}
+}
+
+// waitError blocks until the watch returns and yields its error.
+func (suite *TLSConfigSuite) waitError(w *watch) error {
+	select {
+	case err := <-w.errCh:
+		w.joined = true
+
+		return err
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out waiting for the watch to return")
+
+		return nil
+	}
+}
+
+// leafDER decodes a PEM-encoded certificate into its DER bytes, as they appear in tls.Certificate.
+func (suite *TLSConfigSuite) leafDER(crtPEM []byte) []byte {
+	block, rest := pem.Decode(crtPEM)
+	suite.Require().NotNil(block)
+	suite.Require().Equal("CERTIFICATE", block.Type)
+	suite.Require().Empty(rest)
+
+	return block.Bytes
+}
+
+// certPool builds the cert pool expected for the given set of accepted CAs.
+func (suite *TLSConfigSuite) certPool(acceptedCAs []*x509.PEMEncodedCertificate) *stdx509.CertPool {
+	pool := stdx509.NewCertPool()
+
+	for _, ca := range acceptedCAs {
+		suite.Require().True(pool.AppendCertsFromPEM(ca.Crt))
+	}
+
+	return pool
+}
+
+// serverCertDER returns the DER of the certificate the server config serves right now.
+func (suite *TLSConfigSuite) serverCertDER(serverTLS *stdlibtls.Config) []byte {
+	cert, err := serverTLS.GetCertificate(nil)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cert)
+	suite.Require().NotEmpty(cert.Certificate)
+
+	return cert.Certificate[0]
+}
+
+// clientCertDER returns the DER of the certificate the client config presents right now.
+func (suite *TLSConfigSuite) clientCertDER(clientTLS *stdlibtls.Config) []byte {
+	cert, err := clientTLS.GetClientCertificate(nil)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cert)
+	suite.Require().NotEmpty(cert.Certificate)
+
+	return cert.Certificate[0]
+}
+
+// TestServerConfigMutual checks mutual TLS client auth when skipClientCertVerify is false.
+func (suite *TLSConfigSuite) TestServerConfigMutual() {
+	api := suite.newAPICerts(withClientCert)
+	cfg := suite.newTLSConfig(api, verifyClientCert)
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+	suite.Equal(stdlibtls.RequireAndVerifyClientCert, serverTLS.ClientAuth)
+	suite.Equal(suite.leafDER(api.TypedSpec().Server.Crt), suite.serverCertDER(serverTLS))
+
+	// the client CA pool is only filled in per connection (dynamic client CA), so the base config carries an empty one
+	suite.True(stdx509.NewCertPool().Equal(serverTLS.ClientCAs))
+
+	cfgForClient, err := serverTLS.GetConfigForClient(nil)
+	suite.Require().NoError(err)
+	suite.Equal(stdlibtls.RequireAndVerifyClientCert, cfgForClient.ClientAuth)
+	suite.True(suite.certPool(api.TypedSpec().AcceptedCAs).Equal(cfgForClient.ClientCAs))
+}
+
+// TestServerConfigServerOnly checks server-only TLS when skipClientCertVerify is true.
+func (suite *TLSConfigSuite) TestServerConfigServerOnly() {
+	api := suite.newAPICerts(withClientCert)
+	cfg := suite.newTLSConfig(api, skipClientCertVerify)
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+	suite.Equal(stdlibtls.NoClientCert, serverTLS.ClientAuth)
+	suite.Equal(suite.leafDER(api.TypedSpec().Server.Crt), suite.serverCertDER(serverTLS))
+
+	// client certs are not verified, but the per-connection config is still built the same way
+	cfgForClient, err := serverTLS.GetConfigForClient(nil)
+	suite.Require().NoError(err)
+	suite.Equal(stdlibtls.NoClientCert, cfgForClient.ClientAuth)
+	suite.True(suite.certPool(api.TypedSpec().AcceptedCAs).Equal(cfgForClient.ClientCAs))
+}
+
+// TestClientConfig checks that the client config presents the client cert and trusts the accepted CAs.
+func (suite *TLSConfigSuite) TestClientConfig() {
+	api := suite.newAPICerts(withClientCert)
+	cfg := suite.newTLSConfig(api, verifyClientCert)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(clientTLS)
+
+	suite.Equal(suite.leafDER(api.TypedSpec().Client.Crt), suite.clientCertDER(clientTLS))
+	suite.True(suite.certPool(api.TypedSpec().AcceptedCAs).Equal(clientTLS.RootCAs))
+}
+
+// TestClientConfigWithoutClient checks that ClientConfig is nil without a client cert.
+func (suite *TLSConfigSuite) TestClientConfigWithoutClient() {
+	cfg := suite.newTLSConfig(suite.newAPICerts(withoutClientCert), verifyClientCert)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Nil(clientTLS)
+}
+
+// TestClientConfigWithoutCA checks that an empty set of accepted CAs is tolerated by the
+// certificate provider, but makes the client config unbuildable.
+func (suite *TLSConfigSuite) TestClientConfigWithoutCA() {
+	api := suite.newAPICerts(withClientCert)
+	api.TypedSpec().AcceptedCAs = nil
+
+	cfg := suite.newTLSConfig(api, verifyClientCert)
+
+	_, err := cfg.ClientConfig()
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "no CA cert provided")
+}
+
+// TestWatchRotation checks that Watch reloads server and client certs, and the accepted CAs, on API updates.
+func (suite *TLSConfigSuite) TestWatchRotation() {
+	api := suite.newAPICerts(withClientCert)
+	cfg := suite.newTLSConfig(api, verifyClientCert)
+
+	oldCAs := api.TypedSpec().AcceptedCAs
+
+	serverTLS, err := cfg.ServerConfig()
+	suite.Require().NoError(err)
+	suite.Require().Equal(suite.leafDER(api.TypedSpec().Server.Crt), suite.serverCertDER(serverTLS))
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Require().Equal(suite.leafDER(api.TypedSpec().Client.Crt), suite.clientCertDER(clientTLS))
+
+	w := suite.startWatch(cfg)
+
+	// Refresh the secrets.API object with a new one: it rotates the keys and certs, and
+	// brings in a new CA which is accepted alongside the old one (as on CA rotation).
+	next := suite.newAPICerts(withClientCert)
+	next.TypedSpec().AcceptedCAs = slices.Concat(oldCAs, next.TypedSpec().AcceptedCAs)
+
+	suite.updateAPI(func(api *secrets.API) {
+		*api.TypedSpec() = *next.TypedSpec()
+	})
+
+	suite.waitUpdate(w)
+
+	// The server and client certs are served through the certificate provider, so the
+	// configs built before the rotation now hand out exactly the new certs.
+	suite.Equal(suite.leafDER(next.TypedSpec().Server.Crt), suite.serverCertDER(serverTLS))
+	suite.Equal(suite.leafDER(next.TypedSpec().Client.Crt), suite.clientCertDER(clientTLS))
+
+	// The client CA pool on the server side is dynamic as well: a new connection is
+	// verified against both the old and the new accepted CA.
+	cfgForClient, err := serverTLS.GetConfigForClient(nil)
+	suite.Require().NoError(err)
+	suite.True(suite.certPool(next.TypedSpec().AcceptedCAs).Equal(cfgForClient.ClientCAs))
+
+	// The client-side CA pool, on the other hand, is a snapshot taken when ClientConfig
+	// was called, so this config still trusts the old CA only: apid depends on
+	// APIDFactory.Flush (wired as onPKIUpdate in internal/app/apid/service.go) dropping
+	// the cached backends so that ClientConfig is called again.
+	suite.True(suite.certPool(oldCAs).Equal(clientTLS.RootCAs))
+
+	// A client config built after the rotation trusts both CAs.
+	rotatedClientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.True(suite.certPool(next.TypedSpec().AcceptedCAs).Equal(rotatedClientTLS.RootCAs))
+}
+
+// TestWatchClearsClient checks that removing the client cert makes ClientConfig nil.
+func (suite *TLSConfigSuite) TestWatchClearsClient() {
+	api := suite.newAPICerts(withClientCert)
+	cfg := suite.newTLSConfig(api, verifyClientCert)
+
+	clientTLS, err := cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Require().NotNil(clientTLS, "there should be a client config before the client cert is removed")
+	suite.Require().Equal(suite.leafDER(api.TypedSpec().Client.Crt), suite.clientCertDER(clientTLS))
+
+	w := suite.startWatch(cfg)
+
+	suite.updateAPI(func(api *secrets.API) {
+		api.TypedSpec().Client = nil
+	})
+
+	suite.waitUpdate(w)
+
+	clientTLS, err = cfg.ClientConfig()
+	suite.Require().NoError(err)
+	suite.Nil(clientTLS)
+}
+
+// TestWatchInvalidCA checks that Watch fails, without reporting an update, when the
+// accepted CAs can't be parsed.
+func (suite *TLSConfigSuite) TestWatchInvalidCA() {
+	cfg := suite.newTLSConfig(suite.newAPICerts(withClientCert), verifyClientCert)
+
+	w := suite.startWatch(cfg)
+
+	suite.updateAPI(func(api *secrets.API) {
+		api.TypedSpec().AcceptedCAs = []*x509.PEMEncodedCertificate{{Crt: []byte("not a PEM certificate")}}
+	})
+
+	err := suite.waitError(w)
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "failed to parse CA certs into a CertPool")
+
+	select {
+	case <-w.updated:
+		suite.Fail("onUpdate should not be called when the update fails")
+	default:
+	}
+}
+
+// TestNewTLSConfigInvalidServerCert checks that NewTLSConfig fails on an unusable server keypair.
+func (suite *TLSConfigSuite) TestNewTLSConfigInvalidServerCert() {
+	api := suite.newAPICerts(withoutClientCert)
+	api.TypedSpec().Server = &x509.PEMEncodedCertificateAndKey{Crt: []byte("not a PEM certificate")}
+
+	suite.Require().NoError(suite.resources.Create(suite.ctx, api))
+
+	_, err := provider.NewTLSConfig(suite.ctx, suite.resources, verifyClientCert)
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "failed to parse server cert and key")
+}
+
+// TestNewTLSConfigContextCanceled checks that NewTLSConfig gives up when the context is
+// canceled before the first secrets.API event arrives.
+func (suite *TLSConfigSuite) TestNewTLSConfigContextCanceled() {
+	ctx, cancel := context.WithCancel(suite.ctx)
+	cancel()
+
+	// nothing was created in the state, so there's no event to receive
+	_, err := provider.NewTLSConfig(ctx, suite.resources, verifyClientCert)
+	suite.Require().Error(err)
+	suite.ErrorIs(err, context.Canceled)
 }


### PR DESCRIPTION
# Pull Request

## What? (description)

Add unit tests for the apid TLS provider package (`internal/app/apid/pkg/provider`), replacing the empty placeholder test.

Coverage includes:

- `certificateProvider.Update`: valid certs, missing client cert, invalid server/client keys, invalid/empty CAs, client cleared on update, cert rotation
- `TLSConfig.ServerConfig` / `ClientConfig`: mutual TLS vs server-only, client config present vs `nil`

## Why? (reasoning)

This package is responsible for building apid's server and client TLS configs from COSI `secrets.API` resources. It previously had no real unit tests, only an empty placeholder for coverage estimation.

## Acceptance

Please use the following checklist:

- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] go test ./internal/app/apid/pkg/provider/ -count=1 -v
