### PR TITLE
fix: propagate UKI cmdline to new install flows

### DIFF
--- a/cmd/installer/cmd/installer/root.go
+++ b/cmd/installer/cmd/installer/root.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 
 	"github.com/siderolabs/gen/xerrors"
 	"github.com/spf13/cobra"
@@ -26,6 +27,15 @@ var rootCmd = &cobra.Command{
 }
 
 func setFlagsFromEnvironment() error {
+	if value := os.Getenv(constants.InstallerGrubUseUKICmdlineEnvVar); value != "" {
+		grubUseUKICmdline, err := strconv.ParseBool(value)
+		if err != nil {
+			return xerrors.NewTaggedf[install.InvalidInputTag]("invalid %s value: %w", constants.InstallerGrubUseUKICmdlineEnvVar, err)
+		}
+
+		options.GrubUseUKICmdline = grubUseUKICmdline
+	}
+
 	if metaEnvBase64 := os.Getenv(constants.MetaValuesEnvVar); metaEnvBase64 != "" {
 		if err := options.MetaValues.Decode(metaEnvBase64); err != nil {
 			return xerrors.NewTaggedf[install.InvalidInputTag]("%w", err)

--- a/cmd/installer/cmd/installer/root_test.go
+++ b/cmd/installer/cmd/installer/root_test.go
@@ -10,9 +10,22 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/cmd/installer/pkg/install"
 	installerexitcode "github.com/siderolabs/talos/pkg/installer/exitcode"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
+
+func TestSetFlagsFromEnvironmentGrubUseUKICmdline(t *testing.T) {
+	t.Setenv(constants.InstallerGrubUseUKICmdlineEnvVar, "true")
+
+	oldOptions := options
+	options = &install.Options{}
+
+	t.Cleanup(func() { options = oldOptions })
+
+	require.NoError(t, setFlagsFromEnvironment())
+	require.True(t, options.GrubUseUKICmdline)
+}
 
 func TestExecuteInvalidMetaEnv(t *testing.T) {
 	t.Setenv(constants.MetaValuesEnvVar, "!!!")

--- a/internal/app/lifecycle/container.go
+++ b/internal/app/lifecycle/container.go
@@ -100,7 +100,7 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 	// build container spec
 	mounts := buildMounts()
 	args := buildInstallerArgs(rc.disk, rc.platform, &options)
-	specOpts := buildSpecOpts(img, args, mounts)
+	specOpts := buildSpecOpts(img, args, mounts, options.Environment(nil))
 
 	containerID, err := generateContainerID()
 	if err != nil {
@@ -316,10 +316,11 @@ func buildInstallerArgs(disk, platform string, options *install.Options) []strin
 }
 
 // buildSpecOpts constructs the OCI spec options for the installer container.
-func buildSpecOpts(img client.Image, args []string, mounts []specs.Mount) []oci.SpecOpts {
+func buildSpecOpts(img client.Image, args []string, mounts []specs.Mount, env []string) []oci.SpecOpts {
 	specOpts := []oci.SpecOpts{
 		containerdrunner.WithImageConfigStripped(img),
 		oci.WithProcessArgs(args...),
+		oci.WithEnv(env),
 		oci.WithHostNamespace(specs.NetworkNamespace),
 		oci.WithHostNamespace(specs.PIDNamespace),
 		oci.WithMounts(mounts),

--- a/internal/app/lifecycle/lifecycle.go
+++ b/internal/app/lifecycle/lifecycle.go
@@ -102,6 +102,7 @@ func (s *Service) Install(req *machine.LifecycleServiceInstallRequest, ss grpc.S
 			opts: []install.Option{
 				install.WithForce(true),
 				install.WithZero(false),
+				install.WithGrubUseUKICmdline(true),
 			},
 			send: func(msg string) error {
 				s.logger.Info("installation progress", zap.String("message", msg))

--- a/internal/app/machined/pkg/controllers/runtime/unattended_install.go
+++ b/internal/app/machined/pkg/controllers/runtime/unattended_install.go
@@ -83,6 +83,7 @@ func NewUnattendedInstallController(rt v1alpha1runtime.Runtime) *UnattendedInsta
 				crires.RegistryBuilder(resources),
 				install.WithForce(true),
 				install.WithZero(wipe),
+				install.WithGrubUseUKICmdline(true),
 			); err != nil {
 				return err
 			}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -191,7 +191,7 @@ func RunInstallerContainer(
 		oci.WithApparmorProfile(""),
 		oci.WithSeccompUnconfined,
 		oci.WithAllDevicesAllowed,
-		oci.WithEnv(environment.Get(cfg)),
+		oci.WithEnv(options.Environment(environment.Get(cfg))),
 	}
 
 	if selinux.IsEnabled() {

--- a/internal/pkg/install/options.go
+++ b/internal/pkg/install/options.go
@@ -4,17 +4,25 @@
 
 package install
 
+import (
+	"slices"
+	"strings"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
 // Option is a functional option.
 type Option func(o *Options) error
 
 // Options describes the install options.
 type Options struct {
 	// Deprecated: Pull is not used in new Lifecycle API.
-	Pull            bool
-	Force           bool
-	Upgrade         bool
-	Zero            bool
-	ExtraKernelArgs []string
+	Pull              bool
+	Force             bool
+	Upgrade           bool
+	Zero              bool
+	GrubUseUKICmdline bool
+	ExtraKernelArgs   []string
 }
 
 // DefaultInstallOptions returns default options.
@@ -31,6 +39,21 @@ func (o *Options) Apply(opts ...Option) error {
 	}
 
 	return nil
+}
+
+// Environment returns the installer environment derived from the options.
+func (o *Options) Environment(env []string) []string {
+	env = slices.DeleteFunc(slices.Clone(env), func(value string) bool {
+		name, _, _ := strings.Cut(value, "=")
+
+		return name == constants.InstallerGrubUseUKICmdlineEnvVar
+	})
+
+	if o.GrubUseUKICmdline {
+		env = append(env, constants.InstallerGrubUseUKICmdlineEnvVar+"=true")
+	}
+
+	return env
 }
 
 // WithOptions sets Options as a whole.
@@ -75,6 +98,15 @@ func WithUpgrade(b bool) Option {
 func WithZero(b bool) Option {
 	return func(o *Options) error {
 		o.Zero = b
+
+		return nil
+	}
+}
+
+// WithGrubUseUKICmdline configures GRUB to use the kernel command line embedded in the UKI.
+func WithGrubUseUKICmdline(enabled bool) Option {
+	return func(o *Options) error {
+		o.GrubUseUKICmdline = enabled
 
 		return nil
 	}

--- a/internal/pkg/install/options_test.go
+++ b/internal/pkg/install/options_test.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/install"
+)
+
+func TestWithGrubUseUKICmdline(t *testing.T) {
+	options := install.DefaultInstallOptions()
+
+	require.NoError(t, options.Apply(install.WithGrubUseUKICmdline(true)))
+	require.True(t, options.GrubUseUKICmdline)
+}
+
+func TestEnvironmentIncludesGrubUseUKICmdline(t *testing.T) {
+	options := install.DefaultInstallOptions()
+	require.NoError(t, options.Apply(install.WithGrubUseUKICmdline(true)))
+
+	require.Equal(t,
+		[]string{"EXISTING=value", "INSTALLER_GRUB_USE_UKI_CMDLINE=true"},
+		options.Environment([]string{"EXISTING=value"}),
+	)
+}
+
+func TestEnvironmentOverridesGrubUseUKICmdline(t *testing.T) {
+	options := install.DefaultInstallOptions()
+	require.NoError(t, options.Apply(install.WithGrubUseUKICmdline(true)))
+
+	require.Equal(t,
+		[]string{"EXISTING=value", "INSTALLER_GRUB_USE_UKI_CMDLINE=true"},
+		options.Environment([]string{"EXISTING=value", "INSTALLER_GRUB_USE_UKI_CMDLINE=false"}),
+	)
+}
+
+func TestEnvironmentRemovesUnrequestedGrubUseUKICmdline(t *testing.T) {
+	options := install.DefaultInstallOptions()
+
+	require.Equal(t,
+		[]string{"EXISTING=value"},
+		options.Environment([]string{"EXISTING=value", "INSTALLER_GRUB_USE_UKI_CMDLINE=true"}),
+	)
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1303,6 +1303,9 @@ const (
 	// MetaValuesEnvVar is the name of the environment variable to store encoded meta values for the disk image (installer).
 	MetaValuesEnvVar = "INSTALLER_META_BASE64"
 
+	// InstallerGrubUseUKICmdlineEnvVar controls whether GRUB uses the kernel command line embedded in the UKI.
+	InstallerGrubUseUKICmdlineEnvVar = "INSTALLER_GRUB_USE_UKI_CMDLINE"
+
 	// MaintenanceServiceCommonName is the CN of the maintenance service server certificate.
 	MaintenanceServiceCommonName = "maintenance-service.talos.dev"
 


### PR DESCRIPTION
UKI builds embed the kernel cmdline in the signed binary. GRUB must
use that embedded cmdline instead of supplying one separately. This
option propagates `INSTALLER_GRUB_USE_UKI_CMDLINE=true` into the
installer container environment and defaults to enabled for lifecycle
and unattended install paths.

Closes #13860
