### PR TITLE
fix: ignore HostDNS IPv6 address in node addresses

### DIFF
--- a/internal/app/machined/pkg/controllers/network/node_address.go
+++ b/internal/app/machined/pkg/controllers/network/node_address.go
@@ -136,7 +136,7 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 
 			ip := addr.TypedSpec().Address
 
-			if ip.Addr().IsLoopback() || ip.Addr().IsMulticast() || ip.Addr().IsLinkLocalUnicast() {
+			if ip.Addr().IsLoopback() || ip.Addr().IsMulticast() || ip.Addr().IsLinkLocalUnicast() || ip.Addr() == hostDNSIPv6 {
 				return false
 			}
 

--- a/internal/app/machined/pkg/controllers/network/node_address_test.go
+++ b/internal/app/machined/pkg/controllers/network/node_address_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network/internal/addressutil"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
@@ -128,6 +129,7 @@ func (suite *NodeAddressSuite) TestFilters() {
 		"2001:470:6d:30e:4a62:b3ba:180b:b5b8/64",
 		"127.0.0.1/8",
 		"fdae:41e4:649b:9303:7886:731d:1ce9:4d4/128",
+		constants.HostDNSAddressV6 + "/128",
 	} {
 		suite.newAddress(netip.MustParsePrefix(addr), linkUp)
 	}


### PR DESCRIPTION
This address is not LLA but ULA to make it reachable by CoreDNS pods.

However, it is not a proper node address, and so must not be used for k8s endpoint or similar purposes.

This commit fixes failures to reach Kubernetes service from pods due to endpoints containing HostDNS address instead of a routable one.

Fixes: #13274