### PR TITLE
fix: do proper backoff for NTP Kiss-of-Death responses

### DIFF
--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -197,7 +197,7 @@ func (syncer *Syncer) Run(ctx context.Context) {
 	pollInterval := time.Duration(0)
 
 	for {
-		lastSyncServer, resp, err := syncer.query(ctx)
+		lastSyncServer, resp, kissOfDeath, err := syncer.query(ctx)
 		if err != nil {
 			return
 		}
@@ -209,8 +209,18 @@ func (syncer *Syncer) Run(ctx context.Context) {
 
 		switch {
 		case resp == nil:
-			// if no response was ever received, consider doing short sleep to retry sooner as it's not Kiss-o-Death response
-			pollInterval = syncer.RetryPoll
+			// no valid response received
+			if kissOfDeath {
+				// slow down polling if we got kiss of death response
+				if pollInterval < syncer.MinPoll {
+					pollInterval = syncer.MinPoll
+				} else if pollInterval < syncer.MaxPoll {
+					pollInterval *= 2
+				}
+			} else {
+				// retry sooner, not kiss of death, maybe network issue
+				pollInterval = syncer.RetryPoll
+			}
 		case pollInterval == 0:
 			// first sync
 			pollInterval = syncer.MinPoll
@@ -266,17 +276,21 @@ func (syncer *Syncer) Run(ctx context.Context) {
 	}
 }
 
-func (syncer *Syncer) query(ctx context.Context) (lastSyncServer string, measurement *Measurement, err error) {
+//nolint:gocyclo
+func (syncer *Syncer) query(ctx context.Context) (lastSyncServer string, measurement *Measurement, koD bool, err error) {
 	lastSyncServer = syncer.getLastSyncServer()
 	failedServer := ""
 
 	if lastSyncServer != "" {
-		measurement, err = syncer.queryServer(lastSyncServer)
+		var lastKoD bool
+
+		measurement, lastKoD, err = syncer.queryServer(lastSyncServer)
 		if err != nil {
 			syncer.logger.Error("time query error", zap.String("server", lastSyncServer), zap.Error(err))
 
 			failedServer = lastSyncServer
 			lastSyncServer = ""
+			koD = koD || lastKoD
 			err = nil
 		}
 	}
@@ -286,7 +300,7 @@ func (syncer *Syncer) query(ctx context.Context) (lastSyncServer string, measure
 
 		serverList, err = syncer.resolveServers(ctx)
 		if err != nil {
-			return lastSyncServer, measurement, err
+			return lastSyncServer, measurement, koD, err
 		}
 
 		for _, server := range serverList {
@@ -297,28 +311,32 @@ func (syncer *Syncer) query(ctx context.Context) (lastSyncServer string, measure
 
 			select {
 			case <-ctx.Done():
-				return lastSyncServer, measurement, ctx.Err()
+				return lastSyncServer, measurement, koD, ctx.Err()
 			case <-syncer.restartSyncCh:
 				syncer.restartSync() // re-queue restart for outer loop
 
-				return lastSyncServer, measurement, nil
+				return lastSyncServer, measurement, koD, nil
 			default:
 			}
 
-			measurement, err = syncer.queryServer(server)
+			var lastKoD bool
+
+			measurement, lastKoD, err = syncer.queryServer(server)
 			if err != nil {
 				syncer.logger.Error("time query error", zap.String("server", server), zap.Error(err))
 				err = nil
+				koD = koD || lastKoD
 			} else {
 				syncer.setLastSyncServer(server)
 				lastSyncServer = server
+				koD = false
 
 				break
 			}
 		}
 	}
 
-	return lastSyncServer, measurement, err
+	return lastSyncServer, measurement, koD, err
 }
 
 // IsPTPDevice checks if a given server string represents a PTP device.
@@ -370,7 +388,7 @@ func (syncer *Syncer) lookupIPAddrWithTimeout(ctx context.Context, host string, 
 	return (&net.Resolver{}).LookupIPAddr(ctx, host)
 }
 
-func (syncer *Syncer) queryServer(server string) (*Measurement, error) {
+func (syncer *Syncer) queryServer(server string) (*Measurement, bool, error) {
 	if IsPTPDevice(server) {
 		return syncer.queryPTP(server)
 	}
@@ -382,10 +400,10 @@ func (syncer *Syncer) queryServer(server string) (*Measurement, error) {
 	return syncer.queryNTP(server)
 }
 
-func (syncer *Syncer) queryPTP(device string) (*Measurement, error) {
+func (syncer *Syncer) queryPTP(device string) (*Measurement, bool, error) {
 	ts, err := QueryPTPDevice(device)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	offset := time.Until(time.Unix(ts.Sec, ts.Nsec))
@@ -403,7 +421,7 @@ func (syncer *Syncer) queryPTP(device string) (*Measurement, error) {
 		Spike:       false,
 	}
 
-	return meas, err
+	return meas, false, err
 }
 
 // QueryPTPDevice queries PTP device for current time.
@@ -435,10 +453,10 @@ func QueryPTPDevice(device string) (unix.Timespec, error) {
 	return ts, err
 }
 
-func (syncer *Syncer) queryNTP(server string) (*Measurement, error) {
+func (syncer *Syncer) queryNTP(server string) (*Measurement, bool, error) {
 	resp, err := syncer.NTPQuery(server)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	syncer.logger.Debug(
@@ -455,20 +473,20 @@ func (syncer *Syncer) queryNTP(server string) (*Measurement, error) {
 
 	validationError := resp.Validate()
 	if validationError != nil {
-		return nil, validationError
+		return nil, errors.Is(validationError, ntp.ErrKissOfDeath), validationError
 	}
 
 	return &Measurement{
 		ClockOffset: resp.ClockOffset,
 		Leap:        resp.Leap,
 		Spike:       syncer.isSpike(resp),
-	}, nil
+	}, false, nil
 }
 
-func (syncer *Syncer) queryNTS(server string) (*Measurement, error) {
+func (syncer *Syncer) queryNTS(server string) (*Measurement, bool, error) {
 	session, err := syncer.getNTSSession(server)
 	if err != nil {
-		return nil, fmt.Errorf("NTS session for %s: %w", server, err)
+		return nil, false, fmt.Errorf("NTS session for %s: %w", server, err)
 	}
 
 	resp, err := session.Query()
@@ -483,12 +501,12 @@ func (syncer *Syncer) queryNTS(server string) (*Measurement, error) {
 
 		session, err = syncer.getNTSSession(server)
 		if err != nil {
-			return nil, fmt.Errorf("NTS session refresh for %s: %w", server, err)
+			return nil, false, fmt.Errorf("NTS session refresh for %s: %w", server, err)
 		}
 
 		resp, err = session.Query()
 		if err != nil {
-			return nil, fmt.Errorf("NTS query retry for %s: %w", server, err)
+			return nil, false, fmt.Errorf("NTS query retry for %s: %w", server, err)
 		}
 	}
 
@@ -507,14 +525,14 @@ func (syncer *Syncer) queryNTS(server string) (*Measurement, error) {
 
 	validationError := resp.Validate()
 	if validationError != nil {
-		return nil, validationError
+		return nil, errors.Is(validationError, ntp.ErrKissOfDeath), validationError
 	}
 
 	return &Measurement{
 		ClockOffset: resp.ClockOffset,
 		Leap:        resp.Leap,
 		Spike:       syncer.isSpike(resp),
-	}, nil
+	}, false, nil
 }
 
 func (syncer *Syncer) getNTSSession(server string) (NTSSession, error) {

--- a/internal/pkg/ntp/ntp_test.go
+++ b/internal/pkg/ntp/ntp_test.go
@@ -268,7 +268,8 @@ func (suite *NTPSuite) TestSyncKissOfDeath() {
 	syncer.DisableRTC = true
 
 	syncer.MinPoll = time.Second
-	syncer.MaxPoll = time.Second
+	syncer.MaxPoll = 2 * time.Second
+	syncer.RetryPoll = time.Hour // this should not be used for kiss-of-death responses
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Track separately if any of the servers in the current cycle returned Kiss of Death response, and implement a proper backoff in this case.

If any server returns success, clear Kiss-of-Death flag.

Fixes #13737
