### PR TITLE
fix(talosctl): prevent duplicate QEMU config server ports

### DIFF
--- a/pkg/provision/providers/qemu/api_port.go
+++ b/pkg/provision/providers/qemu/api_port.go
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+)
+
+type apiPortAllocator struct {
+	mu        sync.Mutex
+	allocated map[int]struct{}
+}
+
+func (allocator *apiPortAllocator) allocate(ctx context.Context, host string) (*net.TCPAddr, error) {
+	allocator.mu.Lock()
+	defer allocator.mu.Unlock()
+
+	if allocator.allocated == nil {
+		allocator.allocated = make(map[int]struct{})
+	}
+
+	var listeners []net.Listener
+
+	closeListeners := func() error {
+		var closeErr error
+
+		for _, listener := range listeners {
+			closeErr = errors.Join(closeErr, listener.Close())
+		}
+
+		return closeErr
+	}
+
+	for {
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", net.JoinHostPort(host, "0"))
+		if err != nil {
+			return nil, errors.Join(err, closeListeners())
+		}
+
+		listeners = append(listeners, listener)
+
+		addr := listener.Addr().(*net.TCPAddr)
+		if _, exists := allocator.allocated[addr.Port]; exists {
+			continue
+		}
+
+		if err = closeListeners(); err != nil {
+			return nil, err
+		}
+
+		allocator.allocated[addr.Port] = struct{}{}
+
+		return addr, nil
+	}
+}

--- a/pkg/provision/providers/qemu/api_port_test.go
+++ b/pkg/provision/providers/qemu/api_port_test.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/provision/providers/qemu"
+)
+
+func TestAPIPortAllocator(t *testing.T) {
+	const count = 100
+
+	allocator := qemu.APIPortAllocatorForTest{}
+	ports := make(chan int, count)
+	errs := make(chan error, count)
+
+	var wg sync.WaitGroup
+
+	for range count {
+		wg.Go(func() {
+			addr, err := allocator.Allocate(t.Context(), "127.0.0.1")
+			if err != nil {
+				errs <- err
+
+				return
+			}
+
+			ports <- addr.Port
+		})
+	}
+
+	wg.Wait()
+	close(ports)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	uniquePorts := map[int]struct{}{}
+	for port := range ports {
+		_, exists := uniquePorts[port]
+		require.False(t, exists, "allocated duplicate port %d", port)
+
+		uniquePorts[port] = struct{}{}
+	}
+
+	require.Len(t, uniquePorts, count)
+}

--- a/pkg/provision/providers/qemu/export_test.go
+++ b/pkg/provision/providers/qemu/export_test.go
@@ -4,10 +4,25 @@
 
 package qemu
 
+import (
+	"context"
+	"net"
+)
+
 // FabricDeviceForTest exposes fabric device argument construction for tests.
 func FabricDeviceForTest(clos bool, index int, mac string, mtu int) string {
 	return fabricDevice(&LaunchConfig{
 		CLOSNoNet0: clos,
 		Network:    networkConfig{networkConfigBase: networkConfigBase{MTU: mtu}},
 	}, index, FabricUplink{mac: mac})
+}
+
+// APIPortAllocatorForTest exposes apiPortAllocator for tests.
+type APIPortAllocatorForTest struct {
+	allocator apiPortAllocator
+}
+
+// Allocate reserves an API port for tests.
+func (allocator *APIPortAllocatorForTest) Allocate(ctx context.Context, host string) (*net.TCPAddr, error) {
+	return allocator.allocator.allocate(ctx, host)
 }

--- a/pkg/provision/providers/qemu/node_darwin.go
+++ b/pkg/provision/providers/qemu/node_darwin.go
@@ -13,11 +13,6 @@ import (
 
 // findAPIBindAddrs returns the 0.0.0.0 address to bind to all interfaces on macos with a random port on macos.
 // The bridge interface address is not used as the bridge is not yet created at this stage.
-func (p *provisioner) findAPIBindAddrs(_ context.Context, _ provision.ClusterRequest) (*net.TCPAddr, error) {
-	l, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", "0"))
-	if err != nil {
-		return nil, err
-	}
-
-	return l.Addr().(*net.TCPAddr), l.Close()
+func (p *provisioner) findAPIBindAddrs(ctx context.Context, _ provision.ClusterRequest) (*net.TCPAddr, error) {
+	return p.apiPorts.allocate(ctx, "0.0.0.0")
 }

--- a/pkg/provision/providers/qemu/node_linux.go
+++ b/pkg/provision/providers/qemu/node_linux.go
@@ -12,10 +12,5 @@ import (
 )
 
 func (p *provisioner) findAPIBindAddrs(ctx context.Context, clusterReq provision.ClusterRequest) (*net.TCPAddr, error) {
-	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", net.JoinHostPort(clusterReq.Network.GatewayAddrs[0].String(), "0"))
-	if err != nil {
-		return nil, err
-	}
-
-	return l.Addr().(*net.TCPAddr), l.Close()
+	return p.apiPorts.allocate(ctx, clusterReq.Network.GatewayAddrs[0].String())
 }

--- a/pkg/provision/providers/qemu/qemu.go
+++ b/pkg/provision/providers/qemu/qemu.go
@@ -24,12 +24,14 @@ import (
 
 type provisioner struct {
 	vm.Provisioner
+
+	apiPorts apiPortAllocator
 }
 
 // NewProvisioner initializes qemu provisioner.
 func NewProvisioner(ctx context.Context) (provision.Provisioner, error) {
 	p := &provisioner{
-		vm.Provisioner{
+		Provisioner: vm.Provisioner{
 			Name: "qemu",
 		},
 	}


### PR DESCRIPTION
QEMU node setup selected a config server port by listening on port zero and immediately closing the listener. Concurrent node setup could then select the same ephemeral port twice. The second config server failed to bind while cluster health waited for a node that never started. Serialize port allocation and track every port reserved by the provisioner. Keep duplicate candidate listeners open while searching so the kernel cannot repeatedly return the same port. Use the shared allocator on Linux and Darwin.

Seen in: https://github.com/siderolabs/talos/actions/runs/29801925201/job/88544516926