### PR TITLE
fix: use v1.13 config to test downgrade failure

### DIFF
--- a/internal/integration/cli/upgrade.go
+++ b/internal/integration/cli/upgrade.go
@@ -44,7 +44,7 @@ func (suite *UpgradeSuite) TestIncompatibleMachineConfig() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 
 	config, _ := suite.RunCLI([]string{"get", "--nodes", node, "mc", "v1alpha1", "--output", "jsonpath={.spec}"})
-	suite.Require().Contains(config, "kind: DiscoveryServiceConfig", "downgrade must be guaranteed to fail before touching disk")
+	suite.Require().Contains(config, "kind: ImageVerificationConfig", "downgrade must be guaranteed to fail before touching disk")
 
 	suite.RunCLI(
 		[]string{


### PR DESCRIPTION
## What?

Use `ImageVerificationConfig` to verify that the integration cluster machine configuration is incompatible with the Talos v1.12 installer.

## Why?

The `integration-qemu-13` job generates v1.13-compatible machine configuration via `--talos-version=v1.13`. Discovery therefore remains in the legacy `cluster.discovery` block, so asserting that the config contains the v1.14-only `DiscoveryServiceConfig` fails before the downgrade is attempted.

`ImageVerificationConfig` is present in the CI config patch and was introduced in Talos v1.13, so the v1.12 installer cannot decode it. This preserves the test invariant that the downgrade fails during configuration loading, before touching disk.

## Testing

- `go test -run '^$' -tags='integration,integration_api,integration_cli,integration_k8s' ./internal/integration`
- `go test ./pkg/machinery/config/types/security`
- `git diff --check`
