### PR TITLE
fix: volume mount race (third attempt) around service restart

### DIFF
--- a/internal/app/machined/pkg/automaton/blockautomaton/volume_mount.go
+++ b/internal/app/machined/pkg/automaton/blockautomaton/volume_mount.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xerrors"
@@ -108,6 +109,12 @@ func waitForMountStatus(ctx context.Context, r controller.ReaderWriter, logger *
 	if mountStatus == nil {
 		// wait for the mount status to be established
 		return nil, xerrors.NewTaggedf[automaton.Continue]("waiting for mount status to be established")
+	}
+
+	if mountStatus.Metadata().Phase() != resource.PhaseRunning {
+		// the mount status is left over from the previous generation of the mount request, putting a finalizer
+		// on it would block its teardown forever, so wait for it to be destroyed and re-established
+		return nil, xerrors.NewTaggedf[automaton.Continue]("waiting for mount status to be torn down")
 	}
 
 	if mountStatus.TypedSpec().ReadOnly && !mountContext.options.ReadOnly {

--- a/internal/app/machined/pkg/controllers/block/mount_status.go
+++ b/internal/app/machined/pkg/controllers/block/mount_status.go
@@ -78,6 +78,33 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 					}
 				}
 
+				// first, clean up volume mount statuses which do not match any existing requesters, and finish
+				// tearing down the ones which are already tearing down (a requester might have come back
+				// while its previous volume mount status was still being destroyed)
+				volumeMountStatuses, err := safe.ReaderListAll[*block.VolumeMountStatus](ctx, r, state.WithLabelQuery(resource.LabelEqual("mount-status-id", mountStatus.Metadata().ID())))
+				if err != nil {
+					return fmt.Errorf("failed to read volume mount statuses for mount status %q: %w", mountStatus.Metadata().ID(), err)
+				}
+
+				for volumeMountStatus := range volumeMountStatuses.All() {
+					if volumeMountStatus.Metadata().Phase() == resource.PhaseRunning &&
+						slices.Contains(mountStatus.TypedSpec().Spec.RequesterIDs, volumeMountStatus.Metadata().ID()) {
+						// still active
+						continue
+					}
+
+					okToDestroy, err := r.Teardown(ctx, volumeMountStatus.Metadata())
+					if err != nil {
+						return fmt.Errorf("failed to teardown volume mount status %q: %w", volumeMountStatus.Metadata().ID(), err)
+					}
+
+					if okToDestroy {
+						if err = r.Destroy(ctx, volumeMountStatus.Metadata()); err != nil {
+							return fmt.Errorf("failed to destroy volume mount status %q: %w", volumeMountStatus.Metadata().ID(), err)
+						}
+					}
+				}
+
 				// now "explode" the mount status into volume mount statuses per requester
 				for i, requester := range mountStatus.TypedSpec().Spec.Requesters {
 					requestID := mountStatus.TypedSpec().Spec.RequesterIDs[i]
@@ -100,31 +127,17 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 							return nil
 						},
 					); err != nil {
-						return fmt.Errorf("failed to create volume mount status %q: %w", requestID, err)
-					}
-				}
+						if state.IsPhaseConflictError(err) {
+							// the previous volume mount status for this requester is still tearing down, as someone
+							// holds a finalizer on it; skip it for now, and retry once it is destroyed
+							//
+							// this should never block other requesters or other mount statuses
+							logger.Debug("waiting for volume mount status to be torn down", zap.String("volume_mount_status", requestID))
 
-				// now clean up volume mount statuses that do match any existing requesters
-				volumeMountStatuses, err := safe.ReaderListAll[*block.VolumeMountStatus](ctx, r, state.WithLabelQuery(resource.LabelEqual("mount-status-id", mountStatus.Metadata().ID())))
-				if err != nil {
-					return fmt.Errorf("failed to read volume mount statuses for mount status %q: %w", mountStatus.Metadata().ID(), err)
-				}
-
-				for volumeMountStatus := range volumeMountStatuses.All() {
-					if slices.Contains(mountStatus.TypedSpec().Spec.RequesterIDs, volumeMountStatus.Metadata().ID()) {
-						// still active
-						continue
-					}
-
-					okToDestroy, err := r.Teardown(ctx, volumeMountStatus.Metadata())
-					if err != nil {
-						return fmt.Errorf("failed to teardown volume mount status %q: %w", volumeMountStatus.Metadata().ID(), err)
-					}
-
-					if okToDestroy {
-						if err = r.Destroy(ctx, volumeMountStatus.Metadata()); err != nil {
-							return fmt.Errorf("failed to destroy volume mount status %q: %w", volumeMountStatus.Metadata().ID(), err)
+							continue
 						}
+
+						return fmt.Errorf("failed to create volume mount status %q: %w", requestID, err)
 					}
 				}
 			case resource.PhaseTearingDown:

--- a/internal/app/machined/pkg/controllers/block/mount_status_test.go
+++ b/internal/app/machined/pkg/controllers/block/mount_status_test.go
@@ -134,3 +134,75 @@ func (suite *MountStatusSuite) TestReconcileRequesterGoingOut() {
 	// volume mount status should be destroyed
 	ctest.AssertNoResource[*block.VolumeMountStatus](suite, "requester1/volume1")
 }
+
+// TestReconcileRequesterComingBack covers a requester (e.g. a service being restarted) going away and
+// immediately coming back while its previous volume mount status is still tearing down.
+//
+// The controller should not fail on the conflict, as that would block volume mounts for every other
+// requester and every other mount status on the machine.
+func (suite *MountStatusSuite) TestReconcileRequesterComingBack() {
+	mountStatus1 := block.NewMountStatus(block.NamespaceName, "volume1")
+	mountStatus1.TypedSpec().Spec = block.MountRequestSpec{
+		VolumeID:     "volume1",
+		Requesters:   []string{"requester1"},
+		RequesterIDs: []string{"requester1/volume1"},
+	}
+	mountStatus1.TypedSpec().Target = "/target1"
+	suite.Create(mountStatus1)
+
+	ctest.AssertResource(suite, "requester1/volume1", func(vms *block.VolumeMountStatus, asrt *assert.Assertions) {
+		asrt.Equal(resource.PhaseRunning, vms.Metadata().Phase())
+	})
+
+	// the requester locks the volume mount status
+	suite.AddFinalizer(block.NewVolumeMountStatus(block.NamespaceName, "requester1/volume1").Metadata(), "test-finalizer")
+
+	// the requester goes away, the volume mount status starts tearing down, but it is still locked
+	mountStatus1, err := safe.StateGetByID[*block.MountStatus](suite.Ctx(), suite.State(), mountStatus1.Metadata().ID())
+	suite.Require().NoError(err)
+
+	mountStatus1.TypedSpec().Spec.Requesters = nil
+	mountStatus1.TypedSpec().Spec.RequesterIDs = nil
+	suite.Update(mountStatus1)
+
+	ctest.AssertResource(suite, "requester1/volume1", func(vms *block.VolumeMountStatus, asrt *assert.Assertions) {
+		asrt.Equal(resource.PhaseTearingDown, vms.Metadata().Phase())
+	})
+
+	// the requester comes back before the volume mount status is destroyed
+	mountStatus1, err = safe.StateGetByID[*block.MountStatus](suite.Ctx(), suite.State(), mountStatus1.Metadata().ID())
+	suite.Require().NoError(err)
+
+	mountStatus1.TypedSpec().Spec.Requesters = []string{"requester1"}
+	mountStatus1.TypedSpec().Spec.RequesterIDs = []string{"requester1/volume1"}
+	suite.Update(mountStatus1)
+
+	// the controller should keep running: a mount status sorting after "volume1" should still be reconciled
+	mountStatus2 := block.NewMountStatus(block.NamespaceName, "volume2")
+	mountStatus2.TypedSpec().Spec = block.MountRequestSpec{
+		VolumeID:     "volume2",
+		Requesters:   []string{"requester2"},
+		RequesterIDs: []string{"requester2/volume2"},
+	}
+	mountStatus2.TypedSpec().Target = "/target2"
+	suite.Create(mountStatus2)
+
+	ctest.AssertResource(suite, "requester2/volume2", func(vms *block.VolumeMountStatus, asrt *assert.Assertions) {
+		asrt.Equal(resource.PhaseRunning, vms.Metadata().Phase())
+		asrt.Equal("/target2", vms.TypedSpec().Target)
+	})
+
+	// the stuck volume mount status is still tearing down, as the finalizer is still there
+	ctest.AssertResource(suite, "requester1/volume1", func(vms *block.VolumeMountStatus, asrt *assert.Assertions) {
+		asrt.Equal(resource.PhaseTearingDown, vms.Metadata().Phase())
+	})
+
+	// once the requester releases the previous volume mount status, it should be destroyed and re-created
+	suite.RemoveFinalizer(block.NewVolumeMountStatus(block.NamespaceName, "requester1/volume1").Metadata(), "test-finalizer")
+
+	ctest.AssertResource(suite, "requester1/volume1", func(vms *block.VolumeMountStatus, asrt *assert.Assertions) {
+		asrt.Equal(resource.PhaseRunning, vms.Metadata().Phase())
+		asrt.True(vms.Metadata().Finalizers().Empty())
+		asrt.Equal("/target1", vms.TypedSpec().Target)
+	})
+}

--- a/internal/app/machined/pkg/system/volumes.go
+++ b/internal/app/machined/pkg/system/volumes.go
@@ -19,6 +19,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
+// volumeMountFinalizer is the finalizer a service puts on the `VolumeMountStatus` it uses.
+const volumeMountFinalizer = "service"
+
 func (svcrunner *ServiceRunner) deleteVolumeMountRequest(ctx context.Context, requests []volumeRequest) error {
 	st := svcrunner.runtime.State().V1Alpha2().Resources()
 
@@ -26,7 +29,7 @@ func (svcrunner *ServiceRunner) deleteVolumeMountRequest(ctx context.Context, re
 	slices.Reverse(requests)
 
 	for _, request := range requests {
-		if err := st.RemoveFinalizer(ctx, block.NewVolumeMountStatus(block.NamespaceName, request.requestID).Metadata(), "service"); err != nil {
+		if err := st.RemoveFinalizer(ctx, block.NewVolumeMountStatus(block.NamespaceName, request.requestID).Metadata(), volumeMountFinalizer); err != nil {
 			if !state.IsNotFoundError(err) {
 				return fmt.Errorf("failed to remove finalizer from mount status %q: %w", request.requestID, err)
 			}
@@ -71,30 +74,41 @@ func (cond *volumesMountedCondition) Wait(ctx context.Context) error {
 	for idx := range cond.requests {
 		req := cond.requests[idx]
 
-		// create volume mount request
-		mountRequest := block.NewVolumeMountRequest(block.NamespaceName, req.requestID)
-		mountRequest.TypedSpec().Requester = req.requester
-		mountRequest.TypedSpec().VolumeID = req.volumeID
+		// mount request IDs are stable across service restarts, so a `VolumeMountStatus` observed here
+		// might still belong to the previous generation of the service, and go into tearing down phase
+		// right after we observe it as running; retry until we manage to put a finalizer on a
+		// `VolumeMountStatus` which is still running
+		for {
+			// create volume mount request
+			mountRequest := block.NewVolumeMountRequest(block.NamespaceName, req.requestID)
+			mountRequest.TypedSpec().Requester = req.requester
+			mountRequest.TypedSpec().VolumeID = req.volumeID
 
-		if err := cond.st.Create(ctx, mountRequest); err != nil {
-			if !state.IsConflictError(err) {
-				return fmt.Errorf("failed to create mount request: %w", err)
+			if err := cond.st.Create(ctx, mountRequest); err != nil && !state.IsConflictError(err) {
+				return fmt.Errorf("failed to create mount request %q: %w", req.requestID, err)
 			}
-		}
 
-		// wait for the mount status
-		_, err := cond.st.WatchFor(
-			ctx,
-			block.NewVolumeMountStatus(block.NamespaceName, req.requestID).Metadata(),
-			state.WithEventTypes(state.Created, state.Updated),
-			state.WithPhases(resource.PhaseRunning),
-		)
-		if err != nil {
-			return err
-		}
+			// wait for the mount status
+			_, err := cond.st.WatchFor(
+				ctx,
+				block.NewVolumeMountStatus(block.NamespaceName, req.requestID).Metadata(),
+				state.WithEventTypes(state.Created, state.Updated),
+				state.WithPhases(resource.PhaseRunning),
+			)
+			if err != nil {
+				return err
+			}
 
-		if err = cond.st.AddFinalizer(ctx, block.NewVolumeMountStatus(block.NamespaceName, req.requestID).Metadata(), "service"); err != nil {
-			return err
+			err = cond.lockVolumeMountStatus(ctx, req.requestID)
+			if err == nil {
+				break
+			}
+
+			// the volume mount status went away or started tearing down after we have observed it as running,
+			// so wait for the new one to be established
+			if !state.IsPhaseConflictError(err) && !state.IsNotFoundError(err) {
+				return err
+			}
 		}
 
 		cond.mu.Lock()
@@ -103,6 +117,33 @@ func (cond *volumesMountedCondition) Wait(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// lockVolumeMountStatus puts the service finalizer on the volume mount status, but only if it is still running.
+//
+// Unlike `state.AddFinalizer`, which updates the resource in any phase, this fails with a phase conflict error
+// if the volume mount status is already tearing down: putting a finalizer on it would block its teardown forever,
+// as the finalizer is only removed when the service stops.
+func (cond *volumesMountedCondition) lockVolumeMountStatus(ctx context.Context, requestID string) error {
+	ptr := block.NewVolumeMountStatus(block.NamespaceName, requestID).Metadata()
+
+	current, err := cond.st.Get(ctx, ptr)
+	if err != nil {
+		return err
+	}
+
+	_, err = cond.st.UpdateWithConflicts(
+		ctx, ptr,
+		func(r resource.Resource) error {
+			r.Metadata().Finalizers().Add(volumeMountFinalizer)
+
+			return nil
+		},
+		state.WithUpdateOwner(current.Metadata().Owner()),
+		state.WithExpectedPhase(resource.PhaseRunning),
+	)
+
+	return err
 }
 
 func (cond *volumesMountedCondition) String() string {


### PR DESCRIPTION
The observed pattern:

1. CA rotation applies several config changes back to back, so KubeletServiceController does Stop+Start on kubelet 3–4 times within 6 ms.
2. Mount request IDs are stable across restarts, so generation N+1 aliases generation N's resources. Generation D's WatchFor(..., WithPhases(PhaseRunning)) matched the still-running VolumeMountStatus left by the previous generation.
3. MountStatusController, still on the old view, tore that status down → tearingDown.
4. D's AddFinalizer landed anyway — cosi's state.AddFinalizer updates with WithExpectedPhaseAny() — pinning a tearingDown resource with the service finalizer. D moved on to KUBELET.
5. Next reconcile the requester was back in RequesterIDs, so safe.WriterModify hit a phase conflict and the controller returned the error. It iterates mount statuses in ID order and died on the second one (/var/lib), so KUBELET, LOG and STATE were never processed — hence MountStatus KUBELET mounted but with no controller finalizer, and no VolumeMountStatus service/kubelet-KUBELET. Deadlock: the finalizer is only released when kubelet stops, and kubelet is blocked waiting for the mount the wedged controller must produce.

This looks like `kubelet` service stuck in restart forever waiting for the volumes to be mounted.

The race on attaching a finalizer to the resource which is concurrently being torn down leads to rare, but possible deadlock like this one.
