### PR TITLE
fix: show installer output on upgrade failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4201,7 +4201,6 @@ jobs:
           make ci-temp-release-tag
       - name: e2e-qemu
         env:
-          EXTRA_TEST_ARGS: -talos.skip-ephemeral-policy
           IMAGE_REGISTRY: registry.dev.siderolabs.io
           QEMU_EXTRA_DISKS: "5"
           QEMU_EXTRA_DISKS_DRIVERS: virtiofs,ide,nvme

--- a/.github/workflows/integration-qemu-triggered.yaml
+++ b/.github/workflows/integration-qemu-triggered.yaml
@@ -73,8 +73,7 @@ jobs:
             tagSuffix: -race
             variant: race
             withConfigPatchWorker: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
-          - extraTestArgs: -talos.skip-ephemeral-policy
-            qemuExtraDisks: "5"
+          - qemuExtraDisks: "5"
             qemuExtraDisksDrivers: virtiofs,ide,nvme
             qemuExtraDisksTags: disk0
             userDisksMounts: /var/mnt/extra,/var/mnt/p1,/var/mnt/p2

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -508,7 +508,6 @@ spec:
           - variant: "13"
             withUserDisk: "true"
             userDisksMounts: "/var/mnt/extra,/var/mnt/p1,/var/mnt/p2"
-            extraTestArgs: "-talos.skip-ephemeral-policy"
             withConfigPatch: "@hack/test/patches/image-verification.yaml"
             withConfigPatchWorker: "@hack/test/patches/ephemeral-nvme-pre14.yaml:@hack/test/patches/dm-raid-module.yaml"
             withTalosVersion: "v1.13"

--- a/cmd/talosctl/cmd/talos/lifecycle/lifecycle.go
+++ b/cmd/talosctl/cmd/talos/lifecycle/lifecycle.go
@@ -11,8 +11,10 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
 
@@ -20,6 +22,15 @@ import (
 type ProgressWriter struct {
 	// ongoingInstalls keeps track of ongoing install jobs per node.
 	ongoingInstalls map[string]installJob
+	captureOutput   bool
+	output          map[string]*outputBuffer
+}
+
+const maxCapturedOutputSize = 64 * 1024
+
+// NewProgressWriter initializes a progress writer, optionally retaining a bounded tail of installer output.
+func NewProgressWriter(captureOutput bool) *ProgressWriter {
+	return &ProgressWriter{captureOutput: captureOutput}
 }
 
 // UpdateJob updates the progress of a pull job for a given node and layer ID.
@@ -30,7 +41,112 @@ func (w *ProgressWriter) UpdateJob(node string, status *machine.LifecycleService
 		w.ongoingInstalls = make(map[string]installJob)
 	}
 
+	if message, ok := status.GetResponse().(*machine.LifecycleServiceInstallProgress_Message); ok && w.captureOutput {
+		if w.output == nil {
+			w.output = make(map[string]*outputBuffer)
+		}
+
+		if w.output[node] == nil {
+			w.output[node] = &outputBuffer{}
+		}
+
+		w.output[node].Append(message.Message)
+	}
+
 	w.ongoingInstalls[node] = installJob{Status: status}
+}
+
+func (w *ProgressWriter) outputForNode(node string) string {
+	if w.output[node] == nil {
+		return ""
+	}
+
+	return w.output[node].String()
+}
+
+// Failure formats the classified exit code for a failed operation and includes captured installer output when enabled.
+func (w *ProgressWriter) Failure(node, operation string, exitCode int32) string {
+	var result strings.Builder
+
+	if output := strings.TrimSpace(w.outputForNode(node)); output != "" {
+		fmt.Fprintf(&result, "%s: installer output:\n%s\n", node, output)
+	}
+
+	fmt.Fprintf(&result, "%s: %s failed with exit code %d", node, operation, exitCode)
+
+	if description := exitCodeDescription(exitCode); description != "" {
+		fmt.Fprintf(&result, " (%s)", description)
+	}
+
+	return result.String()
+}
+
+func exitCodeDescription(exitCode int32) string {
+	switch int(exitCode) {
+	case constants.ExitInvalidInput:
+		return "invalid input"
+	case constants.ExitUnsupported:
+		return "unsupported operation"
+	case constants.ExitEnvironment:
+		return "environment error"
+	case constants.ExitDependency:
+		return "dependency error"
+	case constants.ExitIO:
+		return "I/O error"
+	case constants.ExitInstall:
+		return "installation error"
+	default:
+		return ""
+	}
+}
+
+type outputBuffer struct {
+	messages  []string
+	size      int
+	truncated bool
+}
+
+func (buffer *outputBuffer) Append(message string) {
+	if message == "" {
+		return
+	}
+
+	if len(message) > maxCapturedOutputSize {
+		message = message[len(message)-maxCapturedOutputSize:]
+		for len(message) > 0 && !utf8.RuneStart(message[0]) {
+			message = message[1:]
+		}
+
+		message = strings.Clone(message)
+
+		buffer.messages = nil
+		buffer.size = 0
+		buffer.truncated = true
+	}
+
+	for buffer.size+len(message) > maxCapturedOutputSize {
+		buffer.size -= len(buffer.messages[0])
+		buffer.messages[0] = ""
+		buffer.messages = buffer.messages[1:]
+		buffer.truncated = true
+	}
+
+	buffer.messages = append(buffer.messages, message)
+	buffer.size += len(message)
+}
+
+func (buffer *outputBuffer) String() string {
+	var result strings.Builder
+
+	if buffer.truncated {
+		result.WriteString("[earlier installer output truncated]\n")
+	}
+
+	for _, message := range buffer.messages {
+		result.WriteString(message)
+	}
+
+	return result.String()
 }
 
 // PrintLayerProgress prints the current layer pull progress to the reporter.

--- a/cmd/talosctl/cmd/talos/lifecycle/lifecycle_test.go
+++ b/cmd/talosctl/cmd/talos/lifecycle/lifecycle_test.go
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package lifecycle_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/lifecycle"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+)
+
+func TestProgressWriterFailure(t *testing.T) {
+	writer := lifecycle.NewProgressWriter(true)
+
+	for _, message := range []string{
+		"machine configuration is invalid: unknown key\n",
+		"Usage:\n",
+		"  installer install [flags]\n",
+	} {
+		writer.UpdateJob("172.20.0.5", messageProgress(message))
+	}
+
+	writer.UpdateJob("172.20.0.6", messageProgress("output from another node\n"))
+	writer.UpdateJob("172.20.0.5", &machine.LifecycleServiceInstallProgress{
+		Response: &machine.LifecycleServiceInstallProgress_ExitCode{ExitCode: 1},
+	})
+
+	failure := writer.Failure("172.20.0.5", "upgrade", 1)
+
+	assert.Equal(t, `172.20.0.5: installer output:
+machine configuration is invalid: unknown key
+Usage:
+  installer install [flags]
+172.20.0.5: upgrade failed with exit code 1`, failure)
+	assert.NotContains(t, failure, "output from another node")
+}
+
+func TestProgressWriterOutputCapture(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		writer := lifecycle.NewProgressWriter(false)
+		writer.UpdateJob("node", messageProgress("installer diagnostic\n"))
+
+		assert.Equal(t, "node: upgrade failed with exit code 1", writer.Failure("node", "upgrade", 1))
+	})
+
+	t.Run("bounded", func(t *testing.T) {
+		writer := lifecycle.NewProgressWriter(true)
+		writer.UpdateJob("node", messageProgress("oldest output\n"))
+		writer.UpdateJob("node", messageProgress(strings.Repeat("x", 70*1024)))
+
+		failure := writer.Failure("node", "upgrade", 1)
+
+		assert.Contains(t, failure, "[earlier installer output truncated]")
+		assert.NotContains(t, failure, "oldest output")
+		assert.LessOrEqual(t, len(failure), 66*1024)
+	})
+}
+
+func TestProgressWriterFailureExitCodeClassification(t *testing.T) {
+	writer := lifecycle.NewProgressWriter(false)
+
+	for _, test := range []struct {
+		exitCode int32
+		expected string
+	}{
+		{exitCode: 1, expected: "node: upgrade failed with exit code 1"},
+		{exitCode: 2, expected: "node: upgrade failed with exit code 2 (invalid input)"},
+		{exitCode: 3, expected: "node: upgrade failed with exit code 3 (unsupported operation)"},
+		{exitCode: 4, expected: "node: upgrade failed with exit code 4 (environment error)"},
+		{exitCode: 5, expected: "node: upgrade failed with exit code 5 (dependency error)"},
+		{exitCode: 6, expected: "node: upgrade failed with exit code 6 (I/O error)"},
+		{exitCode: 7, expected: "node: upgrade failed with exit code 7 (installation error)"},
+	} {
+		t.Run(test.expected, func(t *testing.T) {
+			assert.Equal(t, test.expected, writer.Failure("node", "upgrade", test.exitCode))
+		})
+	}
+}
+
+func messageProgress(message string) *machine.LifecycleServiceInstallProgress {
+	return &machine.LifecycleServiceInstallProgress{
+		Response: &machine.LifecycleServiceInstallProgress_Message{Message: message},
+	}
+}

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -177,10 +177,9 @@ func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, c
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var (
-		errs error
-		w    lifecycle.ProgressWriter
-	)
+	var errs error
+
+	w := lifecycle.NewProgressWriter(rep.IsColorized())
 
 	finishedUpgrades := map[string]int32{}
 
@@ -228,7 +227,7 @@ func upgradeInternal(ctx context.Context, clientFactory *global.ClientFactory, c
 
 				status = reporter.StatusError
 
-				fmt.Fprintf(&sb, "%s: upgrade failed with exit code %d\n", node, exitCode)
+				fmt.Fprintln(&sb, w.Failure(node, "upgrade", exitCode))
 			} else {
 				fmt.Fprintf(&sb, "%s: upgrade completed\n", node)
 			}

--- a/internal/app/lifecycle/container.go
+++ b/internal/app/lifecycle/container.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/internal/ctrhelper"
 	"github.com/siderolabs/talos/internal/app/lifecycle/internal/containerpid"
+	"github.com/siderolabs/talos/internal/app/lifecycle/internal/output"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/pid"
 	containerdrunner "github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/siderolabs/talos/internal/pkg/capability"
@@ -213,7 +214,7 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 	sendDone := make(chan error, 1)
 
 	go func() {
-		sendDone <- streamOutput(stdoutR, rc.send)
+		sendDone <- output.Stream(stdoutR, rc.send)
 	}()
 
 	// wait for task to exit
@@ -243,28 +244,6 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 	}
 
 	return nil
-}
-
-// streamOutput reads from r line by line and sends each line via the send callback.
-func streamOutput(r io.Reader, send sendFunc) error {
-	buf := make([]byte, 512)
-
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if sendErr := send(string(buf[:n])); sendErr != nil {
-				return fmt.Errorf("failed to send message: %w", sendErr)
-			}
-		}
-
-		if err != nil {
-			if err == io.EOF {
-				return nil
-			}
-
-			return fmt.Errorf("failed to read output: %w", err)
-		}
-	}
 }
 
 // buildMounts constructs the OCI mounts for the installer container.

--- a/internal/app/lifecycle/internal/output/stream.go
+++ b/internal/app/lifecycle/internal/output/stream.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package output streams lifecycle container output.
+package output
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const maxLineSize = 1024 * 1024
+
+// Stream reads complete lines from r and sends each line via send.
+// Lines exceeding maxLineSize are emitted as bounded fragments so the producer
+// is always drained and cannot block lifecycle execution on a full pipe.
+func Stream(r io.Reader, send func(string) error) error {
+	reader := bufio.NewReaderSize(r, maxLineSize)
+
+	var sendErr error
+
+	for {
+		message, err := reader.ReadSlice('\n')
+
+		if len(message) > 0 && sendErr == nil {
+			if err := send(string(message)); err != nil {
+				sendErr = fmt.Errorf("failed to send message: %w", err)
+			}
+		}
+
+		switch {
+		case err == nil:
+			continue
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			return sendErr
+		default:
+			return fmt.Errorf("failed to read output: %w", err)
+		}
+	}
+}

--- a/internal/app/lifecycle/internal/output/stream_test.go
+++ b/internal/app/lifecycle/internal/output/stream_test.go
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package output_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/lifecycle/internal/output"
+)
+
+func TestStream(t *testing.T) {
+	longLine := strings.Repeat("x", 1024) + "\n"
+	input := "machine configuration is invalid: café\n" + longLine + "partial line"
+
+	var messages []string
+
+	err := output.Stream(iotest.OneByteReader(strings.NewReader(input)), func(message string) error {
+		messages = append(messages, message)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"machine configuration is invalid: café\n",
+		longLine,
+		"partial line",
+	}, messages)
+}
+
+func TestStreamErrors(t *testing.T) {
+	t.Run("oversized line", func(t *testing.T) {
+		var messages []string
+
+		err := output.Stream(strings.NewReader(strings.Repeat("x", 2*1024*1024)), func(message string) error {
+			messages = append(messages, message)
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Len(t, messages, 2)
+		assert.Len(t, messages[0], 1024*1024)
+		assert.Len(t, messages[1], 1024*1024)
+	})
+
+	t.Run("reader", func(t *testing.T) {
+		err := output.Stream(iotest.ErrReader(errors.New("read failed")), func(string) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "read failed")
+	})
+
+	t.Run("sender", func(t *testing.T) {
+		reader := strings.NewReader("line\nremaining output\n")
+
+		err := output.Stream(reader, func(string) error {
+			return errors.New("send failed")
+		})
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "send failed")
+		assert.Zero(t, reader.Len(), "output should be drained after a sender failure")
+	})
+}

--- a/internal/integration/cli/upgrade.go
+++ b/internal/integration/cli/upgrade.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_cli
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+)
+
+const incompatibleInstallerImage = "ghcr.io/siderolabs/installer:v1.12.0"
+
+// UpgradeSuite tests upgrade command failure reporting.
+type UpgradeSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *UpgradeSuite) SuiteName() string {
+	return "cli.UpgradeSuite"
+}
+
+// TestIncompatibleMachineConfig verifies that installer diagnostics survive a failed downgrade.
+func (suite *UpgradeSuite) TestIncompatibleMachineConfig() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	if suite.Cluster == nil {
+		suite.T().Skip("requires a disposable provisioned cluster")
+	}
+
+	if suite.Airgapped {
+		suite.T().Skip("requires pulling the old installer image")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+
+	config, _ := suite.RunCLI([]string{"get", "--nodes", node, "mc", "v1alpha1", "--output", "jsonpath={.spec}"})
+	suite.Require().Contains(config, "kind: DiscoveryServiceConfig", "downgrade must be guaranteed to fail before touching disk")
+
+	suite.RunCLI(
+		[]string{
+			"upgrade",
+			"--nodes", node,
+			"--image", incompatibleInstallerImage,
+			"--namespace", "inmem",
+			"--no-reboot",
+		},
+		base.StdoutEmpty(),
+		base.ShouldFail(),
+		base.StderrMatchFunc(func(stderr string) error {
+			for _, expected := range []string{
+				"error loading machine configuration",
+				"not registered",
+				fmt.Sprintf("%s: upgrade failed with exit code 1", node),
+			} {
+				if !strings.Contains(stderr, expected) {
+					return fmt.Errorf("expected upgrade stderr to contain %q", expected)
+				}
+			}
+
+			return nil
+		}),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(UpgradeSuite))
+}


### PR DESCRIPTION
Upgrade/downgrade failures only surfaced a bare exit code, hiding
installer stderr like "machine configuration is invalid" on downgrade
with incompatible config. Capture container stdout per node and classify
exit codes so failures are actionable.

Also move output streaming into internal/app/lifecycle/internal/output
and switch to bufio line reads, fixing 512-byte chunk-split messages.

Fixes https://github.com/siderolabs/talos/issues/13973

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
