### PR TITLE
chore: update disvulncheck date GO-2026-4736

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -6,4 +6,4 @@ ignore:
     date: 2026-07-16
   - id: GO-2026-4736
     reason: 'gobgp NEXT_HOP DoS (GHSA-4p9m-8gc4-rw2h). The advisory records no fixed version, so govulncheck flags every version, but the fix commit osrg/gobgp 583080a7 (2026-03-05, malformed nexthop attribute crash) is already an ancestor of the pinned commit 2132288c5159 (2026-06-29) so the code is not actually affected.'
-    date: 2026-07-14
+    date: 2026-07-21


### PR DESCRIPTION
No fixes available, all versions affected
https://pkg.go.dev/vuln/GO-2026-4736
