### PR TITLE
fix: restore the systemd-timesync best-sample check in spike detection

### DIFF
--- a/api/resource/definitions/time/time.proto
+++ b/api/resource/definitions/time/time.proto
@@ -27,5 +27,12 @@ message StatusSpec {
   int64 epoch = 2;
   // SyncDisabled indicates if time sync is disabled.
   bool sync_disabled = 3;
+  // SpikeDetected indicates that the last time measurement was discarded by the spike filter.
+  //
+  // A discarded measurement is not applied to the clock at all, so a filter which keeps
+  // rejecting looks exactly like a clock which is never corrected.
+  bool spike_detected = 4;
+  // ConsecutiveSpikes is the number of time measurements discarded in a row by the spike filter.
+  int64 consecutive_spikes = 5;
 }
 

--- a/internal/app/machined/pkg/controllers/time/sync.go
+++ b/internal/app/machined/pkg/controllers/time/sync.go
@@ -60,6 +60,8 @@ type NTPSyncer interface {
 	Run(ctx context.Context)
 	Synced() <-chan struct{}
 	EpochChange() <-chan struct{}
+	SpikeStatusChange() <-chan struct{}
+	SpikeStatus() ntp.SpikeStatus
 	SetTimeServers([]string)
 }
 
@@ -121,11 +123,13 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 
 		syncCh  <-chan struct{}
 		epochCh <-chan struct{}
+		spikeCh <-chan struct{}
 		syncer  NTPSyncer
 
-		timeSynced bool
-		epoch      int
-		useNTS     bool
+		timeSynced  bool
+		epoch       int
+		useNTS      bool
+		spikeStatus ntp.SpikeStatus
 
 		timeSyncTimeoutTimer *stdtime.Timer
 		timeSyncTimeoutCh    <-chan stdtime.Time
@@ -158,6 +162,8 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 			timeSynced = true
 		case <-epochCh:
 			epoch++
+		case <-spikeCh:
+			spikeStatus = syncer.SpikeStatus()
 		case <-timeSyncTimeoutCh:
 			timeSynced = true
 			timeSyncTimeoutTimer = nil
@@ -248,6 +254,8 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 			syncer = nil
 			syncCh = nil
 			epochCh = nil
+			spikeCh = nil
+			spikeStatus = ntp.SpikeStatus{}
 		case !syncDisabled && syncer != nil && newUseNTS != useNTS:
 			// NTS setting changed, restart the syncer
 			logger.Info("NTS setting changed, restarting syncer", zap.Bool("useNTS", newUseNTS))
@@ -261,8 +269,10 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 			syncer = ctrl.NewNTPSyncer(logger, timeServers, useNTS)
 			syncCh = syncer.Synced()
 			epochCh = syncer.EpochChange()
+			spikeCh = syncer.SpikeStatusChange()
 
 			timeSynced = false
+			spikeStatus = ntp.SpikeStatus{}
 
 			syncCtx, syncCtxCancel = context.WithCancel(ctx) //nolint:govet,fatcontext
 
@@ -276,8 +286,10 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 			syncer = ctrl.NewNTPSyncer(logger, timeServers, useNTS)
 			syncCh = syncer.Synced()
 			epochCh = syncer.EpochChange()
+			spikeCh = syncer.SpikeStatusChange()
 
 			timeSynced = false
+			spikeStatus = ntp.SpikeStatus{}
 
 			syncCtx, syncCtxCancel = context.WithCancel(ctx) //nolint:govet,fatcontext
 
@@ -296,9 +308,11 @@ func (ctrl *SyncController) Run(ctx context.Context, r controller.Runtime, logge
 
 		if err = safe.WriterModify(ctx, r, time.NewStatus(), func(r *time.Status) error {
 			*r.TypedSpec() = time.StatusSpec{
-				Epoch:        epoch,
-				Synced:       timeSynced,
-				SyncDisabled: syncDisabled,
+				Epoch:             epoch,
+				Synced:            timeSynced,
+				SyncDisabled:      syncDisabled,
+				SpikeDetected:     spikeStatus.Detected,
+				ConsecutiveSpikes: spikeStatus.Consecutive,
 			}
 
 			return nil

--- a/internal/app/machined/pkg/controllers/time/sync_test.go
+++ b/internal/app/machined/pkg/controllers/time/sync_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	timectrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time"
 	v1alpha1runtime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/pkg/ntp"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -186,6 +187,24 @@ func (suite *SyncSuite) TestReconcileSyncChangeConfig() {
 		SyncDisabled: false,
 	})
 
+	mockSyncer.reportSpikeStatus(ntp.SpikeStatus{Detected: true, Consecutive: 3})
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:            true,
+		Epoch:             1,
+		SyncDisabled:      false,
+		SpikeDetected:     true,
+		ConsecutiveSpikes: 3,
+	})
+
+	mockSyncer.reportSpikeStatus(ntp.SpikeStatus{})
+
+	suite.assertTimeStatus(timeresource.StatusSpec{
+		Synced:       true,
+		Epoch:        1,
+		SyncDisabled: false,
+	})
+
 	ctest.UpdateWithConflicts(suite, cfg, func(r *config.MachineConfig) error {
 		r.Container().RawV1Alpha1().MachineConfig.MachineTime = &v1alpha1.TimeConfig{ //nolint:staticcheck
 			TimeDisabled: new(true),
@@ -314,6 +333,8 @@ type mockSyncer struct {
 	useNTS      bool
 	syncedCh    chan struct{}
 	epochCh     chan struct{}
+	spikeCh     chan struct{}
+	spikeStatus ntp.SpikeStatus
 }
 
 func (mock *mockSyncer) Run(ctx context.Context) {
@@ -326,6 +347,25 @@ func (mock *mockSyncer) Synced() <-chan struct{} {
 
 func (mock *mockSyncer) EpochChange() <-chan struct{} {
 	return mock.epochCh
+}
+
+func (mock *mockSyncer) SpikeStatusChange() <-chan struct{} {
+	return mock.spikeCh
+}
+
+func (mock *mockSyncer) SpikeStatus() ntp.SpikeStatus {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.spikeStatus
+}
+
+func (mock *mockSyncer) reportSpikeStatus(status ntp.SpikeStatus) {
+	mock.mu.Lock()
+	mock.spikeStatus = status
+	mock.mu.Unlock()
+
+	mock.spikeCh <- struct{}{}
 }
 
 func (mock *mockSyncer) getTimeServers() (servers []string) {
@@ -355,5 +395,6 @@ func newMockSyncer(_ *zap.Logger, servers []string, useNTS bool) *mockSyncer {
 		useNTS:      useNTS,
 		syncedCh:    make(chan struct{}, 1),
 		epochCh:     make(chan struct{}, 1),
+		spikeCh:     make(chan struct{}, 1),
 	}
 }

--- a/internal/app/machined/pkg/controllers/time/sync_wall_clock_jump_test.go
+++ b/internal/app/machined/pkg/controllers/time/sync_wall_clock_jump_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/time"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/pkg/ntp"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -158,12 +159,14 @@ func (detector *fakeClockJumpDetector) enqueueJump() {
 type noopSyncer struct {
 	syncedCh chan struct{}
 	epochCh  chan struct{}
+	spikeCh  chan struct{}
 }
 
 func newNoopSyncer() *noopSyncer {
 	return &noopSyncer{
 		syncedCh: make(chan struct{}),
 		epochCh:  make(chan struct{}),
+		spikeCh:  make(chan struct{}),
 	}
 }
 
@@ -181,6 +184,14 @@ func (syncer *noopSyncer) sendSynced() {
 
 func (syncer *noopSyncer) EpochChange() <-chan struct{} {
 	return syncer.epochCh
+}
+
+func (syncer *noopSyncer) SpikeStatusChange() <-chan struct{} {
+	return syncer.spikeCh
+}
+
+func (syncer *noopSyncer) SpikeStatus() ntp.SpikeStatus {
+	return ntp.SpikeStatus{}
 }
 
 func (syncer *noopSyncer) SetTimeServers([]string) {}

--- a/internal/pkg/ntp/internal/spike/spike.go
+++ b/internal/pkg/ntp/internal/spike/spike.go
@@ -11,7 +11,19 @@ import (
 	"github.com/beevik/ntp"
 )
 
-const defaultCapacity = 8
+// SampleCount is the number of samples the detector keeps, i.e. the size of the window a
+// change in the network path or in the clock takes to work its way through the detector.
+const SampleCount = 8
+
+// rttInflationFactor is how much the round-trip time of a sample has to exceed the best
+// round-trip time in the window before the best-sample error bound is applied to it.
+//
+// One-directional congestion biases the offset by at most half of the excess delay, so the
+// congestion can only explain an offset larger than the best round-trip time when
+// (RTT-minRTT)/2 > minRTT, i.e. when RTT > 3*minRTT. Below that ratio the offset cannot be
+// an artifact of the extra delay, so the measurement is believed: this is what keeps
+// ordinary round-trip wobble (e.g. an NTP server on the same LAN) from being filtered out.
+const rttInflationFactor = 3
 
 // Sample is a single NTP response sample.
 type Sample struct {
@@ -36,12 +48,33 @@ type Detector struct {
 	samplesJitter float64
 }
 
+// bestSample returns the index of the sample with the lowest round-trip time, i.e. the one
+// which was the least affected by the network.
+//
+// Slots which were never filled in hold a zero round-trip time and are skipped, including
+// when the search starts on one of them.
+func (d *Detector) bestSample(startIndex int) int {
+	indexMin := startIndex
+
+	for i := range d.samples {
+		if d.samples[i].RTT <= 0 {
+			continue
+		}
+
+		if d.samples[indexMin].RTT <= 0 || d.samples[i].RTT < d.samples[indexMin].RTT {
+			indexMin = i
+		}
+	}
+
+	return indexMin
+}
+
 // IsSpike returns true if the given sample is a spike.
 //
 // The sample is added to the detector's internal state.
 func (d *Detector) IsSpike(sample Sample) bool {
 	if d.samples == nil {
-		d.samples = make([]Sample, defaultCapacity)
+		d.samples = make([]Sample, SampleCount)
 	}
 
 	d.packetCount++
@@ -59,17 +92,11 @@ func (d *Detector) IsSpike(sample Sample) bool {
 
 	jitter := d.samplesJitter
 
-	indexMin := currentIndex
+	indexMin := d.bestSample(currentIndex)
 
-	for i := range d.samples {
-		if d.samples[i].RTT == 0 {
-			continue
-		}
-
-		if d.samples[i].RTT < d.samples[indexMin].RTT {
-			indexMin = i
-		}
-	}
+	// the round-trip time of the best sample in the window, zero if the window holds no
+	// usable sample yet (slots which were never filled in have a zero RTT)
+	bestRTT := max(d.samples[indexMin].RTT, 0)
 
 	var j float64
 
@@ -90,15 +117,16 @@ func (d *Detector) IsSpike(sample Sample) bool {
 		return false
 	}
 
-	// This check was specifically removed (while it exists in systemd-timesync),
-	// as I don't understand why it's needed (@smira).
-	// It seems to give false positives when the RTT and Offset are close to each other,
-	// e.g. when NTP server is on the same LAN.
+	// Do not accept anything worse than the maximum possible error of the best sample, but
+	// only once the round-trip of this sample is inflated enough for asymmetric delay to
+	// account for the offset (see rttInflationFactor).
 	//
-	// if math.Abs(sample.Offset) > d.samples[indexMin].RTT {
-	// 	// do not accept anything worse than the maximum possible error of the best sample
-	// 	return true
-	// }
+	// This is what one-directional congestion looks like: the extra delay sits on one leg of
+	// the round-trip and biases the offset by roughly half of it, so a congested poll reports
+	// a large clock error while still staying below the |offset| > RTT check above.
+	if bestRTT > 0 && sample.RTT > rttInflationFactor*bestRTT && math.Abs(sample.Offset) > bestRTT {
+		return true
+	}
 
 	// check that diff to the last offset is not more than 3*(observed jitter)
 	return math.Abs(sample.Offset-d.samples[currentIndex].Offset) > 3*jitter
@@ -107,4 +135,15 @@ func (d *Detector) IsSpike(sample Sample) bool {
 // Jitter returns the current jitter.
 func (d *Detector) Jitter() float64 {
 	return d.samplesJitter
+}
+
+// Reset drops the sample history.
+//
+// The samples describe a single clock observed over a single network path, so they stop
+// being meaningful once either changes: when the time server is switched the round-trip
+// times describe the old path, and when the clock is stepped the offsets describe the old
+// clock. In both cases the detector has to start over instead of measuring the new regime
+// against the old one.
+func (d *Detector) Reset() {
+	*d = Detector{}
 }

--- a/internal/pkg/ntp/internal/spike/spike_test.go
+++ b/internal/pkg/ntp/internal/spike/spike_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/internal/pkg/ntp/internal/spike"
 )
@@ -28,7 +29,8 @@ func TestSpikeDetector(t *testing.T) {
 				{Offset: 0.03, RTT: 0.01},
 				{Offset: 0.01, RTT: 0.01},
 				{Offset: -0.01, RTT: 0.01},
-				{Offset: -0.02, RTT: 0.03}, // not a spike, just a large RTT
+				{Offset: -0.02, RTT: 0.025}, // not a spike, just a large RTT: 2.5x the best sample is not enough
+				//                              asymmetry to explain a 20ms offset on a 10ms path
 			},
 
 			expectedSpikes: []bool{
@@ -38,6 +40,41 @@ func TestSpikeDetector(t *testing.T) {
 				false,
 				false,
 				false,
+			},
+		},
+		{
+			// The best-sample error bound only applies once the round-trip is inflated enough
+			// for one-directional congestion to account for the offset, so the very same
+			// offset is believed on a mildly jittery path and rejected on a congested one.
+			name: "RTT inflation gate",
+
+			samples: []spike.Sample{
+				// fill the whole window with a 5ms path, so that the best sample is 5ms
+				{Offset: 0.011, RTT: 0.005},
+				{Offset: 0.013, RTT: 0.005},
+				{Offset: 0.011, RTT: 0.005},
+				{Offset: 0.013, RTT: 0.005},
+				{Offset: 0.011, RTT: 0.005},
+				{Offset: 0.013, RTT: 0.005},
+				{Offset: 0.011, RTT: 0.005},
+				{Offset: 0.013, RTT: 0.005},
+				{Offset: 0.011, RTT: 0.005},
+				{Offset: 0.012, RTT: 0.014}, // not a spike: 2.8x the best sample, believed
+				{Offset: 0.012, RTT: 0.016}, // spike: 3.2x the best sample, congestion can explain it
+			},
+
+			expectedSpikes: []bool{
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				true,
 			},
 		},
 		{
@@ -66,6 +103,9 @@ func TestSpikeDetector(t *testing.T) {
 			},
 		},
 		{
+			// The best sample in the window bounds how large an offset can be believed, so
+			// adaptation to a permanently slower path takes one full window: the low-RTT
+			// samples have to age out before the new regime becomes the best sample.
 			name: "adjusting to higher RTT",
 
 			samples: []spike.Sample{
@@ -79,7 +119,11 @@ func TestSpikeDetector(t *testing.T) {
 				{Offset: -0.5, RTT: 0.7}, // spike
 				{Offset: 0.5, RTT: 0.7},  // spike
 				{Offset: -0.5, RTT: 0.7}, // spike
-				{Offset: 0.5, RTT: 0.7},  // not a spike anymore, filter adjusted itself
+				{Offset: 0.5, RTT: 0.7},  // spike
+				{Offset: -0.5, RTT: 0.7}, // spike
+				{Offset: 0.5, RTT: 0.7},  // spike
+				{Offset: -0.5, RTT: 0.7}, // spike
+				{Offset: 0.5, RTT: 0.7},  // not a spike anymore, the window is full of the new regime
 				{Offset: -0.5, RTT: 0.7},
 				{Offset: 0.01, RTT: 0.01},
 			},
@@ -92,6 +136,10 @@ func TestSpikeDetector(t *testing.T) {
 				false,
 				false,
 				false,
+				true,
+				true,
+				true,
+				true,
 				true,
 				true,
 				true,
@@ -131,5 +179,78 @@ func TestSpikeDetector(t *testing.T) {
 				assert.Equal(t, test.expectedSpikes[i], isSpike, "unexpected spike: %v (position %d)", test.expectedSpikes[i], i)
 			}
 		})
+	}
+}
+
+// TestSpikeDetectorReset covers switching to a server on a slower path: without a reset the
+// samples of the old path gate the new one until they age out of the window.
+func TestSpikeDetectorReset(t *testing.T) {
+	var detector spike.Detector
+
+	// a LAN server on a 1ms path
+	for range 4 {
+		require.False(t, detector.IsSpike(spike.Sample{Offset: 0.0002, RTT: 0.001}))
+	}
+
+	// the LAN server goes away, the next one in the list sits behind a 60ms path: its samples
+	// are measured against a best sample which describes a network path that is no longer used
+	assert.True(t, detector.IsSpike(spike.Sample{Offset: 0.03, RTT: 0.06}))
+
+	detector.Reset()
+
+	assert.Zero(t, detector.Jitter())
+
+	for range 4 {
+		assert.False(t, detector.IsSpike(spike.Sample{Offset: 0.03, RTT: 0.06}))
+	}
+}
+
+// TestSpikeDetectorAsymmetricDelay replays NTP polls captured from a node whose upstream
+// path suffers ponctual congestion.
+//
+// Asymmetric delay can bias the offset calculation by roughly half the excess RTT, so a
+// congested poll looks like a large clock error. Accepting one slews that error into the
+// clock, and the next poll then reports -- and corrects -- an error the daemon introduced
+// itself, so the clock sawtooths by tens of milliseconds while each individual adjustment
+// still looks plausible.
+//
+// Rejecting these samples cannot rely on the jitter estimate, because the jitter is itself
+// inflated by the congestion (below it reaches 60ms while the path is only 5ms wide).
+func TestSpikeDetectorAsymmetricDelay(t *testing.T) {
+	var detector spike.Detector
+
+	for _, sample := range []spike.Sample{
+		{Offset: 0.0004, RTT: 0.0055},
+		{Offset: -0.0005, RTT: 0.0054},
+		{Offset: 0.0003, RTT: 0.0055},
+		{Offset: -0.0004, RTT: 0.0053},
+		{Offset: 0.0005, RTT: 0.0055},
+		{Offset: -0.0003, RTT: 0.0054},
+		{Offset: 0.0004, RTT: 0.0055},
+		{Offset: -0.0005, RTT: 0.0054},
+	} {
+		require.False(t, detector.IsSpike(sample), "steady state must not be flagged")
+	}
+
+	for _, sample := range []struct {
+		name   string
+		sample spike.Sample
+
+		expectedSpike bool
+	}{
+		// offset ~= (RTT - 5.5ms)/2 throughout: asymmetric delay, not a real clock error
+		{"asymmetric delay, 98ms RTT", spike.Sample{Offset: 0.046067, RTT: 0.098445}, true},
+		// a clean poll in between is believed, as it should be
+		{"clean poll", spike.Sample{Offset: -0.000647, RTT: 0.005533}, false},
+		{"asymmetric delay, 67ms RTT", spike.Sample{Offset: 0.031782, RTT: 0.067470}, true},
+		// |offset| > RTT: too large to be explained by asymmetry on a 5ms path, so the
+		// measurement is trustworthy and is applied
+		{"real offset on a fast path", spike.Sample{Offset: -0.046647, RTT: 0.005483}, false},
+		{"asymmetric delay, 201ms RTT", spike.Sample{Offset: 0.104740, RTT: 0.201382}, true},
+		{"asymmetric delay, 110ms RTT", spike.Sample{Offset: 0.063678, RTT: 0.110155}, true},
+		{"real offset on a fast path, again", spike.Sample{Offset: -0.084529, RTT: 0.005420}, false},
+		{"asymmetric delay, 32ms RTT", spike.Sample{Offset: 0.027669, RTT: 0.032066}, true},
+	} {
+		assert.Equal(t, sample.expectedSpike, detector.IsSpike(sample.sample), "unexpected verdict for %q", sample.name)
 	}
 }

--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -47,7 +47,13 @@ type Syncer struct {
 
 	firstSync bool
 
+	// spikeDetector and spikeServer are only accessed from the Run goroutine.
 	spikeDetector spike.Detector
+	spikeServer   string
+
+	spikeStatusMu sync.Mutex
+	spikeStatus   SpikeStatus
+	spikeStatusCh chan struct{}
 
 	MinPoll, MaxPoll, RetryPoll time.Duration
 
@@ -76,6 +82,18 @@ type Measurement struct {
 	Spike       bool
 }
 
+// SpikeStatus describes the state of the spike filter.
+//
+// A measurement discarded as a spike is not applied to the clock at all, so a filter which
+// keeps rejecting is indistinguishable from a clock which is simply never corrected unless
+// the rejections themselves are reported.
+type SpikeStatus struct {
+	// Detected is true if the last measurement was discarded as a spike.
+	Detected bool
+	// Consecutive is the number of measurements discarded in a row.
+	Consecutive int
+}
+
 // NewSyncer creates new Syncer with default configuration.
 func NewSyncer(logger *zap.Logger, timeServers []string, useNTS bool) *Syncer {
 	syncer := &Syncer{
@@ -86,6 +104,7 @@ func NewSyncer(logger *zap.Logger, timeServers []string, useNTS bool) *Syncer {
 
 		restartSyncCh: make(chan struct{}, 1),
 		epochChangeCh: make(chan struct{}, 1),
+		spikeStatusCh: make(chan struct{}, 1),
 
 		firstSync: true,
 
@@ -116,6 +135,36 @@ func (syncer *Syncer) Synced() <-chan struct{} {
 // EpochChange returns a channel which receives a value each time jumps more than EpochLimit.
 func (syncer *Syncer) EpochChange() <-chan struct{} {
 	return syncer.epochChangeCh
+}
+
+// SpikeStatusChange returns a channel which receives a value each time the state of the
+// spike filter changes.
+func (syncer *Syncer) SpikeStatusChange() <-chan struct{} {
+	return syncer.spikeStatusCh
+}
+
+// SpikeStatus returns the current state of the spike filter.
+func (syncer *Syncer) SpikeStatus() SpikeStatus {
+	syncer.spikeStatusMu.Lock()
+	defer syncer.spikeStatusMu.Unlock()
+
+	return syncer.spikeStatus
+}
+
+func (syncer *Syncer) setSpikeStatus(status SpikeStatus) {
+	syncer.spikeStatusMu.Lock()
+	changed := syncer.spikeStatus != status
+	syncer.spikeStatus = status
+	syncer.spikeStatusMu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	select {
+	case syncer.spikeStatusCh <- struct{}{}:
+	default:
+	}
 }
 
 func (syncer *Syncer) getTimeServers() []string {
@@ -169,7 +218,24 @@ func absDuration(d time.Duration) time.Duration {
 	return d
 }
 
-func (syncer *Syncer) isSpike(resp *ntp.Response) bool {
+func (syncer *Syncer) isSpike(server string, resp *ntp.Response) bool {
+	if syncer.spikeServer != server {
+		// The detector compares a sample against the round-trip times of the samples before it,
+		// which only means something while they all describe the same network path. After a
+		// failover, or after the configured server list changed, the samples of the previous
+		// server would otherwise gate the new one until they age out of the window.
+		if syncer.spikeServer != "" {
+			syncer.logger.Debug(
+				"time server changed, resetting the spike detector",
+				zap.String("previous_server", syncer.spikeServer),
+				zap.String("server", server),
+			)
+		}
+
+		syncer.spikeDetector.Reset()
+		syncer.spikeServer = server
+	}
+
 	return syncer.spikeDetector.IsSpike(spike.SampleFromNTPResponse(resp))
 }
 
@@ -195,6 +261,7 @@ func (syncer *Syncer) Run(ctx context.Context) {
 	}
 
 	pollInterval := time.Duration(0)
+	consecutiveSpikes := 0
 
 	for {
 		lastSyncServer, resp, kissOfDeath, err := syncer.query(ctx)
@@ -202,9 +269,29 @@ func (syncer *Syncer) Run(ctx context.Context) {
 			return
 		}
 
-		spike := false
+		spikeDetected := false
+
 		if resp != nil {
-			spike = resp.Spike
+			spikeDetected = resp.Spike
+
+			if spikeDetected {
+				consecutiveSpikes++
+			} else {
+				consecutiveSpikes = 0
+			}
+
+			if consecutiveSpikes == spike.SampleCount {
+				// a full window of discarded measurements: the clock is not being adjusted at all,
+				// and the detector should have adapted to the new regime by now
+				syncer.logger.Warn(
+					"spike filter discarded a full window of measurements, clock is not being adjusted",
+					zap.String("server", lastSyncServer),
+					zap.Duration("clock_offset", resp.ClockOffset),
+					zap.Duration("jitter", time.Duration(syncer.spikeDetector.Jitter()*float64(time.Second))),
+				)
+			}
+
+			syncer.setSpikeStatus(SpikeStatus{Detected: spikeDetected, Consecutive: consecutiveSpikes})
 		}
 
 		switch {
@@ -224,7 +311,16 @@ func (syncer *Syncer) Run(ctx context.Context) {
 		case pollInterval == 0:
 			// first sync
 			pollInterval = syncer.MinPoll
-		case !spike && absDuration(resp.ClockOffset) > ExpectedAccuracy:
+		case spikeDetected:
+			// The measurement was discarded, so the clock was not adjusted: poll sooner to get a
+			// usable one, and never back off. The offset of a discarded measurement says nothing
+			// about how well the clock is tracking, so letting it pick the interval (systemd-timesync
+			// tests the offset before the spike, and a spike under 25% of the expected accuracy
+			// doubles the interval there) backs off polling precisely while nothing is being applied.
+			if pollInterval > syncer.MinPoll {
+				pollInterval /= 2
+			}
+		case absDuration(resp.ClockOffset) > ExpectedAccuracy:
 			// huge offset, retry sync with minimum interval
 			pollInterval = syncer.MinPoll
 		case absDuration(resp.ClockOffset) < ExpectedAccuracy*25/100: // *0.25
@@ -232,8 +328,8 @@ func (syncer *Syncer) Run(ctx context.Context) {
 			if pollInterval < syncer.MaxPoll {
 				pollInterval *= 2
 			}
-		case spike || absDuration(resp.ClockOffset) > ExpectedAccuracy*75/100: // *0.75
-			// spike was detected or clock offset is too large, decrease poll interval
+		case absDuration(resp.ClockOffset) > ExpectedAccuracy*75/100: // *0.75
+			// clock offset is too large, decrease poll interval
 			if pollInterval > syncer.MinPoll {
 				pollInterval /= 2
 			}
@@ -248,11 +344,12 @@ func (syncer *Syncer) Run(ctx context.Context) {
 			"sample stats",
 			zap.Duration("jitter", time.Duration(syncer.spikeDetector.Jitter()*float64(time.Second))),
 			zap.Duration("poll_interval", pollInterval),
-			zap.Bool("spike", spike),
+			zap.Bool("spike", spikeDetected),
+			zap.Int("consecutive_spikes", consecutiveSpikes),
 			zap.Bool("resp_exists", resp != nil),
 		)
 
-		if resp != nil && !spike {
+		if resp != nil && !spikeDetected {
 			err = syncer.adjustTime(resp.ClockOffset, resp.Leap, lastSyncServer, pollInterval, rtcClock)
 			if err == nil {
 				if !syncer.timeSyncNotified {
@@ -479,7 +576,7 @@ func (syncer *Syncer) queryNTP(server string) (*Measurement, bool, error) {
 	return &Measurement{
 		ClockOffset: resp.ClockOffset,
 		Leap:        resp.Leap,
-		Spike:       syncer.isSpike(resp),
+		Spike:       syncer.isSpike(server, resp),
 	}, false, nil
 }
 
@@ -531,7 +628,7 @@ func (syncer *Syncer) queryNTS(server string) (*Measurement, bool, error) {
 	return &Measurement{
 		ClockOffset: resp.ClockOffset,
 		Leap:        resp.Leap,
-		Spike:       syncer.isSpike(resp),
+		Spike:       syncer.isSpike(server, resp),
 	}, false, nil
 }
 
@@ -717,6 +814,12 @@ func (syncer *Syncer) adjustTime(offset time.Duration, leapSecond ntp.LeapIndica
 		}
 
 		if jump {
+			// The clock was stepped, so the offsets in the spike detector window were measured
+			// against a clock which no longer exists: keeping them would have the detector compare
+			// the corrected clock against the uncorrected one. systemd-timesync does the same
+			// through its poll_resync flag whenever the clock changes underneath it.
+			syncer.spikeDetector.Reset()
+
 			if rtcClock != nil {
 				if rtcErr := rtcClock.Set(time.Now().Add(offset)); rtcErr != nil {
 					syncer.logger.Error("error syncing RTC", zap.Error(rtcErr))

--- a/internal/pkg/ntp/ntp_test.go
+++ b/internal/pkg/ntp/ntp_test.go
@@ -330,6 +330,25 @@ func (suite *NTPSuite) TestSyncWithSpikes() {
 		syncer.Run(ctx)
 	})
 
+	// a discarded measurement is not applied to the clock at all, so the filter has to report
+	// what it is doing for the rejections to be visible at all
+	var spikeReported atomic.Bool
+
+	wg.Go(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-syncer.SpikeStatusChange():
+				if status := syncer.SpikeStatus(); status.Detected {
+					suite.Assert().Positive(status.Consecutive)
+
+					spikeReported.Store(true)
+				}
+			}
+		}
+	})
+
 	select {
 	case <-syncer.Synced():
 	case <-time.After(10 * time.Second):
@@ -348,6 +367,10 @@ func (suite *NTPSuite) TestSyncWithSpikes() {
 			for _, adj := range suite.clockAdjustments {
 				// 1s spike should be filtered out
 				suite.Assert().Equal(time.Millisecond, adj)
+			}
+
+			if !spikeReported.Load() {
+				return retry.ExpectedErrorf("spike filter did not report a discarded measurement")
 			}
 
 			return nil

--- a/pkg/machinery/api/resource/definitions/time/time.pb.go
+++ b/pkg/machinery/api/resource/definitions/time/time.pb.go
@@ -132,9 +132,16 @@ type StatusSpec struct {
 	// Epoch is incremented every time clock jumps more than 15min.
 	Epoch int64 `protobuf:"varint,2,opt,name=epoch,proto3" json:"epoch,omitempty"`
 	// SyncDisabled indicates if time sync is disabled.
-	SyncDisabled  bool `protobuf:"varint,3,opt,name=sync_disabled,json=syncDisabled,proto3" json:"sync_disabled,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SyncDisabled bool `protobuf:"varint,3,opt,name=sync_disabled,json=syncDisabled,proto3" json:"sync_disabled,omitempty"`
+	// SpikeDetected indicates that the last time measurement was discarded by the spike filter.
+	//
+	// A discarded measurement is not applied to the clock at all, so a filter which keeps
+	// rejecting looks exactly like a clock which is never corrected.
+	SpikeDetected bool `protobuf:"varint,4,opt,name=spike_detected,json=spikeDetected,proto3" json:"spike_detected,omitempty"`
+	// ConsecutiveSpikes is the number of time measurements discarded in a row by the spike filter.
+	ConsecutiveSpikes int64 `protobuf:"varint,5,opt,name=consecutive_spikes,json=consecutiveSpikes,proto3" json:"consecutive_spikes,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *StatusSpec) Reset() {
@@ -188,6 +195,20 @@ func (x *StatusSpec) GetSyncDisabled() bool {
 	return false
 }
 
+func (x *StatusSpec) GetSpikeDetected() bool {
+	if x != nil {
+		return x.SpikeDetected
+	}
+	return false
+}
+
+func (x *StatusSpec) GetConsecutiveSpikes() int64 {
+	if x != nil {
+		return x.ConsecutiveSpikes
+	}
+	return 0
+}
+
 var File_resource_definitions_time_time_proto protoreflect.FileDescriptor
 
 const file_resource_definitions_time_time_proto_rawDesc = "" +
@@ -202,12 +223,14 @@ const file_resource_definitions_time_time_proto_rawDesc = "" +
 	"\bconstant\x18\x06 \x01(\x03R\bconstant\x12\x1f\n" +
 	"\vsync_status\x18\a \x01(\bR\n" +
 	"syncStatus\x12\x14\n" +
-	"\x05state\x18\b \x01(\tR\x05state\"_\n" +
+	"\x05state\x18\b \x01(\tR\x05state\"\xb5\x01\n" +
 	"\n" +
 	"StatusSpec\x12\x16\n" +
 	"\x06synced\x18\x01 \x01(\bR\x06synced\x12\x14\n" +
 	"\x05epoch\x18\x02 \x01(\x03R\x05epoch\x12#\n" +
-	"\rsync_disabled\x18\x03 \x01(\bR\fsyncDisabledBr\n" +
+	"\rsync_disabled\x18\x03 \x01(\bR\fsyncDisabled\x12%\n" +
+	"\x0espike_detected\x18\x04 \x01(\bR\rspikeDetected\x12-\n" +
+	"\x12consecutive_spikes\x18\x05 \x01(\x03R\x11consecutiveSpikesBr\n" +
 	"'dev.talos.api.resource.definitions.timeZGgithub.com/siderolabs/talos/pkg/machinery/api/resource/definitions/timeb\x06proto3"
 
 var (

--- a/pkg/machinery/api/resource/definitions/time/time_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/time/time_vtproto.pb.go
@@ -151,6 +151,21 @@ func (m *StatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.ConsecutiveSpikes != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ConsecutiveSpikes))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.SpikeDetected {
+		i--
+		if m.SpikeDetected {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if m.SyncDisabled {
 		i--
 		if m.SyncDisabled {
@@ -232,6 +247,12 @@ func (m *StatusSpec) SizeVT() (n int) {
 	}
 	if m.SyncDisabled {
 		n += 2
+	}
+	if m.SpikeDetected {
+		n += 2
+	}
+	if m.ConsecutiveSpikes != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ConsecutiveSpikes))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -598,6 +619,45 @@ func (m *StatusSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.SyncDisabled = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpikeDetected", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SpikeDetected = bool(v != 0)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ConsecutiveSpikes", wireType)
+			}
+			m.ConsecutiveSpikes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ConsecutiveSpikes |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/resources/time/status.go
+++ b/pkg/machinery/resources/time/status.go
@@ -35,6 +35,15 @@ type StatusSpec struct {
 
 	// SyncDisabled indicates if time sync is disabled.
 	SyncDisabled bool `yaml:"syncDisabled" protobuf:"3"`
+
+	// SpikeDetected indicates that the last time measurement was discarded by the spike filter.
+	//
+	// A discarded measurement is not applied to the clock at all, so a filter which keeps
+	// rejecting looks exactly like a clock which is never corrected.
+	SpikeDetected bool `yaml:"spikeDetected" protobuf:"4"`
+
+	// ConsecutiveSpikes is the number of time measurements discarded in a row by the spike filter.
+	ConsecutiveSpikes int `yaml:"consecutiveSpikes" protobuf:"5"`
 }
 
 // NewStatus initializes a TimeSync resource.

--- a/website/content/v1.14/reference/api.md
+++ b/website/content/v1.14/reference/api.md
@@ -11876,6 +11876,8 @@ StatusSpec describes time sync state.
 | synced | [bool](#bool) |  | Synced indicates whether time is in sync. |
 | epoch | [int64](#int64) |  | Epoch is incremented every time clock jumps more than 15min. |
 | sync_disabled | [bool](#bool) |  | SyncDisabled indicates if time sync is disabled. |
+| spike_detected | [bool](#bool) |  | SpikeDetected indicates that the last time measurement was discarded by the spike filter.<br><br>A discarded measurement is not applied to the clock at all, so a filter which keeps rejecting looks exactly like a clock which is never corrected. |
+| consecutive_spikes | [int64](#int64) |  | ConsecutiveSpikes is the number of time measurements discarded in a row by the spike filter. |
 
 
 


### PR DESCRIPTION
# Pull Request

## What? (description)

Reinstate the one check from systemd's `manager_sample_spike_detection` that was left commented out when the spike detector was ported:

```go
if math.Abs(sample.Offset) > d.samples[indexMin].RTT {
        // do not accept anything worse than the maximum possible error of the best sample
        return true
}
```

Two existing test expectations change as a direct consequence, and are updated in the same commit:

- `adjusting to higher RTT` :  now requires a full sample window (7 rejections, accepted on the 8th) instead of 3 because the low-RTT samples have to age out.
- `no spikes` : its last sample (`Offset: 0.02`, `RTT: 0.03`, best RTT in window `0.01`) is a spike under the reinstated rule. The offset is lowered to `0.005` so the case still tests what it was written to test, that a large RTT alone is not a spike.
- Adds new test, `TestSpikeDetectorAsymmetricDelay`, replays a sequence of polls captured with simulated asymmetric delay.

## Why? (reasoning)

`|offset| > lowestRTT` check is the only functional divergence from the source.

Without it the only remaining discriminator for a spike is `3 * jitter`, and jitter is computed from the samples themselves. That makes the guard self-defeating under sustained bad input: each accepted-into-history bad sample raises the threshold that is supposed to reject the next one.

What this check is protecting against is a **one-directional path delay**. NTP's offset calculation assumes the two legs are symmetric, so when only the forward path is delayed the computed offset is biased by half the excess RTT. A congested poll therefore looks like a large, plausible clock error, and critically it stays *under* the `|offset| > delay` early accept. 

We hit this on a cluster whose upstream path degrades in bursts of 30–120 s (Peaks to ~250 ms against a 4–6 ms baseline).

The consequence is a clock that "sawtooths" which then is adjusting for a few cycles with the jitter getting "poisoned". Here is an extract from this behavior:

| Poll | RTT | Offset | Applied? |
|---|---|---|---|
| 1 | 98.4 ms | +46.07 ms | yes |
| 2 | 67.5 ms | +31.78 ms | yes |
| 3 | 5.5 ms | −46.65 ms | yes — clean poll correcting the error just introduced |
| 4 | 201.4 ms | +104.74 ms | no (only this one was rejected) |
| 5 | 110.2 ms | +63.68 ms | yes |
| 6 | 5.4 ms | −84.53 ms | yes — clean poll correcting again |

By the time poll 5 arrived, jitter had reached ~60 ms on a path only 5 ms wide, so `3 * jitter` could not reject a 63.7 ms offset. The reinstated check rejects it, because it compares against the best sample's RTT rather than against a statistic contaminated by the same congestion. It also rejects polls 1 and 2 samples that the current code accepts.

Note that polls 3 and 6 remain accepted, and should be: with a 5 ms RTT the maximum error attributable to asymmetry is |2.5 ms|, so an offset of tens of ms is a real, trustworthy measurement of a clock that genuinely drifted. 

### False positive and the tradeoff

The check seems to have been removed because of false-positive in a LAN network. Which seems reasonable in this context. 
`|offset| > RTTdelay` fires first whenever the offset is large relative to a short path. But all in all, this is an acceptable tradeoff because in such an environment, the RTT is likely very low(<1ms). So it would skip a clock adjustment of a sub-millisecond offset which isn't specifically justified compared to dozens of ms.


Here is a sample on multiple clusters with rejected sample stats computed based on the actual picked up metrics in logs :  

| Cluster | Nodes | Polls | Baseline RTT | Already rejected by jitter | **with patch** | Both accept | False positives | Max FP | FP rate |
|---|---|---|---|---|---|---|---|---|---|
| cluster1 (NTP server in same DC) | 3 | 103 | **0.272 ms** | 3 | **1** | 0 | 5 | **0.272 ms** | **4.85 %** |
| cluster2 (NTP server in other region) | 6 | 718 | 5.115 ms | 23 | **20** | 1 | 2 | 5.232 ms | 0.28 % |


Closes siderolabs/talos#13601

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`) -- _But I'm not in the list so this doesn't completely pass if I'm correct_
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
~~- [ ] you generated documentation (`make docs`)~~
- [x] you ran unit-tests (`make unit-tests`)