### PR TITLE
fix: make reset during boot phase more robust

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -185,6 +185,9 @@ func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 				"saveMeta", // saving META here to merge in-memory changes with the on-disk ones from the installer
 				FlushMeta,
 			).Append(
+				"denyNewServices",
+				DenyNewServices,
+			).Append(
 				"volumeFinalize",
 				TeardownVolumeLifecycle,
 			).Append(
@@ -448,7 +451,10 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 	case runtime.ModeContainer:
 		return nil
 	default:
-		phases = phases.AppendWhen(
+		phases = phases.Append(
+			"denyNewServices",
+			DenyNewServices,
+		).AppendWhen(
 			!skipNodeRegistration,
 			"drain",
 			CordonAndDrainNode,
@@ -509,6 +515,9 @@ func stopAllPhaselist(r runtime.Runtime, enableKexec bool) PhaseList {
 		)
 	default:
 		phases = phases.Append(
+			"denyNewServices",
+			DenyNewServices,
+		).Append(
 			"stopServices",
 			StopServicesEphemeral,
 		).Append(
@@ -552,6 +561,9 @@ func (*Sequencer) EmergencyVolumeCleanup(r runtime.Runtime) []runtime.Phase {
 		// no volume cleanup needed in container mode
 	default:
 		phases = phases.Append(
+			"denyNewServices",
+			DenyNewServices,
+		).Append(
 			"umount",
 			UnmountPodMounts,
 		).Append(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -443,17 +443,26 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 func StopServicesEphemeral(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		// stopping 'cri' service stops everything which depends on it (kubelet, etcd, ...)
-		return system.Services(nil).StopWithRevDepenencies(ctx, "cri", "trustd")
+		return system.Services(r).StopWithRevDepenencies(ctx, "cri", "trustd")
 	}, "stopServicesForUpgrade"
 }
 
 // StopAllServices represents the StopAllServices task.
 func StopAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		system.Services(nil).Shutdown(ctx)
+		system.Services(r).Shutdown(ctx)
 
 		return nil
 	}, "stopAllServices"
+}
+
+// DenyNewServices represents the DenyNewServices task.
+func DenyNewServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
+		system.Services(r).DenyNewServices()
+
+		return nil
+	}, "denyNewServices"
 }
 
 // SetupSharedFilesystems represents the SetupSharedFilesystems task.

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -39,8 +39,12 @@ type singleton struct {
 	runningMu sync.Mutex
 	running   map[string]struct{}
 
-	mu          sync.Mutex
-	wg          sync.WaitGroup
+	mu sync.Mutex
+	wg sync.WaitGroup
+
+	// denyNewServices is set on DenyNewServices, and it rejects any further Load/Start calls, used on Talos shutdown/reboot paths.
+	denyNewServices bool
+	// terminating is set on Shutdown, and it rejects any further Load/Start/Stop calls, and allows Shutdown to proceed without deadlock.
 	terminating bool
 }
 
@@ -75,7 +79,7 @@ func (s *singleton) Load(services ...Service) []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.terminating {
+	if s.terminating || s.denyNewServices {
 		return nil
 	}
 
@@ -144,7 +148,7 @@ func (s *singleton) Start(serviceIDs ...string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.terminating {
+	if s.terminating || s.denyNewServices {
 		return nil
 	}
 
@@ -475,4 +479,12 @@ func (s *singleton) APIRestart(ctx context.Context, id string) error {
 	}
 
 	return fmt.Errorf("service %q doesn't support restart operation via API", id)
+}
+
+// DenyNewServices sets the denyNewServices flag, which prevents any new services from being loaded or started.
+func (s *singleton) DenyNewServices() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.denyNewServices = true
 }

--- a/internal/app/machined/pkg/system/volumes.go
+++ b/internal/app/machined/pkg/system/volumes.go
@@ -68,9 +68,79 @@ type volumesMountedCondition struct {
 	pendingRequests []volumeRequest
 }
 
+func checkVolumeLifecycleEvent(event state.Event) error {
+	switch event.Type {
+	case state.Created, state.Updated:
+		if event.Resource.Metadata().Phase() != resource.PhaseRunning {
+			return fmt.Errorf("volume lifecycle is not running, cannot mount volumes")
+		}
+	case state.Destroyed:
+		return fmt.Errorf("volume lifecycle is destroyed, cannot mount volumes")
+	case state.Bootstrapped, state.Noop:
+		return fmt.Errorf("unexpected event type %q for volume lifecycle", event.Type)
+	case state.Errored:
+		return fmt.Errorf("watch error: %w", event.Error)
+	}
+
+	return nil
+}
+
+//nolint:gocyclo
+func waitForMountStatusReadyWithLifecycle(ctx context.Context, st state.State, lifecycleWatchCh <-chan state.Event, requestID string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mountStatusWatchCh := make(chan state.Event)
+
+	if err := st.Watch(ctx, block.NewVolumeMountStatus(block.NamespaceName, requestID).Metadata(), mountStatusWatchCh); err != nil {
+		return fmt.Errorf("failed to watch volume mount status %q: %w", requestID, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event := <-lifecycleWatchCh:
+			if err := checkVolumeLifecycleEvent(event); err != nil {
+				return err
+			}
+		case event := <-mountStatusWatchCh:
+			switch event.Type {
+			case state.Created, state.Updated:
+				if event.Resource.Metadata().Phase() == resource.PhaseRunning {
+					return nil
+				}
+			case state.Destroyed:
+				// ignore
+			case state.Errored:
+				return fmt.Errorf("watch error: %w", event.Error)
+			case state.Bootstrapped, state.Noop:
+				return fmt.Errorf("unexpected event type %q for mount status", event.Type)
+			}
+		}
+	}
+}
+
+//nolint:gocyclo
 func (cond *volumesMountedCondition) Wait(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	lifecycleWatchCh := make(chan state.Event)
+
+	if err := cond.st.Watch(ctx, block.NewVolumeLifecycle(block.NamespaceName, block.VolumeLifecycleID).Metadata(), lifecycleWatchCh); err != nil {
+		return fmt.Errorf("failed to watch volume lifecycle: %w", err)
+	}
+
+	// wait for the initial watch event
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case event := <-lifecycleWatchCh:
+		if err := checkVolumeLifecycleEvent(event); err != nil {
+			return err
+		}
+	}
 
 	// we mount all requests sequentially one by one
 	for idx := range cond.requests {
@@ -91,17 +161,11 @@ func (cond *volumesMountedCondition) Wait(ctx context.Context) error {
 			}
 
 			// wait for the mount status
-			_, err := cond.st.WatchFor(
-				ctx,
-				block.NewVolumeMountStatus(block.NamespaceName, req.requestID).Metadata(),
-				state.WithEventTypes(state.Created, state.Updated),
-				state.WithPhases(resource.PhaseRunning),
-			)
-			if err != nil {
+			if err := waitForMountStatusReadyWithLifecycle(ctx, cond.st, lifecycleWatchCh, req.requestID); err != nil {
 				return err
 			}
 
-			err = cond.lockVolumeMountStatus(ctx, req.requestID)
+			err := cond.lockVolumeMountStatus(ctx, req.requestID)
 			if err == nil {
 				break
 			}


### PR DESCRIPTION
There are two parts of the fix:

* deny starting new services once we enter pre-reboot/reset/shutdown phase to avoid having new services start when we are about to shut services down
* in the service volume mount code, act on volume lifecycle changes - if it is going to be torn down, stop adding new requests and locking finalizers, and instead bail out and let all requests die.
