### PR TITLE
fix: skip target settings for external volume mounts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5111,6 +5111,7 @@ jobs:
           QEMU_MEMORY_CONTROLPLANES: "4096"
           QEMU_MEMORY_WORKERS: "4096"
           TAG_SUFFIX: -race
+          WITH_CONFIG_PATCH: '@hack/test/patches/image-verification.yaml'
           WITH_CONFIG_PATCH_WORKER: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
         run: |
           sudo -E make e2e-qemu

--- a/.github/workflows/integration-qemu-triggered.yaml
+++ b/.github/workflows/integration-qemu-triggered.yaml
@@ -72,6 +72,7 @@ jobs:
             qemuMemoryWorkers: "4096"
             tagSuffix: -race
             variant: race
+            withConfigPatch: '@hack/test/patches/image-verification.yaml'
             withConfigPatchWorker: '@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml'
           - extraTestArgs: -talos.skip-ephemeral-policy
             qemuExtraDisks: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -499,6 +499,7 @@ spec:
             buildRace: "true"
             tagSuffix: -race
             extraTestArgs: "-talos.race"
+            withConfigPatch: "@hack/test/patches/image-verification.yaml"
             withConfigPatchWorker: "@hack/test/patches/ephemeral-nvme.yaml:@hack/test/patches/dm-raid-module.yaml"
             qemuExtraDisks: "4"
             qemuExtraDisksDrivers: "virtiofs,ide,nvme"

--- a/internal/app/machined/pkg/controllers/block/mount.go
+++ b/internal/app/machined/pkg/controllers/block/mount.go
@@ -673,7 +673,11 @@ func (ctrl *MountController) handleDiskMountOperation(
 			return fmt.Errorf("failed to mount %q: %w", mountRequest.Metadata().ID(), err)
 		}
 
-		if !mountRequest.TypedSpec().ReadOnly && !mountRequest.TypedSpec().Detached {
+		// external volumes are provided by the host (e.g. virtiofs): the mode and ownership of the mount root
+		// belong to the host, not to Talos, and the SELinux label is already applied by the mount itself.
+		if !mountRequest.TypedSpec().ReadOnly &&
+			!mountRequest.TypedSpec().Detached &&
+			volumeStatus.TypedSpec().Type != block.VolumeTypeExternal {
 			if err = ctrl.updateTargetSettings(mountTarget, volumeStatus.TypedSpec().Filesystem, volumeStatus.TypedSpec().MountSpec); err != nil {
 				manager.Unmount() //nolint:errcheck
 


### PR DESCRIPTION
Talos chmods and chowns the mount root after mounting a read-write
volume. For external volumes the mount root belongs to the host: on
Apple Virtualization.framework (UTM, tart) the virtiofs server runs
unprivileged and the share root may be synthetic, so the chmod fails
with EPERM and the mount is rolled back into a retry loop. Where the
chmod does succeed (virtiofsd running as root under qemu) it silently
rewrites the host share directory to 0755 root:root, which is also
wrong.

Fixes #14058

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
