### PR TITLE
feat(machined): add IPv6-only support for Scaleway platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/metadata.go
@@ -8,26 +8,57 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/siderolabs/talos/pkg/download"
 )
 
+// Metadata extends the SDK's instance.Metadata with fields not yet present in the SDK.
+type Metadata struct {
+	instance.Metadata
+
+	// RoutedIPEnabled is true when the instance is in routed IP mode. In this mode
+	// IPs from PublicIpsV4/V6 are configured statically rather than via DHCP.
+	RoutedIPEnabled bool `json:"routed_ip_enabled"`
+}
+
 const (
-	// ScalewayMetadataEndpoint is the local Scaleway endpoint.
+	// ScalewayMetadataEndpoint is the local Scaleway IPv4 metadata endpoint.
 	ScalewayMetadataEndpoint = "http://169.254.42.42/conf?format=json"
-	// ScalewayUserDataEndpoint is the local Scaleway endpoint for the config.
+	// ScalewayMetadataEndpointIPv6 is the local Scaleway IPv6 metadata endpoint.
+	ScalewayMetadataEndpointIPv6 = "http://[fd00:42::42]/conf?format=json"
+	// ScalewayUserDataEndpoint is the local Scaleway IPv4 endpoint for the config.
 	ScalewayUserDataEndpoint = "http://169.254.42.42/user_data/cloud-init"
+	// ScalewayUserDataEndpointIPv6 is the local Scaleway IPv6 endpoint for the config.
+	ScalewayUserDataEndpointIPv6 = "http://[fd00:42::42]/user_data/cloud-init"
+
+	// metadataIPv4Timeout is how long to wait for the IPv4 metadata endpoint before
+	// falling back to IPv6. Long enough for dual-stack instances where IPv4 needs a
+	// few seconds to come up, short enough not to delay IPv6-only instances too much.
+	metadataIPv4Timeout = 15 * time.Second
 )
 
-func (u *Scaleway) getMetadata(ctx context.Context) (*instance.Metadata, error) {
-	metaConfigDl, err := download.Download(ctx, ScalewayMetadataEndpoint)
+func (u *Scaleway) getMetadata(ctx context.Context) (*Metadata, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, metadataIPv4Timeout)
+	metaConfigDl, err := download.Download(probeCtx, ScalewayMetadataEndpoint,
+		download.WithTimeout(metadataIPv4Timeout))
+
+	cancel()
+
+	if err != nil {
+		log.Printf("IPv4 metadata unreachable (%s), falling back to IPv6", err)
+
+		metaConfigDl, err = download.Download(ctx, ScalewayMetadataEndpointIPv6)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("error fetching metadata: %w", err)
 	}
 
-	var meta instance.Metadata
+	var meta Metadata
 	if err = json.Unmarshal(metaConfigDl, &meta); err != nil {
 		return nil, err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/metadata.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/metadata.go
@@ -8,21 +8,55 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/netip"
+	"time"
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/siderolabs/go-retry/retry"
 
 	"github.com/siderolabs/talos/pkg/download"
 )
 
 const (
-	// ScalewayMetadataEndpoint is the local Scaleway endpoint.
+	// ScalewayMetadataEndpoint is the local Scaleway IPv4 metadata endpoint.
 	ScalewayMetadataEndpoint = "http://169.254.42.42/conf?format=json"
-	// ScalewayUserDataEndpoint is the local Scaleway endpoint for the config.
+	// ScalewayMetadataEndpointIPv6 is the local Scaleway IPv6 metadata endpoint.
+	ScalewayMetadataEndpointIPv6 = "http://[fd00:42::42]/conf?format=json"
+	// ScalewayUserDataEndpoint is the local Scaleway IPv4 endpoint for the config.
 	ScalewayUserDataEndpoint = "http://169.254.42.42/user_data/cloud-init"
+	// ScalewayUserDataEndpointIPv6 is the local Scaleway IPv6 endpoint for the config.
+	ScalewayUserDataEndpointIPv6 = "http://[fd00:42::42]/user_data/cloud-init"
+
+	// endpointAttemptTimeout bounds a single attempt against one address family. An instance
+	// that only has one of them fails over to the other after this long, rather than spending
+	// the whole retry budget on an endpoint it can never reach.
+	endpointAttemptTimeout = 5 * time.Second
 )
 
-func (u *Scaleway) getMetadata(ctx context.Context) (*instance.Metadata, error) {
-	metaConfigDl, err := download.Download(ctx, ScalewayMetadataEndpoint)
+// metadataRoute is the host route to the metadata service, needed to reach it before any
+// address is configured on the link.
+var metadataRoute = netip.MustParsePrefix("169.254.42.42/32")
+
+// downloadAlternating retries against the IPv4 and IPv6 metadata endpoints in turn.
+func downloadAlternating(ctx context.Context, ipv4Endpoint, ipv6Endpoint string, options ...download.Option) ([]byte, error) {
+	endpoints := [...]string{ipv4Endpoint, ipv6Endpoint}
+	attempt := 0
+
+	options = append(options,
+		download.WithEndpointFunc(func(context.Context) (string, error) {
+			endpoint := endpoints[attempt%len(endpoints)]
+			attempt++
+
+			return endpoint, nil
+		}),
+		download.WithRetryOptions(retry.WithAttemptTimeout(endpointAttemptTimeout)),
+	)
+
+	return download.Download(ctx, ipv4Endpoint, options...)
+}
+
+func (s *Scaleway) getMetadata(ctx context.Context) (*instance.Metadata, error) {
+	metaConfigDl, err := downloadAlternating(ctx, ScalewayMetadataEndpoint, ScalewayMetadataEndpointIPv6)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching metadata: %w", err)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -7,10 +7,11 @@ package scaleway
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"log"
 	"net/netip"
-	"strconv"
+	"net/url"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -36,10 +38,28 @@ func (s *Scaleway) Name() string {
 	return "scaleway"
 }
 
+func staticRoute(family nethelpers.Family, dst netip.Prefix, gw netip.Addr, priority uint32) network.RouteSpecSpec {
+	r := network.RouteSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+		OutLinkName: "eth0",
+		Destination: dst,
+		Gateway:     gw,
+		Table:       nethelpers.TableMain,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		Family:      family,
+		Priority:    priority,
+	}
+
+	r.Normalize()
+
+	return r
+}
+
 // ParseMetadata converts Scaleway platform metadata into platform network config.
 //
-//nolint:gocyclo
-func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.PlatformNetworkConfig, error) {
+//nolint:gocyclo,cyclop
+func (s *Scaleway) ParseMetadata(metadata *Metadata) (*runtime.PlatformNetworkConfig, error) {
 	networkConfig := &runtime.PlatformNetworkConfig{}
 
 	if metadata.Hostname != "" {
@@ -56,98 +76,100 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 
 	var publicIPs []string
 
-	if metadata.PublicIP.Address != "" && metadata.PublicIP.Family == "inet" {
-		publicIPs = append(publicIPs, metadata.PublicIP.Address)
-	}
-
 	networkConfig.Links = append(networkConfig.Links, network.LinkSpecSpec{
 		Name:        "eth0",
 		Up:          true,
 		ConfigLayer: network.ConfigPlatform,
 	})
 
-	gw, _ := netip.ParsePrefix("169.254.42.42/32") //nolint:errcheck
-	route := network.RouteSpecSpec{
-		ConfigLayer: network.ConfigPlatform,
-		OutLinkName: "eth0",
-		Destination: gw,
-		Table:       nethelpers.TableMain,
-		Protocol:    nethelpers.ProtocolStatic,
-		Type:        nethelpers.TypeUnicast,
-		Family:      nethelpers.FamilyInet4,
-		Priority:    4 * network.DefaultRouteMetric,
+	u, _ := url.Parse(ScalewayMetadataEndpoint)      //nolint:errcheck
+	metadataAddr, _ := netip.ParseAddr(u.Hostname()) //nolint:errcheck
+	networkConfig.Routes = []network.RouteSpecSpec{
+		staticRoute(nethelpers.FamilyInet4, netip.PrefixFrom(metadataAddr, metadataAddr.BitLen()), netip.Addr{}, 4*network.DefaultRouteMetric),
 	}
 
-	route.Normalize()
-	networkConfig.Routes = []network.RouteSpecSpec{route}
+	if metadata.RoutedIPEnabled {
+		for _, v4 := range metadata.PublicIpsV4 {
+			publicIPs = append(publicIPs, v4.Address)
 
-	if len(metadata.PublicIpsV4) > 0 {
-		networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
-			Operator:  network.OperatorDHCP4,
-			LinkName:  "eth0",
-			RequireUp: true,
-			DHCP4: network.DHCP4OperatorSpec{
-				RouteMetric: network.DefaultRouteMetric,
-			},
-			ConfigLayer: network.ConfigPlatform,
-		})
-	}
+			addr, err := address.IPPrefixFrom(v4.Address, v4.Netmask)
+			if err != nil {
+				return nil, err
+			}
 
-	if metadata.IPv6.Address != "" || len(metadata.PublicIpsV6) > 0 {
-		address := metadata.IPv6.Address
-		netmask := metadata.IPv6.Netmask
-		gateway := metadata.IPv6.Gateway
-
-		if address == "" || netmask == "" || gateway == "" {
-			address = metadata.PublicIpsV6[0].Address
-			netmask = metadata.PublicIpsV6[0].Netmask
-			gateway = metadata.PublicIpsV6[0].Gateway
-		}
-
-		bits, err := strconv.Atoi(netmask)
-		if err != nil {
-			return nil, err
-		}
-
-		ip, err := netip.ParseAddr(address)
-		if err != nil {
-			return nil, err
-		}
-
-		addr := netip.PrefixFrom(ip, bits)
-
-		publicIPs = append(publicIPs, address)
-		networkConfig.Addresses = append(
-			networkConfig.Addresses,
-			network.AddressSpecSpec{
+			networkConfig.Addresses = append(networkConfig.Addresses, network.AddressSpecSpec{
 				ConfigLayer: network.ConfigPlatform,
 				LinkName:    "eth0",
 				Address:     addr,
 				Scope:       nethelpers.ScopeGlobal,
 				Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
-				Family:      nethelpers.FamilyInet6,
-			},
-		)
+				Family:      nethelpers.FamilyInet4,
+			})
 
-		gw, err := netip.ParseAddr(gateway)
+			if v4.Gateway != "" {
+				gw, err := netip.ParseAddr(v4.Gateway)
+				if err != nil {
+					return nil, err
+				}
+
+				// /32 routed IPs require a host route to the gateway before the default route.
+				networkConfig.Routes = append(networkConfig.Routes,
+					staticRoute(nethelpers.FamilyInet4, netip.PrefixFrom(gw, gw.BitLen()), netip.Addr{}, 3*network.DefaultRouteMetric),
+					staticRoute(nethelpers.FamilyInet4, netip.Prefix{}, gw, 2*network.DefaultRouteMetric),
+				)
+			}
+		}
+	} else {
+		if metadata.PublicIP.Family == "inet" && metadata.PublicIP.Address != "" {
+			publicIPs = append(publicIPs, metadata.PublicIP.Address)
+		}
+
+		if len(metadata.PublicIpsV4) > 0 {
+			networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
+				Operator:  network.OperatorDHCP4,
+				LinkName:  "eth0",
+				RequireUp: true,
+				DHCP4: network.DHCP4OperatorSpec{
+					RouteMetric: network.DefaultRouteMetric,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			})
+		}
+	}
+
+	// IPv6: use PublicIpsV6 for all entries; fall back to the legacy IPv6 field on older instances.
+	v6ips := metadata.PublicIpsV6
+	if len(v6ips) == 0 && metadata.IPv6.Address != "" && metadata.IPv6.Netmask != "" && metadata.IPv6.Gateway != "" {
+		v6ips = []instance.MetadataIP{{
+			Address: metadata.IPv6.Address,
+			Netmask: metadata.IPv6.Netmask,
+			Gateway: metadata.IPv6.Gateway,
+		}}
+	}
+
+	for _, v6 := range v6ips {
+		addr, err := address.IPPrefixFrom(v6.Address, v6.Netmask)
 		if err != nil {
 			return nil, err
 		}
 
-		route := network.RouteSpecSpec{
-			ConfigLayer: network.ConfigPlatform,
-			Gateway:     gw,
-			OutLinkName: "eth0",
-			Table:       nethelpers.TableMain,
-			Protocol:    nethelpers.ProtocolStatic,
-			Type:        nethelpers.TypeUnicast,
-			Family:      nethelpers.FamilyInet6,
-			Priority:    2 * network.DefaultRouteMetric,
+		gw, err := netip.ParseAddr(v6.Gateway)
+		if err != nil {
+			return nil, err
 		}
 
-		route.Normalize()
-
-		networkConfig.Routes = append(networkConfig.Routes, route)
+		publicIPs = append(publicIPs, v6.Address)
+		networkConfig.Addresses = append(networkConfig.Addresses, network.AddressSpecSpec{
+			ConfigLayer: network.ConfigPlatform,
+			LinkName:    "eth0",
+			Address:     addr,
+			Scope:       nethelpers.ScopeGlobal,
+			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			Family:      nethelpers.FamilyInet6,
+		})
+		networkConfig.Routes = append(networkConfig.Routes,
+			staticRoute(nethelpers.FamilyInet6, netip.Prefix{}, gw, 2*network.DefaultRouteMetric),
+		)
 	}
 
 	for _, ipStr := range publicIPs {
@@ -187,10 +209,25 @@ func (s *Scaleway) Configuration(ctx context.Context, r state.State) ([]byte, er
 
 	log.Printf("fetching machine config from %q", ScalewayUserDataEndpoint)
 
-	return download.Download(ctx, ScalewayUserDataEndpoint,
+	probeCtx, cancel := context.WithTimeout(ctx, metadataIPv4Timeout)
+	cfg, err := download.Download(probeCtx, ScalewayUserDataEndpoint,
 		download.WithLowSrcPort(),
+		download.WithTimeout(metadataIPv4Timeout),
 		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
 		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
+
+	cancel()
+
+	if err != nil && !stderrors.Is(err, errors.ErrNoConfigSource) {
+		log.Printf("IPv4 user-data unreachable, falling back to IPv6 endpoint %q", ScalewayUserDataEndpointIPv6)
+
+		cfg, err = download.Download(ctx, ScalewayUserDataEndpointIPv6,
+			download.WithLowSrcPort(),
+			download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+			download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
+	}
+
+	return cfg, err
 }
 
 // Mode implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -10,15 +10,16 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
-	"strconv"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/siderolabs/go-procfs/procfs"
+	"github.com/siderolabs/go-retry/retry"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/address"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/internal/netutils"
 	"github.com/siderolabs/talos/pkg/download"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -34,6 +35,40 @@ type Scaleway struct{}
 // Name implements the runtime.Platform interface.
 func (s *Scaleway) Name() string {
 	return "scaleway"
+}
+
+func staticRoute(family nethelpers.Family, dst netip.Prefix, gw netip.Addr, priority uint32) network.RouteSpecSpec {
+	r := network.RouteSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+		OutLinkName: "eth0",
+		Destination: dst,
+		Gateway:     gw,
+		Table:       nethelpers.TableMain,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		Family:      family,
+		Priority:    priority,
+	}
+
+	r.Normalize()
+
+	return r
+}
+
+func staticAddress(addr netip.Prefix) network.AddressSpecSpec {
+	family := nethelpers.FamilyInet6
+	if addr.Addr().Is4() {
+		family = nethelpers.FamilyInet4
+	}
+
+	return network.AddressSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+		LinkName:    "eth0",
+		Address:     addr,
+		Scope:       nethelpers.ScopeGlobal,
+		Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+		Family:      family,
+	}
 }
 
 // ParseMetadata converts Scaleway platform metadata into platform network config.
@@ -54,32 +89,55 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 		networkConfig.Hostnames = append(networkConfig.Hostnames, hostnameSpec)
 	}
 
-	var publicIPs []string
-
-	if metadata.PublicIP.Address != "" && metadata.PublicIP.Family == "inet" {
-		publicIPs = append(publicIPs, metadata.PublicIP.Address)
-	}
-
 	networkConfig.Links = append(networkConfig.Links, network.LinkSpecSpec{
 		Name:        "eth0",
 		Up:          true,
 		ConfigLayer: network.ConfigPlatform,
 	})
 
-	gw, _ := netip.ParsePrefix("169.254.42.42/32") //nolint:errcheck
-	route := network.RouteSpecSpec{
-		ConfigLayer: network.ConfigPlatform,
-		OutLinkName: "eth0",
-		Destination: gw,
-		Table:       nethelpers.TableMain,
-		Protocol:    nethelpers.ProtocolStatic,
-		Type:        nethelpers.TypeUnicast,
-		Family:      nethelpers.FamilyInet4,
-		Priority:    4 * network.DefaultRouteMetric,
+	networkConfig.Routes = []network.RouteSpecSpec{
+		staticRoute(nethelpers.FamilyInet4, metadataRoute, netip.Addr{}, 4*network.DefaultRouteMetric),
 	}
 
-	route.Normalize()
-	networkConfig.Routes = []network.RouteSpecSpec{route}
+	// Instances always run in routed IP mode: public IPs are attached to the instance as
+	// host routes and configured statically. The `routed_ip_enabled` flag is deprecated in
+	// the API and always true, so there is no legacy NAT mode left to detect.
+	// See https://github.com/scaleway/scaleway-sdk-go/issues/3247.
+	var defaultV4RouteSet bool
+
+	for _, v4 := range metadata.PublicIpsV4 {
+		addr, err := address.IPPrefixFrom(v4.Address, v4.Netmask)
+		if err != nil {
+			return nil, err
+		}
+
+		networkConfig.ExternalIPs = append(networkConfig.ExternalIPs, addr.Addr())
+
+		if v4.Gateway == "" {
+			// older instances don't advertise a gateway, let DHCP configure the address and routes
+			continue
+		}
+
+		networkConfig.Addresses = append(networkConfig.Addresses, staticAddress(addr))
+
+		// Use the first advertised gateway so multiple public IPs don't create competing defaults.
+		if defaultV4RouteSet {
+			continue
+		}
+
+		gw, err := netip.ParseAddr(v4.Gateway)
+		if err != nil {
+			return nil, err
+		}
+
+		// /32 routed IPs require a host route to the gateway before the default route.
+		networkConfig.Routes = append(networkConfig.Routes,
+			staticRoute(nethelpers.FamilyInet4, netip.PrefixFrom(gw, gw.BitLen()), netip.Addr{}, 3*network.DefaultRouteMetric),
+			staticRoute(nethelpers.FamilyInet4, netip.Prefix{}, gw, 2*network.DefaultRouteMetric),
+		)
+
+		defaultV4RouteSet = true
+	}
 
 	if len(metadata.PublicIpsV4) > 0 {
 		networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
@@ -88,72 +146,48 @@ func (s *Scaleway) ParseMetadata(metadata *instance.Metadata) (*runtime.Platform
 			RequireUp: true,
 			DHCP4: network.DHCP4OperatorSpec{
 				RouteMetric: network.DefaultRouteMetric,
+				SkipRoutes:  defaultV4RouteSet,
 			},
 			ConfigLayer: network.ConfigPlatform,
 		})
 	}
 
-	if metadata.IPv6.Address != "" || len(metadata.PublicIpsV6) > 0 {
-		address := metadata.IPv6.Address
-		netmask := metadata.IPv6.Netmask
-		gateway := metadata.IPv6.Gateway
-
-		if address == "" || netmask == "" || gateway == "" {
-			address = metadata.PublicIpsV6[0].Address
-			netmask = metadata.PublicIpsV6[0].Netmask
-			gateway = metadata.PublicIpsV6[0].Gateway
-		}
-
-		bits, err := strconv.Atoi(netmask)
-		if err != nil {
-			return nil, err
-		}
-
-		ip, err := netip.ParseAddr(address)
-		if err != nil {
-			return nil, err
-		}
-
-		addr := netip.PrefixFrom(ip, bits)
-
-		publicIPs = append(publicIPs, address)
-		networkConfig.Addresses = append(
-			networkConfig.Addresses,
-			network.AddressSpecSpec{
-				ConfigLayer: network.ConfigPlatform,
-				LinkName:    "eth0",
-				Address:     addr,
-				Scope:       nethelpers.ScopeGlobal,
-				Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
-				Family:      nethelpers.FamilyInet6,
-			},
-		)
-
-		gw, err := netip.ParseAddr(gateway)
-		if err != nil {
-			return nil, err
-		}
-
-		route := network.RouteSpecSpec{
-			ConfigLayer: network.ConfigPlatform,
-			Gateway:     gw,
-			OutLinkName: "eth0",
-			Table:       nethelpers.TableMain,
-			Protocol:    nethelpers.ProtocolStatic,
-			Type:        nethelpers.TypeUnicast,
-			Family:      nethelpers.FamilyInet6,
-			Priority:    2 * network.DefaultRouteMetric,
-		}
-
-		route.Normalize()
-
-		networkConfig.Routes = append(networkConfig.Routes, route)
+	// IPv6: use PublicIpsV6 for all entries; fall back to the legacy IPv6 field on older instances.
+	v6ips := metadata.PublicIpsV6
+	if len(v6ips) == 0 && metadata.IPv6.Address != "" && metadata.IPv6.Netmask != "" && metadata.IPv6.Gateway != "" {
+		v6ips = []instance.MetadataIP{{
+			Address: metadata.IPv6.Address,
+			Netmask: metadata.IPv6.Netmask,
+			Gateway: metadata.IPv6.Gateway,
+		}}
 	}
 
-	for _, ipStr := range publicIPs {
-		if ip, err := netip.ParseAddr(ipStr); err == nil {
-			networkConfig.ExternalIPs = append(networkConfig.ExternalIPs, ip)
+	var defaultV6RouteSet bool
+
+	for _, v6 := range v6ips {
+		addr, err := address.IPPrefixFrom(v6.Address, v6.Netmask)
+		if err != nil {
+			return nil, err
 		}
+
+		networkConfig.ExternalIPs = append(networkConfig.ExternalIPs, addr.Addr())
+		networkConfig.Addresses = append(networkConfig.Addresses, staticAddress(addr))
+
+		// every address shares the same gateway, so the default route is only set once
+		if v6.Gateway == "" || defaultV6RouteSet {
+			continue
+		}
+
+		gw, err := netip.ParseAddr(v6.Gateway)
+		if err != nil {
+			return nil, err
+		}
+
+		networkConfig.Routes = append(networkConfig.Routes,
+			staticRoute(nethelpers.FamilyInet6, netip.Prefix{}, gw, 2*network.DefaultRouteMetric),
+		)
+
+		defaultV6RouteSet = true
 	}
 
 	zone, err := scw.ParseZone(metadata.Location.ZoneID)
@@ -185,12 +219,13 @@ func (s *Scaleway) Configuration(ctx context.Context, r state.State) ([]byte, er
 		return nil, err
 	}
 
-	log.Printf("fetching machine config from %q", ScalewayUserDataEndpoint)
+	log.Printf("fetching machine config from %q or %q", ScalewayUserDataEndpoint, ScalewayUserDataEndpointIPv6)
 
-	return download.Download(ctx, ScalewayUserDataEndpoint,
+	return downloadAlternating(ctx, ScalewayUserDataEndpoint, ScalewayUserDataEndpointIPv6,
 		download.WithLowSrcPort(),
-		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
-		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
+		download.WithErrorOnNotFound(retry.ExpectedError(errors.ErrNoConfigSource)),
+		download.WithErrorOnEmptyResponse(retry.ExpectedError(errors.ErrNoConfigSource)),
+	)
 }
 
 // Mode implements the runtime.Platform interface.
@@ -208,8 +243,13 @@ func (s *Scaleway) KernelArgs(string, quirks.Quirks) procfs.Parameters {
 }
 
 // NetworkConfiguration implements the runtime.Platform interface.
-func (s *Scaleway) NetworkConfiguration(ctx context.Context, _ state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
-	log.Printf("fetching scaleway instance config from: %q", ScalewayMetadataEndpoint)
+func (s *Scaleway) NetworkConfiguration(ctx context.Context, st state.State, ch chan<- *runtime.PlatformNetworkConfig) error {
+	// wait for devices to be ready before proceeding
+	if err := netutils.WaitForDevicesReady(ctx, st); err != nil {
+		return fmt.Errorf("error waiting for devices to be ready: %w", err)
+	}
+
+	log.Printf("fetching scaleway instance config from: %q or %q", ScalewayMetadataEndpoint, ScalewayMetadataEndpointIPv6)
 
 	metadata, err := s.getMetadata(ctx)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
@@ -35,6 +34,12 @@ var expectedNetworkConfigV2 string
 //go:embed testdata/expected-v3.yaml
 var expectedNetworkConfigV3 string
 
+//go:embed testdata/metadata-v4.json
+var rawMetadataV4 []byte
+
+//go:embed testdata/expected-v4.yaml
+var expectedNetworkConfigV4 string
+
 func TestParseMetadata(t *testing.T) {
 	p := &scaleway.Scaleway{}
 
@@ -58,9 +63,14 @@ func TestParseMetadata(t *testing.T) {
 			raw:      rawMetadataV3,
 			expected: expectedNetworkConfigV3,
 		},
+		{
+			name:     "V4",
+			raw:      rawMetadataV4,
+			expected: expectedNetworkConfigV4,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			var metadata instance.Metadata
+			var metadata scaleway.Metadata
 
 			require.NoError(t, json.Unmarshal(tt.raw, &metadata))
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway_test.go
@@ -7,6 +7,7 @@ package scaleway_test
 import (
 	_ "embed"
 	"encoding/json"
+	"net/netip"
 	"testing"
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
@@ -15,6 +16,7 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 )
 
 //go:embed testdata/metadata-v1.json
@@ -26,6 +28,9 @@ var rawMetadataV2 []byte
 //go:embed testdata/metadata-v3.json
 var rawMetadataV3 []byte
 
+//go:embed testdata/metadata-v4.json
+var rawMetadataV4 []byte
+
 //go:embed testdata/expected-v1.yaml
 var expectedNetworkConfigV1 string
 
@@ -34,6 +39,9 @@ var expectedNetworkConfigV2 string
 
 //go:embed testdata/expected-v3.yaml
 var expectedNetworkConfigV3 string
+
+//go:embed testdata/expected-v4.yaml
+var expectedNetworkConfigV4 string
 
 func TestParseMetadata(t *testing.T) {
 	p := &scaleway.Scaleway{}
@@ -58,6 +66,11 @@ func TestParseMetadata(t *testing.T) {
 			raw:      rawMetadataV3,
 			expected: expectedNetworkConfigV3,
 		},
+		{
+			name:     "V4",
+			raw:      rawMetadataV4,
+			expected: expectedNetworkConfigV4,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var metadata instance.Metadata
@@ -73,4 +86,52 @@ func TestParseMetadata(t *testing.T) {
 			assert.Equal(t, tt.expected, string(marshaled))
 		})
 	}
+}
+
+func TestParseMetadataMultipleIPv4Addresses(t *testing.T) {
+	var metadata instance.Metadata
+
+	require.NoError(t, json.Unmarshal(rawMetadataV2, &metadata))
+
+	metadata.PublicIpsV4 = append(metadata.PublicIpsV4, instance.MetadataIP{
+		Address: "192.0.2.10",
+		Gateway: "192.0.2.1",
+		Netmask: "32",
+	})
+
+	networkConfig, err := (&scaleway.Scaleway{}).ParseMetadata(&metadata)
+	require.NoError(t, err)
+
+	assert.Contains(t, networkConfig.ExternalIPs, netip.MustParseAddr("192.0.2.10"))
+	assert.Condition(t, func() bool {
+		for _, address := range networkConfig.Addresses {
+			if address.Address == netip.MustParsePrefix("192.0.2.10/32") {
+				return true
+			}
+		}
+
+		return false
+	})
+
+	var defaultRoutes, gatewayRoutes int
+
+	for _, route := range networkConfig.Routes {
+		if route.Family != nethelpers.FamilyInet4 {
+			continue
+		}
+
+		switch route.Destination {
+		case netip.Prefix{}:
+			defaultRoutes++
+
+			assert.Equal(t, netip.MustParseAddr("11.22.222.1"), route.Gateway)
+		case netip.MustParsePrefix("11.22.222.1/32"):
+			gatewayRoutes++
+		}
+	}
+
+	assert.Equal(t, 1, defaultRoutes)
+	assert.Equal(t, 1, gatewayRoutes)
+	require.Len(t, networkConfig.Operators, 1)
+	assert.True(t, networkConfig.Operators[0].DHCP4.SkipRoutes)
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected-v4.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected-v4.yaml
@@ -1,0 +1,88 @@
+addresses:
+    - address: 51.158.100.1/32
+      linkName: eth0
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+    - address: 2001:bc8:1234:5678:dc00:1ff:fe14:a73b/64
+      linkName: eth0
+      family: inet6
+      scope: global
+      flags: permanent
+      layer: platform
+links:
+    - name: eth0
+      logical: false
+      up: true
+      mtu: 0
+      kind: ""
+      type: netrom
+      layer: platform
+routes:
+    - family: inet4
+      dst: 169.254.42.42/32
+      src: ""
+      gateway: ""
+      outLinkName: eth0
+      table: main
+      priority: 4096
+      scope: link
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: 62.210.0.1/32
+      src: ""
+      gateway: ""
+      outLinkName: eth0
+      table: main
+      priority: 3072
+      scope: link
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet4
+      dst: ""
+      src: ""
+      gateway: 62.210.0.1
+      outLinkName: eth0
+      table: main
+      priority: 2048
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+    - family: inet6
+      dst: ""
+      src: ""
+      gateway: fe80::dc00:ff:fe12:3456
+      outLinkName: eth0
+      table: main
+      priority: 2048
+      scope: global
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
+hostnames:
+    - hostname: scw-talos-v4
+      domainname: ""
+      layer: platform
+resolvers: []
+timeServers: []
+operators: []
+externalIPs:
+    - 51.158.100.1
+    - 2001:bc8:1234:5678:dc00:1ff:fe14:a73b
+metadata:
+    platform: scaleway
+    hostname: scw-talos-v4
+    region: fr-par
+    zone: fr-par-1
+    instanceType: DEV1-M
+    instanceId: 44444444-4444-4444-4444-444444444444
+    providerId: scaleway://instance/fr-par-1/44444444-4444-4444-4444-444444444444

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected-v4.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected-v4.yaml
@@ -1,11 +1,11 @@
 addresses:
-    - address: 11.22.222.222/32
+    - address: 51.158.100.1/32
       linkName: eth0
       family: inet4
       scope: global
       flags: permanent
       layer: platform
-    - address: 2001:111:222:3333::1/64
+    - address: 2001:bc8:1234:5678:dc00:1ff:fe14:a73b/64
       linkName: eth0
       family: inet6
       scope: global
@@ -33,7 +33,7 @@ routes:
       protocol: static
       layer: platform
     - family: inet4
-      dst: 11.22.222.1/32
+      dst: 62.210.0.1/32
       src: ""
       gateway: ""
       outLinkName: eth0
@@ -47,7 +47,7 @@ routes:
     - family: inet4
       dst: ""
       src: ""
-      gateway: 11.22.222.1
+      gateway: 62.210.0.1
       outLinkName: eth0
       table: main
       priority: 2048
@@ -69,7 +69,7 @@ routes:
       protocol: static
       layer: platform
 hostnames:
-    - hostname: scw-talos
+    - hostname: scw-talos-v4
       domainname: ""
       layer: platform
 resolvers: []
@@ -83,13 +83,13 @@ operators:
         skipRoutes: true
       layer: platform
 externalIPs:
-    - 11.22.222.222
-    - 2001:111:222:3333::1
+    - 51.158.100.1
+    - 2001:bc8:1234:5678:dc00:1ff:fe14:a73b
 metadata:
     platform: scaleway
-    hostname: scw-talos
+    hostname: scw-talos-v4
     region: fr-par
-    zone: fr-par-2
-    instanceType: DEV1-S
-    instanceId: 11111111-1111-1111-1111-111111111111
-    providerId: scaleway://instance/fr-par-2/11111111-1111-1111-1111-111111111111
+    zone: fr-par-1
+    instanceType: DEV1-M
+    instanceId: 44444444-4444-4444-4444-444444444444
+    providerId: scaleway://instance/fr-par-1/44444444-4444-4444-4444-444444444444

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/metadata-v4.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/metadata-v4.json
@@ -1,0 +1,43 @@
+{
+    "id": "44444444-4444-4444-4444-444444444444",
+    "name": "scw-talos-v4",
+    "commercial_type": "DEV1-M",
+    "hostname": "scw-talos-v4",
+    "tags": [],
+    "state_detail": "running",
+    "public_ip": {
+        "id": "44444444-4444-4444-4444-444444444444",
+        "address": "2001:bc8:1234:5678:dc00:1ff:fe14:a73b",
+        "dynamic": false,
+        "family": "inet6",
+        "gateway": "fe80::dc00:ff:fe12:3456",
+        "netmask": "64",
+        "provisioning_mode": "slaac"
+    },
+    "public_ips_v4": [
+        {
+            "address": "51.158.100.1",
+            "dynamic": false,
+            "family": "inet",
+            "gateway": "62.210.0.1",
+            "netmask": "32",
+            "provisioning_mode": "dhcp"
+        }
+    ],
+    "public_ips_v6": [
+        {
+            "address": "2001:bc8:1234:5678:dc00:1ff:fe14:a73b",
+            "dynamic": false,
+            "family": "inet6",
+            "gateway": "fe80::dc00:ff:fe12:3456",
+            "netmask": "64",
+            "provisioning_mode": "slaac"
+        }
+    ],
+    "routed_ip_enabled": true,
+    "ipv6": null,
+    "private_ip": null,
+    "location": {
+        "zone_id": "fr-par-1"
+    }
+}


### PR DESCRIPTION
## What? (description)

Add IPv6-only support for Scaleway platform. Also adds `RoutedIPEnabled` to metadata.
Solves https://github.com/siderolabs/talos/issues/13475

## Why? (reasoning)

Previously the scaleway platform only probed the IPv4 metadata endpoint (169.254.42.42), which is unreachable on IPv6-only instances. This change tries IPv4 with a 15-second timeout, then falls back to the IPv6 metadata endpoint (fd00:42::42).

Also adds support for Scaleway's routed IP mode (`RoutedIPEnabled`), where public IPs are configured statically rather than via DHCP.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
