### PR TITLE
fix: enable `noexec` for EPHEMERAL only for new machines

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -141,12 +141,16 @@ DHCPv4 configuration now supports `ignoreRoutes` option to ignore routes provide
 [notes.EPHEMERAL]
         title = "noexec on EPHEMERAL (/var)"
         description = """\
-The EPHEMERAL volume (`/var`) is now mounted with `noexec` in addition to the existing `nosuid` and `nodev`,
-blocking binary execution from `/var`.
+Talos 1.14 clusters now default the EPHEMERAL volume (`/var`) to `noexec` in addition to the existing `nosuid` and `nodev`
+mount options through generated machine configuration.
 
-Workloads that exec binaries placed under `/var` will break.
-For example, Longhorn v1's `instance-manager` exec's engine binaries the `engine-image` DaemonSet drops under `/var/lib/longhorn/engine-binaries/`,
-which now fails with `permission denied`. Affected users can opt out via a `VolumeConfig` document:
+Existing machines are not affected on upgrades.
+
+Note: Workloads that execute binaries placed under `/var` can break on new machines.
+Longhorn v1 and [vCluster](https://www.vcluster.com/docs/vcluster/troubleshoot/noexec-emptydir-volumes) are known to be affected.
+For example, Longhorn v1's `instance-manager` executes engine binaries that the `engine-image` DaemonSet places under
+`/var/lib/longhorn/engine-binaries/`, which now fails with `permission denied`.
+Affected users can opt out via a `VolumeConfig` document:
 
 ```yaml
 apiVersion: v1alpha1
@@ -158,7 +162,7 @@ mount:
 
 > NOTE: Setting `secure: false` will also disable `nosuid` and `nodev`, which may have security implications. Use with caution.
 
-Upgrade note: apply this `VolumeConfig` patch *before* upgrading, otherwise affected workloads will fail after the next reboot. Longhorn v2 (SPDK data engine) runs the data plane inside the instance manager process and is not affected.
+Longhorn v2 (SPDK data engine) runs the data plane inside the instance manager process and is not affected.
 """
 
     [notes.DoT]

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
@@ -7,6 +7,7 @@ package volumeconfig_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -450,7 +451,7 @@ func TestEphemeralVolumeTransformerWithExtraConfig(t *testing.T) {
 func TestEphemeralVolumeSecure(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default is secure", func(t *testing.T) {
+	t.Run("default is not secure", func(t *testing.T) {
 		t.Parallel()
 
 		transformer := volumeconfig.GetEphemeralVolumeTransformer(false)
@@ -460,17 +461,15 @@ func TestEphemeralVolumeSecure(t *testing.T) {
 
 		testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
 			require.NoError(t, err)
-			assert.True(t, vc.TypedSpec().Mount.Secure, "EPHEMERAL should be secure by default")
+			assert.False(t, vc.TypedSpec().Mount.Secure, "EPHEMERAL should not be secure without explicit configuration")
 		})
 	})
 
-	t.Run("secure=false via VolumeConfig overrides default", func(t *testing.T) {
+	t.Run("VolumeConfig defaults to secure", func(t *testing.T) {
 		t.Parallel()
 
-		secureOff := false
 		ephemeralCfg := blockcfg.NewVolumeConfigV1Alpha1()
 		ephemeralCfg.MetaName = constants.EphemeralPartitionLabel
-		ephemeralCfg.MountSpec.MountSecure = &secureOff
 
 		cfg, err := container.New(baseCfg.DeepCopy(), ephemeralCfg)
 		require.NoError(t, err)
@@ -482,9 +481,32 @@ func TestEphemeralVolumeSecure(t *testing.T) {
 
 		testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
 			require.NoError(t, err)
-			assert.False(t, vc.TypedSpec().Mount.Secure, "EPHEMERAL Secure should be overridable via VolumeConfig")
+			assert.True(t, vc.TypedSpec().Mount.Secure)
 		})
 	})
+
+	for _, secure := range []bool{false, true} {
+		t.Run(fmt.Sprintf("secure=%t via VolumeConfig", secure), func(t *testing.T) {
+			t.Parallel()
+
+			ephemeralCfg := blockcfg.NewVolumeConfigV1Alpha1()
+			ephemeralCfg.MetaName = constants.EphemeralPartitionLabel
+			ephemeralCfg.MountSpec.MountSecure = &secure
+
+			cfg, err := container.New(baseCfg.DeepCopy(), ephemeralCfg)
+			require.NoError(t, err)
+
+			transformer := volumeconfig.GetEphemeralVolumeTransformer(false)
+			resources, err := transformer(cfg)
+			require.NoError(t, err)
+			require.Len(t, resources, 1)
+
+			testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, secure, vc.TypedSpec().Mount.Secure)
+			})
+		})
+	}
 }
 
 func testTransformFunc(t *testing.T,

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -10,6 +10,7 @@ import (
 	"github.com/siderolabs/gen/optional"
 
 	"github.com/siderolabs/talos/pkg/machinery/cel"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
@@ -54,10 +55,12 @@ func (w volumesConfigWrapper) ByName(name string) (VolumeConfig, bool) {
 		}
 	}
 
-	return emptyVolumeConfig{}, false
+	return emptyVolumeConfig{secure: name != constants.EphemeralPartitionLabel}, false
 }
 
-type emptyVolumeConfig struct{}
+type emptyVolumeConfig struct {
+	secure bool
+}
 
 func (emptyVolumeConfig) Name() string {
 	return ""
@@ -95,22 +98,24 @@ func (emptyVolumeConfig) MaxSizeNegative() bool {
 	return false
 }
 
-func (emptyVolumeConfig) Mount() VolumeMountConfig {
-	return emptyVolumeMountConfig{}
+func (config emptyVolumeConfig) Mount() VolumeMountConfig {
+	return emptyVolumeMountConfig(config)
 }
 
 func (emptyVolumeConfig) Trim() VolumeTrimConfig {
 	return nil
 }
 
-type emptyVolumeMountConfig struct{}
+type emptyVolumeMountConfig struct {
+	secure bool
+}
 
 func (emptyVolumeMountConfig) DisableAccessTime() bool {
 	return false
 }
 
-func (emptyVolumeMountConfig) Secure() bool {
-	return true
+func (config emptyVolumeMountConfig) Secure() bool {
+	return config.secure
 }
 
 func (emptyVolumeMountConfig) ReadOnly() bool {

--- a/pkg/machinery/config/config/volume_test.go
+++ b/pkg/machinery/config/config/volume_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+func TestEmptyVolumeMountSecureDefault(t *testing.T) {
+	t.Parallel()
+
+	volumes := config.WrapVolumesConfigList()
+
+	for _, test := range []struct {
+		name   string
+		secure bool
+	}{
+		{
+			name: constants.EphemeralPartitionLabel,
+		},
+		{
+			name:   constants.StatePartitionLabel,
+			secure: true,
+		},
+		{
+			name:   "FUTURE_VOLUME",
+			secure: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			volume, ok := volumes.ByName(test.name)
+			require.False(t, ok)
+			assert.Equal(t, test.secure, volume.Mount().Secure())
+		})
+	}
+}

--- a/pkg/machinery/config/generate/block.go
+++ b/pkg/machinery/config/generate/block.go
@@ -15,8 +15,12 @@ func (in *Input) generateBlockConfigs() []config.Document {
 		return nil
 	}
 
+	ephemeralConfig := block.NewVolumeConfigV1Alpha1()
+	ephemeralConfig.MetaName = constants.EphemeralPartitionLabel
+	ephemeralConfig.MountSpec.MountSecure = new(true)
+
 	trimConfig := block.NewFilesystemTrimConfigV1Alpha1()
 	trimConfig.TrimInterval = constants.DefaultFilesystemTrimInterval
 
-	return []config.Document{trimConfig}
+	return []config.Document{ephemeralConfig, trimConfig}
 }

--- a/pkg/machinery/config/generate/generate_test.go
+++ b/pkg/machinery/config/generate/generate_test.go
@@ -19,6 +19,7 @@ import (
 	mc "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/role"
@@ -165,6 +166,61 @@ func TestGenerateRegistryMirrorsOrder(t *testing.T) {
 	named, ok = registryConfigs[1].(mc.NamedDocument)
 	require.True(t, ok)
 	assert.Equal(t, "b.com", named.Name())
+}
+
+func TestGenerateEphemeralVolumeConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name            string
+		versionContract *config.VersionContract
+		expectConfig    bool
+	}{
+		{
+			name:         "current",
+			expectConfig: true,
+		},
+		{
+			name:            "1.14",
+			versionContract: config.TalosVersion1_14,
+			expectConfig:    true,
+		},
+		{
+			name:            "1.13",
+			versionContract: config.TalosVersion1_13,
+		},
+	} {
+		for _, machineType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
+			t.Run(fmt.Sprintf("%s/%s", test.name, machineType), func(t *testing.T) {
+				t.Parallel()
+
+				input, err := generate.NewInput(
+					"test",
+					"https://10.0.1.5:6443",
+					constants.DefaultKubernetesVersion,
+					generate.WithVersionContract(test.versionContract),
+				)
+				require.NoError(t, err)
+
+				cfg, err := input.Config(machineType)
+				require.NoError(t, err)
+
+				volumeConfig, ok := cfg.Volumes().ByName(constants.EphemeralPartitionLabel)
+				require.Equal(t, test.expectConfig, ok)
+
+				if !ok {
+					assert.False(t, volumeConfig.Mount().Secure())
+
+					return
+				}
+
+				ephemeralConfig, ok := volumeConfig.(*blockcfg.VolumeConfigV1Alpha1)
+				require.True(t, ok)
+				require.NotNil(t, ephemeralConfig.MountSpec.MountSecure)
+				assert.True(t, *ephemeralConfig.MountSpec.MountSecure)
+			})
+		}
+	}
 }
 
 // TestGenerateDiscoveryServiceConfig verifies that discovery config generation is gated on the version contract:

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
@@ -46,6 +46,12 @@ hostDNS:
     forwardKubeDNSToHost: true
 ---
 apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+mount:
+    secure: true
+---
+apiVersion: v1alpha1
 kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-worker.yaml
@@ -40,6 +40,12 @@ hostDNS:
     forwardKubeDNSToHost: true
 ---
 apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+mount:
+    secure: true
+---
+apiVersion: v1alpha1
 kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
@@ -70,6 +70,12 @@ params:
     foo: bar
 ---
 apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+mount:
+    secure: true
+---
+apiVersion: v1alpha1
 kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-worker.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-worker.yaml
@@ -61,6 +61,12 @@ params:
     foo: bar
 ---
 apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+mount:
+    secure: true
+---
+apiVersion: v1alpha1
 kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---


### PR DESCRIPTION
Enable `noexec` for EPHEMERAL for newly created machines only.

Fixes: #13720