### PR TITLE
fix: load the raid1 module for configured MD arrays

### DIFF
--- a/hack/test/patches/md-boot-array.yaml
+++ b/hack/test/patches/md-boot-array.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1alpha1
 kind: RAIDArrayConfig
 name: boot
@@ -12,7 +13,3 @@ kind: UnattendedInstallConfig
 provisioning:
     diskSelector:
         match: '"/dev/disk/by-id/md-name-talos:boot" in disk.symlinks'
----
-apiVersion: v1alpha1
-kind: KernelModuleConfig
-name: raid1

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/storage"
 )
 
 // KernelModuleConfigController watches v1alpha1.Config, creates/updates/deletes kernel module specs.
@@ -39,6 +40,11 @@ func (ctrl *KernelModuleConfigController) Inputs() []controller.Input {
 		{
 			Namespace: network.NamespaceName,
 			Type:      network.LinkSpecType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: storage.NamespaceName,
+			Type:      storage.MDArraySpecType,
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -77,6 +83,11 @@ func (ctrl *KernelModuleConfigController) Run(ctx context.Context, r controller.
 			return fmt.Errorf("error listing link specs: %w", err)
 		}
 
+		mdaSpecs, err := safe.ReaderListAll[*storage.MDArraySpec](ctx, r)
+		if err != nil {
+			return fmt.Errorf("error md array specs specs: %w", err)
+		}
+
 		r.StartTrackingOutputs()
 
 		if cfg != nil {
@@ -101,6 +112,13 @@ func (ctrl *KernelModuleConfigController) Run(ctx context.Context, r controller.
 			// as long as they are created by Talos
 			if linkSpec.TypedSpec().Kind == network.LinkKindVRF {
 				modules["vrf"] = struct{}{}
+			}
+		}
+
+		for mdaSpec := range mdaSpecs.All() {
+			// TODO: add support for other RAID levels if needed
+			if mdaSpec.TypedSpec().Level == storage.MDLevelRAID1 {
+				modules["raid1"] = struct{}{}
 			}
 		}
 

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_config_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	runtimeresource "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/storage"
 )
 
 type KernelModuleConfigSuite struct {
@@ -107,6 +108,36 @@ func (suite *KernelModuleConfigSuite) TestReconcileMultiDocConfig() {
 	ctest.AssertResource(suite, "vrf", func(r *runtimeresource.KernelModuleSpec, asrt *assert.Assertions) {
 		asrt.Equal("vrf", r.TypedSpec().Name)
 	})
+}
+
+func (suite *KernelModuleConfigSuite) TestReconcileMDArraySpecs() {
+	suite.Require().NoError(suite.Runtime().RegisterController(&runtimecontrollers.KernelModuleConfigController{}))
+
+	md0 := storage.NewMDArraySpec(storage.NamespaceName, "md0")
+	md0.TypedSpec().Level = storage.MDLevelRAID1
+
+	md1 := storage.NewMDArraySpec(storage.NamespaceName, "md1")
+	md1.TypedSpec().Level = storage.MDLevelRAID1
+
+	suite.Create(md0)
+	suite.Create(md1)
+
+	// both arrays collapse into a single raid1 module spec
+	ctest.AssertResource(suite, "raid1", func(r *runtimeresource.KernelModuleSpec, asrt *assert.Assertions) {
+		asrt.Equal("raid1", r.TypedSpec().Name)
+		asrt.Empty(r.TypedSpec().Parameters)
+	})
+
+	// one array left, module is still required
+	suite.Destroy(md0)
+
+	ctest.AssertResource(suite, "raid1", func(r *runtimeresource.KernelModuleSpec, asrt *assert.Assertions) {
+		asrt.Equal("raid1", r.TypedSpec().Name)
+	})
+
+	suite.Destroy(md1)
+
+	ctest.AssertNoResource[*runtimeresource.KernelModuleSpec](suite, "raid1")
 }
 
 func TestKernelModuleConfigSuite(t *testing.T) {


### PR DESCRIPTION
mdadm might fail to assemble a RAID1 array unless the module was loaded
beforehand. Derive the required module from the MDArraySpec resources
instead of asking users to declare it in the kernel module config.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
