### PR TITLE
fix: panic when KubeProxy is disabled without image override

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -413,8 +413,6 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					}
 				}
 
-				images := images.List(cfgProvider)
-
 				var (
 					server                                         string
 					flannelKubeServiceHost, flannelKubeServicePort string
@@ -457,7 +455,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 
 				if k8sFlannelCNIConfig := cfgProvider.K8sFlannelCNIConfig(); k8sFlannelCNIConfig != nil {
 					res.TypedSpec().FlannelEnabled = true
-					res.TypedSpec().FlannelImage = images.Flannel.String()
+					res.TypedSpec().FlannelImage = images.Flannel().String()
 					res.TypedSpec().FlannelBackendType = k8sFlannelCNIConfig.BackendType()
 					res.TypedSpec().FlannelBackendPort = k8sFlannelCNIConfig.BackendPort().ValueOrZero()
 
@@ -477,7 +475,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					res.TypedSpec().FlannelKubeServiceHost = flannelKubeServiceHost
 					res.TypedSpec().FlannelKubeServicePort = flannelKubeServicePort
 					res.TypedSpec().FlannelKubeNetworkPoliciesEnabled = k8sFlannelCNIConfig.KubeNetworkPoliciesEnabled()
-					res.TypedSpec().FlannelKubeNetworkPoliciesImage = images.KubeNetworkPolicies.String()
+					res.TypedSpec().FlannelKubeNetworkPoliciesImage = images.KubeNetworkPolicies().String()
 					res.TypedSpec().CNIName = constants.FlannelCNI
 				} else {
 					res.TypedSpec().FlannelEnabled = false

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_test.go
@@ -896,6 +896,62 @@ func (suite *K8sControlPlaneSuite) TestReconcileKubeProxyMode() {
 	)
 }
 
+// TestReconcileKubeProxyDisabled verifies that a KubeProxyConfig document with kube-proxy disabled
+// (and, as validation allows in that case, no image set) is handled without a panic.
+func (suite *K8sControlPlaneSuite) TestReconcileKubeProxyDisabled() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	clusterCfg := k8scfg.NewKubeClusterConfigV1Alpha1()
+	clusterCfg.ClusterNameConfig = "test"
+	clusterCfg.ClusterEndpointConfig = meta.URL{URL: u}
+
+	networkCfg := k8scfg.NewKubeNetworkConfigV1Alpha1()
+	networkCfg.NetworkPodSubnets = []meta.Prefix{
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4PodCIDR)},
+	}
+	networkCfg.NetworkServiceSubnets = []meta.Prefix{
+		{Prefix: netip.MustParsePrefix(constants.DefaultIPv4ServiceCIDR)},
+	}
+
+	// kube-proxy is disabled, so no image is set: this is a valid config,
+	// see TestKubeProxyConfigValidate/disabled
+	proxyCfg := k8scfg.NewKubeProxyConfigV1Alpha1()
+	proxyCfg.ProxyEnabled = new(false)
+
+	ctr, err := container.New(
+		&v1alpha1.Config{
+			ConfigVersion: "v1alpha1",
+			MachineConfig: &v1alpha1.MachineConfig{
+				MachineType: "controlplane",
+			},
+			ClusterConfig: &v1alpha1.ClusterConfig{},
+		},
+		clusterCfg,
+		networkCfg,
+		proxyCfg,
+		k8scfg.NewKubeFlannelCNIConfigV1Alpha1(),
+	)
+	suite.Require().NoError(err)
+
+	suite.setupMachine(config.NewMachineConfig(ctr))
+
+	rtestutils.AssertResources(
+		suite.Ctx(), suite.T(), suite.State(), []resource.ID{k8s.BootstrapManifestsConfigID},
+		func(cfg *k8s.BootstrapManifestsConfig, assert *assert.Assertions) {
+			assert.False(cfg.TypedSpec().ProxyEnabled)
+			assert.Empty(cfg.TypedSpec().ProxyImage)
+
+			// non-configurable images are always rendered
+			assert.Equal("ghcr.io/siderolabs/flannel:"+constants.FlannelVersion, cfg.TypedSpec().FlannelImage)
+			assert.Equal(
+				"registry.k8s.io/networking/kube-network-policies:"+constants.KubeNetworkPoliciesVersion,
+				cfg.TypedSpec().FlannelKubeNetworkPoliciesImage,
+			)
+		},
+	)
+}
+
 func TestK8sControlPlaneSuite(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -35,17 +35,34 @@ type Versions struct {
 // The integration test verifies that our constant is accurate.
 const DefaultSandboxImage = "registry.k8s.io/pause:3.10.2"
 
+// Flannel returns the Flannel image built into Talos, mirrored from docker.io/flannel/flannel.
+//
+// It is not configurable, so it never depends on the machine configuration.
+func Flannel() name.Tag {
+	return mustParseTag(fmt.Sprintf("ghcr.io/siderolabs/flannel:%s", constants.FlannelVersion))
+}
+
+// KubeNetworkPolicies returns the kube-network-policies image built into Talos.
+//
+// It is not configurable, so it never depends on the machine configuration.
+func KubeNetworkPolicies() name.Tag {
+	return mustParseTag(fmt.Sprintf("registry.k8s.io/networking/kube-network-policies:%s", constants.KubeNetworkPoliciesVersion))
+}
+
 // List returns default image versions.
+//
+// It panics on any image which is empty in the config, so it should only be used with
+// a config which is known to have all images set (e.g. a synthetic one built in talosctl).
 func List(config config.Config) Versions {
 	var images Versions
 
 	images.Etcd = mustParseTag(config.Cluster().Etcd().Image())
 	images.CoreDNS = mustParseTag(config.K8sCoreDNSConfig().Image())
-	images.Flannel = mustParseTag(fmt.Sprintf("ghcr.io/siderolabs/flannel:%s", constants.FlannelVersion)) // mirrored from docker.io/flannel/flannel
+	images.Flannel = Flannel()
 	images.Kubelet = mustParseTag(config.K8sKubeletConfig().Image())
 	images.KubeAPIServer = mustParseTag(config.K8sAPIServerConfig().Image())
 	images.KubeControllerManager = mustParseTag(config.K8sControllerManagerConfig().Image())
-	images.KubeNetworkPolicies = mustParseTag(fmt.Sprintf("registry.k8s.io/networking/kube-network-policies:%s", constants.KubeNetworkPoliciesVersion))
+	images.KubeNetworkPolicies = KubeNetworkPolicies()
 	images.KubeProxy = mustParseTag(config.K8sProxyConfig().Image())
 	images.KubeScheduler = mustParseTag(config.K8sSchedulerConfig().Image())
 


### PR DESCRIPTION
We can observe a controller panic when KubeProxy is disabled in new config,
and there is no image override set.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
