### PR TITLE
test: restart qemu process several times on startup failures

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -357,9 +357,9 @@ function create_cluster {
     --extra-disks-serials="${QEMU_EXTRA_DISKS_SERIALS:-}" \
     --extra-disks-tags="${QEMU_EXTRA_DISKS_TAGS:-}" \
     --mtu=1430 \
-    --memory="${QEMU_MEMORY_CONTROLPLANES:-2048}" \
+    --memory="${QEMU_MEMORY_CONTROLPLANES:-4096}" \
     --memory-workers="${QEMU_MEMORY_WORKERS:-2048}" \
-    --cpus="${QEMU_CPUS:-2}" \
+    --cpus="${QEMU_CPUS:-4}" \
     --cpus-workers="${QEMU_CPUS_WORKERS:-2}" \
     --cidr=172.20.1.0/24 \
     --install-image="${INSTALLER_IMAGE}" \

--- a/internal/integration/api/testdata/nodeport.yaml
+++ b/internal/integration/api/testdata/nodeport.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Update this if talosctl images integration changes the cached nginx image.
       - image: nginx
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: nginx
         ports:
         - containerPort: 80

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -510,7 +510,15 @@ func (k8sSuite *K8sSuite) WaitForPodToBeRunning(ctx context.Context, timeout tim
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case event := <-watcher.ResultChan():
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				return fmt.Errorf("watcher closed waiting for pod %s/%s", namespace, podName)
+			}
+
 			if event.Type == watch.Error {
 				return fmt.Errorf("error watching pod: %v", event.Object)
 			}
@@ -528,7 +536,15 @@ func (k8sSuite *K8sSuite) WaitForPodToBeRunning(ctx context.Context, timeout tim
 			if pod.Name == podName && pod.Status.Phase == corev1.PodRunning {
 				return nil
 			}
-		case event := <-eventsWatcher.ResultChan():
+		case event, ok := <-eventsWatcher.ResultChan():
+			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				return fmt.Errorf("watcher closed waiting for events in namespace %s", namespace)
+			}
+
 			if event.Type == watch.Error {
 				return fmt.Errorf("error watching event: %v", event.Object)
 			}
@@ -561,6 +577,8 @@ func (k8sSuite *K8sSuite) WaitForPodToBeRunning(ctx context.Context, timeout tim
 }
 
 // WaitForDeploymentAvailable waits for the deployment with the given namespace and name to be running with the requested replicas.
+//
+//nolint:gocyclo
 func (k8sSuite *K8sSuite) WaitForDeploymentAvailable(ctx context.Context, timeout time.Duration, namespace, deplName string, replicas int32) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -578,7 +596,15 @@ func (k8sSuite *K8sSuite) WaitForDeploymentAvailable(ctx context.Context, timeou
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case event := <-watcher.ResultChan():
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				return fmt.Errorf("watcher closed waiting for deployment %s/%s", namespace, deplName)
+			}
+
 			if event.Type == watch.Error {
 				return fmt.Errorf("error watching deployment: %v", event.Object)
 			}

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -26,6 +26,18 @@ import (
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
 
+const (
+	// qemuStartAttempts bounds how many times QEMU is launched before giving up on the VM.
+	qemuStartAttempts = 5
+
+	// qemuStartBackoff is the delay before the first relaunch, doubled on every further attempt.
+	qemuStartBackoff = 500 * time.Millisecond
+
+	// qemuStartupGracePeriod separates "QEMU never came up" from "the VM ran and then died": a
+	// process which exits with an error this soon after being started never got to run the VM.
+	qemuStartupGracePeriod = 5 * time.Second
+)
+
 // LaunchConfig is passed in to the Launch function over stdin.
 type LaunchConfig struct {
 	StatePath string
@@ -452,6 +464,45 @@ func launchVM(config *LaunchConfig) error {
 		)
 	}
 
+	// QEMU runs with `-no-reboot`, so every reboot of the VM is a relaunch, and a relaunch can lose
+	// a race against the host services backing the VM's devices. The known case is virtiofsd: it
+	// exits whenever its vhost-user client disconnects and its supervisor restarts it, so for a
+	// moment after the VM goes down its socket is stale and QEMU gives up with
+	// `Failed to connect to '...': Connection refused` instead of retrying the chardev itself.
+	// Without a retry here the node stays down for the rest of the cluster's lifetime.
+	var launchErr error
+
+	for attempt := range qemuStartAttempts {
+		launchErr = runQemu(config, args)
+
+		if !errors.Is(launchErr, errQemuStartFailed) || attempt == qemuStartAttempts-1 {
+			break
+		}
+
+		backoff := qemuStartBackoff << attempt
+
+		fmt.Fprintf(os.Stderr, "%s, retrying in %s (attempt %d of %d)\n", launchErr, backoff, attempt+1, qemuStartAttempts)
+
+		select {
+		case <-time.After(backoff):
+		case sig := <-config.c:
+			fmt.Fprintf(os.Stderr, "exiting VM as signal %s was received\n", sig)
+
+			return errors.New("process stopped")
+		}
+	}
+
+	return launchErr
+}
+
+// errQemuStartFailed marks a QEMU process which never got past its own startup, as opposed to a VM
+// which ran for a while and then died: only the former is worth relaunching.
+var errQemuStartFailed = errors.New("QEMU failed to start")
+
+// runQemu starts QEMU with the given args and supervises it until the VM exits or is stopped.
+//
+//nolint:gocyclo
+func runQemu(config *LaunchConfig, args []string) error {
 	fmt.Fprintf(os.Stderr, "starting %s with args:\n%s\n", config.ArchitectureData.QemuExecutable(), strings.Join(args, " "))
 	cmd := exec.Command( //nolint:noctx // runs in background
 		config.ArchitectureData.QemuExecutable(),
@@ -462,8 +513,10 @@ func launchVM(config *LaunchConfig) error {
 	cmd.Stderr = os.Stderr
 
 	if err := startQemuCmd(config, cmd); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", errQemuStartFailed, err)
 	}
+
+	startedAt := time.Now()
 
 	done := make(chan error)
 
@@ -485,6 +538,10 @@ func launchVM(config *LaunchConfig) error {
 			return errors.New("process stopped")
 		case err := <-done:
 			if err != nil {
+				if time.Since(startedAt) < qemuStartupGracePeriod {
+					return fmt.Errorf("%w: %w", errQemuStartFailed, err)
+				}
+
 				return fmt.Errorf("process exited with error %s", err)
 			}
 


### PR DESCRIPTION
This was notices with CI and reboot test suite: when virtiofsd is enabled, QEMU connects to it on startup. But the process dies when QEMU disconnects, and talosctl restarts it.

But there is a race - talosctl might start QEMU before virtiofsd is ready (after being restarted) leading to fatal QEMU start failure.

We can't wait for virtiofsd to be ready to be listening, as it requires connecting, and disconnecting would kill virtiofsd.

So instead do a more generic approach of retrying QEMU early startup failures several times.
