### PR TITLE
fix: avoid image cache mount request churn

### DIFF
--- a/internal/app/machined/pkg/controllers/cri/image_cache_config.go
+++ b/internal/app/machined/pkg/controllers/cri/image_cache_config.go
@@ -209,7 +209,7 @@ func (ctrl *ImageCacheConfigController) Run(ctx context.Context, r controller.Ru
 						return fmt.Errorf("error stopping service: %w", err)
 					}
 				}
-			} else {
+			} else if imageCacheDisabled {
 				// if the service is not running, remove the volume mount requests
 				vmrs, err := safe.ReaderListAll[*block.VolumeMountRequest](ctx, r)
 				if err != nil {

--- a/internal/app/machined/pkg/controllers/cri/image_cache_config_test.go
+++ b/internal/app/machined/pkg/controllers/cri/image_cache_config_test.go
@@ -189,6 +189,56 @@ func (suite *ImageCacheConfigSuite) TestReconcileFeatureEnabled() {
 	)
 }
 
+func (suite *ImageCacheConfigSuite) TestReconcileFeatureEnabledWithoutCacheVolumeKeepsMountRequests() {
+	ctrlName := (&crictrl.ImageCacheConfigController{}).Name()
+
+	imageCacheCfg := cricfg.NewImageCacheConfigV1Alpha1()
+	imageCacheCfg.LocalConfig.ConfigEnabled = new(true)
+
+	cfg := config.NewMachineConfig(must(container.New(imageCacheCfg)))
+
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), cfg))
+
+	vs1 := block.NewVolumeStatus(block.NamespaceName, crictrl.VolumeImageCacheISO)
+	vs1.TypedSpec().Phase = block.VolumePhaseMissing
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), vs1))
+
+	vs2 := block.NewVolumeStatus(block.NamespaceName, crictrl.VolumeImageCacheDISK)
+	vs2.TypedSpec().Phase = block.VolumePhaseMissing
+	suite.Require().NoError(suite.State().Create(suite.Ctx(), vs2))
+
+	ctest.AssertResource(suite, cri.ImageCacheConfigID, func(r *cri.ImageCacheConfig, asrt *assert.Assertions) {
+		asrt.Equal(cri.ImageCacheStatusDisabled, r.TypedSpec().Status)
+		asrt.Equal(cri.ImageCacheCopyStatusSkipped, r.TypedSpec().CopyStatus)
+		asrt.Empty(r.TypedSpec().Roots)
+	})
+
+	ids := []string{
+		ctrlName + "-" + crictrl.VolumeImageCacheISO,
+		ctrlName + "-" + crictrl.VolumeImageCacheDISK,
+	}
+
+	ctest.AssertResources(suite, ids, func(vmr *block.VolumeMountRequest, asrt *assert.Assertions) {
+		asrt.Equal(ctrlName, vmr.TypedSpec().Requester)
+		asrt.True(vmr.TypedSpec().ReadOnly)
+	})
+
+	vs2.TypedSpec().Phase = block.VolumePhaseWaiting
+	suite.Update(vs2)
+
+	ctest.AssertResource(suite, cri.ImageCacheConfigID, func(r *cri.ImageCacheConfig, asrt *assert.Assertions) {
+		asrt.Equal(cri.ImageCacheStatusDisabled, r.TypedSpec().Status)
+		asrt.Equal(cri.ImageCacheCopyStatusSkipped, r.TypedSpec().CopyStatus)
+		asrt.Empty(r.TypedSpec().Roots)
+	})
+
+	ctest.AssertResources(suite, ids, func(vmr *block.VolumeMountRequest, asrt *assert.Assertions) {
+		asrt.Equal(ctrlName, vmr.TypedSpec().Requester)
+	})
+
+	suite.Assert().False(suite.serviceRunner.IsServiceRunning())
+}
+
 func (suite *ImageCacheConfigSuite) TestReconcileJustDiskVolume() {
 	ctrlName := (&crictrl.ImageCacheConfigController{}).Name()
 

--- a/internal/integration/api/firewall.go
+++ b/internal/integration/api/firewall.go
@@ -214,7 +214,57 @@ func (suite *FirewallSuite) TestNodePortAccess() {
 		})
 	}
 
-	suite.Require().NoError(eg.Wait())
+	if err := eg.Wait(); err != nil {
+		suite.describeTestNginx()
+		suite.Require().NoError(err)
+	}
+}
+
+// describeTestNginx dumps pod status, container states and events for the test-nginx
+// deployment to help diagnose why the NodePort never became reachable.
+func (suite *FirewallSuite) describeTestNginx() {
+	dumpCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pods, err := suite.Clientset.CoreV1().Pods("default").List(dumpCtx, metav1.ListOptions{LabelSelector: "app=test-nginx"})
+	if err != nil {
+		suite.T().Logf("failed to list test-nginx pods: %v", err)
+
+		return
+	}
+
+	if len(pods.Items) == 0 {
+		suite.T().Log("no test-nginx pods found")
+	}
+
+	for _, pod := range pods.Items {
+		suite.T().Logf("pod %s: phase=%s node=%s reason=%q message=%q",
+			pod.Name, pod.Status.Phase, pod.Spec.NodeName, pod.Status.Reason, pod.Status.Message)
+
+		for _, cs := range pod.Status.ContainerStatuses {
+			switch {
+			case cs.State.Waiting != nil:
+				suite.T().Logf("  container %s waiting: %s: %s", cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+			case cs.State.Terminated != nil:
+				suite.T().Logf("  container %s terminated: %s: %s", cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.Message)
+			case cs.State.Running != nil:
+				suite.T().Logf("  container %s running, ready=%t", cs.Name, cs.Ready)
+			}
+		}
+
+		events, err := suite.Clientset.CoreV1().Events("default").List(dumpCtx, metav1.ListOptions{
+			FieldSelector: "involvedObject.name=" + pod.Name,
+		})
+		if err != nil {
+			suite.T().Logf("  failed to list events for pod %s: %v", pod.Name, err)
+
+			continue
+		}
+
+		for _, ev := range events.Items {
+			suite.T().Logf("  event %s %s: %s", ev.Type, ev.Reason, ev.Message)
+		}
+	}
 }
 
 func init() {

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -26,16 +26,20 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	crictrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/cri"
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/cel"
 	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
 	"github.com/siderolabs/talos/pkg/machinery/client"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	cricfg "github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	crires "github.com/siderolabs/talos/pkg/machinery/resources/cri"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
 
@@ -1845,6 +1849,139 @@ func (suite *VolumesSuite) TestFSTrimDefaultSchedule() {
 				rtestutils.AssertNoResource[*block.VolumeTrimSchedule](ctx, suite.T(), suite.Client.COSI, name)
 			}
 		})
+	}
+}
+
+// TestImageCacheLocalEnabledWithoutCacheVolume verifies that enabling the local image cache on a node
+// without a cache volume doesn't cause VolumeMountRequest create/delete churn.
+func (suite *VolumesSuite) TestImageCacheLocalEnabledWithoutCacheVolume() {
+	node := suite.RandomDiscoveredNodeInternalIP()
+	ctx := client.WithNode(suite.ctx, node)
+
+	suite.T().Logf("using node %s", node)
+
+	cfg, err := suite.ReadConfigFromNode(ctx)
+	suite.Require().NoError(err)
+
+	originalImageCacheDocs := filterImageCacheConfigDocs(cfg.Documents())
+	if cfg.ImageCacheConfig() != nil && len(originalImageCacheDocs) == 0 {
+		suite.T().Skip("image cache is configured via v1alpha1 machine config")
+	}
+
+	defer func() {
+		suite.RemoveMachineConfigDocuments(ctx, cricfg.ImageCacheConfig)
+
+		if len(originalImageCacheDocs) > 0 {
+			patches := make([]any, 0, len(originalImageCacheDocs))
+			for _, doc := range originalImageCacheDocs {
+				patches = append(patches, doc)
+			}
+
+			suite.PatchMachineConfig(ctx, patches...)
+		}
+	}()
+
+	suite.RemoveMachineConfigDocuments(ctx, cricfg.ImageCacheConfig)
+
+	imageCacheCfg := cricfg.NewImageCacheConfigV1Alpha1()
+	imageCacheCfg.LocalConfig.ConfigEnabled = new(bool)
+	*imageCacheCfg.LocalConfig.ConfigEnabled = true
+
+	suite.PatchMachineConfig(ctx, imageCacheCfg)
+
+	volumeIDs := []resource.ID{crictrl.VolumeImageCacheISO, crictrl.VolumeImageCacheDISK}
+	rtestutils.AssertResources(
+		ctx,
+		suite.T(),
+		suite.Client.COSI,
+		volumeIDs,
+		func(*block.VolumeStatus, *assert.Assertions) {},
+	)
+
+	for _, id := range volumeIDs {
+		volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](ctx, suite.Client.COSI, id)
+		suite.Require().NoError(err)
+
+		if volumeStatus.TypedSpec().Phase == block.VolumePhaseReady {
+			suite.T().Skipf("node has ready image cache volume %q", id)
+		}
+	}
+
+	rtestutils.AssertResources(
+		ctx,
+		suite.T(),
+		suite.Client.COSI,
+		[]resource.ID{crires.ImageCacheConfigID},
+		func(cfg *crires.ImageCacheConfig, asrt *assert.Assertions) {
+			asrt.Equal(crires.ImageCacheStatusDisabled, cfg.TypedSpec().Status)
+			asrt.Equal(crires.ImageCacheCopyStatusSkipped, cfg.TypedSpec().CopyStatus)
+			asrt.Empty(cfg.TypedSpec().Roots)
+		},
+	)
+
+	ctrlName := (&crictrl.ImageCacheConfigController{}).Name()
+	mountRequestIDs := []resource.ID{
+		ctrlName + "-" + crictrl.VolumeImageCacheISO,
+		ctrlName + "-" + crictrl.VolumeImageCacheDISK,
+	}
+
+	rtestutils.AssertResources(
+		ctx,
+		suite.T(),
+		suite.Client.COSI,
+		mountRequestIDs,
+		func(vmr *block.VolumeMountRequest, asrt *assert.Assertions) {
+			asrt.Equal(ctrlName, vmr.TypedSpec().Requester)
+		},
+	)
+
+	suite.assertImageCacheMountRequestsStable(ctx, mountRequestIDs, 10*time.Second)
+}
+
+func filterImageCacheConfigDocs(docs []configconfig.Document) []configconfig.Document {
+	result := make([]configconfig.Document, 0, len(docs))
+
+	for _, doc := range docs {
+		if doc.Kind() == cricfg.ImageCacheConfig {
+			result = append(result, doc)
+		}
+	}
+
+	return result
+}
+
+func (suite *VolumesSuite) assertImageCacheMountRequestsStable(ctx context.Context, ids []resource.ID, duration time.Duration) {
+	versions := make(map[resource.ID]resource.Version, len(ids))
+
+	for _, id := range ids {
+		vmr, err := safe.StateGetByID[*block.VolumeMountRequest](ctx, suite.Client.COSI, id)
+		suite.Require().NoError(err)
+
+		versions[id] = vmr.Metadata().Version()
+	}
+
+	deadline := time.After(duration)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			suite.Require().NoError(ctx.Err())
+		case <-deadline:
+			return
+		case <-ticker.C:
+			for _, id := range ids {
+				vmr, err := safe.StateGetByID[*block.VolumeMountRequest](ctx, suite.Client.COSI, id)
+				suite.Require().NoError(err)
+				suite.Require().True(
+					versions[id].Equal(vmr.Metadata().Version()),
+					"image cache mount request %q changed while cache was enabled without a backing volume",
+					id,
+				)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Only perform image-cache mount cleanup when the feature is explicitly
disabled in machine config. A disabled ImageCacheConfig status can also
mean the feature is enabled but no cache volume exists; in that case the
controller must keep its mount requests so future volumes can be observed.

Fixes #13755

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
