### PR TITLE
fix: a condition when unattended install status can flip to installed

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/unattended_install.go
+++ b/internal/app/machined/pkg/controllers/runtime/unattended_install.go
@@ -190,14 +190,17 @@ func (ctrl *UnattendedInstallController) reconcile(
 		if !state.IsNotFoundError(err) {
 			return fmt.Errorf("error getting unattended install status: %w", err)
 		}
-	} else if existing.TypedSpec().Phase == runtime.UnattendedInstallPhaseInstalled {
+	} else if phase := existing.TypedSpec().Phase; phase == runtime.UnattendedInstallPhaseInstalled || phase == runtime.UnattendedInstallPhaseWaitingForReboot {
 		// re-affirm the status (so CleanupOutputs retains it): the install target is fixed and a new
 		// disk later matching the selector must not trigger a reinstall.
-		return ctrl.setStatus(ctx, r, doc, runtime.UnattendedInstallPhaseInstalled, nil)
+		//
+		// the phase is preserved as is: `waiting-for-reboot` must never be downgraded to `installed`,
+		// as the phase gates APIs which shouldn't run in the pre-reboot window (e.g. bootstrap).
+		return ctrl.setStatus(ctx, r, doc, phase, nil)
 	}
 
 	if ctrl.InstalledFunc() {
-		return ctrl.setStatus(ctx, r, doc, runtime.UnattendedInstallPhaseInstalled, nil)
+		return ctrl.setStatus(ctx, r, doc, ctrl.installedPhase(doc), nil)
 	}
 
 	// resolve the target disk from the CEL selector against the discovered disks.
@@ -239,13 +242,7 @@ func (ctrl *UnattendedInstallController) reconcile(
 
 	// the installer already ran this boot: don't run it again, just keep the status as installed.
 	if ctrl.installDone {
-		installPhase := runtime.UnattendedInstallPhaseInstalled
-
-		if ctrl.shouldReboot(doc) {
-			installPhase = runtime.UnattendedInstallPhaseWaitingForReboot
-		}
-
-		return ctrl.setStatus(ctx, r, doc, installPhase, nil)
+		return ctrl.setStatus(ctx, r, doc, ctrl.installedPhase(doc), nil)
 	}
 
 	installerImage := doc.InstallerImage()
@@ -276,8 +273,6 @@ func (ctrl *UnattendedInstallController) reconcile(
 
 	logger.Info("install successful")
 
-	installPhase := runtime.UnattendedInstallPhaseInstalled
-
 	if ctrl.shouldReboot(doc) {
 		logger.Info("requesting reboot after successful install")
 
@@ -286,13 +281,24 @@ func (ctrl *UnattendedInstallController) reconcile(
 		}); err != nil {
 			return fmt.Errorf("failed to create reboot request: %w", err)
 		}
-
-		installPhase = runtime.UnattendedInstallPhaseWaitingForReboot
 	} else {
 		logger.Info("not rebooting after successful install (reboot disabled)")
 	}
 
-	return ctrl.setStatus(ctx, r, doc, installPhase, nil)
+	return ctrl.setStatus(ctx, r, doc, ctrl.installedPhase(doc), nil)
+}
+
+// installedPhase returns the phase to report once the install is complete for this boot.
+//
+// If the node is going to reboot after the install, the phase stays `waiting-for-reboot` until the
+// reboot actually happens: reporting `installed` would open up the APIs gated on this phase (e.g.
+// bootstrap) in the window before the reboot, and any such action would be lost on reboot.
+func (ctrl *UnattendedInstallController) installedPhase(doc talosconfig.UnattendedInstallConfig) runtime.UnattendedInstallPhase {
+	if ctrl.installDone && ctrl.shouldReboot(doc) {
+		return runtime.UnattendedInstallPhaseWaitingForReboot
+	}
+
+	return runtime.UnattendedInstallPhaseInstalled
 }
 
 func (ctrl *UnattendedInstallController) getInstallerFromBootEntry(ctx context.Context, r controller.Runtime) (string, error) {

--- a/internal/app/machined/pkg/controllers/runtime/unattended_install_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/unattended_install_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -198,6 +199,41 @@ func (suite *UnattendedInstallSuite) TestAlreadyInstalledNoDisk() {
 
 	suite.Assert().EqualValues(0, installCalls.Load())
 	rtestutils.AssertNoResource[*runtime.RebootRequest](suite.Ctx(), suite.T(), suite.State(), runtime.RebootRequestID)
+}
+
+// TestNoDowngradeToInstalled ensures the phase stays `waiting-for-reboot` once the install is done and
+// a reboot was requested, even though the node now reports itself as installed (the installer wrote META).
+//
+// The phase gates the bootstrap API: reporting `installed` in the pre-reboot window would allow a
+// bootstrap which is then silently lost on the reboot.
+func (suite *UnattendedInstallSuite) TestNoDowngradeToInstalled() {
+	var (
+		installed    atomic.Bool
+		installCalls atomic.Int64
+	)
+
+	suite.register(&installed, &installCalls)
+	suite.createConfig()
+	suite.createDisk("sda")
+
+	rtestutils.AssertResource[*runtime.UnattendedInstallStatus](suite.Ctx(), suite.T(), suite.State(), runtime.UnattendedInstallStatusID,
+		func(status *runtime.UnattendedInstallStatus, asrt *assert.Assertions) {
+			asrt.Equal(runtime.UnattendedInstallPhaseWaitingForReboot, status.TypedSpec().Phase)
+		})
+
+	// the installer wrote META, so the node now reports itself as installed, and the disk it partitioned
+	// triggers another reconcile before the reboot happens.
+	installed.Store(true)
+	suite.createDisk("sdb")
+
+	suite.Assert().Never(func() bool {
+		status, err := safe.StateGetByID[*runtime.UnattendedInstallStatus](suite.Ctx(), suite.State(), runtime.UnattendedInstallStatusID)
+		suite.Require().NoError(err)
+
+		return status.TypedSpec().Phase != runtime.UnattendedInstallPhaseWaitingForReboot
+	}, time.Second, 100*time.Millisecond)
+
+	suite.Assert().EqualValues(1, installCalls.Load())
 }
 
 // TestNoReinstallOnNewDisk ensures a new disk matching the selector after a completed install does not

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -157,7 +157,9 @@ func (r *Runtime) NodeName() (string, error) {
 
 // IsBootstrapAllowed checks whether bootstrap is allowed.
 //
-// CRI must be running and healthy, and an in-progress unattended install must not be in a pre-reboot phase.
+// CRI must be running and healthy, an in-progress unattended install must not be in a pre-reboot phase,
+// and no reboot should be pending: the bootstrap state is in-memory, so a bootstrap performed right
+// before a reboot would be silently lost.
 func (r *Runtime) IsBootstrapAllowed() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -186,6 +188,16 @@ func (r *Runtime) IsBootstrapAllowed() bool {
 	}
 
 	if status != nil && status.TypedSpec().Phase != runtimeres.UnattendedInstallPhaseInstalled {
+		return false
+	}
+
+	// the RebootRequest resource is only created once a reboot was requested, and it is never destroyed,
+	// so anything but "not found" (including a failed lookup) means bootstrap should not proceed.
+	if _, err = safe.ReaderGetByID[*runtimeres.RebootRequest](
+		ctx,
+		r.s.V1Alpha2().Resources(),
+		runtimeres.RebootRequestID,
+	); !state.IsNotFoundError(err) {
 		return false
 	}
 


### PR DESCRIPTION
This was observed in one of the CI runs:

* Talos boots, unattended install is triggered
* install finishes, and the status goes to 'WaitingForReboot'
* another resource change triggers a reconcile
* the status flips to 'Installed'
* this status allows bootstrap API to succeed, while the machine is actually rebooting
* the end result is that bootstrap is lost, and the cluster never bootstraps etcd, leading to test failure.
