### PR TITLE
fix: user volume bind mount options

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
@@ -45,12 +45,11 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 		userVolumeResource := VolumeResource{
 			VolumeID:           volumeID,
 			Label:              block.UserVolumeLabel,
-			MountTransformFunc: HandleUserVolumeMountRequest(userVolumeConfig), // This is overridden for Directory type below.
+			MountTransformFunc: HandleUserVolumeMountRequest(userVolumeConfig),
 		}
 
 		switch userVolumeConfig.Type().ValueOr(block.VolumeTypePartition) {
 		case block.VolumeTypeDirectory:
-			userVolumeResource.MountTransformFunc = DefaultMountTransform
 			userVolumeResource.TransformFunc = NewBuilder().
 				WithType(block.VolumeTypeDirectory).
 				WithMount(block.MountSpec{

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
@@ -115,8 +115,9 @@ func TestUserVolumeTransformer(t *testing.T) {
 				})
 
 				testMountTransformFunc(t, resources[0].MountTransformFunc, func(t *testing.T, m *block.VolumeMountRequest, err error) {
-					// default mount transform is noop
 					require.NoError(t, err)
+					assert.True(t, m.TypedSpec().Secure)
+					assert.True(t, m.TypedSpec().NoExec)
 				})
 			},
 		},

--- a/internal/app/machined/pkg/controllers/block/mount.go
+++ b/internal/app/machined/pkg/controllers/block/mount.go
@@ -33,12 +33,13 @@ import (
 )
 
 type mountContext struct {
-	point             *mount.Point
-	readOnly          bool
-	disableAccessTime bool
-	secure            bool
-	noExec            bool
-	unmounter         func() error
+	point               *mount.Point
+	readOnly            bool
+	disableAccessTime   bool
+	secure              bool
+	noExec              bool
+	securityInitialized bool
+	unmounter           func() error
 }
 
 // MountController performs actual mount/unmount operations based on the MountRequests.
@@ -390,9 +391,11 @@ func (ctrl *MountController) handleBindMountOperation(
 			}
 		}
 
-		opts := []mount.ManagerOption{
-			mount.WithSelinuxLabel(volumeStatus.TypedSpec().MountSpec.SelinuxLabel),
-		}
+		opts := bindMountOptions(
+			volumeStatus.TypedSpec().MountSpec.SelinuxLabel,
+			mountRequest.TypedSpec().Secure,
+			mountRequest.TypedSpec().NoExec,
+		)
 
 		manager := mount.NewManager(slices.Concat(
 			[]mount.ManagerOption{
@@ -426,11 +429,22 @@ func (ctrl *MountController) handleBindMountOperation(
 		ctrl.activeMounts[mountRequest.Metadata().ID()] = &mountContext{
 			point:     mountpoint,
 			readOnly:  mountRequest.TypedSpec().ReadOnly,
+			secure:    mountRequest.TypedSpec().Secure,
+			noExec:    mountRequest.TypedSpec().NoExec,
 			unmounter: manager.Unmount,
 		}
 	}
 
-	return nil
+	mountCtx := ctrl.activeMounts[mountRequest.Metadata().ID()]
+
+	return updateMountSecurity(
+		logger,
+		mountRequest.Metadata().ID(),
+		volumeStatus.Metadata().ID(),
+		mountCtx,
+		mountRequest.TypedSpec().Secure,
+		mountRequest.TypedSpec().NoExec,
+	)
 }
 
 //nolint:gocyclo
@@ -681,12 +695,13 @@ func (ctrl *MountController) handleDiskMountOperation(
 		)
 
 		mountCtx = &mountContext{
-			point:             mountpoint,
-			readOnly:          mountRequest.TypedSpec().ReadOnly,
-			disableAccessTime: mountRequest.TypedSpec().DisableAccessTime,
-			secure:            mountRequest.TypedSpec().Secure,
-			noExec:            mountRequest.TypedSpec().NoExec,
-			unmounter:         manager.Unmount,
+			point:               mountpoint,
+			readOnly:            mountRequest.TypedSpec().ReadOnly,
+			disableAccessTime:   mountRequest.TypedSpec().DisableAccessTime,
+			secure:              mountRequest.TypedSpec().Secure,
+			noExec:              mountRequest.TypedSpec().NoExec,
+			securityInitialized: true,
+			unmounter:           manager.Unmount,
 		}
 		ctrl.activeMounts[mountRequest.Metadata().ID()] = mountCtx
 	}
@@ -730,36 +745,76 @@ func (ctrl *MountController) handleDiskMountOperation(
 		mountCtx.disableAccessTime = mountRequest.TypedSpec().DisableAccessTime
 	}
 
-	//nolint:dupl
-	if mountCtx.secure != mountRequest.TypedSpec().Secure {
-		err := mountCtx.point.SetSecure(mountRequest.TypedSpec().Secure)
-		if err != nil {
-			return fmt.Errorf("failed to update secure for %q: %w", mountRequest.Metadata().ID(), err)
-		}
+	return updateMountSecurity(
+		logger,
+		mountRequest.Metadata().ID(),
+		volumeStatus.Metadata().ID(),
+		mountCtx,
+		mountRequest.TypedSpec().Secure,
+		mountRequest.TypedSpec().NoExec,
+	)
+}
 
-		logger.Info(
-			"volume mount attributes updated",
-			zap.String("volume", volumeStatus.Metadata().ID()),
-			zap.String("secure", fmt.Sprintf("%v -> %v", mountCtx.secure, mountRequest.TypedSpec().Secure)),
-		)
-
-		mountCtx.secure = mountRequest.TypedSpec().Secure
+func bindMountOptions(selinuxLabel string, secure, noExec bool) []mount.ManagerOption {
+	opts := []mount.ManagerOption{
+		mount.WithSelinuxLabel(selinuxLabel),
 	}
 
-	//nolint:dupl
-	if mountCtx.noExec != mountRequest.TypedSpec().NoExec {
-		err := mountCtx.point.SetNoExec(mountRequest.TypedSpec().NoExec)
-		if err != nil {
-			return fmt.Errorf("failed to update noexec for %q: %w", mountRequest.Metadata().ID(), err)
+	if secure {
+		opts = append(opts, mount.WithSecure())
+	}
+
+	if noExec {
+		opts = append(opts, mount.WithNoExec())
+	}
+
+	return opts
+}
+
+func updateMountSecurity(logger *zap.Logger, mountID, volumeID string, mountCtx *mountContext, secure, noExec bool) error {
+	initialize := !mountCtx.securityInitialized
+
+	if initialize || mountCtx.secure != secure {
+		if err := mountCtx.point.SetSecure(secure); err != nil {
+			return fmt.Errorf("failed to update secure for %q: %w", mountID, err)
 		}
 
+		if !initialize {
+			logger.Info(
+				"volume mount attributes updated",
+				zap.String("volume", volumeID),
+				zap.String("secure", fmt.Sprintf("%v -> %v", mountCtx.secure, secure)),
+			)
+		}
+
+		mountCtx.secure = secure
+	}
+
+	if initialize || mountCtx.noExec != noExec {
+		if err := mountCtx.point.SetNoExec(noExec); err != nil {
+			return fmt.Errorf("failed to update noexec for %q: %w", mountID, err)
+		}
+
+		if !initialize {
+			logger.Info(
+				"volume mount attributes updated",
+				zap.String("volume", volumeID),
+				zap.String("no_exec", fmt.Sprintf("%v -> %v", mountCtx.noExec, noExec)),
+			)
+		}
+
+		mountCtx.noExec = noExec
+	}
+
+	if initialize {
 		logger.Info(
-			"volume mount attributes updated",
-			zap.String("volume", volumeStatus.Metadata().ID()),
-			zap.String("no_exec", fmt.Sprintf("%v -> %v", mountCtx.noExec, mountRequest.TypedSpec().NoExec)),
+			"volume mount attributes initialized",
+			zap.String("volume", volumeID),
+			zap.Bool("secure", secure),
+			zap.Bool("no_exec", noExec),
 		)
 
-		mountCtx.noExec = mountRequest.TypedSpec().NoExec
+		mountCtx.securityInitialized = true
 	}
 
 	return nil

--- a/pkg/machinery/config/types/block/user_volume_config.go
+++ b/pkg/machinery/config/types/block/user_volume_config.go
@@ -271,8 +271,8 @@ func (s *UserVolumeConfigV1Alpha1) Validate(validation.RuntimeMode, ...validatio
 			validationErrors = errors.Join(validationErrors, errors.New("filesystem spec is invalid for volumeType directory"))
 		}
 
-		if !s.MountSpec.IsZero() {
-			validationErrors = errors.Join(validationErrors, errors.New("mount spec is invalid for volumeType directory"))
+		if s.MountSpec.MountDisableAccessTime != nil {
+			validationErrors = errors.Join(validationErrors, errors.New("mount.disableAccessTime is invalid for volumeType directory"))
 		}
 
 	case block.VolumeTypeDisk:

--- a/pkg/machinery/config/types/block/user_volume_config_test.go
+++ b/pkg/machinery/config/types/block/user_volume_config_test.go
@@ -408,6 +408,32 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 			expectedErrors: "filesystem spec is invalid for volumeType directory",
 		},
 		{
+			name: "secure mount for directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = new(blockres.VolumeTypeDirectory)
+				c.MountSpec.MountSecure = new(false)
+
+				return c
+			},
+		},
+		{
+			name: "disable access time for directory",
+
+			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {
+				c := block.NewUserVolumeConfigV1Alpha1()
+				c.MetaName = constants.EphemeralPartitionLabel
+				c.VolumeType = new(blockres.VolumeTypeDirectory)
+				c.MountSpec.MountDisableAccessTime = new(true)
+
+				return c
+			},
+
+			expectedErrors: "mount.disableAccessTime is invalid for volumeType directory",
+		},
+		{
 			name: "invalid volumeType",
 
 			cfg: func(t *testing.T) *block.UserVolumeConfigV1Alpha1 {


### PR DESCRIPTION
Directory user volumes replaced their mount request transform with a
no-op, so bind mounts inherited EPHEMERAL attributes without applying
the configured secure and noexec policy.

Preserve the user-volume mount transform, apply and reconcile security
attributes on bind mounts, and explicitly initialize them after cloning
the source mount so secure: false clears inherited nosuid and nodev.
Allow secure on directory volume configs while continuing to reject
disableAccessTime, which bind mounts do not support.


Fixes: #14043