### PR TITLE
fix: support persistent volumemount requests for services

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -2,8 +2,8 @@ ignore_ttl: 168h # 7 days, each entry must be revalidated after this time, and e
 
 ignore:
   - id: GO-2026-5932
-    reason: No fix available; golang.org/x/crypto/openpgp only reachable via cosign legacy PGP signature verification, which Talos does not use (sigstore-based verification).
-    date: 2026-07-16
+    reason: No fix available. golang.org/x/crypto/openpgp is imported transitively because Cosign pulls Rekor's legacy rekord/v0.0.1 PGP implementation. Talos verifies Sigstore/X.509 signatures and does not use PGP; Cosign's legacy .sig path is an OCI storage format, not PGP. The reported PCR, error, io.Reader/io.Writer, and DSSE-to-rekord call chains are govulncheck VTA interface/factory false positives.
+    date: 2026-07-21
   - id: GO-2026-4736
-    reason: 'gobgp NEXT_HOP DoS (GHSA-4p9m-8gc4-rw2h). The advisory records no fixed version, so govulncheck flags every version, but the fix commit osrg/gobgp 583080a7 (2026-03-05, malformed nexthop attribute crash) is already an ancestor of the pinned commit 2132288c5159 (2026-06-29) so the code is not actually affected.'
-    date: 2026-07-14
+    reason: 'gobgp NEXT_HOP DoS (GHSA-4p9m-8gc4-rw2h). The reachable recvMessageloop symbol is real, but the advisory records no fixed version, so govulncheck flags every version. Fix commit osrg/gobgp 583080a7 is an ancestor of pinned commit 2132288c5159, whose source skips ValidateUpdateMsg when parsing has already selected error handling, so it is not affected.'
+    date: 2026-07-21

--- a/internal/app/machined/pkg/controllers/block/volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config.go
@@ -43,30 +43,43 @@ func (ctrl *VolumeConfigController) Name() string {
 
 // Inputs implements controller.Controller interface.
 func (ctrl *VolumeConfigController) Inputs() []controller.Input {
-	return []controller.Input{
-		{
+	inputs := make([]controller.Input, 0, 4+len(constants.Overlays))
+
+	inputs = append(inputs,
+		controller.Input{
 			Namespace: config.NamespaceName,
 			Type:      config.MachineConfigType,
 			ID:        optional.Some(config.ActiveID),
 			Kind:      controller.InputWeak,
 		},
-		{
+		controller.Input{
 			Namespace: runtime.NamespaceName,
 			Type:      runtime.MetaKeyType,
 			ID:        optional.Some(runtime.MetaKeyTagToID(meta.StateEncryptionConfig)),
 			Kind:      controller.InputWeak,
 		},
-		{
+		controller.Input{
 			Namespace: block.NamespaceName,
 			Type:      block.VolumeMountRequestType,
 			Kind:      controller.InputDestroyReady,
 		},
-		{
+		controller.Input{
 			Namespace: block.NamespaceName,
 			Type:      block.VolumeConfigType,
 			Kind:      controller.InputDestroyReady,
 		},
+	)
+
+	for _, overlay := range constants.Overlays {
+		inputs = append(inputs, controller.Input{
+			Namespace: block.NamespaceName,
+			Type:      block.MountStatusType,
+			ID:        optional.Some(overlay.Path),
+			Kind:      controller.InputWeak,
+		})
 	}
+
+	return inputs
 }
 
 // Outputs implements controller.Controller interface.
@@ -117,6 +130,10 @@ func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtim
 			cfg = machineCfg.Config()
 		}
 
+		if err = ctrl.reconcileOverlayMountRequests(ctx, r); err != nil {
+			return err
+		}
+
 		if err := ctrl.setupStateEncryption(ctx, logger, cfg); err != nil {
 			return err
 		}
@@ -152,6 +169,35 @@ func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtim
 			return fmt.Errorf("error cleaning up unused volumes: %w", err)
 		}
 	}
+}
+
+func (ctrl *VolumeConfigController) reconcileOverlayMountRequests(ctx context.Context, r controller.ReaderWriter) error {
+	for _, overlay := range constants.Overlays {
+		// Let the service mount the overlay first, then adopt it to keep it mounted across service restarts.
+		mountStatus, err := safe.ReaderGetByID[*block.MountStatus](ctx, r, overlay.Path)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return fmt.Errorf("failed to get overlay mount status %q: %w", overlay.Path, err)
+		}
+
+		if mountStatus.Metadata().Phase() != resource.PhaseRunning {
+			continue
+		}
+
+		if err = safe.WriterModify(ctx, r, block.NewVolumeMountRequest(block.NamespaceName, overlay.Path), func(request *block.VolumeMountRequest) error {
+			request.TypedSpec().Requester = ctrl.Name()
+			request.TypedSpec().VolumeID = overlay.Path
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to create overlay mount request %q: %w", overlay.Path, err)
+		}
+	}
+
+	return nil
 }
 
 func (ctrl *VolumeConfigController) setupStateEncryption(ctx context.Context, l *zap.Logger, cfg configconfig.Config) error { //nolint:gocyclo

--- a/internal/app/machined/pkg/controllers/block/volume_config_test.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config_test.go
@@ -99,6 +99,10 @@ func (suite *VolumeConfigSuite) TestReconcileDefaults() {
 	})
 	ctest.AssertNoResource[*block.VolumeConfig](suite, constants.EphemeralPartitionLabel)
 
+	for _, overlay := range constants.Overlays {
+		ctest.AssertNoResource[*block.VolumeMountRequest](suite, overlay.Path)
+	}
+
 	// create a dummy machine config
 	u, err := url.Parse("https://foo:6443")
 	suite.Require().NoError(err)
@@ -186,6 +190,44 @@ func (suite *VolumeConfigSuite) TestReconcileDefaults() {
 		func(r *block.VolumeConfig, asrt *assert.Assertions) {
 			asrt.Equal(block.VolumeTypeOverlay, r.TypedSpec().Type)
 		})
+
+	for _, overlay := range constants.Overlays {
+		ctest.AssertNoResource[*block.VolumeMountRequest](suite, overlay.Path)
+	}
+
+	for _, overlay := range constants.Overlays {
+		mountStatus := block.NewMountStatus(block.NamespaceName, overlay.Path)
+		mountStatus.TypedSpec().Spec.VolumeID = overlay.Path
+		mountStatus.TypedSpec().Target = overlay.Path
+		suite.Create(mountStatus)
+	}
+
+	ctest.AssertResources(suite,
+		xslices.Map(constants.Overlays, func(target constants.SELinuxLabeledPath) resource.ID {
+			return target.Path
+		}),
+		func(r *block.VolumeMountRequest, asrt *assert.Assertions) {
+			asrt.Equal(r.Metadata().ID(), r.TypedSpec().VolumeID)
+			asrt.Equal("block.VolumeConfigController", r.TypedSpec().Requester)
+			asrt.Empty(r.Metadata().Labels().Raw())
+		})
+
+	for _, overlay := range constants.Overlays {
+		mountStatus := block.NewMountStatus(block.NamespaceName, overlay.Path)
+		suite.Require().NoError(suite.State().AddFinalizer(suite.Ctx(), mountStatus.Metadata(), "test"))
+
+		ready, err := suite.State().Teardown(suite.Ctx(), mountStatus.Metadata())
+		suite.Require().NoError(err)
+		suite.Require().False(ready)
+
+		// The request is a runtime-lifetime pin; volume teardown makes it inert without deleting it.
+		ctest.AssertResource(suite, overlay.Path, func(*block.VolumeMountRequest, *assert.Assertions) {})
+
+		suite.Require().NoError(suite.State().RemoveFinalizer(suite.Ctx(), mountStatus.Metadata(), "test"))
+		suite.Destroy(mountStatus)
+
+		ctest.AssertResource(suite, overlay.Path, func(*block.VolumeMountRequest, *assert.Assertions) {})
+	}
 }
 
 func (suite *VolumeConfigSuite) TestReconcileEncryptedSTATE() {


### PR DESCRIPTION
When restarting CRI we shouldn't teardown and re-create `/opt`, we need to persist it. Support transient and persistent volume requests.

Service destroy or shutdown removes both.