### PR TITLE
fix: record PID properly when under sandboxd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ KUBESTR_URL ?= https://github.com/kastenhq/kubestr/releases/download/$(KUBESTR_V
 HELM_URL ?= https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 CILIUM_CLI_URL ?= https://github.com/cilium/cilium-cli/releases/download/$(CILIUM_CLI_VERSION)/cilium-$(OPERATING_SYSTEM)-amd64.tar.gz
 TESTPKGS ?= github.com/siderolabs/talos/...
-RELEASES ?= v1.12.6 v1.13.0
+RELEASES ?= v1.12.9 v1.13.7
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -359,7 +359,7 @@ func init() {
 		fmt.Sprintf("%s:%s", images.InstallerImageRepository("metal"), version.Trim(version.Tag)),
 		"the container image to use for performing the install")
 	upgradeCmd.Flags().StringVar(
-		&upgradeCmdFlags.namespace, "namespace", "inmem",
+		&upgradeCmdFlags.namespace, "namespace", "system",
 		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance",
 	)
 	upgradeCmd.Flags().VarP(

--- a/internal/app/lifecycle/container.go
+++ b/internal/app/lifecycle/container.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -24,9 +25,11 @@ import (
 	"github.com/siderolabs/go-procfs/procfs"
 
 	"github.com/siderolabs/talos/internal/app/internal/ctrhelper"
+	"github.com/siderolabs/talos/internal/app/lifecycle/internal/containerpid"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/pid"
 	containerdrunner "github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/siderolabs/talos/internal/pkg/capability"
+	"github.com/siderolabs/talos/internal/pkg/cgroup"
 	"github.com/siderolabs/talos/internal/pkg/install"
 	"github.com/siderolabs/talos/internal/pkg/selinux"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -97,15 +100,21 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 		return fmt.Errorf("installer image %q not found in containerd store: %w", rc.imageRef, err)
 	}
 
-	// build container spec
-	mounts := buildMounts()
-	args := buildInstallerArgs(rc.disk, rc.platform, &options)
-	specOpts := buildSpecOpts(img, args, mounts, options.Environment(nil))
-
 	containerID, err := generateContainerID()
 	if err != nil {
 		return fmt.Errorf("failed to generate container ID: %v", err)
 	}
+
+	// Pin the installer to a fixed cgroup instead of the containerd default (which is derived
+	// from the containerd namespace and the container ID): it is a critical system component,
+	// so it gets a named cgroup like the other ones under 'system', and the path is known here
+	// without asking containerd for the container spec back.
+	cgroupPath := cgroup.Path(constants.CgroupInstaller)
+
+	// build container spec
+	mounts := buildMounts()
+	args := buildInstallerArgs(rc.disk, rc.platform, &options)
+	specOpts := buildSpecOpts(img, args, mounts, options.Environment(nil), cgroupPath)
 
 	// create container
 	ctr, err := c8dClient.NewContainer(
@@ -169,15 +178,29 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 		return fmt.Errorf("failed to start task: %w", err)
 	}
 
-	if err := pidRecorder("installer", int32(task.Pid()), false); err != nil {
-		return fmt.Errorf("failed to record installer PID: %w", err)
-	}
+	localPID, err := containerpid.NewResolver().Resolve(cgroupPath, task.Pid())
 
-	defer func() {
-		if err := pidRecorder("installer", 0, true); err != nil {
-			log.Printf("failed to clear installer PID record: %v", err)
+	switch {
+	case errors.Is(err, containerpid.ErrGone):
+		// nothing left to record; the task exit status handled below carries the real failure
+		log.Printf("not recording installer PID: %v", err)
+	case err != nil:
+		stdoutW.Close() //nolint:errcheck
+
+		return fmt.Errorf("failed to resolve installer PID: %w", err)
+	default:
+		if err := pidRecorder("installer", localPID, false); err != nil {
+			stdoutW.Close() //nolint:errcheck
+
+			return fmt.Errorf("failed to record installer PID: %w", err)
 		}
-	}()
+
+		defer func() {
+			if err := pidRecorder("installer", 0, true); err != nil {
+				log.Printf("failed to clear installer PID record: %v", err)
+			}
+		}()
+	}
 
 	statusC, err := task.Wait(detachedCtx)
 	if err != nil {
@@ -316,11 +339,12 @@ func buildInstallerArgs(disk, platform string, options *install.Options) []strin
 }
 
 // buildSpecOpts constructs the OCI spec options for the installer container.
-func buildSpecOpts(img client.Image, args []string, mounts []specs.Mount, env []string) []oci.SpecOpts {
+func buildSpecOpts(img client.Image, args []string, mounts []specs.Mount, env []string, cgroupPath string) []oci.SpecOpts {
 	specOpts := []oci.SpecOpts{
 		containerdrunner.WithImageConfigStripped(img),
 		oci.WithProcessArgs(args...),
 		oci.WithEnv(env),
+		oci.WithCgroup(cgroupPath),
 		oci.WithHostNamespace(specs.NetworkNamespace),
 		oci.WithHostNamespace(specs.PIDNamespace),
 		oci.WithMounts(mounts),

--- a/internal/app/lifecycle/internal/containerpid/containerpid.go
+++ b/internal/app/lifecycle/internal/containerpid/containerpid.go
@@ -1,0 +1,155 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package containerpid translates container PIDs reported by containerd into the PID
+// namespace of the calling process.
+package containerpid
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// ErrGone is returned by [Resolver.Resolve] when no process in the container cgroup matches
+// the PID containerd reported: the container init exited between the task start and the
+// lookup, and only its children (if any) are left behind.
+var ErrGone = errors.New("container process is gone")
+
+// Resolver resolves container init PIDs by reading cgroupfs and procfs.
+type Resolver struct {
+	cgroupMountPath string
+	procPath        string
+}
+
+// NewResolver initializes a resolver reading the default /sys/fs/cgroup and /proc mount points.
+func NewResolver() *Resolver {
+	return NewResolverWithPaths(constants.CgroupMountPath, "/proc")
+}
+
+// NewResolverWithPaths initializes a resolver reading non-default mount points.
+func NewResolverWithPaths(cgroupMountPath, procPath string) *Resolver {
+	return &Resolver{
+		cgroupMountPath: cgroupMountPath,
+		procPath:        procPath,
+	}
+}
+
+// Resolve translates the container init PID reported by containerd into the PID namespace
+// this process runs in.
+//
+// containerd resolves task PIDs in its own PID namespace. When the CRI containerd runs
+// under sandboxd it lives in the sandbox PID namespace, and so do the shim and the
+// container it creates — oci.WithHostNamespace(PIDNamespace) only inherits the runtime's
+// namespace, which is the sandbox one, not the root one. A PID namespace can only be
+// entered downwards, so the container cannot be placed back into the root namespace; the
+// translation has to happen here instead.
+//
+// cgroupfs renders PIDs in the PID namespace of the process reading it, so the cgroup of
+// the container (cgroupPath, relative to the cgroupfs mount point) lists PIDs directly
+// usable by the caller. The sandbox namespace is created with CLONE_NEWPID|CLONE_NEWNS only
+// (see sandboxd's beforeSandboxdExec), so no cgroup namespace is involved and the cgroup
+// path means the same thing on both sides.
+//
+// nsPID identifies the container init among the cgroup members: as the container shares the
+// runtime's PID namespace, the innermost NSpid of the process is exactly the PID containerd
+// reported. Without a sandbox the two namespaces coincide and this resolves to nsPID itself.
+//
+// If the container init is not (or no longer) in the cgroup, the error is [ErrGone].
+func (r *Resolver) Resolve(cgroupPath string, nsPID uint32) (int32, error) {
+	procsPath := filepath.Join(r.cgroupMountPath, cgroupPath, "cgroup.procs")
+
+	contents, err := os.ReadFile(procsPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s: %w", procsPath, err)
+	}
+
+	for field := range strings.FieldsSeq(string(contents)) {
+		candidate, err := strconv.ParseInt(field, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse PID %q from %s: %w", field, procsPath, err)
+		}
+
+		innermost, err := r.readInnermostPID(int32(candidate))
+
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			// the process exited between reading the cgroup and reading its status
+			continue
+		case err != nil:
+			return 0, err
+		}
+
+		if innermost == int32(nsPID) {
+			return int32(candidate), nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: no process with PID %d (as seen by containerd) found in %s", ErrGone, nsPID, procsPath)
+}
+
+// readInnermostPID returns the PID the process sees for itself, i.e. its PID in the
+// innermost PID namespace it belongs to.
+//
+// The pid argument is resolved in the caller's PID namespace, as usual for /proc.
+// The NSpid field of /proc/<pid>/status lists the process PID at every namespace level,
+// starting at the level of the reading process and descending to the namespace the process
+// itself lives in, so its last entry is the PID the process sees for itself. For a process
+// in the caller's own namespace there is a single entry and the result equals pid.
+//
+// If the process is gone, the returned error wraps [io/fs.ErrNotExist], so callers racing
+// against process exit can tell that apart from a malformed status file.
+func (r *Resolver) readInnermostPID(pid int32) (int32, error) {
+	statusPath := filepath.Join(r.procPath, strconv.Itoa(int(pid)), "status")
+
+	// /proc/<pid>/status is small enough to read in one go.
+	contents, err := os.ReadFile(statusPath)
+	if err != nil {
+		// a process which goes away mid-read reports ESRCH instead of ENOENT, normalize it
+		// so that callers have a single signal for "the process is gone"
+		if errors.Is(err, syscall.ESRCH) {
+			err = fmt.Errorf("%w: %w", fs.ErrNotExist, err)
+		}
+
+		return 0, err
+	}
+
+	innermost, err := parseInnermostPID(contents)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse %s: %w", statusPath, err)
+	}
+
+	return innermost, nil
+}
+
+// parseInnermostPID extracts the last NSpid entry from the contents of /proc/<pid>/status.
+func parseInnermostPID(contents []byte) (int32, error) {
+	for line := range strings.Lines(string(contents)) {
+		rest, ok := strings.CutPrefix(line, "NSpid:")
+		if !ok {
+			continue
+		}
+
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return 0, errors.New("NSpid field is empty")
+		}
+
+		innermost, err := strconv.ParseInt(fields[len(fields)-1], 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse NSpid entry %q: %w", fields[len(fields)-1], err)
+		}
+
+		return int32(innermost), nil
+	}
+
+	return 0, errors.New("no NSpid field found")
+}

--- a/internal/app/lifecycle/internal/containerpid/containerpid_test.go
+++ b/internal/app/lifecycle/internal/containerpid/containerpid_test.go
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package containerpid_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/lifecycle/internal/containerpid"
+)
+
+const cgroupPath = "system/installer"
+
+// fakeProcfs builds a cgroupfs/procfs pair: the container cgroup lists procs, and each
+// entry of statuses becomes a /proc/<pid>/status file.
+func fakeProcfs(t *testing.T, procs string, statuses map[int32]string) *containerpid.Resolver {
+	t.Helper()
+
+	root := t.TempDir()
+
+	cgroupMountPath := filepath.Join(root, "cgroup")
+	procPath := filepath.Join(root, "proc")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(cgroupMountPath, cgroupPath), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupMountPath, cgroupPath, "cgroup.procs"), []byte(procs), 0o644))
+
+	for pid, status := range statuses {
+		procDir := filepath.Join(procPath, strconv.Itoa(int(pid)))
+
+		require.NoError(t, os.MkdirAll(procDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(procDir, "status"), []byte(status), 0o644))
+	}
+
+	return containerpid.NewResolverWithPaths(cgroupMountPath, procPath)
+}
+
+// status renders a /proc/<pid>/status stub with the given NSpid entries.
+func status(nsPIDs ...int32) string {
+	entries := make([]string, 0, len(nsPIDs))
+
+	for _, nsPID := range nsPIDs {
+		entries = append(entries, strconv.Itoa(int(nsPID)))
+	}
+
+	return "Name:\tinstaller\nState:\tS (sleeping)\nNSpid:\t" + strings.Join(entries, "\t") + "\nNSpgid:\t1\n"
+}
+
+func TestResolve(t *testing.T) {
+	// the container init and two of its children, as seen by machined (4242...) and by
+	// the containerd running in the sandbox PID namespace (17...)
+	sandboxed := map[int32]string{
+		4242: status(4242, 16),
+		4243: status(4243, 17),
+		4244: status(4244, 18),
+	}
+
+	for _, test := range []struct {
+		name     string
+		procs    string
+		statuses map[int32]string
+		nsPID    uint32
+		expected int32
+	}{
+		{
+			name:     "sandboxed container init",
+			procs:    "4242\n4243\n4244\n",
+			statuses: sandboxed,
+			nsPID:    17,
+			expected: 4243,
+		},
+		{
+			name:     "single process in the cgroup",
+			procs:    "4243\n",
+			statuses: sandboxed,
+			nsPID:    17,
+			expected: 4243,
+		},
+		{
+			name:  "no PID namespace nesting",
+			procs: "4242\n4243\n",
+			statuses: map[int32]string{
+				4242: status(4242),
+				4243: status(4243),
+			},
+			nsPID:    4243,
+			expected: 4243,
+		},
+		{
+			name:     "process exited while scanning",
+			procs:    "4241\n4243\n",
+			statuses: sandboxed, // no status for 4241: it is gone, and skipped
+			nsPID:    17,
+			expected: 4243,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pid, err := fakeProcfs(t, test.procs, test.statuses).Resolve(cgroupPath, test.nsPID)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, pid)
+		})
+	}
+}
+
+func TestResolveGone(t *testing.T) {
+	statuses := map[int32]string{
+		4242: status(4242, 16),
+		4244: status(4244, 18),
+	}
+
+	for _, test := range []struct {
+		name     string
+		procs    string
+		statuses map[int32]string
+	}{
+		{
+			name:     "init exited, children linger",
+			procs:    "4242\n4244\n",
+			statuses: statuses,
+		},
+		{
+			name:     "whole cgroup exited",
+			procs:    "4242\n4243\n4244\n",
+			statuses: nil,
+		},
+		{
+			name:     "empty cgroup",
+			procs:    "",
+			statuses: statuses,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := fakeProcfs(t, test.procs, test.statuses).Resolve(cgroupPath, 17)
+
+			assert.ErrorIs(t, err, containerpid.ErrGone)
+		})
+	}
+}
+
+func TestResolveError(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		procs       string
+		statuses    map[int32]string
+		expectedErr string
+	}{
+		{
+			name:        "malformed cgroup.procs",
+			procs:       "4243\nnot-a-pid\n",
+			statuses:    map[int32]string{4243: status(4243, 16)},
+			expectedErr: `failed to parse PID "not-a-pid"`,
+		},
+		{
+			name:        "status without NSpid",
+			procs:       "4243\n",
+			statuses:    map[int32]string{4243: "Name:\tinstaller\nNSpgid:\t1\n"},
+			expectedErr: "no NSpid field found",
+		},
+		{
+			name:        "status with empty NSpid",
+			procs:       "4243\n",
+			statuses:    map[int32]string{4243: "Name:\tinstaller\nNSpid:\t\n"},
+			expectedErr: "NSpid field is empty",
+		},
+		{
+			name:        "status with malformed NSpid",
+			procs:       "4243\n",
+			statuses:    map[int32]string{4243: "Name:\tinstaller\nNSpid:\t4243\txyz\n"},
+			expectedErr: `failed to parse NSpid entry "xyz"`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := fakeProcfs(t, test.procs, test.statuses).Resolve(cgroupPath, 17)
+
+			assert.ErrorContains(t, err, test.expectedErr)
+			// a malformed procfs/cgroupfs is a real problem, not a process which raced away
+			assert.NotErrorIs(t, err, containerpid.ErrGone)
+		})
+	}
+}
+
+func TestResolveMissingCgroup(t *testing.T) {
+	resolver := fakeProcfs(t, "", nil)
+
+	_, err := resolver.Resolve("system/no-such-container", 17)
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.NotErrorIs(t, err, containerpid.ErrGone)
+}
+
+// TestResolveLive resolves the PID of the test process itself via the cgroup it runs in.
+func TestResolveLive(t *testing.T) {
+	selfCgroup, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Skip("no procfs available")
+	}
+
+	// cgroupv2 lists a single "0::<path>" entry
+	_, path, ok := strings.Cut(strings.TrimSpace(string(selfCgroup)), "0::")
+	if !ok {
+		t.Skip("not running under cgroupv2")
+	}
+
+	if _, err = os.Stat(filepath.Join("/sys/fs/cgroup", path, "cgroup.procs")); err != nil {
+		t.Skip("own cgroup is not readable under /sys/fs/cgroup")
+	}
+
+	// the test process is read from its own PID namespace, so its innermost PID is the
+	// one os.Getpid() reports
+	pid, err := containerpid.NewResolver().Resolve(path, uint32(os.Getpid()))
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(os.Getpid()), pid)
+}

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -318,6 +318,11 @@ type upgradeOptions struct {
 	// Use the legacy MachineService.Upgrade path instead.
 	UpgradeStage  bool
 	TargetVersion string
+	// Use in-memory containerd: in general we should prefer to use CRI containerd,
+	// but we should use in-memory for 'enforcing' mode due to SELinux restrictions.
+	//
+	// Ignored for legacy upgrade paths (before 1.13).
+	UpgradeUseInmemoryContainerd bool
 }
 
 //nolint:gocyclo,cyclop
@@ -366,8 +371,12 @@ func (suite *BaseSuite) tryUpgradeViaLifecycleService(
 	suite.T().Logf("pre-pulling installer image %q on node %s", options.TargetInstallerImage, node.IPs[0])
 
 	containerdInstance := &common.ContainerdInstance{
-		Driver:    common.ContainerDriver_CONTAINERD,
+		Driver:    common.ContainerDriver_CRI,
 		Namespace: common.ContainerdNamespace_NS_SYSTEM,
+	}
+
+	if options.UpgradeUseInmemoryContainerd {
+		containerdInstance.Driver = common.ContainerDriver_CONTAINERD
 	}
 
 	nodes := []string{node.IPs[0].String()}

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -45,6 +45,8 @@ type upgradeSpec struct {
 	ControlplaneNodes int
 	WorkerNodes       int
 
+	UpgradeUseInmemoryContainerd bool
+
 	// Deprecated: staged upgrades are not supported by the new LifecycleService API.
 	// Use the legacy MachineService.Upgrade path instead.
 	UpgradeStage            bool
@@ -58,15 +60,15 @@ type upgradeSpec struct {
 
 const (
 	// These versions should be kept in sync with Makefile variable RELEASES.
-	previousRelease = "v1.12.6"
-	stableRelease   = "v1.13.0" // or soon-to-be-stable
+	previousRelease = "v1.12.9"
+	stableRelease   = "v1.13.7" // or soon-to-be-stable
 	// The current version (the one being built on CI) is DefaultSettings.CurrentVersion.
 
 	// Command to find Kubernetes version for past releases:
 	//
 	//  git show ${TAG}:pkg/machinery/constants/constants.go | grep KubernetesVersion
-	previousK8sVersion = "1.35.2" // constants.DefaultKubernetesVersion in the previousRelease
-	stableK8sVersion   = "1.36.0" // constants.DefaultKubernetesVersion in the stableRelease
+	previousK8sVersion = "1.35.4" // constants.DefaultKubernetesVersion in the previousRelease
+	stableK8sVersion   = "1.36.2" // constants.DefaultKubernetesVersion in the stableRelease
 	currentK8sVersion  = constants.DefaultKubernetesVersion
 )
 
@@ -265,8 +267,9 @@ func upgradeCurrentToCurrentEnforcing() upgradeSpec {
 
 		TargetCmdlineContains: "enforcing=1",
 
-		WithApplyConfig: true,
-		WithEnforcing:   true,
+		WithApplyConfig:              true,
+		WithEnforcing:                true,
+		UpgradeUseInmemoryContainerd: true,
 	}
 }
 
@@ -400,9 +403,10 @@ func (suite *UpgradeSuite) TestRolling() {
 	}
 
 	options := upgradeOptions{
-		TargetInstallerImage: suite.spec.TargetInstallerImage,
-		UpgradeStage:         suite.spec.UpgradeStage,
-		TargetVersion:        suite.spec.TargetVersion,
+		TargetInstallerImage:         suite.spec.TargetInstallerImage,
+		UpgradeStage:                 suite.spec.UpgradeStage,
+		TargetVersion:                suite.spec.TargetVersion,
+		UpgradeUseInmemoryContainerd: suite.spec.UpgradeUseInmemoryContainerd,
 	}
 
 	// upgrade master nodes

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -866,6 +866,9 @@ const (
 	// CgroupExtensions is the cgroup name for system extension processes.
 	CgroupExtensions = CgroupSystem + "/extensions"
 
+	// CgroupInstaller is the cgroup name for the installer container (install/upgrade).
+	CgroupInstaller = CgroupSystem + "/installer"
+
 	// CgroupDashboard is the cgroup name for dashboard process.
 	CgroupDashboard = CgroupSystem + "/dashboard"
 

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -3472,7 +3472,7 @@ talosctl upgrade [flags]
   -h, --help                       help for upgrade
   -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-beta.1")
       --legacy                     force use of legacy upgrade method
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "inmem")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
       --no-reboot                  do not reboot the node after upgrade (skip reboot and drain)
   -n, --nodes strings              target the specified nodes
       --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")


### PR DESCRIPTION
When sandbodxd is enabled, CRI runs in its own PID namespace, so the PID returned by containerd API no longer matches the actual PID on the host.

The fix is to read via cgroups, which returns PIDs always from the point of view of the caller, so in our case machined, so this way the recorder PID resolves correctly, and machined allows unix socket connection from the installer.

Without this fix, the upgrades actually failed with default `talosctl upgrade` settings, which is to use CRI containerd.

In order to catch this bug, change upgrade tests to match `talosctl upgrade` behavior: use CRI containerd for upgrades.
