### PR TITLE
feat: skip pod check if desired number of pods is zero

### DIFF
--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -44,7 +44,7 @@ func DefaultClusterChecks() []ClusterCheck {
 						return err
 					}
 
-					if !present {
+					if !present || replicas == 0 {
 						return conditions.ErrSkipAssertion
 					}
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What?
Some CNI-s have built in [kube-proxy feature](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf), and disables the stock kube-proxy by settings a custom node selector:

```
  nodeSelector:
    operator.tigera.io/disable-kube-proxy: "true"
```

## Why?

But talosctl check for kube-proxy and waiting forever for kube-proxy pods. This patch skips the pod check if the desired pod number is zero.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
