### PR TITLE
fix: keep host dns enabled during bootstrap

### DIFF
--- a/internal/app/machined/pkg/controllers/network/hostdns_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config.go
@@ -92,13 +92,15 @@ func (ctrl *HostDNSConfigController) Run(ctx context.Context, r controller.Runti
 			res.TypedSpec().ListenAddresses = []netip.AddrPort{
 				netip.MustParseAddrPort("127.0.0.53:53"),
 			}
+			// Keep resolv.conf pointed at Host DNS during early bootstrap. The active
+			// machine configuration can disable it once it is loaded.
+			res.TypedSpec().Enabled = cfg == nil
+			res.TypedSpec().ResolveMemberNames = false
 
 			res.TypedSpec().ServiceHostDNSAddress = netip.Addr{}
 			res.TypedSpec().ServiceHostDNSAddressV6 = netip.Addr{}
 
 			if hostDNSConfig == nil {
-				res.TypedSpec().Enabled = false
-
 				return nil
 			}
 

--- a/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
@@ -31,6 +31,39 @@ type HostDNSConfigSuite struct {
 
 func (suite *HostDNSConfigSuite) TestNoConfig() {
 	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
+		asrt.True(r.TypedSpec().Enabled)
+		asrt.Equal(
+			[]netip.AddrPort{netip.MustParseAddrPort("127.0.0.53:53")},
+			r.TypedSpec().ListenAddresses,
+		)
+		asrt.Equal(netip.Addr{}, r.TypedSpec().ServiceHostDNSAddress)
+		asrt.False(r.TypedSpec().ResolveMemberNames)
+	})
+}
+
+func (suite *HostDNSConfigSuite) TestConfigDisabled() {
+	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
+		asrt.True(r.TypedSpec().Enabled)
+	})
+
+	cfg := config.NewMachineConfig(
+		container.NewV1Alpha1(
+			&v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineFeatures: &v1alpha1.FeaturesConfig{
+						HostDNSSupport: &v1alpha1.HostDNSConfig{ //nolint:staticcheck // testing legacy config
+							HostDNSConfigEnabled: new(false),
+						},
+					},
+				},
+			},
+		),
+	)
+
+	suite.Create(cfg)
+
+	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
 		asrt.False(r.TypedSpec().Enabled)
 		asrt.Equal(
 			[]netip.AddrPort{netip.MustParseAddrPort("127.0.0.53:53")},


### PR DESCRIPTION
Host DNS was disabled until the machine configuration arrived, causing resolv.conf to switch from public resolvers to the local resolver during network reconciliation. Go caches resolver configuration for five seconds, so the first installer pull kept using an unreachable resolver.

Enable Host DNS before configuration is available, then honor the active configuration once loaded. A local cluster reproduction when gateway dns arrives late confirmed the first installer lookup immediately used gateway DNS and there was no `/etc/resolv.conf` churn.