### PR TITLE
 fix: ignore insecure-only imager assets

### DIFF
--- a/cmd/installer/cmd/imager/root.go
+++ b/cmd/installer/cmd/imager/root.go
@@ -155,7 +155,8 @@ var rootCmd = &cobra.Command{
 
 			if cmdFlags.BaseInstallerImage != "" {
 				prof.Input.BaseInstaller = profile.ContainerAsset{
-					ImageRef: cmdFlags.BaseInstallerImage,
+					ImageRef:      cmdFlags.BaseInstallerImage,
+					ForceInsecure: cmdFlags.Insecure,
 				}
 			}
 
@@ -168,18 +169,14 @@ var rootCmd = &cobra.Command{
 
 				if _, err := name.ParseReference(cmdFlags.ImageCache, parseOpts...); err == nil {
 					prof.Input.ImageCache = profile.ContainerAsset{
-						ImageRef: cmdFlags.ImageCache,
+						ImageRef:      cmdFlags.ImageCache,
+						ForceInsecure: cmdFlags.Insecure,
 					}
 				} else {
 					prof.Input.ImageCache = profile.ContainerAsset{
 						OCIPath: cmdFlags.ImageCache,
 					}
 				}
-			}
-
-			if cmdFlags.Insecure {
-				prof.Input.BaseInstaller.ForceInsecure = cmdFlags.Insecure
-				prof.Input.ImageCache.ForceInsecure = cmdFlags.Insecure
 			}
 
 			if cmdFlags.SecurebootIncludeWellKnownCerts {


### PR DESCRIPTION
# Pull Request

## What? (description)

Fix imager asset presence checks so `forceInsecure` alone does not make a container asset configured.

Changes:
- `forceInsecure` is set only when `--base-installer-image` creates `baseInstaller`
- `forceInsecure` is set only when `--image-cache` is an image ref
- OCI image cache path is left without `forceInsecure`
- absent image cache stays absent

## Why? (reasoning)

`imager --insecure` can set `imageCache.forceInsecure: true` without an image cache image. That made imager try to pull an empty image ref.

Closes #13824

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

Targeted tests run:

```sh
GOCACHE=/tmp/talos-go-cache go test ./pkg/imager/profile ./pkg/imager
```
