### PR TITLE
fix: preserve trailing rate-limited trigger events

### DIFF
--- a/internal/app/machined/pkg/controllers/internal/trigger/trigger.go
+++ b/internal/app/machined/pkg/controllers/internal/trigger/trigger.go
@@ -33,7 +33,7 @@ func NewRateLimitedTrigger(ctx context.Context, trigger Trigger, rateLimit rate.
 	t := &RateLimitedTrigger{
 		trigger: trigger,
 		limiter: rate.NewLimiter(rateLimit, burst),
-		ch:      make(chan struct{}),
+		ch:      make(chan struct{}, 1),
 	}
 
 	go t.run(ctx)
@@ -53,8 +53,8 @@ func NewDefaultRateLimitedTrigger(ctx context.Context, trigger Trigger) *RateLim
 
 // QueueReconcile implements Trigger interface.
 //
-// The event is queued if the goroutine is ready to accept it (otherwise it's already
-// busy processing a previous event).
+// At most one pending event is queued while the goroutine is processing the previous event.
+// Additional events are coalesced into the pending event.
 // This function returns immediately.
 func (t *RateLimitedTrigger) QueueReconcile() {
 	select {

--- a/internal/app/machined/pkg/controllers/internal/trigger/trigger_test.go
+++ b/internal/app/machined/pkg/controllers/internal/trigger/trigger_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/internal/trigger"
 )
@@ -42,4 +44,34 @@ func TestRateLimitedTrigger(t *testing.T) {
 	}
 
 	assert.InDelta(t, int64(14), mock.Get(), 5)
+}
+
+func TestRateLimitedTriggerQueuesTrailingEvent(t *testing.T) {
+	mock := &mockTrigger{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	trig := trigger.NewRateLimitedTrigger(ctx, mock, rate.Every(250*time.Millisecond), 1)
+
+	// Consume the initial burst token.
+	trig.QueueReconcile()
+	require.Eventually(t, func() bool {
+		return mock.Get() == 1
+	}, time.Second, time.Millisecond)
+
+	baseline := mock.Get()
+
+	// The worker dequeues this event and blocks in limiter.Wait.
+	trig.QueueReconcile()
+	require.Never(t, func() bool {
+		return mock.Get() > baseline
+	}, 50*time.Millisecond, time.Millisecond)
+
+	// This event must remain pending until the rate-limited event is forwarded.
+	trig.QueueReconcile()
+
+	require.Eventually(t, func() bool {
+		return mock.Get() == baseline+2
+	}, time.Second, time.Millisecond)
 }


### PR DESCRIPTION
RateLimitedTrigger used a nonblocking send to an unbuffered channel. An event arriving while the worker forwarded the previous wakeup was dropped. If that event was the final RTM_NEWLINK transition, LinkStatus kept a stale operational state and RequireUp DHCP never started.

The natural race is narrow. Reproduce it deterministically by retaining the unbuffered channel and adding a 250ms sleep immediately after `t.trigger.QueueReconcile()` in the worker. Then run:

  make initramfs PLATFORM=linux/amd64
  _out/talosctl-darwin-arm64 cluster create dev \
    --remote-endpoint=storm.goose-piano.ts.net:50100 \
    --name dhcp-repro --cidr 172.16.0.0/24 \
    --control-plane-port 6444 --controlplanes 3 --workers 2 \
    --with-bootloader=false --skip-injecting-config \
    --skip-unattended-install-config --wait=false

This left one node without a DHCP lease even though the guest reported carrier and the host TAP and veth were both UP,LOWER_UP. The e2e-cilium job hit the same failure on control plane 3 and timed out waiting for the node Talos API:

https://github.com/siderolabs/talos/actions/runs/29801925248/job/88544517041

Before this fix, TestRateLimitedTriggerQueuesTrailingEvent also times out because the mock receives only the first reconciliation. A one-slot channel makes the test pass by retaining one pending dirty event while still coalescing bursts. With the same 250ms QEMU fault injection, all five nodes then receive DHCP leases.

Validated with the regression test for 100 iterations, the trigger package race test, the Linux TestLinkStatusSuite, and the five-node QEMU A/B test.