### PR TITLE
feat: bump CoreDNS, Flannel

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -502,7 +502,7 @@ var imageK8sBundleCmdFlags = struct {
 	etcdVersion                pflag.Value
 	kubeNetworkPoliciesVersion pflag.Value
 }{
-	k8sVersion:                 flags.Semver(constants.DefaultKubernetesVersion),
+	k8sVersion:                 flags.Semver("v" + constants.DefaultKubernetesVersion),
 	flannelVersion:             flags.Semver(constants.FlannelVersion),
 	corednsVersion:             flags.Semver(constants.DefaultCoreDNSVersion),
 	etcdVersion:                flags.Semver(constants.DefaultEtcdVersion),

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,9 +22,9 @@ Linux: 6.18.38
 Kubernetes: 1.36.2
 containerd: 2.3.3
 etcd: v3.7.0
-Flannel: v0.28.5
+Flannel: 0.28.7
 runc: 1.5.0
-CoreDNS: 1.14.2
+CoreDNS: 1.14.4
 
 Talos is built with Go 1.26.5.
 """

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -58,6 +58,7 @@ func StringChoice(defaultValue string, otherChoices ...string) pflag.Value {
 
 type semverValue struct {
 	value      semver.Version
+	prefix     string
 	validators []SemverValidateFunc
 }
 
@@ -66,6 +67,10 @@ type SemverValidateFunc func(v semver.Version) error
 
 // Set implements pflag.Value interface.
 func (v *semverValue) Set(s string) error {
+	if strings.HasPrefix(s, "v") {
+		v.prefix = "v"
+	}
+
 	vers, err := semver.ParseTolerant(s)
 	if err != nil {
 		return err
@@ -86,7 +91,7 @@ func (v *semverValue) Set(s string) error {
 func (v *semverValue) Type() string { return "semver" }
 
 // String implements pflag.Value interface.
-func (v *semverValue) String() string { return "v" + v.value.String() }
+func (v *semverValue) String() string { return v.prefix + v.value.String() }
 
 // Semver returns a pflag.Value that parses and stores a semantic version.
 //
@@ -96,6 +101,12 @@ func (v *semverValue) String() string { return "v" + v.value.String() }
 // The returned value is initialized with defaultValue, which is used until Set
 // is called successfully.
 func Semver(defaultValue string, validators ...SemverValidateFunc) pflag.Value {
+	var prefix string
+
+	if strings.HasPrefix(defaultValue, "v") {
+		prefix = "v"
+	}
+
 	v, err := semver.ParseTolerant(defaultValue)
 	if err != nil {
 		panic(err)
@@ -103,6 +114,7 @@ func Semver(defaultValue string, validators ...SemverValidateFunc) pflag.Value {
 
 	return &semverValue{
 		value:      v,
+		prefix:     prefix,
 		validators: validators,
 	}
 }

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -41,7 +41,7 @@ func List(config config.Config) Versions {
 
 	images.Etcd = mustParseTag(config.Cluster().Etcd().Image())
 	images.CoreDNS = mustParseTag(config.K8sCoreDNSConfig().Image())
-	images.Flannel = mustParseTag(fmt.Sprintf("ghcr.io/siderolabs/flannel:%s", constants.FlannelVersion)) // mirrored from docker.io/flannelcni/flannel
+	images.Flannel = mustParseTag(fmt.Sprintf("ghcr.io/siderolabs/flannel:%s", constants.FlannelVersion)) // mirrored from docker.io/flannel/flannel
 	images.Kubelet = mustParseTag(config.Machine().Kubelet().Image())
 	images.KubeAPIServer = mustParseTag(config.K8sAPIServerConfig().Image())
 	images.KubeControllerManager = mustParseTag(config.K8sControllerManagerConfig().Image())

--- a/pkg/machinery/config/types/k8s/coredns_test.go
+++ b/pkg/machinery/config/types/k8s/coredns_test.go
@@ -27,7 +27,7 @@ func TestKubeCoreDNSConfigMarshalStability(t *testing.T) {
 
 	cfg := k8s.NewKubeCoreDNSConfigV1Alpha1()
 	cfg.PodEnabled = new(true)
-	cfg.PodImage = constants.CoreDNSImage + ":" + constants.DefaultCoreDNSVersion
+	cfg.PodImage = constants.CoreDNSImage + ":v1.14.2"
 
 	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestKubeCoreDNSConfigUnmarshal(t *testing.T) {
 			MetaKind:       k8s.KubeCoreDNSConfig,
 		},
 		PodEnabled: new(true),
-		PodImage:   constants.CoreDNSImage + ":" + constants.DefaultCoreDNSVersion,
+		PodImage:   constants.CoreDNSImage + ":v1.14.2",
 	}, docs[0])
 }
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -402,7 +402,7 @@ const (
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
 	// renovate: datasource=docker depName=registry.k8s.io/coredns/coredns
-	DefaultCoreDNSVersion = "v1.14.2"
+	DefaultCoreDNSVersion = "v1.14.4"
 
 	// LabelNodeRoleControlPlane is the node label required by a control plane node.
 	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
@@ -1241,11 +1241,11 @@ const (
 	// FlannelVersion is the version of flannel to use.
 	//
 	// Note: while updating, make sure to copy flannel image from docker.io to ghcr.io:
-	//   crane cp docker.io/flannel/flannel:vX.Y.Z ghcr.io/siderolabs/flannel:vX.Y.Z
+	//   crane cp docker.io/flannel/flannel:X.Y.Z ghcr.io/siderolabs/flannel:X.Y.Z
 	// And sign the image using image-signer.
 	//
 	// renovate: datasource=github-releases depName=flannel-io/flannel
-	FlannelVersion = "v0.28.5"
+	FlannelVersion = "0.28.7"
 
 	// FlannelDefaultBackend is the default backend for flannel.
 	FlannelDefaultBackend = "vxlan"
@@ -1256,7 +1256,7 @@ const (
 	// KubeNetworkPoliciesVersion is the version of kube-network-policies when network policies are enabled for flannel.
 	//
 	// renovate: datasource=docker depName=registry.k8s.io/networking/kube-network-policies
-	KubeNetworkPoliciesVersion = "v1.0.0"
+	KubeNetworkPoliciesVersion = "v1.1.0"
 
 	// PlatformMetal is the name of the metal platform.
 	PlatformMetal = "metal"

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -2515,12 +2515,12 @@ talosctl image k8s-bundle [flags]
 ### Options
 
 ```
-      --coredns-version semver                 CoreDNS semantic version (default v1.14.2)
+      --coredns-version semver                 CoreDNS semantic version (default v1.14.4)
       --etcd-version semver                    ETCD semantic version (default v3.7.0)
-      --flannel-version semver                 Flannel CNI semantic version (default v0.28.5)
+      --flannel-version semver                 Flannel CNI semantic version (default 0.28.7)
   -h, --help                                   help for k8s-bundle
       --k8s-version semver                     Kubernetes semantic version (default v1.36.2)
-      --kube-network-policies-version semver   kube-network-policies semantic version (default v1.0.0)
+      --kube-network-policies-version semver   kube-network-policies semantic version (default v1.1.0)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/v1.14/reference/configuration/kubernetes/kubecorednsconfig.md
+++ b/website/content/v1.14/reference/configuration/kubernetes/kubecorednsconfig.md
@@ -17,7 +17,7 @@ title: KubeCoreDNSConfig
 apiVersion: v1alpha1
 kind: KubeCoreDNSConfig
 enabled: true # By default, CoreDNS deployment is enabled.
-image: registry.k8s.io/coredns/coredns:v1.14.2 # The container image used to run the CoreDNS.
+image: registry.k8s.io/coredns/coredns:v1.14.4 # The container image used to run the CoreDNS.
 {{< /highlight >}}
 
 


### PR DESCRIPTION
CoreDNS: 1.14.4 (multi-arch)
Flannel: 0.28.7 (they changed tags to skip `v`)
KubeNetworkPolicies: 1.1.0 (used with Flannel)
