### PR TITLE
fix: preserve kmsg reconciliation after config changes

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log.go
@@ -167,9 +167,11 @@ func (ctrl *KmsgLogDeliveryController) deliverLogs(ctx context.Context, r contro
 			return nil
 		case <-r.EventCh():
 			// config changed, restart the loop
+			r.QueueReconcile()
+
 			return nil
 		case <-ctrl.drainSub.EventCh():
-			// drain started, assume that ksmg is drained if there're no new messages in drainTimeout
+			// drain started, assume that kmsg is drained if there're no new messages in drainTimeout
 			drainTimer = time.NewTimer(drainTimeout)
 			drainTimerCh = drainTimer.C
 


### PR DESCRIPTION
The delivery loop consumes the runtime event that signals a configuration change before returning to the outer reconciliation loop. The outer loop then waits for another event, so kernel log delivery remains stopped when no unrelated update arrives.

Queue another reconciliation before returning from delivery. The failing dead-destination test reproduced within 100 race runs without the fix, then passed 100 runs with it; the complete kmsg suite passed 20 runs.