### PR TITLE
fix: fix a nil-map assignment panic in configpatcher

### DIFF
--- a/pkg/machinery/config/configpatcher/apply_test.go
+++ b/pkg/machinery/config/configpatcher/apply_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
 )
 
 //go:embed testdata/apply/config.yaml
@@ -133,6 +134,24 @@ func TestApplyMultiDoc(t *testing.T) {
 			assert.Equal(t, expectedMultidoc, string(bytes))
 		})
 	}
+}
+
+func TestApplyToEmptyConfig(t *testing.T) {
+	patches, err := configpatcher.LoadPatches([]string{
+		"@testdata/multidoc/strategic2.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := container.New()
+	require.NoError(t, err)
+
+	out, err := configpatcher.Apply(configpatcher.WithConfig(cfg), patches)
+	require.NoError(t, err)
+
+	patched, err := out.Config()
+	require.NoError(t, err)
+
+	require.Len(t, patched.Documents(), 2)
 }
 
 //go:embed testdata/auditpolicy/config.yaml

--- a/pkg/machinery/config/configpatcher/strategic.go
+++ b/pkg/machinery/config/configpatcher/strategic.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"slices"
 
-	"github.com/siderolabs/gen/xslices"
-
 	coreconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
@@ -42,9 +40,11 @@ func StrategicMerge(cfg coreconfig.Provider, patch StrategicMergePatch) (corecon
 		return id
 	}
 
-	leftIndex := xslices.ToMap(left, func(d config.Document) (string, config.Document) {
-		return documentID(d), d
-	})
+	leftIndex := make(map[string]config.Document, len(left))
+
+	for _, d := range left {
+		leftIndex[documentID(d)] = d
+	}
 
 	for _, rightDoc := range right {
 		id := documentID(rightDoc)


### PR DESCRIPTION
When patching an empty config, we tried to assign to a nil map, which caused a panic. Initialize an empty map rather than a nil map to prevent this.