### PR TITLE
fix: configure bonds during initial link creation

### DIFF
--- a/internal/app/machined/pkg/controllers/ctest/ctest.go
+++ b/internal/app/machined/pkg/controllers/ctest/ctest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -39,6 +40,7 @@ type DefaultSuite struct {
 
 	AfterSetup    func(suite *DefaultSuite)
 	AfterTearDown func(suite *DefaultSuite)
+	Logger        *zap.Logger
 	Timeout       time.Duration
 }
 
@@ -60,7 +62,12 @@ func (suite *DefaultSuite) SetupTest() {
 
 	var err error
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, zaptest.NewLogger(suite.T()))
+	logger := suite.Logger
+	if logger == nil {
+		logger = zaptest.NewLogger(suite.T())
+	}
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
 	suite.Require().NoError(err)
 
 	suite.startRuntime()

--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -195,6 +195,19 @@ func findLink(links []rtnetlink.LinkMessage, name string, allowAliases bool) *rt
 	return nil
 }
 
+func rawLinkData(link *rtnetlink.LinkMessage) []byte {
+	if link == nil || link.Attributes == nil || link.Attributes.Info == nil || link.Attributes.Info.Data == nil {
+		return nil
+	}
+
+	linkData, ok := link.Attributes.Info.Data.(*rtnetlink.LinkData)
+	if !ok {
+		return nil
+	}
+
+	return linkData.Data
+}
+
 // syncLink syncs kernel state with the LinkSpec link.
 //
 // This method is really long, but it's hard to break it down in multiple pieces, are those pieces and steps are inter-dependent, so, instead,
@@ -253,14 +266,7 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 		}
 	case resource.PhaseRunning:
 		existing := findLink(*links, link.TypedSpec().Name, !link.TypedSpec().Logical) // allow aliases for physical links
-
-		var existingRawLinkData []byte
-
-		if existing != nil && existing.Attributes != nil && existing.Attributes.Info != nil && existing.Attributes.Info.Data != nil {
-			if existingLinkData, ok := existing.Attributes.Info.Data.(*rtnetlink.LinkData); ok {
-				existingRawLinkData = existingLinkData.Data
-			}
-		}
+		existingRawLinkData := rawLinkData(existing)
 
 		// check if type/kind matches for the existing logical link
 		if existing != nil && link.TypedSpec().Logical {
@@ -381,6 +387,13 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 				}
 			}
 
+			if link.TypedSpec().Kind == network.LinkKindBond {
+				data, err = networkadapter.BondMasterSpec(&link.TypedSpec().BondMaster).Encode()
+				if err != nil {
+					return fmt.Errorf("error encoding bond attributes for link %q: %w", link.TypedSpec().Name, err)
+				}
+			}
+
 			// vrf settings should be set on interface creation (parent + vrf settings)
 			if link.TypedSpec().VRFSlave.MasterName != "" {
 				master := findLink(*links, link.TypedSpec().VRFSlave.MasterName, false)
@@ -434,6 +447,8 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 			if existing == nil {
 				return fmt.Errorf("created link %q not found in the link list", link.TypedSpec().Name)
 			}
+
+			existingRawLinkData = rawLinkData(existing)
 		}
 
 		// sync bond settings

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
@@ -36,6 +40,8 @@ import (
 
 type LinkSpecSuite struct {
 	ctest.DefaultSuite
+
+	observedLogs *observer.ObservedLogs
 }
 
 func (suite *LinkSpecSuite) uniqueDummyInterface() string {
@@ -572,6 +578,14 @@ func (suite *LinkSpecSuite) TestBond8023ad() {
 		}
 	})
 
+	for _, entry := range suite.observedLogs.FilterMessage("controller failed").All() {
+		suite.Require().NotContains(fmt.Sprint(entry.ContextMap()["error"]), bondName)
+	}
+
+	for _, entry := range suite.observedLogs.FilterMessage("updating bond settings").All() {
+		suite.Require().NotEqual(bondName, entry.ContextMap()["link"])
+	}
+
 	// teardown the links
 	for _, r := range append(dummies, bond) {
 		suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), r.Metadata()))
@@ -867,8 +881,13 @@ func TestLinkSpecSuite(t *testing.T) {
 		t.Skip("requires root")
 	}
 
+	observerCore, observedLogs := observer.New(zap.DebugLevel)
+	logger := zap.New(zapcore.NewTee(zaptest.NewLogger(t).Core(), observerCore))
+
 	suite.Run(t, &LinkSpecSuite{
+		observedLogs: observedLogs,
 		DefaultSuite: ctest.DefaultSuite{
+			Logger:  logger,
 			Timeout: 15 * time.Second,
 			AfterSetup: func(suite *ctest.DefaultSuite) {
 				// create fake device ready status


### PR DESCRIPTION
LinkSpecController created a bond without BondMasterSpec data and kept using link data captured before creation. Every new bond therefore failed its first reconciliation, backed off, and updated its settings only after the controller restarted.

Under a loaded FIPS unit-test run, this delay consumed most of the TestBond8023ad assertion window and left LinkStatus stale at MTU 1500:

https://github.com/siderolabs/talos/actions/runs/29983454295/job/89130746536

Encode bond attributes in RTM_NEWLINK and refresh raw link data after relisting the new interface. This lets bond creation, MTU updates, and slave attachment complete in the first reconciliation.

Capture controller logs in TestBond8023ad and reject either a controller failure or follow-up bond settings update. The focused normal and FIPS tests pass 100 iterations, the full network suite and race test pass, and make lint-go passes.