### PR TITLE
feat: add support for static VLAN configuration to the dashboard

### DIFF
--- a/internal/pkg/dashboard/formdata.go
+++ b/internal/pkg/dashboard/formdata.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -36,6 +37,7 @@ type NetworkConfigFormData struct {
 	DNSServers  string
 	TimeServers string
 	Iface       string
+	VLANID      string
 	Mode        string
 	Addresses   string
 	Gateway     string
@@ -107,12 +109,39 @@ func (formData *NetworkConfigFormData) ToPlatformNetworkConfig() (*runtime.Platf
 			},
 		}
 
+		// the physical link is always brought up, but if a VLAN ID is set, the L3 config (addresses, routes, DHCP)
+		// is bound to the logical VLAN link layered on top of it instead of the physical link itself
+		linkName := formData.Iface
+
+		if strings.TrimSpace(formData.VLANID) != "" {
+			vlanID, vlanErr := parseVLANID(formData.VLANID)
+			if vlanErr != nil {
+				errs = multierror.Append(errs, vlanErr)
+			} else {
+				linkName = nethelpers.VLANLinkName(formData.Iface, vlanID)
+
+				config.Links = append(config.Links, network.LinkSpecSpec{
+					Name:       linkName,
+					Logical:    true,
+					Up:         true,
+					Type:       nethelpers.LinkEther,
+					Kind:       network.LinkKindVLAN,
+					ParentName: formData.Iface,
+					VLAN: network.VLANSpec{
+						VID:      vlanID,
+						Protocol: nethelpers.VLANProtocol8021Q,
+					},
+					ConfigLayer: network.ConfigPlatform,
+				})
+			}
+		}
+
 		switch formData.Mode {
 		case ModeDHCP:
 			config.Operators = []network.OperatorSpecSpec{
 				{
 					Operator:  network.OperatorDHCP4,
-					LinkName:  formData.Iface,
+					LinkName:  linkName,
 					RequireUp: true,
 					DHCP4: network.DHCP4OperatorSpec{
 						RouteMetric: 1024,
@@ -121,7 +150,7 @@ func (formData *NetworkConfigFormData) ToPlatformNetworkConfig() (*runtime.Platf
 				},
 			}
 		case ModeStatic:
-			config.Addresses, err = formData.buildAddresses(formData.Iface)
+			config.Addresses, err = formData.buildAddresses(linkName)
 			if err != nil {
 				errs = multierror.Append(errs, err)
 			}
@@ -130,7 +159,7 @@ func (formData *NetworkConfigFormData) ToPlatformNetworkConfig() (*runtime.Platf
 				errs = multierror.Append(errs, errors.New("no addresses specified"))
 			}
 
-			config.Routes, err = formData.buildRoutes(formData.Iface)
+			config.Routes, err = formData.buildRoutes(linkName)
 			if err != nil {
 				errs = multierror.Append(errs, err)
 			}
@@ -229,6 +258,20 @@ func (formData *NetworkConfigFormData) buildRoutes(linkName string) ([]network.R
 			ConfigLayer: network.ConfigPlatform,
 		},
 	}, nil
+}
+
+// parseVLANID parses and range-checks a VLAN ID.
+func parseVLANID(text string) (uint16, error) {
+	vlanID, err := strconv.Atoi(strings.TrimSpace(text))
+	if err != nil {
+		return 0, fmt.Errorf("VLAN ID: %w", err)
+	}
+
+	if vlanID < 1 || vlanID > 4094 {
+		return 0, fmt.Errorf("VLAN ID must be in the range 1..4094, got %d", vlanID)
+	}
+
+	return uint16(vlanID), nil
 }
 
 func (formData *NetworkConfigFormData) splitInputList(text string) []string {

--- a/internal/pkg/dashboard/formdata_test.go
+++ b/internal/pkg/dashboard/formdata_test.go
@@ -175,6 +175,152 @@ func TestFilledFormModeDHCP(t *testing.T) {
 	}, *config)
 }
 
+func TestFilledFormModeDHCPVLAN(t *testing.T) {
+	formData := dashboard.NetworkConfigFormData{
+		Iface:  "eth0",
+		VLANID: "100",
+		Mode:   dashboard.ModeDHCP,
+	}
+
+	config, err := formData.ToPlatformNetworkConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, runtime.PlatformNetworkConfig{
+		Links: []network.LinkSpecSpec{
+			{
+				Name:        "eth0",
+				Logical:     false,
+				Up:          true,
+				Type:        nethelpers.LinkEther,
+				ConfigLayer: network.ConfigPlatform,
+			},
+			{
+				Name:       "eth0.100",
+				Logical:    true,
+				Up:         true,
+				Type:       nethelpers.LinkEther,
+				Kind:       network.LinkKindVLAN,
+				ParentName: "eth0",
+				VLAN: network.VLANSpec{
+					VID:      100,
+					Protocol: nethelpers.VLANProtocol8021Q,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			},
+		},
+		Operators: []network.OperatorSpecSpec{
+			{
+				Operator:  network.OperatorDHCP4,
+				LinkName:  "eth0.100",
+				RequireUp: true,
+				DHCP4: network.DHCP4OperatorSpec{
+					RouteMetric: 1024,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			},
+		},
+	}, *config)
+}
+
+func TestFilledFormModeStaticVLAN(t *testing.T) {
+	formData := dashboard.NetworkConfigFormData{
+		Iface:     "eth42",
+		VLANID:    " 4094 ",
+		Mode:      dashboard.ModeStatic,
+		Addresses: "1.2.3.4/24",
+		Gateway:   "3.4.5.6",
+	}
+
+	config, err := formData.ToPlatformNetworkConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, runtime.PlatformNetworkConfig{
+		Links: []network.LinkSpecSpec{
+			{
+				Name:        "eth42",
+				Logical:     false,
+				Up:          true,
+				Type:        nethelpers.LinkEther,
+				ConfigLayer: network.ConfigPlatform,
+			},
+			{
+				Name:       "eth42.4094",
+				Logical:    true,
+				Up:         true,
+				Type:       nethelpers.LinkEther,
+				Kind:       network.LinkKindVLAN,
+				ParentName: "eth42",
+				VLAN: network.VLANSpec{
+					VID:      4094,
+					Protocol: nethelpers.VLANProtocol8021Q,
+				},
+				ConfigLayer: network.ConfigPlatform,
+			},
+		},
+		Addresses: []network.AddressSpecSpec{
+			{
+				Address:     netip.MustParsePrefix("1.2.3.4/24"),
+				LinkName:    "eth42.4094",
+				Family:      nethelpers.FamilyInet4,
+				Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+				ConfigLayer: network.ConfigPlatform,
+			},
+		},
+		Routes: []network.RouteSpecSpec{
+			{
+				Family:      nethelpers.FamilyInet4,
+				Gateway:     netip.MustParseAddr("3.4.5.6"),
+				OutLinkName: "eth42.4094",
+				Table:       nethelpers.TableMain,
+				Scope:       nethelpers.ScopeGlobal,
+				Type:        nethelpers.TypeUnicast,
+				Protocol:    nethelpers.ProtocolStatic,
+				ConfigLayer: network.ConfigPlatform,
+			},
+		},
+	}, *config)
+}
+
+func TestFilledFormVLANIDInvalid(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		vlanID      string
+		expectedErr string
+	}{
+		{
+			name:        "not a number",
+			vlanID:      "foo",
+			expectedErr: "VLAN ID: strconv.Atoi",
+		},
+		{
+			name:        "zero",
+			vlanID:      "0",
+			expectedErr: "VLAN ID must be in the range 1..4094, got 0",
+		},
+		{
+			name:        "out of range",
+			vlanID:      "4095",
+			expectedErr: "VLAN ID must be in the range 1..4094, got 4095",
+		},
+		{
+			name:        "negative",
+			vlanID:      "-1",
+			expectedErr: "VLAN ID must be in the range 1..4094, got -1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			formData := dashboard.NetworkConfigFormData{
+				Iface:  "eth0",
+				VLANID: test.vlanID,
+				Mode:   dashboard.ModeDHCP,
+			}
+
+			_, err := formData.ToPlatformNetworkConfig()
+			assert.ErrorContains(t, err, test.expectedErr)
+		})
+	}
+}
+
 func TestFilledFormModeStaticNoAddresses(t *testing.T) {
 	formData := dashboard.NetworkConfigFormData{
 		Iface: "eth0",

--- a/internal/pkg/dashboard/networkconfig.go
+++ b/internal/pkg/dashboard/networkconfig.go
@@ -29,6 +29,7 @@ const (
 	formItemDNSServers  = "DNS Servers"
 	formItemTimeServers = "Time Servers"
 	formItemInterface   = "Interface"
+	formItemVLANID      = "VLAN ID"
 	formItemMode        = "Mode"
 	formItemAddresses   = "Addresses"
 	formItemGateway     = "Gateway"
@@ -52,6 +53,7 @@ type NetworkConfigGrid struct {
 	dnsServersField   *tview.InputField
 	timeServersField  *tview.InputField
 	interfaceDropdown *tview.DropDown
+	vlanIDField       *tview.InputField
 	modeDropdown      *tview.DropDown
 	addressesField    *tview.InputField
 	gatewayField      *tview.InputField
@@ -120,6 +122,9 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 		tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tview.Styles.PrimaryTextColor),
 	)
 
+	widget.vlanIDField = tview.NewInputField().SetLabel(formItemVLANID).SetAcceptanceFunc(tview.InputFieldInteger)
+	widget.vlanIDField.SetBlurFunc(widget.formEdited)
+
 	widget.modeDropdown = tview.NewDropDown().SetLabel(formItemMode)
 	widget.modeDropdown.SetBlurFunc(widget.formEdited)
 	widget.modeDropdown.SetOptions([]string{ModeDHCP, ModeStatic}, func(_ string, _ int) {
@@ -140,6 +145,7 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 	widget.configForm.AddFormItem(widget.dnsServersField)
 	widget.configForm.AddFormItem(widget.timeServersField)
 	widget.configForm.AddFormItem(widget.interfaceDropdown)
+	widget.configForm.AddFormItem(widget.vlanIDField)
 	widget.configForm.AddFormItem(widget.modeDropdown)
 	widget.configForm.AddFormItem(widget.addressesField)
 	widget.configForm.AddFormItem(widget.gatewayField)
@@ -213,6 +219,10 @@ func (widget *NetworkConfigGrid) formEdited() {
 
 	ifaceSelected := currentInterface != "" && currentInterface != interfaceNone
 	if ifaceSelected {
+		if itemIndex := widget.configForm.GetFormItemIndex(formItemVLANID); itemIndex == -1 {
+			widget.configForm.AddFormItem(widget.vlanIDField)
+		}
+
 		if itemIndex := widget.configForm.GetFormItemIndex(formItemMode); itemIndex == -1 {
 			widget.configForm.AddFormItem(widget.modeDropdown)
 		}
@@ -240,8 +250,13 @@ func (widget *NetworkConfigGrid) formEdited() {
 		}
 	} else {
 		resetDropdown(widget.modeDropdown)
+		resetInputField(widget.vlanIDField)
 		resetInputField(widget.addressesField)
 		resetInputField(widget.gatewayField)
+
+		if itemIndex := widget.configForm.GetFormItemIndex(formItemVLANID); itemIndex != -1 {
+			widget.configForm.RemoveFormItem(itemIndex)
+		}
 
 		if itemIndex := widget.configForm.GetFormItemIndex(formItemMode); itemIndex != -1 {
 			widget.configForm.RemoveFormItem(itemIndex)
@@ -264,6 +279,7 @@ func (widget *NetworkConfigGrid) formEdited() {
 		DNSServers:  widget.dnsServersField.GetText(),
 		TimeServers: widget.timeServersField.GetText(),
 		Iface:       currentInterface,
+		VLANID:      widget.vlanIDField.GetText(),
 		Mode:        currentMode,
 		Addresses:   widget.addressesField.GetText(),
 		Gateway:     widget.gatewayField.GetText(),
@@ -322,6 +338,7 @@ func (widget *NetworkConfigGrid) clearForm() {
 	widget.dnsServersField.SetText("")
 	widget.timeServersField.SetText("")
 	widget.interfaceDropdown.SetCurrentOption(0)
+	widget.vlanIDField.SetText("")
 	widget.modeDropdown.SetCurrentOption(0)
 	widget.addressesField.SetText("")
 	widget.gatewayField.SetText("")


### PR DESCRIPTION
Fixes #13904

Now dashboard can configure the static VLAN, it can be used to bootstrap the network config enough to allow external Talos API communication for environments where untagged interface doesn't provide any networking.
