### PR TITLE
fix: split the up/finished service events

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -409,7 +409,7 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 		logger.Printf("waiting for %d services", len(svcs.List()))
 
 		for _, svc := range svcs.List() {
-			cond := system.WaitForService(system.StateEventUp, svc.AsProto().GetId())
+			cond := system.WaitForServiceAnyEvent([]system.StateEvent{system.StateEventUp, system.StateEventFinished}, svc.AsProto().GetId())
 			all = append(all, cond)
 		}
 

--- a/internal/app/machined/pkg/system/export_test.go
+++ b/internal/app/machined/pkg/system/export_test.go
@@ -9,10 +9,17 @@ import (
 	"github.com/siderolabs/talos/pkg/conditions"
 )
 
+// Singleton exports the unexported singleton type so that tests can name it.
+type Singleton = singleton
+
 func NewServices(runtime runtime.Runtime) *singleton { //nolint:revive
 	return newServices(runtime)
 }
 
 func WaitForServiceWithInstance(instance *singleton, event StateEvent, service string) conditions.Condition {
-	return waitForService(instance, event, service)
+	return waitForService(instance, []StateEvent{event}, service)
+}
+
+func WaitForServiceAnyEventWithInstance(instance *singleton, events []StateEvent, service string) conditions.Condition {
+	return waitForService(instance, events, service)
 }

--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -129,6 +129,30 @@ func (m *MockRunner) String() string {
 	return "MockRunner()"
 }
 
+// MockFinishingRunner models a one-shot service: it runs to completion right away,
+// and it never reports events.StateRunning, so the service is never 'up'.
+type MockFinishingRunner struct{}
+
+func (MockFinishingRunner) Open() error {
+	return nil
+}
+
+func (MockFinishingRunner) Close() error {
+	return nil
+}
+
+func (MockFinishingRunner) Run(events.Recorder, pid.Recorder) error {
+	return nil
+}
+
+func (MockFinishingRunner) Stop() error {
+	return nil
+}
+
+func (MockFinishingRunner) String() string {
+	return "MockFinishingRunner()"
+}
+
 type MockCondition struct {
 	done chan struct{}
 	desc string

--- a/internal/app/machined/pkg/system/service_events.go
+++ b/internal/app/machined/pkg/system/service_events.go
@@ -7,8 +7,11 @@ package system
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/talos/pkg/conditions"
 )
@@ -28,7 +31,7 @@ type serviceCondition struct {
 	waitingRegister bool
 	instance        *singleton
 
-	event   StateEvent
+	events  []StateEvent
 	service string
 }
 
@@ -47,8 +50,10 @@ func (sc *serviceCondition) Wait(ctx context.Context) error {
 func (sc *serviceCondition) waitEvent(ctx context.Context, svcrunner *ServiceRunner) error {
 	notifyCh := make(chan struct{}, 1)
 
-	svcrunner.Subscribe(sc.event, notifyCh)
-	defer svcrunner.Unsubscribe(sc.event, notifyCh)
+	for _, ev := range sc.events {
+		svcrunner.Subscribe(ev, notifyCh)
+		defer svcrunner.Unsubscribe(ev, notifyCh)
+	}
 
 	select {
 	case <-ctx.Done():
@@ -100,18 +105,27 @@ func (sc *serviceCondition) String() string {
 		return fmt.Sprintf("service %q to be registered", sc.service)
 	}
 
-	return fmt.Sprintf("service %q to be %q", sc.service, string(sc.event))
+	if len(sc.events) == 1 {
+		return fmt.Sprintf("service %q to be %q", sc.service, string(sc.events[0]))
+	}
+
+	return fmt.Sprintf("service %q to be %s", sc.service, strings.Join(xslices.Map(sc.events, func(e StateEvent) string { return string(e) }), "/"))
 }
 
 // WaitForService waits for service to reach some state event.
 func WaitForService(event StateEvent, service string) conditions.Condition {
-	return waitForService(instance, event, service)
+	return waitForService(instance, []StateEvent{event}, service)
 }
 
-func waitForService(instance *singleton, event StateEvent, service string) conditions.Condition {
+// WaitForServiceAnyEvent waits for service to reach some state event (one of).
+func WaitForServiceAnyEvent(events []StateEvent, service string) conditions.Condition {
+	return waitForService(instance, events, service)
+}
+
+func waitForService(instance *singleton, events []StateEvent, service string) conditions.Condition {
 	return &serviceCondition{
 		instance: instance,
-		event:    event,
+		events:   events,
 		service:  service,
 	}
 }

--- a/internal/app/machined/pkg/system/service_events_test.go
+++ b/internal/app/machined/pkg/system/service_events_test.go
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package system_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-retry/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/system"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/system/events"
+)
+
+func upOrFinished() []system.StateEvent {
+	return []system.StateEvent{system.StateEventUp, system.StateEventFinished}
+}
+
+// waitForServiceState blocks until the service reports the expected state.
+func waitForServiceState(t *testing.T, services *system.Singleton, id string, expected events.ServiceState) {
+	t.Helper()
+
+	require.NoError(t, retry.Constant(time.Minute, retry.WithUnits(10*time.Millisecond)).Retry(func() error {
+		for _, svcrunner := range services.List() {
+			svc := svcrunner.AsProto()
+
+			if svc.Id != id {
+				continue
+			}
+
+			if svc.State != expected.String() {
+				return retry.ExpectedErrorf("service %q is %q, expected %q", id, svc.State, expected)
+			}
+
+			return nil
+		}
+
+		return retry.ExpectedErrorf("service %q is not registered", id)
+	}))
+}
+
+// TestWaitForServiceAnyEventUp asserts that a multi-event wait is satisfied by the first
+// of the events to happen - here, the service coming up.
+func TestWaitForServiceAnyEventUp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	services := system.NewServices(newRuntime(t))
+	t.Cleanup(func() { services.Shutdown(context.Background()) })
+
+	services.LoadAndStart(&MockService{name: "up-service"})
+
+	require.NoError(t, system.WaitForServiceAnyEventWithInstance(services, upOrFinished(), "up-service").Wait(ctx))
+
+	waitForServiceState(t, services, "up-service", events.StateRunning)
+}
+
+// TestWaitForServiceAnyEventFinished asserts that a multi-event wait is satisfied by a
+// service which ran to completion, while a wait for 'up' alone is not: a finished
+// service is not up.
+func TestWaitForServiceAnyEventFinished(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	services := system.NewServices(newRuntime(t))
+	t.Cleanup(func() { services.Shutdown(context.Background()) })
+
+	services.LoadAndStart(&MockService{name: "oneshot-service", runner: MockFinishingRunner{}})
+
+	waitForServiceState(t, services, "oneshot-service", events.StateFinished)
+
+	// the runner never reports StateRunning, so 'finished' is the only event which can
+	// satisfy this condition
+	require.NoError(t, system.WaitForServiceAnyEventWithInstance(services, upOrFinished(), "oneshot-service").Wait(ctx))
+
+	upCtx, upCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer upCancel()
+
+	assert.ErrorIs(t,
+		system.WaitForServiceWithInstance(services, system.StateEventUp, "oneshot-service").Wait(upCtx),
+		context.DeadlineExceeded)
+}
+
+// TestWaitForServiceAnyEventFinishedEdge is TestWaitForServiceAnyEventFinished with the
+// wait established before the service finishes, so the condition is completed by the
+// state transition notification rather than by the state check done on subscribe.
+func TestWaitForServiceAnyEventFinishedEdge(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	cond := NewMockCondition("gate")
+
+	services := system.NewServices(newRuntime(t))
+	t.Cleanup(func() { services.Shutdown(context.Background()) })
+
+	services.LoadAndStart(&MockService{name: "gated-service", condition: cond, runner: MockFinishingRunner{}})
+
+	// hold the service in StateWaiting while the wait below subscribes
+	waitForServiceState(t, services, "gated-service", events.StateWaiting)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- system.WaitForServiceAnyEventWithInstance(services, upOrFinished(), "gated-service").Wait(ctx)
+	}()
+
+	// give the goroutine above a chance to subscribe before the service finishes;
+	// if it loses the race the condition is still satisfied, just via the state check
+	// in Subscribe() instead of the notification
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case err := <-errCh:
+		require.FailNowf(t, "condition completed early", "service is still waiting on its condition: %v", err)
+	default:
+	}
+
+	close(cond.done)
+
+	require.NoError(t, <-errCh)
+
+	waitForServiceState(t, services, "gated-service", events.StateFinished)
+}
+
+func TestServiceConditionString(t *testing.T) {
+	assert.Equal(t,
+		`service "foo" to be "up"`,
+		system.WaitForServiceWithInstance(nil, system.StateEventUp, "foo").String())
+
+	assert.Equal(t,
+		`service "foo" to be up/finished`,
+		system.WaitForServiceAnyEventWithInstance(nil, upOrFinished(), "foo").String())
+}

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -226,7 +226,9 @@ func (svcrunner *ServiceRunner) Run(notifyChannels ...chan<- struct{}) error {
 	condition := svcrunner.service.Condition(svcrunner.runtime)
 
 	if dependencies := svcrunner.service.DependsOn(svcrunner.runtime); len(dependencies) > 0 {
-		serviceConditions := xslices.Map(dependencies, func(dep string) conditions.Condition { return waitForService(instance, StateEventUp, dep) })
+		serviceConditions := xslices.Map(dependencies, func(dep string) conditions.Condition {
+			return waitForService(instance, []StateEvent{StateEventUp}, dep)
+		})
 		serviceDependencies := conditions.WaitForAll(serviceConditions...)
 
 		condition = conditions.WaitForAll(serviceDependencies, condition)
@@ -463,10 +465,10 @@ func (svcrunner *ServiceRunner) inStateLocked(event StateEvent) bool {
 	switch event {
 	case StateEventUp:
 		// up when:
-		//   a) either skipped or already finished
+		//   a) skipped
 		//   b) or running and healthy (if supports health checks)
 		switch svcrunner.state { //nolint:exhaustive
-		case events.StateSkipped, events.StateFinished:
+		case events.StateSkipped:
 			return true
 		case events.StateRunning:
 			// check if service supports health checks
@@ -486,11 +488,7 @@ func (svcrunner *ServiceRunner) inStateLocked(event StateEvent) bool {
 			return false
 		}
 	case StateEventFinished:
-		if svcrunner.state == events.StateFinished {
-			return true
-		}
-
-		return false
+		return svcrunner.state == events.StateFinished
 	default:
 		panic("unsupported event")
 	}

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -361,12 +361,12 @@ func (s *singleton) stopServices(ctx context.Context, services []string, waitFor
 	for name, svcrunner := range servicesToStop {
 		shutdownWg.Add(1)
 
-		stoppedConds = append(stoppedConds, waitForService(s, StateEventDown, name))
+		stoppedConds = append(stoppedConds, waitForService(s, []StateEvent{StateEventDown}, name))
 
 		go func(svcrunner *ServiceRunner, reverseDeps []string) {
 			defer shutdownWg.Done()
 
-			conds := xslices.Map(reverseDeps, func(dep string) conditions.Condition { return waitForService(s, StateEventDown, dep) })
+			conds := xslices.Map(reverseDeps, func(dep string) conditions.Condition { return waitForService(s, []StateEvent{StateEventDown}, dep) })
 			allDeps := conditions.WaitForAll(conds...)
 
 			if err := allDeps.Wait(shutdownCtx); err != nil {


### PR DESCRIPTION
They were aliased 7 years ago to fix the issue which is no longer present in the codebase.

Now dependency on the service to be 'up' means it's up, not finished. This might break any dependency on services which are single-shot, but I couldn't find any so far.

This fixes an issue when a service which was not up goes through a restart sequence, in the middle of a restart it enters 'Finished' state which leads to Talos assuming it's up, unlocking dependent services in a wrong way.
