### PR TITLE
fix: adjust cluster size for VFAT on ISO

### DIFF
--- a/pkg/imager/iso/uefi.go
+++ b/pkg/imager/iso/uefi.go
@@ -29,6 +29,40 @@ const (
 //go:embed loader.conf.tmpl
 var loaderConfigTemplate string
 
+// fatSectorsPerCluster picks the cluster size for the ESP holding the UKI.
+//
+// mkfs.vfat defaults to a single 512 byte sector per cluster at the sizes we
+// build here, which leaves the ESP with a ~900 KiB FAT per copy and a cluster
+// chain of ~200k entries for a single ~100 MiB UKI. Firmware walks that chain
+// on every boot, which is painful on slow media (e.g. an optical drive).
+//
+// The cluster size is capped so that the cluster count stays above the FAT32
+// minimum of 65525: most implementations (EDK2 included) derive the FAT type
+// from the cluster count, so a FAT32 filesystem below that floor reads back as
+// FAT16 and fails to mount.
+func fatSectorsPerCluster(sizeBytes int64) uint {
+	const (
+		sectorSize = 512
+		// FAT32 minimum cluster count, plus room for the reserved sectors and the FATs themselves.
+		minClusters = 65525 + 2048
+		maxSPC      = 8
+	)
+
+	sectors := sizeBytes / sectorSize
+
+	spc := uint(1)
+
+	for next := spc * 2; next <= maxSPC; next *= 2 {
+		if sectors/int64(next) < minClusters {
+			break
+		}
+
+		spc = next
+	}
+
+	return spc
+}
+
 // CreateUEFI creates an iso using a UKI, systemd-boot.
 //
 // The ISO created supports only booting in UEFI mode, and supports SecureBoot.
@@ -79,6 +113,7 @@ func (options Options) CreateUEFI(ctx context.Context, printf func(string, ...an
 	fopts := []makefs.Option{
 		makefs.WithLabel(constants.EFIPartitionLabel),
 		makefs.WithReproducible(true),
+		makefs.WithSectorsPerCluster(fatSectorsPerCluster(isoSize)),
 	}
 
 	if err := makefs.VFAT(ctx, efiBootImg, fopts...); err != nil {

--- a/pkg/makefs/makefs.go
+++ b/pkg/makefs/makefs.go
@@ -20,6 +20,7 @@ type Options struct {
 	ConfigFile             string
 	SourceDirectory        string
 	SectorSize             uint
+	SectorsPerCluster      uint
 	DeviceSize             uint64
 	MinAllocationGroupSize uint64
 	Force                  bool
@@ -81,6 +82,19 @@ func WithSourceDirectory(sourceDir string) Option {
 func WithSectorSize(sectorSize uint) Option {
 	return func(o *Options) {
 		o.SectorSize = sectorSize
+	}
+}
+
+// WithSectorsPerCluster overrides the cluster size (in sectors) used by mkfs.
+//
+// It is only honored by VFAT. Zero leaves the mkfs defaults alone.
+//
+// Note that FAT type is derived from the cluster count by most implementations,
+// so growing the cluster size on a small filesystem may push it below the 65525
+// cluster minimum and turn a FAT32 filesystem into one that reads as FAT16.
+func WithSectorsPerCluster(sectorsPerCluster uint) Option {
+	return func(o *Options) {
+		o.SectorsPerCluster = sectorsPerCluster
 	}
 }
 

--- a/pkg/makefs/vfat.go
+++ b/pkg/makefs/vfat.go
@@ -37,6 +37,10 @@ func VFAT(ctx context.Context, partname string, setters ...Option) error {
 		args = append(args, "-S", strconv.FormatUint(uint64(opts.SectorSize), 10))
 	}
 
+	if opts.SectorsPerCluster > 0 {
+		args = append(args, "-s", strconv.FormatUint(uint64(opts.SectorsPerCluster), 10))
+	}
+
 	args = append(args, partname)
 
 	_, err := cmd.RunWithOptions(ctx, "mkfs.vfat", args)

--- a/pkg/makefs/vfat_test.go
+++ b/pkg/makefs/vfat_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package makefs_test
 
 import (
@@ -40,6 +41,30 @@ func TestVFATCustomSectorSize(t *testing.T) {
 	require.NoError(t, c.Run())
 
 	assert.Contains(t, stdout.String(), "sector size: 4096 bytes")
+}
+
+func TestVFATCustomClusterSize(t *testing.T) {
+	if _, err := exec.LookPath("minfo"); err != nil {
+		t.Skip("minfo not found in PATH, skipping test")
+	}
+
+	tempDir := t.TempDir()
+	vfatImg := filepath.Join(tempDir, "test.img")
+
+	f, err := os.Create(vfatImg)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(100*1024*1024))
+	require.NoError(t, f.Close())
+
+	require.NoError(t, makefs.VFAT(t.Context(), vfatImg, makefs.WithLabel("TEST"), makefs.WithSectorsPerCluster(4)))
+
+	var stdout bytes.Buffer
+
+	c := exec.CommandContext(t.Context(), "minfo", "-i", vfatImg)
+	c.Stdout = &stdout
+	require.NoError(t, c.Run())
+
+	assert.Contains(t, stdout.String(), "cluster size: 4 sectors")
 }
 
 func TestVFATWithSourceDirectory(t *testing.T) {


### PR DESCRIPTION
As a small improvement, adjust cluster size for small-ish VFAT partitions when the ISO is small (< 260 MiB) to optimize for bigger cluster sizes and reduce number of reads (improving performance).

VFAT when created for disk images (e.g. 2GiB partition) gets a correct size anyways, as it's big enough, and mkfs defaults kick in.
