### PR TITLE
fix: use inmem containerd for installs/upgrades

### DIFF
--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -359,7 +359,7 @@ func init() {
 		fmt.Sprintf("%s:%s", images.InstallerImageRepository("metal"), version.Trim(version.Tag)),
 		"the container image to use for performing the install")
 	upgradeCmd.Flags().StringVar(
-		&upgradeCmdFlags.namespace, "namespace", "system",
+		&upgradeCmdFlags.namespace, "namespace", "inmem",
 		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance",
 	)
 	upgradeCmd.Flags().VarP(

--- a/website/content/v1.14/reference/cli.md
+++ b/website/content/v1.14/reference/cli.md
@@ -3472,7 +3472,7 @@ talosctl upgrade [flags]
   -h, --help                       help for upgrade
   -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-beta.0")
       --legacy                     force use of legacy upgrade method
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "inmem")
       --no-reboot                  do not reboot the node after upgrade (skip reboot and drain)
   -n, --nodes strings              target the specified nodes
       --progress string            output mode for upgrade progress. Values: [auto plain] (default "auto")


### PR DESCRIPTION
This matches pre-lifecycle behavior - use inmemory containerd.

Using CRI breaks due to #13919, and also there's a problem with SELinux rules.

This is a simplest fix to keep things compatible, and it matches the way upgrade tests do the upgrade.
