### PR TITLE
chore: build custom-gcl for the host OS/arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1376,9 +1376,15 @@ COPY --link --from=integration-test-provision-linux-build /src/integration.test 
 # All depend on lint-go-config (gating) by bind-mounting /verified from it.
 # Cache mounts: Go cache shared (concurrency-safe), lint cache locked (golangci-lint corruption protection).
 
-FROM base AS lint-golangci-lint-custom
+FROM base AS golangci-lint-plugin-builder
 RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=shared \
-    go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint custom
+    go build -o /usr/local/bin/golangci-lint github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+
+FROM golangci-lint-plugin-builder AS lint-golangci-lint-custom
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/.cache,id=talos/.cache,sharing=shared \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} golangci-lint custom
 
 FROM scratch AS golangci-lint-custom
 COPY --link --from=lint-golangci-lint-custom /src/custom-gcl /custom-gcl

--- a/Makefile
+++ b/Makefile
@@ -561,8 +561,8 @@ lint-fmt: ## Run all linter formatters and fix up the source tree.
 	@$(MAKE) local-lint-golangci-lint-fmt DEST=./ PLATFORM=linux/$(ARCH)
 
 .PHONY: golangci-lint-custom
-golangci-lint-custom: ## Builds the custom golangci-lint binary with the loglinter plugin and outputs it to the artifact directory.
-	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PLATFORM=linux/$(ARCH) PUSH=false
+golangci-lint-custom: ## Builds the custom golangci-lint binary with the loglinter plugin for the host OS/arch and outputs it to the artifact directory.
+	@$(MAKE) local-$@ DEST=$(ARTIFACTS) PLATFORM=$(OPERATING_SYSTEM)/$(ARCH) PUSH=false
 
 check-dirty: ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi


### PR DESCRIPTION
`make golangci-lint-custom` always produced a linux binary, so on macOS the result couldn't be run by an editor.
