### PR TITLE
fix: ensure VolumeConfigs are published in provisioning order

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/resources.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/resources.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package volumeconfig
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block/internal/volumes"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+// BuildVolumeResources builds the volume resources in the order they are to be published.
+func BuildVolumeResources(
+	ctx context.Context, cfg configconfig.Config, encryptionMeta *runtime.MetaKey, inContainer, isAgent bool,
+) ([]VolumeResource, error) {
+	transformers := append(
+		GetSystemVolumeTransformers(ctx, encryptionMeta, inContainer, isAgent),
+		UserVolumeTransformers...,
+	)
+
+	var resources []VolumeResource
+
+	for _, transformer := range transformers {
+		transformed, err := transformer(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		resources = append(resources, transformed...)
+	}
+
+	// each volume config is published separately, so VolumeManagerController may pick up any prefix
+	// of this sequence. Publishing in provisioning order makes every such prefix a valid provisioning
+	// prefix, so a volume is never provisioned ahead of the volumes which should come first
+	// (e.g. EPHEMERAL grows to fill the disk, and must never be provisioned before the promotable
+	// system volumes which share the system disk with it in the same wave).
+	return sortByProvisioningOrder(resources)
+}
+
+// sortByProvisioningOrder sorts the volume resources into the order VolumeManagerController
+// provisions them, i.e. by [volumes.CompareVolumeConfigs].
+//
+// The provisioning order is a property of the resulting VolumeConfig spec, so each resource is
+// transformed into a throwaway VolumeConfig to figure out where it belongs. This is safe as the
+// transform functions only set fields on the spec: they never read the previous spec, and never
+// touch the metadata.
+func sortByProvisioningOrder(resources []VolumeResource) ([]VolumeResource, error) {
+	specs := make(map[string]*block.VolumeConfig, len(resources))
+
+	for _, rsrc := range resources {
+		volumeConfig := block.NewVolumeConfig(block.NamespaceName, rsrc.VolumeID)
+
+		if err := rsrc.TransformFunc(volumeConfig); err != nil {
+			return nil, fmt.Errorf("error building volume config %s: %w", rsrc.VolumeID, err)
+		}
+
+		specs[rsrc.VolumeID] = volumeConfig
+	}
+
+	sorted := slices.Clone(resources)
+
+	slices.SortStableFunc(sorted, func(a, b VolumeResource) int {
+		return volumes.CompareVolumeConfigs(specs[a.VolumeID], specs[b.VolumeID])
+	})
+
+	return sorted, nil
+}

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/resources_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/resources_test.go
@@ -1,0 +1,165 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package volumeconfig_test
+
+import (
+	"net/url"
+	"slices"
+	"testing"
+
+	"github.com/siderolabs/gen/value"
+	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block/internal/volumes"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig"
+	machineruntime "github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+// TestBuildVolumeResourcesProvisioningOrder verifies that BuildVolumeResources returns volume configs
+// in the very order VolumeManagerController provisions them.
+//
+// The manager picks up volume configs as they are published, so it may observe any prefix of the
+// published sequence. Publishing out of provisioning order lets it provision a volume too early:
+// notably, EPHEMERAL grows to fill the system disk, so provisioning it before the promotable system
+// volumes which share the disk leaves them with no space at all.
+func TestBuildVolumeResourcesProvisioningOrder(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+
+		promoteSystemVolumes bool
+
+		// expected order of the volumes which get a partition provisioned on the system disk
+		expectedPartitions []string
+	}{
+		{
+			// the promotable system volumes are directories under EPHEMERAL, so they don't get a
+			// partition at all: STATE is provisioned first (it is the smallest), and EPHEMERAL last
+			// as it grows to fill whatever is left.
+			name: "default layout",
+
+			expectedPartitions: []string{
+				constants.StatePartitionLabel,
+				constants.EphemeralPartitionLabel,
+			},
+		},
+		{
+			// each promotable system volume is capped at 50GiB and doesn't grow, so all of them have
+			// to be provisioned before the growing EPHEMERAL.
+			name: "promoted system volumes",
+
+			promoteSystemVolumes: true,
+
+			expectedPartitions: []string{
+				constants.StatePartitionLabel,
+				constants.CRIContainerdVolumeID,
+				constants.EtcdDataVolumeID,
+				constants.KubeletDataVolumeID,
+				constants.LogVolumeID,
+				constants.EphemeralPartitionLabel,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			resources, err := volumeconfig.BuildVolumeResources(
+				t.Context(), machineConfig(t, test.promoteSystemVolumes), nil,
+				machineruntime.ModeMetal.InContainer(), machineruntime.ModeMetal.IsAgent(),
+			)
+			require.NoError(t, err)
+
+			configs := transformAll(t, resources)
+
+			// the published order is the order the manager provisions volumes in
+			assert.True(t, slices.IsSortedFunc(configs, volumes.CompareVolumeConfigs),
+				"volume configs are not published in provisioning order: %v", volumeIDs(configs))
+
+			partitions := xslices.Filter(configs, func(c *block.VolumeConfig) bool {
+				return c.TypedSpec().Type == block.VolumeTypePartition && !value.IsZero(c.TypedSpec().Provisioning)
+			})
+
+			assert.Equal(t, test.expectedPartitions, volumeIDs(partitions))
+
+			// Directory-backed volumes have no provisioning instructions at all, so they are published
+			// before EPHEMERAL rather than after it. That is fine (and is what the manager has always
+			// done with them): the manager marks a directory volume ready without touching the disk,
+			// and MountController only creates the directory once the parent mount is up.
+			ephemeralIdx := slices.Index(volumeIDs(configs), constants.EphemeralPartitionLabel)
+
+			for _, c := range configs {
+				if c.TypedSpec().Type != block.VolumeTypeDirectory {
+					continue
+				}
+
+				assert.Less(t, slices.Index(volumeIDs(configs), c.Metadata().ID()), ephemeralIdx,
+					"directory volume %q should be published before EPHEMERAL", c.Metadata().ID())
+			}
+		})
+	}
+}
+
+// transformAll builds the VolumeConfig each resource would be published as, preserving the order.
+func transformAll(t *testing.T, resources []volumeconfig.VolumeResource) []*block.VolumeConfig {
+	t.Helper()
+
+	return xslices.Map(resources, func(r volumeconfig.VolumeResource) *block.VolumeConfig {
+		volumeConfig := block.NewVolumeConfig(block.NamespaceName, r.VolumeID)
+
+		require.NoError(t, r.TransformFunc(volumeConfig))
+
+		return volumeConfig
+	})
+}
+
+func volumeIDs(configs []*block.VolumeConfig) []string {
+	return xslices.Map(configs, func(c *block.VolumeConfig) string { return c.Metadata().ID() })
+}
+
+// machineConfig returns a minimal machine config, optionally promoting every promotable system volume
+// onto a dedicated partition on the system disk, next to a growing EPHEMERAL.
+func machineConfig(t *testing.T, promoteSystemVolumes bool) configconfig.Config {
+	t.Helper()
+
+	u, err := url.Parse("https://foo:6443")
+	require.NoError(t, err)
+
+	docs := []configconfig.Document{
+		&v1alpha1.Config{
+			ConfigVersion: "v1alpha1",
+			MachineConfig: &v1alpha1.MachineConfig{},
+			ClusterConfig: &v1alpha1.ClusterConfig{
+				ControlPlane: &v1alpha1.ControlPlaneConfig{
+					Endpoint: &v1alpha1.Endpoint{
+						URL: u,
+					},
+				},
+			},
+		},
+	}
+
+	if promoteSystemVolumes {
+		for _, volumeID := range configconfig.PromotableSystemVolumeNames {
+			docs = append(docs, &blockcfg.VolumeConfigV1Alpha1{
+				MetaName:         volumeID,
+				ProvisioningSpec: blockcfg.ProvisioningSpec{ProvisioningMaxSize: blockcfg.MustSize("50GiB")},
+			})
+		}
+	}
+
+	ctr, err := container.New(docs...)
+	require.NoError(t, err)
+
+	return ctr
+}

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes.go
@@ -18,6 +18,10 @@ import (
 )
 
 // CompareVolumeConfigs compares two volume configs in the proposed order of provisioning.
+//
+// VolumeConfigs which are otherwise equivalent are ordered by their ID, so that
+// the provisioning order doesn't depend on the order the configs are fed in.
+// VolumeConfigController relies on this to publish volume configs in exactly this order.
 func CompareVolumeConfigs(a, b *block.VolumeConfig) int {
 	// first, sort volumes without provisioning instructions first, as they don't block provisioning of other volumes
 	if c := cmpBool(!value.IsZero(a.TypedSpec().Provisioning), !value.IsZero(b.TypedSpec().Provisioning)); c != 0 {
@@ -46,7 +50,12 @@ func CompareVolumeConfigs(a, b *block.VolumeConfig) int {
 	desiredSizeA := cmp.Or(a.TypedSpec().Provisioning.PartitionSpec.MaxSize, math.MaxUint64)
 	desiredSizeB := cmp.Or(b.TypedSpec().Provisioning.PartitionSpec.MaxSize, math.MaxUint64)
 
-	return cmp.Compare(desiredSizeA, desiredSizeB)
+	if c := cmp.Compare(desiredSizeA, desiredSizeB); c != 0 {
+		return c
+	}
+
+	// Break the tie on the volume ID to make the order independent of incoming order.
+	return cmp.Compare(a.Metadata().ID(), b.Metadata().ID())
 }
 
 func cmpBool(a, b bool) int {

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumes_test.go
@@ -129,6 +129,31 @@ func TestCompareVolumeConfigs(t *testing.T) {
 
 			expected: -1,
 		},
+		{
+			// resA is "A" and resB is "B", so equivalent specs are ordered by volume ID
+			name: "equivalent specs are ordered by ID",
+
+			a: &block.VolumeConfigSpec{
+				Provisioning: block.ProvisioningSpec{
+					Wave: block.WaveSystemDisk,
+					PartitionSpec: block.PartitionSpec{
+						MinSize: 100,
+						MaxSize: 200,
+					},
+				},
+			},
+			b: &block.VolumeConfigSpec{
+				Provisioning: block.ProvisioningSpec{
+					Wave: block.WaveSystemDisk,
+					PartitionSpec: block.PartitionSpec{
+						MinSize: 100,
+						MaxSize: 200,
+					},
+				},
+			},
+
+			expected: -1,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/app/machined/pkg/controllers/block/volume_config.go
+++ b/internal/app/machined/pkg/controllers/block/volume_config.go
@@ -121,20 +121,9 @@ func (ctrl *VolumeConfigController) Run(ctx context.Context, r controller.Runtim
 			return err
 		}
 
-		transformers := append(
-			volumeconfig.GetSystemVolumeTransformers(ctx, encryptionMeta, ctrl.V1Alpha1Mode.InContainer(), ctrl.V1Alpha1Mode.IsAgent()),
-			volumeconfig.UserVolumeTransformers...,
-		)
-
-		var resources []volumeconfig.VolumeResource
-
-		for _, transformer := range transformers {
-			r, err := transformer(cfg)
-			if err != nil {
-				return err
-			}
-
-			resources = append(resources, r...)
+		resources, err := volumeconfig.BuildVolumeResources(ctx, cfg, encryptionMeta, ctrl.V1Alpha1Mode.InContainer(), ctrl.V1Alpha1Mode.IsAgent())
+		if err != nil {
+			return err
 		}
 
 		volumeConfigsByID, volumeMountRequestsByID, err := ctrl.getExistingVolumes(ctx, r)


### PR DESCRIPTION
The `VolumeConfigController` may currently publish `VolumeConfigs` out of provisioning order. The `VolumeManagerController` will consume them and provision the volumes respectively. This can cause `EPHEMERAL` to be provisioned before other volumes, and grow to the max available size, preventing the remaining volume provisioning from finishing (no space left). See log excerpt below:

```sh
[    1.984545] [talos] partition created {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "CRI", "disk": "/dev/vda", "partition": 4, "label": "CRI", "size": "954 MiB"}
[    1.987988] [talos] service[apid](Running): Started task apid (PID 251) for container apid
[    2.090072] [talos] formatting filesystem {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "CRI", "device": "/dev/vda4", "filesystem": "xfs"}
[    2.102369] [talos] volume status {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "CRI", "phase": "waiting -> ready", "location": "/dev/vda4", "parentLocation": "/dev/vda"}
[    2.208547] [talos] partition created {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "ETCD", "disk": "/dev/vda", "partition": 5, "label": "ETCD", "size": "954 MiB"}
[    2.213499] [talos] created route {"component": "controller-runtime", "controller": "network.RouteSpecController", "destination": "default", "gateway": "172.24.0.1", "table": "main", "link": "enp0s6", "priority": 1024, "family": "inet4", "type": "unicast"}
[    2.314431] [talos] formatting filesystem {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "ETCD", "device": "/dev/vda5", "filesystem": "xfs"}
[    2.327490] [talos] volume status {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "ETCD", "phase": "waiting -> ready", "location": "/dev/vda5", "parentLocation": "/dev/vda"}
[    2.434182] [talos] partition created {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "EPHEMERAL", "disk": "/dev/vda", "partition": 6, "label": "EPHEMERAL", "size": "8.0 GiB"}
[    2.536292] [talos] formatting filesystem {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "EPHEMERAL", "device": "/dev/vda6", "filesystem": "xfs"}
[    2.548686] [talos] volume status {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "EPHEMERAL", "phase": "waiting -> ready", "location": "/dev/vda6", "parentLocation": "/dev/vda"}
[    2.549670] [talos] task diskSizeCheck (1/1): disk size is OK
[    2.549955] [talos] task diskSizeCheck (1/1): disk size is 8176 MiB
[    2.550289] [talos] task diskSizeCheck (1/1): done, 652.825675ms
[    2.550619] [talos] phase diskSizeCheck (2/9): done, 654.066921ms
[    2.550948] [talos] phase env (3/9): 2 tasks(s)
[    2.551206] [talos] task waitForCARoots (2/2): starting
[    2.551525] [talos] task setUserEnvVars (1/2): starting
[    2.552316] [talos] task setUserEnvVars (1/2): done, 1.097746ms
[    2.553305] [talos] task waitForCARoots (2/2): done, 323.607µs
[    2.554163] [talos] volume status {"component": "controller-runtime", "controller": "block.VolumeManagerController", "volume": "KUBELET", "phase": "waiting -> failed", "error": "no disks matched for volume (1 matched selector): 1 have not enough space, 0 have wrong format, 0 have other issues"}
```

This PR aims to make the publishing order in line with the expected provisioning order.