### PR TITLE
fix: use context without cancelation for etcd locks

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -3,7 +3,7 @@ ignore_ttl: 168h # 7 days, each entry must be revalidated after this time, and e
 ignore:
   - id: GO-2026-5932
     reason: No fix available. golang.org/x/crypto/openpgp is imported transitively because Cosign pulls Rekor's legacy rekord/v0.0.1 PGP implementation. Talos verifies Sigstore/X.509 signatures and does not use PGP; Cosign's legacy .sig path is an OCI storage format, not PGP. The reported PCR, error, io.Reader/io.Writer, and DSSE-to-rekord call chains are govulncheck VTA interface/factory false positives.
-    date: 2026-07-21
+    date: 2026-07-28
   - id: GO-2026-4736
     reason: 'gobgp NEXT_HOP DoS (GHSA-4p9m-8gc4-rw2h). The reachable recvMessageloop symbol is real, but the advisory records no fixed version, so govulncheck flags every version. Fix commit osrg/gobgp 583080a7 is an ancestor of pinned commit 2132288c5159, whose source skips ValidateUpdateMsg when parsing has already selected error handling, so it is not affected.'
-    date: 2026-07-21
+    date: 2026-07-28

--- a/internal/app/machined/pkg/controllers/network/operator/vip.go
+++ b/internal/app/machined/pkg/controllers/network/operator/vip.go
@@ -222,7 +222,20 @@ func (vip *VIP) campaign(ctx context.Context, notifyCh chan<- struct{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to create concurrency session: %w", err)
 	}
-	defer sess.Close() //nolint:errcheck
+
+	defer func() {
+		// Revoke the session lease to drop this node's election key.
+		//
+		// `Election.Campaign` cleans the key up itself when the campaign is interrupted, but it
+		// does so on the client context, which is canceled at the very same moment the campaign
+		// is aborted, so that attempt always fails. The etcd election is a FIFO queue ordered by
+		// create revision, so a key left behind by a node which is no longer campaigning delays
+		// the failover for every node queued behind it until the lease expires (60s).
+		if err := ec.RevokeSession(ctx, sess); err != nil {
+			// etcd is expected to be unreachable when the machine is shutting down
+			vip.logger.Debug("failed revoking etcd session", zap.Error(err))
+		}
+	}()
 
 	election := concurrency.NewElection(sess, vip.etcdElectionKey())
 
@@ -242,7 +255,9 @@ func (vip *VIP) campaign(ctx context.Context, notifyCh chan<- struct{}) error {
 		}
 	}
 
-	campaignErrCh := make(chan error)
+	// buffered, as the loop below stops waiting for the campaign on other events, and the
+	// goroutine should not be leaked blocking on the send
+	campaignErrCh := make(chan error, 1)
 
 	go func() {
 		campaignErrCh <- election.Campaign(ctx, hostname)
@@ -299,7 +314,7 @@ campaignLoop:
 
 	defer func() {
 		// use a new context to resign, as `ctx` might be canceled
-		resignCtx, resignCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		resignCtx, resignCancel := context.WithTimeout(context.WithoutCancel(ctx), etcd.CleanupTimeout)
 		defer resignCancel()
 
 		election.Resign(resignCtx) //nolint:errcheck

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/siderolabs/gen/channel"
-	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-retry/retry"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -222,13 +221,12 @@ func (k8sSuite *K8sSuite) EnsureResourceIsDeleted(
 func (k8sSuite *K8sSuite) WaitForEventExists(ctx context.Context, ns string, checkFn func(event eventsv1.Event) bool) error {
 	return retry.Constant(15*time.Second).RetryWithContext(ctx, func(ctx context.Context) error {
 		events, err := k8sSuite.Clientset.EventsV1().Events(ns).List(ctx, metav1.ListOptions{})
-
-		filteredEvents := xslices.Filter(events.Items, func(item eventsv1.Event) bool {
-			return checkFn(item)
-		})
-
-		if len(filteredEvents) == 0 {
+		if err != nil {
 			return retry.ExpectedError(err)
+		}
+
+		if !slices.ContainsFunc(events.Items, checkFn) {
+			return retry.ExpectedErrorf("no matching event found in namespace %q", ns)
 		}
 
 		return nil

--- a/internal/pkg/etcd/lock.go
+++ b/internal/pkg/etcd/lock.go
@@ -7,7 +7,6 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.uber.org/zap"
@@ -27,7 +26,31 @@ func WithLock(ctx context.Context, key string, logger *zap.Logger, f func() erro
 		return fmt.Errorf("error creating etcd session: %w", err)
 	}
 
-	defer session.Close() //nolint:errcheck
+	// Revoke the session lease to release the lock, instead of dropping the mutex key with
+	// `Mutex.Unlock`.
+	//
+	// `Mutex.Unlock` is a no-op unless the client-side bookkeeping says the key was written, and
+	// that bookkeeping is unreliable exactly when it matters: `Mutex.tryAcquire` assigns the
+	// revision only after its transaction returns, so a transaction which is applied by etcd but
+	// whose response never reaches a canceled client leaves the key in place while `Unlock`
+	// reports `ErrLockReleased` and deletes nothing. The mutex is a FIFO queue ordered by create
+	// revision, so such a key blocks every other waiter until its lease expires (60s).
+	//
+	// The lease is what the key hangs off, so revoking it drops the key whatever the client
+	// believes, and it is a single round-trip for the common path too.
+	defer func() {
+		logger.Debug("releasing mutex", zap.String("key", key))
+
+		if err := etcdClient.RevokeSession(ctx, session); err != nil {
+			level := zap.ErrorLevel
+			if ctx.Err() != nil {
+				// etcd is expected to be unreachable while the machine is shutting down
+				level = zap.DebugLevel
+			}
+
+			logger.Log(level, "error releasing mutex", zap.String("key", key), zap.Error(err))
+		}
+	}()
 
 	mutex := concurrency.NewMutex(session, key)
 
@@ -38,17 +61,6 @@ func WithLock(ctx context.Context, key string, logger *zap.Logger, f func() erro
 	}
 
 	logger.Debug("mutex acquired", zap.String("key", key))
-
-	defer func() {
-		logger.Debug("releasing mutex", zap.String("key", key))
-
-		unlockCtx, unlockCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer unlockCancel()
-
-		if err = mutex.Unlock(unlockCtx); err != nil {
-			logger.Error("error releasing mutex", zap.String("key", key), zap.Error(err))
-		}
-	}()
 
 	return f()
 }

--- a/internal/pkg/etcd/session.go
+++ b/internal/pkg/etcd/session.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+// CleanupTimeout bounds the best-effort cleanup RPCs issued when an etcd lock is released or an
+// election campaign is torn down.
+//
+// The cleanup runs on a context detached from the caller's one, as the caller's context is
+// usually already canceled at that point (that is what aborted the lock or the campaign), but it
+// must never block indefinitely: on machine shutdown the local etcd is stopped before the
+// controller runtime is torn down, so the cleanup RPCs have no chance to ever complete.
+const CleanupTimeout = 10 * time.Second
+
+// RevokeSession stops refreshing the session lease and revokes it on a context detached from ctx.
+//
+// This is what `concurrency.Session.Close` does, but with a context under our control:
+// `Session.Close` revokes the lease on the session context, which defaults to the etcd client
+// context, so it fails instantly once that context is canceled, and otherwise blocks for the
+// whole session TTL (60s) when etcd is unreachable. Neither is useful: the point of the revoke is
+// to run exactly when the caller is going away.
+//
+// Revoking the lease drops every key attached to it, which for the `concurrency` package means
+// the mutex and election keys of this session. Both are FIFO queues ordered by create revision,
+// so a key left behind by a participant which is already gone blocks everybody queued behind it
+// until the lease expires on its own.
+func (c *Client) RevokeSession(ctx context.Context, session *concurrency.Session) error {
+	// stop refreshing the lease; this is local-only and doesn't talk to etcd
+	session.Orphan()
+
+	revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(ctx), CleanupTimeout)
+	defer revokeCancel()
+
+	if _, err := c.Revoke(revokeCtx, session.Lease()); err != nil {
+		return fmt.Errorf("error revoking etcd session lease: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This should prevent the cancelation to fall into the 60s mutex timeout locking the controllers from running (the service account Talos controller).

Also fix an issue in the integration test - the nil err was passed to retry causing false positive.

There is still a lingering issue with `FeatureNotEnabled` test, as it runs before other tests and stops early at CRD not registered, but the second statement there does not match Talos code.
