### PR TITLE
feat: support experimental k8s-less and etcd-less mode

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -219,6 +219,10 @@ func (m *Maker[T]) initVersionContract() error {
 		return fmt.Errorf("error parsing Talos version %q: %w", m.Ops.TalosVersion, err)
 	}
 
+	if m.Ops.SkipEtcdK8sConfig {
+		versionContract = versionContract.DisableEtcd().DisableKubernetes()
+	}
+
 	m.VersionContract = versionContract
 
 	return nil

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -72,6 +72,7 @@ type Common struct {
 	SkipInjectingConfig         bool
 	SkipUnattendedInstallConfig bool
 	TalosVersion                string
+	SkipEtcdK8sConfig           bool
 	EnableKubeSpan              bool
 	EnableClusterDiscovery      bool
 	ConfigPatch                 []string

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -132,6 +132,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		forceEndpointFlag             = "endpoint"
 		kubePrismFlag                 = "kubeprism-port"
 		diskEncryptionKeyTypesFlag    = "disk-encryption-key-types"
+		skipEtcdK8sFlag               = "skip-etcd-k8s"
 	)
 
 	unImplementedFlagsDarwin := []string{
@@ -202,6 +203,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		common.BoolVar(&cOps.WithJSONLogs, withJSONLogsFlag, cOps.WithJSONLogs, "enable JSON logs receiver and configure Talos to send logs there")
 		common.BoolVar(&cOps.WithUUIDHostnames, withUUIDHostnamesFlag, cOps.WithUUIDHostnames, "use machine UUIDs as default hostnames")
 		common.BoolVar(&cOps.NetworkIPv6, networkIPv6Flag, cOps.NetworkIPv6, "enable IPv6 network in the cluster")
+		common.BoolVar(&cOps.SkipEtcdK8sConfig, skipEtcdK8sFlag, cOps.SkipEtcdK8sConfig, "skip etcd and Kubernetes machine configuration (experimental)")
 
 		return common
 	}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 
 	"github.com/siderolabs/go-kubeconfig"
+	"google.golang.org/grpc/codes"
 	"k8s.io/client-go/tools/clientcmd"
 
 	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker"
+	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/provision/access"
@@ -106,18 +108,24 @@ func saveConfig(talosConfigObj *clientconfig.Config, talosconfigPath string) (er
 	return c.Save(talosconfigPath)
 }
 
+//nolint:gocyclo
 func mergeKubeconfig(ctx context.Context, clusterAccess *access.Adapter) error {
+	k8sconfig, err := clusterAccess.Kubeconfig(ctx)
+	if err != nil {
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			// no Kubernetes, skip kubeconfig
+			return nil
+		}
+
+		return fmt.Errorf("error fetching kubeconfig: %w", err)
+	}
+
 	kubeconfigPath, err := kubeconfig.SinglePath()
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(os.Stderr, "\nmerging kubeconfig into %q\n", kubeconfigPath)
-
-	k8sconfig, err := clusterAccess.Kubeconfig(ctx)
-	if err != nil {
-		return fmt.Errorf("error fetching kubeconfig: %w", err)
-	}
 
 	kubeConfig, err := clientcmd.Load(k8sconfig)
 	if err != nil {

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -73,6 +73,7 @@ var genConfigCmdFlags struct {
 	withDocs                bool
 	withClusterDiscovery    bool
 	withKubeSpan            bool
+	skipK8sEtcd             bool
 	withSecrets             string
 }
 
@@ -192,16 +193,20 @@ func writeConfig(args []string) error {
 		genOptions = append(genOptions, generate.WithRegistryMirror(left, right))
 	}
 
-	if genConfigCmdFlags.talosVersion != "" {
-		var versionContract *config.VersionContract
+	var versionContract *config.VersionContract
 
+	if genConfigCmdFlags.talosVersion != "" {
 		versionContract, err = config.ParseContractFromVersion(genConfigCmdFlags.talosVersion)
 		if err != nil {
 			return fmt.Errorf("invalid talos-version: %w", err)
 		}
-
-		genOptions = append(genOptions, generate.WithVersionContract(versionContract))
 	}
+
+	if genConfigCmdFlags.skipK8sEtcd {
+		versionContract = versionContract.DisableEtcd().DisableKubernetes()
+	}
+
+	genOptions = append(genOptions, generate.WithVersionContract(versionContract))
 
 	// Add KubeSpan configuration based on version
 	if genConfigCmdFlags.withKubeSpan {
@@ -219,7 +224,7 @@ func writeConfig(args []string) error {
 			return fmt.Errorf("failed to load secrets bundle: %w", err)
 		}
 
-		if err = secretsBundle.Validate(); err != nil {
+		if err = secretsBundle.Validate(versionContract); err != nil {
 			return fmt.Errorf("failed to validate secrets bundle: %w", err)
 		}
 
@@ -452,6 +457,9 @@ func init() {
 		`destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout`)
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.outputDir, "output-dir", "", "destination to output generated files") // kept for backwards compatibility
 	genConfigCmd.Flags().MarkHidden("output-dir")                                                                           //nolint:errcheck
+
+	genConfigCmd.Flags().BoolVar(&genConfigCmdFlags.skipK8sEtcd, "skip-k8s-etcd", false, "skip generating etcd & Kubernetes configuration (experimental)")
+	genConfigCmd.Flags().MarkHidden("skip-k8s-etcd") //nolint:errcheck
 
 	Cmd.AddCommand(genConfigCmd)
 }

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -418,6 +418,13 @@ func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (r
 		return nil, err
 	}
 
+	hasEtcdCA := s.Controller.Runtime().Config() != nil && s.Controller.Runtime().Config().Cluster() != nil && s.Controller.Runtime().Config().Cluster().Etcd().CA() != nil
+	if !hasEtcdCA {
+		// there is no etcd CA in the machine config, but we already have machine type (previous check),
+		// so reject the bootstrap as a terminal error
+		return nil, status.Error(codes.InvalidArgument, "etcd is not configured, bootstrap is not possible")
+	}
+
 	timeCtx, timeCtxCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer timeCtxCancel()
 

--- a/internal/app/machined/pkg/controllers/k8s/address_filter.go
+++ b/internal/app/machined/pkg/controllers/k8s/address_filter.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -93,14 +94,18 @@ func (ctrl *AddressFilterController) Run(ctx context.Context, r controller.Runti
 
 		r.StartTrackingOutputs()
 
-		if cfg != nil && cfg.Config().K8sNetworkConfig() != nil {
-			k8sNetwork := cfg.Config().K8sNetworkConfig()
+		if cfg != nil {
+			var podCIDRs, serviceCIDRs []netip.Prefix
 
-			podCIDRs := k8sNetwork.PodCIDRs()
-			serviceCIDRs := k8sNetwork.ServiceCIDRs()
+			if cfg.Config().K8sNetworkConfig() != nil {
+				k8sNetwork := cfg.Config().K8sNetworkConfig()
 
-			if nodeStatus != nil {
-				podCIDRs = append(podCIDRs, nodeStatus.TypedSpec().PodCIDRs...)
+				podCIDRs = slices.Clone(k8sNetwork.PodCIDRs())
+				serviceCIDRs = slices.Clone(k8sNetwork.ServiceCIDRs())
+
+				if nodeStatus != nil {
+					podCIDRs = slices.Concat(podCIDRs, nodeStatus.TypedSpec().PodCIDRs)
+				}
 			}
 
 			if err = safe.WriterModify(ctx, r, network.NewNodeAddressFilter(network.NamespaceName, k8s.NodeAddressFilterNoK8s), func(r *network.NodeAddressFilter) error {
@@ -112,7 +117,17 @@ func (ctrl *AddressFilterController) Run(ctx context.Context, r controller.Runti
 			}
 
 			if err = safe.WriterModify(ctx, r, network.NewNodeAddressFilter(network.NamespaceName, k8s.NodeAddressFilterOnlyK8s), func(r *network.NodeAddressFilter) error {
-				r.TypedSpec().IncludeSubnets = slices.Concat(podCIDRs, serviceCIDRs)
+				if len(podCIDRs)+len(serviceCIDRs) > 0 {
+					r.TypedSpec().IncludeSubnets = slices.Concat(podCIDRs, serviceCIDRs)
+					r.TypedSpec().ExcludeSubnets = nil
+				} else {
+					// if k8s is disabled, we want to exclude all networks from "k8s-only" filter
+					r.TypedSpec().IncludeSubnets = nil
+					r.TypedSpec().ExcludeSubnets = []netip.Prefix{
+						netip.MustParsePrefix("0.0.0.0/0"),
+						netip.MustParsePrefix("::/0"),
+					}
+				}
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/address_filter_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/address_filter_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -28,7 +29,7 @@ type K8sAddressFilterSuite struct {
 	ctest.DefaultSuite
 }
 
-func (suite *K8sAddressFilterSuite) TestReconcile() {
+func (suite *K8sAddressFilterSuite) TestReconcileK8s() {
 	u, err := url.Parse("https://foo:6443")
 	suite.Require().NoError(err)
 
@@ -108,6 +109,32 @@ func (suite *K8sAddressFilterSuite) TestReconcile() {
 			"[10.32.0.0/12 fd00:10:32::/102 192.168.0.0/24 10.200.0.0/22 fd40:10:200::/112]",
 			fmt.Sprintf("%s", spec.ExcludeSubnets),
 		)
+	})
+}
+
+func (suite *K8sAddressFilterSuite) TestReconcileNoK8s() {
+	cfg := config.NewMachineConfig(
+		container.NewV1Alpha1(
+			&v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{},
+			},
+		),
+	)
+	suite.Create(cfg)
+
+	ctest.AssertResources(suite, []resource.ID{k8s.NodeAddressFilterOnlyK8s, k8s.NodeAddressFilterNoK8s}, func(res *network.NodeAddressFilter, asrt *assert.Assertions) {
+		spec := res.TypedSpec()
+
+		asrt.Empty(spec.IncludeSubnets)
+
+		switch res.Metadata().ID() {
+		case k8s.NodeAddressFilterOnlyK8s:
+			asrt.Equal("[0.0.0.0/0 ::/0]", fmt.Sprintf("%s", spec.ExcludeSubnets))
+		case k8s.NodeAddressFilterNoK8s:
+			asrt.Empty(spec.ExcludeSubnets)
+		}
 	})
 }
 

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -347,6 +347,9 @@ func NewControlPlaneSchedulerController() *ControlPlaneSchedulerController {
 				func(machineConfig *config.MachineConfig) bool {
 					return machineConfig.Config().K8sSchedulerConfig() != nil
 				},
+				func(machineConfig *config.MachineConfig) bool {
+					return machineConfig.Config().K8sClusterConfig() != nil
+				},
 			),
 			TransformFunc: func(ctx context.Context, r controller.Reader, logger *zap.Logger, machineConfig *config.MachineConfig, res *k8s.SchedulerConfig) error {
 				schedulerConfig := machineConfig.Config().K8sSchedulerConfig()

--- a/internal/app/machined/pkg/controllers/runtime/machine_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/resources/time"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -91,6 +92,11 @@ func (ctrl *MachineStatusController) Inputs() []controller.Input {
 			Type:      k8s.NodeStatusType,
 			Kind:      controller.InputWeak,
 		},
+		{
+			Namespace: secrets.NamespaceName,
+			Type:      secrets.KubeletType,
+			Kind:      controller.InputWeak,
+		},
 	}
 }
 
@@ -136,6 +142,17 @@ func (ctrl *MachineStatusController) Run(ctx context.Context, r controller.Runti
 			machineType = machineTypeResource.MachineType()
 		}
 
+		hasKubernetes := true
+
+		_, err = safe.ReaderGetByID[*secrets.Kubelet](ctx, r, secrets.KubeletID)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				hasKubernetes = false
+			} else {
+				return fmt.Errorf("error getting kubelet config: %w", err)
+			}
+		}
+
 		ctrl.mu.Lock()
 		currentStage := ctrl.currentStage
 		ctrl.mu.Unlock()
@@ -144,7 +161,7 @@ func (ctrl *MachineStatusController) Run(ctx context.Context, r controller.Runti
 
 		var unmetConditions []runtime.UnmetCondition
 
-		for _, check := range ctrl.getReadinessChecks(currentStage, machineType) {
+		for _, check := range ctrl.getReadinessChecks(currentStage, machineType, hasKubernetes) {
 			if err := check.f(ctx, r); err != nil {
 				ready = false
 
@@ -180,24 +197,36 @@ type readinessCheck struct {
 	f    func(context.Context, controller.Runtime) error
 }
 
-func (ctrl *MachineStatusController) getReadinessChecks(stage runtime.MachineStage, machineType machine.Type) []readinessCheck {
+func (ctrl *MachineStatusController) getReadinessChecks(stage runtime.MachineStage, machineType machine.Type, hasKubernetes bool) []readinessCheck {
 	requiredServices := []string{
 		"apid",
 		"machined",
-		"kubelet",
+	}
+
+	if hasKubernetes {
+		requiredServices = append(
+			requiredServices,
+			"kubelet",
+		)
 	}
 
 	if machineType.IsControlPlane() {
+		if hasKubernetes {
+			requiredServices = append(
+				requiredServices,
+				"etcd",
+			)
+		}
+
 		requiredServices = append(
 			requiredServices,
-			"etcd",
 			"trustd",
 		)
 	}
 
 	switch stage { //nolint:exhaustive
 	case runtime.MachineStageBooting, runtime.MachineStageRunning:
-		return []readinessCheck{
+		checks := []readinessCheck{
 			{
 				name: "time",
 				f:    ctrl.timeSyncCheck,
@@ -214,11 +243,16 @@ func (ctrl *MachineStatusController) getReadinessChecks(stage runtime.MachineSta
 				name: "staticPods",
 				f:    ctrl.staticPodsCheck,
 			},
-			{
+		}
+
+		if hasKubernetes {
+			checks = append(checks, readinessCheck{
 				name: "nodeReady",
 				f:    ctrl.nodeReadyCheck,
-			},
+			})
 		}
+
+		return checks
 	default:
 		return nil
 	}

--- a/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 	timeres "github.com/siderolabs/talos/pkg/machinery/resources/time"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -86,13 +87,15 @@ func (suite *MachineStatusSuite) TestReconcile() {
 
 	suite.assertMachineStatus(runtime.MachineStageBooting, false, []string{"time", "network", "services"})
 
+	suite.Create(secrets.NewKubelet(secrets.KubeletID))
+
 	machineType := config.NewMachineType()
 	machineType.SetMachineType(machine.TypeControlPlane)
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), machineType))
+	suite.Create(machineType)
 
 	timeStatus := timeres.NewStatus()
 	timeStatus.TypedSpec().Synced = true
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), timeStatus))
+	suite.Create(timeStatus)
 
 	suite.eventCh <- v1alpha1runtime.EventInfo{
 		Event: v1alpha1runtime.Event{
@@ -119,7 +122,7 @@ func (suite *MachineStatusSuite) TestReconcile() {
 	networkStatus.TypedSpec().ConnectivityReady = true
 	networkStatus.TypedSpec().EtcFilesReady = true
 	networkStatus.TypedSpec().HostnameReady = true
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), networkStatus))
+	suite.Create(networkStatus)
 
 	suite.assertMachineStatus(runtime.MachineStageRunning, false, []string{"services"})
 
@@ -127,24 +130,24 @@ func (suite *MachineStatusSuite) TestReconcile() {
 		serviceStatus := v1alpha1.NewService(service)
 		serviceStatus.TypedSpec().Running = true
 		serviceStatus.TypedSpec().Healthy = true
-		suite.Require().NoError(suite.State().Create(suite.Ctx(), serviceStatus))
+		suite.Create(serviceStatus)
 	}
 
 	suite.assertMachineStatus(runtime.MachineStageRunning, true, nil)
 
 	nodename := k8s.NewNodename(k8s.NamespaceName, k8s.NodenameID)
 	nodename.TypedSpec().Nodename = "test"
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), nodename))
+	suite.Create(nodename)
 
 	suite.assertMachineStatus(runtime.MachineStageRunning, false, []string{"nodeReady"})
 
 	nodeStatus := k8s.NewNodeStatus(k8s.NamespaceName, "test")
-	suite.Require().NoError(suite.State().Create(suite.Ctx(), nodeStatus))
+	suite.Create(nodeStatus)
 
 	suite.assertMachineStatus(runtime.MachineStageRunning, false, []string{"nodeReady"})
 
 	nodeStatus.TypedSpec().NodeReady = true
-	suite.Require().NoError(suite.State().Update(suite.Ctx(), nodeStatus))
+	suite.Update(nodeStatus)
 
 	suite.assertMachineStatus(runtime.MachineStageRunning, true, nil)
 

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -59,17 +59,19 @@ type RootEtcdController = transform.Controller[*config.MachineConfig, *secrets.E
 func NewRootEtcdController() *RootEtcdController {
 	return transform.NewController(
 		transform.Settings[*config.MachineConfig, *secrets.EtcdRoot]{
-			Name:                    "secrets.RootEtcdController",
-			MapMetadataOptionalFunc: rootMapFunc(secrets.NewEtcdRoot(secrets.EtcdRootID), true),
+			Name: "secrets.RootEtcdController",
+			MapMetadataOptionalFunc: rootMapFunc(
+				secrets.NewEtcdRoot(secrets.EtcdRootID), true,
+				func(cfg *config.MachineConfig) bool {
+					// skip the controller if the etcd secret is not present
+					return cfg.Config().Cluster().Etcd().CA() != nil
+				},
+			),
 			TransformFunc: func(ctx context.Context, r controller.Reader, logger *zap.Logger, cfg *config.MachineConfig, res *secrets.EtcdRoot) error {
 				cfgProvider := cfg.Config()
 				etcdSecrets := res.TypedSpec()
 
 				etcdSecrets.EtcdCA = cfgProvider.Cluster().Etcd().CA()
-
-				if etcdSecrets.EtcdCA == nil {
-					return errors.New("missing cluster.etcdCA secret")
-				}
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/secrets/root_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/root_test.go
@@ -42,8 +42,11 @@ type RootSuite struct {
 	ctest.DefaultSuite
 }
 
-func (suite *RootSuite) genConfig(controlplane bool) talosconfig.Config {
-	input, err := generate.NewInput("test-cluster", "http://localhost:6443", "1.28.0")
+func (suite *RootSuite) genConfig(controlplane bool, versionContract *talosconfig.VersionContract) talosconfig.Config {
+	input, err := generate.NewInput(
+		"test-cluster", "http://localhost:6443", "1.28.0",
+		generate.WithVersionContract(versionContract),
+	)
 	suite.Require().NoError(err)
 
 	var cfg talosconfig.Provider
@@ -63,7 +66,7 @@ func (suite *RootSuite) genConfig(controlplane bool) talosconfig.Config {
 }
 
 func (suite *RootSuite) TestReconcileControlPlane() {
-	cfg := suite.genConfig(true)
+	cfg := suite.genConfig(true, talosconfig.TalosVersionCurrent)
 
 	rtestutils.AssertResources(
 		suite.Ctx(), suite.T(), suite.State(), []resource.ID{secrets.EtcdRootID},
@@ -101,8 +104,33 @@ func (suite *RootSuite) TestReconcileControlPlane() {
 	)
 }
 
+func (suite *RootSuite) TestReconcileControlPlaneNoK8sEtcd() {
+	cfg := suite.genConfig(
+		true,
+		talosconfig.TalosVersionCurrent.DisableEtcd().DisableKubernetes(),
+	)
+
+	rtestutils.AssertResources(
+		suite.Ctx(), suite.T(), suite.State(), []resource.ID{secrets.OSRootID},
+		func(res *secrets.OSRoot, asrt *assert.Assertions) {
+			asrt.Equal(res.TypedSpec().IssuingCA, cfg.Machine().Security().IssuingCA())
+			asrt.Equal(
+				[]*x509.PEMEncodedCertificate{
+					{
+						Crt: cfg.Machine().Security().IssuingCA().Crt,
+					},
+				},
+				res.TypedSpec().AcceptedCAs,
+			)
+		},
+	)
+
+	rtestutils.AssertNoResource[*secrets.EtcdRoot](suite.Ctx(), suite.T(), suite.State(), secrets.EtcdRootID)
+	rtestutils.AssertNoResource[*secrets.KubernetesRoot](suite.Ctx(), suite.T(), suite.State(), secrets.KubernetesRootID)
+}
+
 func (suite *RootSuite) TestReconcileWorker() {
-	cfg := suite.genConfig(false)
+	cfg := suite.genConfig(false, talosconfig.TalosVersionCurrent)
 
 	rtestutils.AssertResources(
 		suite.Ctx(), suite.T(), suite.State(), []resource.ID{secrets.OSRootID},
@@ -119,6 +147,6 @@ func (suite *RootSuite) TestReconcileWorker() {
 		},
 	)
 
-	rtestutils.AssertNoResource[*secrets.Etcd](suite.Ctx(), suite.T(), suite.State(), secrets.EtcdRootID)
-	rtestutils.AssertNoResource[*secrets.Kubernetes](suite.Ctx(), suite.T(), suite.State(), secrets.KubernetesRootID)
+	rtestutils.AssertNoResource[*secrets.EtcdRoot](suite.Ctx(), suite.T(), suite.State(), secrets.EtcdRootID)
+	rtestutils.AssertNoResource[*secrets.KubernetesRoot](suite.Ctx(), suite.T(), suite.State(), secrets.KubernetesRootID)
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -349,6 +349,8 @@ func StartDashboard(_ runtime.Sequence, _ any) (runtime.TaskExecutionFunc, strin
 }
 
 // StartAllServices represents the task to start the system services.
+//
+//nolint:gocyclo
 func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		// nb: Treating the beginning of "service starts" as the activate event for a normal
@@ -365,13 +367,6 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 
 		svcs := system.Services(r)
 
-		// Load kubelet and CRI, but don't start them; their service controllers
-		// will start them once their rendered configuration is ready.
-		svcs.Load(
-			&services.Kubelet{},
-			&services.CRI{},
-		)
-
 		serviceList := []system.Service{}
 
 		// When workload isolation is enabled (SecurityProfileConfig), the sandbox
@@ -381,19 +376,27 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 			serviceList = append(serviceList, &services.Sandboxd{})
 		}
 
+		shouldStartEtcd := r.Config() != nil && r.Config().Cluster() != nil && r.Config().Cluster().Etcd().CA() != nil
+
 		switch t := r.Config().Machine().Type(); t {
 		case machine.TypeInit:
 			serviceList = append(
 				serviceList,
 				&services.Trustd{},
-				&services.Etcd{Bootstrap: true},
 			)
+
+			if shouldStartEtcd {
+				serviceList = append(serviceList, &services.Etcd{Bootstrap: true})
+			}
 		case machine.TypeControlPlane:
 			serviceList = append(
 				serviceList,
 				&services.Trustd{},
-				&services.Etcd{},
 			)
+
+			if shouldStartEtcd {
+				serviceList = append(serviceList, &services.Etcd{})
+			}
 		case machine.TypeWorker:
 			// nothing
 		case machine.TypeUnknown:

--- a/internal/integration/provision/k8s_less.go
+++ b/internal/integration/provision/k8s_less.go
@@ -1,0 +1,235 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_provision
+
+package provision
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/mgmt/helpers"
+	"github.com/siderolabs/talos/pkg/images"
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+)
+
+// K8sLessSuite provides basic verification of Talos with Kubernetes and etcd disabled.
+type K8sLessSuite struct {
+	BaseSuite
+
+	track int
+}
+
+// SuiteName ...
+func (suite *K8sLessSuite) SuiteName() string {
+	return fmt.Sprintf("provision.K8sLessSuite-TR%d", suite.track)
+}
+
+// TestBasicFlows verifies cluster creation, basic health, operations, etc.
+//
+//nolint:gocyclo
+func (suite *K8sLessSuite) TestBasicFlows() {
+	options := clusterOptions{
+		ClusterName: "k8s-less",
+
+		ControlplaneNodes: DefaultSettings.ControlplaneNodes,
+		WorkerNodes:       0,
+
+		SourceKernelPath:    helpers.ArtifactPath(constants.KernelAssetWithArch),
+		SourceInitramfsPath: helpers.ArtifactPath(constants.InitramfsAssetWithArch),
+		SourceInstallerImage: fmt.Sprintf(
+			"%s/%s:%s",
+			DefaultSettings.TargetInstallImageRegistry,
+			images.DefaultInstallerImageName, //nolint:staticcheck // legacy is only used in tests
+			DefaultSettings.CurrentVersion,
+		),
+		SourceVersion:    DefaultSettings.CurrentVersion,
+		SourceK8sVersion: constants.DefaultKubernetesVersion,
+
+		VersionContract: config.TalosVersionCurrent.DisableEtcd().DisableKubernetes(),
+	}
+
+	suite.setupCluster(options)
+
+	ctx := suite.ctx
+	c, err := suite.clusterAccess.Client()
+	suite.Require().NoError(err)
+
+	suite.Run("machine status is ready", func() {
+		for _, node := range suite.Cluster.Info().Nodes {
+			nodeCtx := client.WithNode(ctx, node.IPs[0].String())
+
+			rtestutils.AssertResource(nodeCtx, suite.T(), c.COSI, runtime.MachineStatusID, func(r *runtime.MachineStatus, asrt *assert.Assertions) {
+				asrt.True(r.TypedSpec().Status.Ready)
+				asrt.Empty(r.TypedSpec().Status.UnmetConditions)
+				asrt.Equal(runtime.MachineStageRunning, r.TypedSpec().Stage)
+			})
+		}
+	})
+
+	suite.Run("no kubelet and etcd", func() {
+		for _, node := range suite.Cluster.Info().Nodes {
+			nodeCtx := client.WithNode(ctx, node.IPs[0].String())
+
+			rtestutils.AssertNoResource[*v1alpha1.Service](nodeCtx, suite.T(), c.COSI, "etcd")
+			rtestutils.AssertNoResource[*v1alpha1.Service](nodeCtx, suite.T(), c.COSI, "kubelet")
+		}
+	})
+
+	suite.Run("cluster discovery is working", func() {
+		for _, node := range suite.Cluster.Info().Nodes {
+			nodeCtx := client.WithNode(ctx, node.IPs[0].String())
+
+			rtestutils.AssertLength[*cluster.Member](nodeCtx, suite.T(), c.COSI, options.ControlplaneNodes)
+		}
+	})
+
+	suite.Run("host DNS is enabled", func() {
+		for _, node := range suite.Cluster.Info().Nodes {
+			nodeCtx := client.WithNode(ctx, node.IPs[0].String())
+
+			rtestutils.AssertResource(nodeCtx, suite.T(), c.COSI, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
+				asrt.True(r.TypedSpec().Enabled)
+			})
+		}
+	})
+
+	suite.Run("reboot", func() {
+		nodeCtx := client.WithNode(ctx, suite.Cluster.Info().Nodes[0].IPs[0].String())
+
+		oldBootID, err := safe.StateGetByID[*runtime.BootID](nodeCtx, c.COSI, runtime.BootIDID)
+		suite.Require().NoError(err)
+
+		suite.Require().NoError(c.Reboot(nodeCtx))
+
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			newBootID, err := safe.StateGetByID[*runtime.BootID](nodeCtx, c.COSI, runtime.BootIDID)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			asrt.NotEqual(oldBootID.TypedSpec().BootID, newBootID.TypedSpec().BootID)
+		}, time.Minute, time.Second)
+
+		suite.waitForClusterHealth()
+	})
+
+	suite.Run("reset", func() {
+		nodeCtx := client.WithNode(ctx, suite.Cluster.Info().Nodes[1].IPs[0].String())
+
+		oldBootID, err := safe.StateGetByID[*runtime.BootID](nodeCtx, c.COSI, runtime.BootIDID)
+		suite.Require().NoError(err)
+
+		oldIdentity, err := safe.StateGetByID[*cluster.Identity](nodeCtx, c.COSI, cluster.LocalIdentity)
+		suite.Require().NoError(err)
+
+		suite.Require().NoError(c.Reset(nodeCtx, true, true))
+
+		suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+			asrt := assert.New(collect)
+
+			newBootID, err := safe.StateGetByID[*runtime.BootID](nodeCtx, c.COSI, runtime.BootIDID)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			asrt.NotEqual(oldBootID.TypedSpec().BootID, newBootID.TypedSpec().BootID)
+
+			newIdentity, err := safe.StateGetByID[*cluster.Identity](nodeCtx, c.COSI, cluster.LocalIdentity)
+			if !asrt.NoError(err) {
+				return
+			}
+
+			asrt.NotEqual(oldIdentity.TypedSpec().NodeID, newIdentity.TypedSpec().NodeID)
+		}, time.Minute, time.Second)
+
+		suite.waitForClusterHealth()
+	})
+
+	suite.Run("upgrade", func() {
+		nodeCtx := client.WithNode(ctx, suite.Cluster.Info().Nodes[2].IPs[0].String())
+
+		ctrd := &common.ContainerdInstance{
+			Driver:    common.ContainerDriver_CRI,
+			Namespace: common.ContainerdNamespace_NS_SYSTEM,
+		}
+
+		pullClient, err := c.ImageClient.Pull(
+			nodeCtx,
+			&machine.ImageServicePullRequest{
+				Containerd: ctrd,
+				ImageRef:   options.SourceInstallerImage,
+			},
+		)
+		suite.Require().NoError(err)
+
+		var imgRef string
+
+		for {
+			msg, err := pullClient.Recv()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			suite.Require().NoError(err)
+
+			switch {
+			case msg.GetName() != "":
+				imgRef = msg.GetName()
+			case msg.GetPullProgress() != nil:
+				suite.T().Logf("pull progress: %s", msg.GetPullProgress().GetProgress().Fmt())
+			}
+		}
+
+		suite.Require().NotEmpty(imgRef)
+
+		upgradeClient, err := c.LifecycleClient.Upgrade(
+			nodeCtx,
+			&machine.LifecycleServiceUpgradeRequest{
+				Containerd: ctrd,
+				Source: &machine.InstallArtifactsSource{
+					ImageName: imgRef,
+				},
+			},
+		)
+		suite.Require().NoError(err)
+
+		for {
+			msg, err := upgradeClient.Recv()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			suite.Require().NoError(err)
+
+			if msg.GetProgress() != nil {
+				suite.T().Logf("upgrade progress: %s", msg.GetProgress().Fmt())
+			}
+		}
+	})
+}
+
+func init() {
+	allSuites = append(
+		allSuites,
+		&K8sLessSuite{track: 3},
+	)
+}

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -778,6 +778,10 @@ type clusterOptions struct {
 	SourceVersion        string
 	SourceK8sVersion     string
 
+	// If set, sets the machine config version contract, otherwise
+	// version contract is derived from the SourceVersion.
+	VersionContract *config.VersionContract
+
 	WithEncryption          bool
 	WithTrustedBoot         bool
 	WithBios                bool
@@ -864,8 +868,12 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 
 	suite.controlPlaneEndpoint = suite.provisioner.GetExternalKubernetesControlPlaneEndpoint(request.Network, constants.DefaultControlPlanePort)
 
-	versionContract, err := config.ParseContractFromVersion(options.SourceVersion)
-	suite.Require().NoError(err)
+	versionContract := options.VersionContract
+
+	if versionContract == nil {
+		versionContract, err = config.ParseContractFromVersion(options.SourceVersion)
+		suite.Require().NoError(err)
+	}
 
 	genOptions, bundleOptions := suite.provisioner.GenOptions(request.Network, versionContract)
 

--- a/internal/pkg/dashboard/components/kubernetesinfo.go
+++ b/internal/pkg/dashboard/components/kubernetesinfo.go
@@ -57,6 +57,15 @@ func NewKubernetesInfo() *KubernetesInfo {
 	return kubernetes
 }
 
+// Configured returns true if Kubernetes is configured on the selected node.
+//
+// Kubernetes is assumed to be configured if the Kubernetes version was detected.
+func (widget *KubernetesInfo) Configured() bool {
+	data, ok := widget.nodeMap[widget.selectedNode]
+
+	return ok && data.kubernetesVersion != notAvailable
+}
+
 // OnNodeSelect implements the NodeSelectListener interface.
 func (widget *KubernetesInfo) OnNodeSelect(node string) {
 	if node != widget.selectedNode {

--- a/internal/pkg/dashboard/summary.go
+++ b/internal/pkg/dashboard/summary.go
@@ -26,6 +26,11 @@ type SummaryGrid struct {
 	node       string
 	logViewers map[string]*components.LogViewer
 
+	talosInfo         *components.TalosInfo
+	kubernetesInfo    *components.KubernetesInfo
+	networkInfo       *components.NetworkInfo
+	kubernetesVisible bool
+
 	diagnostics        *components.Diagnostics
 	diagnosticsVisible bool
 }
@@ -40,34 +45,29 @@ func NewSummaryGrid(app *tview.Application) *SummaryGrid {
 		logViewers: make(map[string]*components.LogViewer),
 	}
 
-	widget.SetRows(summaryTopFixedRows, 0).SetColumns(-3, -2, -3)
-
-	talosInfo := components.NewTalosInfo()
-	widget.AddItem(talosInfo, 0, 0, 1, 1, 0, 0, false)
-
-	kubernetesInfo := components.NewKubernetesInfo()
-	widget.AddItem(kubernetesInfo, 0, 1, 1, 1, 0, 0, false)
-
-	networkInfo := components.NewNetworkInfo()
-	widget.AddItem(networkInfo, 0, 2, 1, 1, 0, 0, false)
-
+	widget.talosInfo = components.NewTalosInfo()
+	widget.kubernetesInfo = components.NewKubernetesInfo()
+	widget.networkInfo = components.NewNetworkInfo()
 	widget.diagnostics = components.NewDiagnostics()
 
+	// the Kubernetes column is hidden until the Kubernetes version is detected
+	widget.refreshLayout()
+
 	widget.apiDataListeners = []APIDataListener{
-		kubernetesInfo,
+		widget.kubernetesInfo,
 	}
 
 	widget.resourceListeners = []ResourceDataListener{
-		talosInfo,
-		kubernetesInfo,
-		networkInfo,
+		widget.talosInfo,
+		widget.kubernetesInfo,
+		widget.networkInfo,
 		widget.diagnostics,
 	}
 
 	widget.nodeSelectListeners = []NodeSelectListener{
-		talosInfo,
-		kubernetesInfo,
-		networkInfo,
+		widget.talosInfo,
+		widget.kubernetesInfo,
+		widget.networkInfo,
 		widget.diagnostics,
 	}
 
@@ -84,6 +84,7 @@ func (widget *SummaryGrid) OnNodeSelect(node string) {
 		nodeSelectListener.OnNodeSelect(node)
 	}
 
+	widget.updateKubernetesVisibility()
 	widget.updateDiagnostics()
 }
 
@@ -92,6 +93,8 @@ func (widget *SummaryGrid) OnAPIDataChange(node string, data *apidata.Data) {
 	for _, dataWidget := range widget.apiDataListeners {
 		dataWidget.OnAPIDataChange(node, data)
 	}
+
+	widget.updateKubernetesVisibility()
 }
 
 // OnResourceDataChange implements the ResourceDataListener interface.
@@ -100,12 +103,59 @@ func (widget *SummaryGrid) OnResourceDataChange(nodeResource resourcedata.Data) 
 		resourceListener.OnResourceDataChange(nodeResource)
 	}
 
+	widget.updateKubernetesVisibility()
 	widget.updateDiagnostics()
 }
 
 // OnLogDataChange implements the LogDataListener interface.
 func (widget *SummaryGrid) OnLogDataChange(node, logLine, logError string) {
 	widget.logViewer(node).WriteLog(logLine, logError)
+}
+
+// updateKubernetesVisibility shows or hides the Kubernetes column based on whether
+// Kubernetes is configured on the selected node.
+func (widget *SummaryGrid) updateKubernetesVisibility() {
+	if widget.kubernetesInfo.Configured() == widget.kubernetesVisible {
+		return
+	}
+
+	widget.kubernetesVisible = !widget.kubernetesVisible
+
+	widget.refreshLayout()
+}
+
+// refreshLayout re-builds the grid layout, as the number of columns depends on
+// the Kubernetes column visibility.
+func (widget *SummaryGrid) refreshLayout() {
+	widget.Clear()
+
+	widget.diagnosticsVisible = false
+	widget.SetRows(summaryTopFixedRows, 0)
+
+	if widget.kubernetesVisible {
+		widget.SetColumns(-3, -2, -3)
+
+		widget.AddItem(widget.talosInfo, 0, 0, 1, 1, 0, 0, false)
+		widget.AddItem(widget.kubernetesInfo, 0, 1, 1, 1, 0, 0, false)
+		widget.AddItem(widget.networkInfo, 0, 2, 1, 1, 0, 0, false)
+	} else {
+		widget.SetColumns(-1, -1)
+
+		widget.AddItem(widget.talosInfo, 0, 0, 1, 1, 0, 0, false)
+		widget.AddItem(widget.networkInfo, 0, 1, 1, 1, 0, 0, false)
+	}
+
+	widget.updateLogViewer()
+	widget.updateDiagnostics()
+}
+
+// columns returns the number of grid columns in the current layout.
+func (widget *SummaryGrid) columns() int {
+	if widget.kubernetesVisible {
+		return 3
+	}
+
+	return 2
 }
 
 func (widget *SummaryGrid) updateDiagnostics() {
@@ -118,7 +168,7 @@ func (widget *SummaryGrid) updateDiagnostics() {
 		widget.diagnosticsVisible = false
 	case height > 0 && !widget.diagnosticsVisible:
 		widget.SetRows(summaryTopFixedRows, 0, height)
-		widget.AddItem(widget.diagnostics, 2, 0, 1, 3, 0, 0, false)
+		widget.AddItem(widget.diagnostics, 2, 0, 1, widget.columns(), 0, 0, false)
 		widget.diagnosticsVisible = true
 	case height > 0:
 		widget.SetRows(summaryTopFixedRows, 0, height)
@@ -134,7 +184,7 @@ func (widget *SummaryGrid) updateLogViewer() {
 
 	for currNode, logViewer := range widget.logViewers {
 		if currNode == widget.node {
-			widget.AddItem(logViewer, 1, 0, 1, 3, 0, 0, false)
+			widget.AddItem(logViewer, 1, 0, 1, widget.columns(), 0, 0, false)
 
 			widget.app.SetFocus(logViewer)
 

--- a/internal/pkg/logind/logind_test.go
+++ b/internal/pkg/logind/logind_test.go
@@ -83,3 +83,44 @@ func TestIntegration(t *testing.T) {
 
 	assert.NoError(t, <-errCh)
 }
+
+func TestIntegrationNoKubelet(t *testing.T) {
+	// test same flow as TestIntegration, but this time without kubelet connection
+	// to ensure there is no wait for the lock that was never required
+	dir := t.TempDir()
+
+	socketPathService := filepath.Join(dir, "system_bus_service")
+	socketPathClient := filepath.Join(dir, "system_bus_client")
+
+	broker, err := logind.NewBroker(t.Context(), socketPathService, socketPathClient)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- broker.Run(ctx)
+	}()
+
+	serviceConn, err := logind.NewServiceMock(socketPathService)
+	require.NoError(t, err)
+
+	defer serviceConn.Close() //nolint:errcheck
+
+	t.Log("emitting shutdown signal")
+
+	require.NoError(t, serviceConn.EmitShutdown())
+
+	t.Log("waiting for inhibit lock release")
+
+	assert.NoError(t, serviceConn.WaitLockRelease(ctx))
+
+	assert.NoError(t, serviceConn.Close())
+	assert.NoError(t, broker.Close())
+
+	cancel()
+
+	assert.NoError(t, <-errCh)
+}

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -106,6 +106,11 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 			// connection timeout
 			case strings.Contains(err.Error(), "error reading from server: EOF"):
 				return retry.ExpectedError(err)
+			case statusCode == codes.InvalidArgument:
+				// no etcd, skipping bootstrap
+				fmt.Fprintln(out, "skipping bootstrap, no etcd configured")
+
+				return nil
 			}
 
 			return err

--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 )
 
@@ -25,15 +27,15 @@ func DefaultClusterChecks() []ClusterCheck {
 		[]ClusterCheck{
 			// wait for all the nodes to report ready at k8s level
 			func(cluster ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("all k8s nodes to report ready", func(ctx context.Context) error {
-					if cniDisabled, err := cniDisabledStatus(ctx, cluster); err != nil {
-						return err
-					} else if cniDisabled {
-						return conditions.ErrSkipAssertion
-					}
-
-					return K8sAllNodesReadyAssertion(ctx, cluster)
-				}, 5*time.Second)
+				return conditions.PollingCondition(
+					"all k8s nodes to report ready",
+					skipIf(cluster, cniDisabledStatus,
+						func(ctx context.Context) error {
+							return K8sAllNodesReadyAssertion(ctx, cluster)
+						},
+					),
+					5*time.Second,
+				)
 			},
 
 			// wait for kube-proxy to report ready
@@ -54,24 +56,24 @@ func DefaultClusterChecks() []ClusterCheck {
 
 			// wait for coredns to report ready
 			func(cluster ClusterInfo) conditions.Condition {
-				return conditions.PollingCondition("coredns to report ready", func(ctx context.Context) error {
-					if cniDisabled, err := cniDisabledStatus(ctx, cluster); err != nil {
-						return err
-					} else if cniDisabled {
-						return conditions.ErrSkipAssertion
-					}
+				return conditions.PollingCondition(
+					"coredns to report ready",
+					skipIf(cluster, cniDisabledStatus,
+						func(ctx context.Context) error {
+							present, replicas, err := DeploymentPresent(ctx, cluster, "kube-system", "k8s-app=kube-dns")
+							if err != nil {
+								return err
+							}
 
-					present, replicas, err := DeploymentPresent(ctx, cluster, "kube-system", "k8s-app=kube-dns")
-					if err != nil {
-						return err
-					}
+							if !present {
+								return conditions.ErrSkipAssertion
+							}
 
-					if !present {
-						return conditions.ErrSkipAssertion
-					}
-
-					return K8sPodReadyAssertion(ctx, cluster, replicas, "kube-system", "k8s-app=kube-dns")
-				}, 5*time.Second)
+							return K8sPodReadyAssertion(ctx, cluster, replicas, "kube-system", "k8s-app=kube-dns")
+						},
+					),
+					5*time.Second,
+				)
 			},
 
 			// wait for all the nodes to be schedulable
@@ -82,20 +84,6 @@ func DefaultClusterChecks() []ClusterCheck {
 			},
 		},
 	)
-}
-
-func cniDisabledStatus(ctx context.Context, cluster ClusterInfo) (bool, error) {
-	cli, err := cluster.Client()
-	if err != nil {
-		return false, err
-	}
-
-	bmc, err := safe.ReaderGetByID[*k8s.BootstrapManifestsConfig](ctx, cli.COSI, k8s.BootstrapManifestsConfigID)
-	if err != nil {
-		return false, err
-	}
-
-	return bmc.TypedSpec().CNIName == constants.NoneCNI, nil
 }
 
 // K8sComponentsReadinessChecks returns a set of K8s cluster readiness checks which are specific to the k8s components
@@ -138,23 +126,41 @@ func PreBootSequenceChecks() []ClusterCheck {
 	return []ClusterCheck{
 		// wait for etcd to be healthy on all control plane nodes
 		func(cluster ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
-			}, 5*time.Second)
+			return conditions.PollingCondition(
+				"etcd to be healthy",
+				skipIf(
+					cluster, etcdDisabled,
+					func(ctx context.Context) error {
+						return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+					},
+				),
+				5*time.Second)
 		},
 
 		// wait for etcd members to be consistent across nodes
 		func(cluster ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be consistent across nodes", func(ctx context.Context) error {
-				return EtcdConsistentAssertion(ctx, cluster)
-			}, 5*time.Second)
+			return conditions.PollingCondition(
+				"etcd members to be consistent across nodes",
+				skipIf(
+					cluster, etcdDisabled,
+					func(ctx context.Context) error {
+						return EtcdConsistentAssertion(ctx, cluster)
+					},
+				),
+				5*time.Second)
 		},
 
 		// wait for etcd members to be the control plane nodes
 		func(cluster ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("etcd members to be control plane nodes", func(ctx context.Context) error {
-				return EtcdControlPlaneNodesAssertion(ctx, cluster)
-			}, 5*time.Second)
+			return conditions.PollingCondition(
+				"etcd members to be control plane nodes",
+				skipIf(
+					cluster, etcdDisabled,
+					func(ctx context.Context) error {
+						return EtcdControlPlaneNodesAssertion(ctx, cluster)
+					},
+				),
+				5*time.Second)
 		},
 
 		// wait for apid to be ready on all the nodes
@@ -187,9 +193,15 @@ func PreBootSequenceChecks() []ClusterCheck {
 
 		// wait for kubelet to be healthy on all
 		func(cluster ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("kubelet to be healthy", func(ctx context.Context) error {
-				return ServiceHealthAssertion(ctx, cluster, "kubelet", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
-			}, 5*time.Second)
+			return conditions.PollingCondition(
+				"kubelet to be healthy",
+				skipIf(
+					cluster, kubeletDisabled,
+					func(ctx context.Context) error {
+						return ServiceHealthAssertion(ctx, cluster, "kubelet", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+					},
+				),
+				5*time.Second)
 		},
 
 		// wait for all nodes to finish booting
@@ -199,4 +211,69 @@ func PreBootSequenceChecks() []ClusterCheck {
 			}, 5*time.Second)
 		},
 	}
+}
+
+func skipIf(cluster ClusterInfo, check func(context.Context, ClusterInfo) (bool, error), assertion conditions.AssertionFunc) conditions.AssertionFunc {
+	return func(ctx context.Context) error {
+		skip, err := check(ctx, cluster)
+		if err != nil {
+			return err
+		}
+
+		if skip {
+			return conditions.ErrSkipAssertion
+		}
+
+		return assertion(ctx)
+	}
+}
+
+func etcdDisabled(ctx context.Context, cluster ClusterInfo) (bool, error) {
+	cli, err := cluster.Client()
+	if err != nil {
+		return false, err
+	}
+
+	cfg, err := safe.ReaderGetByID[*config.MachineConfig](ctx, cli.COSI, config.ActiveID)
+	if err != nil {
+		return false, err
+	}
+
+	return cfg.Config().Cluster() == nil || cfg.Config().Cluster().Etcd() == nil || cfg.Config().Cluster().Etcd().CA() == nil, nil
+}
+
+func kubeletDisabled(ctx context.Context, cluster ClusterInfo) (bool, error) {
+	cli, err := cluster.Client()
+	if err != nil {
+		return false, err
+	}
+
+	_, err = safe.ReaderGetByID[*k8s.KubeletConfig](ctx, cli.COSI, k8s.KubeletID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return true, nil
+		}
+
+		return false, err
+	}
+
+	return false, nil
+}
+
+func cniDisabledStatus(ctx context.Context, cluster ClusterInfo) (bool, error) {
+	cli, err := cluster.Client()
+	if err != nil {
+		return false, err
+	}
+
+	bmc, err := safe.ReaderGetByID[*k8s.BootstrapManifestsConfig](ctx, cli.COSI, k8s.BootstrapManifestsConfigID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return true, nil
+		}
+
+		return false, err
+	}
+
+	return bmc.TypedSpec().CNIName == constants.NoneCNI, nil
 }

--- a/pkg/cluster/check/kubernetes.go
+++ b/pkg/cluster/check/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/go-pointer"
@@ -20,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/siderolabs/talos/pkg/cluster"
+	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -30,6 +32,11 @@ import (
 func K8sAllNodesReportedAssertion(ctx context.Context, cl ClusterInfo) error {
 	clientset, err := cl.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return conditions.ErrSkipAssertion
+		}
+
 		return err
 	}
 
@@ -83,6 +90,11 @@ func K8sAllNodesReportedAssertion(ctx context.Context, cl ClusterInfo) error {
 func K8sFullControlPlaneAssertion(ctx context.Context, cl ClusterInfo) error {
 	clientset, err := cl.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return conditions.ErrSkipAssertion
+		}
+
 		return err
 	}
 
@@ -216,6 +228,11 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cl ClusterInfo) error {
 func K8sAllNodesReadyAssertion(ctx context.Context, cluster cluster.K8sProvider) error {
 	clientset, err := cluster.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return conditions.ErrSkipAssertion
+		}
+
 		return err
 	}
 
@@ -249,6 +266,11 @@ func K8sAllNodesReadyAssertion(ctx context.Context, cluster cluster.K8sProvider)
 func K8sAllNodesSchedulableAssertion(ctx context.Context, cluster cluster.K8sProvider) error {
 	clientset, err := cluster.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return conditions.ErrSkipAssertion
+		}
+
 		return err
 	}
 
@@ -280,6 +302,11 @@ func K8sAllNodesSchedulableAssertion(ctx context.Context, cluster cluster.K8sPro
 func K8sPodReadyAssertion(ctx context.Context, cluster cluster.K8sProvider, replicas int, namespace, labelSelector string) error {
 	clientset, err := cluster.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return conditions.ErrSkipAssertion
+		}
+
 		return err
 	}
 
@@ -362,6 +389,11 @@ func K8sPodReadyAssertion(ctx context.Context, cluster cluster.K8sProvider, repl
 func DaemonSetPresent(ctx context.Context, cluster cluster.K8sProvider, namespace, labelSelector string) (bool, int, error) {
 	clientset, err := cluster.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return false, 0, conditions.ErrSkipAssertion
+		}
+
 		return false, 0, err
 	}
 
@@ -383,6 +415,11 @@ func DaemonSetPresent(ctx context.Context, cluster cluster.K8sProvider, namespac
 func DeploymentPresent(ctx context.Context, cluster cluster.K8sProvider, namespace, labelSelector string) (bool, int, error) {
 	clientset, err := cluster.K8sClient(ctx)
 	if err != nil {
+		// No Kubernetes config, skip the check
+		if client.StatusCode(err) == codes.FailedPrecondition {
+			return false, 0, conditions.ErrSkipAssertion
+		}
+
 		return false, 0, err
 	}
 
@@ -403,29 +440,51 @@ func DeploymentPresent(ctx context.Context, cluster cluster.K8sProvider, namespa
 }
 
 // K8sControlPlaneStaticPods checks whether all the controlplane nodes are running required Kubernetes static pods.
+//
+//nolint:gocyclo
 func K8sControlPlaneStaticPods(ctx context.Context, cl ClusterInfo) error {
 	expectedNodes := append(cl.NodesByType(machine.TypeInit), cl.NodesByType(machine.TypeControlPlane)...)
 
-	// using here new Talos COSI API, Talos 1.2+ required
 	c, err := cl.Client()
 	if err != nil {
 		return err
 	}
 
 	for _, node := range expectedNodes {
-		expectedStaticPods := map[string]struct{}{
-			"kube-system/kube-apiserver":          {},
-			"kube-system/kube-controller-manager": {},
-			"kube-system/kube-scheduler":          {},
-		}
+		expectedStaticPods := map[string]struct{}{}
 
-		items, err := safe.StateListAll[*k8s.StaticPodStatus](client.WithNode(ctx, node.InternalIP.String()), c.COSI)
-		if err != nil {
-			if client.StatusCode(err) == codes.Unimplemented {
-				// old version of Talos without COSI API
-				return nil
+		nodeCtx := client.WithNode(ctx, node.InternalIP.String())
+
+		for _, staticPod := range []struct {
+			id                 string
+			configResourceType resource.Type
+		}{
+			{
+				id:                 "kube-system/kube-apiserver",
+				configResourceType: k8s.APIServerConfigType,
+			},
+			{
+				id:                 "kube-system/kube-controller-manager",
+				configResourceType: k8s.ControllerManagerConfigType,
+			},
+			{
+				id:                 "kube-system/kube-scheduler",
+				configResourceType: k8s.SchedulerConfigType,
+			},
+		} {
+			// Talos 1.14 introduces more IDs for the same type, so use simple List API to avoid sticking to IDs
+			items, err := c.COSI.List(nodeCtx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, staticPod.configResourceType, "", resource.VersionUndefined))
+			if err != nil {
+				return fmt.Errorf("error listing static pods config for node %s: %w", node.InternalIP, err)
 			}
 
+			if len(items.Items) > 0 {
+				expectedStaticPods[staticPod.id] = struct{}{}
+			}
+		}
+
+		items, err := safe.StateListAll[*k8s.StaticPodStatus](nodeCtx, c.COSI)
+		if err != nil {
 			return fmt.Errorf("error listing static pods on node %s: %w", node.InternalIP, err)
 		}
 

--- a/pkg/grpc/middleware/auth/unix/authorizer.go
+++ b/pkg/grpc/middleware/auth/unix/authorizer.go
@@ -155,7 +155,7 @@ func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			a.logf("timed out waiting for runner state to be populated with PID")
+			a.logf("timed out waiting for runner state to be populated with PID (%d)", pid)
 
 			return role.Set{}, ErrNotAuthorized
 		case wrappedEvent := <-eventCh:

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -267,21 +267,26 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 		}
 	}
 
-	// control plane specific checks
-	if container.Machine() != nil && container.Machine().Type().IsControlPlane() {
-		hasLegacyEtcdEncryptionConfig := container.Cluster() != nil && (container.Cluster().SecretboxEncryptionSecret() != "" || container.Cluster().AESCBCEncryptionSecret() != "")
-		hasKubeEtcdEncryptionConfig := container.K8sEtcdEncryptionConfig() != nil
-
-		if !hasLegacyEtcdEncryptionConfig && !hasKubeEtcdEncryptionConfig {
-			errs = multierror.Append(errs, fmt.Errorf("etcd encryption config is required for control plane machines"))
-		}
-	}
-
 	// machine type specific checks
 	var machineType machine.Type
 
 	if container.Machine() != nil {
 		machineType = container.Machine().Type()
+	}
+
+	// control plane specific checks
+	if machineType.IsControlPlane() {
+		// switching here on api-server CA config instead of api-server config,
+		// as due to backwards compatibility reasons, the empty legacy `.cluster.apiServer` config
+		// resolves to "default api-server".
+		if container.K8sAPIServerCAConfig() != nil {
+			hasLegacyEtcdEncryptionConfig := container.Cluster() != nil && (container.Cluster().SecretboxEncryptionSecret() != "" || container.Cluster().AESCBCEncryptionSecret() != "")
+			hasKubeEtcdEncryptionConfig := container.K8sEtcdEncryptionConfig() != nil
+
+			if !hasLegacyEtcdEncryptionConfig && !hasKubeEtcdEncryptionConfig {
+				errs = multierror.Append(errs, fmt.Errorf("etcd encryption config is required for control plane machines running kube-apiserver"))
+			}
+		}
 	}
 
 	controlplaneDocs := findMatchingDocs[ControlplaneOnlyConfig](container.documents)

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -252,6 +252,10 @@ func TestValidateContainer(t *testing.T) {
 		},
 	}
 
+	v1alpha1CfgControlplane := v1alpha1Cfg.DeepCopy()
+	v1alpha1CfgControlplane.MachineConfig.MachineType = "controlplane"
+	v1alpha1CfgControlplane.MachineConfig.MachineCA.Key = []byte("controlplane-key")
+
 	resolverConfig := network.NewResolverConfigV1Alpha1()
 	resolverConfig.ResolverNameservers = []network.NameserverConfig{
 		{
@@ -292,6 +296,8 @@ func TestValidateContainer(t *testing.T) {
 	)
 
 	discoveryServiceConfig := cluster.NewDiscoveryServiceConfigV1Alpha1("default", must.Value(url.Parse("https://discovery.api/"))(t))
+
+	apiServerCAConfig := k8s.NewKubeAPIServerCAConfigV1Alpha1()
 
 	for _, tt := range []struct {
 		name        string
@@ -380,6 +386,12 @@ func TestValidateContainer(t *testing.T) {
 		{
 			name:      "discovery with kubespan and identity",
 			documents: []config.Document{discoveryServiceConfig, discoveryIdentityConfig, kubespanConfig},
+		},
+		{
+			name:      "api-server CA without etcd encryption",
+			documents: []config.Document{v1alpha1CfgControlplane, apiServerCAConfig},
+
+			expectedError: "1 error occurred:\n\t* etcd encryption config is required for control plane machines running kube-apiserver\n\n",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -20,26 +20,29 @@ import (
 type VersionContract struct {
 	Major int
 	Minor int
+
+	disableKubernetes bool
+	disableEtcd       bool
 }
 
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
-	TalosVersion1_14    = &VersionContract{1, 14}
-	TalosVersion1_13    = &VersionContract{1, 13}
-	TalosVersion1_12    = &VersionContract{1, 12}
-	TalosVersion1_11    = &VersionContract{1, 11}
-	TalosVersion1_10    = &VersionContract{1, 10}
-	TalosVersion1_9     = &VersionContract{1, 9}
-	TalosVersion1_8     = &VersionContract{1, 8}
-	TalosVersion1_7     = &VersionContract{1, 7}
-	TalosVersion1_6     = &VersionContract{1, 6}
-	TalosVersion1_5     = &VersionContract{1, 5}
-	TalosVersion1_4     = &VersionContract{1, 4}
-	TalosVersion1_3     = &VersionContract{1, 3}
-	TalosVersion1_2     = &VersionContract{1, 2}
-	TalosVersion1_1     = &VersionContract{1, 1}
-	TalosVersion1_0     = &VersionContract{1, 0}
+	TalosVersion1_14    = &VersionContract{Major: 1, Minor: 14}
+	TalosVersion1_13    = &VersionContract{Major: 1, Minor: 13}
+	TalosVersion1_12    = &VersionContract{Major: 1, Minor: 12}
+	TalosVersion1_11    = &VersionContract{Major: 1, Minor: 11}
+	TalosVersion1_10    = &VersionContract{Major: 1, Minor: 10}
+	TalosVersion1_9     = &VersionContract{Major: 1, Minor: 9}
+	TalosVersion1_8     = &VersionContract{Major: 1, Minor: 8}
+	TalosVersion1_7     = &VersionContract{Major: 1, Minor: 7}
+	TalosVersion1_6     = &VersionContract{Major: 1, Minor: 6}
+	TalosVersion1_5     = &VersionContract{Major: 1, Minor: 5}
+	TalosVersion1_4     = &VersionContract{Major: 1, Minor: 4}
+	TalosVersion1_3     = &VersionContract{Major: 1, Minor: 3}
+	TalosVersion1_2     = &VersionContract{Major: 1, Minor: 2}
+	TalosVersion1_1     = &VersionContract{Major: 1, Minor: 1}
+	TalosVersion1_0     = &VersionContract{Major: 1, Minor: 0}
 )
 
 var versionRegexp = regexp.MustCompile(`^v(\d+)\.(\d+)($|\.)`)
@@ -63,7 +66,7 @@ func ParseContractFromVersion(version string) (*VersionContract, error) {
 
 // String returns string representation of the contract.
 func (contract *VersionContract) String() string {
-	if contract == nil {
+	if contract == nil || (contract.Major == 0 && contract.Minor == 0) {
 		return "current"
 	}
 
@@ -72,15 +75,60 @@ func (contract *VersionContract) String() string {
 
 // Greater compares contract to another contract.
 func (contract *VersionContract) Greater(other *VersionContract) bool {
-	if contract == nil {
-		return other != nil
+	contractNil := contract == nil || contract.Major == 0 && contract.Minor == 0
+	otherNil := other == nil || other.Major == 0 && other.Minor == 0
+
+	if contractNil {
+		return !otherNil
 	}
 
-	if other == nil {
+	if otherNil {
 		return false
 	}
 
 	return contract.Major > other.Major || (contract.Major == other.Major && contract.Minor > other.Minor)
+}
+
+// DisableKubernetes produces new version contract with Kubernetes disabled.
+func (contract *VersionContract) DisableKubernetes() *VersionContract {
+	if contract == nil {
+		return &VersionContract{disableKubernetes: true}
+	}
+
+	newContract := *contract
+	newContract.disableKubernetes = true
+
+	return &newContract
+}
+
+// DisableEtcd produces new version contract with etcd disabled.
+func (contract *VersionContract) DisableEtcd() *VersionContract {
+	if contract == nil {
+		return &VersionContract{disableEtcd: true}
+	}
+
+	newContract := *contract
+	newContract.disableEtcd = true
+
+	return &newContract
+}
+
+// KubernetesDisabled returns true if Kubernetes should be disabled in the generated config.
+func (contract *VersionContract) KubernetesDisabled() bool {
+	if contract == nil {
+		return false
+	}
+
+	return contract.disableKubernetes
+}
+
+// EtcdDisabled returns true if etcd should be disabled in the generated config.
+func (contract *VersionContract) EtcdDisabled() bool {
+	if contract == nil {
+		return false
+	}
+
+	return contract.disableEtcd
 }
 
 // PodSecurityAdmissionEnabled returns true if pod security admission should be enabled by default.

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -30,7 +30,7 @@ func TestContractParseVersion(t *testing.T) {
 		"v1.5":           config.TalosVersion1_5,
 		"v1.5.":          config.TalosVersion1_5,
 		"v1.5.1":         config.TalosVersion1_5,
-		"v1.88":          {1, 88},
+		"v1.88":          {Major: 1, Minor: 88},
 		"v1.5.3-alpha.4": config.TalosVersion1_5,
 		"1.6":            config.TalosVersion1_6,
 	} {
@@ -42,6 +42,32 @@ func TestContractParseVersion(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		})
 	}
+}
+
+func TestContractDisableKubernetesEtcd(t *testing.T) {
+	t.Parallel()
+
+	var contract *config.VersionContract
+
+	assert.False(t, contract.KubernetesDisabled())
+	assert.True(t, contract.DisableKubernetes().KubernetesDisabled())
+
+	assert.False(t, contract.EtcdDisabled())
+	assert.True(t, contract.DisableEtcd().EtcdDisabled())
+
+	assert.True(t, contract.DisableEtcd().DisableKubernetes().Greater(config.TalosVersion1_14))
+	assert.Equal(t, "current", contract.DisableEtcd().DisableKubernetes().String())
+
+	contract = config.TalosVersion1_14
+
+	assert.False(t, contract.KubernetesDisabled())
+	assert.True(t, contract.DisableKubernetes().KubernetesDisabled())
+
+	assert.False(t, contract.EtcdDisabled())
+	assert.True(t, contract.DisableEtcd().EtcdDisabled())
+
+	assert.True(t, contract.DisableEtcd().DisableKubernetes().Greater(config.TalosVersion1_13))
+	assert.Equal(t, "v1.14", contract.DisableEtcd().DisableKubernetes().String())
 }
 
 func TestContractCurrent(t *testing.T) {

--- a/pkg/machinery/config/generate/generate_test.go
+++ b/pkg/machinery/config/generate/generate_test.go
@@ -363,6 +363,29 @@ func TestGenerateDiscoveryIdentityConfig(t *testing.T) {
 	}
 }
 
+func TestGenerateNoEtcdKubernetes(t *testing.T) {
+	t.Parallel()
+
+	input, err := generate.NewInput(
+		"bare", "https://10.0.1.5", constants.DefaultKubernetesVersion,
+		generate.WithVersionContract(config.TalosVersionCurrent.DisableEtcd().DisableKubernetes()),
+	)
+	require.NoError(t, err)
+
+	for _, machineType := range []machine.Type{machine.TypeControlPlane, machine.TypeWorker} {
+		t.Run(machineType.String(), func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := input.Config(machineType)
+			require.NoError(t, err)
+
+			warnings, err := cfg.ValidateAsClient(runtimeMode{})
+			require.NoError(t, err)
+			assert.Empty(t, warnings)
+		})
+	}
+}
+
 type runtimeMode struct {
 	requiresInstall bool
 }

--- a/pkg/machinery/config/generate/init.go
+++ b/pkg/machinery/config/generate/init.go
@@ -153,9 +153,9 @@ func (in *Input) init() ([]config.Document, error) {
 		SchedulerConfig: nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), &v1alpha1.SchedulerConfig{ //nolint:staticcheck // legacy configuration
 			ContainerImage: fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, in.KubernetesVersion),
 		}),
-		EtcdConfig: &v1alpha1.EtcdConfig{
+		EtcdConfig: nilIf(in.Options.VersionContract.EtcdDisabled(), &v1alpha1.EtcdConfig{
 			RootCA: in.Options.SecretsBundle.Certs.Etcd,
-		},
+		}),
 		ClusterNetwork: nilIf(
 			in.Options.VersionContract.MultidocKubernetesConfigSupported(),
 			&v1alpha1.ClusterNetworkConfig{
@@ -167,7 +167,7 @@ func (in *Input) init() ([]config.Document, error) {
 		ClusterCA:             nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), in.Options.SecretsBundle.Certs.K8s),
 		ClusterAggregatorCA:   nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), in.Options.SecretsBundle.Certs.K8sAggregator),
 		ClusterServiceAccount: nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), in.Options.SecretsBundle.Certs.K8sServiceAccount),
-		BootstrapToken:        in.Options.SecretsBundle.Secrets.BootstrapToken,
+		BootstrapToken:        nilIf(in.Options.VersionContract.KubernetesDisabled(), in.Options.SecretsBundle.Secrets.BootstrapToken),
 	}
 
 	var customCNIURL *url.URL

--- a/pkg/machinery/config/generate/kubernetes.go
+++ b/pkg/machinery/config/generate/kubernetes.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (in *Input) generateKubernetesControlplaneConfigs(controlplaneURL *url.URL, certSANs []string, customCNIURL *url.URL) []config.Document {
-	if !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
+	if in.Options.VersionContract.KubernetesDisabled() || !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
 		return nil
 	}
 
@@ -153,8 +153,9 @@ func (in *Input) generateKubernetesControlplaneConfigs(controlplaneURL *url.URL,
 	return result
 }
 
+//nolint:gocyclo
 func (in *Input) generateKubernetesUniversalConfigs(isControlplane bool, controlPlaneURL *url.URL) []config.Document {
-	if !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
+	if in.Options.VersionContract.KubernetesDisabled() || !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
 		return nil
 	}
 

--- a/pkg/machinery/config/generate/secrets/bundle.go
+++ b/pkg/machinery/config/generate/secrets/bundle.go
@@ -266,7 +266,7 @@ func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
 		bundle.Certs = &Certs{}
 	}
 
-	if bundle.Certs.Etcd == nil {
+	if bundle.Certs.Etcd == nil && !versionContract.EtcdDisabled() {
 		etcd, err := NewEtcdCA(bundle.Clock.Now(), versionContract)
 		if err != nil {
 			return err
@@ -278,48 +278,50 @@ func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
 		}
 	}
 
-	if bundle.Certs.K8s == nil {
-		kubernetesCA, err := NewKubernetesCA(bundle.Clock.Now(), versionContract)
-		if err != nil {
-			return err
-		}
-
-		bundle.Certs.K8s = &x509.PEMEncodedCertificateAndKey{
-			Crt: kubernetesCA.CrtPEM,
-			Key: kubernetesCA.KeyPEM,
-		}
-	}
-
-	if bundle.Certs.K8sAggregator == nil {
-		aggregatorCA, err := NewAggregatorCA(bundle.Clock.Now(), versionContract)
-		if err != nil {
-			return err
-		}
-
-		bundle.Certs.K8sAggregator = &x509.PEMEncodedCertificateAndKey{
-			Crt: aggregatorCA.CrtPEM,
-			Key: aggregatorCA.KeyPEM,
-		}
-	}
-
-	if bundle.Certs.K8sServiceAccount == nil {
-		if versionContract.UseRSAServiceAccountKey() {
-			serviceAccount, err := x509.NewRSAKey()
+	if !versionContract.KubernetesDisabled() {
+		if bundle.Certs.K8s == nil {
+			kubernetesCA, err := NewKubernetesCA(bundle.Clock.Now(), versionContract)
 			if err != nil {
 				return err
 			}
 
-			bundle.Certs.K8sServiceAccount = &x509.PEMEncodedKey{
-				Key: serviceAccount.KeyPEM,
+			bundle.Certs.K8s = &x509.PEMEncodedCertificateAndKey{
+				Crt: kubernetesCA.CrtPEM,
+				Key: kubernetesCA.KeyPEM,
 			}
-		} else {
-			serviceAccount, err := x509.NewECDSAKey()
+		}
+
+		if bundle.Certs.K8sAggregator == nil {
+			aggregatorCA, err := NewAggregatorCA(bundle.Clock.Now(), versionContract)
 			if err != nil {
 				return err
 			}
 
-			bundle.Certs.K8sServiceAccount = &x509.PEMEncodedKey{
-				Key: serviceAccount.KeyPEM,
+			bundle.Certs.K8sAggregator = &x509.PEMEncodedCertificateAndKey{
+				Crt: aggregatorCA.CrtPEM,
+				Key: aggregatorCA.KeyPEM,
+			}
+		}
+
+		if bundle.Certs.K8sServiceAccount == nil {
+			if versionContract.UseRSAServiceAccountKey() {
+				serviceAccount, err := x509.NewRSAKey()
+				if err != nil {
+					return err
+				}
+
+				bundle.Certs.K8sServiceAccount = &x509.PEMEncodedKey{
+					Key: serviceAccount.KeyPEM,
+				}
+			} else {
+				serviceAccount, err := x509.NewECDSAKey()
+				if err != nil {
+					return err
+				}
+
+				bundle.Certs.K8sServiceAccount = &x509.PEMEncodedKey{
+					Key: serviceAccount.KeyPEM,
+				}
 			}
 		}
 	}
@@ -340,32 +342,34 @@ func (bundle *Bundle) populate(versionContract *config.VersionContract) error {
 		bundle.Secrets = &Secrets{}
 	}
 
-	if bundle.Secrets.BootstrapToken == "" {
-		token, err := genToken(6, 16)
-		if err != nil {
-			return err
-		}
-
-		bundle.Secrets.BootstrapToken = token
-	}
-
-	if versionContract.Greater(config.TalosVersion1_2) {
-		if bundle.Secrets.SecretboxEncryptionSecret == "" {
-			secretboxEncryptionSecret, err := cis.CreateEncryptionToken()
+	if !versionContract.KubernetesDisabled() {
+		if bundle.Secrets.BootstrapToken == "" {
+			token, err := genToken(6, 16)
 			if err != nil {
 				return err
 			}
 
-			bundle.Secrets.SecretboxEncryptionSecret = secretboxEncryptionSecret
+			bundle.Secrets.BootstrapToken = token
 		}
-	} else {
-		if bundle.Secrets.AESCBCEncryptionSecret == "" {
-			aesCBCEncryptionSecret, err := cis.CreateEncryptionToken()
-			if err != nil {
-				return err
-			}
 
-			bundle.Secrets.AESCBCEncryptionSecret = aesCBCEncryptionSecret
+		if versionContract.Greater(config.TalosVersion1_2) {
+			if bundle.Secrets.SecretboxEncryptionSecret == "" {
+				secretboxEncryptionSecret, err := cis.CreateEncryptionToken()
+				if err != nil {
+					return err
+				}
+
+				bundle.Secrets.SecretboxEncryptionSecret = secretboxEncryptionSecret
+			}
+		} else {
+			if bundle.Secrets.AESCBCEncryptionSecret == "" {
+				aesCBCEncryptionSecret, err := cis.CreateEncryptionToken()
+				if err != nil {
+					return err
+				}
+
+				bundle.Secrets.AESCBCEncryptionSecret = aesCBCEncryptionSecret
+			}
 		}
 	}
 
@@ -425,7 +429,7 @@ func (bundle *Bundle) GenerateTalosAPIClientCertificateWithTTL(roles role.Set, c
 // Validate the bundle.
 //
 //nolint:gocyclo,cyclop
-func (bundle *Bundle) Validate() error {
+func (bundle *Bundle) Validate(versionContract *config.VersionContract) error {
 	var multiErr error
 
 	if bundle.Cluster == nil {
@@ -440,19 +444,21 @@ func (bundle *Bundle) Validate() error {
 		}
 	}
 
-	if bundle.Secrets == nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("secrets is required"))
-	} else {
-		if bundle.Secrets.BootstrapToken == "" {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("secrets.bootstraptoken is required"))
-		}
+	if !versionContract.KubernetesDisabled() {
+		if bundle.Secrets == nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("secrets is required"))
+		} else {
+			if bundle.Secrets.BootstrapToken == "" {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("secrets.bootstraptoken is required"))
+			}
 
-		if bundle.Secrets.AESCBCEncryptionSecret == "" && bundle.Secrets.SecretboxEncryptionSecret == "" {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("one of [secrets.secretboxencryptionsecret, secrets.aescbcencryptionsecret] is required"))
-		}
+			if bundle.Secrets.AESCBCEncryptionSecret == "" && bundle.Secrets.SecretboxEncryptionSecret == "" {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("one of [secrets.secretboxencryptionsecret, secrets.aescbcencryptionsecret] is required"))
+			}
 
-		if bundle.Secrets.AESCBCEncryptionSecret != "" && bundle.Secrets.SecretboxEncryptionSecret != "" {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("only one of [secrets.secretboxencryptionsecret, secrets.aescbcencryptionsecret] is allowed"))
+			if bundle.Secrets.AESCBCEncryptionSecret != "" && bundle.Secrets.SecretboxEncryptionSecret != "" {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("only one of [secrets.secretboxencryptionsecret, secrets.aescbcencryptionsecret] is allowed"))
+			}
 		}
 	}
 
@@ -462,7 +468,7 @@ func (bundle *Bundle) Validate() error {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("trustdinfo.token is required"))
 	}
 
-	if err := bundle.validateCerts(); err != nil {
+	if err := bundle.validateCerts(versionContract); err != nil {
 		multiErr = multierror.Append(multiErr, err)
 	}
 
@@ -470,41 +476,45 @@ func (bundle *Bundle) Validate() error {
 }
 
 //nolint:gocyclo,cyclop
-func (bundle *Bundle) validateCerts() error {
+func (bundle *Bundle) validateCerts(versionContract *config.VersionContract) error {
 	if bundle.Certs == nil {
 		return errors.New("certs is required")
 	}
 
 	var multiErr error
 
-	if bundle.Certs.Etcd == nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.etcd is required"))
-	} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.Etcd); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.etcd is invalid: %w", err))
+	if !versionContract.EtcdDisabled() {
+		if bundle.Certs.Etcd == nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.etcd is required"))
+		} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.Etcd); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.etcd is invalid: %w", err))
+		}
 	}
 
-	if bundle.Certs.K8s == nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8s is required"))
-	} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.K8s); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8s is invalid: %w", err))
-	}
+	if !versionContract.KubernetesDisabled() {
+		if bundle.Certs.K8s == nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8s is required"))
+		} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.K8s); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8s is invalid: %w", err))
+		}
 
-	if bundle.Certs.K8sAggregator == nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8saggregator is required"))
-	} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.K8sAggregator); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8saggregator is invalid: %w", err))
+		if bundle.Certs.K8sAggregator == nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8saggregator is required"))
+		} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.K8sAggregator); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8saggregator is invalid: %w", err))
+		}
+
+		if bundle.Certs.K8sServiceAccount == nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8sserviceaccount is required"))
+		} else if _, err := bundle.Certs.K8sServiceAccount.GetKey(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8sserviceaccount.key is invalid: %w", err))
+		}
 	}
 
 	if bundle.Certs.OS == nil {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.os is required"))
 	} else if err := validatePEMEncodedCertificateAndKey(bundle.Certs.OS); err != nil {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.os is invalid: %w", err))
-	}
-
-	if bundle.Certs.K8sServiceAccount == nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8sserviceaccount is required"))
-	} else if _, err := bundle.Certs.K8sServiceAccount.GetKey(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("certs.k8sserviceaccount.key is invalid: %w", err))
 	}
 
 	return multiErr

--- a/pkg/machinery/config/generate/secrets/generate_test.go
+++ b/pkg/machinery/config/generate/secrets/generate_test.go
@@ -43,12 +43,18 @@ func TestNewBundle(t *testing.T) {
 			name:            "current",
 			versionContract: config.TalosVersionCurrent,
 		},
+		{
+			name:            "current + no k8s + no etcd",
+			versionContract: config.TalosVersionCurrent.DisableKubernetes().DisableEtcd(),
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), test.versionContract)
+			bundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), test.versionContract)
 			require.NoError(t, err)
+
+			require.NoError(t, bundle.Validate(test.versionContract))
 		})
 	}
 }

--- a/pkg/machinery/config/generate/secrets/validate_test.go
+++ b/pkg/machinery/config/generate/secrets/validate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 
+	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 )
 
@@ -26,11 +27,11 @@ func TestValidate(t *testing.T) {
 
 	var bundle secrets.Bundle
 	require.NoError(t, yaml.Unmarshal(validSecrets, &bundle))
-	require.NoError(t, bundle.Validate())
+	require.NoError(t, bundle.Validate(config.TalosVersionCurrent))
 
 	var invalidBundle secrets.Bundle
 	require.NoError(t, yaml.Unmarshal(invalidSecrets, &invalidBundle))
-	require.EqualError(t, invalidBundle.Validate(), `6 errors occurred:
+	require.EqualError(t, invalidBundle.Validate(config.TalosVersionCurrent), `6 errors occurred:
 	* cluster.secret is required
 	* one of [secrets.secretboxencryptionsecret, secrets.aescbcencryptionsecret] is required
 	* trustdinfo is required

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -110,7 +110,6 @@ func (in *Input) worker() ([]config.Document, error) {
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterID:      nilIf(in.Options.VersionContract.DiscoveryIdentityMultidocConfig(), in.Options.SecretsBundle.Cluster.ID),     //nolint:staticcheck // legacy configuration
 		ClusterSecret:  nilIf(in.Options.VersionContract.DiscoveryIdentityMultidocConfig(), in.Options.SecretsBundle.Cluster.Secret), //nolint:staticcheck // legacy configuration
-		ClusterCA:      nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), &x509.PEMEncodedCertificateAndKey{Crt: in.Options.SecretsBundle.Certs.K8s.Crt}),
 		BootstrapToken: in.Options.SecretsBundle.Secrets.BootstrapToken,
 		ControlPlane: nilIf(in.Options.VersionContract.MultidocKubernetesConfigSupported(), &v1alpha1.ControlPlaneConfig{
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
@@ -123,6 +122,10 @@ func (in *Input) worker() ([]config.Document, error) {
 				ServiceSubnet: in.ServiceNet,
 			},
 		),
+	}
+
+	if !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
+		cluster.ClusterCA = &x509.PEMEncodedCertificateAndKey{Crt: in.Options.SecretsBundle.Certs.K8s.Crt} //nolint:staticcheck // legacy configuration
 	}
 
 	if !in.Options.VersionContract.MultidocKubernetesConfigSupported() && in.Options.CNICustomURL != "" {

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -188,6 +188,7 @@ talosctl cluster create dev [flags]
       --primary-disks int                        number of primary disks to create for each VM (each sized by --disk) (default 1)
       --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --skip-etcd-k8s                            skip etcd and Kubernetes machine configuration (experimental)
       --skip-injecting-config                    skip injecting config from embedded metadata server, write config files to current directory
       --skip-injecting-extra-cmdline             skip injecting extra kernel cmdline parameters via EFI vars through bootloader
       --skip-k8s-node-readiness-check            skip k8s node readiness checks


### PR DESCRIPTION
If no K8s & etcd configs are present, continue running Talos as normal. Only controlplane mode will be supported/tested.
