### PR TITLE
feat: log peer address in gRPC request log

### DIFF
--- a/pkg/grpc/middleware/log/log.go
+++ b/pkg/grpc/middleware/log/log.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/gen/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -41,7 +42,18 @@ var sensitiveFields = map[string]struct{}{
 
 // ExtractMetadata formats metadata from incoming grpc context as string for the log.
 func ExtractMetadata(ctx context.Context) string {
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+
+	// the peer address always comes from the connection itself, never from the client-supplied metadata
+	delete(md, "peer")
+
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		md["peer"] = []string{p.Addr.String()}
+	}
+
 	keys := maps.Keys(md)
 	slices.Sort(keys)
 

--- a/pkg/grpc/middleware/log/log_test.go
+++ b/pkg/grpc/middleware/log/log_test.go
@@ -5,10 +5,12 @@
 package log_test
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metadata "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 
 	"github.com/siderolabs/talos/pkg/grpc/middleware/log"
 )
@@ -17,12 +19,42 @@ func TestExtractMetadata(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		md       metadata.MD
+		peer     *peer.Peer
+		noMD     bool
 		expected string
 	}{
 		{
 			name:     "empty",
 			md:       metadata.MD{},
 			expected: "",
+		},
+		{
+			name:     "no metadata",
+			noMD:     true,
+			expected: "",
+		},
+		{
+			name:     "no metadata with peer",
+			noMD:     true,
+			peer:     &peer.Peer{Addr: &net.TCPAddr{IP: net.IPv4(10, 5, 0, 2), Port: 34567}},
+			expected: "peer=10.5.0.2:34567",
+		},
+		{
+			name:     "peer without address",
+			md:       metadata.Pairs("foo", "bar"),
+			peer:     &peer.Peer{},
+			expected: "foo=bar",
+		},
+		{
+			name:     "peer address overrides client-supplied metadata",
+			md:       metadata.Pairs("foo", "bar", "peer", "spoofed"),
+			peer:     &peer.Peer{Addr: &net.TCPAddr{IP: net.IPv4(10, 5, 0, 2), Port: 34567}},
+			expected: "foo=bar;peer=10.5.0.2:34567",
+		},
+		{
+			name:     "client-supplied peer metadata is dropped",
+			md:       metadata.Pairs("foo", "bar", "peer", "spoofed"),
+			expected: "foo=bar",
 		},
 		{
 			name:     "regular",
@@ -36,7 +68,14 @@ func TestExtractMetadata(t *testing.T) {
 		},
 	} {
 		ctx := t.Context()
-		ctx = metadata.NewIncomingContext(ctx, test.md)
+
+		if !test.noMD {
+			ctx = metadata.NewIncomingContext(ctx, test.md)
+		}
+
+		if test.peer != nil {
+			ctx = peer.NewContext(ctx, test.peer)
+		}
 
 		assert.Equal(t, test.expected, log.ExtractMetadata(ctx), test.name)
 	}


### PR DESCRIPTION
The apid request log records the method, result, duration, gRPC metadata (including talos-role) and user-agent, but not the source address of the caller. When several operators share the same role, a destructive call such as Reboot or ApplyConfiguration cannot be attributed to a source.

peer.FromContext(ctx) is already called in Injector.extractRoles (pkg/grpc/middleware/authz/injector.go), where only AuthInfo is used and the address is discarded. A helper peerAddress() already exists in the same file, and the address is already logged in the ReadOnlyWithAdminOnSiderolink branch — the default path just doesn't use it.

This adds a peer= field to the request log line in both the unary and stream interceptors.

Before:

OK [/machine.MachineService/Version] 3.39ms stream Success (:authority=192.168.1.155:50000;content-type=application/grpc;talos-role=os:admin;user-agent=grpc-go/1.81.1)

After:

OK [/machine.MachineService/Version] 3.39ms stream Success (peer=192.168.1.140:53578;:authority=192.168.1.155:50000;content-type=application/grpc;talos-role=os:admin;user-agent=grpc-go/1.81.1)

Tested with a custom build of v1.13.8 on a metal node. Proxied internal calls show the node's own address; the outer entry carries the real client address.