### PR TITLE
fix: add ca-certificates to talosctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -671,6 +671,7 @@ COPY --link --from=talosctl-windows-arm64 / /
 
 FROM scratch AS talosctl
 ARG TARGETARCH
+COPY --link --from=pkg-ca-certificates /etc/ssl/certs/ca-certificates /etc/ssl/certs/ca-certificates
 COPY --link --from=talosctl-all /talosctl-linux-${TARGETARCH} /talosctl
 ARG TAG
 ENV VERSION=${TAG}


### PR DESCRIPTION
Add ca-certificates to talostl image, so actions
like `talosctl images talos-bundle` don't fail
with certificate errors.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
