### PR TITLE
fix: validate kubespan & discovery config correctly for multi-doc

### DIFF
--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -243,18 +243,27 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 		}
 	}
 
+	// Discovery requires a cluster identity
+	if discoveryConfigs := container.DiscoveryServiceConfigs(); len(discoveryConfigs) > 0 {
+		identity := container.DiscoveryIdentityConfig()
+
+		if identity == nil || identity.ClusterID() == "" {
+			errs = multierror.Append(errs, fmt.Errorf("cluster ID (.cluster.id or DiscoveryIdentityConfig) should be set when cluster discovery (DiscoveryServiceConfig) is enabled"))
+		}
+
+		if identity == nil || identity.ClusterSecret() == "" {
+			errs = multierror.Append(errs, fmt.Errorf("cluster secret (.cluster.secret or DiscoveryIdentityConfig) should be set when cluster discovery (DiscoveryServiceConfig) is enabled"))
+		}
+	}
+
 	// KubeSpan requires a cluster identity, provided either by the deprecated .cluster.id/.cluster.secret
 	// or by a DiscoveryIdentityConfig document. The identity may live in a separate document, so this
 	// cross-document check is done at the container level.
 	if kubeSpanConfig := container.NetworkKubeSpanConfig(); kubeSpanConfig != nil && kubeSpanConfig.Enabled() {
-		identity := container.DiscoveryIdentityConfig()
+		discoveryEnabled := len(container.DiscoveryServiceConfigs()) > 0
 
-		if identity == nil || identity.ClusterID() == "" {
-			errs = multierror.Append(errs, fmt.Errorf("cluster ID (.cluster.id or DiscoveryIdentityConfig) should be set when .machine.network.kubespan is enabled"))
-		}
-
-		if identity == nil || identity.ClusterSecret() == "" {
-			errs = multierror.Append(errs, fmt.Errorf("cluster secret (.cluster.secret or DiscoveryIdentityConfig) should be set when .machine.network.kubespan is enabled"))
+		if !discoveryEnabled {
+			errs = multierror.Append(errs, fmt.Errorf("KubeSpan requires cluster discovery to be enabled"))
 		}
 	}
 

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
@@ -282,6 +283,16 @@ func TestValidateContainer(t *testing.T) {
 		},
 	}
 
+	kubespanConfig := network.NewKubeSpanV1Alpha1()
+	kubespanConfig.ConfigEnabled = new(true)
+
+	discoveryIdentityConfig := cluster.NewDiscoveryIdentityConfigV1Alpha1(
+		"MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
+		"vlf2HU1NEZL3Ezi9Tk+RZBLJUbjnsHnTzs3wK9JNk6Q=",
+	)
+
+	discoveryServiceConfig := cluster.NewDiscoveryServiceConfigV1Alpha1("default", must.Value(url.Parse("https://discovery.api/"))(t))
+
 	for _, tt := range []struct {
 		name        string
 		documents   []config.Document
@@ -352,6 +363,23 @@ func TestValidateContainer(t *testing.T) {
 			documents: []config.Document{v1alpha1Cfg, kubeEtcdEncryptionConfig},
 
 			expectedError: "1 error occurred:\n\t* the following document kinds are only allowed on control plane machines: [KubeEtcdEncryptionConfig]\n\n",
+		},
+		{
+			name:      "kubespan without discovery",
+			documents: []config.Document{v1alpha1Cfg, kubespanConfig},
+
+			expectedError: "1 error occurred:\n\t* KubeSpan requires cluster discovery to be enabled\n\n",
+		},
+		{
+			name:      "discovery without identity",
+			documents: []config.Document{discoveryServiceConfig, kubespanConfig},
+
+			expectedError: "2 errors occurred:\n\t* cluster ID (.cluster.id or DiscoveryIdentityConfig) should be set when cluster discovery (DiscoveryServiceConfig) is enabled\n" +
+				"\t* cluster secret (.cluster.secret or DiscoveryIdentityConfig) should be set when cluster discovery (DiscoveryServiceConfig) is enabled\n\n",
+		},
+		{
+			name:      "discovery with kubespan and identity",
+			documents: []config.Document{discoveryServiceConfig, discoveryIdentityConfig, kubespanConfig},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -267,14 +267,6 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 	}
 
 	if kcfg := c.NetworkKubeSpanConfig(); kcfg != nil && kcfg.Enabled() {
-		if !c.ClusterConfig.Discovery().Enabled() {
-			result = multierror.Append(result, errors.New(".cluster.discovery should be enabled when .machine.network.kubespan is enabled"))
-		}
-
-		// Note: the cluster identity (.cluster.id/.cluster.secret or the DiscoveryIdentityConfig document)
-		// requirement for KubeSpan is validated at the container level (see container.validateContainer),
-		// since the identity may live in a separate document.
-
 		for _, cidr := range kcfg.Filters().Endpoints() {
 			cidr = strings.TrimPrefix(cidr, "!")
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -1209,34 +1209,6 @@ func TestValidate(t *testing.T) {
 				"\t* [networking.os.device.route[7]]: either network or gateway should be set\n\n",
 		},
 		{
-			name: "KubeSpanNoDiscovery",
-			config: &v1alpha1.Config{
-				ConfigVersion: "v1alpha1",
-				MachineConfig: &v1alpha1.MachineConfig{
-					MachineType: "controlplane",
-					MachineCA: &x509.PEMEncodedCertificateAndKey{
-						Crt: []byte("foo"),
-						Key: []byte("bar"),
-					},
-					MachineNetwork: &v1alpha1.NetworkConfig{
-						NetworkKubeSpan: &v1alpha1.NetworkKubeSpan{
-							KubeSpanEnabled: new(true),
-						},
-					},
-				},
-				ClusterConfig: &v1alpha1.ClusterConfig{
-					ControlPlane: &v1alpha1.ControlPlaneConfig{
-						Endpoint: &v1alpha1.Endpoint{
-							endpointURL,
-						},
-					},
-				},
-			},
-			// .cluster.id/.cluster.secret requirements moved to container-level validation
-			// (the identity may live in a separate DiscoveryIdentityConfig document).
-			expectedError: "1 error occurred:\n\t* .cluster.discovery should be enabled when .machine.network.kubespan is enabled\n\n",
-		},
-		{
 			name: "DiscoveryServiceEndpoint",
 			config: &v1alpha1.Config{
 				ConfigVersion: "v1alpha1",


### PR DESCRIPTION
As KubeSpan and discovery config might be (or might be not) moved to multi-doc, drop the validation in v1alpha1, as it might not see the full picture if discovery is enabled or not.

Instead, do a container level validation:

* Discovery requires cluster ID/secret
* KubeSpan requires Discovery.
