### PR TITLE
fix: avoid small panics

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -7,6 +7,7 @@ package apid
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -99,6 +100,11 @@ outerLoop:
 			case state.Destroyed:
 				serviceConfig = nil
 			case state.Errored:
+				if ctx.Err() != nil || errors.Is(event.Error(), context.Canceled) {
+					// shutting down
+					break outerLoop
+				}
+
 				return fmt.Errorf("service config watch error: %w", event.Error())
 			case state.Bootstrapped, state.Noop:
 				// ignore

--- a/internal/app/apid/pkg/provider/provider.go
+++ b/internal/app/apid/pkg/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	stdlibtls "crypto/tls"
 	stdx509 "crypto/x509"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -74,6 +75,8 @@ func NewTLSConfig(ctx context.Context, resources state.State, skipClientCertVeri
 }
 
 // Watch for changes in API certificates and updates the TLSConfig.
+//
+//nolint:gocyclo
 func (tlsConfig *TLSConfig) Watch(ctx context.Context, onUpdate func()) error {
 	for {
 		var event state.Event
@@ -91,6 +94,11 @@ func (tlsConfig *TLSConfig) Watch(ctx context.Context, onUpdate func()) error {
 			// ignore, we'll get another event
 			continue
 		case state.Errored:
+			if ctx.Err() != nil || errors.Is(event.Error, context.Canceled) {
+				// shutting down
+				return nil //nolint:nilerr // we're shutting down, so this is not an error
+			}
+
 			return fmt.Errorf("error watching API certificates: %w", event.Error)
 		}
 

--- a/internal/app/machined/pkg/controllers/runtime/mount_status.go
+++ b/internal/app/machined/pkg/controllers/runtime/mount_status.go
@@ -77,6 +77,11 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 				return fmt.Errorf("failed to get volume status %q: %w", mountStatus.TypedSpec().Spec.VolumeID, err)
 			}
 
+			if volumeStatus == nil {
+				// volume status doesn't exist, so we can't create a mount status for it
+				continue
+			}
+
 			if volumeStatus.TypedSpec().Type != block.VolumeTypePartition && volumeStatus.TypedSpec().Type != block.VolumeTypeDisk {
 				// legacy volume statuses shouldn't show up for non-partition/disk volumes
 				continue

--- a/internal/app/trustd/internal/provider/provider.go
+++ b/internal/app/trustd/internal/provider/provider.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	stdlibtls "crypto/tls"
 	stdx509 "crypto/x509"
+	"errors"
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -91,7 +91,12 @@ func (tlsConfig *TLSConfig) Watch(ctx context.Context) error {
 			// ignore, we'll get another event
 			continue
 		case state.Errored:
-			log.Printf("error watching for trustd certificates: %s", event.Error)
+			if ctx.Err() != nil || errors.Is(event.Error, context.Canceled) {
+				// shutting down
+				return nil //nolint:nilerr // we're shutting down, so this is not an error
+			}
+
+			return fmt.Errorf("error watching for trustd certificates: %w", event.Error)
 		}
 
 		trustdCerts := event.Resource.(*secrets.Trustd) //nolint:forcetypeassert


### PR DESCRIPTION
None of these are critical panics, but they produce noise/confusion:

* controller panic (it was restarted, but still good to avoid it)
* trustd panic on shutdown (wrong flow control)
* small reported errors on shutdown instead of graceful shutdown on context cancel in apid
