### PR TITLE
fix: truncate files replaced by system extensions

### DIFF
--- a/internal/pkg/extensions/compress.go
+++ b/internal/pkg/extensions/compress.go
@@ -217,7 +217,7 @@ func handleFileOp(st fs.FileInfo, srcPath, dstPath string, op func(string) error
 
 	defer src.Close() //nolint:errcheck
 
-	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY, st.Mode().Perm())
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, st.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/extensions/compress_test.go
+++ b/internal/pkg/extensions/compress_test.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package extensions_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/extensions"
+)
+
+func TestCopyFilesTruncatesExistingDestination(t *testing.T) {
+	t.Parallel()
+
+	sourcePath := filepath.Join(t.TempDir(), "modules.softdep")
+	destinationPath := filepath.Join(t.TempDir(), "modules.softdep")
+
+	require.NoError(t, os.WriteFile(sourcePath, []byte("short\n"), 0o644))
+	require.NoError(t, os.WriteFile(destinationPath, []byte("long destination content\n"), 0o644))
+	require.NoError(t, extensions.CopyFiles(sourcePath, destinationPath))
+
+	contents, err := os.ReadFile(destinationPath)
+	require.NoError(t, err)
+	require.Equal(t, "short\n", string(contents))
+}

--- a/internal/pkg/extensions/export_test.go
+++ b/internal/pkg/extensions/export_test.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package extensions
+
+// CopyFiles is a test export of the copyFiles function to allow testing of the function in isolation.
+func CopyFiles(srcPath, dstPath string) error {
+	return copyFiles(srcPath, dstPath)
+}


### PR DESCRIPTION
## What

Open extension destination files with `O_TRUNC` when copying regular files and
add a regression test for replacing a longer file with a shorter one.

## Why

`O_CREATE|O_WRONLY` overwrites from offset zero but does not shrink an existing
destination. If an extension replaces a generated metadata file such as
`modules.softdep` with shorter content, bytes from the previous file remain at
the end and can corrupt the result.

## Validation

- `go test ./internal/pkg/extensions -run '^TestCopyFilesTruncatesExistingDestination$'`
  passes.
- The full package run executes the new test successfully; the unrelated
  existing `TestCompress` cannot complete on this macOS host because
  `mksquashfs` is not installed.
- `git diff --check` passes.
- Gitleaks reports no findings in `internal/pkg/extensions`.

The change does not alter extension ordering, permissions, symlink handling, or
the behavior for newly created files.
