### PR TITLE
fix: share IPC namespace with the host for extension services

### DIFF
--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -127,6 +127,7 @@ func (svc *Extension) getOCIOptions(envVars []string, mounts []specs.Mount) []oc
 		containerd.WithRootfsPropagation(svc.Spec.Container.Security.RootfsPropagation),
 		oci.WithMounts(mounts),
 		oci.WithHostNamespace(specs.NetworkNamespace),
+		oci.WithHostNamespace(specs.IPCNamespace),
 		oci.WithSelinuxLabel(""),
 		oci.WithApparmorProfile(""),
 		oci.WithCapabilities(capability.AllGrantableCapabilities()),


### PR DESCRIPTION
There is an interaction between multipath-tools, devicemapper and udevd which sometimes crosses the extension service and the host when used via CSI.

Allow to share IPC namespace so that the SysV locks works across the boundary of the extension service.
