### PR TITLE
fix(talosctl): uncordon nodes when a drain fails

### DIFF
--- a/cmd/talosctl/cmd/talos/drain.go
+++ b/cmd/talosctl/cmd/talos/drain.go
@@ -30,6 +30,12 @@ type nodeUpdate struct {
 // and performs cordon + drain on all of them in parallel.
 //
 // It returns a map of talosIP -> k8sNodeName for use in the uncordon phase.
+//
+// On error the map is still returned (partially populated): each node name is
+// recorded before that node is cordoned, so the map holds every node that may
+// have been cordoned before the failure. A caller that proceeds past a failed
+// drain (e.g. the upgrade path, which has already staged a new image on disk)
+// can then still uncordon those nodes instead of leaving them SchedulingDisabled.
 func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
 	// For kubeconfig - build a random endpoint client (to go to the controlplane).
 	c, err := clientFactory.BuildRandomEndpointClient(ctx)
@@ -103,7 +109,10 @@ func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainT
 	<-aggregatorDone
 
 	if err != nil {
-		return nil, err
+		// Return the partially-populated map alongside the error: it holds the
+		// nodes that were cordoned before the failure, so a caller that continues
+		// past a failed drain can still uncordon them.
+		return k8sNames, err
 	}
 
 	return k8sNames, nil

--- a/cmd/talosctl/cmd/talos/drain.go
+++ b/cmd/talosctl/cmd/talos/drain.go
@@ -29,7 +29,10 @@ type nodeUpdate struct {
 // drainNodes runs Phase 1: resolves the Kubernetes node name for each Talos node
 // and performs cordon + drain on all of them in parallel.
 //
-// It returns a map of talosIP -> k8sNodeName for use in the uncordon phase.
+// It returns a map of talosIP -> k8sNodeName for use in the uncordon phase. The
+// map is returned on error too: each name is recorded before that node is
+// cordoned, so it holds every node that may have been cordoned before the
+// failure and the caller can restore them.
 func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainTimeout time.Duration, rep *reporter.Reporter) (map[string]string, error) {
 	// For kubeconfig - build a random endpoint client (to go to the controlplane).
 	c, err := clientFactory.BuildRandomEndpointClient(ctx)
@@ -103,17 +106,39 @@ func drainNodes(ctx context.Context, clientFactory *global.ClientFactory, drainT
 	<-aggregatorDone
 
 	if err != nil {
-		return nil, err
+		return k8sNames, err
 	}
 
 	return k8sNames, nil
 }
 
-// uncordonNodes runs Phase 3: waits for each Kubernetes node to become Ready,
-// then uncordons all of them in parallel.
+// uncordonAbortTimeout bounds the uncordon that follows a failed drain. That path
+// runs detached from the caller's context, so it needs a ceiling of its own. The
+// budget is dominated by fetching the admin kubeconfig over the Talos API rather
+// than by the get and the at-most-one patch per node.
+const uncordonAbortTimeout = time.Minute
+
+// uncordonNodes runs Phase 3: waits for each node recorded by drainNodes to become
+// Ready, then uncordons them in parallel.
 //
 // nodeNames maps talosIP -> k8sNodeName (produced by drainNodes).
-func uncordonNodes(ctx context.Context, clientFactory *global.ClientFactory, nodeNames map[string]string, timeout time.Duration, rep *reporter.Reporter) error {
+//
+// afterFailedDrain marks the abort path, where nothing was rebooted and so there
+// is no readiness to wait for. Waiting anyway would poll any node that is not
+// Ready for the full timeout and then leave it cordoned. That path also detaches
+// from ctx, which is already canceled whenever the drain failed because the
+// operator interrupted it.
+func uncordonNodes(
+	ctx context.Context, clientFactory *global.ClientFactory, nodeNames map[string]string,
+	timeout time.Duration, afterFailedDrain bool, rep *reporter.Reporter,
+) error {
+	if afterFailedDrain {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), uncordonAbortTimeout)
+		defer cancel()
+	}
+
 	// For kubeconfig - build a random endpoint client (to go to the controlplane).
 	c, err := clientFactory.BuildRandomEndpointClient(ctx)
 	if err != nil {
@@ -151,13 +176,15 @@ func uncordonNodes(ctx context.Context, clientFactory *global.ClientFactory, nod
 				updateCh <- nodeUpdate{node: k8sNodeName, update: upd}
 			}
 
-			reportFn(reporter.Update{
-				Message: fmt.Sprintf("%s: waiting for node to become Ready", k8sNodeName),
-				Status:  reporter.StatusRunning,
-			})
+			if !afterFailedDrain {
+				reportFn(reporter.Update{
+					Message: fmt.Sprintf("%s: waiting for node to become Ready", k8sNodeName),
+					Status:  reporter.StatusRunning,
+				})
 
-			if waitErr := nodedrain.WaitForNodeReady(ctx, clientset, k8sNodeName, timeout); waitErr != nil {
-				return fmt.Errorf("error waiting for node %q to become Ready: %w", k8sNodeName, waitErr)
+				if waitErr := nodedrain.WaitForNodeReady(ctx, clientset, k8sNodeName, timeout); waitErr != nil {
+					return fmt.Errorf("error waiting for node %q to become Ready: %w", k8sNodeName, waitErr)
+				}
 			}
 
 			return nodedrain.Uncordon(ctx, clientset, k8sNodeName, reportFn)

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -76,15 +76,24 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 	}
 
 	nodeNames, err := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rep)
+
+	// Register the uncordon before checking the error: on a partial drain failure
+	// drainNodes still returns the nodes it managed to cordon. Unlike upgrade there
+	// is no staged image forcing us onward, so aborting the reboot is fine - but the
+	// nodes that were cordoned must still be restored to schedulable rather than left
+	// SchedulingDisabled. On the abort path the nodes never rebooted, so the deferred
+	// WaitForNodeReady returns immediately and the uncordon proceeds.
+	defer func() {
+		if len(nodeNames) > 0 {
+			if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, rebootCmdFlags.timeout, rep); uncordonErr != nil {
+				retErr = errors.Join(retErr, uncordonErr)
+			}
+		}
+	}()
+
 	if err != nil {
 		return fmt.Errorf("error draining nodes: %w", err)
 	}
-
-	defer func() {
-		if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, rebootCmdFlags.timeout, rep); uncordonErr != nil {
-			retErr = errors.Join(retErr, uncordonErr)
-		}
-	}()
 
 	return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 }

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -75,16 +75,23 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 		return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 	}
 
-	nodeNames, err := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rep)
-	if err != nil {
-		return fmt.Errorf("error draining nodes: %w", err)
-	}
+	nodeNames, drainErr := drainNodes(ctx, clientFactory, rebootCmdFlags.drainTimeout, rep)
 
+	// Registered before the error check so that an aborted reboot still restores
+	// whatever the drain had already cordoned.
 	defer func() {
-		if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, rebootCmdFlags.timeout, rep); uncordonErr != nil {
-			retErr = errors.Join(retErr, uncordonErr)
+		if len(nodeNames) > 0 {
+			if uncordonErr := uncordonNodes(
+				ctx, clientFactory, nodeNames, rebootCmdFlags.timeout, drainErr != nil, rep,
+			); uncordonErr != nil {
+				retErr = errors.Join(retErr, uncordonErr)
+			}
 		}
 	}()
+
+	if drainErr != nil {
+		return fmt.Errorf("error draining nodes: %w", drainErr)
+	}
 
 	return rebootInternal(ctx, clientFactory, rebootCmdFlags.wait, rebootCmdFlags.debug, rebootCmdFlags.timeout, rep, opts...)
 }

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -145,23 +145,22 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 	var nodeNames map[string]string
 
 	if upgradeCmdFlags.drain {
+		// Register the uncordon before draining: drainNodes returns the nodes it
+		// cordoned even on error, so a drain that fails after cordoning some nodes
+		// no longer leaves them SchedulingDisabled when the upgrade aborts below.
+		defer func() {
+			if len(nodeNames) > 0 {
+				if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, upgradeCmdFlags.timeout, rep); uncordonErr != nil {
+					retErr = errors.Join(retErr, uncordonErr)
+				}
+			}
+		}()
+
 		nodeNames, err = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, rep)
 		if err != nil {
 			return err
 		}
 	}
-
-	defer func() {
-		if !upgradeCmdFlags.drain {
-			return
-		}
-
-		if len(nodeNames) > 0 {
-			if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, upgradeCmdFlags.timeout, rep); uncordonErr != nil {
-				retErr = errors.Join(retErr, uncordonErr)
-			}
-		}
-	}()
 
 	if !upgradeCmdFlags.noReboot {
 		err = rebootInternal(ctx, clientFactory, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -145,23 +145,25 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 	var nodeNames map[string]string
 
 	if upgradeCmdFlags.drain {
-		nodeNames, err = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, rep)
-		if err != nil {
-			return err
+		var drainErr error
+
+		// Registered before the drain so that an aborted upgrade still restores
+		// whatever the drain had already cordoned.
+		defer func() {
+			if len(nodeNames) > 0 {
+				if uncordonErr := uncordonNodes(
+					ctx, clientFactory, nodeNames, upgradeCmdFlags.timeout, drainErr != nil, rep,
+				); uncordonErr != nil {
+					retErr = errors.Join(retErr, uncordonErr)
+				}
+			}
+		}()
+
+		nodeNames, drainErr = drainNodes(ctx, clientFactory, upgradeCmdFlags.drainTimeout, rep)
+		if drainErr != nil {
+			return drainErr
 		}
 	}
-
-	defer func() {
-		if !upgradeCmdFlags.drain {
-			return
-		}
-
-		if len(nodeNames) > 0 {
-			if uncordonErr := uncordonNodes(ctx, clientFactory, nodeNames, upgradeCmdFlags.timeout, rep); uncordonErr != nil {
-				retErr = errors.Join(retErr, uncordonErr)
-			}
-		}
-	}()
 
 	if !upgradeCmdFlags.noReboot {
 		err = rebootInternal(ctx, clientFactory, upgradeCmdFlags.wait, upgradeCmdFlags.debug, upgradeCmdFlags.timeout, rep, opts...)


### PR DESCRIPTION
## What? (description)

When `talosctl upgrade` or `talosctl reboot --drain` drains the Kubernetes node before rebooting and the drain fails after cordoning one or more nodes, those nodes are left `SchedulingDisabled`. The early `return` on a drain error fires before the uncordon defer is registered, and `drainNodes` returns a `nil` map on error — discarding even the nodes it successfully cordoned — so nothing uncordons them.

This makes `drainNodes` return the partially-populated map alongside the error, and registers the uncordon defer before the drain error check in both callers, so a failed drain restores the nodes it cordoned instead of stranding them.

## Why? (reasoning)

`drainNodes` records each node name before cordoning it, then cordons and evicts. If cordoning succeeds but the drain then fails (eviction timeout, PDB blocking, apiserver hiccup), the node is already cordoned. The old `return nil, err` threw away that set, and the callers returned before their uncordon defer was in scope, so the operator was left with `SchedulingDisabled` nodes after an already-failed command.

The reboot decision is unchanged: `upgrade` still aborts on a failed drain (the staged image is applied by a later reboot, and whether to reboot is the caller's call). This PR only ensures a failed drain does not leave nodes cordoned.

## Acceptance

- [ ] you linked an issue (if applicable) — N/A
- [ ] you included tests (if applicable) — the drain/upgrade/reboot paths take a live `*global.ClientFactory` + gRPC + k8s clientset with no mock seam, and the package has no unit tests for this flow
- [ ] you ran conformance (`make conformance`) — not run (containerized)
- [x] you formatted your code (`make fmt`) — `gofmt` clean
- [ ] you linted your code (`make lint`) — not run (needs repo container plugin)
- [ ] you generated documentation (`make docs`) — N/A
- [ ] you ran unit-tests (`make unit-tests`) — not run (containerized)

Verified locally: `go build ./cmd/talosctl/...`, `go vet ./cmd/talosctl/cmd/talos/...`, `gofmt`.



One behaviour here goes past the original request: interrupting a drain with Ctrl+C. A drain runs under a context that SIGINT cancels, so without this the uncordon this PR adds would fail before it starts, and an interrupted drain would leave the nodes SchedulingDisabled. The uncordon on that path therefore runs on a context detached from the caller's, with a one minute ceiling. A second Ctrl+C still aborts immediately, because the signal handler restores the default disposition after the first one. If you would rather keep this PR to the plain uncordon fix, I can move that part to a separate PR.
