### PR TITLE
fix: use symlinks for init aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -802,19 +802,14 @@ COPY --link --from=machined-build-amd64 /machined /rootfs/usr/bin/init
 
 RUN <<END
     # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/poweroff
-    chmod +x /rootfs/usr/bin/poweroff
+    ln -s init /rootfs/usr/bin/poweroff
     # some extensions like qemu-guest agent will call '/sbin/shutdown'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/shutdown
-    chmod +x /rootfs/usr/bin/shutdown
+    ln -s init /rootfs/usr/bin/shutdown
     # the orderly_reboot call by the kernel (e.g. hyper-v restart request) will call '/sbin/reboot'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/reboot
-    chmod +x /rootfs/usr/bin/reboot
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/dashboard
-    chmod +x /rootfs/usr/bin/dashboard
+    ln -s init /rootfs/usr/bin/reboot
+    ln -s init /rootfs/usr/bin/dashboard
     # sandboxd is PID 1 of the sandbox PID+mount namespace, re-exec'd by machined
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/sandboxd
-    chmod +x /rootfs/usr/bin/sandboxd
+    ln -s init /rootfs/usr/bin/sandboxd
 END
 # NB: We run the cleanup step before creating extra directories, files, and
 # symlinks to avoid accidentally cleaning them up.
@@ -899,19 +894,14 @@ COPY --link --from=machined-build-arm64 /machined /rootfs/usr/bin/init
 
 RUN <<END
     # the orderly_poweroff call by the kernel will call '/sbin/poweroff'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/poweroff
-    chmod +x /rootfs/usr/bin/poweroff
+    ln -s init /rootfs/usr/bin/poweroff
     # some extensions like qemu-guest agent will call '/sbin/shutdown'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/shutdown
-    chmod +x /rootfs/usr/bin/shutdown
+    ln -s init /rootfs/usr/bin/shutdown
     # the orderly_reboot call by the kernel (e.g. hyper-v restart request) will call '/sbin/reboot'
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/reboot
-    chmod +x /rootfs/usr/bin/reboot
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/dashboard
-    chmod +x /rootfs/usr/bin/dashboard
+    ln -s init /rootfs/usr/bin/reboot
+    ln -s init /rootfs/usr/bin/dashboard
     # sandboxd is PID 1 of the sandbox PID+mount namespace, re-exec'd by machined
-    ln /rootfs/usr/bin/init /rootfs/usr/bin/sandboxd
-    chmod +x /rootfs/usr/bin/sandboxd
+    ln -s init /rootfs/usr/bin/sandboxd
 END
 # NB: We run the cleanup step before creating extra directories, files, and
 # symlinks to avoid accidentally cleaning them up.

--- a/internal/pkg/selinux/policy/file_contexts
+++ b/internal/pkg/selinux/policy/file_contexts
@@ -24,13 +24,8 @@
 /lib/modules	system_u:object_r:module_t:s0
 /usr/bin/runc	system_u:object_r:containerd_exec_t:s0
 /usr/bin/init	--	system_u:object_r:init_exec_t:s0
-/usr/bin/reboot	system_u:object_r:init_exec_t:s0
 /usr/bin/udevadm	--	system_u:object_r:udev_exec_t:s0
-/usr/bin/poweroff	system_u:object_r:init_exec_t:s0
-/usr/bin/sandboxd	system_u:object_r:init_exec_t:s0
-/usr/bin/shutdown	system_u:object_r:init_exec_t:s0
 /usr/bin/modprobe	--	system_u:object_r:modprobe_exec_t:s0
-/usr/bin/dashboard	system_u:object_r:init_exec_t:s0
 /usr/bin/containerd	system_u:object_r:containerd_exec_t:s0
 /usr/bin/systemd-udevd	--	system_u:object_r:udev_exec_t:s0
 /usr/bin/containerd-shim-runc-v2	system_u:object_r:containerd_exec_t:s0

--- a/internal/pkg/selinux/policy/selinux/services/machined.cil
+++ b/internal/pkg/selinux/policy/selinux/services/machined.cil
@@ -2,11 +2,6 @@
 (call system_f (init_exec_t))
 (context init_exec_t (system_u object_r init_exec_t (systemLow systemLow)))
 (filecon "/usr/bin/init" file init_exec_t)
-(filecon "/usr/bin/reboot" any init_exec_t)
-(filecon "/usr/bin/poweroff" any init_exec_t)
-(filecon "/usr/bin/shutdown" any init_exec_t)
-(filecon "/usr/bin/dashboard" any init_exec_t)
-(filecon "/usr/bin/sandboxd" any init_exec_t)
 
 (type init_t)
 (roletype system_r init_t)

--- a/tools/labeled-squashfs/main_test.go
+++ b/tools/labeled-squashfs/main_test.go
@@ -30,7 +30,7 @@ func TestLookupAgainstTalosFileContexts(t *testing.T) {
 	}{
 		// Exact-match literal entries.
 		{"/usr/bin/init", typeReg, "system_u:object_r:init_exec_t:s0", true},
-		{"/usr/bin/poweroff", typeAny, "system_u:object_r:init_exec_t:s0", true},
+		{"/usr/bin/poweroff", typeAny, "system_u:object_r:bin_exec_t:s0", true},
 		{"/usr/bin/runc", typeAny, "system_u:object_r:containerd_exec_t:s0", true},
 		// Regex match: /etc(/.*)? covers both /etc and /etc/foo.
 		{"/etc", typeDir, "system_u:object_r:etc_t:s0", true},


### PR DESCRIPTION
The hardlinks are lost in multiple places in the process of building initramfs/squashfs path.

So instead, use symlinks which are functionally same, but they are preserved correctly.
