### PR TITLE
fix: size the receive/send buffers for nftables netlink

### DIFF
--- a/internal/app/machined/pkg/controllers/network/nftables_chain.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain.go
@@ -14,12 +14,28 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
+	"github.com/mdlayher/netlink"
 	"go.uber.org/zap"
 
 	networkadapter "github.com/siderolabs/talos/internal/app/machined/pkg/adapters/network"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
+
+// nfTablesSocketBufferSize is the netlink socket send/receive buffer size for the nftables connection.
+//
+// The whole ruleset is committed as a single netlink batch, which runs into two independent kernel
+// limits if the socket is left at the 208 KiB defaults (`net.core.{r,w}mem_default`):
+//
+//   - the batch is written with one `sendmsg`, which the kernel rejects with EMSGSIZE once the batch
+//     exceeds `sk_sndbuf - 32`;
+//   - the kernel queues an ACK for every message in the batch before that `sendmsg` returns, and
+//     accounts them by skb `truesize` (~768 B floor each), so the receive queue overruns and the
+//     failure surfaces as ENOBUFS on the following `recvmsg`.
+//
+// The receive side is the tighter of the two by roughly 5x, since ACKs echo the request back and the
+// `truesize` floor inflates the small messages the ruleset is made of.
+const nfTablesSocketBufferSize = 8 * 1024 * 1024
 
 // NfTablesChainController applies network.NfTablesChain to the Linux nftables interface.
 type NfTablesChainController struct {
@@ -55,6 +71,23 @@ func (ctrl *NfTablesChainController) Run(ctx context.Context, r controller.Runti
 		ctrl.TableName = constants.DefaultNfTablesTableName
 	}
 
+	conn, err := nftables.New(
+		nftables.AsLasting(),
+		nftables.WithSockOptions(func(nc *netlink.Conn) error {
+			// these try SO_{RCV,SND}BUFFORCE first, so they are not capped by `net.core.{r,w}mem_max`.
+			if err := nc.SetReadBuffer(nfTablesSocketBufferSize); err != nil {
+				return err
+			}
+
+			return nc.SetWriteBuffer(nfTablesSocketBufferSize)
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating nftables connection: %w", err)
+	}
+
+	defer conn.CloseLasting() //nolint:errcheck
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -62,9 +95,7 @@ func (ctrl *NfTablesChainController) Run(ctx context.Context, r controller.Runti
 		case <-r.EventCh():
 		}
 
-		var conn nftables.Conn
-
-		if err := ctrl.preCreateIptablesNFTable(logger, &conn); err != nil {
+		if err := ctrl.preCreateIptablesNFTable(logger, conn); err != nil {
 			return fmt.Errorf("error pre-creating iptables-nft table: %w", err)
 		}
 

--- a/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
+++ b/internal/app/machined/pkg/controllers/network/nftables_chain_test.go
@@ -635,6 +635,44 @@ func (s *NfTablesChainSuite) TestICMPTypeMatch() {
 }`)
 }
 
+// TestLargeRuleset verifies that a ruleset too big for the default netlink socket buffers still
+// gets applied, as the whole ruleset is committed in a single netlink batch.
+//
+// With the 208 KiB defaults this trips both of the limits described on nfTablesSocketBufferSize:
+// ENOBUFS on the receive side past ~91 rules, and EMSGSIZE on the send side past ~443.
+//
+// See https://github.com/siderolabs/talos/issues/14001.
+func (s *NfTablesChainSuite) TestLargeRuleset() {
+	// each rule carries an anonymous set, costing two netlink messages on top of the rule itself:
+	// ~1500 messages and ~240 KB on the wire, past both limits
+	const numRules = 500
+
+	chain := network.NewNfTablesChain(network.NamespaceName, "test1")
+	chain.TypedSpec().Type = nethelpers.ChainTypeFilter
+	chain.TypedSpec().Hook = nethelpers.ChainHookInput
+	chain.TypedSpec().Priority = nethelpers.ChainPriorityFilter
+	chain.TypedSpec().Policy = nethelpers.VerdictAccept
+	chain.TypedSpec().Rules = make([]network.NfTablesRule, 0, numRules)
+
+	for i := range numRules {
+		chain.TypedSpec().Rules = append(chain.TypedSpec().Rules, network.NfTablesRule{
+			MatchSourceAddress: &network.NfTablesAddressMatch{
+				IncludeSubnets: []netip.Prefix{
+					netip.PrefixFrom(netip.AddrFrom4([4]byte{10, byte(i >> 8), byte(i), 0}), 24),
+				},
+			},
+			Verdict: new(nethelpers.VerdictAccept),
+		})
+	}
+
+	s.Require().NoError(s.State().Create(s.Ctx(), chain))
+
+	// the ruleset is too large to compare verbatim, so just check that every rule made it through
+	s.Eventually(func() bool {
+		return strings.Count(s.nftOutput(), "ip saddr") == numRules
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
 func TestNftablesChainSuite(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")


### PR DESCRIPTION
Without this fix, kernel default send/receive buffers are used which might not be enough, as the full transaction of replacing the firewall is atomic, and basically we need to send (and then receive ACKs) for every piece of the firewall.

Provide proper sizing for send/receive buffers.
Also, create one connection per controller run and use that.

Fixes #14001
