### PR TITLE
feat: implement support for primary setting for the BondConfig

### DIFF
--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -105,6 +105,10 @@ message BondMasterSpec {
   // ARPAllTargets specifies whether ARP probes should be sent to any or all targets.
   talos.resource.definitions.enums.NethelpersARPAllTargets arp_all_targets = 5;
   // PrimaryIndex is a device index specifying which slave is the primary device.
+  //
+  // This is the resolved form of Primary: it is what the kernel reports back, and it is filled in
+  // by the link spec controller right before applying the settings. Configuration layers should set
+  // Primary instead, as interface indexes are not stable.
   uint32 primary_index = 6;
   // PrimaryReselect specifies the policy under which the primary slave should be reselected.
   talos.resource.definitions.enums.NethelpersPrimaryReselect primary_reselect = 7;
@@ -155,6 +159,10 @@ message BondMasterSpec {
   talos.resource.definitions.enums.NethelpersADLACPActive adlacp_active = 27;
   // MissedMax is the number of arp_interval monitor checks that must fail in order for an interface to be marked down by the ARP monitor.
   uint32 missed_max = 28;
+  // Primary is the name of the slave link which should be used as the primary device.
+  //
+  // Only meaningful for the active-backup, balance-tlb and balance-alb modes.
+  string primary = 29;
 }
 
 // BondSlave contains a bond's master name and slave index.

--- a/internal/app/machined/pkg/controllers/network/bond_primary_test.go
+++ b/internal/app/machined/pkg/controllers/network/bond_primary_test.go
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network_test
+
+import (
+	"testing"
+
+	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/stretchr/testify/assert"
+
+	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+func TestResolveBondPrimary(t *testing.T) {
+	t.Parallel()
+
+	links := []rtnetlink.LinkMessage{
+		{
+			Index: 2,
+			Attributes: &rtnetlink.LinkAttributes{
+				Name:     "eno1",
+				Alias:    new("uplink"),
+				AltNames: []string{"slot-1"},
+			},
+		},
+		{
+			Index: 3,
+			Attributes: &rtnetlink.LinkAttributes{
+				Name: "eno2",
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name    string
+		primary string
+		links   []rtnetlink.LinkMessage
+
+		expectedIndex *uint32
+	}{
+		{
+			name:    "by name",
+			primary: "eno1",
+			links:   links,
+
+			expectedIndex: new(uint32(2)),
+		},
+		{
+			name:    "second link",
+			primary: "eno2",
+			links:   links,
+
+			expectedIndex: new(uint32(3)),
+		},
+		{
+			name:    "by alias",
+			primary: "uplink",
+			links:   links,
+
+			expectedIndex: new(uint32(2)),
+		},
+		{
+			name:    "by altname",
+			primary: "slot-1",
+			links:   links,
+
+			expectedIndex: new(uint32(2)),
+		},
+		{
+			name:    "no primary configured",
+			primary: "",
+			links:   links,
+
+			expectedIndex: nil,
+		},
+		{
+			// the NIC hasn't shown up yet, or has been unplugged: leaving the index unset means the
+			// attribute is not encoded at all, so the kernel's current primary is left alone rather
+			// than being cleared (the kernel resolves an unknown index to an empty name)
+			name:    "primary link absent",
+			primary: "eno3",
+			links:   links,
+
+			expectedIndex: nil,
+		},
+		{
+			name:    "no links at all",
+			primary: "eno1",
+			links:   nil,
+
+			expectedIndex: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := network.BondMasterSpec{
+				Mode:    nethelpers.BondModeActiveBackup,
+				Primary: test.primary,
+				// a stale index left over from a previous resolution must always be recomputed
+				PrimaryIndex: new(uint32(42)),
+			}
+
+			resolved, primaryLink := netctrl.ResolveBondPrimaryForTest(spec, test.links)
+
+			if test.expectedIndex == nil {
+				assert.Nil(t, resolved.PrimaryIndex)
+				assert.Nil(t, primaryLink)
+			} else {
+				assert.Equal(t, *test.expectedIndex, *resolved.PrimaryIndex)
+				assert.Equal(t, *test.expectedIndex, primaryLink.Index)
+			}
+
+			// the name is carried through untouched, and the input spec is not mutated
+			assert.Equal(t, test.primary, resolved.Primary)
+			assert.Equal(t, uint32(42), *spec.PrimaryIndex)
+		})
+	}
+}

--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -283,7 +283,7 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline, linkNameResolver *network.Link
 			bondLinkSpec.MTU = uint32(mtu)
 		}
 
-		if err := SetBondMasterLegacy(&bondLinkSpec, &bondOptions); err != nil {
+		if err := SetBondMasterLegacy(&bondLinkSpec, &bondOptions, linkNameResolver.Resolve); err != nil {
 			return settings, fmt.Errorf("error setting bond master: %w", err)
 		}
 

--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -57,7 +57,6 @@ func TestCmdlineParse(t *testing.T) {
 					NumPeerNotif:    1,
 					TLBDynamicLB:    1,
 					UseCarrier:      true,
-					PrimaryIndex:    new(uint32(0)),
 					MissedMax:       2,
 				},
 			},
@@ -406,7 +405,6 @@ func TestCmdlineParse(t *testing.T) {
 							NumPeerNotif:    1,
 							TLBDynamicLB:    1,
 							UseCarrier:      true,
-							PrimaryIndex:    new(uint32(0)),
 						},
 					},
 					{

--- a/internal/app/machined/pkg/controllers/network/export_test.go
+++ b/internal/app/machined/pkg/controllers/network/export_test.go
@@ -6,6 +6,7 @@ package network
 
 // Test exports for unexported route helpers (consumed by the external network_test package).
 var (
-	BuildMultipathForTest = buildMultipath
-	MultipathEqualForTest = multipathEqual
+	BuildMultipathForTest     = buildMultipath
+	MultipathEqualForTest     = multipathEqual
+	ResolveBondPrimaryForTest = resolveBondPrimary
 )

--- a/internal/app/machined/pkg/controllers/network/internal/bgp/imports_test.go
+++ b/internal/app/machined/pkg/controllers/network/internal/bgp/imports_test.go
@@ -155,18 +155,21 @@ func TestBGPRouteImportLifecycle(t *testing.T) {
 func TestBGPImportFamilies(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]bgppacket.Family{bgppacket.RF_IPv4_UC},
 		internalbgp.ImportFamiliesForTest([]netip.Prefix{
 			netip.MustParsePrefix("198.51.100.0/24"),
 			netip.MustParsePrefix("203.0.113.0/24"),
 		}),
 	)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]bgppacket.Family{bgppacket.RF_IPv6_UC},
 		internalbgp.ImportFamiliesForTest([]netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}),
 	)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]bgppacket.Family{bgppacket.RF_IPv4_UC, bgppacket.RF_IPv6_UC},
 		internalbgp.ImportFamiliesForTest([]netip.Prefix{
 			netip.MustParsePrefix("198.51.100.0/24"),

--- a/internal/app/machined/pkg/controllers/network/link_config.go
+++ b/internal/app/machined/pkg/controllers/network/link_config.go
@@ -350,7 +350,7 @@ func (ctrl *LinkConfigController) processDevicesConfiguration(
 		}
 
 		if device.Bond() != nil {
-			if err := SetBondMasterLegacy(linkMap[deviceInterface], device.Bond()); err != nil {
+			if err := SetBondMasterLegacy(linkMap[deviceInterface], device.Bond(), linkNameResolver.Resolve); err != nil {
 				logger.Error("error parsing bond config", zap.Error(err))
 			}
 		}
@@ -477,7 +477,7 @@ func (ctrl *LinkConfigController) processLinkConfigs(linkMap map[string]*network
 			parentLink := linkNameResolver.Resolve(specificLinkConfig.ParentLink())
 			vlanLink(linkMap[linkName], linkName, parentLink, networkVLANConfigToVlaner{specificLinkConfig})
 		case talosconfig.NetworkBondConfig:
-			SendBondMaster(linkMap[linkName], specificLinkConfig)
+			SendBondMaster(linkMap[linkName], specificLinkConfig, linkNameResolver.Resolve)
 
 			bondedLinks := xslices.Map(specificLinkConfig.Links(), linkNameResolver.Resolve)
 

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -488,6 +488,7 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyle() {
 	bc1.BondMode = new(nethelpers.BondModeActiveBackup)
 	bc1.BondLinks = []string{"dummy2", "dummy3"}
 	bc1.BondUpDelay = new(uint32(200))
+	bc1.BondPrimary = new("dummy2")
 
 	br1 := networkcfg.NewBridgeConfigV1Alpha1("br0")
 	br1.BridgeLinks = []string{"enp0s2", "eth1"}
@@ -562,6 +563,9 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyle() {
 				asrt.Equal(nethelpers.BondModeActiveBackup, r.TypedSpec().BondMaster.Mode)
 				asrt.EqualValues(200, r.TypedSpec().BondMaster.UpDelay)
 				asrt.Nil(r.TypedSpec().BondMaster.ADLACPActive)
+				asrt.Equal("dummy2", r.TypedSpec().BondMaster.Primary)
+				// the name is resolved to an index only when the settings are applied
+				asrt.Nil(r.TypedSpec().BondMaster.PrimaryIndex)
 			case "br0":
 				asrt.True(r.TypedSpec().Up)
 				asrt.True(r.TypedSpec().Logical)
@@ -569,6 +573,45 @@ func (suite *LinkConfigSuite) TestMachineConfigurationNewStyle() {
 				asrt.Equal(network.LinkKindBridge, r.TypedSpec().Kind)
 				asrt.True(r.TypedSpec().BridgeMaster.STP.Enabled)
 				asrt.True(r.TypedSpec().BridgeMaster.VLAN.FilteringEnabled)
+			}
+		},
+	)
+}
+
+// TestMachineConfigurationNewStyleBondPrimaryAlias checks that the bond primary is resolved through
+// link aliases, the same way the list of bonded links is.
+func (suite *LinkConfigSuite) TestMachineConfigurationNewStyleBondPrimaryAlias() {
+	suite.Require().NoError(suite.Runtime().RegisterController(&netctrl.LinkConfigController{}))
+
+	bc := networkcfg.NewBondConfigV1Alpha1("bond0")
+	bc.BondMode = new(nethelpers.BondModeActiveBackup)
+	bc.BondLinks = []string{"uplink", "eth1"}
+	bc.BondPrimary = new("uplink")
+	bc.BondPrimaryReselect = new(nethelpers.PrimaryReselectAlways)
+
+	ctr, err := container.New(bc)
+	suite.Require().NoError(err)
+
+	suite.Create(config.NewMachineConfig(ctr))
+
+	status := network.NewLinkStatus(network.NamespaceName, "eth0")
+	status.TypedSpec().AltNames = []string{"uplink"}
+	suite.Create(status)
+
+	suite.assertLinks(
+		[]string{
+			"configuration/bond0",
+			"configuration/eth0",
+			"configuration/eth1",
+		}, func(r *network.LinkSpec, asrt *assert.Assertions) {
+			switch r.TypedSpec().Name {
+			case "bond0":
+				asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
+				// "uplink" is an alias of eth0, so the primary is stored under the real link name
+				asrt.Equal("eth0", r.TypedSpec().BondMaster.Primary)
+				asrt.Equal(nethelpers.PrimaryReselectAlways, r.TypedSpec().BondMaster.PrimaryReselect)
+			case "eth0", "eth1":
+				asrt.Equal("bond0", r.TypedSpec().BondSlave.MasterName)
 			}
 		},
 	)

--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -235,6 +235,32 @@ func findLink(links []rtnetlink.LinkMessage, name string, allowAliases bool) *rt
 	return nil
 }
 
+// resolveBondPrimary returns a copy of the bond master spec with PrimaryIndex resolved from Primary,
+// along with the link the primary resolved to (nil if it isn't present).
+//
+// The configuration layers name the primary slave, while the kernel's IFLA_BOND_PRIMARY is an interface
+// index. Indexes are not stable across reboots, renames or NIC re-plugs, so the resolution has to happen
+// against the live link list every time the settings are applied rather than once at config parsing time.
+//
+// If the primary link is not present right now, PrimaryIndex is left unset, which means "don't touch the
+// primary": the attribute is not encoded, so the kernel keeps whatever it has. Applying it anyway would be
+// actively harmful — the kernel resolves an unknown index to an empty name and *clears* the primary. The
+// controller watches RTMGRP_LINK, so a primary which shows up later converges on the next reconcile.
+func resolveBondPrimary(bondMaster network.BondMasterSpec, links []rtnetlink.LinkMessage) (network.BondMasterSpec, *rtnetlink.LinkMessage) {
+	bondMaster.PrimaryIndex = nil
+
+	if bondMaster.Primary == "" {
+		return bondMaster, nil
+	}
+
+	primaryLink := findLink(links, bondMaster.Primary, true)
+	if primaryLink != nil {
+		bondMaster.PrimaryIndex = new(primaryLink.Index)
+	}
+
+	return bondMaster, primaryLink
+}
+
 func rawLinkData(link *rtnetlink.LinkMessage) []byte {
 	if link == nil || link.Attributes == nil || link.Attributes.Info == nil || link.Attributes.Info.Data == nil {
 		return nil
@@ -476,7 +502,9 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 			}
 
 			if link.TypedSpec().Kind == network.LinkKindBond {
-				data, err = networkadapter.BondMasterSpec(&link.TypedSpec().BondMaster).Encode()
+				bondMaster, _ := resolveBondPrimary(link.TypedSpec().BondMaster, *links)
+
+				data, err = networkadapter.BondMasterSpec(&bondMaster).Encode()
 				if err != nil {
 					return fmt.Errorf("error encoding bond attributes for link %q: %w", link.TypedSpec().Name, err)
 				}
@@ -558,19 +586,38 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 				return fmt.Errorf("error parsing bond attributes for %q: %w", link.TypedSpec().Name, err)
 			}
 
-			// primaryIndex might be reported from the kernel, but if it's nil in the spec, we should treat it as equal
-			if existingBond.PrimaryIndex != nil && link.TypedSpec().BondMaster.PrimaryIndex == nil {
-				existingBond.PrimaryIndex = nil
-			}
+			// the spec carries the primary as a link name, but the kernel talks in interface indexes, and those
+			// are not stable, so resolve the name against the current link list on every reconcile
+			expectedBond, primaryLink := resolveBondPrimary(link.TypedSpec().BondMaster, *links)
 
-			if !existingBond.Equal(&link.TypedSpec().BondMaster) {
+			// decide on the primary here rather than leaving it to Equal, which is deliberately lenient about it.
+			//
+			// The kernel only reports IFLA_BOND_PRIMARY while the primary slave is actually enslaved, so its answer
+			// is only worth comparing against once the primary link has joined the bond. Outside of that, an unset
+			// primary on the kernel side doesn't mean drift:
+			//
+			//   - the primary link hasn't been enslaved yet: the name we asked for is already pending in the bond's
+			//     params, and bond_enslave picks it up when the link joins;
+			//   - the primary link is gone (unplugged, driver unloaded): the kernel dropped it, and re-applying would
+			//     tear the bond down and re-enslave every remaining slave exactly when a failover is in flight;
+			//   - nothing asks for a primary at all: whatever the kernel has stays put.
+			primaryEnslaved := expectedBond.PrimaryIndex != nil &&
+				primaryLink != nil && pointer.SafeDeref(primaryLink.Attributes.Master) == existing.Index
+
+			primaryDiffers := primaryEnslaved &&
+				(existingBond.PrimaryIndex == nil || *existingBond.PrimaryIndex != *expectedBond.PrimaryIndex)
+
+			// take the primary out of the picture for Equal, which is only asked about the remaining settings
+			existingBond.PrimaryIndex = expectedBond.PrimaryIndex
+
+			if primaryDiffers || !existingBond.Equal(&expectedBond) {
 				logger.Debug(
 					"updating bond settings",
 					zap.String("old", fmt.Sprintf("%+v", existingBond)),
-					zap.String("new", fmt.Sprintf("%+v", link.TypedSpec().BondMaster)),
+					zap.String("new", fmt.Sprintf("%+v", expectedBond)),
 				)
 
-				data, err := networkadapter.BondMasterSpec(&link.TypedSpec().BondMaster).Encode()
+				data, err := networkadapter.BondMasterSpec(&expectedBond).Encode()
 				if err != nil {
 					return fmt.Errorf("error encoding bond attributes for %q: %w", link.TypedSpec().Name, err)
 				}

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -720,6 +720,178 @@ func (suite *LinkSpecSuite) TestBondActiveBackup() {
 	})
 }
 
+// bondWithSlaves builds an active-backup bond with the given primary (by name) plus two dummy slaves.
+//
+// The slaves are returned separately from the bond so that a test can create the slave links first,
+// which is what happens with real NICs: the physical links already exist by the time the bond is built.
+func (suite *LinkSpecSuite) bondWithSlaves(primary func(dummyNames []string) string) (bondName string, dummyNames []string, dummies []resource.Resource, bond resource.Resource) {
+	bondName = suite.uniqueDummyInterface()
+
+	for range 2 {
+		dummyNames = append(dummyNames, suite.uniqueDummyInterface())
+	}
+
+	for idx, dummyName := range dummyNames {
+		dummy := network.NewLinkSpec(network.NamespaceName, dummyName)
+		*dummy.TypedSpec() = network.LinkSpecSpec{
+			Name:    dummyName,
+			Type:    nethelpers.LinkEther,
+			Kind:    "dummy",
+			Up:      true,
+			Logical: true,
+			BondSlave: network.BondSlave{
+				MasterName: bondName,
+				SlaveIndex: idx,
+			},
+			ConfigLayer: network.ConfigDefault,
+		}
+
+		dummies = append(dummies, dummy)
+	}
+
+	bondSpec := network.NewLinkSpec(network.NamespaceName, bondName)
+	*bondSpec.TypedSpec() = network.LinkSpecSpec{
+		Name:    bondName,
+		Type:    nethelpers.LinkEther,
+		Kind:    network.LinkKindBond,
+		Up:      true,
+		Logical: true,
+		BondMaster: network.BondMasterSpec{
+			Mode:            nethelpers.BondModeActiveBackup,
+			HashPolicy:      nethelpers.BondXmitPolicyLayer2,
+			LACPRate:        nethelpers.LACPRateSlow,
+			ARPValidate:     nethelpers.ARPValidateNone,
+			ARPAllTargets:   nethelpers.ARPAllTargetsAny,
+			Primary:         primary(dummyNames),
+			PrimaryReselect: nethelpers.PrimaryReselectAlways,
+			FailOverMac:     nethelpers.FailOverMACNone,
+		},
+		ConfigLayer: network.ConfigDefault,
+	}
+
+	networkadapter.BondMasterSpec(&bondSpec.TypedSpec().BondMaster).FillDefaults()
+
+	return bondName, dummyNames, dummies, bondSpec
+}
+
+// assertBondSettingsNotReapplied checks that the bond settings converged on the first apply.
+//
+// A mismatch between the spec and what the kernel reports makes the link spec controller bring the
+// bond down and unslave every slave before rewriting the settings, so a primary which never compares
+// equal would flap the bond on every reconcile.
+func (suite *LinkSpecSuite) assertBondSettingsNotReapplied(bondName string) {
+	for _, entry := range suite.observedLogs.FilterMessage("controller failed").All() {
+		suite.Require().NotContains(fmt.Sprint(entry.ContextMap()["error"]), bondName)
+	}
+
+	for _, entry := range suite.observedLogs.FilterMessage("updating bond settings").All() {
+		suite.Require().NotEqual(bondName, entry.ContextMap()["link"])
+	}
+}
+
+// TestBondPrimary checks that a primary named in the spec is resolved to the slave's interface index
+// and reported back by the kernel.
+func (suite *LinkSpecSuite) TestBondPrimary() {
+	// deliberately pick the *second* slave, so a pass can't be explained by the bond just defaulting
+	// to the first link that came up
+	bondName, dummyNames, dummies, bond := suite.bondWithSlaves(func(dummyNames []string) string { return dummyNames[1] })
+	primaryName := dummyNames[1]
+
+	// bring the slave links up first, so the primary can be resolved when the bond is created
+	for _, res := range dummies {
+		suite.Create(res)
+	}
+
+	var primaryIndex uint32
+
+	ctest.AssertResource(suite, primaryName, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.NotZero(r.TypedSpec().Index)
+
+		primaryIndex = r.TypedSpec().Index
+	})
+
+	suite.Create(bond)
+
+	ctest.AssertResource(suite, bondName, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
+
+		if asrt.NotNil(r.TypedSpec().BondMaster.PrimaryIndex) {
+			asrt.Equal(primaryIndex, *r.TypedSpec().BondMaster.PrimaryIndex)
+		}
+	})
+
+	// the primary resolved on the first pass, so the settings should have been written exactly once
+	suite.assertBondSettingsNotReapplied(bondName)
+
+	for _, res := range append(dummies, bond) {
+		suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), res.Metadata()))
+	}
+
+	ctest.AssertNoResource[*network.LinkStatus](suite, bondName)
+}
+
+// TestBondPrimaryAppliedLate covers the ordering where the bond is created before its slaves exist —
+// the primary can't be resolved yet, so it has to be applied on a later reconcile once the slave shows
+// up. Without that, a bond whose slaves are logical links would silently never get a primary.
+func (suite *LinkSpecSuite) TestBondPrimaryAppliedLate() {
+	bondName, dummyNames, dummies, bond := suite.bondWithSlaves(func(dummyNames []string) string { return dummyNames[1] })
+	primaryName := dummyNames[1]
+
+	// everything at once: SortLinks puts the bond master ahead of its slaves, so the bond is created
+	// while the slave links still don't exist
+	for _, res := range append(dummies, bond) {
+		suite.Create(res)
+	}
+
+	var primaryIndex uint32
+
+	ctest.AssertResource(suite, primaryName, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.NotZero(r.TypedSpec().Index)
+
+		primaryIndex = r.TypedSpec().Index
+	})
+
+	ctest.AssertResource(suite, bondName, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
+
+		if asrt.NotNil(r.TypedSpec().BondMaster.PrimaryIndex) {
+			asrt.Equal(primaryIndex, *r.TypedSpec().BondMaster.PrimaryIndex)
+		}
+	})
+
+	for _, res := range append(dummies, bond) {
+		suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), res.Metadata()))
+	}
+
+	ctest.AssertNoResource[*network.LinkStatus](suite, bondName)
+}
+
+// TestBondPrimaryNotPresent checks that naming a primary which doesn't exist doesn't break the bond,
+// and — more importantly — doesn't put the controller into a loop where it rewrites the bond settings
+// on every reconcile because the unresolvable name never matches what the kernel reports.
+func (suite *LinkSpecSuite) TestBondPrimaryNotPresent() {
+	bondName, _, dummies, bond := suite.bondWithSlaves(func([]string) string { return "tlos-absent0" })
+
+	for _, res := range append(dummies, bond) {
+		suite.Create(res)
+	}
+
+	ctest.AssertResource(suite, bondName, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.Equal(network.LinkKindBond, r.TypedSpec().Kind)
+		asrt.Contains([]nethelpers.OperationalState{nethelpers.OperStateUp, nethelpers.OperStateUnknown}, r.TypedSpec().OperationalState)
+		// no primary was ever applied, so the kernel doesn't report one
+		asrt.Nil(r.TypedSpec().BondMaster.PrimaryIndex)
+	})
+
+	suite.assertBondSettingsNotReapplied(bondName)
+
+	for _, res := range append(dummies, bond) {
+		suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), res.Metadata()))
+	}
+
+	ctest.AssertNoResource[*network.LinkStatus](suite, bondName)
+}
+
 //nolint:gocyclo
 func (suite *LinkSpecSuite) TestBond8023ad() {
 	bondName := suite.uniqueDummyInterface()

--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -6,8 +6,6 @@
 package network
 
 import (
-	"net"
-
 	"github.com/siderolabs/gen/pair/ordered"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
@@ -25,7 +23,9 @@ func SetBondSlave(link *network.LinkSpecSpec, bond ordered.Pair[string, int]) {
 }
 
 // SendBondMaster sets the bond master spec.
-func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConfig) {
+//
+// resolveLinkName resolves a link alias to the actual link name.
+func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConfig, resolveLinkName func(string) string) {
 	link.Logical = true
 	link.Kind = network.LinkKindBond
 	link.Type = nethelpers.LinkEther
@@ -51,6 +51,12 @@ func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConf
 		link.BondMaster.ADLACPActive = nil
 	}
 
+	if primary, ok := bond.Primary().Get(); ok {
+		link.BondMaster.Primary = resolveLinkName(primary)
+	} else {
+		link.BondMaster.Primary = ""
+	}
+
 	link.BondMaster.PrimaryReselect = bond.PrimaryReselect().ValueOrZero()
 	link.BondMaster.ResendIGMP = bond.ResendIGMP().ValueOrZero()
 	link.BondMaster.MinLinks = bond.MinLinks().ValueOrZero()
@@ -67,8 +73,10 @@ func SendBondMaster(link *network.LinkSpecSpec, bond talosconfig.NetworkBondConf
 
 // SetBondMasterLegacy sets the bond master spec.
 //
+// resolveLinkName resolves a link alias to the actual link name.
+//
 //nolint:gocyclo
-func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond) error {
+func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond, resolveLinkName func(string) string) error {
 	link.Logical = true
 	link.Kind = network.LinkKindBond
 	link.Type = nethelpers.LinkEther
@@ -98,17 +106,10 @@ func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond) erro
 		return err
 	}
 
-	var primary uint32
+	var primary string
 
 	if bond.Primary() != "" {
-		var iface *net.Interface
-
-		iface, err = net.InterfaceByName(bond.Primary())
-		if err != nil {
-			return err
-		}
-
-		primary = uint32(iface.Index)
+		primary = resolveLinkName(bond.Primary())
 	}
 
 	primaryReselect, err := nethelpers.PrimaryReselectByName(bond.PrimaryReselect())
@@ -132,7 +133,7 @@ func SetBondMasterLegacy(link *network.LinkSpecSpec, bond talosconfig.Bond) erro
 		LACPRate:        lacpRate,
 		ARPValidate:     arpValidate,
 		ARPAllTargets:   arpAllTargets,
-		PrimaryIndex:    new(primary),
+		Primary:         primary,
 		PrimaryReselect: primaryReselect,
 		FailOverMac:     failOverMAC,
 		ADSelect:        adSelect,

--- a/internal/integration/api/discovery.go
+++ b/internal/integration/api/discovery.go
@@ -284,7 +284,8 @@ func (suite *DiscoverySuite) TestServiceEndpoints() {
 		return cluster.ServiceEndpoint{Name: c.Name(), Endpoint: addr, Insecure: insecure}
 	})
 
-	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
+	rtestutils.AssertResources(
+		nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
 		func(cfg *cluster.Config, asrt *assert.Assertions) {
 			asrt.ElementsMatch(expected, cfg.TypedSpec().ServiceEndpoints)
 		},
@@ -324,7 +325,8 @@ func (suite *DiscoverySuite) TestDiscoveryServiceConfigDocument() {
 	suite.PatchMachineConfig(nodeCtx, cfgDocument)
 
 	// the cluster Config resource should now include the extra named endpoint
-	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
+	rtestutils.AssertResources(
+		nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
 		func(cfg *cluster.Config, asrt *assert.Assertions) {
 			asrt.Contains(xslices.Map(cfg.TypedSpec().ServiceEndpoints, func(ep cluster.ServiceEndpoint) string { return ep.Name }), extraName)
 		},
@@ -339,7 +341,8 @@ func (suite *DiscoverySuite) TestDiscoveryServiceConfigDocument() {
 	suite.RemoveMachineConfigDocumentsByName(nodeCtx, clustertypes.DiscoveryServiceKind, extraName)
 
 	// after removal, the extra endpoint disappears from the resource
-	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
+	rtestutils.AssertResources(
+		nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
 		func(cfg *cluster.Config, asrt *assert.Assertions) {
 			asrt.NotContains(xslices.Map(cfg.TypedSpec().ServiceEndpoints, func(ep cluster.ServiceEndpoint) string { return ep.Name }), extraName)
 		},
@@ -373,7 +376,8 @@ func (suite *DiscoverySuite) TestDiscoveryServiceConfigDocument() {
 	suite.RemoveMachineConfigDocuments(nodeCtx, clustertypes.DiscoveryServiceKind)
 
 	// the cluster Config resource should no longer carry any service endpoints
-	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
+	rtestutils.AssertResources(
+		nodeCtx, suite.T(), suite.Client.COSI, []string{cluster.ConfigID},
 		func(cfg *cluster.Config, asrt *assert.Assertions) {
 			asrt.Empty(cfg.TypedSpec().ServiceEndpoints)
 		},

--- a/internal/integration/api/network-config.go
+++ b/internal/integration/api/network-config.go
@@ -552,6 +552,79 @@ func (suite *NetworkConfigSuite) TestBondConfig() {
 	rtestutils.AssertNoResource[*networkres.RouteStatus](nodeCtx, suite.T(), suite.Client.COSI, routeID)
 }
 
+// TestBondPrimaryConfig tests that the bond primary named in the config is applied to the kernel.
+//
+// The kernel reports IFLA_BOND_PRIMARY as an interface index, while the config names the link, so this
+// covers the name-to-index resolution end to end.
+func (suite *NetworkConfigSuite) TestBondPrimaryConfig() {
+	if suite.Cluster == nil {
+		suite.T().Skip("skipping if cluster is not qemu/docker")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	suite.T().Logf("testing on node %q", node)
+
+	dummyNames := xslices.Map([]int{0, 1}, func(int) string {
+		return fmt.Sprintf("dummy%d", rand.IntN(10000))
+	})
+
+	dummyConfigs := xslices.Map(dummyNames, func(name string) any {
+		return network.NewDummyLinkConfigV1Alpha1(name)
+	})
+
+	// deliberately the second link, so a pass can't be explained by the bond defaulting to the first slave
+	primaryName := dummyNames[1]
+
+	bondName := "agg." + strconv.Itoa(rand.IntN(10000))
+
+	bond := network.NewBondConfigV1Alpha1(bondName)
+	bond.BondLinks = dummyNames
+	bond.BondMode = new(nethelpers.BondModeActiveBackup)
+	bond.BondMIIMon = new(uint32(100))
+	bond.BondPrimary = new(primaryName)
+	bond.BondPrimaryReselect = new(nethelpers.PrimaryReselectAlways)
+	bond.LinkUp = new(true)
+
+	suite.PatchMachineConfig(nodeCtx, append(dummyConfigs, bond)...)
+
+	var primaryIndex uint32
+
+	rtestutils.AssertResource(
+		nodeCtx, suite.T(), suite.Client.COSI, primaryName,
+		func(link *networkres.LinkStatus, asrt *assert.Assertions) {
+			asrt.Equal("dummy", link.TypedSpec().Kind)
+			asrt.NotZero(link.TypedSpec().MasterIndex)
+			asrt.NotZero(link.TypedSpec().Index)
+
+			primaryIndex = link.TypedSpec().Index
+		},
+	)
+
+	rtestutils.AssertResource(
+		nodeCtx, suite.T(), suite.Client.COSI, bondName,
+		func(link *networkres.LinkStatus, asrt *assert.Assertions) {
+			asrt.Equal("bond", link.TypedSpec().Kind)
+			asrt.Equal(nethelpers.BondModeActiveBackup, link.TypedSpec().BondMaster.Mode)
+			asrt.Equal(nethelpers.PrimaryReselectAlways, link.TypedSpec().BondMaster.PrimaryReselect)
+
+			if asrt.NotNil(link.TypedSpec().BondMaster.PrimaryIndex) {
+				asrt.Equal(primaryIndex, *link.TypedSpec().BondMaster.PrimaryIndex)
+			}
+		},
+	)
+
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.BondKind, bondName)
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.DummyLinkKind, dummyNames...)
+
+	for _, dummyName := range dummyNames {
+		rtestutils.AssertNoResource[*networkres.LinkStatus](nodeCtx, suite.T(), suite.Client.COSI, dummyName)
+	}
+
+	rtestutils.AssertNoResource[*networkres.LinkStatus](nodeCtx, suite.T(), suite.Client.COSI, bondName)
+}
+
 // TestBridgeConfig tests creation of bridge interfaces.
 func (suite *NetworkConfigSuite) TestBridgeConfig() {
 	if suite.Cluster == nil {

--- a/internal/integration/api/node-annotations.go
+++ b/internal/integration/api/node-annotations.go
@@ -149,7 +149,8 @@ func (suite *NodeAnnotationsSuite) setNodeAnnotations(nodeIP string, nodeAnnotat
 			nodeConfig.AnnotationsConfig = nodeAnnotations
 
 			return nil
-		})
+		},
+	)
 	suite.Require().NoError(err)
 
 	bytes, err := nodeConfig.Bytes()

--- a/internal/integration/api/node-labels.go
+++ b/internal/integration/api/node-labels.go
@@ -182,7 +182,8 @@ func (suite *NodeLabelsSuite) setNodeLabels(nodeIP string, nodeLabels map[string
 			nodeConfig.LabelsConfig = nodeLabels
 
 			return nil
-		})
+		},
+	)
 	suite.Require().NoError(err)
 
 	bytes, err := nodeConfig.Bytes()

--- a/internal/integration/api/node-taints.go
+++ b/internal/integration/api/node-taints.go
@@ -178,7 +178,8 @@ func (suite *NodeTaintsSuite) setNodeTaints(nodeIP string, nodeTaints map[string
 			nodeConfig.TaintsConfig = nodeTaints
 
 			return nil
-		}))(suite.T())
+		},
+	))(suite.T())
 
 	bytes, err := nodeConfig.Bytes()
 	suite.Require().NoError(err)

--- a/internal/integration/api/proxy-url.go
+++ b/internal/integration/api/proxy-url.go
@@ -130,7 +130,8 @@ func (suite *ProxyURLSuite) TestProxyURL() {
 		endpoint = currentCtx.Endpoints[0]
 	}
 
-	c, err := client.New(suite.ctx,
+	c, err := client.New(
+		suite.ctx,
 		client.WithConfigContext(&ctxWithProxy),
 		client.WithEndpoints(endpoint),
 	)

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -327,7 +327,8 @@ func (suite *RebootSuite) TestRebootWithFailingUserVolume() {
 	defer suite.RemoveMachineConfigDocumentsByName(nodeCtx, blockcfg.UserVolumeConfigKind, volumeID)
 
 	// the user volume should fail to allocate (no disk matched the selector)
-	rtestutils.AssertResources(nodeCtx, suite.T(), suite.Client.COSI, []string{userVolumeID},
+	rtestutils.AssertResources(
+		nodeCtx, suite.T(), suite.Client.COSI, []string{userVolumeID},
 		func(vs *block.VolumeStatus, asrt *assert.Assertions) {
 			asrt.Equal(block.VolumePhaseFailed, vs.TypedSpec().Phase)
 		},

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -469,7 +469,8 @@ func (suite *VolumesSuite) TestUserVolumesPartition() {
 		userVolumesWithTrimSchedule = userVolumeIDs[1:2]
 	}
 
-	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, userVolumesWithTrimSchedule,
+	rtestutils.AssertResources(
+		ctx, suite.T(), suite.Client.COSI, userVolumesWithTrimSchedule,
 		func(vs *block.VolumeTrimSchedule, asrt *assert.Assertions) {
 			expectedInterval := constants.DefaultFilesystemTrimInterval
 

--- a/pkg/machinery/api/resource/definitions/network/network.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network.pb.go
@@ -725,6 +725,10 @@ type BondMasterSpec struct {
 	// ARPAllTargets specifies whether ARP probes should be sent to any or all targets.
 	ArpAllTargets enums.NethelpersARPAllTargets `protobuf:"varint,5,opt,name=arp_all_targets,json=arpAllTargets,proto3,enum=talos.resource.definitions.enums.NethelpersARPAllTargets" json:"arp_all_targets,omitempty"`
 	// PrimaryIndex is a device index specifying which slave is the primary device.
+	//
+	// This is the resolved form of Primary: it is what the kernel reports back, and it is filled in
+	// by the link spec controller right before applying the settings. Configuration layers should set
+	// Primary instead, as interface indexes are not stable.
 	PrimaryIndex uint32 `protobuf:"varint,6,opt,name=primary_index,json=primaryIndex,proto3" json:"primary_index,omitempty"`
 	// PrimaryReselect specifies the policy under which the primary slave should be reselected.
 	PrimaryReselect enums.NethelpersPrimaryReselect `protobuf:"varint,7,opt,name=primary_reselect,json=primaryReselect,proto3,enum=talos.resource.definitions.enums.NethelpersPrimaryReselect" json:"primary_reselect,omitempty"`
@@ -774,7 +778,11 @@ type BondMasterSpec struct {
 	// ADLACPActive specifies whether to send LACPDU frames periodically.
 	AdlacpActive enums.NethelpersADLACPActive `protobuf:"varint,27,opt,name=adlacp_active,json=adlacpActive,proto3,enum=talos.resource.definitions.enums.NethelpersADLACPActive" json:"adlacp_active,omitempty"`
 	// MissedMax is the number of arp_interval monitor checks that must fail in order for an interface to be marked down by the ARP monitor.
-	MissedMax     uint32 `protobuf:"varint,28,opt,name=missed_max,json=missedMax,proto3" json:"missed_max,omitempty"`
+	MissedMax uint32 `protobuf:"varint,28,opt,name=missed_max,json=missedMax,proto3" json:"missed_max,omitempty"`
+	// Primary is the name of the slave link which should be used as the primary device.
+	//
+	// Only meaningful for the active-backup, balance-tlb and balance-alb modes.
+	Primary       string `protobuf:"bytes,29,opt,name=primary,proto3" json:"primary,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1003,6 +1011,13 @@ func (x *BondMasterSpec) GetMissedMax() uint32 {
 		return x.MissedMax
 	}
 	return 0
+}
+
+func (x *BondMasterSpec) GetPrimary() string {
+	if x != nil {
+		return x.Primary
+	}
+	return ""
 }
 
 // BondSlave contains a bond's master name and slave index.
@@ -6026,7 +6041,7 @@ const file_resource_definitions_network_network_proto_rawDesc = "" +
 	"\baccepted\x18\t \x01(\rR\baccepted\x12\x1b\n" +
 	"\tbfd_state\x18\n" +
 	" \x01(\tR\bbfdState\x12\x1a\n" +
-	"\binstance\x18\v \x01(\tR\binstance\"\x8a\f\n" +
+	"\binstance\x18\v \x01(\tR\binstance\"\xa4\f\n" +
 	"\x0eBondMasterSpec\x12H\n" +
 	"\x04mode\x18\x01 \x01(\x0e24.talos.resource.definitions.enums.NethelpersBondModeR\x04mode\x12_\n" +
 	"\vhash_policy\x18\x02 \x01(\x0e2>.talos.resource.definitions.enums.NethelpersBondXmitHashPolicyR\n" +
@@ -6062,7 +6077,8 @@ const file_resource_definitions_network_network_proto_rawDesc = "" +
 	"\rnsip6_targets\x18\x1a \x03(\v2\r.common.NetIPR\fnsip6Targets\x12]\n" +
 	"\radlacp_active\x18\x1b \x01(\x0e28.talos.resource.definitions.enums.NethelpersADLACPActiveR\fadlacpActive\x12\x1d\n" +
 	"\n" +
-	"missed_max\x18\x1c \x01(\rR\tmissedMax\"M\n" +
+	"missed_max\x18\x1c \x01(\rR\tmissedMax\x12\x18\n" +
+	"\aprimary\x18\x1d \x01(\tR\aprimary\"M\n" +
 	"\tBondSlave\x12\x1f\n" +
 	"\vmaster_name\x18\x01 \x01(\tR\n" +
 	"masterName\x12\x1f\n" +

--- a/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network_vtproto.pb.go
@@ -822,6 +822,15 @@ func (m *BondMasterSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Primary) > 0 {
+		i -= len(m.Primary)
+		copy(dAtA[i:], m.Primary)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Primary)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xea
+	}
 	if m.MissedMax != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MissedMax))
 		i--
@@ -6436,6 +6445,10 @@ func (m *BondMasterSpec) SizeVT() (n int) {
 	if m.MissedMax != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.MissedMax))
 	}
+	l = len(m.Primary)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -10907,6 +10920,38 @@ func (m *BondMasterSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 29:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Primary", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Primary = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/network.go
+++ b/pkg/machinery/config/config/network.go
@@ -292,6 +292,7 @@ type NetworkBondConfig interface {
 	ADActorSysPrio() optional.Optional[uint16]
 	ADUserPortKey() optional.Optional[uint16]
 	ADLACPActive() optional.Optional[nethelpers.ADLACPActive]
+	Primary() optional.Optional[string]
 	PrimaryReselect() optional.Optional[nethelpers.PrimaryReselect]
 	ResendIGMP() optional.Optional[uint32]
 	MinLinks() optional.Optional[uint32]

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -304,7 +304,8 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 		slices.Sort(kinds)
 		kinds = slices.Compact(kinds)
 
-		errs = multierror.Append(errs,
+		errs = multierror.Append(
+			errs,
 			fmt.Errorf(
 				"the following document kinds are only allowed on control plane machines: %v",
 				kinds,

--- a/pkg/machinery/config/generate/kubernetes.go
+++ b/pkg/machinery/config/generate/kubernetes.go
@@ -48,7 +48,8 @@ func (in *Input) generateKubernetesControlplaneConfigs(controlplaneURL *url.URL,
 	var etcdEncryptionProvidersList []any
 
 	if in.Options.SecretsBundle.Secrets.SecretboxEncryptionSecret != "" {
-		etcdEncryptionProvidersList = append(etcdEncryptionProvidersList,
+		etcdEncryptionProvidersList = append(
+			etcdEncryptionProvidersList,
 			map[string]any{
 				"secretbox": map[string]any{
 					"keys": []any{
@@ -63,7 +64,8 @@ func (in *Input) generateKubernetesControlplaneConfigs(controlplaneURL *url.URL,
 	}
 
 	if in.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret != "" {
-		etcdEncryptionProvidersList = append(etcdEncryptionProvidersList,
+		etcdEncryptionProvidersList = append(
+			etcdEncryptionProvidersList,
 			map[string]any{
 				"secretbox": map[string]any{
 					"keys": []any{

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -3966,6 +3966,13 @@
           "markdownDescription": "Whether to send LACPDU frames periodically, defaults to \"on\" if mode is 802.3ad.",
           "x-intellij-html-description": "\u003cp\u003eWhether to send LACPDU frames periodically, defaults to \u0026ldquo;on\u0026rdquo; if mode is 802.3ad.\u003c/p\u003e\n"
         },
+        "primary": {
+          "type": "string",
+          "title": "primary",
+          "description": "Name of the link (interface) which should be used as the primary slave of the bond.\n\nThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the “active-backup”, “balance-tlb” and “balance-alb” modes.\n\nMust be one of the links listed in links.\n",
+          "markdownDescription": "Name of the link (interface) which should be used as the primary slave of the bond.\n\nThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the \"active-backup\", \"balance-tlb\" and \"balance-alb\" modes.\n\nMust be one of the links listed in `links`.",
+          "x-intellij-html-description": "\u003cp\u003eName of the link (interface) which should be used as the primary slave of the bond.\u003c/p\u003e\n\n\u003cp\u003eThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the \u0026ldquo;active-backup\u0026rdquo;, \u0026ldquo;balance-tlb\u0026rdquo; and \u0026ldquo;balance-alb\u0026rdquo; modes.\u003c/p\u003e\n\n\u003cp\u003eMust be one of the links listed in \u003ccode\u003elinks\u003c/code\u003e.\u003c/p\u003e\n"
+        },
         "primaryReselect": {
           "enum": [
             "always",
@@ -3973,9 +3980,9 @@
             "failure"
           ],
           "title": "primaryReselect",
-          "description": "Policy under which the primary slave should be reselected.\n",
-          "markdownDescription": "Policy under which the primary slave should be reselected.",
-          "x-intellij-html-description": "\u003cp\u003ePolicy under which the primary slave should be reselected.\u003c/p\u003e\n"
+          "description": "Policy under which the primary slave should be reselected.\n\nHas no effect unless primary is set.\n",
+          "markdownDescription": "Policy under which the primary slave should be reselected.\n\nHas no effect unless `primary` is set.",
+          "x-intellij-html-description": "\u003cp\u003ePolicy under which the primary slave should be reselected.\u003c/p\u003e\n\n\u003cp\u003eHas no effect unless \u003ccode\u003eprimary\u003c/code\u003e is set.\u003c/p\u003e\n"
         },
         "resendIGMP": {
           "type": "integer",

--- a/pkg/machinery/config/types/network/bond.go
+++ b/pkg/machinery/config/types/network/bond.go
@@ -8,7 +8,9 @@ package network
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
+	"slices"
 
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-pointer"
@@ -237,7 +239,20 @@ type BondConfigV1Alpha1 struct {
 	//     - "off"
 	BondADLACPActive *nethelpers.ADLACPActive `yaml:"adLACPActive,omitempty"`
 	//   description: |
+	//     Name of the link (interface) which should be used as the primary slave of the bond.
+	//
+	//     The primary link, when up, is always the active one; the other links are only used when the
+	//     primary is down. Only meaningful for the "active-backup", "balance-tlb" and "balance-alb" modes.
+	//
+	//     Must be one of the links listed in `links`.
+	//   examples:
+	//    - value: >
+	//       "enp1s2"
+	BondPrimary *string `yaml:"primary,omitempty"`
+	//   description: |
 	//     Policy under which the primary slave should be reselected.
+	//
+	//     Has no effect unless `primary` is set.
 	//   examples:
 	//    - value: >
 	//       "always"
@@ -363,8 +378,51 @@ func (s *BondConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.Opti
 		warnings = append(warnings, s.validateFor8023AD()...)
 	}
 
+	primaryWarnings, primaryErrs := s.validatePrimary()
+	errs, warnings = errors.Join(errs, primaryErrs), append(warnings, primaryWarnings...)
+
 	extraWarnings, extraErrs := s.CommonLinkConfig.Validate()
 	errs, warnings = errors.Join(errs, extraErrs), append(warnings, extraWarnings...)
+
+	return warnings, errs
+}
+
+// usesPrimary mirrors the kernel's bond_uses_primary(): the primary slave only has an effect in the
+// modes which have a single active slave at a time.
+func (s *BondConfigV1Alpha1) usesPrimary() bool {
+	if s.BondMode == nil {
+		return false
+	}
+
+	switch *s.BondMode {
+	case nethelpers.BondModeActiveBackup, nethelpers.BondModeTLB, nethelpers.BondModeALB:
+		return true
+	case nethelpers.BondModeRoundrobin, nethelpers.BondModeXOR, nethelpers.BondModeBroadcast, nethelpers.BondMode8023AD:
+		return false
+	default:
+		return false
+	}
+}
+
+func (s *BondConfigV1Alpha1) validatePrimary() ([]string, error) {
+	var (
+		errs     error
+		warnings []string
+	)
+
+	if s.BondPrimary != nil {
+		if *s.BondPrimary == "" {
+			errs = errors.Join(errs, errors.New("primary link name can't be empty"))
+		} else if !slices.Contains(s.BondLinks, *s.BondPrimary) {
+			errs = errors.Join(errs, fmt.Errorf("primary link %q is not in the list of bonded links", *s.BondPrimary))
+		}
+
+		if s.BondMode != nil && !s.usesPrimary() {
+			errs = errors.Join(errs, fmt.Errorf("primary link is not supported in %q bond mode", *s.BondMode))
+		}
+	} else if s.BondPrimaryReselect != nil && s.usesPrimary() {
+		warnings = append(warnings, "primaryReselect has no effect unless primary is specified")
+	}
 
 	return warnings, errs
 }
@@ -533,6 +591,15 @@ func (s *BondConfigV1Alpha1) ADLACPActive() optional.Optional[nethelpers.ADLACPA
 	}
 
 	return optional.Some(*s.BondADLACPActive)
+}
+
+// Primary implements NetworkBondConfig interface.
+func (s *BondConfigV1Alpha1) Primary() optional.Optional[string] {
+	if s.BondPrimary == nil {
+		return optional.None[string]()
+	}
+
+	return optional.Some(*s.BondPrimary)
 }
 
 // PrimaryReselect implements NetworkBondConfig interface.

--- a/pkg/machinery/config/types/network/bond_test.go
+++ b/pkg/machinery/config/types/network/bond_test.go
@@ -89,6 +89,36 @@ func TestBondConfigUnmarshal(t *testing.T) {
 	}, docs[0])
 }
 
+// TestBondConfigPrimaryRoundtrip covers the `primary` YAML key end to end: the 802.3ad fixture above
+// can't carry it, since a primary is only valid in the single-active-slave modes.
+func TestBondConfigPrimaryRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := network.NewBondConfigV1Alpha1("bond0")
+	cfg.BondLinks = []string{"eth0", "eth1"}
+	cfg.BondMode = new(nethelpers.BondModeActiveBackup)
+	cfg.BondPrimary = new("eth0")
+	cfg.BondPrimaryReselect = new(nethelpers.PrimaryReselectBetter)
+
+	warnings, err := cfg.Validate(validationMode{})
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(marshaled), "primary: eth0\n")
+	assert.Contains(t, string(marshaled), "primaryReselect: better\n")
+
+	provider, err := configloader.NewFromBytes(marshaled)
+	require.NoError(t, err)
+
+	docs := provider.Documents()
+	require.Len(t, docs, 1)
+
+	assert.Equal(t, cfg, docs[0])
+}
+
 func TestBondValidate(t *testing.T) {
 	t.Parallel()
 
@@ -130,6 +160,87 @@ func TestBondValidate(t *testing.T) {
 			},
 
 			expectedError: "bond mode must be specified",
+		},
+		{
+			name: "primary not in links",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeActiveBackup)
+				cfg.BondPrimary = new("eth2")
+
+				return cfg
+			},
+
+			expectedError: `primary link "eth2" is not in the list of bonded links`,
+		},
+		{
+			name: "primary empty",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeActiveBackup)
+				cfg.BondPrimary = new("")
+
+				return cfg
+			},
+
+			expectedError: "primary link name can't be empty",
+		},
+		{
+			name: "primary in unsupported mode",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeRoundrobin)
+				cfg.BondPrimary = new("eth0")
+
+				return cfg
+			},
+
+			expectedError: `primary link is not supported in "balance-rr" bond mode`,
+		},
+		{
+			name: "primaryReselect without primary",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeActiveBackup)
+				cfg.BondPrimaryReselect = new(nethelpers.PrimaryReselectAlways)
+
+				return cfg
+			},
+
+			expectedWarnings: []string{"primaryReselect has no effect unless primary is specified"},
+		},
+		{
+			name: "primary with primaryReselect",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeActiveBackup)
+				cfg.BondPrimary = new("eth0")
+				cfg.BondPrimaryReselect = new(nethelpers.PrimaryReselectAlways)
+
+				return cfg
+			},
+		},
+		{
+			name: "primaryReselect in unsupported mode is not warned about",
+
+			cfg: func() *network.BondConfigV1Alpha1 {
+				cfg := network.NewBondConfigV1Alpha1("bond0")
+				cfg.BondLinks = []string{"eth0", "eth1"}
+				cfg.BondMode = new(nethelpers.BondModeBroadcast)
+				cfg.BondPrimaryReselect = new(nethelpers.PrimaryReselectAlways)
+
+				return cfg
+			},
 		},
 		{
 			name: "valid",

--- a/pkg/machinery/config/types/network/deep_copy.generated.go
+++ b/pkg/machinery/config/types/network/deep_copy.generated.go
@@ -137,6 +137,10 @@ func (o *BondConfigV1Alpha1) DeepCopy() *BondConfigV1Alpha1 {
 		cp.BondADLACPActive = new(nethelpers.ADLACPActive)
 		*cp.BondADLACPActive = *o.BondADLACPActive
 	}
+	if o.BondPrimary != nil {
+		cp.BondPrimary = new(string)
+		*cp.BondPrimary = *o.BondPrimary
+	}
 	if o.BondPrimaryReselect != nil {
 		cp.BondPrimaryReselect = new(nethelpers.PrimaryReselect)
 		*cp.BondPrimaryReselect = *o.BondPrimaryReselect

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -486,10 +486,17 @@ func (BondConfigV1Alpha1) Doc() *encoder.Doc {
 				},
 			},
 			{
+				Name:        "primary",
+				Type:        "string",
+				Note:        "",
+				Description: "Name of the link (interface) which should be used as the primary slave of the bond.\n\nThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the \"active-backup\", \"balance-tlb\" and \"balance-alb\" modes.\n\nMust be one of the links listed in `links`.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Name of the link (interface) which should be used as the primary slave of the bond." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "primaryReselect",
 				Type:        "PrimaryReselect",
 				Note:        "",
-				Description: "Policy under which the primary slave should be reselected.",
+				Description: "Policy under which the primary slave should be reselected.\n\nHas no effect unless `primary` is set.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Policy under which the primary slave should be reselected." /* encoder.LineComment */, "" /* encoder.FootComment */},
 				Values: []string{
 					"always",
@@ -588,9 +595,10 @@ func (BondConfigV1Alpha1) Doc() *encoder.Doc {
 	doc.Fields[18].AddExample("", 65535)
 	doc.Fields[19].AddExample("", 0)
 	doc.Fields[20].AddExample("", "on")
-	doc.Fields[21].AddExample("", "always")
-	doc.Fields[27].AddExample("", 1)
-	doc.Fields[28].AddExample("", 0)
+	doc.Fields[21].AddExample("", "enp1s2")
+	doc.Fields[22].AddExample("", "always")
+	doc.Fields[28].AddExample("", 1)
+	doc.Fields[29].AddExample("", 0)
 
 	return doc
 }

--- a/pkg/machinery/resources/network/link.go
+++ b/pkg/machinery/resources/network/link.go
@@ -39,7 +39,11 @@ type BondMasterSpec struct {
 	// ARPAllTargets specifies whether ARP probes should be sent to any or all targets.
 	ARPAllTargets nethelpers.ARPAllTargets `yaml:"arpAllTargets" protobuf:"5"`
 	// PrimaryIndex is a device index specifying which slave is the primary device.
-	PrimaryIndex *uint32 `yaml:"primary,omitempty" protobuf:"6"`
+	//
+	// This is the resolved form of Primary: it is what the kernel reports back, and it is filled in
+	// by the link spec controller right before applying the settings. Configuration layers should set
+	// Primary instead, as interface indexes are not stable.
+	PrimaryIndex *uint32 `yaml:"primaryIndex,omitempty" protobuf:"6"`
 	// PrimaryReselect specifies the policy under which the primary slave should be reselected.
 	PrimaryReselect nethelpers.PrimaryReselect `yaml:"primaryReselect" protobuf:"7"`
 	// FailOverMac whether active-backup mode should set all slaves to the same MAC address at enslavement, when enabled, or perform special handling.
@@ -89,9 +93,17 @@ type BondMasterSpec struct {
 	ADLACPActive *nethelpers.ADLACPActive `yaml:"adLacpActive,omitempty" protobuf:"27"`
 	// MissedMax is the number of arp_interval monitor checks that must fail in order for an interface to be marked down by the ARP monitor.
 	MissedMax uint8 `yaml:"missedMax,omitempty" protobuf:"28"`
+	// Primary is the name of the slave link which should be used as the primary device.
+	//
+	// Only meaningful for the active-backup, balance-tlb and balance-alb modes.
+	Primary string `yaml:"primary,omitempty" protobuf:"29"`
 }
 
 // Equal checks two BondMasterSpecs for equality.
+//
+// Primary is deliberately not compared: it is the unresolved (by name) form of PrimaryIndex, and the
+// kernel only ever reports back the index. Callers comparing a desired spec against the kernel state
+// must resolve Primary into PrimaryIndex first, otherwise the two would never compare equal.
 //
 //nolint:gocyclo,cyclop
 func (spec *BondMasterSpec) Equal(other *BondMasterSpec) bool {
@@ -115,6 +127,10 @@ func (spec *BondMasterSpec) Equal(other *BondMasterSpec) bool {
 		return false
 	}
 
+	// if either side doesn't have a primary, consider them equal: the kernel only reports a primary while
+	// the primary slave is actually enslaved, so it drops the attribute when e.g. the primary NIC is
+	// unplugged. Comparing those as unequal would tear the whole bond down and re-enslave every slave
+	// exactly when a failover is in flight.
 	if spec.PrimaryIndex != nil && other.PrimaryIndex != nil && *spec.PrimaryIndex != *other.PrimaryIndex {
 		return false
 	}
@@ -266,7 +282,8 @@ func (spec *BondMasterSpec) IsZero() bool {
 		len(spec.ARPIPTargets) == 0 &&
 		len(spec.NSIP6Targets) == 0 &&
 		spec.ADLACPActive == nil &&
-		spec.MissedMax == 0
+		spec.MissedMax == 0 &&
+		spec.Primary == ""
 }
 
 // BridgeMasterSpec describes bridge settings if Kind == "bridge".

--- a/pkg/machinery/resources/network/link_spec_test.go
+++ b/pkg/machinery/resources/network/link_spec_test.go
@@ -115,7 +115,7 @@ bondMaster:
     lacpRate: fast
     arpValidate: all
     arpAllTargets: any
-    primary: 3
+    primaryIndex: 3
     primaryReselect: better
     failOverMac: follow
     adSelect: count

--- a/pkg/machinery/resources/network/link_status_test.go
+++ b/pkg/machinery/resources/network/link_status_test.go
@@ -146,7 +146,7 @@ bondMaster:
     lacpRate: fast
     arpValidate: all
     arpAllTargets: any
-    primary: 3
+    primaryIndex: 3
     primaryReselect: better
     failOverMac: follow
     adSelect: count

--- a/pkg/machinery/resources/network/link_test.go
+++ b/pkg/machinery/resources/network/link_test.go
@@ -11,8 +11,101 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
+
+func TestBondMasterSpecEqualPrimary(t *testing.T) {
+	t.Parallel()
+
+	base := func() network.BondMasterSpec {
+		return network.BondMasterSpec{
+			Mode:            nethelpers.BondModeActiveBackup,
+			PrimaryReselect: nethelpers.PrimaryReselectAlways,
+		}
+	}
+
+	withIndex := func(idx uint32) network.BondMasterSpec {
+		spec := base()
+		spec.PrimaryIndex = new(idx)
+
+		return spec
+	}
+
+	for _, test := range []struct {
+		name        string
+		spec, other network.BondMasterSpec
+
+		expected bool
+	}{
+		{
+			name:     "both unset",
+			spec:     base(),
+			other:    base(),
+			expected: true,
+		},
+		{
+			name:     "same index",
+			spec:     withIndex(4),
+			other:    withIndex(4),
+			expected: true,
+		},
+		{
+			name:     "different index",
+			spec:     withIndex(4),
+			other:    withIndex(5),
+			expected: false,
+		},
+		{
+			// the kernel stops reporting IFLA_BOND_PRIMARY once the primary slave leaves the bond
+			// (NIC unplugged, driver unloaded); treating that as drift would tear the bond down and
+			// re-enslave every remaining slave in the middle of a failover
+			name:     "kernel dropped the primary",
+			spec:     withIndex(4),
+			other:    base(),
+			expected: true,
+		},
+		{
+			// nothing in the config asks for a primary, so whatever the kernel has stays put
+			name:     "primary set out of band",
+			spec:     base(),
+			other:    withIndex(4),
+			expected: true,
+		},
+		{
+			// Primary is the unresolved form and must never be compared directly: the kernel only
+			// ever reports the index back, so comparing it would make the two never converge
+			name: "differing names with matching indexes",
+			spec: func() network.BondMasterSpec {
+				spec := withIndex(4)
+				spec.Primary = "eno1"
+
+				return spec
+			}(),
+			other:    withIndex(4),
+			expected: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, test.spec.Equal(&test.other))
+			assert.Equal(t, test.expected, test.other.Equal(&test.spec), "Equal should be symmetric")
+		})
+	}
+}
+
+func TestBondMasterSpecZero(t *testing.T) {
+	t.Parallel()
+
+	var zeroSpec network.BondMasterSpec
+
+	assert.True(t, zeroSpec.IsZero())
+
+	withPrimary := network.BondMasterSpec{Primary: "eno1"}
+
+	assert.False(t, withPrimary.IsZero())
+}
 
 func TestWireguardPeer(t *testing.T) {
 	t.Parallel()

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -10001,7 +10001,7 @@ BondMasterSpec describes bond settings if Kind == "bond".
 | lacp_rate | [talos.resource.definitions.enums.NethelpersLACPRate](#talos.resource.definitions.enums.NethelpersLACPRate) |  | LACPRate specifies the rate at which LACPDU frames are sent. |
 | arp_validate | [talos.resource.definitions.enums.NethelpersARPValidate](#talos.resource.definitions.enums.NethelpersARPValidate) |  | ARPValidate specifies whether or not ARP probes and replies should be validated. |
 | arp_all_targets | [talos.resource.definitions.enums.NethelpersARPAllTargets](#talos.resource.definitions.enums.NethelpersARPAllTargets) |  | ARPAllTargets specifies whether ARP probes should be sent to any or all targets. |
-| primary_index | [uint32](#uint32) |  | PrimaryIndex is a device index specifying which slave is the primary device. |
+| primary_index | [uint32](#uint32) |  | PrimaryIndex is a device index specifying which slave is the primary device.<br><br>This is the resolved form of Primary: it is what the kernel reports back, and it is filled in by the link spec controller right before applying the settings. Configuration layers should set Primary instead, as interface indexes are not stable. |
 | primary_reselect | [talos.resource.definitions.enums.NethelpersPrimaryReselect](#talos.resource.definitions.enums.NethelpersPrimaryReselect) |  | PrimaryReselect specifies the policy under which the primary slave should be reselected. |
 | fail_over_mac | [talos.resource.definitions.enums.NethelpersFailOverMAC](#talos.resource.definitions.enums.NethelpersFailOverMAC) |  | FailOverMac whether active-backup mode should set all slaves to the same MAC address at enslavement, when enabled, or perform special handling. |
 | ad_select | [talos.resource.definitions.enums.NethelpersADSelect](#talos.resource.definitions.enums.NethelpersADSelect) |  | ADSelect specifies the aggregate selection policy for 802.3ad. |
@@ -10024,6 +10024,7 @@ BondMasterSpec describes bond settings if Kind == "bond".
 | nsip6_targets | [common.NetIP](#common.NetIP) | repeated | NSIP6Targets is the list of IPv6 addresses to use for NS link monitoring when ARPInterval is set.<br><br>Maximum of 16 targets are supported. |
 | adlacp_active | [talos.resource.definitions.enums.NethelpersADLACPActive](#talos.resource.definitions.enums.NethelpersADLACPActive) |  | ADLACPActive specifies whether to send LACPDU frames periodically. |
 | missed_max | [uint32](#uint32) |  | MissedMax is the number of arp_interval monitor checks that must fail in order for an interface to be marked down by the ARP monitor. |
+| primary | [string](#string) |  | Primary is the name of the slave link which should be used as the primary device.<br><br>Only meaningful for the active-backup, balance-tlb and balance-alb modes. |
 
 
 

--- a/website/content/v1.15/reference/configuration/network/bondconfig.md
+++ b/website/content/v1.15/reference/configuration/network/bondconfig.md
@@ -68,6 +68,9 @@ routes:
 # # Whether to send LACPDU frames periodically, defaults to "on" if mode is 802.3ad.
 # adLACPActive: on
 
+# # Name of the link (interface) which should be used as the primary slave of the bond.
+# primary: enp1s2
+
 # # Policy under which the primary slave should be reselected.
 # primaryReselect: always
 
@@ -140,7 +143,10 @@ adUserPortKey: 0
 |`adLACPActive` |ADLACPActive |Whether to send LACPDU frames periodically, defaults to "on" if mode is 802.3ad. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 adLACPActive: on
 {{< /highlight >}}</details> |`on`<br />`off`<br /> |
-|`primaryReselect` |PrimaryReselect |Policy under which the primary slave should be reselected. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`primary` |string |Name of the link (interface) which should be used as the primary slave of the bond.<br><br>The primary link, when up, is always the active one; the other links are only used when the<br>primary is down. Only meaningful for the "active-backup", "balance-tlb" and "balance-alb" modes.<br><br>Must be one of the links listed in `links`. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+primary: enp1s2
+{{< /highlight >}}</details> | |
+|`primaryReselect` |PrimaryReselect |Policy under which the primary slave should be reselected.<br><br>Has no effect unless `primary` is set. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 primaryReselect: always
 {{< /highlight >}}</details> |`always`<br />`better`<br />`failure`<br /> |
 |`resendIGMP` |uint32 |The number of times IGMP packets should be resent.  | |

--- a/website/content/v1.15/schemas/config.schema.json
+++ b/website/content/v1.15/schemas/config.schema.json
@@ -3966,6 +3966,13 @@
           "markdownDescription": "Whether to send LACPDU frames periodically, defaults to \"on\" if mode is 802.3ad.",
           "x-intellij-html-description": "\u003cp\u003eWhether to send LACPDU frames periodically, defaults to \u0026ldquo;on\u0026rdquo; if mode is 802.3ad.\u003c/p\u003e\n"
         },
+        "primary": {
+          "type": "string",
+          "title": "primary",
+          "description": "Name of the link (interface) which should be used as the primary slave of the bond.\n\nThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the “active-backup”, “balance-tlb” and “balance-alb” modes.\n\nMust be one of the links listed in links.\n",
+          "markdownDescription": "Name of the link (interface) which should be used as the primary slave of the bond.\n\nThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the \"active-backup\", \"balance-tlb\" and \"balance-alb\" modes.\n\nMust be one of the links listed in `links`.",
+          "x-intellij-html-description": "\u003cp\u003eName of the link (interface) which should be used as the primary slave of the bond.\u003c/p\u003e\n\n\u003cp\u003eThe primary link, when up, is always the active one; the other links are only used when the\nprimary is down. Only meaningful for the \u0026ldquo;active-backup\u0026rdquo;, \u0026ldquo;balance-tlb\u0026rdquo; and \u0026ldquo;balance-alb\u0026rdquo; modes.\u003c/p\u003e\n\n\u003cp\u003eMust be one of the links listed in \u003ccode\u003elinks\u003c/code\u003e.\u003c/p\u003e\n"
+        },
         "primaryReselect": {
           "enum": [
             "always",
@@ -3973,9 +3980,9 @@
             "failure"
           ],
           "title": "primaryReselect",
-          "description": "Policy under which the primary slave should be reselected.\n",
-          "markdownDescription": "Policy under which the primary slave should be reselected.",
-          "x-intellij-html-description": "\u003cp\u003ePolicy under which the primary slave should be reselected.\u003c/p\u003e\n"
+          "description": "Policy under which the primary slave should be reselected.\n\nHas no effect unless primary is set.\n",
+          "markdownDescription": "Policy under which the primary slave should be reselected.\n\nHas no effect unless `primary` is set.",
+          "x-intellij-html-description": "\u003cp\u003ePolicy under which the primary slave should be reselected.\u003c/p\u003e\n\n\u003cp\u003eHas no effect unless \u003ccode\u003eprimary\u003c/code\u003e is set.\u003c/p\u003e\n"
         },
         "resendIGMP": {
           "type": "integer",


### PR DESCRIPTION
Fixes #13969

This is tricky due to the way Linux kernel reports and accepts setting the primary link - we need to ensure we don't override and re-create the bond for no good reason.
