### PR TITLE
test: skip iptables compatibility test in enforcing

### DIFF
--- a/internal/integration/api/iptables.go
+++ b/internal/integration/api/iptables.go
@@ -34,6 +34,10 @@ func (suite *IPTablesSuite) SetupTest() {
 	if !suite.Capabilities().RunsTalosKernel {
 		suite.T().Skip("skipping kernel test since Talos kernel is not running")
 	}
+
+	if suite.SelinuxEnforcing {
+		suite.T().Skip("skipping in SELinux enforcing mode: host namespace debug mode doesn't function")
+	}
 }
 
 // TearDownTest ...


### PR DESCRIPTION
The hostns debug mode doesn't function under enforcing.
