### PR TITLE
fix: ignore unmanaged address flags in AddressSpecController

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_merge.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge.go
@@ -33,7 +33,21 @@ func NewAddressMergeController() controller.Controller {
 					continue
 				}
 
-				addresses[id] = address.TypedSpec()
+				spec := *address.TypedSpec()
+
+				// drop the flags which are managed by the kernel, as Talos can't set or enforce them
+				if unmanaged := spec.Flags.Unmanaged(); unmanaged != 0 {
+					logger.Warn(
+						"dropping kernel-managed address flags",
+						zap.String("address", id),
+						zap.Stringer("layer", spec.ConfigLayer),
+						zap.Stringer("flags", unmanaged),
+					)
+
+					spec.Flags = spec.Flags.Managed()
+				}
+
+				addresses[id] = &spec
 			}
 
 			return addresses

--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -101,6 +101,29 @@ func (suite *AddressMergeSuite) TestMerge() {
 	suite.assertNoAddress("eth0/10.0.0.35/32")
 }
 
+func (suite *AddressMergeSuite) TestMergeKernelManagedFlags() {
+	// kernel-managed flags should never make it into the final address spec
+	static := network.NewAddressSpec(network.ConfigNamespaceName, "configuration/eth0/10.0.0.35/32")
+	*static.TypedSpec() = network.AddressSpecSpec{
+		Address:     netip.MustParsePrefix("10.0.0.35/32"),
+		LinkName:    "eth0",
+		Family:      nethelpers.FamilyInet4,
+		Scope:       nethelpers.ScopeGlobal,
+		Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent | nethelpers.AddressTemporary | nethelpers.AddressTentative | nethelpers.AddressDADFailed),
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+
+	suite.Create(static)
+
+	suite.assertAddresses(
+		[]string{
+			"eth0/10.0.0.35/32",
+		}, func(r *network.AddressSpec, asrt *assert.Assertions) {
+			asrt.Equal(nethelpers.AddressFlags(nethelpers.AddressPermanent), r.TypedSpec().Flags)
+		},
+	)
+}
+
 func (suite *AddressMergeSuite) TestMergeFlapping() {
 	// simulate two conflicting address definitions which are getting removed/added constantly
 	dhcp := network.NewAddressSpec(network.ConfigNamespaceName, "dhcp/eth0/10.0.0.1/8")

--- a/internal/app/machined/pkg/controllers/network/address_spec.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec.go
@@ -165,6 +165,14 @@ func findAddress(addrs []rtnetlink.AddressMessage, linkIndex uint32, ipPrefix ne
 	return nil
 }
 
+// addressFlags returns the flags of the address as reported by the kernel.
+//
+// The kernel reports the flags twice: truncated to 8 bits in the message header, and in full
+// in the IFA_FLAGS attribute (which might be missing on old kernels).
+func addressFlags(addr *rtnetlink.AddressMessage) nethelpers.AddressFlags {
+	return nethelpers.AddressFlags(addr.Attributes.Flags) | nethelpers.AddressFlags(addr.Flags)
+}
+
 //nolint:gocyclo
 func (ctrl *AddressSpecController) syncAddress(ctx context.Context, r controller.Runtime, logger *zap.Logger, conn *rtnetlink.Conn,
 	links []rtnetlink.LinkMessage, addrs []rtnetlink.AddressMessage, address *network.AddressSpec,
@@ -201,14 +209,17 @@ func (ctrl *AddressSpecController) syncAddress(ctx context.Context, r controller
 			return nil
 		}
 
+		expectedFlags := address.TypedSpec().Flags.Managed()
+
 		if existing := findAddress(addrs, linkIndex, address.TypedSpec().Address); existing != nil {
-			// clear out tentative flag, it is set by the kernel, we shouldn't try to enforce it
-			existing.Flags &= ^uint8(nethelpers.AddressTentative)
-			existing.Attributes.Flags &= ^uint32(nethelpers.AddressTentative)
+			// compare only the flags managed by Talos: the rest of the flags are set and cleared by the kernel
+			// on its own (e.g. IFA_F_SECONDARY for the IPv4 addresses sharing the subnet, or IFA_F_TENTATIVE
+			// while IPv6 DAD is in progress), so enforcing them would delete and re-create the address in a loop
+			existingFlags := addressFlags(existing).Managed()
 
 			// check if existing matches the spec: if it does, skip update
-			if existing.Scope == uint8(address.TypedSpec().Scope) && existing.Flags == uint8(address.TypedSpec().Flags) &&
-				existing.Attributes.Flags == uint32(address.TypedSpec().Flags) && existing.Attributes.Priority == address.TypedSpec().Priority {
+			if existing.Scope == uint8(address.TypedSpec().Scope) && existingFlags == expectedFlags &&
+				existing.Attributes.Priority == address.TypedSpec().Priority {
 				return nil
 			}
 
@@ -218,8 +229,8 @@ func (ctrl *AddressSpecController) syncAddress(ctx context.Context, r controller
 				zap.String("link", address.TypedSpec().LinkName),
 				zap.Stringer("old_scope", nethelpers.Scope(existing.Scope)),
 				zap.Stringer("new_scope", address.TypedSpec().Scope),
-				zap.Stringer("old_flags", nethelpers.AddressFlags(existing.Attributes.Flags)),
-				zap.Stringer("new_flags", address.TypedSpec().Flags),
+				zap.Stringer("old_flags", existingFlags),
+				zap.Stringer("new_flags", expectedFlags),
 				zap.Uint32("old_priority", existing.Attributes.Priority),
 				zap.Uint32("new_priority", address.TypedSpec().Priority),
 			)
@@ -236,14 +247,14 @@ func (ctrl *AddressSpecController) syncAddress(ctx context.Context, r controller
 		if err := conn.Address.New(&rtnetlink.AddressMessage{
 			Family:       uint8(address.TypedSpec().Family),
 			PrefixLength: uint8(address.TypedSpec().Address.Bits()),
-			Flags:        uint8(address.TypedSpec().Flags),
+			Flags:        uint8(expectedFlags),
 			Scope:        uint8(address.TypedSpec().Scope),
 			Index:        linkIndex,
 			Attributes: &rtnetlink.AddressAttributes{
 				Address:   address.TypedSpec().Address.Addr().AsSlice(),
 				Local:     address.TypedSpec().Address.Addr().AsSlice(),
 				Broadcast: addressutil.BroadcastAddr(address.TypedSpec().Address),
-				Flags:     uint32(address.TypedSpec().Flags),
+				Flags:     uint32(expectedFlags),
 				Priority:  address.TypedSpec().Priority,
 			},
 		}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/address_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sys/unix"
@@ -37,39 +38,19 @@ func (suite *AddressSpecSuite) uniqueDummyInterface() string {
 }
 
 func assertLinkAddress(asrt *assert.Assertions, linkName, address string) {
-	addr := netip.MustParsePrefix(address)
-
-	iface, err := net.InterfaceByName(linkName)
-	asrt.NoError(err)
-
-	conn, err := rtnetlink.Dial(nil)
-	asrt.NoError(err)
-
-	defer conn.Close() //nolint:errcheck
-
-	linkAddresses, err := conn.Address.List()
-	asrt.NoError(err)
-
-	for _, linkAddress := range linkAddresses {
-		if linkAddress.Index != uint32(iface.Index) {
-			continue
-		}
-
-		if int(linkAddress.PrefixLength) != addr.Bits() {
-			continue
-		}
-
-		if !linkAddress.Attributes.Address.Equal(addr.Addr().AsSlice()) {
-			continue
-		}
-
-		return
+	if findLinkAddress(asrt, linkName, address) == nil {
+		asrt.Failf("address not found", "address %s not found on %q", address, linkName)
 	}
-
-	asrt.Failf("address not found", "address %s not found on %q", addr, linkName)
 }
 
 func assertNoLinkAddress(asrt *assert.Assertions, linkName, address string) {
+	if findLinkAddress(asrt, linkName, address) != nil {
+		asrt.Failf("address is still there", "address %s is assigned to %q", address, linkName)
+	}
+}
+
+// findLinkAddress returns the address as assigned to the link, or nil if it is not assigned.
+func findLinkAddress(asrt *assert.Assertions, linkName, address string) *rtnetlink.AddressMessage {
 	addr := netip.MustParsePrefix(address)
 
 	iface, err := net.InterfaceByName(linkName)
@@ -85,9 +66,11 @@ func assertNoLinkAddress(asrt *assert.Assertions, linkName, address string) {
 
 	for _, linkAddress := range linkAddresses {
 		if linkAddress.Index == uint32(iface.Index) && int(linkAddress.PrefixLength) == addr.Bits() && linkAddress.Attributes.Address.Equal(addr.Addr().AsSlice()) {
-			asrt.Failf("address is still there", "address %s is assigned to %q", addr, linkName)
+			return &linkAddress
 		}
 	}
+
+	return nil
 }
 
 func (suite *AddressSpecSuite) TestLoopback() {
@@ -217,6 +200,94 @@ func (suite *AddressSpecSuite) TestDummy() {
 	suite.Require().NoError(err)
 
 	suite.Destroy(dummy)
+}
+
+// TestDummySecondary verifies that the addresses sharing the subnet are not being re-created in a loop:
+// the kernel marks all but the first IPv4 address in the subnet as IFA_F_SECONDARY, and Talos should not
+// try to enforce the flags it doesn't manage.
+func (suite *AddressSpecSuite) TestDummySecondary() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(
+		conn.Link.New(
+			&rtnetlink.LinkMessage{
+				Type: unix.ARPHRD_ETHER,
+				Attributes: &rtnetlink.LinkAttributes{
+					Name: dummyInterface,
+					MTU:  1400,
+					Info: &rtnetlink.LinkInfo{
+						Kind: "dummy",
+					},
+				},
+			},
+		),
+	)
+
+	iface, err := net.InterfaceByName(dummyInterface)
+	suite.Require().NoError(err)
+
+	defer conn.Link.Delete(uint32(iface.Index)) //nolint:errcheck
+
+	addresses := []string{"10.99.0.1/24", "10.99.0.2/24"}
+
+	specs := xslices.Map(addresses, func(address string) *network.AddressSpec {
+		spec := network.NewAddressSpec(network.NamespaceName, dummyInterface+"/"+address)
+		*spec.TypedSpec() = network.AddressSpecSpec{
+			Address:     netip.MustParsePrefix(address),
+			LinkName:    dummyInterface,
+			Family:      nethelpers.FamilyInet4,
+			Scope:       nethelpers.ScopeGlobal,
+			ConfigLayer: network.ConfigDefault,
+			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+		}
+
+		suite.Create(spec)
+
+		return spec
+	})
+
+	suite.Assert().EventuallyWithT(func(collect *assert.CollectT) {
+		for _, address := range addresses {
+			assertLinkAddress(assert.New(collect), dummyInterface, address)
+		}
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// the kernel should have marked the second address as secondary
+	secondary := findLinkAddress(suite.Assert(), dummyInterface, addresses[1])
+	suite.Require().NotNil(secondary)
+	suite.Assert().NotZero(secondary.Attributes.Flags & uint32(nethelpers.AddressTemporary))
+
+	// remember the creation timestamps of the addresses, they should not change as the addresses
+	// should not be re-created
+	created := xslices.Map(addresses, func(address string) uint32 {
+		addr := findLinkAddress(suite.Assert(), dummyInterface, address)
+		suite.Require().NotNil(addr)
+
+		return addr.Attributes.CacheInfo.Created
+	})
+
+	// force the controller to reconcile the addresses a couple of times
+	for range 3 {
+		for _, spec := range specs {
+			res, err := suite.State().Get(suite.Ctx(), spec.Metadata())
+			suite.Require().NoError(err)
+
+			suite.Update(res)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	for i, address := range addresses {
+		addr := findLinkAddress(suite.Assert(), dummyInterface, address)
+		suite.Require().NotNil(addr)
+		suite.Assert().Equalf(created[i], addr.Attributes.CacheInfo.Created, "address %s was re-created", address)
+	}
 }
 
 func (suite *AddressSpecSuite) TestDummyAlias() {

--- a/pkg/machinery/nethelpers/address_flags.go
+++ b/pkg/machinery/nethelpers/address_flags.go
@@ -23,6 +23,20 @@ func (flags AddressFlags) String() string {
 	return strings.Join(values, ",")
 }
 
+// Managed masks out the address flags which are managed by Talos.
+//
+// See [AddressFlagsManaged].
+func (flags AddressFlags) Managed() AddressFlags {
+	return flags & AddressFlagsManaged
+}
+
+// Unmanaged returns the address flags which are managed by the kernel.
+//
+// See [AddressFlagsManaged].
+func (flags AddressFlags) Unmanaged() AddressFlags {
+	return flags &^ AddressFlagsManaged
+}
+
 // AddressFlagsString converts string representation of flags into AddressFlags.
 func AddressFlagsString(s string) (AddressFlags, error) {
 	flags := AddressFlags(0)
@@ -72,4 +86,27 @@ const (
 	AddressNoPrefixRoute                          // noprefixroute
 	AddressMCAutoJoin                             // mcautojoin
 	AddressStablePrivacy                          // stableprivacy
+)
+
+// AddressFlagsManaged is a bitmask of the address flags which are managed (i.e. can be set and enforced) by Talos.
+//
+// All other flags are managed by the kernel: they are reported as part of the address status, but they
+// should never appear in an address spec, and they should be ignored when the desired state of an address is
+// compared with the actual state, as the kernel sets and clears them on its own:
+//
+//   - AddressTemporary (IFA_F_SECONDARY) is set by the kernel for any IPv4 address which shares the subnet with
+//     an address already assigned to the link (and for the temporary IPv6 addresses)
+//   - AddressTentative and AddressOptimistic are set while IPv6 DAD is in progress, and cleared once it completes
+//   - AddressDADFailed is set when IPv6 DAD fails
+//   - AddressDeprecated and AddressStablePrivacy are set by the kernel for the addresses it manages itself (SLAAC)
+//
+// AddressPermanent is kept in the managed set: the kernel derives it from the address lifetime, and Talos always
+// assigns addresses without a lifetime, so the flag is stable for the addresses Talos manages.
+const AddressFlagsManaged = AddressFlags(
+	AddressPermanent |
+		AddressNoDAD |
+		AddressHome |
+		AddressManagementTemp |
+		AddressNoPrefixRoute |
+		AddressMCAutoJoin,
 )

--- a/pkg/machinery/nethelpers/address_flags_test.go
+++ b/pkg/machinery/nethelpers/address_flags_test.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nethelpers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+)
+
+func TestAddressFlagsManaged(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		flags nethelpers.AddressFlags
+
+		expectedManaged   nethelpers.AddressFlags
+		expectedUnmanaged nethelpers.AddressFlags
+	}{
+		{
+			name:  "empty",
+			flags: 0,
+		},
+		{
+			name:  "permanent",
+			flags: nethelpers.AddressFlags(nethelpers.AddressPermanent),
+
+			expectedManaged: nethelpers.AddressFlags(nethelpers.AddressPermanent),
+		},
+		{
+			name:  "secondary IPv4 address",
+			flags: nethelpers.AddressFlags(nethelpers.AddressPermanent | nethelpers.AddressTemporary),
+
+			expectedManaged:   nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			expectedUnmanaged: nethelpers.AddressFlags(nethelpers.AddressTemporary),
+		},
+		{
+			name:  "IPv6 address in DAD",
+			flags: nethelpers.AddressFlags(nethelpers.AddressPermanent | nethelpers.AddressTentative | nethelpers.AddressOptimistic),
+
+			expectedManaged:   nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			expectedUnmanaged: nethelpers.AddressFlags(nethelpers.AddressTentative | nethelpers.AddressOptimistic),
+		},
+		{
+			name:  "SLAAC address",
+			flags: nethelpers.AddressFlags(nethelpers.AddressManagementTemp | nethelpers.AddressStablePrivacy | nethelpers.AddressDeprecated),
+
+			expectedManaged:   nethelpers.AddressFlags(nethelpers.AddressManagementTemp),
+			expectedUnmanaged: nethelpers.AddressFlags(nethelpers.AddressStablePrivacy | nethelpers.AddressDeprecated),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expectedManaged, test.flags.Managed())
+			assert.Equal(t, test.expectedUnmanaged, test.flags.Unmanaged())
+			assert.Equal(t, test.flags, test.flags.Managed()|test.flags.Unmanaged())
+		})
+	}
+}


### PR DESCRIPTION
Some flags on the address are set by the Linux kernel, and not managed by Talos at all. Due to the reconciliation logic of the controller, a flag set by the kernel caused the controller attempt to clear it by removing and re-adding the address, which is not acceptable.

Fix that by splitting the flags into managed/unmanaged parts, and ignoring the unmanaged part completely on reconcile.

Also gate that unmanaged flags can't enter the address spec generated by any Talos internals.

Fixes #13932
