### PR TITLE
fix: respect authentication-config extra arg for legacy config

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final.go
@@ -36,6 +36,8 @@ import (
 type ControlPlaneAPIServerFinalController = transform.Controller[*k8s.APIServerConfig, *k8s.APIServerConfig]
 
 // NewControlPlaneAPIServerFinalController instantiates the controller.
+//
+//nolint:gocyclo
 func NewControlPlaneAPIServerFinalController() *ControlPlaneAPIServerFinalController {
 	return transform.NewController(
 		transform.Settings[*k8s.APIServerConfig, *k8s.APIServerConfig]{
@@ -170,7 +172,13 @@ func NewControlPlaneAPIServerFinalController() *ControlPlaneAPIServerFinalContro
 					"tls-min-version":                  argsbuilder.MergeDenied,
 					"tls-private-key-file":             argsbuilder.MergeDenied,
 					"authorization-config":             argsbuilder.MergeDenied,
-					"authentication-config":            argsbuilder.MergeDenied,
+				}
+
+				// Talos only owns the structured authentication config file when it renders one, so the flag
+				// is denied in extra args in that case. On the legacy `.cluster.apiServer` path Talos never
+				// sets the flag, so the user is free to point kube-apiserver at their own file.
+				if cfg.UseAuthenticationConfig {
+					mergePolicies["authentication-config"] = argsbuilder.MergeDenied
 				}
 
 				if err := builder.Merge(extraArgs, argsbuilder.WithMergePolicies(mergePolicies)); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_final_test.go
@@ -872,6 +872,32 @@ func (suite *ControlPlaneAPIServerFinalSuite) TestTransform() {
 			}(),
 		},
 		{
+			// Regression for siderolabs/talos#14030: on the legacy `.cluster.apiServer` path Talos doesn't
+			// render an authentication config file, so a user-supplied `authentication-config` extra arg must
+			// be passed through rather than rejected. `--anonymous-auth=false` stays, matching Talos <= 1.13.
+			name:    "legacy path: user-supplied authentication-config in extra args",
+			k8sRoot: baseK8sRoot(),
+			input: func() k8s.APIServerConfigSpec {
+				s := baseSpec()
+				s.UseAuthenticationConfig = false
+				s.ExtraArgs = map[string]k8s.ArgValues{
+					"authentication-config": {Values: []string{"/var/apiserver/conf/auth-config.yaml"}},
+				}
+
+				return s
+			}(),
+			expected: func() k8s.APIServerConfigSpec {
+				s := baseSpec()
+				s.Args = withAnonymousAuth(withAuthArgs(
+					commonArgs(defaultAudiences, defaultIssuers),
+					"--authentication-config=/var/apiserver/conf/auth-config.yaml",
+					"--authorization-config="+authzConfigPath,
+				))
+
+				return s
+			}(),
+		},
+		{
 			// Pass-through fields, conditional advertise-address & cloud-provider, and additive extra args.
 			name:    "pass-through fields, advertised address, cloud provider and extra args",
 			k8sRoot: baseK8sRoot(),
@@ -1095,13 +1121,20 @@ func (suite *ControlPlaneAPIServerFinalSuite) TestTransform() {
 // TestRejectsDeniedExtraArgs verifies that extra args which collide with a MergeDenied
 // policy cause the transform to fail, so no final APIServerConfig is produced.
 func (suite *ControlPlaneAPIServerFinalSuite) TestRejectsDeniedExtraArgs() {
-	for _, arg := range []string{
-		"tls-min-version",
-		"tls-cert-file",
-		"proxy-client-key-file",
-		"etcd-servers",
+	for _, tt := range []struct {
+		arg string
+		// useAuthenticationConfig makes Talos render & own the structured authentication config file.
+		useAuthenticationConfig bool
+	}{
+		{arg: "tls-min-version"},
+		{arg: "tls-cert-file"},
+		{arg: "proxy-client-key-file"},
+		{arg: "etcd-servers"},
+		// authentication-config is only denied when Talos itself renders the file, see
+		// "legacy path: user-supplied authentication-config in extra args" for the other half.
+		{arg: "authentication-config", useAuthenticationConfig: true},
 	} {
-		suite.Run(arg, func() {
+		suite.Run(tt.arg, func() {
 			setK8sRoot(suite, secrets.KubernetesRootSpec{
 				APIAudiences: []string{"https://localhost:6443"},
 				IssuerURL:    "https://localhost:6443",
@@ -1109,13 +1142,14 @@ func (suite *ControlPlaneAPIServerFinalSuite) TestRejectsDeniedExtraArgs() {
 
 			in := k8s.NewAPIServerConfig(k8s.APIServerConfigID)
 			*in.TypedSpec() = k8s.APIServerConfigSpec{
-				Image:                "registry.k8s.io/kube-apiserver:v1.32.0",
-				ControlPlaneEndpoint: "https://localhost:6443",
-				EtcdServers:          []string{"https://127.0.0.1:2379"},
-				LocalPort:            6443,
-				ServiceCIDRs:         []string{"10.96.0.0/12"},
+				Image:                   "registry.k8s.io/kube-apiserver:v1.32.0",
+				ControlPlaneEndpoint:    "https://localhost:6443",
+				EtcdServers:             []string{"https://127.0.0.1:2379"},
+				LocalPort:               6443,
+				ServiceCIDRs:            []string{"10.96.0.0/12"},
+				UseAuthenticationConfig: tt.useAuthenticationConfig,
 				ExtraArgs: map[string]k8s.ArgValues{
-					arg: {Values: []string{"override"}},
+					tt.arg: {Values: []string{"override"}},
 				},
 			}
 


### PR DESCRIPTION
Fixes #14030

This allows pre-1.14 config to function properly, while 1.14+ config has native supoport for authentication config.

The merge deny uncoditional was obviously wrong.
