### PR TITLE
feat: allow passing extra QEMU arguments per node

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -82,6 +82,9 @@ type LaunchConfig struct {
 	// API
 	APIBindAddress *net.TCPAddr
 
+	// ExtraQEMUArgs is appended verbatim to the QEMU command line.
+	ExtraQEMUArgs []string
+
 	// sd-stub
 	sdStubExtraCmdline       string
 	sdStubExtraCmdlineConfig string
@@ -463,6 +466,10 @@ func launchVM(config *LaunchConfig) error {
 			"base=2011-11-11T11:11:00,clock=rt",
 		)
 	}
+
+	// Extra caller-supplied QEMU arguments (e.g. an emulated BMC device set),
+	// appended last so they can reference devices declared above.
+	args = append(args, config.ExtraQEMUArgs...)
 
 	// QEMU runs with `-no-reboot`, so every reboot of the VM is a relaunch, and a relaunch can lose
 	// a race against the host services backing the VM's devices. The known case is virtiofsd: it

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -190,6 +190,7 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 		TFTPServer:                nodeReq.TFTPServer,
 		IPXEBootFileName:          nodeReq.IPXEBootFilename,
 		APIBindAddress:            apiBind,
+		ExtraQEMUArgs:             nodeReq.ExtraQEMUArgs,
 		IOMMUEnabled:              opts.IOMMUEnabled,
 		Network:                   getLaunchNetworkConfig(state, clusterReq, nodeReq),
 

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -237,6 +237,13 @@ type NodeRequest struct {
 	// This doesn't apply to boots from ISO or from the disk image.
 	ExtraKernelArgs *procfs.Cmdline
 
+	// ExtraQEMUArgs passes additional command-line arguments verbatim to the
+	// QEMU process for this node (QEMU provisioner only). This is a generic
+	// extension point for provisioners that need to attach extra QEMU devices
+	// (for example an emulated BMC) without the provision library having to know
+	// about them.
+	ExtraQEMUArgs []string
+
 	// SDStubKernelArgs passes additional kernel args via the systemd-stub.
 	//
 	// This applies to boots from ISO and from the disk image.


### PR DESCRIPTION
Add a per-node option to pass additional command-line arguments verbatim to the QEMU process, plumbed through the launch configuration and appended to the QEMU invocation. This is a generic extension point for provisioners that need to attach extra QEMU devices, for example an emulated BMC, without the provision library having to know about them.