### PR TITLE
test: avoid control plane static pod suite race

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -96,9 +96,12 @@ func (suite *ControlPlaneStaticPodSuite) TestEtcdUnhealthyPreservesStaticPods() 
 		return nil
 	})
 
+	ctx := suite.Ctx()
+	st := suite.State()
+
 	for _, id := range staticPodIDs {
 		suite.Never(func() bool {
-			_, err := suite.State().Get(suite.Ctx(), k8s.NewStaticPod(k8s.NamespaceName, id).Metadata())
+			_, err := st.Get(ctx, k8s.NewStaticPod(k8s.NamespaceName, id).Metadata())
 
 			return state.IsNotFoundError(err)
 		}, 500*time.Millisecond, 10*time.Millisecond)


### PR DESCRIPTION
assert.Never evaluates its condition in a goroutine and can return while the final invocation is still running. The static pod condition read State and Ctx through the shared suite after its test ended, racing the next test as DefaultSuite.SetupTest replaced both fields.

This caused the unrelated unit-tests-race failure in the CRI configuration pull request:

https://github.com/siderolabs/talos/actions/runs/30011869690/job/89223000785

Capture the state and context before entering the Never loop so a late callback retains the values belonging to its own test. The unfixed focused test reproduces both suite field races, while the same ordering passes 100 race-detector iterations with the fix. The full Kubernetes controller package race test and make lint-go pass.