### PR TITLE
test: inspect host mount state from the current thread

### DIFF
--- a/internal/pkg/hostns/hostns_test.go
+++ b/internal/pkg/hostns/hostns_test.go
@@ -133,7 +133,7 @@ func TestSetupRollbackOnError(t *testing.T) {
 func mountTargets(t *testing.T) []string {
 	t.Helper()
 
-	data, err := os.ReadFile("/proc/self/mountinfo")
+	data, err := os.ReadFile("/proc/thread-self/mountinfo")
 	require.NoError(t, err)
 
 	var targets []string
@@ -154,11 +154,11 @@ func isMounted(t *testing.T, target string) bool {
 }
 
 // isUnbindable reports whether the mount at target carries the "unbindable"
-// propagation type (per /proc/self/mountinfo optional fields).
+// propagation type (per /proc/thread-self/mountinfo optional fields).
 func isUnbindable(t *testing.T, target string) bool {
 	t.Helper()
 
-	data, err := os.ReadFile("/proc/self/mountinfo")
+	data, err := os.ReadFile("/proc/thread-self/mountinfo")
 	require.NoError(t, err)
 
 	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {


### PR DESCRIPTION
The host namespace tests lock one goroutine to an OS thread before unsharing its mount namespace. /proc/self/mountinfo reports the thread leader mount namespace, so scheduling the test elsewhere makes its assertions inspect the original namespace and report every setup mount as absent.

Use /proc/thread-self/mountinfo so the assertions observe the namespace where setup ran. The race reproducer failed repeatedly across 50 runs before this change and passed all 50 afterward.