### PR TITLE
fix: flaky tests

### DIFF
--- a/internal/app/machined/pkg/controllers/block/volume_manager_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_manager_test.go
@@ -159,9 +159,14 @@ func (suite *VolumeManagerSuite) TestFailingSystemVolumeStillBlocks() {
 	_, err := suite.State().Teardown(suite.Ctx(), lifecycle.Metadata())
 	suite.Require().NoError(err)
 
+	// Capture ctx/state in locals: Never leaks its last condition goroutine past
+	// return, and reading suite.Ctx()/suite.State() there races the next test's
+	// SetupTest overwriting those fields.
+	ctx, st := suite.Ctx(), suite.State()
+
 	// lifecycle finalizer must NOT be removed while the system volume is not closed
 	suite.Assert().Never(func() bool {
-		lc, err := safe.StateGetByID[*block.VolumeLifecycle](suite.Ctx(), suite.State(), block.VolumeLifecycleID)
+		lc, err := safe.StateGetByID[*block.VolumeLifecycle](ctx, st, block.VolumeLifecycleID)
 		if err != nil {
 			return false
 		}

--- a/internal/app/machined/pkg/controllers/cri/image_cache_config.go
+++ b/internal/app/machined/pkg/controllers/cri/image_cache_config.go
@@ -112,7 +112,7 @@ func (ctrl *ImageCacheConfigController) Outputs() []controller.Output {
 
 // Volume configuration constants.
 const (
-	VolumeImageCacheISO  = "IMAGECACHE-ISO"
+	VolumeImageCacheISO  = constants.ImageCacheISOLabel
 	VolumeImageCacheDISK = constants.ImageCachePartitionLabel
 
 	MinImageCacheSize = 500 * 1024 * 1024      // 500MB

--- a/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
@@ -186,10 +186,15 @@ func (suite *MachineStatusSuite) TestReconcile() {
 		},
 	}
 
+	// Capture ctx/state in locals: Never leaks its last condition goroutine past
+	// return, and reading suite.Ctx()/suite.State() there races the next test's
+	// SetupTest overwriting those fields.
+	ctx, st := suite.Ctx(), suite.State()
+
 	// Poll over a short window to verify the stage never flips to "rebooting" or any other stage after the NOOP event.
 	suite.Require().Never(
 		func() bool {
-			status, err := safe.StateGetByID[*runtime.MachineStatus](suite.Ctx(), suite.State(), runtime.MachineStatusID)
+			status, err := safe.StateGetByID[*runtime.MachineStatus](ctx, st, runtime.MachineStatusID)
 			suite.NoError(err, "status should exist")
 
 			return status.TypedSpec().Stage != runtime.MachineStageShuttingDown

--- a/internal/integration/api/storage.go
+++ b/internal/integration/api/storage.go
@@ -1566,18 +1566,37 @@ func (suite *StorageSuite) deleteLVMVolumes(node string, pvDisks []string) {
 	// wipe RPCs by re-running pvcreate / vgcreate.
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, storagecfg.LVMVolumeGroupConfigKind, vgName)
 
-	if err := suite.Client.VolumeGroupRemove(nodeCtx, &machineapi.LVMServiceVolumeGroupRemoveRequest{
-		VolumeGroup: vgName,
-	}); !isAlreadyGone(err) {
-		suite.T().Logf("VolumeGroupRemove %s failed: %v", vgName, err)
-	}
+	const (
+		removeTimeout  = 60 * time.Second
+		removeInterval = 2 * time.Second
+	)
+
+	// Removing config docs (user volume, LV) only patches config; the actual
+	// unmount + LV teardown happens asynchronously via the reconciler. Retry
+	// the wipe RPCs until the LV closes ("logical volume is open") and the PVs
+	// are no longer in use, otherwise the disks are never released.
+	suite.Require().Eventually(func() bool {
+		err := suite.Client.VolumeGroupRemove(nodeCtx, &machineapi.LVMServiceVolumeGroupRemoveRequest{
+			VolumeGroup: vgName,
+		})
+		if !isAlreadyGone(err) {
+			suite.T().Logf("VolumeGroupRemove %s failed: %v", vgName, err)
+		}
+
+		return isAlreadyGone(err)
+	}, removeTimeout, removeInterval, "VolumeGroupRemove %s never succeeded", vgName)
 
 	for _, dev := range pvDisks {
-		if err := suite.Client.PhysicalVolumeRemove(nodeCtx, &machineapi.LVMServicePhysicalVolumeRemoveRequest{
-			Device: dev,
-		}); !isAlreadyGone(err) {
-			suite.T().Logf("PhysicalVolumeRemove %s failed: %v", dev, err)
-		}
+		suite.Require().Eventually(func() bool {
+			err := suite.Client.PhysicalVolumeRemove(nodeCtx, &machineapi.LVMServicePhysicalVolumeRemoveRequest{
+				Device: dev,
+			})
+			if !isAlreadyGone(err) {
+				suite.T().Logf("PhysicalVolumeRemove %s failed: %v", dev, err)
+			}
+
+			return isAlreadyGone(err)
+		}, removeTimeout, removeInterval, "PhysicalVolumeRemove %s never succeeded", dev)
 	}
 }
 

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
-	crictrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/cri"
 	"github.com/siderolabs/talos/internal/integration/base"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
@@ -1889,7 +1888,7 @@ func (suite *VolumesSuite) TestImageCacheLocalEnabledWithoutCacheVolume() {
 
 	suite.PatchMachineConfig(ctx, imageCacheCfg)
 
-	volumeIDs := []resource.ID{crictrl.VolumeImageCacheISO, crictrl.VolumeImageCacheDISK}
+	volumeIDs := []resource.ID{constants.ImageCacheISOLabel, constants.ImageCachePartitionLabel}
 	rtestutils.AssertResources(
 		ctx,
 		suite.T(),
@@ -1919,10 +1918,10 @@ func (suite *VolumesSuite) TestImageCacheLocalEnabledWithoutCacheVolume() {
 		},
 	)
 
-	ctrlName := (&crictrl.ImageCacheConfigController{}).Name()
+	ctrlName := "cri.ImageCacheConfigController"
 	mountRequestIDs := []resource.ID{
-		ctrlName + "-" + crictrl.VolumeImageCacheISO,
-		ctrlName + "-" + crictrl.VolumeImageCacheDISK,
+		ctrlName + "-" + constants.ImageCacheISOLabel,
+		ctrlName + "-" + constants.ImageCachePartitionLabel,
 	}
 
 	rtestutils.AssertResources(

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1310,6 +1310,9 @@ const (
 	// MetalAgentModeFlagPath is the path to the file indicating if the node is running in Metal Agent mode.
 	MetalAgentModeFlagPath = "/usr/local/etc/is-metal-agent"
 
+	// ImageCacheISOLabel is the label for the image cache ISO.
+	ImageCacheISOLabel = "IMAGECACHE-ISO"
+
 	// ImageCachePartitionLabel is the label for the image cache partition.
 	ImageCachePartitionLabel = "IMAGECACHE"
 


### PR DESCRIPTION
1. retry LVM teardown until volume closes

TestLVMUserVolumeOnLogicalVolume tears down a UserVolume mounted on
an LV, then wipes the VG/PVs. Config-doc removal is async, so the
LV stays open when VolumeGroupRemove fires ("logical volume is
open"), PVs stay in use, and the disks are never released -> disk
count assertion fails 0/3.

Wrap VolumeGroupRemove/PhysicalVolumeRemove in Eventually so the
wipe retries until the reconciler finishes the unmount + LV
teardown.

2. fix data race in VolumeManagerSuite and VolumeManager tests.

Never leaks its final condition goroutine past return; reading
suite.Ctx()/suite.State() there races the next test's SetupTest
overwriting those fields. Capture ctx/state in locals first.

3. Fix integration build for Darwin.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
