### PR TITLE
fix: provide correct handler for Ctrl-Alt-Delete sequence

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -116,6 +116,11 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 				Key:   "proc.sys.net.bridge.bridge-nf-call-ip6tables",
 				Value: "1",
 			},
+			{
+				Key: "proc.sys.kernel.ctrl-alt-del",
+				// Make Ctrl-Alt-Del trigger a SIGINT to init process
+				Value: "0",
+			},
 		}...)
 	}
 

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -76,6 +76,10 @@ func getParams(mode runtime.Mode) []*kernel.Param {
 				Key:   "proc.sys.fs.protected_fifos",
 				Value: "2",
 			},
+			{
+				Key:   "proc.sys.kernel.ctrl-alt-del",
+				Value: "0",
+			},
 		}...)
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -198,14 +199,42 @@ func (c *Controller) Sequencer() runtime.Sequencer {
 func (c *Controller) ListenForEvents(ctx context.Context) error {
 	sigs := make(chan os.Signal, 1)
 
-	signal.Notify(sigs, syscall.SIGTERM)
+	var signalsToHandle, signalsToIgnore []os.Signal
 
-	errCh := make(chan error, 2)
+	if c.r.State().Platform().Mode() == runtime.ModeContainer {
+		signalsToHandle = []os.Signal{syscall.SIGTERM}
+		signalsToIgnore = []os.Signal{syscall.SIGINT}
+	} else {
+		signalsToHandle = []os.Signal{syscall.SIGINT}
+		signalsToIgnore = []os.Signal{syscall.SIGTERM}
+	}
 
-	go func() {
-		<-sigs
-		signal.Stop(sigs)
+	signal.Notify(sigs, signalsToHandle...)
+	signal.Ignore(signalsToIgnore...)
 
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		c.listenForSignals(ctx, sigs, slices.Concat(signalsToHandle, signalsToIgnore))
+
+		return nil
+	})
+
+	if c.r.State().Platform().Mode() != runtime.ModeContainer {
+		eg.Go(func() error {
+			return c.listenForACPI(ctx)
+		})
+	}
+
+	return eg.Wait()
+}
+
+func (c *Controller) listenForSignals(ctx context.Context, sigs chan os.Signal, allSignals []os.Signal) {
+	sig := <-sigs
+
+	switch sig {
+	case syscall.SIGTERM:
+		// in container mode, SIGTERM is used to signal container shutdown
 		log.Printf("shutdown via SIGTERM received")
 
 		if err := c.Run(ctx, runtime.SequenceShutdown, &machine.ShutdownRequest{Force: true}, runtime.WithTakeover()); err != nil {
@@ -213,35 +242,35 @@ func (c *Controller) ListenForEvents(ctx context.Context) error {
 				log.Printf("shutdown failed: %v", err)
 			}
 		}
+	case syscall.SIGINT:
+		// in metal mode, SIGINT is sent on Ctrl+Alt+Del, we should reboot the machine in this case
+		log.Printf("reboot via SIGINT received")
 
-		errCh <- nil
-	}()
-
-	if c.r.State().Platform().Mode() == runtime.ModeContainer {
-		return nil
-	}
-
-	go func() {
-		if err := acpi.StartACPIListener(); err != nil {
-			errCh <- err
-
-			return
-		}
-
-		log.Printf("shutdown via ACPI received")
-
-		if err := c.Run(ctx, runtime.SequenceShutdown, &machine.ShutdownRequest{Force: true}, runtime.WithTakeover()); err != nil {
+		if err := c.Run(ctx, runtime.SequenceReboot, &machine.RebootRequest{Mode: machine.RebootRequest_FORCE}, runtime.WithTakeover()); err != nil {
 			if !runtime.IsRebootError(err) {
-				log.Printf("failed to run shutdown sequence: %s", err)
+				log.Printf("reboot failed: %v", err)
 			}
 		}
+	}
 
-		errCh <- nil
-	}()
+	// ignore further signals, since we are already shutting down or rebooting
+	signal.Ignore(allSignals...)
+}
 
-	err := <-errCh
+func (c *Controller) listenForACPI(ctx context.Context) error {
+	if err := acpi.StartACPIListener(); err != nil {
+		return err
+	}
 
-	return err
+	log.Printf("shutdown via ACPI received")
+
+	if err := c.Run(ctx, runtime.SequenceShutdown, &machine.ShutdownRequest{Force: true}, runtime.WithTakeover()); err != nil {
+		if !runtime.IsRebootError(err) {
+			log.Printf("failed to run shutdown sequence: %s", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *Controller) run(ctx context.Context, seq runtime.Sequence, phases []runtime.Phase, data any) error {

--- a/internal/integration/provision/external_triggers.go
+++ b/internal/integration/provision/external_triggers.go
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_provision
+
+package provision
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
+	"github.com/siderolabs/talos/pkg/images"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// ExternalTriggerSuite ...
+type ExternalTriggerSuite struct {
+	BaseSuite
+
+	track int
+}
+
+// SuiteName ...
+func (suite *ExternalTriggerSuite) SuiteName() string {
+	return fmt.Sprintf("provision.UpgradeSuite.ExternalTrigger-TR%d", suite.track)
+}
+
+// TestTriggers verifies that external triggers like Ctrl+Alt+Del and ACPI power off are handled correctly.
+//
+//nolint:dupl,gocyclo
+func (suite *ExternalTriggerSuite) TestTriggers() {
+	const (
+		numControlplanes = 2
+	)
+
+	suite.setupCluster(clusterOptions{
+		ClusterName: "external-trigger",
+
+		ControlplaneNodes: numControlplanes,
+
+		SourceKernelPath:    helpers.ArtifactPath(constants.KernelAssetWithArch),
+		SourceInitramfsPath: helpers.ArtifactPath(constants.InitramfsAssetWithArch),
+		SourceInstallerImage: fmt.Sprintf(
+			"%s/%s:%s",
+			DefaultSettings.TargetInstallImageRegistry,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
+			DefaultSettings.CurrentVersion,
+		),
+		SourceVersion:    DefaultSettings.CurrentVersion,
+		SourceK8sVersion: constants.DefaultKubernetesVersion,
+
+		WithSkipInjectingConfig: true,
+	})
+
+	maintenanceClients := make([]*client.Client, len(suite.Cluster.Info().Nodes))
+
+	for i, machine := range suite.Cluster.Info().Nodes {
+		var err error
+
+		maintenanceClients[i], err = client.New(
+			suite.ctx,
+			client.WithMaintenanceMode(machine.IPs[0].String(), nil),
+		)
+		suite.Require().NoError(err)
+	}
+
+	defer func() {
+		for _, c := range maintenanceClients {
+			suite.Require().NoError(c.Close())
+		}
+	}()
+
+	suite.Run("wait for maintenance API", func() {
+		// we should be able to query version API for every machine
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			for _, maintenanceClient := range maintenanceClients {
+				version, err := maintenanceClient.Version(suite.ctx)
+				if !asrt.NoError(err) {
+					return
+				}
+
+				suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
+			}
+		}, time.Minute, time.Second, "version API should be available")
+	})
+
+	suite.Run("trigger Ctrl+Alt+Delete", func() {
+		// using machine 0 for this test
+		c := maintenanceClients[0]
+
+		events := make(chan client.EventResult)
+
+		ctx, cancel := context.WithTimeout(suite.ctx, 10*time.Second)
+		defer cancel()
+
+		suite.Require().NoError(c.EventsWatchV2(ctx, events))
+
+		suite.sendMonitorCommand(ctx, suite.Cluster.Info().Nodes[0].Name, "sendkey ctrl-alt-delete")
+
+		for {
+			select {
+			case <-ctx.Done():
+				suite.Fail("timeout waiting for Ctrl+Alt+Delete event")
+			case event := <-events:
+				suite.Require().NoError(event.Error)
+
+				if taskEvent, ok := event.Event.Payload.(*machine.TaskEvent); ok {
+					if taskEvent.Action == machine.TaskEvent_START && taskEvent.Task == "reboot" {
+						suite.T().Logf("received reboot event")
+
+						return
+					}
+				}
+			}
+		}
+	})
+
+	suite.Run("trigger poweroff", func() {
+		// using machine 1 for this test
+		c := maintenanceClients[1]
+
+		events := make(chan client.EventResult)
+
+		ctx, cancel := context.WithTimeout(suite.ctx, 10*time.Second)
+		defer cancel()
+
+		suite.Require().NoError(c.EventsWatchV2(ctx, events))
+
+		suite.sendMonitorCommand(ctx, suite.Cluster.Info().Nodes[1].Name, "system_powerdown")
+
+		for {
+			select {
+			case <-ctx.Done():
+				suite.Fail("timeout waiting for shutdown event")
+			case event := <-events:
+				suite.Require().NoError(event.Error)
+
+				if sequenceEvent, ok := event.Event.Payload.(*machine.SequenceEvent); ok {
+					if sequenceEvent.Action == machine.SequenceEvent_START && sequenceEvent.Sequence == "shutdown" {
+						suite.T().Logf("received shutdown event")
+
+						return
+					}
+				}
+			}
+		}
+	})
+}
+
+func init() {
+	allSuites = append(
+		allSuites,
+		&ExternalTriggerSuite{track: 3},
+	)
+}

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -733,6 +734,23 @@ func (suite *BaseSuite) upgradeKubernetes(fromVersion, toVersion string, skipKub
 	}
 
 	suite.Require().NoError(kubernetes.Upgrade(suite.ctx, suite.clusterAccess, options))
+}
+
+func (suite *BaseSuite) sendMonitorCommand(ctx context.Context, nodeName, command string) {
+	statePath, err := suite.Cluster.StatePath()
+	suite.Require().NoError(err)
+
+	socketPath := filepath.Join(statePath, nodeName+".monitor")
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	suite.Require().NoError(err)
+
+	defer func() {
+		suite.Require().NoError(conn.Close())
+	}()
+
+	_, err = conn.Write([]byte(command + "\n"))
+	suite.Require().NoError(err)
 }
 
 type clusterOptions struct {


### PR DESCRIPTION
The Linux default is to trigger a panic reboot of the kernel without any disk sync.

As soon as machined boots up, it overrides the sysctl to redirect Ctrl-Alt-Delete to be `SIGINT` to the init process (machined), which triggers a force reboot on the signal.

This turns reboot into graceful enough one.

Fixes #13732

(if the original issue is to ignore the signal, that would be a separate piece of work, but now it's possible to do so)
