### PR TITLE
fix: generate backwards compatible etcd encryption config

### DIFF
--- a/pkg/machinery/config/generate/kubernetes.go
+++ b/pkg/machinery/config/generate/kubernetes.go
@@ -37,22 +37,51 @@ func (in *Input) generateKubernetesControlplaneConfigs(controlplaneURL *url.URL,
 		flannelConfig.FlannelBackendPort = constants.FlannelDefaultBackendPort
 	}
 
+	// The list and order of the providers is important, it should be in sync
+	// with the k8stemplates/apiserver.go legacy path, but we can't reuse the same
+	// code here, as we can't pull in the dependency on k8s machinery
+	//
+	// Preserving the names and order is important for the case when someone takes
+	// pre-1.14 cluster and regenerates the machine config using 1.14 version contract,
+	// which will update this configuration document to the new format, but the rendered
+	// configuration for kube-apiserver should match to allow secrets to be decrypted correctly.
+	var etcdEncryptionProvidersList []any
+
+	if in.Options.SecretsBundle.Secrets.SecretboxEncryptionSecret != "" {
+		etcdEncryptionProvidersList = append(etcdEncryptionProvidersList,
+			map[string]any{
+				"secretbox": map[string]any{
+					"keys": []any{
+						map[string]any{
+							"name":   "key2",
+							"secret": in.Options.SecretsBundle.Secrets.SecretboxEncryptionSecret,
+						},
+					},
+				},
+			},
+		)
+	}
+
+	if in.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret != "" {
+		etcdEncryptionProvidersList = append(etcdEncryptionProvidersList,
+			map[string]any{
+				"secretbox": map[string]any{
+					"keys": []any{
+						map[string]any{
+							"name":   "key1",
+							"secret": in.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret,
+						},
+					},
+				},
+			},
+		)
+	}
+
 	etcdEncryptionConfig := k8s.NewKubeEtcdEncryptionConfigV1Alpha1()
 	etcdEncryptionConfig.Config.Object = map[string]any{
 		"resources": []any{
 			map[string]any{
-				"providers": []any{
-					map[string]any{
-						"secretbox": map[string]any{
-							"keys": []any{
-								map[string]any{
-									"name":   "key1",
-									"secret": in.Options.SecretsBundle.Secrets.SecretboxEncryptionSecret,
-								},
-							},
-						},
-					},
-				},
+				"providers": etcdEncryptionProvidersList,
 				"resources": []any{
 					"secrets",
 				},

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/base-controlplane.yaml
@@ -181,7 +181,7 @@ config:
         - providers:
             - secretbox:
                 keys:
-                    - name: key1
+                    - name: key2
                       secret: 45yd2Ke+sytiICojDf8aibTfgt99nzJmO53cjDqrCto=
           resources:
             - secrets

--- a/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
+++ b/pkg/machinery/config/types/v1alpha1/testdata/stability/v1.14/overrides-controlplane.yaml
@@ -202,7 +202,7 @@ config:
         - providers:
             - secretbox:
                 keys:
-                    - name: key1
+                    - name: key2
                       secret: 45yd2Ke+sytiICojDf8aibTfgt99nzJmO53cjDqrCto=
           resources:
             - secrets


### PR DESCRIPTION
This is a breaking change for 1.14.0-beta.0, but it maintains perfect compatiblity back to < 1.14 versions.

There are two upgrade paths:

* in the supported Talos upgrade path, when machine config doesn't change, Talos would generate perfectly comptatible etcd encryption config from legacy (but supported) `.cluster.*` properties
* if someone bumps `talos_version` contract and tries to apply the machine config, Talos will generate `KubeEtcdEncryptionConfig` document based on secrets bundle.

The problem was that those two do no match perfectly - Talos 1.13 would have used `key2` for Secretbox and `key1` for AES-CBC, while the generated config put `key1` for Secretbox.

This fixes not really recommended path of re-generating machine config using new version contract on upgrade.

It is incompatible for beta.0 clusters, as it changes secretbox encryption config to use `key2` (but it can be "restored" using a config patch).

See https://github.com/siderolabs/talos/issues/13885
