### PR TITLE
test: update airgapped patches

### DIFF
--- a/hack/test/patches/image-cache.yaml
+++ b/hack/test/patches/image-cache.yaml
@@ -8,21 +8,21 @@ kind: RegistryMirrorConfig
 name: '*'
 skipFallback: true
 endpoints:
-  - url: http://172.20.0.251:65000
+  - url: http://172.20.1.1:65000
 ---
 apiVersion: v1alpha1
 kind: RegistryMirrorConfig
 name: k8s.gcr.io
 skipFallback: true
 endpoints:
-  - url: http://172.20.0.251:65000
+  - url: http://172.20.1.1:65000
 ---
 apiVersion: v1alpha1
 kind: RegistryMirrorConfig
 name: registry.k8s.io
 skipFallback: true
 endpoints:
-  - url: http://172.20.0.251:65000
+  - url: http://172.20.1.1:65000
 ---
 apiVersion: v1alpha1
 kind: VolumeConfig


### PR DESCRIPTION
In the image-cache tests, we want a "dead" fallback mirror to ensure that all image pulls go via the image cache.

Fix the IP to point it to the bridge and a port which should be dead, which should give us quick "connection refused" instead of long(er) "i/o timeout" on unrelated IP.
