### PR TITLE
feat: tag published cloud images with a build type

### DIFF
--- a/tools/cloud-image-uploader/README.md
+++ b/tools/cloud-image-uploader/README.md
@@ -1,5 +1,24 @@
 # cloud-image-uploader
 
+## Image tags
+
+Published images are tagged with their build type, which is what cleanup tooling keys off
+of to decide how long an image should stick around:
+
+- AWS: the tag `BuildType`, on both the AMI and the EBS snapshot backing it.
+- GCP: the label `build-type` on the image. GCP label keys must be lowercase, hence the
+  different spelling.
+
+The values are the same on both:
+
+| Value | Meaning |
+| --- | --- |
+| `e2e` | throwaway image built for an e2e run |
+| `nightly` | branch build, versioned by `git describe` (e.g. `v1.14.0-alpha.1-101-g11a7fbe4c`) |
+| `release` | tagged release, including `alpha`/`beta`/`rc` pre-releases |
+
+The value is derived from `--tag` and `--name-prefix`.
+
 ## vmimport role
 
 Role should be pre-created before running this command.

--- a/tools/cloud-image-uploader/aws.go
+++ b/tools/cloud-image-uploader/aws.go
@@ -258,6 +258,21 @@ func (au *AWSUploader) registerAMI(ctx context.Context, region string, svc *ec2.
 	return g.Wait()
 }
 
+// imageTags are applied to both the AMI and the snapshot backing it, so that cleanup
+// tooling can apply a retention policy without parsing image names.
+func (au *AWSUploader) imageTags(imageName string) []types.Tag {
+	return []types.Tag{
+		{
+			Key:   new("Name"),
+			Value: new(imageName),
+		},
+		{
+			Key:   new(BuildTypeTagKey),
+			Value: new(au.Options.BuildType),
+		},
+	}
+}
+
 //nolint:gocyclo
 func (au *AWSUploader) tagSnapshot(ctx context.Context, svc *ec2.Client, snapshotID, imageName string) {
 	if snapshotID == "" {
@@ -266,10 +281,7 @@ func (au *AWSUploader) tagSnapshot(ctx context.Context, svc *ec2.Client, snapsho
 
 	_, tagErr := svc.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: []string{snapshotID},
-		Tags: []types.Tag{{
-			Key:   new("Name"),
-			Value: new(imageName),
-		}},
+		Tags:      au.imageTags(imageName),
 	})
 	if tagErr != nil {
 		log.Printf("WARNING: failed to tag snapshot %s: %v", snapshotID, tagErr)
@@ -422,6 +434,12 @@ func (au *AWSUploader) registerAMIArch(ctx context.Context, region string, svc *
 		Description:        new(fmt.Sprintf("Talos AMI %s %s %s", au.Options.Tag, arch, region)),
 		Architecture:       awsArchitectures[arch],
 		ImdsSupport:        types.ImdsSupportValuesV20,
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeImage,
+				Tags:         au.imageTags(imageName),
+			},
+		},
 	}
 
 	registerResp, err := svc.RegisterImage(ctx, registerReq)

--- a/tools/cloud-image-uploader/buildtype.go
+++ b/tools/cloud-image-uploader/buildtype.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// BuildTypeTagKey is the AWS tag applied to published AMIs and their snapshots so that
+// cleanup tooling can tell them apart without parsing names.
+const BuildTypeTagKey = "BuildType"
+
+// BuildTypeLabelKey is the GCP equivalent of BuildTypeTagKey. GCP label keys are
+// restricted to `[a-z]([-a-z0-9]*[a-z0-9])?`, so the AWS spelling can't be reused.
+const BuildTypeLabelKey = "build-type"
+
+// Build types published by this tool.
+const (
+	// BuildTypeE2E is a throwaway image built for an e2e run.
+	BuildTypeE2E = "e2e"
+	// BuildTypeNightly is an untagged build off a branch, identified by a git-describe version.
+	BuildTypeNightly = "nightly"
+	// BuildTypeRelease is a tagged release, including alpha/beta/rc pre-releases.
+	BuildTypeRelease = "release"
+)
+
+// describeSuffix matches the commits-since-tag and abbreviated SHA that `git describe`
+// appends to a version off a branch, e.g. the `-101-g11a7fbe4c` in
+// `v1.14.0-alpha.1-101-g11a7fbe4c`.
+var describeSuffix = regexp.MustCompile(`-\d+-g[0-9a-f]+$`)
+
+// releaseTag matches a clean release tag, e.g. v1.14.0 or v1.14.0-alpha.1.
+var releaseTag = regexp.MustCompile(`^v\d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?$`)
+
+// DeriveBuildType works out the build type of the images being published.
+//
+// An e2e run names its images with a prefix. Everything else is versioned by
+// `git describe`, which appends a commit count and SHA when HEAD isn't exactly on a
+// tag -- that suffix is what separates a nightly from a release.
+func DeriveBuildType(tag, namePrefix string) string {
+	if strings.Contains(namePrefix, "e2e") {
+		return BuildTypeE2E
+	}
+
+	if describeSuffix.MatchString(tag) {
+		return BuildTypeNightly
+	}
+
+	if releaseTag.MatchString(tag) {
+		return BuildTypeRelease
+	}
+
+	// not a recognizable release tag, so treat it as a branch build and let it age out
+	// rather than accumulating forever.
+	return BuildTypeNightly
+}

--- a/tools/cloud-image-uploader/buildtype_test.go
+++ b/tools/cloud-image-uploader/buildtype_test.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import "testing"
+
+func TestDeriveBuildType(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		tag        string
+		namePrefix string
+		expected   string
+	}{
+		{
+			name:     "stable release",
+			tag:      "v1.13.4",
+			expected: BuildTypeRelease,
+		},
+		{
+			name:     "alpha release",
+			tag:      "v1.14.0-alpha.1",
+			expected: BuildTypeRelease,
+		},
+		{
+			name:     "rc release",
+			tag:      "v1.14.0-rc.0",
+			expected: BuildTypeRelease,
+		},
+		{
+			name:     "nightly off a pre-release tag",
+			tag:      "v1.14.0-alpha.1-101-g11a7fbe4c",
+			expected: BuildTypeNightly,
+		},
+		{
+			name:     "nightly off a stable tag",
+			tag:      "v1.13.4-7-gdeadbeef",
+			expected: BuildTypeNightly,
+		},
+		{
+			name:     "unrecognizable version",
+			tag:      "some-branch-build",
+			expected: BuildTypeNightly,
+		},
+		{
+			name:       "e2e run keeps its build type despite a release tag",
+			tag:        "v1.13.4",
+			namePrefix: "talos-e2e",
+			expected:   BuildTypeE2E,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if actual := DeriveBuildType(test.tag, test.namePrefix); actual != test.expected {
+				t.Errorf("DeriveBuildType(%q, %q) = %q, expected %q", test.tag, test.namePrefix, actual, test.expected)
+			}
+		})
+	}
+}

--- a/tools/cloud-image-uploader/gcp.go
+++ b/tools/cloud-image-uploader/gcp.go
@@ -267,6 +267,9 @@ func (u *GCPUploder) insertImage(imageName, arch string) (operationID, imageLink
 				Type: "UEFI_COMPATIBLE",
 			},
 		},
+		Labels: map[string]string{
+			BuildTypeLabelKey: u.Options.BuildType,
+		},
 		Name: imageName,
 		RawDisk: &compute.ImageRawDisk{
 			Source: u.imagePath,

--- a/tools/cloud-image-uploader/main.go
+++ b/tools/cloud-image-uploader/main.go
@@ -71,6 +71,10 @@ func run() error {
 
 	pflag.Parse()
 
+	DefaultOptions.BuildType = DeriveBuildType(DefaultOptions.Tag, DefaultOptions.NamePrefix)
+
+	log.Printf("derived build type %q from tag %q", DefaultOptions.BuildType, DefaultOptions.Tag)
+
 	seed := make([]byte, 8)
 	if _, err = cryptorand.Read(seed); err != nil {
 		log.Fatalf("error seeding rand: %s", err)

--- a/tools/cloud-image-uploader/options.go
+++ b/tools/cloud-image-uploader/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	Tag           string
 	ArtifactsPath string
 	NamePrefix    string
+	BuildType     string
 	Architectures []string
 	TargetClouds  []string
 

--- a/tools/cloud-image-uploader/role-policy.json
+++ b/tools/cloud-image-uploader/role-policy.json
@@ -26,6 +26,7 @@
             "ec2:ModifySnapshotAttribute",
             "ec2:CopySnapshot",
             "ec2:RegisterImage",
+            "ec2:CreateTags",
             "ec2:Describe*"
          ],
          "Resource":"*"


### PR DESCRIPTION
This PR brings tagging to the images we publish so cloud-cleaner can tell them apart.

Every AMI and the EBS snapshot behind it now gets a `BuildType` tag, set to one of `e2e`, `nightly`, or `release`. Previously the AMI got no tags at all and the snapshot got only a `Name`, so anything clean up was guess work from image name.

GCP images get the same thing as a `build-type` label, spelled lowercase because that's all GCP allows in a label key.

The build type is worked out from the tag we're building, so nothing calling this needs to change. An e2e name prefix means `e2e`, a git-describe version like `v1.14.0-alpha.1-101-g11a7fbe4c` means `nightly`, and a clean tag like `v1.14.0-alpha.1` means `release`.

Lastly, the vmimport role policy picks up `ec2:CreateTags`, which it needs now that we're tagging both images and snapshots.

