### PR TITLE
feat: allow attaching extra disks to controlplane machines

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -502,7 +502,7 @@ func (m *Qemu) getLegacyDiskEncryptionPatch(keys []*v1alpha1.EncryptionKey) (con
 }
 
 func (m *Qemu) initDisks() error {
-	workerExtraDisks := make([]*provision.Disk, 0, len(m.EOps.Disks.Requests())-1)
+	extraDisks := make([]*provision.Disk, 0, len(m.EOps.Disks.Requests())-1)
 
 	// Every node gets PrimaryDisks identical primary disks (cloned from the
 	// first disk request). More than one lets a node build an MD array across
@@ -524,9 +524,9 @@ func (m *Qemu) initDisks() error {
 		})
 	}
 
-	// get worker extra disks
+	// get extra disks
 	for _, d := range m.EOps.Disks.Requests()[1:] {
-		workerExtraDisks = append(workerExtraDisks, &provision.Disk{
+		extraDisks = append(extraDisks, &provision.Disk{
 			Size:            d.Size.Bytes(),
 			SkipPreallocate: !m.EOps.PreallocateDisks,
 			Driver:          d.Driver,
@@ -545,8 +545,8 @@ func (m *Qemu) initDisks() error {
 	}
 
 	m.ForEachNode(func(i int, node *provision.NodeRequest) {
-		if node.Type == machine.TypeWorker {
-			node.Disks = slices.Concat(node.Disks, workerExtraDisks)
+		if node.Type == machine.TypeWorker || m.EOps.ExtraDisksOnControlplanes {
+			node.Disks = slices.Concat(node.Disks, extraDisks)
 		}
 	})
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
@@ -160,6 +160,37 @@ func TestQemuMaker_Disks(t *testing.T) {
 	}, workerDisks)
 }
 
+func TestQemuMaker_ExtraDisksOnControlplanes(t *testing.T) {
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+
+	disks := flags.Disks{}
+	err := disks.Set("virtio:10GiB,nvme:20GiB,virtio:30GiB")
+	require.NoError(t, err)
+
+	qOps.Disks = disks
+	qOps.ExtraDisksOnControlplanes = true
+	cOps.Controlplanes = 1
+	cOps.Workers = 1
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    qOps,
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	req, err := m.GetClusterConfigs()
+	require.NoError(t, err)
+
+	controlplaneDisks := req.ClusterRequest.Nodes[0].Disks
+	workerDisks := req.ClusterRequest.Nodes[1].Disks
+
+	assert.Equal(t, 3, len(controlplaneDisks))
+	assert.Equal(t, 3, len(workerDisks))
+	assert.Equal(t, workerDisks, controlplaneDisks)
+}
+
 func TestQemuMaker_DiskEncryption_StatePartition(t *testing.T) {
 	cOps := clusterops.GetCommon()
 	qOps := clusterops.GetQemu()

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -115,6 +115,7 @@ type Qemu struct {
 	Nameservers               []string
 	Disks                     flags.Disks
 	PrimaryDisks              int
+	ExtraDisksOnControlplanes bool
 	DiskBlockSize             uint
 	PreallocateDisks          bool
 	ClusterUserVolumes        []string

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -91,6 +91,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		extraDisksTagsFlag              = "extra-disks-tags"
 		extraDisksSerialsFlag           = "extra-disks-serials"
 		extraDiskSizeFlag               = "extra-disks-size"
+		extraDisksOnControlplanesFlag   = "extra-disks-on-controlplanes"
 		targetArchFlag                  = "arch"
 		cniBinPathFlag                  = "cni-bin-path"
 		cniConfDirFlag                  = "cni-conf-dir"
@@ -330,6 +331,8 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksTags, extraDisksTagsFlag, nil, "tags for each extra disk (only used by virtiofs)")
 	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksSerials, extraDisksSerialsFlag, nil, "serials for each extra disk")
 	createCmd.Flags().IntVar(&legacyOps.extraDiskSize, extraDiskSizeFlag, 5*1024, "default limit on disk size in MB (each VM)")
+	createCmd.Flags().BoolVar(&qOps.ExtraDisksOnControlplanes, extraDisksOnControlplanesFlag, false,
+		"attach the extra disks to controlplane machines as well (by default they are attached only to workers)")
 
 	clustercmd.AddProvisionerFlag(createCmd)
 	cli.Should(createCmd.Flags().MarkHidden(clustercmd.ProvisionerFlagName))

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -160,6 +160,7 @@ talosctl cluster create dev [flags]
       --extra-boot-kernel-args string            add extra kernel args to the initial boot from vmlinuz and initramfs
       --extra-disks int                          number of extra disks to create for each worker VM
       --extra-disks-drivers strings              driver for each extra disk (virtio, ide, ahci, scsi, nvme, megaraid)
+      --extra-disks-on-controlplanes             attach the extra disks to controlplane machines as well (by default they are attached only to workers)
       --extra-disks-serials strings              serials for each extra disk
       --extra-disks-size int                     default limit on disk size in MB (each VM) (default 5120)
       --extra-disks-tags strings                 tags for each extra disk (only used by virtiofs)


### PR DESCRIPTION
The extra disks created for a local QEMU cluster were always attached only to worker machines, so a cluster without workers could not get machines with more than one disk. Add an opt-in flag to attach the extra disks to controlplane machines as well. The default behavior stays unchanged.
