### PR TITLE
fix: drop the OOM config rule about overall system memory PSI

### DIFF
--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -343,6 +343,17 @@ func (suite *ResetSuite) TestResetDuringBoot() {
 	node := suite.RandomDiscoveredNodeInternalIP()
 	nodeCtx := client.WithNode(suite.ctx, node)
 
+	// The reset below is requested while the node is still booting, and the KUBELET volume is only
+	// mounted once the kubelet service starts, so ResetNode can't read the cert at that point.
+	// Capture it here instead, while the node is fully booted: the reboot doesn't touch the volume.
+	kubeletCertBefore, err := suite.HashKubeletCert(suite.ctx, node)
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(kubeletCertBefore, "kubelet cert should be readable on a booted node")
+
+	// EPHEMERAL is the only volume wiped below, so the kubelet PKI only survives the reset if
+	// KUBELET has a partition of its own.
+	kubeletSurvivesReset := !suite.KubeletVolumeIsDirectory(suite.ctx, node)
+
 	suite.T().Log("rebooting node", node)
 
 	bootIDBefore, err := suite.ReadBootID(nodeCtx)
@@ -373,6 +384,15 @@ func (suite *ResetSuite) TestResetDuringBoot() {
 			},
 		},
 	}, true)
+
+	kubeletCertAfter, err := suite.HashKubeletCert(suite.ctx, node)
+	suite.Require().NoError(err)
+
+	if kubeletSurvivesReset {
+		suite.Assert().Equal(kubeletCertBefore, kubeletCertAfter, "kubelet cert should be unchanged (KUBELET volume was not wiped)")
+	} else {
+		suite.Assert().NotEqual(kubeletCertBefore, kubeletCertAfter, "reset should lead to new kubelet cert being generated")
+	}
 }
 
 func init() {

--- a/internal/integration/api/rotate.go
+++ b/internal/integration/api/rotate.go
@@ -8,10 +8,14 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -29,7 +33,7 @@ import (
 
 // RotateCASuite verifies rotation of Talos and Kubernetes CAs.
 type RotateCASuite struct {
-	base.APISuite
+	base.K8sSuite
 
 	ctx       context.Context //nolint:containedctx
 	ctxCancel context.CancelFunc
@@ -190,6 +194,43 @@ func (suite *RotateCASuite) TestKubernetes() {
 	suite.Require().NoError(kubernetes.Rotate(rotationCtx, options))
 
 	suite.AssertClusterHealthy(rotationCtx)
+
+	suite.rollKubeProxy(suite.newRotationContext())
+}
+
+// rollKubeProxy restarts kube-proxy once the Kubernetes CA rotation is over.
+//
+// kube-proxy talks to the API server with the in-cluster kubeconfig which trusts the service account
+// CA bundle, and client-go only re-reads that CA from disk every 5 minutes, so a kube-proxy which
+// happened to pick up the intermediate CA keeps failing to watch Services and EndpointSlices long
+// after the rotation is done: it silently stops programming rules for Services created in the
+// meantime.
+func (suite *RotateCASuite) rollKubeProxy(ctx context.Context) {
+	const (
+		namespace     = "kube-system"
+		daemonSetName = "kube-proxy"
+		labelSelector = "k8s-app=kube-proxy"
+	)
+
+	daemonSets := suite.Clientset.AppsV1().DaemonSets(namespace)
+
+	_, err := daemonSets.Get(ctx, daemonSetName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		suite.T().Logf("skipping kube-proxy restart: daemonset %s/%s is not found", namespace, daemonSetName)
+
+		return
+	}
+
+	suite.Require().NoError(err)
+
+	suite.T().Logf("restarting kube-proxy")
+
+	patch := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`, time.Now().Format(time.RFC3339Nano))
+
+	_, err = daemonSets.Patch(ctx, daemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.WaitForDaemonSetReady(ctx, 3*time.Minute, namespace, labelSelector))
 }
 
 func (suite *RotateCASuite) restartAPIServices(ctx context.Context, c *client.Client) {

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -390,7 +390,10 @@ func (apiSuite *APISuite) ClearConnectionRefused(ctx context.Context, nodes ...s
 
 // HashKubeletCert returns hash of the kubelet certificate file.
 //
-// This function can be used to verify that the node ephemeral partition got wiped.
+// This function can be used to verify that the KUBELET volume got wiped.
+//
+// An empty string is returned if the certificate is not there: the KUBELET volume is only mounted
+// once the kubelet service starts, so the cert is not readable on a node which is still booting.
 func (apiSuite *APISuite) HashKubeletCert(ctx context.Context, node string) (string, error) {
 	reqCtx, reqCtxCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer reqCtxCancel()
@@ -399,6 +402,10 @@ func (apiSuite *APISuite) HashKubeletCert(ctx context.Context, node string) (str
 
 	reader, err := apiSuite.Client.Read(reqCtx, "/var/lib/kubelet/pki/kubelet-client-current.pem")
 	if err != nil {
+		if client.StatusCode(err) == codes.NotFound {
+			return "", nil
+		}
+
 		return "", err
 	}
 
@@ -406,11 +413,12 @@ func (apiSuite *APISuite) HashKubeletCert(ctx context.Context, node string) (str
 
 	hash := sha256.New()
 
-	_, err = io.Copy(hash, reader)
-	if err != nil {
-		if client.StatusCode(err) != codes.NotFound { // not found, swallow it
+	if _, err = io.Copy(hash, reader); err != nil {
+		if client.StatusCode(err) != codes.NotFound {
 			return "", err
 		}
+
+		return "", reader.Close()
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), reader.Close()
@@ -668,7 +676,7 @@ func (apiSuite *APISuite) PatchV1Alpha1Config(provider config.Provider, patch fu
 
 // ResetNode wraps the reset node sequence with checks, waiting for the reset to finish and verifying the result.
 //
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (apiSuite *APISuite) ResetNode(ctx context.Context, node string, resetSpec *machineapi.ResetRequest, runHealthChecks bool) {
 	apiSuite.T().Logf("resetting node %q with graceful %v mode %s, system %v, user %v", node, resetSpec.Graceful, resetSpec.Mode, resetSpec.SystemPartitionsToWipe, resetSpec.UserDisksToWipe)
 
@@ -699,7 +707,7 @@ func (apiSuite *APISuite) ResetNode(ctx context.Context, node string, resetSpec 
 				break
 			}
 
-			if part.Label == constants.EphemeralPartitionLabel && apiSuite.kubeletVolumeIsDirectory(ctx, node) {
+			if part.Label == constants.EphemeralPartitionLabel && apiSuite.KubeletVolumeIsDirectory(ctx, node) {
 				kubeletIsGoingToBeReset = true
 
 				break
@@ -768,17 +776,22 @@ waitLoop:
 		postReset, err := apiSuite.HashKubeletCert(ctx, node)
 		apiSuite.Require().NoError(err)
 
-		if kubeletIsGoingToBeReset {
+		switch {
+		case preReset == "":
+			// the KUBELET volume was not mounted when the reset was requested (e.g. the node was still
+			// booting), so there is nothing to compare the cert against
+			apiSuite.T().Log("skipping the kubelet cert check: the cert was not readable before the reset")
+		case kubeletIsGoingToBeReset:
 			apiSuite.Assert().NotEqual(preReset, postReset, "reset should lead to new kubelet cert being generated")
-		} else {
+		default:
 			apiSuite.Assert().Equal(preReset, postReset, "kubelet cert should be unchanged (KUBELET volume was not wiped)")
 		}
 	}
 }
 
-// kubeletVolumeIsDirectory reports whether the KUBELET system volume is backed by a directory under
+// KubeletVolumeIsDirectory reports whether the KUBELET system volume is backed by a directory under
 // EPHEMERAL (vs. a dedicated partition) on the node.
-func (apiSuite *APISuite) kubeletVolumeIsDirectory(ctx context.Context, node string) bool {
+func (apiSuite *APISuite) KubeletVolumeIsDirectory(ctx context.Context, node string) bool {
 	nodeCtx := client.WithNode(ctx, node)
 
 	volumeStatus, err := safe.StateGetByID[*block.VolumeStatus](nodeCtx, apiSuite.Client.COSI, constants.KubeletDataVolumeID)

--- a/internal/integration/k8s/oom.go
+++ b/internal/integration/k8s/oom.go
@@ -56,7 +56,8 @@ func (suite *OomSuite) TestOom() {
 		suite.T().Skip("skipping OOM test since provisioner is not qemu")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// overarching timeout should be longer than the sum of all timeouts in the test
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Minute)
 	suite.T().Cleanup(cancel)
 
 	oomPodManifest := suite.ParseManifests(oomPodSpec)
@@ -74,7 +75,7 @@ func (suite *OomSuite) TestOom() {
 		for {
 			select {
 			case <-ticker.C:
-				pods, err := suite.Clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+				pods, err := suite.Clientset.CoreV1().Pods("default").List(cleanUpCtx, metav1.ListOptions{
 					LabelSelector: "app=stress-mem",
 				})
 
@@ -154,6 +155,9 @@ func (suite *OomSuite) waitForOOMKilled(ctx context.Context, timeToObserve, time
 	watchCh := make(chan state.Event)
 	workerNodes := suite.DiscoverNodeInternalIPsByType(ctx, machine.TypeWorker)
 
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	// start watching OOM events on all worker nodes
 	for _, workerNode := range workerNodes {
 		suite.Assert().NoError(suite.Client.COSI.WatchKind(
@@ -192,6 +196,13 @@ func (suite *OomSuite) waitForOOMKilled(ctx context.Context, timeToObserve, time
 			for _, proc := range res.Processes {
 				if strings.Contains(proc, substr) {
 					numOOMObserved++
+
+					if numOOMObserved >= n {
+						// if we already observed enough OOM events, consider it a success
+						suite.T().Logf("observed %d OOM events containing process substring %q", numOOMObserved, substr)
+
+						return true
+					}
 
 					break
 				}

--- a/pkg/machinery/config/types/runtime/testdata/oom.yaml
+++ b/pkg/machinery/config/types/runtime/testdata/oom.yaml
@@ -3,6 +3,6 @@ kind: OOMConfig
 triggerExpression: |-
     multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 &&
-    time_since_trigger > duration("5s") || memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
+    time_since_trigger > duration("5s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))'
 sampleInterval: 100ms

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -1435,8 +1435,7 @@ const (
 
 	// DefaultOOMTriggerExpression is the default CEL expression used to determine whether to trigger OOM.
 	DefaultOOMTriggerExpression = `(multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
-	     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 && time_since_trigger > duration("5s")) ||
-		(memory_full_avg10 > 75.0 && time_since_trigger > duration("10s"))`
+	     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 && time_since_trigger > duration("5s"))`
 
 	// DefaultOOMCgroupRankingExpression is the default CEL expression used to rank cgroups for OOM killer.
 	DefaultOOMCgroupRankingExpression = `memory_max.hasValue() ? 0.0 :

--- a/website/content/v1.14/reference/configuration/runtime/oomconfig.md
+++ b/website/content/v1.14/reference/configuration/runtime/oomconfig.md
@@ -19,7 +19,7 @@ kind: OOMConfig
 triggerExpression: |- # This expression defines when to trigger OOM action.
     multiply_qos_vectors(d_qos_memory_full_total, {System: 8.0, Podruntime: 4.0}) > 3000.0 &&
     multiply_qos_vectors(qos_memory_full_avg10, {System: 1.0, Podruntime: 1.0}) > 5.0 &&
-    time_since_trigger > duration("5s") || memory_full_avg10 > 75.0 && time_since_trigger > duration("10s")
+    time_since_trigger > duration("5s")
 cgroupRankingExpression: 'memory_max.hasValue() ? 0.0 : ({Besteffort: 1.0, Burstable: 0.5, Guaranteed: 0.0, Podruntime: 0.0, System: 0.0}[class] * double(memory_current.orValue(0u)))' # This expression defines how to rank cgroups for OOM handler.
 sampleInterval: 100ms # How often should the trigger expression be evaluated.
 {{< /highlight >}}


### PR DESCRIPTION
Fixes #13746

It looks like overall memory PSI might have false triggers related to pods running with memory limits doing heavy IO - this might raise overall system memory PSI (due to lack of buffers due to the memory limit), triggering the OOM on a system with perfectly enough free RAM.

Leave only the targeted condition which protects system/runtime containers to ensure that controlplane is always responsive even under memory pressure which doesn't trigger kernel OOM.
