### PR TITLE
fix(machined): wait for host namespace commands through reaper

### DIFF
--- a/internal/app/debug/hostns.go
+++ b/internal/app/debug/hostns.go
@@ -6,6 +6,7 @@ package debug
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,6 +18,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	ocispec "github.com/opencontainers/image-spec/identity"
+	"github.com/siderolabs/go-cmd/pkg/cmd/proc/reaper"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 
@@ -238,9 +240,15 @@ func launchInHostNs(
 		Env:  env,
 		Dir:  "/",
 	}
+	notifyCh := make(chan reaper.ProcessInfo, 8)
+
+	usingReaper := reaper.Notify(notifyCh)
+	if usingReaper {
+		defer reaper.Stop(notifyCh)
+	}
 
 	if tty {
-		return runWithOpenPty(ctx, cmd, merged, ptyMaster, ptySlave, stdin, stdout, cgroupFd, controlC)
+		return runWithOpenPty(ctx, cmd, merged, ptyMaster, ptySlave, stdin, stdout, cgroupFd, controlC, usingReaper, notifyCh)
 	}
 
 	cmd.Stdin = stdin
@@ -264,15 +272,24 @@ func launchInHostNs(
 
 	go runControlLoop(ctx, done, controlC, cmd.Process.Pid, nil)
 
-	if waitErr := cmd.Wait(); waitErr != nil {
-		if exitErr, ok := waitErr.(*exec.ExitError); ok {
-			return exitErr.ExitCode(), nil
-		}
+	return waitHostNsCommand(cmd, usingReaper, notifyCh)
+}
 
-		return 1, waitErr
+func waitHostNsCommand(cmd *exec.Cmd, usingReaper bool, notifyCh <-chan reaper.ProcessInfo) (int, error) {
+	waitErr := reaper.WaitWrapper(usingReaper, notifyCh, cmd)
+	if waitErr == nil {
+		return 0, nil
 	}
 
-	return 0, nil
+	if execErr, execErrOk := errors.AsType[*exec.ExitError](waitErr); execErrOk {
+		return execErr.ExitCode(), nil
+	}
+
+	if reaperExitErr, reaperExitErrOk := errors.AsType[*reaper.ExitError](waitErr); reaperExitErrOk {
+		return reaperExitErr.ExitCode, nil
+	}
+
+	return 1, waitErr
 }
 
 // runControlLoop handles out-of-band control messages for a running host-ns child:
@@ -339,6 +356,8 @@ func runWithOpenPty(
 	stdout io.Writer,
 	cgroupFd *os.File,
 	controlC <-chan hostNsControl,
+	usingReaper bool,
+	notifyCh <-chan reaper.ProcessInfo,
 ) (int, error) {
 	defer ptyMaster.Close() //nolint:errcheck
 
@@ -399,15 +418,7 @@ func runWithOpenPty(
 		}
 	}()
 
-	if waitErr := cmd.Wait(); waitErr != nil {
-		if exitErr, ok := waitErr.(*exec.ExitError); ok {
-			return exitErr.ExitCode(), nil
-		}
-
-		return 1, waitErr
-	}
-
-	return 0, nil
+	return waitHostNsCommand(cmd, usingReaper, notifyCh)
 }
 
 // openPty opens a new pseudo-terminal pair using Linux's /dev/ptmx.

--- a/internal/app/debug/hostns_export.go
+++ b/internal/app/debug/hostns_export.go
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package debug
+
+import (
+	"os/exec"
+
+	"github.com/siderolabs/go-cmd/pkg/cmd/proc/reaper"
+)
+
+// WaitHostNsCommand exposes the waitHostNsCommand function for testing purposes only.
+func WaitHostNsCommand(cmd *exec.Cmd, usingReaper bool, notifyCh chan reaper.ProcessInfo) (int, error) {
+	return waitHostNsCommand(cmd, usingReaper, notifyCh)
+}

--- a/internal/app/debug/hostns_test.go
+++ b/internal/app/debug/hostns_test.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package debug_test
+
+import (
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/siderolabs/go-cmd/pkg/cmd/proc/reaper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/debug"
+)
+
+func TestWaitHostNsCommandWithReaper(t *testing.T) {
+	reaper.Run()
+	t.Cleanup(reaper.Shutdown)
+
+	for _, expectedExitCode := range []int{0, 42} {
+		t.Run(strconv.Itoa(expectedExitCode), func(t *testing.T) {
+			cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", "exit "+strconv.Itoa(expectedExitCode))
+			notifyCh := make(chan reaper.ProcessInfo, 8)
+
+			usingReaper := reaper.Notify(notifyCh)
+			require.True(t, usingReaper)
+			t.Cleanup(func() { reaper.Stop(notifyCh) })
+
+			require.NoError(t, cmd.Start())
+
+			exitCode, err := debug.WaitHostNsCommand(cmd, usingReaper, notifyCh)
+
+			require.NoError(t, err)
+			require.Equal(t, expectedExitCode, exitCode)
+		})
+	}
+}


### PR DESCRIPTION
Machined runs as PID 1, so its global process reaper can collect a host namespace child before exec.Cmd.Wait does. The command can complete successfully while the API reports "waitid: no child processes" and returns exit code 1.

This caused ExtensionsSuiteQEMU/TestExtensionsUtilLinuxTools to fail after fstrim had already printed its version:

* https://github.com/siderolabs/talos/actions/runs/29801925199/job/88544516896

Register PTY and non-PTY commands with the process reaper before starting them, wait through reaper.WaitWrapper, and preserve exit codes returned by either exec or the reaper.

Add a regression test covering successful and non-zero exits while the process reaper is active. The focused test passed 100 iterations, and the full internal/app/debug package tests pass.