### PR TITLE
fix: image pull via the API should not have timeout or retries

### DIFF
--- a/internal/app/images/images.go
+++ b/internal/app/images/images.go
@@ -17,6 +17,8 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zapio"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -94,6 +96,9 @@ func (svc *Service) Pull(req *machine.ImageServicePullRequest, srv grpc.ServerSt
 	//nolint:errcheck
 	defer client.Close()
 
+	logWriter := &zapio.Writer{Log: svc.logger, Level: zapcore.DebugLevel}
+	defer logWriter.Close() //nolint:errcheck
+
 	img, err := image.Pull(
 		ctx,
 		cri.RegistryBuilder(svc.controller.Runtime().State().V1Alpha2().Resources()),
@@ -101,7 +106,7 @@ func (svc *Service) Pull(req *machine.ImageServicePullRequest, srv grpc.ServerSt
 		client,
 		req.GetImageRef(),
 		image.WithSkipIfAlreadyPulled(),
-		image.WithMaxNotFoundRetries(0), // return an error immediately if the image is not found
+		image.WithLogWriter(logWriter),
 		image.WithProgressReporter(image.NewSimpleProgressReporter(func(lpp progress.LayerPullProgress) {
 			srv.Send(&machine.ImageServicePullResponse{ //nolint:errcheck
 				Response: &machine.ImageServicePullResponse_PullProgress{

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
@@ -102,7 +102,6 @@ func (s *Server) ImagePull(ctx context.Context, req *machine.ImagePullRequest) (
 		s.Controller.Runtime().State().V1Alpha2().Resources(),
 		client, req.Reference,
 		image.WithSkipIfAlreadyPulled(),
-		image.WithMaxNotFoundRetries(0), // return an error immediately if the image is not found
 	)
 	if err != nil {
 		if errdefs.IsNotFound(err) {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -104,7 +104,7 @@ func (e *Etcd) PreFunc(ctx context.Context, r runtime.Runtime) error {
 		return fmt.Errorf("failed to get etcd spec: %w", err)
 	}
 
-	img, err := image.Pull(
+	img, err := image.PullWithRetriesAndTimeout(
 		containerdctx,
 		cri.RegistryBuilder(r.State().V1Alpha2().Resources()),
 		r.State().V1Alpha2().Resources(),

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -72,7 +72,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, r runtime.Runtime) error {
 	// Pull the image and unpack it.
 	containerdctx := namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
 
-	img, err := image.Pull(
+	img, err := image.PullWithRetriesAndTimeout(
 		containerdctx,
 		cri.RegistryBuilder(r.State().V1Alpha2().Resources()),
 		r.State().V1Alpha2().Resources(),

--- a/internal/pkg/containers/image/aliases.go
+++ b/internal/pkg/containers/image/aliases.go
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import (
+	"context"
+	"maps"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/errdefs"
+	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func manageAliases(ctx context.Context, client *containerd.Client, namedRef reference.Named, img containerd.Image) error {
+	// re-tag pulled image
+	imageDigest := img.Target().Digest.String()
+
+	refs := []string{imageDigest}
+
+	if _, ok := namedRef.(reference.NamedTagged); ok {
+		refs = append(refs, namedRef.String())
+	}
+
+	if _, ok := namedRef.(reference.Canonical); ok {
+		refs = append(refs, namedRef.String())
+	} else {
+		refs = append(refs, namedRef.Name()+"@"+imageDigest)
+	}
+
+	for _, newRef := range refs {
+		if err := createAlias(ctx, client, newRef, img.Target(), img.Labels()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createAlias(ctx context.Context, client *containerd.Client, name string, desc ocispec.Descriptor, labels map[string]string) error {
+	img := images.Image{
+		Name:   name,
+		Target: desc,
+		Labels: labels,
+	}
+
+	oldImg, err := client.ImageService().Create(ctx, img)
+	if err == nil || !errdefs.IsAlreadyExists(err) {
+		return err
+	}
+
+	if oldImg.Target.Digest == img.Target.Digest && maps.Equal(oldImg.Labels, img.Labels) {
+		return nil
+	}
+
+	_, err = client.ImageService().Update(ctx, img, "target", "labels")
+
+	return err
+}

--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -6,29 +6,10 @@ package image
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	stdlog "log"
-	"maps"
+	"io"
+	"log"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/snapshotters"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/distribution/reference"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/siderolabs/go-retry/retry"
-	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/siderolabs/talos/internal/pkg/containers/image/progress"
-	"github.com/siderolabs/talos/internal/pkg/containers/image/verify"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cri"
 )
 
@@ -46,6 +27,7 @@ type PullOptions struct {
 	SkipIfAlreadyPulled bool
 	MaxNotFoundRetries  int
 	NewProgressReporter NewProgressReporter
+	LogWriter           io.Writer
 }
 
 // DefaultPullOptions returns default options for Pull function.
@@ -53,6 +35,7 @@ func DefaultPullOptions() PullOptions {
 	return PullOptions{
 		SkipIfAlreadyPulled: false,
 		MaxNotFoundRetries:  5,
+		LogWriter:           log.Writer(),
 	}
 }
 
@@ -64,6 +47,9 @@ func WithSkipIfAlreadyPulled() PullOption {
 }
 
 // WithMaxNotFoundRetries sets the maximum number of retries for not found errors.
+//
+// This option is only honored in the PullWithRetriesAndTimeout function,
+// the Pull function will ignore this option and will not retry on not found errors.
 func WithMaxNotFoundRetries(maxRetries int) PullOption {
 	return func(opts *PullOptions) {
 		opts.MaxNotFoundRetries = maxRetries
@@ -77,242 +63,16 @@ func WithProgressReporter(newReporter NewProgressReporter) PullOption {
 	}
 }
 
-// ProgressReporter is an interface for reporting image pull progress.
-type ProgressReporter interface {
-	Start()
-	Stop()
-	Update(progress.LayerPullProgress)
-}
+// WithLogWriter sets the writer for internal containerd logs.
+func WithLogWriter(logWriter io.Writer) PullOption {
+	return func(opts *PullOptions) {
+		if logWriter == nil {
+			logWriter = io.Discard
+		}
 
-// NewProgressReporter creates a new progress reporter.
-type NewProgressReporter func(imageRef string) ProgressReporter
+		opts.LogWriter = logWriter
+	}
+}
 
 // RegistriesBuilder is a function that returns registries configuration.
 type RegistriesBuilder = func(context.Context) (cri.Registries, error)
-
-// NewSimpleProgressReporter creates a simple progress reporter that just needs Update function.
-func NewSimpleProgressReporter(updateFn func(progress.LayerPullProgress)) NewProgressReporter {
-	return func(imageRef string) ProgressReporter {
-		return &simpleProgressReporter{
-			updateFn: updateFn,
-		}
-	}
-}
-
-type simpleProgressReporter struct {
-	updateFn func(progress.LayerPullProgress)
-}
-
-func (s *simpleProgressReporter) Start() {}
-
-func (s *simpleProgressReporter) Stop() {}
-
-func (s *simpleProgressReporter) Update(p progress.LayerPullProgress) {
-	s.updateFn(p)
-}
-
-// Pull is a convenience function that wraps the containerd image pull func with
-// retry functionality.
-//
-//nolint:gocyclo,cyclop
-func Pull(
-	ctx context.Context,
-	registryBuilder RegistriesBuilder,
-	resources state.State,
-	client *containerd.Client,
-	ref string,
-	opt ...PullOption,
-) (img containerd.Image, err error) {
-	opts := DefaultPullOptions()
-
-	for _, o := range opt {
-		o(&opts)
-	}
-
-	namedRef, err := reference.ParseDockerRef(ref)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
-	}
-
-	// normalize reference
-	ref = namedRef.String()
-
-	if opts.SkipIfAlreadyPulled {
-		img, err = client.GetImage(ctx, ref)
-		if err == nil {
-			var unpacked bool
-
-			unpacked, err = img.IsUnpacked(ctx, "")
-			if err == nil && unpacked {
-				if err = manageAliases(ctx, client, namedRef, img); err == nil {
-					return img, nil
-				}
-			}
-		}
-	}
-
-	containerdLogger := logrus.New()
-	containerdLogger.Out = stdlog.Default().Writer()
-	containerdLogger.Formatter = &logrus.TextFormatter{
-		DisableColors:    true,
-		DisableQuote:     true,
-		DisableTimestamp: true,
-	}
-
-	ctx = log.WithLogger(ctx, containerdLogger.WithField("image", ref))
-
-	notFoundErrors := 0
-
-	err = retry.Exponential(PullTimeout, retry.WithUnits(PullRetryInterval), retry.WithErrorLogging(true)).RetryWithContext(ctx, func(ctx context.Context) error {
-		registriesConfig, err := registryBuilder(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get configured registries: %w", err)
-		}
-
-		resolver := NewResolver(registriesConfig)
-		tagFetcher := NewTagFetcher(registriesConfig)
-
-		verifyResult, err := verify.ImageSignature(ctx, zap.NewNop(), resources, resolver, tagFetcher, ref)
-		if err != nil {
-			switch status.Code(err) { //nolint:exhaustive
-			case codes.PermissionDenied:
-				// verification denied by matched rule, no need to retry
-				return errors.New(status.Convert(err).Message())
-			case codes.NotFound:
-				// verification failed because image not found, no need to retry
-				notFoundErrors++
-
-				if notFoundErrors > opts.MaxNotFoundRetries {
-					return err
-				}
-
-				return retry.ExpectedError(err)
-			default:
-				return retry.ExpectedError(err)
-			}
-		}
-
-		containerdRemoteOpts := []containerd.RemoteOpt{
-			containerd.WithPullUnpack,
-			containerd.WithChildLabelMap(images.ChildGCLabelsFilterLayers),
-			containerd.WithResolver(resolver),
-		}
-
-		pullRef := ref
-
-		if verifyResult.Verified {
-			containerdRemoteOpts = append(
-				containerdRemoteOpts,
-				containerd.WithPullLabel(constants.ImageLabelVerified, verifyResult.Message),
-			)
-
-			pullRef = verifyResult.DigestedImageRef
-		}
-
-		if opts.NewProgressReporter != nil {
-			reporter := opts.NewProgressReporter(ref)
-
-			reporter.Start()
-			defer reporter.Stop()
-
-			pp := progress.NewPullProgress(
-				client.ContentStore(),
-				client.SnapshotService("overlayfs"),
-				reporter.Update,
-			)
-
-			finishProgress := pp.ShowProgress(ctx)
-			defer finishProgress()
-
-			containerdRemoteOpts = append(
-				containerdRemoteOpts,
-				containerd.WithImageHandler(
-					images.HandlerFunc(
-						func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-							if images.IsLayerType(desc.MediaType) {
-								pp.Add(desc)
-							}
-
-							return nil, nil
-						},
-					),
-				),
-				containerd.WithImageHandlerWrapper(snapshotters.AppendInfoHandlerWrapper(ref)),
-			)
-		}
-
-		if img, err = client.Pull(
-			ctx,
-			pullRef,
-			containerdRemoteOpts...,
-		); err != nil {
-			err = fmt.Errorf("failed to pull image %q: %w", ref, err)
-			if errors.Is(err, errdefs.ErrNotFound) {
-				notFoundErrors++
-
-				if notFoundErrors > opts.MaxNotFoundRetries {
-					return err
-				}
-			}
-
-			return retry.ExpectedError(err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if err = manageAliases(ctx, client, namedRef, img); err != nil {
-		return nil, err
-	}
-
-	return img, nil
-}
-
-func manageAliases(ctx context.Context, client *containerd.Client, namedRef reference.Named, img containerd.Image) error {
-	// re-tag pulled image
-	imageDigest := img.Target().Digest.String()
-
-	refs := []string{imageDigest}
-
-	if _, ok := namedRef.(reference.NamedTagged); ok {
-		refs = append(refs, namedRef.String())
-	}
-
-	if _, ok := namedRef.(reference.Canonical); ok {
-		refs = append(refs, namedRef.String())
-	} else {
-		refs = append(refs, namedRef.Name()+"@"+imageDigest)
-	}
-
-	for _, newRef := range refs {
-		if err := createAlias(ctx, client, newRef, img.Target(), img.Labels()); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func createAlias(ctx context.Context, client *containerd.Client, name string, desc ocispec.Descriptor, labels map[string]string) error {
-	img := images.Image{
-		Name:   name,
-		Target: desc,
-		Labels: labels,
-	}
-
-	oldImg, err := client.ImageService().Create(ctx, img)
-	if err == nil || !errdefs.IsAlreadyExists(err) {
-		return err
-	}
-
-	if oldImg.Target.Digest == img.Target.Digest && maps.Equal(oldImg.Labels, img.Labels) {
-		return nil
-	}
-
-	_, err = client.ImageService().Update(ctx, img, "target", "labels")
-
-	return err
-}

--- a/internal/pkg/containers/image/progress.go
+++ b/internal/pkg/containers/image/progress.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import "github.com/siderolabs/talos/internal/pkg/containers/image/progress"
+
+// ProgressReporter is an interface for reporting image pull progress.
+type ProgressReporter interface {
+	Start()
+	Stop()
+	Update(progress.LayerPullProgress)
+}
+
+// NewProgressReporter creates a new progress reporter.
+type NewProgressReporter func(imageRef string) ProgressReporter
+
+// NewSimpleProgressReporter creates a simple progress reporter that just needs Update function.
+func NewSimpleProgressReporter(updateFn func(progress.LayerPullProgress)) NewProgressReporter {
+	return func(imageRef string) ProgressReporter {
+		return &simpleProgressReporter{
+			updateFn: updateFn,
+		}
+	}
+}
+
+type simpleProgressReporter struct {
+	updateFn func(progress.LayerPullProgress)
+}
+
+func (s *simpleProgressReporter) Start() {}
+
+func (s *simpleProgressReporter) Stop() {}
+
+func (s *simpleProgressReporter) Update(p progress.LayerPullProgress) {
+	s.updateFn(p)
+}

--- a/internal/pkg/containers/image/pull.go
+++ b/internal/pkg/containers/image/pull.go
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/siderolabs/go-retry/retry"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/progress"
+	"github.com/siderolabs/talos/internal/pkg/containers/image/verify"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// Error tags used internally to identify retriable errors.
+type (
+	imageNotFoundTag                    struct{}
+	imageSignatureVerificationFailedTag struct{}
+	imageTerminalErrorTag               struct{}
+)
+
+// Pull performs a single attempt to pull an image from a registry.
+//
+// If configured, the pull is skipped if the image is already present and unpacked in the containerd client.
+// The ctx should have a containerd namespace on it already.
+func Pull(
+	ctx context.Context,
+	registryBuilder RegistriesBuilder,
+	resources state.State,
+	client *containerd.Client,
+	ref string,
+	opt ...PullOption,
+) (img containerd.Image, err error) {
+	opts := DefaultPullOptions()
+
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	namedRef, err := reference.ParseDockerRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
+	}
+
+	return pullInternal(ctx, registryBuilder, resources, client, namedRef, opts)
+}
+
+// PullWithRetriesAndTimeout performs a pull with retries and timeout.
+//
+// It is a wrapper around Pull that adds retry logic and timeout handling.
+// This method is used in Talos internally when performing unattended pulls of images,
+// e.g. for the kubelet/etcd services.
+// When pulling via the API, or under retry/backoff control, use Pull method directly instead.
+func PullWithRetriesAndTimeout(
+	ctx context.Context,
+	registryBuilder RegistriesBuilder,
+	resources state.State,
+	client *containerd.Client,
+	ref string,
+	opt ...PullOption,
+) (img containerd.Image, err error) {
+	opts := DefaultPullOptions()
+
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	namedRef, err := reference.ParseDockerRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
+	}
+
+	notFoundErrors := 0
+
+	err = retry.Exponential(
+		PullTimeout,
+		retry.WithUnits(PullRetryInterval),
+		retry.WithErrorLogging(true)).
+		RetryWithContext(
+			ctx,
+			func(ctx context.Context) error {
+				img, err = pullInternal(ctx, registryBuilder, resources, client, namedRef, opts)
+				if err != nil {
+					switch {
+					case xerrors.TagIs[imageNotFoundTag](err):
+						notFoundErrors++
+						if notFoundErrors > opts.MaxNotFoundRetries {
+							return err
+						}
+
+						return retry.ExpectedError(err)
+					case xerrors.TagIs[imageSignatureVerificationFailedTag](err):
+						return err // image verification failure is terminal
+					case xerrors.TagIs[imageTerminalErrorTag](err):
+						return err // other terminal error, no need to retry
+					default:
+						return retry.ExpectedError(err)
+					}
+				}
+
+				return nil
+			},
+		)
+
+	return img, err
+}
+
+//nolint:gocyclo
+func pullInternal(
+	ctx context.Context,
+	registryBuilder RegistriesBuilder,
+	resources state.State,
+	client *containerd.Client,
+	namedRef reference.Named,
+	opts PullOptions,
+) (img containerd.Image, err error) {
+	// normalize reference
+	ref := namedRef.String()
+
+	if opts.SkipIfAlreadyPulled {
+		img, err = client.GetImage(ctx, ref)
+		if err == nil {
+			var unpacked bool
+
+			unpacked, err = img.IsUnpacked(ctx, "")
+			if err == nil && unpacked {
+				if err = manageAliases(ctx, client, namedRef, img); err == nil {
+					return img, nil
+				}
+			}
+		}
+	}
+
+	containerdLogger := logrus.New()
+	containerdLogger.Out = opts.LogWriter
+	containerdLogger.Formatter = &logrus.TextFormatter{
+		DisableColors:    true,
+		DisableQuote:     true,
+		DisableTimestamp: true,
+	}
+
+	ctx = log.WithLogger(ctx, containerdLogger.WithField("image", ref))
+
+	registriesConfig, err := registryBuilder(ctx)
+	if err != nil {
+		return nil, xerrors.NewTaggedf[imageTerminalErrorTag]("failed to get configured registries: %w", err)
+	}
+
+	resolver := NewResolver(registriesConfig)
+	tagFetcher := NewTagFetcher(registriesConfig)
+
+	verifyResult, err := verify.ImageSignature(ctx, zap.NewNop(), resources, resolver, tagFetcher, ref)
+	if err != nil {
+		switch status.Code(err) { //nolint:exhaustive
+		case codes.PermissionDenied:
+			// verification denied by matched rule, no need to retry
+			return nil, xerrors.NewTagged[imageSignatureVerificationFailedTag](errors.New(status.Convert(err).Message()))
+		case codes.NotFound:
+			// verification failed because image not found
+			return nil, xerrors.NewTagged[imageNotFoundTag](err)
+		default:
+			return nil, err
+		}
+	}
+
+	containerdRemoteOpts := []containerd.RemoteOpt{
+		containerd.WithPullUnpack,
+		containerd.WithChildLabelMap(images.ChildGCLabelsFilterLayers),
+		containerd.WithResolver(resolver),
+	}
+
+	pullRef := ref
+
+	if verifyResult.Verified {
+		containerdRemoteOpts = append(
+			containerdRemoteOpts,
+			containerd.WithPullLabel(constants.ImageLabelVerified, verifyResult.Message),
+		)
+
+		pullRef = verifyResult.DigestedImageRef
+	}
+
+	if opts.NewProgressReporter != nil {
+		reporter := opts.NewProgressReporter(ref)
+
+		reporter.Start()
+		defer reporter.Stop()
+
+		pp := progress.NewPullProgress(
+			client.ContentStore(),
+			client.SnapshotService("overlayfs"),
+			reporter.Update,
+		)
+
+		finishProgress := pp.ShowProgress(ctx)
+		defer finishProgress()
+
+		containerdRemoteOpts = append(
+			containerdRemoteOpts,
+			containerd.WithImageHandler(
+				images.HandlerFunc(
+					func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+						if images.IsLayerType(desc.MediaType) {
+							pp.Add(desc)
+						}
+
+						return nil, nil
+					},
+				),
+			),
+			containerd.WithImageHandlerWrapper(snapshotters.AppendInfoHandlerWrapper(ref)),
+		)
+	}
+
+	img, err = client.Pull(
+		ctx,
+		pullRef,
+		containerdRemoteOpts...,
+	)
+	if err != nil {
+		err = fmt.Errorf("failed to pull image %q: %w", ref, err)
+		if errors.Is(err, errdefs.ErrNotFound) {
+			return nil, xerrors.NewTagged[imageNotFoundTag](err)
+		}
+
+		return nil, err
+	}
+
+	if err = manageAliases(ctx, client, namedRef, img); err != nil {
+		return nil, xerrors.NewTagged[imageTerminalErrorTag](err)
+	}
+
+	return img, nil
+}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -85,7 +85,7 @@ func RunInstallerContainer(
 	if img == nil || err != nil && errdefs.IsNotFound(err) {
 		log.Printf("pulling %q", ref)
 
-		img, err = image.Pull(ctx, registryBuilder, resources, client, ref, image.WithProgressReporter(console.NewProgressReporter))
+		img, err = image.PullWithRetriesAndTimeout(ctx, registryBuilder, resources, client, ref, image.WithProgressReporter(console.NewProgressReporter))
 	}
 
 	if err != nil {

--- a/internal/pkg/install/pull.go
+++ b/internal/pkg/install/pull.go
@@ -39,7 +39,7 @@ func PullAndValidateInstallerImage(ctx context.Context, resources state.State, r
 
 	defer client.Close() //nolint:errcheck
 
-	img, err := image.Pull(
+	img, err := image.PullWithRetriesAndTimeout(
 		containerdctx, registryBuilder, resources, client, ref,
 		image.WithSkipIfAlreadyPulled(),
 		image.WithProgressReporter(console.NewProgressReporter),


### PR DESCRIPTION
Fixes #13948

There is a bit of moving code around for better readability, but the tl;dr of the changes is:

* the new `Pull` method doesn't do any timeouts or retries on top of whatever `ctx` passed in, it is used in the API
* the new method `PullWithRetriesAndTimeout` matches previous `Pull` method semantics - automatically retries and provides global pull timeout - this is used internally when pulling etcd/kubelet images, in the legacy Upgrade API.

Also for the new pull API a proper logger is used, so that containerd client logs don't flow to the console.

There should be no functional changes execept for image pull APIs to have no timeout/retries.
