### PR TITLE
test: use tiny hostns debug image 

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -731,7 +731,7 @@ var imageIntegrationCmd = &cobra.Command{
 			"registry.k8s.io/kube-apiserver:v1.27.0",
 			"registry.k8s.io/kube-apiserver:v1.27.1",
 			"docker.io/library/alpine:3.23",
-			constants.DebugHostNsImage,
+			constants.DebugNixyBoxImage,
 			"docker.io/library/nginx:latest",
 			imageIntegrationCmdFlags.registryAndUser + "/installer:" +
 				imageIntegrationCmdFlags.installerTag,

--- a/internal/integration/api/extensions_qemu.go
+++ b/internal/integration/api/extensions_qemu.go
@@ -331,28 +331,22 @@ func (suite *ExtensionsSuiteQEMU) TestExtensionsZFS() {
 
 	suite.Require().NotEmpty(userDisks, "expected at least one user disks to be available")
 
-	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node,
+	stdout, exitCode := suite.RunDebugContainer(suite.ctx, node,
 		"zpool", "create", "-m", "/var/tank", "tank", userDisks[0],
 	)
-	suite.Require().NoError(err)
 	suite.Require().EqualValues(0, exitCode, "zpool create failed: %s", stdout)
 	suite.Require().Equal("", stdout)
 
-	stdout, exitCode, err = suite.RunDebugContainer(suite.ctx, node,
+	stdout, exitCode = suite.RunDebugContainer(suite.ctx, node,
 		"zfs", "create", "-V", "1gb", "tank/vol",
 	)
-	suite.Require().NoError(err)
 	suite.Require().EqualValues(0, exitCode, "zfs create failed: %s", stdout)
 	suite.Require().Equal("", stdout)
 
 	defer func() {
-		if _, _, err := suite.RunDebugContainer(suite.ctx, node, "zfs", "destroy", "tank/vol"); err != nil {
-			suite.T().Logf("failed to remove zfs dataset tank/vol: %v", err)
-		}
+		suite.RunDebugContainer(suite.ctx, node, "zfs", "destroy", "tank/vol")
 
-		if _, _, err := suite.RunDebugContainer(suite.ctx, node, "zpool", "destroy", "tank"); err != nil {
-			suite.T().Logf("failed to remove zpool tank: %v", err)
-		}
+		suite.RunDebugContainer(suite.ctx, node, "zpool", "destroy", "tank")
 
 		// Wipe the disk so no zfs label lingers (otherwise the pool is re-discovered
 		// as a volume after the test).
@@ -422,10 +416,9 @@ func (suite *ExtensionsSuiteQEMU) checkZFSPoolMounted(t *assert.CollectT, node s
 func (suite *ExtensionsSuiteQEMU) TestExtensionsUtilLinuxTools() {
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
 
-	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node,
+	stdout, exitCode := suite.RunDebugContainer(suite.ctx, node,
 		"/usr/local/sbin/fstrim", "--version",
 	)
-	suite.Require().NoError(err)
 	suite.Require().EqualValues(0, exitCode, "fstrim --version failed: %s", stdout)
 	suite.Require().Contains(stdout, "fstrim from util-linux")
 }

--- a/internal/integration/api/iptables.go
+++ b/internal/integration/api/iptables.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/siderolabs/talos/internal/integration/base"
-	"github.com/siderolabs/talos/pkg/machinery/client"
-	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 )
 
 // IPTablesSuite ...
@@ -123,26 +121,12 @@ func (suite *IPTablesSuite) TestLegacyXTables() {
 		suite.T().Skip("skipping kernel test since Talos kernel is not running")
 	}
 
-	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
-
-	memoryInfo, err := suite.Client.Memory(client.WithNode(suite.ctx, node))
-	suite.Require().NoError(err)
-
-	suite.Require().Len(memoryInfo.GetMessages(), 1)
-
-	// memTotal is in KiB, so 1.5GiB is our threshold for skipping the test on low-memory nodes
-	if memoryInfo.GetMessages()[0].GetMeminfo().GetMemtotal() < 1536*1024 {
-		suite.T().Skip("skipping test on low-memory node, debug container image is too large")
-	}
-
-	suite.T().Logf("using node %s", node)
+	node := suite.RandomDiscoveredNodeInternalIP()
 
 	// this is a regression test mimicking operations done by Cilium
-	out, exitCode, err := suite.RunDebugContainer(suite.ctx, node, "sh", "-c", xtablesProbeScript)
-	suite.Require().NoError(err)
+	out, exitCode := suite.RunDebugContainer(suite.ctx, node, "sh", "-c", xtablesProbeScript)
 
 	suite.T().Logf("output:\n%s", out)
-
 	suite.Assert().Zero(exitCode, "iptables-nft probes failed with exit code %d, output:\n%s", exitCode, out)
 }
 

--- a/internal/integration/api/wipe.go
+++ b/internal/integration/api/wipe.go
@@ -129,8 +129,7 @@ func (suite *WipeSuite) TestWipeFilesystem() {
 
 	userDisk := userDisks[0]
 
-	stdout, exitCode, err := suite.RunDebugContainer(suite.ctx, node, "mkfs.xfs", userDisk)
-	suite.Require().NoError(err)
+	stdout, exitCode := suite.RunDebugContainer(suite.ctx, node, "mkfs.xfs", userDisk)
 	suite.Require().EqualValues(0, exitCode, "mkfs.xfs failed: %s", stdout)
 
 	// now Talos should report the disk as xfs formatted
@@ -139,7 +138,7 @@ func (suite *WipeSuite) TestWipeFilesystem() {
 	nodeCtx := client.WithNode(suite.ctx, node)
 
 	// wait for Talos to discover xfs
-	_, err = suite.Client.COSI.WatchFor(
+	_, err := suite.Client.COSI.WatchFor(
 		nodeCtx,
 		block.NewDiscoveredVolume(block.NamespaceName, deviceName).Metadata(),
 		state.WithEventTypes(state.Created, state.Updated),

--- a/internal/integration/base/debug_exec.go
+++ b/internal/integration/base/debug_exec.go
@@ -23,9 +23,7 @@ import (
 // on the node via the DebugService, returning the combined stdout/stderr output and the exit code.
 // Note: in non-TTY mode the server multiplexes stdout and stderr into a single stream, so the
 // returned output contains both.
-//
-//nolint:gocyclo
-func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, args ...string) (string, int32, error) {
+func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, args ...string) (string, int32) {
 	nodeCtx := client.WithNode(ctx, node)
 
 	containerd := &common.ContainerdInstance{
@@ -36,11 +34,9 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, ar
 	// pull the image into the system namespace first
 	rcv, err := apiSuite.Client.ImageClient.Pull(nodeCtx, &machineapi.ImageServicePullRequest{
 		Containerd: containerd,
-		ImageRef:   constants.DebugHostNsImage,
+		ImageRef:   constants.DebugNixyBoxImage,
 	})
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to pull image %q: %w", constants.DebugHostNsImage, err)
-	}
+	apiSuite.Require().NoError(err, "failed to pull image %q", constants.DebugNixyBoxImage)
 
 	var pulledImage string
 
@@ -51,18 +47,18 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, ar
 				break
 			}
 
-			return "", 0, fmt.Errorf("failed to pull image %q: %w", constants.DebugHostNsImage, err)
+			apiSuite.Require().NoError(err, "failed to pull image %q", constants.DebugNixyBoxImage)
 		}
 
 		pulledImage = msg.GetName()
 	}
 
-	cli, err := apiSuite.Client.DebugClient.ContainerRun(nodeCtx)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to start debug container: %w", err)
-	}
+	apiSuite.Require().NotEmpty(pulledImage, "expected pulled image name in the response")
 
-	if err = cli.Send(&machineapi.DebugContainerRunRequest{
+	cli, err := apiSuite.Client.DebugClient.ContainerRun(nodeCtx)
+	apiSuite.Require().NoError(err, "failed to start debug container stream")
+
+	err = cli.Send(&machineapi.DebugContainerRunRequest{
 		Request: &machineapi.DebugContainerRunRequest_Spec{
 			Spec: &machineapi.DebugContainerRunRequestSpec{
 				Containerd: containerd,
@@ -71,14 +67,12 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, ar
 				Profile:    machineapi.DebugContainerRunRequestSpec_PROFILE_HOST_NS,
 			},
 		},
-	}); err != nil {
-		return "", 0, fmt.Errorf("failed to send debug container spec: %w", err)
-	}
+	})
+	apiSuite.Require().NoError(err, "failed to send debug container spec")
 
 	// no interactive input is sent, close the send side right away
-	if err = cli.CloseSend(); err != nil {
-		return "", 0, fmt.Errorf("failed to close debug container send stream: %w", err)
-	}
+	err = cli.CloseSend()
+	apiSuite.Require().NoError(err, "failed to close debug container send stream")
 
 	var (
 		out         strings.Builder
@@ -95,7 +89,7 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, ar
 				break
 			}
 
-			return out.String(), 0, fmt.Errorf("error receiving debug container output: %w", err)
+			apiSuite.Require().NoError(err, "error receiving debug container output")
 		}
 
 		switch resp := msg.GetResp().(type) {
@@ -108,8 +102,8 @@ func (apiSuite *APISuite) RunDebugContainer(ctx context.Context, node string, ar
 	}
 
 	if !gotExitCode {
-		return out.String(), 0, fmt.Errorf("debug container stream closed without an exit code")
+		apiSuite.Require().NoError(fmt.Errorf("debug container stream closed without an exit code"))
 	}
 
-	return out.String(), exitCode, nil
+	return out.String(), exitCode
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -806,6 +806,13 @@ const (
 	// mount namespace.
 	DebugHostNsImage = "docker.io/nixos/nix:latest"
 
+	// DebugNixyBoxImage is a tiny image used in the integration tests.
+	// It has Nix-like layout, but it contains only statically linked shell
+	// based on busybox.
+	// This image is small to ensure safe use in the integration tests,
+	// as the image is pulled to the tmpfs.
+	DebugNixyBoxImage = "ghcr.io/siderolabs/nixybox:v2026.06.0"
+
 	// DebugHostNsWorkdirBase is the disk-backed base directory for PROFILE_HOST_NS
 	// overlay upper/work layers. It lives on the EPHEMERAL partition (/var) so that
 	// writes to the session root (nix eval cache, /tmp, /etc) and the /nix store do


### PR DESCRIPTION
The image used (nixos) is pretty huge (~660MB) and it lands in tmpfs
containerd, so replace it with tiny (1.5MB) image which has everything
the test actually needs.

While I'm at it, refactor the helper to never return errors, and assert
the errors on its own.