### PR TITLE
fix: run overlay installer in sd-boot image

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
@@ -304,6 +304,12 @@ func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Option
 		})
 	}
 
+	if opts.ExtraInstallStep != nil {
+		if err := opts.ExtraInstallStep(); err != nil {
+			return nil, err
+		}
+	}
+
 	return partitionOptions, nil
 }
 


### PR DESCRIPTION
Hi Sidero team, 

`sd-boot` never runs `opts.ExtraInstallStep()`, so images built this way are missing artificats that devices, like the RPI5 (`config.txt`, `u-boot.bin`), needs to boot.

I added the `opts.ExtraInstallStep()` at the same spot, where [grub](https://github.com/siderolabs/talos/blob/main/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go#L140) has it, in the `GenerateAssets` function.

I verified it on a RPI5:

|  imager   |                     ESP contents                     |   result   |
| --------- | ---------------------------------------------------- | ---------- |
| unpatched | EFI/, loader/                                        | no boot :c |
| patched   | + config.txt, u-boot.bin, dtbs, overlays/ | boots :)   |

Cheers,
Chris