### PR TITLE
fix: data race in Never condition closures

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/machine_status_test.go
@@ -198,7 +198,9 @@ func (suite *MachineStatusSuite) TestReconcile() {
 	suite.Require().Never(
 		func() bool {
 			status, err := safe.StateGetByID[*runtime.MachineStatus](ctx, st, runtime.MachineStatusID)
-			suite.NoError(err, "status should exist")
+			if err != nil {
+				return false
+			}
 
 			return status.TypedSpec().Stage != runtime.MachineStageShuttingDown
 		},

--- a/internal/app/machined/pkg/controllers/runtime/unattended_install_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/unattended_install_test.go
@@ -226,9 +226,16 @@ func (suite *UnattendedInstallSuite) TestNoDowngradeToInstalled() {
 	installed.Store(true)
 	suite.createDisk("sdb")
 
+	// Capture ctx/state in locals: Never leaks its last condition goroutine past
+	// return, and reading suite.Ctx()/suite.State() there races the next test's
+	// SetupTest overwriting those fields.
+	ctx, st := suite.Ctx(), suite.State()
+
 	suite.Assert().Never(func() bool {
-		status, err := safe.StateGetByID[*runtime.UnattendedInstallStatus](suite.Ctx(), suite.State(), runtime.UnattendedInstallStatusID)
-		suite.Require().NoError(err)
+		status, err := safe.StateGetByID[*runtime.UnattendedInstallStatus](ctx, st, runtime.UnattendedInstallStatusID)
+		if err != nil {
+			return false
+		}
 
 		return status.TypedSpec().Phase != runtime.UnattendedInstallPhaseWaitingForReboot
 	}, time.Second, 100*time.Millisecond)


### PR DESCRIPTION
testify Never abandons its in-flight condition goroutine when the
timeout fires. Touching suite state from that closure races the next
test SetupTest, which overwrites suite.ctx/state, and assertions
there run on an already-finished T.

Capture ctx/state in locals before the call and return false on error
instead of asserting inside the goroutine.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
