### PR TITLE
feat: allow "duplicate" kinds in the config patches

### DIFF
--- a/pkg/machinery/config/configdiff/mergepatch_test.go
+++ b/pkg/machinery/config/configdiff/mergepatch_test.go
@@ -304,9 +304,9 @@ kind: NetworkDefaultActionConfig
 			require.NoError(t, err)
 
 			for i, patch := range patches {
-				provider := patch.(configpatcher.StrategicMergePatch).Provider()
+				strategicPatch := patch.(configpatcher.StrategicMergePatch)
 
-				patchBytes, err := provider.Bytes()
+				patchBytes, err := strategicPatch.Bytes()
 				require.NoError(t, err)
 
 				require.Equal(t, string(patchBytes), string(tt.patchesAsBytes[i]))

--- a/pkg/machinery/config/configloader/configloader.go
+++ b/pkg/machinery/config/configloader/configloader.go
@@ -35,13 +35,17 @@ func newConfig(r io.Reader, opt ...Opt) (config config.Provider, err error) {
 	// preserve the original contents
 	r = io.TeeReader(r, &buf)
 
-	manifests, err := dec.Decode(r, opts.allowPatchDelete)
+	manifests, err := dec.Decode(r, opts.allowPatchDelete, opts.noValidation)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(manifests) == 0 {
 		return nil, ErrNoConfig
+	}
+
+	if opts.noValidation {
+		return container.NewReadonlyUnvalidated(buf.Bytes(), manifests...), nil
 	}
 
 	return container.NewReadonly(buf.Bytes(), manifests...)
@@ -77,6 +81,7 @@ func NewFromBytes(source []byte, o ...Opt) (config.Provider, error) {
 // Opts represents the options for the config loader.
 type Opts struct {
 	allowPatchDelete bool
+	noValidation     bool
 }
 
 // Opt is a functional option for the config loader.
@@ -86,6 +91,13 @@ type Opt func(*Opts)
 func WithAllowPatchDelete() Opt {
 	return func(o *Opts) {
 		o.allowPatchDelete = true
+	}
+}
+
+// WithNoValidation disables validation of the config.
+func WithNoValidation() Opt {
+	return func(o *Opts) {
+		o.noValidation = true
 	}
 }
 

--- a/pkg/machinery/config/configloader/internal/decoder/decoder.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder.go
@@ -43,8 +43,8 @@ const (
 type Decoder struct{}
 
 // Decode decodes all known manifests.
-func (d *Decoder) Decode(r io.Reader, allowPatchDelete bool) ([]config.Document, error) {
-	return parse(r, allowPatchDelete)
+func (d *Decoder) Decode(r io.Reader, allowPatchDelete, allowDuplicates bool) ([]config.Document, error) {
+	return parse(r, allowPatchDelete, allowDuplicates)
 }
 
 // NewDecoder initializes and returns a `Decoder`.
@@ -59,7 +59,7 @@ type documentID struct {
 }
 
 //nolint:gocyclo
-func parse(r io.Reader, allowPatchDelete bool) (decoded []config.Document, err error) {
+func parse(r io.Reader, allowPatchDelete, allowDuplicates bool) (decoded []config.Document, err error) {
 	// Recover from yaml.v3 panics because we rely on machine configuration loading _a lot_.
 	defer func() {
 		if p := recover(); p != nil {
@@ -123,8 +123,10 @@ func parse(r io.Reader, allowPatchDelete bool) (decoded []config.Document, err e
 				Name:       findValue(manifest, "name", false),
 			}
 
-			if _, ok := knownDocuments[id]; ok {
-				return nil, fmt.Errorf("duplicate document %s/%s/%s is not allowed (line %d)", id.APIVersion, id.Kind, id.Name, manifest.Line)
+			if !allowDuplicates {
+				if _, ok := knownDocuments[id]; ok {
+					return nil, fmt.Errorf("duplicate document %s/%s/%s is not allowed (line %d)", id.APIVersion, id.Kind, id.Name, manifest.Line)
+				}
 			}
 
 			knownDocuments[id] = struct{}{}

--- a/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
+++ b/pkg/machinery/config/configloader/internal/decoder/decoder_test.go
@@ -363,7 +363,7 @@ test: true
 			t.Parallel()
 
 			d := decoder.NewDecoder()
-			actual, err := d.Decode(bytes.NewReader(tt.source), false)
+			actual, err := d.Decode(bytes.NewReader(tt.source), false, false)
 
 			if tt.expected != nil {
 				assert.Equal(t, tt.expected, actual)
@@ -392,7 +392,7 @@ func TestDecoderV1Alpha1Config(t *testing.T) {
 			require.NoError(t, err)
 
 			d := decoder.NewDecoder()
-			_, err = d.Decode(bytes.NewReader(contents), false)
+			_, err = d.Decode(bytes.NewReader(contents), false, false)
 
 			assert.NoError(t, err)
 		})
@@ -406,9 +406,13 @@ func TestDoubleV1Alpha1(t *testing.T) {
 	contents := must.Value(files.ReadFile("v1alpha1.yaml"))(t)
 
 	d := decoder.NewDecoder()
-	_, err := d.Decode(bytes.NewReader(contents), false)
+	_, err := d.Decode(bytes.NewReader(contents), false, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "not allowed")
+
+	// now try with the allow duplicates
+	_, err = d.Decode(bytes.NewReader(contents), false, true)
+	require.NoError(t, err)
 }
 
 func BenchmarkDecoderV1Alpha1Config(b *testing.B) {
@@ -419,7 +423,7 @@ func BenchmarkDecoderV1Alpha1Config(b *testing.B) {
 
 	for b.Loop() {
 		d := decoder.NewDecoder()
-		_, err = d.Decode(bytes.NewReader(contents), false)
+		_, err = d.Decode(bytes.NewReader(contents), false, false)
 
 		assert.NoError(b, err)
 	}

--- a/pkg/machinery/config/configpatcher/apply_test.go
+++ b/pkg/machinery/config/configpatcher/apply_test.go
@@ -367,3 +367,43 @@ func TestPatchLink(t *testing.T) {
 		})
 	}
 }
+
+//go:embed testdata/patchmixed/base.yaml
+var mixedBase []byte
+
+//go:embed testdata/patchmixed/expected.yaml
+var mixedExpected string
+
+func TestPatchMixed(t *testing.T) {
+	patches, err := configpatcher.LoadPatches([]string{
+		"@testdata/patchmixed/patch.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := configloader.NewFromBytes(mixedBase)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		input configpatcher.Input
+	}{
+		{
+			name:  "WithConfig",
+			input: configpatcher.WithConfig(cfg),
+		},
+		{
+			name:  "WithBytes",
+			input: configpatcher.WithBytes(mixedBase),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := configpatcher.Apply(tt.input, patches)
+			require.NoError(t, err)
+
+			bytes, err := out.Bytes()
+			require.NoError(t, err)
+
+			assert.Equal(t, mixedExpected, string(bytes))
+		})
+	}
+}

--- a/pkg/machinery/config/configpatcher/load.go
+++ b/pkg/machinery/config/configpatcher/load.go
@@ -21,7 +21,7 @@ type patch []map[string]any
 // LoadPatch loads the strategic merge patch or JSON patch (JSON/YAML for JSON patch).
 func LoadPatch(in []byte) (Patch, error) {
 	// Try configloader first, as it is more strict about the config format
-	cfg, strategicErr := configloader.NewFromBytes(in, configloader.WithAllowPatchDelete())
+	cfg, strategicErr := configloader.NewFromBytes(in, configloader.WithAllowPatchDelete(), configloader.WithNoValidation())
 	if strategicErr == nil {
 		return NewStrategicMergePatch(cfg), nil
 	}

--- a/pkg/machinery/config/configpatcher/load_test.go
+++ b/pkg/machinery/config/configpatcher/load_test.go
@@ -73,7 +73,13 @@ func TestLoadStrategic(t *testing.T) {
 	p, ok := raw.(configpatcher.StrategicMergePatch)
 	require.True(t, ok)
 
-	assert.Equal(t, "foo.bar", p.Provider().NetworkHostnameConfig().Hostname())
+	require.Len(t, p.Documents(), 1)
+	assert.Equal(t, "v1alpha1", p.Documents()[0].Kind())
+
+	b, err := p.Bytes()
+	require.NoError(t, err)
+
+	assert.Equal(t, strategicPatch, b)
 }
 
 func TestLoadJSONPatches(t *testing.T) {

--- a/pkg/machinery/config/configpatcher/strategic.go
+++ b/pkg/machinery/config/configpatcher/strategic.go
@@ -20,7 +20,7 @@ import (
 // StrategicMergePatch is a strategic merge config patch.
 type StrategicMergePatch interface {
 	Documents() []config.Document
-	Provider() coreconfig.Provider
+	Bytes() ([]byte, error)
 }
 
 // StrategicMerge performs strategic merge config patching.
@@ -73,7 +73,9 @@ func StrategicMerge(cfg coreconfig.Provider, patch StrategicMergePatch) (corecon
 		} else if _, isSel := rightDoc.(configloader.Selector); !isSel {
 			// only append documents which are not delete selectors;
 			// a delete selector for a non-existent document is silently skipped
-			left = append(left, rightDoc)
+			cloned := rightDoc.Clone()
+			left = append(left, cloned)
+			leftIndex[id] = cloned
 		}
 	}
 
@@ -93,6 +95,6 @@ func (s strategicMergePatch) Documents() []config.Document {
 	return s.provider.Documents()
 }
 
-func (s strategicMergePatch) Provider() coreconfig.Provider { return s.provider }
+func (s strategicMergePatch) Bytes() ([]byte, error) { return s.provider.Bytes() }
 
 var _ StrategicMergePatch = strategicMergePatch{}

--- a/pkg/machinery/config/configpatcher/testdata/patchmixed/base.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchmixed/base.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1alpha1
+kind: RegistryMirrorConfig
+name: registry.k8s.io
+endpoints:
+  - url: http://172.20.0.1:5001
+---
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth0
+addresses:
+  - address: 10.0.42.136/24
+routes:
+  - gateway: 10.0.42.1

--- a/pkg/machinery/config/configpatcher/testdata/patchmixed/expected.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchmixed/expected.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1alpha1
+kind: RegistryMirrorConfig
+name: registry.k8s.io
+endpoints:
+    - url: http://172.20.0.251:50001
+skipFallback: true
+---
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth0
+addresses:
+    - address: 10.0.42.136/24
+routes:
+    - gateway: 10.0.42.1

--- a/pkg/machinery/config/configpatcher/testdata/patchmixed/patch.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patchmixed/patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1alpha1
+kind: RegistryMirrorConfig
+name: registry.k8s.io
+endpoints:
+  $patch: delete
+---
+apiVersion: v1alpha1
+kind: RegistryMirrorConfig
+name: registry.k8s.io
+endpoints:
+  - url: http://172.20.0.251:50001
+---
+apiVersion: v1alpha1
+kind: RegistryMirrorConfig
+name: registry.k8s.io
+skipFallback: true

--- a/pkg/machinery/config/container/container.go
+++ b/pkg/machinery/config/container/container.go
@@ -117,6 +117,18 @@ func NewReadonly(bytes []byte, documents ...config.Document) (*Container, error)
 	return c, nil
 }
 
+// NewReadonlyUnvalidated creates a read-only container which does not validate the documents at all.
+//
+// Some methods of the provider don't work at all for such containers.
+// This method is meant to be used only for loading config patches.
+func NewReadonlyUnvalidated(bytes []byte, documents ...config.Document) *Container {
+	return &Container{
+		documents: slices.Clone(documents),
+		bytes:     bytes,
+		readonly:  true,
+	}
+}
+
 // NewV1Alpha1 creates a container with (only) v1alpha1.Config document.
 func NewV1Alpha1(config *v1alpha1.Config) *Container {
 	return &Container{


### PR DESCRIPTION
This applies to a single multi-document config patch.

Allow the patch documents to have duplicates across kinds/names. The config patch code was re-using the path for machine configuration loading, so allow to load skipping all validations - the patches can be pretty much relaxed compared to real machine config.

Adjust patch interface to leave less assumptions on what can be done - we can either iterate over patch documents, or convert patch back to bytes.
