### PR TITLE
fix: teardown ephemeral mount request during reset

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1456,13 +1456,13 @@ func UnmountEphemeralPartition(runtime.Sequence, any) (runtime.TaskExecutionFunc
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
 		mountRequest := blockres.NewVolumeMountRequest(blockres.NamespaceName, constants.EphemeralPartitionLabel).Metadata()
 
-		err := r.State().V1Alpha2().Resources().Destroy(ctx, mountRequest)
+		err := r.State().V1Alpha2().Resources().TeardownAndDestroy(ctx, mountRequest)
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				return nil
 			}
 
-			return fmt.Errorf("failed to destroy EPHEMERAL mount request: %w", err)
+			return fmt.Errorf("failed to teardown EPHEMERAL mount request: %w", err)
 		}
 
 		return nil

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks_test.go
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1_test
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+func TestUnmountEphemeralPartitionWaitsForFinalizers(t *testing.T) {
+	t.Setenv("PLATFORM", "container")
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	runtimeState, err := v1alpha1.NewState()
+	require.NoError(t, err)
+
+	resources := runtimeState.V1Alpha2().Resources()
+	mountRequest := blockres.NewVolumeMountRequest(blockres.NamespaceName, constants.EphemeralPartitionLabel)
+
+	require.NoError(t, resources.Create(ctx, mountRequest))
+	require.NoError(t, resources.AddFinalizer(ctx, mountRequest.Metadata(), "mount-controller"))
+
+	finalizerRemoved := make(chan error, 1)
+
+	go func() {
+		_, watchErr := resources.WatchFor(ctx, mountRequest.Metadata(), state.WithPhases(resource.PhaseTearingDown))
+		if watchErr != nil {
+			finalizerRemoved <- watchErr
+
+			return
+		}
+
+		finalizerRemoved <- resources.RemoveFinalizer(ctx, mountRequest.Metadata(), "mount-controller")
+	}()
+
+	task, _ := v1alpha1.UnmountEphemeralPartition(runtime.SequenceReset, nil)
+	err = task(ctx, log.New(io.Discard, "", 0), v1alpha1.NewRuntime(runtimeState, nil, nil))
+
+	require.NoError(t, err)
+	require.NoError(t, <-finalizerRemoved)
+
+	_, err = resources.Get(ctx, mountRequest.Metadata())
+	require.True(t, state.IsNotFoundError(err))
+}


### PR DESCRIPTION
Reset can take over boot while the EPHEMERAL VolumeMountRequest is still active. UnmountEphemeralPartition destroyed the request directly, which fails once the mount controller has attached its finalizer and bypasses the teardown lifecycle needed to unmount the volume safely.

This left TestResetDuringBoot waiting for volume finalization until its timeout:

https://github.com/siderolabs/talos/actions/runs/29472046792/job/87536976826

Use TeardownAndDestroy so the request enters the tearing-down phase and waits for controllers to release their finalizers before deletion.

Add a deterministic regression test with an active mount request whose finalizer is released only after observing PhaseTearingDown. The test fails against Destroy with a pending-finalizers error and passes 100 iterations with the fix. The v1alpha1 package, focused race test, and make lint-go pass.