### PR TITLE
fix: rework bootloader install and image generation

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -584,21 +584,9 @@ func (i *Installer) getBootPartitions(ctx context.Context, mode Mode, bootloader
 
 	bootloaderOptions := i.generateBootloaderOptions(ctx, mode, nil)
 
-	partitionOptions, err := bootloader.GenerateAssets(bootloaderOptions)
+	partitionOptions, err := bootloader.PrepareBootPartitions(bootloaderOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate bootloader assets: %w", err)
-	}
-
-	efiPartitionPresent := slices.ContainsFunc(partitionOptions, func(p partition.Options) bool {
-		return p.Label == constants.EFIPartitionLabel && p.SourceDirectory != ""
-	})
-
-	// We need to move out bootloaderOptions.MountPrefix+/boot/EFI to bootloaderOptions.MountPrefix+/EFI otherwise
-	// BOOT partition will be populated with EFI directory inside boot directory.
-	if efiPartitionPresent {
-		if err := os.Rename(filepath.Join(bootloaderOptions.MountPrefix, constants.EFIMountPoint), filepath.Join(bootloaderOptions.MountPrefix, "EFI")); err != nil {
-			return nil, fmt.Errorf("failed to move EFI directory: %w", err)
-		}
+		return nil, fmt.Errorf("failed to prepare bootloader partitions: %w", err)
 	}
 
 	return partitionOptions, nil

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/bootloader.go
@@ -25,10 +25,16 @@ import (
 
 // Bootloader describes a bootloader.
 type Bootloader interface {
-	GenerateAssets(options options.InstallOptions) ([]partition.Options, error)
+	// PrepareBootPartitions prepares the set of partitions to create for the bootloader.
+	//
+	// In image mode, this also pre-populates the assets to be written to the bootloader partitions
+	// when formatting the filesystem.
+	// In install mode, this only returns a list of partitions to create, and the assets are written to the partitions during Install.
+	PrepareBootPartitions(options options.InstallOptions) ([]partition.Options, error)
 	// Install the bootloader.
 	//
 	// Install mounts the partitions as required.
+	// Install is not called in image mode.
 	Install(options options.InstallOptions) (*options.InstallResult, error)
 	// Upgrade upgrades the bootloader installation.
 	//

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/dual/dual.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/dual/dual.go
@@ -24,7 +24,7 @@ import (
 // Config describes a dual-boot bootloader.
 // this is a dummy implementation of the bootloader interface
 // allowing to install GRUB for BIOS and sd-boot for UEFI
-// so we only care about `GenerateAssets()`.
+// so we only care about `PrepareBootPartitions()`.
 type Config struct{}
 
 // New creates a new bootloader.
@@ -32,23 +32,32 @@ func New() *Config {
 	return &Config{}
 }
 
-// GenerateAssets generates the dual-boot bootloader assets and returns the partition options with source directory set.
-func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Options, error) {
+// PrepareBootPartitions prepares the set of partitions to create for the bootloader.
+//
+// In image mode, this also pre-populates the assets to be written to the bootloader partitions
+// when formatting the filesystem.
+// In install mode, this only returns a list of partitions to create, and the assets are written to the partitions during Install.
+func (c *Config) PrepareBootPartitions(opts options.InstallOptions) ([]partition.Options, error) {
 	if opts.Arch == "arm64" {
 		return nil, fmt.Errorf("dual-boot bootloader is not supported on arm64 architecture, either GRUB or sd-boot must be used")
 	}
 
-	// here we'll use the grub and sd-boot GenerateAssets logic
+	if !opts.ImageMode {
+		return nil, fmt.Errorf("dual-boot bootloader is only supported in image mode")
+	}
+
+	// here we'll use the grub and sd-boot PrepareBootPartitions logic
 	// and remove the grub `EFI` directory after we're done
-	if _, err := grub.NewConfig().GenerateAssets(opts); err != nil {
+	if _, err := grub.NewConfig().PrepareBootPartitions(opts); err != nil {
 		return nil, fmt.Errorf("failed to install GRUB bootloader: %w", err)
 	}
 
-	if err := os.RemoveAll(filepath.Join(opts.MountPrefix, constants.EFIMountPoint)); err != nil {
+	// cleanup the GRUB EFI assets directory, since we don't need it for dual-boot
+	if err := os.RemoveAll(filepath.Join(opts.MountPrefix, "EFI")); err != nil {
 		return nil, fmt.Errorf("failed to cleanup GRUB EFI assets directory: %w", err)
 	}
 
-	if _, err := sdboot.New().GenerateAssets(opts); err != nil {
+	if _, err := sdboot.New().PrepareBootPartitions(opts); err != nil {
 		return nil, fmt.Errorf("failed to generate sd-boot assets: %w", err)
 	}
 
@@ -70,13 +79,11 @@ func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Option
 		),
 	}
 
-	if opts.ImageMode {
-		partitionOptions = xslices.Map(partitionOptions, func(o partition.Options) partition.Options {
-			o.Reproducible = true
+	partitionOptions = xslices.Map(partitionOptions, func(o partition.Options) partition.Options {
+		o.Reproducible = true
 
-			return o
-		})
-	}
+		return o
+	})
 
 	return partitionOptions, nil
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -93,24 +93,31 @@ func (c *Config) KexecLoad(r runtime.Runtime, disk string) error {
 	return err
 }
 
-// GenerateAssets generates the bootloader assets and returns partition options to create the bootloader partitions.
-func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Options, error) {
-	if err := c.generateAssets(opts); err != nil {
-		return nil, err
-	}
-
+// PrepareBootPartitions prepares the set of partitions to create for the bootloader.
+//
+// In image mode, this also pre-populates the assets to be written to the bootloader partitions
+// when formatting the filesystem.
+// In install mode, this only returns a list of partitions to create, and the assets are written to the partitions during Install.
+func (c *Config) PrepareBootPartitions(opts options.InstallOptions) ([]partition.Options, error) {
 	quirk := quirks.New(opts.Version)
 
 	efiFormatOptions := []partition.FormatOption{
 		partition.WithLabel(constants.EFIPartitionLabel),
 	}
 
+	bootFormatOptions := []partition.FormatOption{
+		partition.WithLabel(constants.BootPartitionLabel),
+	}
+
 	if opts.ImageMode {
-		// in bios install mode grub generated assets only contains the grub config file and kernel and initramfs
-		// so we don't need to set the source directory for the EFI partition
 		efiFormatOptions = append(
 			efiFormatOptions,
 			partition.WithSourceDirectory(filepath.Join(opts.MountPrefix, "EFI")),
+		)
+
+		bootFormatOptions = append(
+			bootFormatOptions,
+			partition.WithSourceDirectory(filepath.Join(opts.MountPrefix, constants.BootMountPoint)),
 		)
 	}
 
@@ -124,8 +131,7 @@ func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Option
 		partition.NewPartitionOptions(
 			false,
 			quirk,
-			partition.WithLabel(constants.BootPartitionLabel),
-			partition.WithSourceDirectory(filepath.Join(opts.MountPrefix, constants.BootMountPoint)),
+			bootFormatOptions...,
 		),
 	}
 
@@ -135,11 +141,15 @@ func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Option
 
 			return o
 		})
-	}
 
-	if opts.ExtraInstallStep != nil {
-		if err := opts.ExtraInstallStep(); err != nil {
+		if err := c.copyAssets(opts); err != nil {
 			return nil, err
+		}
+
+		if opts.ExtraInstallStep != nil {
+			if err := opts.ExtraInstallStep(); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/install.go
@@ -75,8 +75,18 @@ func (c *Config) Install(opts options.InstallOptions) (*options.InstallResult, e
 		opts.BootDisk,
 		mountSpecs,
 		func() error {
+			if err := c.copyAssets(opts); err != nil {
+				return err
+			}
+
 			if err := c.runGrubInstall(context.Background(), opts, efiFound); err != nil {
 				return err
+			}
+
+			if opts.ExtraInstallStep != nil {
+				if err := opts.ExtraInstallStep(); err != nil {
+					return err
+				}
 			}
 
 			return nil
@@ -197,7 +207,7 @@ func (c *Config) generateGrubImage(ctx context.Context, opts options.InstallOpti
 
 	copyInstructions = append(copyInstructions, utils.SourceDestination(
 		grubEFIPath,
-		filepath.Join(opts.MountPrefix, constants.EFIMountPoint, efiFile),
+		filepath.Join(opts.MountPrefix, "EFI", efiFile),
 	))
 
 	if err := utils.CopyFiles(
@@ -211,7 +221,7 @@ func (c *Config) generateGrubImage(ctx context.Context, opts options.InstallOpti
 }
 
 //nolint:gocyclo
-func (c *Config) generateAssets(opts options.InstallOptions) error {
+func (c *Config) copyAssets(opts options.InstallOptions) error {
 	cmdline := opts.Cmdline
 
 	// if we have a kernel path, assume that the kernel and initramfs are available

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/upgrade.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/upgrade.go
@@ -63,7 +63,7 @@ func (c *Config) Upgrade(opts options.InstallOptions) (*options.InstallResult, e
 				return err
 			}
 
-			if err := c.generateAssets(opts); err != nil {
+			if err := c.copyAssets(opts); err != nil {
 				return err
 			}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/export_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/export_test.go
@@ -8,5 +8,5 @@ package sdboot
 var (
 	FindMatchingUKIFile = findMatchingUKIFile
 	GenerateNextUKIName = generateNextUKIName
-	GenerateAssets      = (*Config).generateAssets
+	CopyAssets          = (*Config).copyAssets
 )

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/generate_assets_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/generate_assets_test.go
@@ -86,7 +86,7 @@ func TestGenerateAssets(t *testing.T) {
 				Printf:               func(string, ...any) {},
 			}
 
-			require.NoError(t, sdboot.GenerateAssets(&sdboot.Config{}, opts, ukiFileName))
+			require.NoError(t, sdboot.CopyAssets(&sdboot.Config{}, opts, ukiFileName))
 
 			loaderDir := filepath.Join(mountPrefix, constants.EFIMountPoint, "loader")
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/sdboot/sdboot.go
@@ -274,49 +274,103 @@ func (c *Config) KexecLoad(r runtime.Runtime, disk string) error {
 	return err
 }
 
-// GenerateAssets generates the sd-boot bootloader assets and returns the partition options with source directory set.
-func (c *Config) GenerateAssets(opts options.InstallOptions) ([]partition.Options, error) {
-	ukiFileName, err := generateNextUKIName(opts.Version, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := c.generateAssets(opts, ukiFileName); err != nil {
-		return nil, err
-	}
-
+// PrepareBootPartitions prepares the set of partitions to create for the bootloader.
+//
+// In image mode, this also pre-populates the assets to be written to the bootloader partitions
+// when formatting the filesystem.
+// In install mode, this only returns a list of partitions to create, and the assets are written to the partitions during Install.
+func (c *Config) PrepareBootPartitions(opts options.InstallOptions) ([]partition.Options, error) {
 	quirk := quirks.New(opts.Version)
+
+	formatOptions := []partition.FormatOption{
+		partition.WithLabel(constants.EFIPartitionLabel),
+	}
+
+	if opts.ImageMode {
+		formatOptions = append(formatOptions, partition.WithSourceDirectory(filepath.Join(opts.MountPrefix, "EFI")))
+	}
 
 	partitionOptions := []partition.Options{
 		partition.NewPartitionOptions(
 			true,
 			quirk,
-			partition.WithLabel(constants.EFIPartitionLabel),
-			partition.WithSourceDirectory(filepath.Join(opts.MountPrefix, "EFI")),
+			formatOptions...,
 		),
 	}
 
-	if opts.ImageMode {
-		partitionOptions = xslices.Map(partitionOptions, func(o partition.Options) partition.Options {
-			o.Reproducible = true
-
-			return o
-		})
+	if !opts.ImageMode {
+		// in non-image mode, the actual asset copying will happen in the Install step
+		return partitionOptions, nil
 	}
+
+	// in image mode, we populate the directory with the bootloader assets
+	ukiFileName, err := generateNextUKIName(opts.Version, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.copyAssets(opts, ukiFileName); err != nil {
+		return nil, err
+	}
+
+	// move the files out of constants.EFIMountPoint into the "EFI" directory to prevent it being pulled into the GRUB /boot partition in dual-boot mode
+	if err := os.Rename(filepath.Join(opts.MountPrefix, constants.EFIMountPoint), filepath.Join(opts.MountPrefix, "EFI")); err != nil {
+		return nil, fmt.Errorf("failed to move EFI directory: %w", err)
+	}
+
+	partitionOptions = xslices.Map(partitionOptions, func(o partition.Options) partition.Options {
+		o.Reproducible = true
+
+		return o
+	})
 
 	return partitionOptions, nil
 }
 
 // Install the bootloader.
-// here we don't need to mount anything since we just need to write the EFI variables
-// since the partitions are already pre-populated.
+//
+// This method only runs in non-image mode, so mount the EFI partition, copy the UKI and sd-boot.efi, and update the EFI variables.
 func (c *Config) Install(opts options.InstallOptions) (*options.InstallResult, error) {
 	ukiFileName, err := generateNextUKIName(opts.Version, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.setup(opts, ukiFileName)
+	var installResult *options.InstallResult
+
+	err = mount.PartitionOp(
+		opts.BootDisk,
+		[]mount.Spec{
+			{
+				PartitionLabel: constants.EFIPartitionLabel,
+				FilesystemType: partition.FilesystemTypeVFAT,
+				MountTarget:    filepath.Join(opts.MountPrefix, constants.EFIMountPoint),
+			},
+		},
+		func() error {
+			if err := c.copyAssets(opts, ukiFileName); err != nil {
+				return err
+			}
+
+			var err error
+
+			installResult, err = c.setup(opts, ukiFileName)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		[]blkid.ProbeOption{
+			// installation happens with locked blockdevice
+			blkid.WithSkipLocking(true),
+		},
+		nil,
+		nil,
+		opts.BlkidInfo,
+	)
+
+	return installResult, err
 }
 
 // Upgrade the bootloader.
@@ -364,7 +418,7 @@ func (c *Config) Upgrade(opts options.InstallOptions) (*options.InstallResult, e
 				}
 			}
 
-			if err := c.generateAssets(opts, ukiPath); err != nil {
+			if err := c.copyAssets(opts, ukiPath); err != nil {
 				return err
 			}
 
@@ -438,7 +492,7 @@ func (c *Config) setup(opts options.InstallOptions, ukiFileName string) (*option
 	}, nil
 }
 
-func (c *Config) generateAssets(opts options.InstallOptions, ukiFileName string) error {
+func (c *Config) copyAssets(opts options.InstallOptions, ukiFileName string) error {
 	loaderDir := filepath.Join(opts.MountPrefix, constants.EFIMountPoint, "loader")
 
 	if err := os.MkdirAll(loaderDir, 0o755); err != nil {


### PR DESCRIPTION
The most important change is that install process (on the machine) no longer populates the filesystem via mkfs, as this requires an extra copy of the boot asset during the install, which in turn lands on tmpfs when doing unattended install requiring extra memory.

I renamed `GenerateAssets` to `PrepareBootPartitions` to make the purpose of the method more clear.

Clean up GRUB/sd-boot/dual, removing some hacks along the way.

In image mode, there should be no change - filesystems are pre-populated before calling makefs, while in install mode the assets are copyied directly to the mounted filesystem (same as upgrade).
