### PR TITLE
feat: provide different heuristics for xfs allocation groups

### DIFF
--- a/api/resource/definitions/block/block.proto
+++ b/api/resource/definitions/block/block.proto
@@ -133,6 +133,10 @@ message FilesystemSpec {
   talos.resource.definitions.enums.BlockFilesystemType type = 1;
   // Filesystem label.
   string label = 2;
+  // MinAllocationGroupSize is the minimum XFS allocation group size in bytes.
+  //
+  // Zero leaves the mkfs.xfs defaults alone.
+  uint64 min_allocation_group_size = 3;
 }
 
 // LocatorSpec is the spec for volume locator.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -29,6 +29,34 @@ CoreDNS: 1.14.6
 Talos is built with Go 1.26.5.
 """
 
+    [notes.xfsallocationgroups]
+        title = "XFS Allocation Group Geometry"
+        description = """\
+On non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of CPUs, bounding the
+allocation group size from below at 4 GiB only. On machines with many cores and a modest disk this produces
+hundreds of tiny allocation groups, which squeezes the AG-local reflink/rmap metadata (leading to spurious
+`ENOSPC` on reflink-heavy workloads while the filesystem still has plenty of free space) and inflates the
+journal at the same time.
+
+Talos now keeps XFS allocation groups at 64 GiB or above when it formats a volume. The bound can be changed
+per volume, and setting it to zero restores the stock `mkfs.xfs` behavior:
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+filesystem:
+  xfs:
+    minAllocationGroupSize: 128GiB
+```
+
+The same `filesystem.xfs.minAllocationGroupSize` setting is available for `UserVolumeConfig`.
+
+Note: allocation group geometry is fixed when the filesystem is created, so this only affects volumes
+formatted by Talos 1.14 or later. Existing volumes keep their current geometry until they are wiped and
+re-created (e.g. `talosctl reset --system-labels-to-wipe=EPHEMERAL`).
+"""
+
     [notes.etcfileconfig]
         title = "EtcFileConfig"
         description = """\

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/format.go
@@ -5,6 +5,7 @@
 package volumes
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -100,10 +101,10 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 		zap.Stringer("filesystem", volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Type),
 	)
 
+	makefsOptions := []makefs.Option{makefs.WithPrintf(logger.Sugar().Debugf)}
+
 	switch volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Type { //nolint:exhaustive
 	case block.FilesystemTypeXFS:
-		var makefsOptions []makefs.Option
-
 		// xfs doesn't support by default filesystems < 300 MiB
 		if volumeContext.Status.Size <= 300*1024*1024 {
 			makefsOptions = append(makefsOptions, makefs.WithUnsupportedFSOption(true))
@@ -115,12 +116,19 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 
 		makefsOptions = append(makefsOptions, makefs.WithConfigFile(quirks.New("").XFSMkfsConfig()))
 
+		// mkfs.xfs only scales the allocation group count (and the journal size) to the CPU count on
+		// non-rotational devices, so the minimum allocation group size is only relevant there.
+		if disk := volumeContext.FindDisk(cmp.Or(volumeContext.Status.ParentLocation, volumeContext.Status.Location)); disk != nil && !disk.Rotational {
+			makefsOptions = append(makefsOptions,
+				makefs.WithDeviceSize(volumeContext.Status.Size),
+				makefs.WithMinAllocationGroupSize(volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.MinAllocationGroupSize),
+			)
+		}
+
 		if err = makefs.XFS(ctx, volumeContext.Status.MountLocation, makefsOptions...); err != nil {
 			return xerrors.NewTaggedf[Retryable]("error formatting XFS: %w", err)
 		}
 	case block.FilesystemTypeEXT4:
-		var makefsOptions []makefs.Option
-
 		if volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label != "" {
 			makefsOptions = append(makefsOptions, makefs.WithLabel(volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label))
 		}
@@ -129,8 +137,6 @@ func Format(ctx context.Context, logger *zap.Logger, volumeContext ManagerContex
 			return xerrors.NewTaggedf[Retryable]("error formatting ext4: %w", err)
 		}
 	case block.FilesystemTypeBtrfs:
-		var makefsOptions []makefs.Option
-
 		if volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label != "" {
 			makefsOptions = append(makefsOptions, makefs.WithLabel(volumeContext.Cfg.TypedSpec().Provisioning.FilesystemSpec.Label))
 		}

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/locate.go
@@ -5,6 +5,7 @@
 package volumes
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 
@@ -175,13 +176,8 @@ func locateVolumeByMatch(vc ManagerContext) (bool, error) {
 		matchContext := map[string]any{"volume": dv}
 
 		// Resolve the parent disk for CEL context
-		for _, diskCtx := range vc.Disks {
-			if (dv.ParentDevPath != "" && diskCtx.Disk.DevPath == dv.ParentDevPath) ||
-				(dv.ParentDevPath == "" && diskCtx.Disk.DevPath == dv.DevPath) {
-				matchContext["disk"] = diskCtx.Disk
-
-				break
-			}
+		if disk := vc.FindDisk(cmp.Or(dv.ParentDevPath, dv.DevPath)); disk != nil {
+			matchContext["disk"] = disk
 		}
 
 		matches, err := spec.Locator.Match.EvalBool(env, matchContext)

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes.go
@@ -125,8 +125,9 @@ func GetEphemeralVolumeTransformer(inContainer bool) volumeConfigTransformer {
 							TypeUUID:        partition.LinuxFilesystemData,
 						},
 						FilesystemSpec: block.FilesystemSpec{
-							Type:  block.FilesystemTypeXFS,
-							Label: constants.EphemeralPartitionLabel,
+							Type:                   block.FilesystemTypeXFS,
+							Label:                  constants.EphemeralPartitionLabel,
+							MinAllocationGroupSize: minAllocationGroupSize(extraVolumeConfig.Filesystem()),
 						},
 					}).
 					WithMount(block.MountSpec{
@@ -270,8 +271,9 @@ func manageStateConfigPresent(cfg configconfig.Config) func(vc *block.VolumeConf
 					TypeUUID: partition.LinuxFilesystemData,
 				},
 				FilesystemSpec: block.FilesystemSpec{
-					Type:  block.FilesystemTypeXFS,
-					Label: constants.StatePartitionLabel,
+					Type:                   block.FilesystemTypeXFS,
+					Label:                  constants.StatePartitionLabel,
+					MinAllocationGroupSize: minAllocationGroupSize(extraVolumeConfig.Filesystem()),
 				},
 			}).
 			WithTrim(cfg, extraVolumeConfig).
@@ -394,8 +396,9 @@ func GetPromotableSystemVolumesTransformer(inContainer bool) volumeConfigTransfo
 							TypeUUID:        partition.LinuxFilesystemData,
 						},
 						FilesystemSpec: block.FilesystemSpec{
-							Type:  block.FilesystemTypeXFS,
-							Label: volume.ID,
+							Type:                   block.FilesystemTypeXFS,
+							Label:                  volume.ID,
+							MinAllocationGroupSize: minAllocationGroupSize(extraVolumeConfig.Filesystem()),
 						},
 					}).
 					WithMount(mountSpec).

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/system_volumes_test.go
@@ -764,6 +764,72 @@ func TestEphemeralVolumeTransformerWithExtraConfig(t *testing.T) {
 	})
 }
 
+func TestEphemeralVolumeMinAllocationGroupSize(t *testing.T) {
+	t.Parallel()
+
+	const defaultMinAGSize = 64 * 1024 * 1024 * 1024
+
+	t.Run("Talos default without configuration", func(t *testing.T) {
+		t.Parallel()
+
+		transformer := volumeconfig.GetEphemeralVolumeTransformer(false)
+		resources, err := transformer(container.NewV1Alpha1(&baseCfg))
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+			assert.EqualValues(t, defaultMinAGSize, vc.TypedSpec().Provisioning.FilesystemSpec.MinAllocationGroupSize)
+		})
+	})
+
+	t.Run("overridden by VolumeConfig", func(t *testing.T) {
+		t.Parallel()
+
+		ephemeralCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		ephemeralCfg.MetaName = constants.EphemeralPartitionLabel
+		ephemeralCfg.FilesystemSpec.XFSSpec = &blockcfg.XFSSpec{
+			MinAllocationGroupSizeConfig: blockcfg.MustByteSize("16GiB"),
+		}
+
+		cfg, err := container.New(baseCfg.DeepCopy(), ephemeralCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetEphemeralVolumeTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+			assert.EqualValues(t, 16*1024*1024*1024, vc.TypedSpec().Provisioning.FilesystemSpec.MinAllocationGroupSize)
+		})
+	})
+
+	t.Run("mkfs defaults when set to zero", func(t *testing.T) {
+		t.Parallel()
+
+		ephemeralCfg := blockcfg.NewVolumeConfigV1Alpha1()
+		ephemeralCfg.MetaName = constants.EphemeralPartitionLabel
+		ephemeralCfg.FilesystemSpec.XFSSpec = &blockcfg.XFSSpec{
+			MinAllocationGroupSizeConfig: blockcfg.MustByteSize("0"),
+		}
+
+		cfg, err := container.New(baseCfg.DeepCopy(), ephemeralCfg)
+		require.NoError(t, err)
+
+		transformer := volumeconfig.GetEphemeralVolumeTransformer(false)
+		resources, err := transformer(cfg)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+			require.NoError(t, err)
+			assert.Zero(t, vc.TypedSpec().Provisioning.FilesystemSpec.MinAllocationGroupSize)
+		})
+	})
+}
+
 func TestEphemeralVolumeSecure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/types.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
 	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
 
@@ -34,6 +35,20 @@ type volumeConfigTransformer func(c configconfig.Config) ([]VolumeResource, erro
 type SkipUserVolumeMountRequest struct{}
 
 var noMatch = cel.MustExpression(cel.ParseBooleanExpression("false", celenv.Empty()))
+
+// minAllocationGroupSize resolves the effective XFS minimum allocation group size: the configured
+// override if there is one, and the Talos default otherwise.
+func minAllocationGroupSize(filesystem configconfig.SystemVolumeFilesystemConfig) uint64 {
+	if filesystem != nil {
+		if xfs := filesystem.XFS(); xfs != nil {
+			if size, ok := xfs.MinAllocationGroupSize().Get(); ok {
+				return size
+			}
+		}
+	}
+
+	return quirks.New("").XFSMinAllocationGroupSize()
+}
 
 func labelVolumeMatch(label string) cel.Expression {
 	return cel.MustExpression(cel.ParseBooleanExpression(fmt.Sprintf("volume.partition_label == '%s'", label), celenv.VolumeLocator()))

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
@@ -78,7 +78,8 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 						Grow:     true,
 					},
 					FilesystemSpec: block.FilesystemSpec{
-						Type: userVolumeConfig.Filesystem().Type(),
+						Type:                   userVolumeConfig.Filesystem().Type(),
+						MinAllocationGroupSize: minAllocationGroupSize(userVolumeConfig.Filesystem()),
 					},
 				}).
 				WithMount(block.MountSpec{
@@ -113,7 +114,8 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 						TypeUUID:        partition.LinuxFilesystemData,
 					},
 					FilesystemSpec: block.FilesystemSpec{
-						Type: userVolumeConfig.Filesystem().Type(),
+						Type:                   userVolumeConfig.Filesystem().Type(),
+						MinAllocationGroupSize: minAllocationGroupSize(userVolumeConfig.Filesystem()),
 					},
 				}).
 				WithMount(block.MountSpec{

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
@@ -97,3 +97,18 @@ type ManagerContext struct {
 	EncryptionHelpers       encryption.Helpers
 	ShouldCloseVolume       bool
 }
+
+// FindDisk returns the disk with the given device path, or nil if it is not known.
+func (ctx ManagerContext) FindDisk(devPath string) *blockpb.DiskSpec {
+	if devPath == "" {
+		return nil
+	}
+
+	for _, diskCtx := range ctx.Disks {
+		if diskCtx.Disk.DevPath == devPath {
+			return diskCtx.Disk
+		}
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/controllers/block/user_disk_config.go
+++ b/internal/app/machined/pkg/controllers/block/user_disk_config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
 	machineconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
@@ -200,7 +201,8 @@ func (ctrl *UserDiskConfigController) processUserDiskPartition(
 					TypeUUID: partition.LinuxFilesystemData,
 				},
 				FilesystemSpec: block.FilesystemSpec{
-					Type: block.FilesystemTypeXFS,
+					Type:                   block.FilesystemTypeXFS,
+					MinAllocationGroupSize: quirks.New("").XFSMinAllocationGroupSize(),
 				},
 			}
 

--- a/pkg/machinery/api/resource/definitions/block/block.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block.pb.go
@@ -883,9 +883,13 @@ type FilesystemSpec struct {
 	// Filesystem type.
 	Type enums.BlockFilesystemType `protobuf:"varint,1,opt,name=type,proto3,enum=talos.resource.definitions.enums.BlockFilesystemType" json:"type,omitempty"`
 	// Filesystem label.
-	Label         string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Label string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+	// MinAllocationGroupSize is the minimum XFS allocation group size in bytes.
+	//
+	// Zero leaves the mkfs.xfs defaults alone.
+	MinAllocationGroupSize uint64 `protobuf:"varint,3,opt,name=min_allocation_group_size,json=minAllocationGroupSize,proto3" json:"min_allocation_group_size,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *FilesystemSpec) Reset() {
@@ -930,6 +934,13 @@ func (x *FilesystemSpec) GetLabel() string {
 		return x.Label
 	}
 	return ""
+}
+
+func (x *FilesystemSpec) GetMinAllocationGroupSize() uint64 {
+	if x != nil {
+		return x.MinAllocationGroupSize
+	}
+	return 0
 }
 
 // LocatorSpec is the spec for volume locator.
@@ -2751,10 +2762,11 @@ const file_resource_definitions_block_block_proto_rawDesc = "" +
 	"\n" +
 	"block_size\x18\x05 \x01(\x04R\tblockSize\x12!\n" +
 	"\fperf_options\x18\x06 \x03(\tR\vperfOptions\x12%\n" +
-	"\x0eallow_discards\x18\a \x01(\bR\rallowDiscards\"q\n" +
+	"\x0eallow_discards\x18\a \x01(\bR\rallowDiscards\"\xac\x01\n" +
 	"\x0eFilesystemSpec\x12I\n" +
 	"\x04type\x18\x01 \x01(\x0e25.talos.resource.definitions.enums.BlockFilesystemTypeR\x04type\x12\x14\n" +
-	"\x05label\x18\x02 \x01(\tR\x05label\"\x90\x01\n" +
+	"\x05label\x18\x02 \x01(\tR\x05label\x129\n" +
+	"\x19min_allocation_group_size\x18\x03 \x01(\x04R\x16minAllocationGroupSize\"\x90\x01\n" +
 	"\vLocatorSpec\x12;\n" +
 	"\x05match\x18\x01 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\x05match\x12D\n" +
 	"\n" +

--- a/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/block/block_vtproto.pb.go
@@ -838,6 +838,11 @@ func (m *FilesystemSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.MinAllocationGroupSize != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MinAllocationGroupSize))
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.Label) > 0 {
 		i -= len(m.Label)
 		copy(dAtA[i:], m.Label)
@@ -2832,6 +2837,9 @@ func (m *FilesystemSpec) SizeVT() (n int) {
 	l = len(m.Label)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.MinAllocationGroupSize != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MinAllocationGroupSize))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5856,6 +5864,25 @@ func (m *FilesystemSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Label = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinAllocationGroupSize", wireType)
+			}
+			m.MinAllocationGroupSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MinAllocationGroupSize |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/volume.go
+++ b/pkg/machinery/config/config/volume.go
@@ -36,6 +36,7 @@ type VolumesConfig interface {
 type VolumeConfig interface {
 	NamedDocument
 	Provisioning() VolumeProvisioningConfig
+	Filesystem() SystemVolumeFilesystemConfig
 	Encryption() EncryptionConfig
 	Mount() VolumeMountConfig
 	VolumeTrimConfigProvider
@@ -78,6 +79,14 @@ func (emptyVolumeConfig) Name() string {
 
 func (emptyVolumeConfig) Provisioning() VolumeProvisioningConfig {
 	return emptyVolumeConfig{}
+}
+
+func (config emptyVolumeConfig) Filesystem() SystemVolumeFilesystemConfig {
+	return config
+}
+
+func (emptyVolumeConfig) XFS() XFSFilesystemConfig {
+	return nil
 }
 
 func (emptyVolumeConfig) Encryption() EncryptionConfig {
@@ -205,10 +214,25 @@ type ExternalVolumeMountConfigSpec interface {
 
 // FilesystemConfig defines the interface to access filesystem configuration.
 type FilesystemConfig interface {
+	SystemVolumeFilesystemConfig
 	// Type returns the filesystem type.
 	Type() block.FilesystemType
 	// ProjectQuotaSupport returns true if the filesystem should support project quotas.
 	ProjectQuotaSupport() bool
+}
+
+// SystemVolumeFilesystemConfig is the subset of the filesystem configuration which can be set for
+// system volumes (the filesystem type is fixed, and project quota support comes from machine
+// features).
+type SystemVolumeFilesystemConfig interface {
+	// XFS returns the XFS-specific filesystem configuration, if any.
+	XFS() XFSFilesystemConfig
+}
+
+// XFSFilesystemConfig defines the interface to access XFS-specific filesystem configuration.
+type XFSFilesystemConfig interface {
+	// MinAllocationGroupSize returns the minimum XFS allocation group size in bytes.
+	MinAllocationGroupSize() optional.Optional[uint64]
 }
 
 // SwapVolumeConfig defines the interface to access swap volume configuration.

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -396,6 +396,13 @@
           "description": "Enables project quota support, valid only for ‘xfs’ filesystem.\n\nNote: changing this value might require a full remount of the filesystem.\n",
           "markdownDescription": "Enables project quota support, valid only for 'xfs' filesystem.\n\nNote: changing this value might require a full remount of the filesystem.",
           "x-intellij-html-description": "\u003cp\u003eEnables project quota support, valid only for \u0026lsquo;xfs\u0026rsquo; filesystem.\u003c/p\u003e\n\n\u003cp\u003eNote: changing this value might require a full remount of the filesystem.\u003c/p\u003e\n"
+        },
+        "xfs": {
+          "$ref": "#/$defs/block.XFSSpec",
+          "title": "xfs",
+          "description": "XFS-specific filesystem options, valid only for ‘xfs’ filesystem.\n",
+          "markdownDescription": "XFS-specific filesystem options, valid only for 'xfs' filesystem.",
+          "x-intellij-html-description": "\u003cp\u003eXFS-specific filesystem options, valid only for \u0026lsquo;xfs\u0026rsquo; filesystem.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -595,6 +602,20 @@
       ],
       "description": "SwapVolumeConfig is a disk swap volume configuration document.\\nSwap volume is automatically allocated as a partition on the specified disk\\nand activated as swap, removing a swap volume deactivates swap.\\nThe partition label is automatically generated as `s-\u003cname\u003e`.\\n"
     },
+    "block.SystemVolumeFilesystemSpec": {
+      "properties": {
+        "xfs": {
+          "$ref": "#/$defs/block.XFSSpec",
+          "title": "xfs",
+          "description": "XFS-specific filesystem options.\n",
+          "markdownDescription": "XFS-specific filesystem options.",
+          "x-intellij-html-description": "\u003cp\u003eXFS-specific filesystem options.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SystemVolumeFilesystemSpec describes how the system volume is formatted.\\n\\nThe filesystem type is fixed for system volumes, and project quota support is configured via\\nmachine features, so only the filesystem-specific tunables are exposed here.\\n"
+    },
     "block.TrimConfig": {
       "properties": {
         "enabled": {
@@ -768,6 +789,13 @@
           "markdownDescription": "The provisioning describes how the volume is provisioned.",
           "x-intellij-html-description": "\u003cp\u003eThe provisioning describes how the volume is provisioned.\u003c/p\u003e\n"
         },
+        "filesystem": {
+          "$ref": "#/$defs/block.SystemVolumeFilesystemSpec",
+          "title": "filesystem",
+          "description": "The filesystem describes how the volume is formatted.\n\nNote: this only takes effect at the time the volume is formatted.\n",
+          "markdownDescription": "The filesystem describes how the volume is formatted.\n\nNote: this only takes effect at the time the volume is formatted.",
+          "x-intellij-html-description": "\u003cp\u003eThe filesystem describes how the volume is formatted.\u003c/p\u003e\n\n\u003cp\u003eNote: this only takes effect at the time the volume is formatted.\u003c/p\u003e\n"
+        },
         "encryption": {
           "$ref": "#/$defs/block.EncryptionSpec",
           "title": "encryption",
@@ -825,6 +853,20 @@
       "additionalProperties": false,
       "type": "object",
       "description": "VolumeSelector selects an existing volume."
+    },
+    "block.XFSSpec": {
+      "properties": {
+        "minAllocationGroupSize": {
+          "type": "string",
+          "title": "minAllocationGroupSize",
+          "description": "The minimum size of an XFS allocation group.\n\nOn non-rotational devices mkfs.xfs sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\n\nSet to zero to use the mkfs.xfs defaults unchanged.\n\nNote: this only affects volumes at the time they are formatted.\n\nSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.\n",
+          "markdownDescription": "The minimum size of an XFS allocation group.\n\nOn non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\n\nSet to zero to use the `mkfs.xfs` defaults unchanged.\n\nNote: this only affects volumes at the time they are formatted.\n\nSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.",
+          "x-intellij-html-description": "\u003cp\u003eThe minimum size of an XFS allocation group.\u003c/p\u003e\n\n\u003cp\u003eOn non-rotational devices \u003ccode\u003emkfs.xfs\u003c/code\u003e sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\u003c/p\u003e\n\n\u003cp\u003eSet to zero to use the \u003ccode\u003emkfs.xfs\u003c/code\u003e defaults unchanged.\u003c/p\u003e\n\n\u003cp\u003eNote: this only affects volumes at the time they are formatted.\u003c/p\u003e\n\n\u003cp\u003eSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "XFSSpec configures XFS-specific filesystem options."
     },
     "block.ZswapConfigV1Alpha1": {
       "properties": {

--- a/pkg/machinery/config/types/block/block_doc.go
+++ b/pkg/machinery/config/types/block/block_doc.go
@@ -822,8 +822,46 @@ func (FilesystemSpec) Doc() *encoder.Doc {
 				Description: "Enables project quota support, valid only for 'xfs' filesystem.\n\nNote: changing this value might require a full remount of the filesystem.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Enables project quota support, valid only for 'xfs' filesystem." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "xfs",
+				Type:        "XFSSpec",
+				Note:        "",
+				Description: "XFS-specific filesystem options, valid only for 'xfs' filesystem.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "XFS-specific filesystem options, valid only for 'xfs' filesystem." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
+
+	return doc
+}
+
+func (XFSSpec) Doc() *encoder.Doc {
+	doc := &encoder.Doc{
+		Type:        "XFSSpec",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "XFSSpec configures XFS-specific filesystem options." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "XFSSpec configures XFS-specific filesystem options.",
+		AppearsIn: []encoder.Appearance{
+			{
+				TypeName:  "FilesystemSpec",
+				FieldName: "xfs",
+			},
+			{
+				TypeName:  "SystemVolumeFilesystemSpec",
+				FieldName: "xfs",
+			},
+		},
+		Fields: []encoder.Doc{
+			{
+				Name:        "minAllocationGroupSize",
+				Type:        "ByteSize",
+				Note:        "",
+				Description: "The minimum size of an XFS allocation group.\n\nOn non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\n\nSet to zero to use the `mkfs.xfs` defaults unchanged.\n\nNote: this only affects volumes at the time they are formatted.\n\nSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The minimum size of an XFS allocation group." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+		},
+	}
+
+	doc.Fields[0].AddExample("", "128GiB")
 
 	return doc
 }
@@ -853,6 +891,13 @@ func (VolumeConfigV1Alpha1) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The provisioning describes how the volume is provisioned." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
+				Name:        "filesystem",
+				Type:        "SystemVolumeFilesystemSpec",
+				Note:        "",
+				Description: "The filesystem describes how the volume is formatted.\n\nNote: this only takes effect at the time the volume is formatted.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "The filesystem describes how the volume is formatted." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "encryption",
 				Type:        "EncryptionSpec",
 				Note:        "",
@@ -877,6 +922,31 @@ func (VolumeConfigV1Alpha1) Doc() *encoder.Doc {
 	}
 
 	doc.AddExample("", exampleVolumeConfigEphemeralV1Alpha1())
+
+	return doc
+}
+
+func (SystemVolumeFilesystemSpec) Doc() *encoder.Doc {
+	doc := &encoder.Doc{
+		Type:        "SystemVolumeFilesystemSpec",
+		Comments:    [3]string{"" /* encoder.HeadComment */, "SystemVolumeFilesystemSpec describes how the system volume is formatted." /* encoder.LineComment */, "" /* encoder.FootComment */},
+		Description: "SystemVolumeFilesystemSpec describes how the system volume is formatted.\n\nThe filesystem type is fixed for system volumes, and project quota support is configured via\nmachine features, so only the filesystem-specific tunables are exposed here.\n",
+		AppearsIn: []encoder.Appearance{
+			{
+				TypeName:  "VolumeConfigV1Alpha1",
+				FieldName: "filesystem",
+			},
+		},
+		Fields: []encoder.Doc{
+			{
+				Name:        "xfs",
+				Type:        "XFSSpec",
+				Note:        "",
+				Description: "XFS-specific filesystem options.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "XFS-specific filesystem options." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+		},
+	}
 
 	return doc
 }
@@ -1062,7 +1132,9 @@ func GetFileDoc() *encoder.FileDoc {
 			UserVolumeConfigV1Alpha1{}.Doc(),
 			UserMountSpec{}.Doc(),
 			FilesystemSpec{}.Doc(),
+			XFSSpec{}.Doc(),
 			VolumeConfigV1Alpha1{}.Doc(),
+			SystemVolumeFilesystemSpec{}.Doc(),
 			MountSpec{}.Doc(),
 			ProvisioningSpec{}.Doc(),
 			DiskSelector{}.Doc(),

--- a/pkg/machinery/config/types/block/deep_copy.generated.go
+++ b/pkg/machinery/config/types/block/deep_copy.generated.go
@@ -261,6 +261,18 @@ func (o *UserVolumeConfigV1Alpha1) DeepCopy() *UserVolumeConfigV1Alpha1 {
 		cp.FilesystemSpec.ProjectQuotaSupportConfig = new(bool)
 		*cp.FilesystemSpec.ProjectQuotaSupportConfig = *o.FilesystemSpec.ProjectQuotaSupportConfig
 	}
+	if o.FilesystemSpec.XFSSpec != nil {
+		cp.FilesystemSpec.XFSSpec = new(XFSSpec)
+		*cp.FilesystemSpec.XFSSpec = *o.FilesystemSpec.XFSSpec
+		if o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value != nil {
+			cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value = new(uint64)
+			*cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value = *o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value
+		}
+		if o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw != nil {
+			cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw = make([]byte, len(o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw))
+			copy(cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw, o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw)
+		}
+	}
 	if o.EncryptionSpec.EncryptionKeys != nil {
 		cp.EncryptionSpec.EncryptionKeys = make([]EncryptionKey, len(o.EncryptionSpec.EncryptionKeys))
 		copy(cp.EncryptionSpec.EncryptionKeys, o.EncryptionSpec.EncryptionKeys)
@@ -385,6 +397,18 @@ func (o *VolumeConfigV1Alpha1) DeepCopy() *VolumeConfigV1Alpha1 {
 		if o.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw != nil {
 			cp.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw = make([]byte, len(o.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw))
 			copy(cp.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw, o.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw)
+		}
+	}
+	if o.FilesystemSpec.XFSSpec != nil {
+		cp.FilesystemSpec.XFSSpec = new(XFSSpec)
+		*cp.FilesystemSpec.XFSSpec = *o.FilesystemSpec.XFSSpec
+		if o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value != nil {
+			cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value = new(uint64)
+			*cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value = *o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.value
+		}
+		if o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw != nil {
+			cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw = make([]byte, len(o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw))
+			copy(cp.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw, o.FilesystemSpec.XFSSpec.MinAllocationGroupSizeConfig.raw)
 		}
 	}
 	if o.EncryptionSpec.EncryptionKeys != nil {

--- a/pkg/machinery/config/types/block/testdata/uservolumeconfig_xfs.yaml
+++ b/pkg/machinery/config/types/block/testdata/uservolumeconfig_xfs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: build-cache
+provisioning:
+    diskSelector:
+        match: '!system_disk'
+    minSize: 10GiB
+filesystem:
+    xfs:
+        minAllocationGroupSize: 128GiB

--- a/pkg/machinery/config/types/block/testdata/volumeconfig_xfs.yaml
+++ b/pkg/machinery/config/types/block/testdata/volumeconfig_xfs.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+filesystem:
+    xfs:
+        minAllocationGroupSize: 128GiB

--- a/pkg/machinery/config/types/block/user_volume_config.go
+++ b/pkg/machinery/config/types/block/user_volume_config.go
@@ -373,11 +373,37 @@ type FilesystemSpec struct {
 	//
 	//     Note: changing this value might require a full remount of the filesystem.
 	ProjectQuotaSupportConfig *bool `yaml:"projectQuotaSupport,omitempty"`
+	//   description: |
+	//     XFS-specific filesystem options, valid only for 'xfs' filesystem.
+	XFSSpec *XFSSpec `yaml:"xfs,omitempty"`
+}
+
+// XFSSpec configures XFS-specific filesystem options.
+type XFSSpec struct {
+	//  description: |
+	//    The minimum size of an XFS allocation group.
+	//
+	//    On non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of
+	//    CPUs, which on machines with many cores and a modest disk yields hundreds of tiny
+	//    allocation groups. Talos bounds the allocation group size from below to keep the geometry
+	//    sane; this option overrides that bound.
+	//
+	//    Set to zero to use the `mkfs.xfs` defaults unchanged.
+	//
+	//    Note: this only affects volumes at the time they are formatted.
+	//
+	//    Size is specified in bytes, but can be expressed in human readable format, e.g. 100MB.
+	//  examples:
+	//    - value: >
+	//        "128GiB"
+	//  schema:
+	//    type: string
+	MinAllocationGroupSizeConfig ByteSize `yaml:"minAllocationGroupSize,omitempty"`
 }
 
 // IsZero checks if the filesystem spec is zero.
 func (s FilesystemSpec) IsZero() bool {
-	return s.FilesystemType == block.FilesystemTypeNone && s.ProjectQuotaSupportConfig == nil
+	return s.FilesystemType == block.FilesystemTypeNone && s.ProjectQuotaSupportConfig == nil && s.XFSSpec == nil
 }
 
 // Type implements config.FilesystemConfig interface.
@@ -392,6 +418,15 @@ func (s FilesystemSpec) Type() block.FilesystemType {
 // ProjectQuotaSupport implements config.FilesysteemConfig interface.
 func (s FilesystemSpec) ProjectQuotaSupport() bool {
 	return pointer.SafeDeref(s.ProjectQuotaSupportConfig)
+}
+
+// XFS implements config.FilesystemConfig interface.
+func (s FilesystemSpec) XFS() config.XFSFilesystemConfig {
+	if s.XFSSpec == nil {
+		return nil
+	}
+
+	return s.XFSSpec
 }
 
 // Validate implements config.Validator interface.
@@ -409,7 +444,20 @@ func (s FilesystemSpec) Validate() ([]string, error) {
 		return nil, fmt.Errorf("project quota support is only available for xfs filesystem")
 	}
 
+	if s.XFSSpec != nil && s.Type() != block.FilesystemTypeXFS {
+		return nil, fmt.Errorf("xfs options are only available for xfs filesystem")
+	}
+
 	return nil, nil
+}
+
+// MinAllocationGroupSize implements config.XFSFilesystemConfig interface.
+func (s *XFSSpec) MinAllocationGroupSize() optional.Optional[uint64] {
+	if s.MinAllocationGroupSizeConfig.IsZero() {
+		return optional.None[uint64]()
+	}
+
+	return optional.Some(s.MinAllocationGroupSizeConfig.Value())
 }
 
 // IsZero checks if the mount spec is zero.

--- a/pkg/machinery/config/types/block/user_volume_config_test.go
+++ b/pkg/machinery/config/types/block/user_volume_config_test.go
@@ -87,6 +87,22 @@ func TestUserVolumeConfigMarshalUnmarshal(t *testing.T) {
 				return c
 			},
 		},
+		{
+			name:     "xfs min allocation group size",
+			filename: "uservolumeconfig_xfs.yaml",
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = "build-cache"
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`!system_disk`)))
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+				c.FilesystemSpec.XFSSpec = &block.XFSSpec{
+					MinAllocationGroupSizeConfig: block.MustByteSize("128GiB"),
+				}
+
+				return c
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -300,6 +316,25 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 			},
 
 			expectedErrors: "project quota support is only available for xfs filesystem",
+		},
+		{
+			name: "xfs options not supported",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`system_disk`)))
+				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
+				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.XFSSpec = &block.XFSSpec{
+					MinAllocationGroupSizeConfig: block.MustByteSize("128GiB"),
+				}
+
+				return c
+			},
+
+			expectedErrors: "xfs options are only available for xfs filesystem",
 		},
 		{
 			name: "provisioning spec for directory",

--- a/pkg/machinery/config/types/block/volume_config.go
+++ b/pkg/machinery/config/types/block/volume_config.go
@@ -76,6 +76,11 @@ type VolumeConfigV1Alpha1 struct {
 	//     The provisioning describes how the volume is provisioned.
 	ProvisioningSpec ProvisioningSpec `yaml:"provisioning,omitempty"`
 	//   description: |
+	//     The filesystem describes how the volume is formatted.
+	//
+	//     Note: this only takes effect at the time the volume is formatted.
+	FilesystemSpec SystemVolumeFilesystemSpec `yaml:"filesystem,omitempty"`
+	//   description: |
 	//     The encryption describes how the volume is encrypted.
 	EncryptionSpec EncryptionSpec `yaml:"encryption,omitempty"`
 	//   description: |
@@ -84,6 +89,30 @@ type VolumeConfigV1Alpha1 struct {
 	//   description: |
 	//     The trim describes the per-volume filesystem trim (fstrim) configuration.
 	TrimSpec *TrimConfig `yaml:"trim,omitempty"`
+}
+
+// SystemVolumeFilesystemSpec describes how the system volume is formatted.
+//
+// The filesystem type is fixed for system volumes, and project quota support is configured via
+// machine features, so only the filesystem-specific tunables are exposed here.
+type SystemVolumeFilesystemSpec struct {
+	//   description: |
+	//     XFS-specific filesystem options.
+	XFSSpec *XFSSpec `yaml:"xfs,omitempty"`
+}
+
+// IsZero checks if the filesystem spec is zero.
+func (s SystemVolumeFilesystemSpec) IsZero() bool {
+	return s.XFSSpec == nil
+}
+
+// XFS implements config.SystemVolumeFilesystemConfig interface.
+func (s SystemVolumeFilesystemSpec) XFS() config.XFSFilesystemConfig {
+	if s.XFSSpec == nil {
+		return nil
+	}
+
+	return s.XFSSpec
 }
 
 // MountSpec describes how the volume is mounted.
@@ -269,6 +298,11 @@ func (s *VolumeConfigV1Alpha1) validateVolumeConstraints() error {
 		validationErrors = errors.Join(validationErrors, mountNotAllowed(s.MetaName, s.MountSpec))
 	case constants.ImageCachePartitionLabel:
 		validationErrors = errors.Join(validationErrors, mountNotAllowed(s.MetaName, s.MountSpec))
+
+		// the image cache is formatted as ext4, so the xfs options don't apply.
+		if !s.FilesystemSpec.IsZero() {
+			validationErrors = errors.Join(validationErrors, fmt.Errorf("filesystem config is not allowed for the %q volume", s.MetaName))
+		}
 	case constants.EtcdDataVolumeID, constants.CRIContainerdVolumeID, constants.KubeletDataVolumeID, constants.LogVolumeID:
 		// these volumes default to a directory under EPHEMERAL and can be placed on a dedicated
 		// partition via provisioning (optionally encrypted). Mount config only takes effect on the
@@ -345,6 +379,11 @@ func (s *VolumeConfigV1Alpha1) RuntimeValidate(ctx context.Context, st state.Sta
 // Provisioning implements config.VolumeConfig interface.
 func (s *VolumeConfigV1Alpha1) Provisioning() config.VolumeProvisioningConfig {
 	return s.ProvisioningSpec
+}
+
+// Filesystem implements config.VolumeConfig interface.
+func (s *VolumeConfigV1Alpha1) Filesystem() config.SystemVolumeFilesystemConfig {
+	return s.FilesystemSpec
 }
 
 // Encryption implements config.VolumeConfig interface.

--- a/pkg/machinery/config/types/block/volume_config_test.go
+++ b/pkg/machinery/config/types/block/volume_config_test.go
@@ -82,6 +82,20 @@ func TestVolumeConfigMarshalUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:     "xfs min allocation group size",
+			filename: "volumeconfig_xfs.yaml",
+			cfg: func(*testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+
+				c.FilesystemSpec.XFSSpec = &block.XFSSpec{
+					MinAllocationGroupSizeConfig: block.MustByteSize("128GiB"),
+				}
+
+				return c
+			},
+		},
+		{
 			name:     "state",
 			filename: "volumeconfig_state.yaml",
 			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
@@ -157,6 +171,22 @@ func TestVolumeConfigValidate(t *testing.T) {
 			},
 
 			expectedErrors: "only [\"STATE\" \"EPHEMERAL\" \"IMAGECACHE\" \"ETCD\" \"CRI\" \"KUBELET\" \"LOG\"] volumes are supported",
+		},
+		{
+			name: "filesystem config for image cache",
+
+			cfg: func(t *testing.T) *block.VolumeConfigV1Alpha1 {
+				c := block.NewVolumeConfigV1Alpha1()
+				c.MetaName = constants.ImageCachePartitionLabel
+
+				c.FilesystemSpec.XFSSpec = &block.XFSSpec{
+					MinAllocationGroupSizeConfig: block.MustByteSize("128GiB"),
+				}
+
+				return c
+			},
+
+			expectedErrors: "filesystem config is not allowed for the \"IMAGECACHE\" volume",
 		},
 		{
 			name: "invalid disk selector",

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -265,6 +265,23 @@ func (q Quirks) XFSMkfsConfig() string {
 	}
 }
 
+// minTalosVersionXFSAllocationGroupFloor is the version that started bounding the mkfs.xfs
+// concurrency-based allocation group geometry by a minimum allocation group size.
+var minTalosVersionXFSAllocationGroupFloor = semver.MustParse("1.14.0")
+
+// XFSMinAllocationGroupSize returns the minimum XFS allocation group size (in bytes) Talos enforces
+// when mkfs.xfs would otherwise scale the allocation group count to the CPU count.
+//
+// Zero means that the mkfs.xfs defaults are left alone.
+func (q Quirks) XFSMinAllocationGroupSize() uint64 {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v != nil && q.v.LT(minTalosVersionXFSAllocationGroupFloor) {
+		return 0
+	}
+
+	return 64 * gib
+}
+
 var maxTalosVersionIMASupported = semver.MustParse("1.10.99")
 
 // SupportsIMA returns true if the Talos version has IMA support.

--- a/pkg/machinery/imager/quirks/quirks_test.go
+++ b/pkg/machinery/imager/quirks/quirks_test.go
@@ -201,6 +201,46 @@ func TestXFSMkfsConfigFile(t *testing.T) {
 	}
 }
 
+func TestXFSMinAllocationGroupSize(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		version string
+
+		expected uint64
+	}{
+		{
+			version:  "1.10.0",
+			expected: 0,
+		},
+		{
+			version:  "1.13.0",
+			expected: 0,
+		},
+		{
+			version:  "1.13.5",
+			expected: 0,
+		},
+		{
+			version:  "1.14.0",
+			expected: 64 * 1024 * 1024 * 1024,
+		},
+		{
+			version:  "1.15.0",
+			expected: 64 * 1024 * 1024 * 1024,
+		},
+		{
+			expected: 64 * 1024 * 1024 * 1024,
+		},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, quirks.New(test.version).XFSMinAllocationGroupSize())
+		})
+	}
+}
+
 func TestPartitionSizes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/machinery/resources/block/volume_config.go
+++ b/pkg/machinery/resources/block/volume_config.go
@@ -156,6 +156,10 @@ type FilesystemSpec struct {
 	Type FilesystemType `yaml:"type" protobuf:"1"`
 	// Filesystem label.
 	Label string `yaml:"label,omitempty" protobuf:"2"`
+	// MinAllocationGroupSize is the minimum XFS allocation group size in bytes.
+	//
+	// Zero leaves the mkfs.xfs defaults alone.
+	MinAllocationGroupSize uint64 `yaml:"minAllocationGroupSize,omitempty" protobuf:"3"`
 }
 
 // EncryptionSpec is the spec for volume encryption.

--- a/pkg/makefs/makefs.go
+++ b/pkg/makefs/makefs.go
@@ -16,13 +16,15 @@ type Option func(*Options)
 
 // Options for makefs.
 type Options struct {
-	Label               string
-	ConfigFile          string
-	SourceDirectory     string
-	SectorSize          uint
-	Force               bool
-	Reproducible        bool
-	UnsupportedFSOption bool
+	Label                  string
+	ConfigFile             string
+	SourceDirectory        string
+	SectorSize             uint
+	DeviceSize             uint64
+	MinAllocationGroupSize uint64
+	Force                  bool
+	Reproducible           bool
+	UnsupportedFSOption    bool
 
 	Printf func(string, ...any)
 }
@@ -79,6 +81,24 @@ func WithSourceDirectory(sourceDir string) Option {
 func WithSectorSize(sectorSize uint) Option {
 	return func(o *Options) {
 		o.SectorSize = sectorSize
+	}
+}
+
+// WithDeviceSize sets the size of the device being formatted, in bytes.
+//
+// It is only used to derive filesystem geometry, see WithMinAllocationGroupSize.
+func WithDeviceSize(size uint64) Option {
+	return func(o *Options) {
+		o.DeviceSize = size
+	}
+}
+
+// WithMinAllocationGroupSize sets the minimum allocation group size (in bytes) for XFS.
+//
+// It has no effect unless WithDeviceSize is set as well. Zero leaves the mkfs defaults alone.
+func WithMinAllocationGroupSize(size uint64) Option {
+	return func(o *Options) {
+		o.MinAllocationGroupSize = size
 	}
 }
 

--- a/pkg/makefs/xfs.go
+++ b/pkg/makefs/xfs.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
+	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-cmd/pkg/cmd"
 	"golang.org/x/sys/unix"
 )
@@ -19,6 +21,32 @@ const (
 	// FilesystemTypeXFS is the filesystem type for XFS.
 	FilesystemTypeXFS = "xfs"
 )
+
+// XFSConcurrency computes the value for the mkfs.xfs `concurrency=` option which keeps the
+// allocation groups at or above minAGSize bytes.
+//
+// On non-rotational devices mkfs.xfs sizes the allocation group count to the number of CPUs,
+// bounding the allocation group size from below at 4 GiB only. On a machine with many cores and a
+// modest disk that produces hundreds of tiny allocation groups, which squeezes the AG-local
+// reflink/rmap metadata and inflates the journal at the same time. Capping the concurrency level
+// restores a sane geometry.
+//
+// The zero optional means that the option should not be passed at all (mkfs.xfs defaults apply).
+// A value of 0 forces the classic geometry. 1 is never returned, as mkfs.xfs reads it as the magic
+// "number of CPUs" value rather than as a literal count.
+func XFSConcurrency(deviceSize, minAGSize uint64, numCPU int) optional.Optional[int] {
+	if minAGSize == 0 || deviceSize == 0 || numCPU <= 0 {
+		return optional.None[int]()
+	}
+
+	concurrency := min(uint64(numCPU), deviceSize/minAGSize)
+
+	if concurrency < 2 {
+		return optional.Some(0)
+	}
+
+	return optional.Some(int(concurrency))
+}
 
 // XFSGrow expands a XFS filesystem to the maximum possible. The partition
 // MUST be mounted, or this will fail.
@@ -72,6 +100,16 @@ func XFS(ctx context.Context, partname string, setters ...Option) error {
 
 	if opts.SectorSize > 0 {
 		args = append(args, "-s", fmt.Sprintf("size=%d", opts.SectorSize))
+	}
+
+	// bound both the allocation group geometry and the journal, as mkfs.xfs scales both by the
+	// number of CPUs on non-rotational devices
+	if concurrency, ok := XFSConcurrency(opts.DeviceSize, opts.MinAllocationGroupSize, runtime.NumCPU()).Get(); ok {
+		args = append(
+			args,
+			"-d", fmt.Sprintf("concurrency=%d", concurrency),
+			"-l", fmt.Sprintf("concurrency=%d", concurrency),
+		)
 	}
 
 	if opts.SourceDirectory != "" {

--- a/pkg/makefs/xfs_test.go
+++ b/pkg/makefs/xfs_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/siderolabs/gen/optional"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -202,4 +203,105 @@ func TestXFSReproducibility(t *testing.T) {
 	require.NoError(t, fileData.Close())
 
 	assert.Equal(t, sum1.Sum(nil), sum2.Sum(nil))
+}
+
+func TestXFSConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gib = 1024 * 1024 * 1024
+		tib = 1024 * gib
+	)
+
+	for _, test := range []struct {
+		name string
+
+		deviceSize uint64
+		minAGSize  uint64
+		numCPU     int
+
+		expected optional.Optional[int]
+	}{
+		{
+			name: "disabled",
+
+			deviceSize: 930 * gib,
+			minAGSize:  0,
+			numCPU:     128,
+
+			expected: optional.None[int](),
+		},
+		{
+			name: "unknown device size",
+
+			deviceSize: 0,
+			minAGSize:  64 * gib,
+			numCPU:     128,
+
+			expected: optional.None[int](),
+		},
+		{
+			// smaller than a single allocation group: fall back to the classic geometry, and never
+			// emit 1, which mkfs.xfs reads as the magic "number of CPUs" value
+			name: "smaller than min AG size",
+
+			deviceSize: 40 * gib,
+			minAGSize:  64 * gib,
+			numCPU:     128,
+
+			expected: optional.Some(0),
+		},
+		{
+			// exactly one allocation group would fit, still not enough to beat the magic value
+			name: "exactly one AG",
+
+			deviceSize: 100 * gib,
+			minAGSize:  64 * gib,
+			numCPU:     128,
+
+			expected: optional.Some(0),
+		},
+		{
+			name: "capped by min AG size",
+
+			deviceSize: 464 * gib,
+			minAGSize:  64 * gib,
+			numCPU:     128,
+
+			expected: optional.Some(7),
+		},
+		{
+			name: "capped by min AG size, many cores",
+
+			deviceSize: 1900 * gib,
+			minAGSize:  64 * gib,
+			numCPU:     384,
+
+			expected: optional.Some(29),
+		},
+		{
+			name: "capped by CPU count",
+
+			deviceSize: 15 * tib,
+			minAGSize:  64 * gib,
+			numCPU:     32,
+
+			expected: optional.Some(32),
+		},
+		{
+			name: "no CPUs reported",
+
+			deviceSize: 930 * gib,
+			minAGSize:  64 * gib,
+			numCPU:     0,
+
+			expected: optional.None[int](),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, makefs.XFSConcurrency(test.deviceSize, test.minAGSize, test.numCPU))
+		})
+	}
 }

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -6558,6 +6558,7 @@ FilesystemSpec is the spec for volume filesystem.
 | ----- | ---- | ----- | ----------- |
 | type | [talos.resource.definitions.enums.BlockFilesystemType](#talos.resource.definitions.enums.BlockFilesystemType) |  | Filesystem type. |
 | label | [string](#string) |  | Filesystem label. |
+| min_allocation_group_size | [uint64](#uint64) |  | MinAllocationGroupSize is the minimum XFS allocation group size in bytes.<br><br>Zero leaves the mkfs.xfs defaults alone. |
 
 
 

--- a/website/content/v1.14/reference/configuration/block/uservolumeconfig.md
+++ b/website/content/v1.14/reference/configuration/block/uservolumeconfig.md
@@ -221,6 +221,25 @@ FilesystemSpec configures the filesystem for the volume.
 |-------|------|-------------|----------|
 |`type` |FilesystemType |Filesystem type. Default is `xfs`.  |`ext4`<br />`xfs`<br />`btrfs`<br /> |
 |`projectQuotaSupport` |bool |Enables project quota support, valid only for 'xfs' filesystem.<br><br>Note: changing this value might require a full remount of the filesystem.  | |
+|`xfs` |<a href="#UserVolumeConfig.filesystem.xfs">XFSSpec</a> |XFS-specific filesystem options, valid only for 'xfs' filesystem.  | |
+
+
+
+
+### xfs {#UserVolumeConfig.filesystem.xfs}
+
+XFSSpec configures XFS-specific filesystem options.
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`minAllocationGroupSize` |ByteSize |The minimum size of an XFS allocation group.<br><br>On non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of<br>CPUs, which on machines with many cores and a modest disk yields hundreds of tiny<br>allocation groups. Talos bounds the allocation group size from below to keep the geometry<br>sane; this option overrides that bound.<br><br>Set to zero to use the `mkfs.xfs` defaults unchanged.<br><br>Note: this only affects volumes at the time they are formatted.<br><br>Size is specified in bytes, but can be expressed in human readable format, e.g. 100MB. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+minAllocationGroupSize: 128GiB
+{{< /highlight >}}</details> | |
+
+
 
 
 

--- a/website/content/v1.14/reference/configuration/block/volumeconfig.md
+++ b/website/content/v1.14/reference/configuration/block/volumeconfig.md
@@ -63,6 +63,7 @@ provisioning:
 |-------|------|-------------|----------|
 |`name` |string |Name of the volume.  | |
 |`provisioning` |<a href="#VolumeConfig.provisioning">ProvisioningSpec</a> |The provisioning describes how the volume is provisioned.  | |
+|`filesystem` |<a href="#VolumeConfig.filesystem">SystemVolumeFilesystemSpec</a> |The filesystem describes how the volume is formatted.<br><br>Note: this only takes effect at the time the volume is formatted.  | |
 |`encryption` |<a href="#VolumeConfig.encryption">EncryptionSpec</a> |The encryption describes how the volume is encrypted.  | |
 |`mount` |<a href="#VolumeConfig.mount">MountSpec</a> |The mount describes additional mount options.  | |
 |`trim` |<a href="#VolumeConfig.trim">TrimConfig</a> |The trim describes the per-volume filesystem trim (fstrim) configuration.  | |
@@ -106,6 +107,44 @@ DiskSelector selects a disk for the volume.
 match: disk.size > 120u * GB && disk.size < 1u * TB
 {{< /highlight >}}match SATA disks that are not rotational and not system disks:{{< highlight yaml >}}
 match: disk.transport == "sata" && !disk.rotational && !system_disk
+{{< /highlight >}}</details> | |
+
+
+
+
+
+
+
+
+## filesystem {#VolumeConfig.filesystem}
+
+SystemVolumeFilesystemSpec describes how the system volume is formatted.
+
+The filesystem type is fixed for system volumes, and project quota support is configured via
+machine features, so only the filesystem-specific tunables are exposed here.
+
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`xfs` |<a href="#VolumeConfig.filesystem.xfs">XFSSpec</a> |XFS-specific filesystem options.  | |
+
+
+
+
+### xfs {#VolumeConfig.filesystem.xfs}
+
+XFSSpec configures XFS-specific filesystem options.
+
+
+
+
+| Field | Type | Description | Value(s) |
+|-------|------|-------------|----------|
+|`minAllocationGroupSize` |ByteSize |The minimum size of an XFS allocation group.<br><br>On non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of<br>CPUs, which on machines with many cores and a modest disk yields hundreds of tiny<br>allocation groups. Talos bounds the allocation group size from below to keep the geometry<br>sane; this option overrides that bound.<br><br>Set to zero to use the `mkfs.xfs` defaults unchanged.<br><br>Note: this only affects volumes at the time they are formatted.<br><br>Size is specified in bytes, but can be expressed in human readable format, e.g. 100MB. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+minAllocationGroupSize: 128GiB
 {{< /highlight >}}</details> | |
 
 

--- a/website/content/v1.14/schemas/config.schema.json
+++ b/website/content/v1.14/schemas/config.schema.json
@@ -396,6 +396,13 @@
           "description": "Enables project quota support, valid only for ‘xfs’ filesystem.\n\nNote: changing this value might require a full remount of the filesystem.\n",
           "markdownDescription": "Enables project quota support, valid only for 'xfs' filesystem.\n\nNote: changing this value might require a full remount of the filesystem.",
           "x-intellij-html-description": "\u003cp\u003eEnables project quota support, valid only for \u0026lsquo;xfs\u0026rsquo; filesystem.\u003c/p\u003e\n\n\u003cp\u003eNote: changing this value might require a full remount of the filesystem.\u003c/p\u003e\n"
+        },
+        "xfs": {
+          "$ref": "#/$defs/block.XFSSpec",
+          "title": "xfs",
+          "description": "XFS-specific filesystem options, valid only for ‘xfs’ filesystem.\n",
+          "markdownDescription": "XFS-specific filesystem options, valid only for 'xfs' filesystem.",
+          "x-intellij-html-description": "\u003cp\u003eXFS-specific filesystem options, valid only for \u0026lsquo;xfs\u0026rsquo; filesystem.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,
@@ -595,6 +602,20 @@
       ],
       "description": "SwapVolumeConfig is a disk swap volume configuration document.\\nSwap volume is automatically allocated as a partition on the specified disk\\nand activated as swap, removing a swap volume deactivates swap.\\nThe partition label is automatically generated as `s-\u003cname\u003e`.\\n"
     },
+    "block.SystemVolumeFilesystemSpec": {
+      "properties": {
+        "xfs": {
+          "$ref": "#/$defs/block.XFSSpec",
+          "title": "xfs",
+          "description": "XFS-specific filesystem options.\n",
+          "markdownDescription": "XFS-specific filesystem options.",
+          "x-intellij-html-description": "\u003cp\u003eXFS-specific filesystem options.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SystemVolumeFilesystemSpec describes how the system volume is formatted.\\n\\nThe filesystem type is fixed for system volumes, and project quota support is configured via\\nmachine features, so only the filesystem-specific tunables are exposed here.\\n"
+    },
     "block.TrimConfig": {
       "properties": {
         "enabled": {
@@ -768,6 +789,13 @@
           "markdownDescription": "The provisioning describes how the volume is provisioned.",
           "x-intellij-html-description": "\u003cp\u003eThe provisioning describes how the volume is provisioned.\u003c/p\u003e\n"
         },
+        "filesystem": {
+          "$ref": "#/$defs/block.SystemVolumeFilesystemSpec",
+          "title": "filesystem",
+          "description": "The filesystem describes how the volume is formatted.\n\nNote: this only takes effect at the time the volume is formatted.\n",
+          "markdownDescription": "The filesystem describes how the volume is formatted.\n\nNote: this only takes effect at the time the volume is formatted.",
+          "x-intellij-html-description": "\u003cp\u003eThe filesystem describes how the volume is formatted.\u003c/p\u003e\n\n\u003cp\u003eNote: this only takes effect at the time the volume is formatted.\u003c/p\u003e\n"
+        },
         "encryption": {
           "$ref": "#/$defs/block.EncryptionSpec",
           "title": "encryption",
@@ -825,6 +853,20 @@
       "additionalProperties": false,
       "type": "object",
       "description": "VolumeSelector selects an existing volume."
+    },
+    "block.XFSSpec": {
+      "properties": {
+        "minAllocationGroupSize": {
+          "type": "string",
+          "title": "minAllocationGroupSize",
+          "description": "The minimum size of an XFS allocation group.\n\nOn non-rotational devices mkfs.xfs sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\n\nSet to zero to use the mkfs.xfs defaults unchanged.\n\nNote: this only affects volumes at the time they are formatted.\n\nSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.\n",
+          "markdownDescription": "The minimum size of an XFS allocation group.\n\nOn non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\n\nSet to zero to use the `mkfs.xfs` defaults unchanged.\n\nNote: this only affects volumes at the time they are formatted.\n\nSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.",
+          "x-intellij-html-description": "\u003cp\u003eThe minimum size of an XFS allocation group.\u003c/p\u003e\n\n\u003cp\u003eOn non-rotational devices \u003ccode\u003emkfs.xfs\u003c/code\u003e sizes the allocation group count to the number of\nCPUs, which on machines with many cores and a modest disk yields hundreds of tiny\nallocation groups. Talos bounds the allocation group size from below to keep the geometry\nsane; this option overrides that bound.\u003c/p\u003e\n\n\u003cp\u003eSet to zero to use the \u003ccode\u003emkfs.xfs\u003c/code\u003e defaults unchanged.\u003c/p\u003e\n\n\u003cp\u003eNote: this only affects volumes at the time they are formatted.\u003c/p\u003e\n\n\u003cp\u003eSize is specified in bytes, but can be expressed in human readable format, e.g. 100MB.\u003c/p\u003e\n"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "XFSSpec configures XFS-specific filesystem options."
     },
     "block.ZswapConfigV1Alpha1": {
       "properties": {


### PR DESCRIPTION
Fixes #13697

The problem comes from the mkfs.xfs default allocation strategy: it caps the minimum AG size to 4 GiBs, and sets number of AGs by default to number of CPUs. For nodes with high CPU count this might lead to pathologocially high number of AGs for filesystems of relatively small size (e.g. 384 cores and 1 TiB filesystem).

As in fact the disk might be sliced into multiple relatively small chunks, apply another enforcement to cap AG to be no less than 64 GiB for filesystems in Talos 1.14+.

We allow this setting to be overridden or changed even more via volume configuration documents.
