### PR TITLE
fix: collapse machined/apid logs with authz messages

### DIFF
--- a/internal/app/apid/service.go
+++ b/internal/app/apid/service.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/siderolabs/go-debug"
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -117,15 +116,12 @@ func runService(ctx context.Context, resources state.State, config *runtime.APIS
 
 	networkServer := func() *grpc.Server {
 		injector := &authz.Injector{
-			Mode: authz.Enabled,
+			Mode:    authz.Enabled,
+			Verbose: true,
 		}
 
 		if config.TypedSpec().ReadonlyRoleMode {
 			injector.Mode = authz.ReadOnlyWithAdminOnSiderolink
-		}
-
-		if debug.Enabled {
-			injector.Logger = log.New(log.Writer(), "apid/authz/injector/http ", log.Flags()).Printf
 		}
 
 		return factory.NewServer(

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -7,7 +7,6 @@ package services
 import (
 	"context"
 	"io"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -160,17 +159,13 @@ type machinedService struct {
 // Main is an entrypoint to the API service.
 func (s *machinedService) Main(ctx context.Context, _ runtime.Runtime, logWriter io.Writer) error {
 	injector := &authz.Injector{
-		Mode: authz.MetadataOnly,
-	}
-
-	if debug.Enabled {
-		injector.Logger = log.New(logWriter, "machined/authz/injector ", log.Flags()).Printf
+		Mode:    authz.MetadataOnly,
+		Verbose: debug.Enabled,
 	}
 
 	authorizer := &authz.Authorizer{
 		Rules:         rules,
 		FallbackRoles: role.MakeSet(role.Admin),
-		Logger:        log.New(logWriter, "machined/authz/authorizer ", log.Flags()).Printf,
 	}
 
 	// machined's own identity, used to recognize the kernel static usermode helper
@@ -226,7 +221,6 @@ func (s *machinedService) Main(ctx context.Context, _ runtime.Runtime, logWriter
 				AllowNamespaceMatch: true,
 			},
 		},
-		Logger: log.New(logWriter, "machined/authz/unix/authorizer ", log.Flags()).Printf,
 	}
 
 	logger := logging.ZapLogger(

--- a/pkg/grpc/middleware/auth/unix/authorizer.go
+++ b/pkg/grpc/middleware/auth/unix/authorizer.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/talos/pkg/grpc/middleware/authz"
+	grpclog "github.com/siderolabs/talos/pkg/grpc/middleware/log"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
@@ -62,15 +63,6 @@ type Authorizer struct {
 
 	// UsermodeHelperRoles is the role set granted to a recognized usermode helper.
 	UsermodeHelperRoles role.Set
-
-	// Logger.
-	Logger func(format string, v ...any)
-}
-
-func (a *Authorizer) logf(format string, v ...any) {
-	if a.Logger != nil {
-		a.Logger(format, v...)
-	}
 }
 
 func (a *Authorizer) matchService(servicePID *runtime.ServicePID, pid int32, mountNamespace string) (role.Set, bool) {
@@ -109,7 +101,7 @@ func (a *Authorizer) matchUsermodeHelper(creds PeerCredentials) bool {
 func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	peerCreds, ok := GetPeerCredentials(ctx)
 	if !ok {
-		a.logf("no peer credentials found in context")
+		grpclog.Annotatef(ctx, "no peer credentials found in context")
 
 		return role.Set{}, ErrNotAuthorized
 	}
@@ -130,7 +122,7 @@ func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	for servicePID := range servicePIDs.All() {
 		allowedRoles, matched := a.matchService(servicePID, pid, mountNamespace)
 		if matched {
-			a.logf("authorized based on PID (%d) match with service %q (allowed roles %s)", pid, servicePID.Metadata().ID(), allowedRoles.Strings())
+			grpclog.Annotatef(ctx, "authorized based on PID (%d) match with service %q (allowed roles %s)", pid, servicePID.Metadata().ID(), allowedRoles.Strings())
 
 			return allowedRoles, nil
 		}
@@ -140,7 +132,7 @@ func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	// this same binary in this same mount namespace, but has an ephemeral PID that never appears as
 	// a service PID, so it would otherwise fall through to the watch below and time out.
 	if a.matchUsermodeHelper(peerCreds) {
-		a.logf("authorized usermode helper (PID %d) with roles %s", pid, a.UsermodeHelperRoles.Strings())
+		grpclog.Annotatef(ctx, "authorized usermode helper (PID %d) with roles %s", pid, a.UsermodeHelperRoles.Strings())
 
 		return a.UsermodeHelperRoles, nil
 	}
@@ -155,7 +147,7 @@ func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			a.logf("timed out waiting for runner state to be populated with PID (%d)", pid)
+			grpclog.Annotatef(ctx, "timed out waiting for runner state to be populated with PID (%d)", pid)
 
 			return role.Set{}, ErrNotAuthorized
 		case wrappedEvent := <-eventCh:
@@ -168,7 +160,7 @@ func (a *Authorizer) Authorize(ctx context.Context) (role.Set, error) {
 
 				allowedRoles, matched := a.matchService(servicePID, pid, mountNamespace)
 				if matched {
-					a.logf("authorized based on PID (%d) match with service %q (allowed roles %s)", pid, servicePID.Metadata().ID(), allowedRoles.Strings())
+					grpclog.Annotatef(ctx, "authorized based on PID (%d) match with service %q (allowed roles %s)", pid, servicePID.Metadata().ID(), allowedRoles.Strings())
 
 					return allowedRoles, nil
 				}

--- a/pkg/grpc/middleware/authz/authorizer.go
+++ b/pkg/grpc/middleware/authz/authorizer.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	grpclog "github.com/siderolabs/talos/pkg/grpc/middleware/log"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
@@ -25,15 +26,6 @@ type Authorizer struct {
 
 	// Defines roles for gRPC methods not present in Rules.
 	FallbackRoles role.Set
-
-	// Logger.
-	Logger func(format string, v ...any)
-}
-
-func (a *Authorizer) logf(format string, v ...any) {
-	if a.Logger != nil {
-		a.Logger(format, v...)
-	}
 }
 
 // authorize returns error if the user is not authorized (doesn't have a valid role) to call the given gRPC method.
@@ -41,18 +33,19 @@ func (a *Authorizer) logf(format string, v ...any) {
 func (a *Authorizer) authorize(ctx context.Context, method string) error {
 	allowedRoles, found := a.Rules[method]
 	if !found {
-		a.logf("no explicit rule found for %q, falling back to %v", method, a.FallbackRoles.Strings())
+		grpclog.Annotatef(ctx, "no explicit rule found, falling back to %v", a.FallbackRoles.Strings())
+
 		allowedRoles = a.FallbackRoles
 	}
 
 	clientRoles := GetRoles(ctx)
 	if allowedRoles.IncludesAny(clientRoles) {
-		a.logf("authorized (%v includes %v)", allowedRoles.Strings(), clientRoles.Strings())
+		grpclog.Annotatef(ctx, "authorized (%v includes %v)", allowedRoles.Strings(), clientRoles.Strings())
 
 		return nil
 	}
 
-	a.logf("not authorized (%v doesn't include %v)", allowedRoles.Strings(), clientRoles.Strings())
+	grpclog.Annotatef(ctx, "not authorized (%v doesn't include %v)", allowedRoles.Strings(), clientRoles.Strings())
 
 	return ErrNotAuthorized
 }

--- a/pkg/grpc/middleware/authz/injector.go
+++ b/pkg/grpc/middleware/authz/injector.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 
+	grpclog "github.com/siderolabs/talos/pkg/grpc/middleware/log"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
@@ -57,14 +58,16 @@ type Injector struct {
 	// When not specified, it defaults to isSideroLinkPeer.
 	SideroLinkPeerCheckFunc SideroLinkPeerCheckFunc
 
-	// Logger.
-	Logger func(format string, v ...any)
+	// Verbose enables reporting of the role extraction details as part of the request log line.
+	Verbose bool
 }
 
-func (i *Injector) logf(format string, v ...any) {
-	if i.Logger != nil {
-		i.Logger(format, v...)
+func (i *Injector) annotatef(ctx context.Context, format string, v ...any) {
+	if !i.Verbose {
+		return
 	}
+
+	grpclog.Annotatef(ctx, format, v...)
 }
 
 // extractRoles returns roles extracted from the user's certificate (in case of the first apid instance),
@@ -79,7 +82,7 @@ func (i *Injector) extractRoles(ctx context.Context) role.Set {
 
 	switch i.Mode {
 	case Disabled:
-		i.logf("RBAC is disabled, injecting all roles")
+		i.annotatef(ctx, "RBAC is disabled, injecting all roles")
 
 		return role.All
 
@@ -93,7 +96,7 @@ func (i *Injector) extractRoles(ctx context.Context) role.Set {
 		}
 
 		if siderolinkPeerAddr, siderolinkPeer := check(ctx); siderolinkPeer {
-			i.logf("inject admin role for SideroLink peer %q", siderolinkPeerAddr)
+			i.annotatef(ctx, "inject admin role for SideroLink peer %q", siderolinkPeerAddr)
 
 			return adminRoleSet
 		}
@@ -101,7 +104,7 @@ func (i *Injector) extractRoles(ctx context.Context) role.Set {
 		return readerRoleSet
 
 	case MetadataOnly:
-		roles, _ := getFromMetadata(ctx, i.logf)
+		roles, _ := getFromMetadata(ctx, i.annotatef)
 
 		return roles
 
@@ -127,18 +130,18 @@ func (i *Injector) extractRoles(ctx context.Context) role.Set {
 		// TODO validate cert.KeyUsage, cert.ExtKeyUsage, cert.Issuer.Organization, other fields there?
 
 		roles, unknownRoles := role.Parse(strings)
-		i.logf("parsed peer's certificate orgs %v as %v (unknownRoles = %v)", strings, roles.Strings(), unknownRoles)
+		i.annotatef(ctx, "parsed peer's certificate orgs %v as %v (unknownRoles = %v)", strings, roles.Strings(), unknownRoles)
 
 		// trust gRPC metadata from clients with impersonator role if present
 		// (including requests proxied from other apid instances)
 		if roles.Includes(role.Impersonator) {
-			metadataRoles, ok := getFromMetadata(ctx, i.logf)
+			metadataRoles, ok := getFromMetadata(ctx, i.annotatef)
 			if ok {
 				return metadataRoles
 			}
 
 			// that's a real user with impersonator role then
-			i.logf("no roles in metadadata, returning parsed roles")
+			i.annotatef(ctx, "no roles in metadata, returning parsed roles")
 		}
 
 		return roles

--- a/pkg/grpc/middleware/authz/metadata.go
+++ b/pkg/grpc/middleware/authz/metadata.go
@@ -23,7 +23,7 @@ func SetMetadata(md metadata.MD, roles role.Set) {
 }
 
 // getFromMetadata returns roles extracted from gRPC metadata.
-func getFromMetadata(ctx context.Context, logf func(format string, v ...any)) (role.Set, bool) {
+func getFromMetadata(ctx context.Context, annotate func(ctx context.Context, format string, v ...any)) (role.Set, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		panic("no request metadata")
@@ -31,17 +31,13 @@ func getFromMetadata(ctx context.Context, logf func(format string, v ...any)) (r
 
 	strings := md.Get(mdKey)
 	if len(strings) == 0 {
-		if logf != nil {
-			logf("no roles in metadata")
-		}
+		annotate(ctx, "no roles in metadata")
 
 		return role.Zero, false
 	}
 
 	roles, unknownRoles := role.Parse(strings)
-	if logf != nil {
-		logf("parsed metadata %v as %v (unknownRoles = %v)", strings, roles.Strings(), unknownRoles)
-	}
+	annotate(ctx, "parsed metadata %v as %v (unknownRoles = %v)", strings, roles.Strings(), unknownRoles)
 
 	return roles, true
 }

--- a/pkg/grpc/middleware/log/annotations.go
+++ b/pkg/grpc/middleware/log/annotations.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// annotationsKey is used to store the request annotations in the context.
+type annotationsKey struct{}
+
+// annotations accumulates messages to be reported as part of the request log line.
+type annotations struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (a *annotations) add(message string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.messages = append(a.messages, message)
+}
+
+// String formats the collected messages, returning an empty string if there are none.
+func (a *annotations) String() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if len(a.messages) == 0 {
+		return ""
+	}
+
+	return " {" + strings.Join(a.messages, "; ") + "}"
+}
+
+// withAnnotations returns a context which collects annotations for the request.
+func withAnnotations(ctx context.Context) (context.Context, *annotations) {
+	a := &annotations{}
+
+	return context.WithValue(ctx, annotationsKey{}, a), a
+}
+
+// Annotatef appends a message to the log line of the gRPC request being handled.
+//
+// Interceptors and handlers use it to report details (e.g. authorization decisions) which
+// end up on the single log line the logging middleware emits once the request is complete.
+//
+// If the context doesn't carry the annotations (the server has no logging middleware installed),
+// the message is dropped.
+func Annotatef(ctx context.Context, format string, v ...any) {
+	a, ok := ctx.Value(annotationsKey{}).(*annotations)
+	if !ok {
+		return
+	}
+
+	a.add(fmt.Sprintf(format, v...))
+}

--- a/pkg/grpc/middleware/log/annotations_test.go
+++ b/pkg/grpc/middleware/log/annotations_test.go
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package log_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/siderolabs/talos/pkg/grpc/middleware/log"
+)
+
+type testLogger struct {
+	lines []string
+}
+
+func (l *testLogger) Printf(format string, v ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, v...))
+}
+
+type testStream struct {
+	grpc.ServerStream
+
+	ctx context.Context //nolint:containedctx
+}
+
+func (s *testStream) Context() context.Context {
+	return s.ctx
+}
+
+func TestAnnotateUnary(t *testing.T) {
+	logger := &testLogger{}
+	middleware := log.NewMiddleware(logger)
+
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("foo", "bar"))
+
+	_, err := middleware.UnaryInterceptor()(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(ctx context.Context, _ any) (any, error) {
+			log.Annotatef(ctx, "authorized based on PID (%d)", 42)
+			log.Annotatef(ctx, "authorized (%v includes %v)", []string{"os:admin"}, []string{"os:admin"})
+
+			return nil, nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, logger.lines, 1)
+	assert.Regexp(t,
+		regexp.MustCompile(`^OK \[/test\.Service/Method\] \S+ unary Success \{authorized based on PID \(42\); `+
+			`authorized \(\[os:admin\] includes \[os:admin\]\)\} \(foo=bar\)$`),
+		logger.lines[0])
+}
+
+func TestAnnotateStream(t *testing.T) {
+	logger := &testLogger{}
+	middleware := log.NewMiddleware(logger)
+
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("foo", "bar"))
+
+	err := middleware.StreamInterceptor()(nil, &testStream{ctx: ctx}, &grpc.StreamServerInfo{FullMethod: "/test.Service/Method"},
+		func(_ any, stream grpc.ServerStream) error {
+			log.Annotatef(stream.Context(), "not authorized")
+
+			return nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, logger.lines, 1)
+	assert.Regexp(t,
+		regexp.MustCompile(`^OK \[/test\.Service/Method\] \S+ stream Success \{not authorized\} \(foo=bar\)$`),
+		logger.lines[0])
+}
+
+func TestAnnotateNoAnnotations(t *testing.T) {
+	logger := &testLogger{}
+	middleware := log.NewMiddleware(logger)
+
+	_, err := middleware.UnaryInterceptor()(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) {
+			return nil, nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, logger.lines, 1)
+	assert.Regexp(t, regexp.MustCompile(`^OK \[/test\.Service/Method\] \S+ unary Success \(\)$`), logger.lines[0])
+}
+
+func TestAnnotateNoMiddleware(t *testing.T) {
+	// should be a no-op, not a panic
+	log.Annotatef(t.Context(), "no logging middleware installed")
+}

--- a/pkg/grpc/middleware/log/log.go
+++ b/pkg/grpc/middleware/log/log.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"github.com/siderolabs/gen/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -64,6 +65,8 @@ func (m *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		startTime := time.Now()
 
+		ctx, annotations := withAnnotations(ctx)
+
 		resp, err := handler(ctx, req)
 
 		duration := time.Since(startTime)
@@ -74,7 +77,7 @@ func (m *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			msg = err.Error()
 		}
 
-		m.logger.Printf("%s [%s] %s unary %s (%s)", code, info.FullMethod, duration, msg, ExtractMetadata(ctx))
+		m.logger.Printf("%s [%s] %s unary %s%s (%s)", code, info.FullMethod, duration, msg, annotations, ExtractMetadata(ctx))
 
 		return resp, err
 	}
@@ -85,7 +88,12 @@ func (m *Middleware) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		startTime := time.Now()
 
-		err := handler(srv, stream)
+		ctx, annotations := withAnnotations(stream.Context())
+
+		wrapped := grpc_middleware.WrapServerStream(stream)
+		wrapped.WrappedContext = ctx
+
+		err := handler(srv, wrapped)
 
 		duration := time.Since(startTime)
 		code := status.Code(err)
@@ -95,7 +103,7 @@ func (m *Middleware) StreamInterceptor() grpc.StreamServerInterceptor {
 			msg = err.Error()
 		}
 
-		m.logger.Printf("%s [%s] %s stream %s (%s)", code, info.FullMethod, duration, msg, ExtractMetadata(stream.Context()))
+		m.logger.Printf("%s [%s] %s stream %s%s (%s)", code, info.FullMethod, duration, msg, annotations, ExtractMetadata(ctx))
 
 		return err
 	}


### PR DESCRIPTION
Instead of isssuing several log lines per API calls, e.g.:

```
machined/authz/unix/authorizer authorized based on PID (260) match with service "dashboard" (allowed roles [os:meta:writer os:reader])
machined/authz/authorizer authorized ([os:admin os:operator os:reader] includes [os:meta:writer os:reader])
machined OK [/machine.MachineService/LoadAvg] 499.113µs unary Success (:authority=localhost;content-type=application/grpc;grpc-accept-encoding=gzip;runtime=Talos;talos-role=os:meta:writer,os:reader;user-agent=grpc-go/1.82.1)
```

Now issue a single line with authz messages augmented into the API log line:

```
 machined OK [/machine.MachineService/LoadAvg] 499.113µs unary Success {authorized based on PID (260) match with service "dashboard" (allowed roles [os:meta:writer os:reader]); authorized ([os:admin os:operator os:reader] includes [os:meta:writer os:reader])} (:authority=localhost;content-type=application/grpc;grpc-accept-encoding=gzip;runtime=Talos;talos-role=os:meta:writer,os:reader;user-agent=grpc-go/1.82.1)
```

This reduces number of log lines per API call, and also matches the authz messages with the exact API call.

For `apid`, now enable logs of injecting roles via the incoming API call which were previously under debug mode.
