### PR TITLE
fix: support image factory URLs with explicit port

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/preset/preset.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/preset/preset.go
@@ -124,12 +124,7 @@ func applyDefaultSettings(presetOps Options, cOps *clusterops.Common, qOps *clus
 		installerName += secureBootSuffix
 	}
 
-	installerURL, err := url.JoinPath(presetOps.ImageFactoryURL.Host, installerName, presetOps.SchematicID+":"+cOps.TalosVersion)
-	if err != nil {
-		return fmt.Errorf("failed to build installer image URL: %w", err)
-	}
-
-	qOps.NodeInstallImage = installerURL
+	qOps.NodeInstallImage = fmt.Sprintf("%s/%s/%s:%s", presetOps.ImageFactoryURL.Host, installerName, presetOps.SchematicID, cOps.TalosVersion)
 
 	return nil
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/preset/preset_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/preset/preset_test.go
@@ -128,3 +128,21 @@ func TestMaintenance(t *testing.T) {
 	require.True(t, cOps.SkipInjectingConfig)
 	require.False(t, cOps.ApplyConfigEnabled)
 }
+
+func TestInstallerImageWithPort(t *testing.T) {
+	imageFactoryURL, err := url.Parse("http://127.0.0.1:8080")
+	require.NoError(t, err)
+
+	cOps := clusterops.GetCommon()
+	qOps := clusterops.GetQemu()
+	qOps.TargetArch = "arm64"
+	cOps.TalosVersion = "v9.9.9"
+
+	err = preset.Apply(preset.Options{
+		SchematicID:     "123schematic123",
+		ImageFactoryURL: imageFactoryURL,
+	}, &cOps, &qOps, []string{preset.PXE{}.Name()})
+	require.NoError(t, err)
+
+	require.Equal(t, "127.0.0.1:8080/metal-installer/123schematic123:v9.9.9", qOps.NodeInstallImage)
+}


### PR DESCRIPTION
Fixes #13989

## Description

`talosctl cluster create qemu` fails with a self-hosted Image Factory when `--image-factory-url` contains an IPv4 address with an explicit port:

```
failed to build installer image URL: parse "127.0.0.1:8080": first path segment in URL cannot contain colon
```

## Root cause

`applyDefaultSettings` built the installer image reference by passing `ImageFactoryURL.Host` (e.g. `127.0.0.1:8080`) to `net/url.JoinPath`. The installer reference is an OCI image reference (`host/metal-installer/<schematic-id>:<version>`), not an HTTP URL, and `url.JoinPath` rejects a colon in the first path segment, which breaks for any host with an explicit port. Hosts without a port (e.g. `factory.talos.dev`) worked by accident.

## Fix

Build the reference directly as an OCI image reference (`fmt.Sprintf`), which is how the value is consumed downstream (`machine.install.image`).

## Test

Added `TestInstallerImageWithPort`, reproducing the failure with `http://127.0.0.1:8080` before the fix and asserting the correct reference after:

```
127.0.0.1:8080/metal-installer/123schematic123:v9.9.9
```

Existing preset tests (default `factory.talos.dev` host) still pass unchanged.
