### PR TITLE
feat: talosctl dashboard log filtering

### DIFF
--- a/internal/pkg/dashboard/components/logviewer.go
+++ b/internal/pkg/dashboard/components/logviewer.go
@@ -5,6 +5,9 @@
 package components
 
 import (
+	"strings"
+	"unicode"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -13,13 +16,28 @@ import (
 type LogViewer struct {
 	tview.Grid
 
+	app *tview.Application
+
 	logs tview.TextView
+
+	entries []logEntry
+
+	filterInput  *tview.InputField
+	filterActive bool
+	filterText   string
+}
+
+// logEntry holds a single raw log line, kept so the view can be re-filtered.
+type logEntry struct {
+	text    string
+	isError bool
 }
 
 // NewLogViewer initializes LogViewer.
-func NewLogViewer() *LogViewer {
+func NewLogViewer(app *tview.Application) *LogViewer {
 	widget := &LogViewer{
 		Grid: *tview.NewGrid(),
+		app:  app,
 		logs: *tview.NewTextView(),
 	}
 
@@ -44,8 +62,28 @@ func NewLogViewer() *LogViewer {
 				return nil
 			}
 
+			if event.Rune() == '/' {
+				widget.activateSearch()
+
+				return nil
+			}
+
 			return event
 		})
+
+	widget.filterInput = tview.NewInputField()
+	widget.filterInput.SetLabel("filter: ")
+	widget.filterInput.SetLabelColor(tcell.ColorYellow)
+	widget.filterInput.SetFieldBackgroundColor(tcell.ColorDefault)
+	widget.filterInput.SetChangedFunc(func(text string) {
+		widget.filterText = text
+		widget.renderLogs()
+	})
+	widget.filterInput.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEscape {
+			widget.deactivateSearch()
+		}
+	})
 
 	widget.SetRows(1, 0).SetColumns(0)
 
@@ -55,13 +93,155 @@ func NewLogViewer() *LogViewer {
 	return widget
 }
 
-// WriteLog writes the log line to the widget.
-func (widget *LogViewer) WriteLog(logLine, logError string) {
-	if logError != "" {
-		logLine = "[red]" + tview.Escape(logError) + "[-]\n"
-	} else {
-		logLine = tview.Escape(logLine) + "\n"
+// activateSearch shows the search input below the log view.
+func (widget *LogViewer) activateSearch() {
+	if widget.filterActive {
+		widget.app.SetFocus(widget.filterInput)
+
+		return
 	}
 
-	widget.logs.Write([]byte(logLine)) //nolint:errcheck
+	widget.filterActive = true
+	widget.filterInput.SetText(widget.filterText)
+	widget.SetRows(1, 0, 1)
+	widget.AddItem(widget.filterInput, 2, 0, 1, 1, 0, 0, true)
+	widget.app.SetFocus(widget.filterInput)
+}
+
+// deactivateSearch hides the search input and clears the filter.
+func (widget *LogViewer) deactivateSearch() {
+	if widget.filterText != "" {
+		widget.filterText = ""
+		widget.filterInput.SetText("")
+		widget.renderLogs()
+	}
+
+	if !widget.filterActive {
+		return
+	}
+
+	widget.filterActive = false
+	widget.RemoveItem(widget.filterInput)
+	widget.SetRows(1, 0)
+	widget.app.SetFocus(&widget.logs)
+}
+
+// WriteLog writes the log line to the widget.
+func (widget *LogViewer) WriteLog(logLine, logError string) {
+	entry := logEntry{text: logLine, isError: logError != ""}
+	if entry.isError {
+		entry.text = logError
+	}
+
+	// drop the noData placeholder before the first line is appended
+	if len(widget.entries) == 0 {
+		widget.logs.Clear()
+	}
+
+	widget.entries = append(widget.entries, entry)
+	if len(widget.entries) > maxLogLines {
+		widget.entries = widget.entries[len(widget.entries)-maxLogLines:]
+	}
+
+	if formatted, ok := formatLogEntry(entry, widget.filterText); ok {
+		widget.logs.Write([]byte(formatted)) //nolint:errcheck
+	}
+}
+
+// renderLogs rebuilds the log view from the buffered entries, applying the current filter.
+func (widget *LogViewer) renderLogs() {
+	widget.logs.Clear()
+
+	for _, entry := range widget.entries {
+		if formatted, ok := formatLogEntry(entry, widget.filterText); ok {
+			widget.logs.Write([]byte(formatted)) //nolint:errcheck
+		}
+	}
+
+	widget.logs.ScrollToEnd()
+}
+
+// lowerWithOffsets lowercases text and returns, for each byte index of the result,
+// the byte index in text it originated from. The returned slice has one extra
+// trailing entry equal to len(text), so the end of a match is always addressable.
+func lowerWithOffsets(text string) (string, []int) {
+	var sb strings.Builder
+
+	sb.Grow(len(text))
+
+	offsets := make([]int, 0, len(text)+1)
+
+	for i, r := range text {
+		before := sb.Len()
+
+		sb.WriteRune(unicode.ToLower(r))
+
+		for range sb.Len() - before {
+			offsets = append(offsets, i)
+		}
+	}
+
+	return sb.String(), append(offsets, len(text))
+}
+
+// formatLogEntry renders a single log entry as tview markup, highlighting filter
+// matches. The second return value is false when filter is non-empty and the
+// entry doesn't match, meaning the line should not be displayed.
+func formatLogEntry(entry logEntry, filter string) (string, bool) {
+	if filter == "" {
+		if entry.isError {
+			return "[red]" + tview.Escape(entry.text) + "[-]\n", true
+		}
+
+		return tview.Escape(entry.text) + "\n", true
+	}
+
+	lowText, offsets := lowerWithOffsets(entry.text)
+	lowFilter := strings.ToLower(filter)
+
+	if !strings.Contains(lowText, lowFilter) {
+		return "", false
+	}
+
+	baseColor := ""
+	if entry.isError {
+		baseColor = "[red]"
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(baseColor)
+
+	// search in the lowercased text, but always slice the original text through
+	// offsets: lowercasing may change byte lengths, so a lowercased index is never
+	// a valid index into entry.text.
+	searchStart := 0
+
+	for {
+		rel := strings.Index(lowText[searchStart:], lowFilter)
+		if rel < 0 {
+			sb.WriteString(tview.Escape(entry.text[offsets[searchStart]:]))
+
+			break
+		}
+
+		matchLow := searchStart + rel
+		matchStart, matchEnd := offsets[matchLow], offsets[matchLow+len(lowFilter)]
+
+		sb.WriteString(tview.Escape(entry.text[offsets[searchStart]:matchStart]))
+		sb.WriteString("[yellow]")
+		sb.WriteString(tview.Escape(entry.text[matchStart:matchEnd]))
+		sb.WriteString("[-]")
+		sb.WriteString(baseColor)
+
+		searchStart = matchLow + len(lowFilter)
+	}
+
+	if baseColor != "" {
+		sb.WriteString("[-]")
+	}
+
+	sb.WriteString("\n")
+
+	return sb.String(), true
 }

--- a/internal/pkg/dashboard/components/logviewer_test.go
+++ b/internal/pkg/dashboard/components/logviewer_test.go
@@ -1,0 +1,235 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:testpackage
+package components
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// TestFormatLogEntry covers the two responsibilities of formatLogEntry: deciding
+// whether an entry is visible under the current filter, and rendering it as tview
+// markup with the filter matches highlighted.
+//
+// The multi-byte cases exist because lowercasing can change the byte length of a
+// string (Go applies simple case mapping, so U+212A KELVIN SIGN and U+0130 LATIN
+// CAPITAL LETTER I WITH DOT ABOVE both shrink). A byte index taken from the
+// lowercased text is therefore not a valid index into the original text, and using
+// one either splits a rune or runs past the end of the string.
+func TestFormatLogEntry(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		entry    logEntry
+		filter   string
+		expected string
+		expectOk bool
+	}{
+		{
+			// An empty filter shows every entry verbatim, with a trailing newline.
+			name:     "no filter",
+			entry:    logEntry{text: "hello world"},
+			expected: "hello world\n",
+			expectOk: true,
+		},
+		{
+			// Error entries are wrapped in the red color tag, as they were before
+			// filtering existed.
+			name:     "no filter, error entry",
+			entry:    logEntry{text: "boom", isError: true},
+			expected: "[red]boom[-]\n",
+			expectOk: true,
+		},
+		{
+			// Log lines are not trusted as markup: a literal "[red]" in the log must
+			// be escaped so tview renders it instead of switching color.
+			name:     "no filter escapes markup",
+			entry:    logEntry{text: "[red]not a color"},
+			expected: "[red[]not a color\n",
+			expectOk: true,
+		},
+		{
+			// A non-matching entry is hidden: ok is false and the caller writes nothing.
+			name:     "filter does not match",
+			entry:    logEntry{text: "hello world"},
+			filter:   "nope",
+			expected: "",
+			expectOk: false,
+		},
+		{
+			// Matching is case-insensitive, but the highlighted span is taken from the
+			// original text, so the log line keeps its own casing.
+			name:     "filter matches, original casing preserved",
+			entry:    logEntry{text: "Hello World"},
+			filter:   "hello",
+			expected: "[yellow]Hello[-] World\n",
+			expectOk: true,
+		},
+		{
+			// The same, with the casing difference on the filter side.
+			name:     "uppercase filter matches lowercase text",
+			entry:    logEntry{text: "hello world"},
+			filter:   "WORLD",
+			expected: "hello [yellow]world[-]\n",
+			expectOk: true,
+		},
+		{
+			// Every occurrence is highlighted, not only the first, and the search
+			// resumes after each match rather than rescanning it.
+			name:     "multiple matches",
+			entry:    logEntry{text: "ab AB ab"},
+			filter:   "ab",
+			expected: "[yellow]ab[-] [yellow]AB[-] [yellow]ab[-]\n",
+			expectOk: true,
+		},
+		{
+			// Closing a highlight with "[-]" resets to the default color, not to red,
+			// so the red tag has to be re-emitted after every match on an error entry.
+			name:     "error entry restores base color after each match",
+			entry:    logEntry{text: "err x err", isError: true},
+			filter:   "err",
+			expected: "[red][yellow]err[-][red] x [yellow]err[-][red][-]\n",
+			expectOk: true,
+		},
+		{
+			// Escaping still applies to the segments around and inside a highlight.
+			name:     "match escapes markup",
+			entry:    logEntry{text: "[red]hi"},
+			filter:   "hi",
+			expected: "[red[][yellow]hi[-]\n",
+			expectOk: true,
+		},
+		{
+			// The filter is a 3-byte U+212A KELVIN SIGN that lowercases to a 1-byte
+			// "k". Widening the match by len(filter) instead of by the lowercased
+			// length reaches two bytes past the end of a 4-byte line, which used to
+			// panic with "slice bounds out of range".
+			name:     "filter lowercases to fewer bytes",
+			entry:    logEntry{text: "abck"},
+			filter:   "K",
+			expected: "abc[yellow]k[-]\n",
+			expectOk: true,
+		},
+		{
+			// Same shrinkage, this time in the log line: the KELVIN SIGN ahead of the
+			// match makes the lowercased text two bytes shorter than the original, so
+			// a lowercased index points into the middle of that rune.
+			name:     "text lowercases to fewer bytes",
+			entry:    logEntry{text: "Kx"},
+			filter:   "x",
+			expected: "K[yellow]x[-]\n",
+			expectOk: true,
+		},
+		{
+			// The match lands on the rune that changes length, so the highlighted span
+			// is 3 bytes wide in the original while the filter that found it is 1.
+			name:     "match on the shrinking rune itself",
+			entry:    logEntry{text: "aKb"},
+			filter:   "k",
+			expected: "a[yellow]K[-]b\n",
+			expectOk: true,
+		},
+		{
+			// A second, more realistic shrinking rune: U+0130 LATIN CAPITAL LETTER I
+			// WITH DOT ABOVE is 2 bytes and lowercases to a 1-byte "i". The whole line
+			// is one match, so the shrinkage falls inside the highlighted span.
+			name:     "turkish dotted capital i",
+			entry:    logEntry{text: "İstanbul"},
+			filter:   "istanbul",
+			expected: "[yellow]İstanbul[-]\n",
+			expectOk: true,
+		},
+		{
+			// Log lines come off the wire and are not guaranteed to be valid UTF-8.
+			// Ranging over such a string yields RuneError for the bad byte, which
+			// still has to produce a usable offset instead of panicking.
+			name:     "invalid utf-8 does not panic",
+			entry:    logEntry{text: "a\xffb"},
+			filter:   "b",
+			expected: "a\xff[yellow]b[-]\n",
+			expectOk: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			actual, ok := formatLogEntry(test.entry, test.filter)
+
+			if ok != test.expectOk {
+				t.Fatalf("ok = %v, expected %v", ok, test.expectOk)
+			}
+
+			if actual != test.expected {
+				t.Fatalf("got %q, expected %q", actual, test.expected)
+			}
+		})
+	}
+}
+
+// TestFormatLogEntryKeepsTextValid checks the corruption half of the byte-index
+// bug, which the table above cannot express as an expected string: with enough
+// shrinkage ahead of the match, a lowercased index lands inside a multi-byte rune
+// and the rendered line silently becomes invalid UTF-8 without ever panicking.
+func TestFormatLogEntryKeepsTextValid(t *testing.T) {
+	// Two KELVIN SIGNs put the lowercased text four bytes behind the original, so
+	// the old code split the second one and emitted a lone continuation byte.
+	actual, ok := formatLogEntry(logEntry{text: "KKx"}, "x")
+	if !ok {
+		t.Fatal("expected the entry to match")
+	}
+
+	if !utf8.ValidString(actual) {
+		t.Fatalf("output is not valid UTF-8: %q", actual)
+	}
+}
+
+// TestLowerWithOffsets checks the invariants formatLogEntry relies on when it maps
+// a position found in the lowercased text back onto the original: the offsets cover
+// every byte of the lowered result plus one trailing sentinel, they never decrease,
+// and they always stay within the original string. Together those guarantee that
+// slicing the original through them can neither run out of bounds nor split a rune.
+func TestLowerWithOffsets(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		text     string
+		expected string
+	}{
+		// The empty string still gets the sentinel; ASCII exercises the one-byte-per-
+		// offset path; Cyrillic keeps the byte length across the case change; the last
+		// case shrinks by two bytes on the first rune and one on the second.
+		{name: "empty", text: "", expected: ""},
+		{name: "ascii", text: "AbC", expected: "abc"},
+		{name: "multi-byte, same length", text: "ЖУК", expected: "жук"},
+		{name: "multi-byte, shrinking", text: "Kİ", expected: "ki"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lowered, offsets := lowerWithOffsets(test.text)
+
+			if lowered != test.expected {
+				t.Fatalf("got %q, expected %q", lowered, test.expected)
+			}
+
+			if len(offsets) != len(lowered)+1 {
+				t.Fatalf("len(offsets) = %d, expected %d", len(offsets), len(lowered)+1)
+			}
+
+			if offsets[len(offsets)-1] != len(test.text) {
+				t.Fatalf("sentinel = %d, expected %d", offsets[len(offsets)-1], len(test.text))
+			}
+
+			previous := 0
+
+			for i, offset := range offsets {
+				if offset < previous {
+					t.Fatalf("offsets[%d] = %d is smaller than the previous offset %d", i, offset, previous)
+				}
+
+				if offset > len(test.text) {
+					t.Fatalf("offsets[%d] = %d is out of range for a %d-byte string", i, offset, len(test.text))
+				}
+
+				previous = offset
+			}
+		})
+	}
+}

--- a/internal/pkg/dashboard/summary.go
+++ b/internal/pkg/dashboard/summary.go
@@ -198,7 +198,7 @@ func (widget *SummaryGrid) updateLogViewer() {
 func (widget *SummaryGrid) logViewer(node string) *components.LogViewer {
 	logViewer, ok := widget.logViewers[node]
 	if !ok {
-		logViewer = components.NewLogViewer()
+		logViewer = components.NewLogViewer(widget.app)
 
 		widget.logViewers[node] = logViewer
 	}


### PR DESCRIPTION
Adds log filtering to `talosctl dashboard`, by substring, case insensitive.

- Enter filtering mode with `/` - just like in `k9s`, `less` or `vim`. 
- Exit filtering mode with ESC.


<img width="1686" height="680" alt="Screenshot From 2026-08-18 13-14-08" src="https://github.com/user-attachments/assets/3a2a114d-05f2-4522-9b1e-8be29e101e78" />

I'm not adding a tooltip just yet, I think we should consider a broader "help" popup separately. There's the same case to be made about filtering in the "Resources" tab (F3).