### PR TITLE
test: fix the flakiness in image pull in provision-3 pipeline

### DIFF
--- a/internal/app/machined/pkg/controllers/network/hostdns_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config.go
@@ -94,12 +94,7 @@ func (ctrl *HostDNSConfigController) Run(ctx context.Context, r controller.Runti
 			}
 			// Keep resolv.conf pointed at Host DNS during early bootstrap. The active
 			// machine configuration can disable it once it is loaded.
-			//
-			// A partial machine configuration (no v1alpha1 document, e.g. a SideroLink config
-			// applied in maintenance mode) carries no Host DNS settings, and must not disable it:
-			// stopping the listener breaks in-flight name resolution, as Go caches
-			// /etc/resolv.conf for 5 seconds and keeps sending queries to 127.0.0.53.
-			res.TypedSpec().Enabled = cfg == nil || cfg.Provider().RawV1Alpha1() == nil
+			res.TypedSpec().Enabled = cfg == nil
 			res.TypedSpec().ResolveMemberNames = false
 
 			res.TypedSpec().ServiceHostDNSAddress = netip.Addr{}

--- a/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostdns_config_test.go
@@ -11,16 +11,13 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
-	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	netctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
-	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	networkcfg "github.com/siderolabs/talos/pkg/machinery/config/types/network"
-	siderolinkcfg "github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
@@ -247,49 +244,6 @@ func (suite *HostDNSConfigSuite) TestLegacyConfigForwardKubeDNSIPv6Only() {
 		network.LayeredID(network.ConfigOperator, network.AddressID("lo", netip.MustParsePrefix(constants.HostDNSAddress+"/32"))),
 		rtestutils.WithNamespace(network.ConfigNamespaceName),
 	)
-}
-
-func (suite *HostDNSConfigSuite) TestPartialConfigKeepsHostDNSEnabled() {
-	rc := networkcfg.NewResolverConfigV1Alpha1()
-	rc.ResolverHostDNS = networkcfg.HostDNSConfig{
-		HostDNSEnabled:            new(true),
-		HostDNSResolveMemberNames: new(true),
-	}
-
-	ctr, err := container.New(&v1alpha1.Config{ConfigVersion: "v1alpha1", MachineConfig: &v1alpha1.MachineConfig{}}, rc)
-	suite.Require().NoError(err)
-
-	suite.Create(config.NewMachineConfig(ctr))
-
-	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
-		asrt.True(r.TypedSpec().Enabled)
-		asrt.True(r.TypedSpec().ResolveMemberNames)
-	})
-
-	// replace it with a partial config (no v1alpha1 document), the way a SideroLink config document
-	// is applied in maintenance mode: it configures no host DNS, so host DNS should stay enabled
-	apiURL, err := url.Parse("https://siderolink.api/?jointoken=foo")
-	suite.Require().NoError(err)
-
-	sideroLinkCfg := siderolinkcfg.NewConfigV1Alpha1()
-	sideroLinkCfg.APIUrlConfig = meta.URL{URL: apiURL}
-
-	partialCtr, err := container.New(sideroLinkCfg)
-	suite.Require().NoError(err)
-
-	current, err := safe.StateGetByID[*config.MachineConfig](suite.Ctx(), suite.State(), config.ActiveID)
-	suite.Require().NoError(err)
-
-	partial := config.NewMachineConfig(partialCtr)
-	partial.Metadata().SetVersion(current.Metadata().Version())
-
-	suite.Update(partial)
-
-	ctest.AssertResource(suite, network.HostDNSConfigID, func(r *network.HostDNSConfig, asrt *assert.Assertions) {
-		// resolveMemberNames flipping back proves the controller reconciled the partial config
-		asrt.False(r.TypedSpec().ResolveMemberNames)
-		asrt.True(r.TypedSpec().Enabled)
-	})
 }
 
 func (suite *HostDNSConfigSuite) TestResolverConfigDocument() {

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -31,6 +31,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/meta"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
@@ -124,9 +125,20 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 	)
 	suite.Require().NoError(err)
 
+	hostDNSConfig := network.NewResolverConfigV1Alpha1()
+	hostDNSConfig.ResolverHostDNS = network.HostDNSConfig{
+		HostDNSEnabled: new(true),
+	}
+
+	hostDNSPatch, err := container.New(hostDNSConfig)
+	suite.Require().NoError(err)
+
 	maintenancePatched, err := configpatcher.Apply(
 		configpatcher.WithConfig(sideroLinkConfig),
-		[]configpatcher.Patch{configpatcher.NewStrategicMergePatch(registryMirrorConfig)},
+		[]configpatcher.Patch{
+			configpatcher.NewStrategicMergePatch(registryMirrorConfig),
+			configpatcher.NewStrategicMergePatch(hostDNSPatch),
+		},
 	)
 	suite.Require().NoError(err)
 


### PR DESCRIPTION
This reverts commit 63ef4df995ef4d08cbe9c6c4d58c34d7cbf012af to keep the HostDNS config the same, but adds explicit HostDNS config in the test.
