### PR TITLE
feat: update `talosctl rollback` to wait for ready state

### DIFF
--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -623,6 +623,7 @@ message RollbackRequest {}
 
 message Rollback {
   common.Metadata metadata = 1;
+  string actor_id = 2;
 }
 
 message RollbackResponse {

--- a/cmd/talosctl/cmd/talos/rollback.go
+++ b/cmd/talosctl/cmd/talos/rollback.go
@@ -11,9 +11,21 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
+	"github.com/siderolabs/talos/pkg/reporter"
 )
+
+var rollbackCmdFlags = struct {
+	trackableActionCmdFlags
+
+	progress flags.PflagExtended[reporter.OutputMode]
+}{
+	progress: reporter.NewOutputModeFlag(),
+}
 
 // rollbackCmd represents the rollback command.
 var rollbackCmd = &cobra.Command{
@@ -21,34 +33,73 @@ var rollbackCmd = &cobra.Command{
 	Short: "Rollback a node to the previous installation",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if rollbackCmdFlags.debug {
+			rollbackCmdFlags.wait = true
+		}
+
 		ctx := cmd.Context()
 
-		clientFactory, err := NewClientFactory(ctx, nil)
+		clientFactory, err := NewClientFactory(ctx, &rollbackCmdFlags, action.GRPCDialOptions()...)
 		if err != nil {
 			return err
 		}
 
 		defer clientFactory.Close() //nolint:errcheck
 
-		responseChan := multiplex.UnaryViaFactory(
-			ctx, clientFactory,
-			func(ctx context.Context, c *client.Client) (struct{}, error) {
-				return struct{}{}, c.Rollback(ctx)
-			},
-		)
-
-		var errs error
-
-		for resp := range responseChan {
-			if resp.Err != nil {
-				errs = errors.Join(errs, fmt.Errorf("error executing rollback on node %s: %w", resp.Node, resp.Err))
+		if !rollbackCmdFlags.wait {
+			if err := helpers.ClientVersionCheck(ctx, clientFactory); err != nil {
+				return err
 			}
+
+			responseChan := multiplex.UnaryViaFactory(
+				ctx, clientFactory,
+				func(ctx context.Context, c *client.Client) (struct{}, error) {
+					return struct{}{}, c.Rollback(ctx)
+				},
+			)
+
+			var errs error
+
+			for resp := range responseChan {
+				if resp.Err != nil {
+					errs = errors.Join(errs, fmt.Errorf("error executing rollback on node %s: %w", resp.Node, resp.Err))
+				}
+			}
+
+			return errs
 		}
 
-		return errs
+		rep := reporter.New(
+			reporter.WithOutputMode(rollbackCmdFlags.progress.Value()),
+		)
+
+		return action.NewTracker(
+			clientFactory,
+			action.MachineReadyEventFn,
+			rollbackGetActorID,
+			action.WithPostCheck(action.BootIDChangedPostCheckFn),
+			action.WithDebug(rollbackCmdFlags.debug),
+			action.WithTimeout(rollbackCmdFlags.timeout),
+			action.WithReporter(rep),
+		).Run(ctx)
 	},
 }
 
+func rollbackGetActorID(ctx context.Context, c *client.Client) (string, error) {
+	resp, err := c.RollbackWithResponse(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.GetMessages()) == 0 {
+		return "", errors.New("no messages returned from action run")
+	}
+
+	return resp.GetMessages()[0].GetActorId(), nil
+}
+
 func init() {
+	rollbackCmd.Flags().Var(rollbackCmdFlags.progress, "progress", fmt.Sprintf("output mode for rollback progress. Values: %v", rollbackCmdFlags.progress.Options()))
+	rollbackCmdFlags.addTrackActionFlags(rollbackCmd)
 	addCommand(rollbackCmd)
 }

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -365,7 +365,9 @@ func (s *Server) Reboot(ctx context.Context, in *machine.RebootRequest) (reply *
 
 // Rollback implements the machine.MachineServer interface.
 func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*machine.RollbackResponse, error) {
-	log.Printf("rollback via API received")
+	actorID := uuid.New().String()
+
+	log.Printf("rollback via API received. actor id: %s", actorID)
 
 	if err := s.checkSupported(runtime.Rollback); err != nil {
 		return nil, err
@@ -391,8 +393,10 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 		return nil, err
 	}
 
+	rebootCtx := context.WithValue(context.Background(), runtime.ActorIDCtxKey{}, actorID)
+
 	go func() {
-		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in, runtime.WithTakeover()); err != nil {
+		if err := s.Controller.Run(rebootCtx, runtime.SequenceReboot, in, runtime.WithTakeover()); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reboot failed:", err)
 			}
@@ -401,7 +405,9 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 
 	return &machine.RollbackResponse{
 		Messages: []*machine.Rollback{
-			{},
+			{
+				ActorId: actorID,
+			},
 		},
 	}, nil
 }

--- a/pkg/machinery/api/machine/machine.pb.go
+++ b/pkg/machinery/api/machine/machine.pb.go
@@ -4444,6 +4444,7 @@ func (*RollbackRequest) Descriptor() ([]byte, []int) {
 type Rollback struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Metadata      *common.Metadata       `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	ActorId       string                 `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4483,6 +4484,13 @@ func (x *Rollback) GetMetadata() *common.Metadata {
 		return x.Metadata
 	}
 	return nil
+}
+
+func (x *Rollback) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
 }
 
 type RollbackResponse struct {
@@ -11923,9 +11931,10 @@ const file_machine_machine_proto_rawDesc = "" +
 	"\x03ids\x18\x02 \x03(\tR\x03ids\"L\n" +
 	"\x16LogsContainersResponse\x122\n" +
 	"\bmessages\x18\x01 \x03(\v2\x16.machine.LogsContainerR\bmessages\"\x11\n" +
-	"\x0fRollbackRequest\"8\n" +
+	"\x0fRollbackRequest\"S\n" +
 	"\bRollback\x12,\n" +
-	"\bmetadata\x18\x01 \x01(\v2\x10.common.MetadataR\bmetadata\"A\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x10.common.MetadataR\bmetadata\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\"A\n" +
 	"\x10RollbackResponse\x12-\n" +
 	"\bmessages\x18\x01 \x03(\v2\x11.machine.RollbackR\bmessages\"b\n" +
 	"\x11ContainersRequest\x12\x1c\n" +

--- a/pkg/machinery/api/machine/machine_vtproto.pb.go
+++ b/pkg/machinery/api/machine/machine_vtproto.pb.go
@@ -3742,6 +3742,13 @@ func (m *Rollback) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ActorId) > 0 {
+		i -= len(m.ActorId)
+		copy(dAtA[i:], m.ActorId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ActorId)))
+		i--
+		dAtA[i] = 0x12
+	}
 	if m.Metadata != nil {
 		if vtmsg, ok := interface{}(m.Metadata).(interface {
 			MarshalToSizedBufferVT([]byte) (int, error)
@@ -12089,6 +12096,10 @@ func (m *Rollback) SizeVT() (n int) {
 		} else {
 			l = proto.Size(m.Metadata)
 		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ActorId)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -23007,6 +23018,38 @@ func (m *Rollback) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ActorId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -384,6 +384,16 @@ func (c *Client) Rollback(ctx context.Context) (err error) {
 	return err
 }
 
+// RollbackWithResponse rolls back the node to the previous installation and returns the response.
+func (c *Client) RollbackWithResponse(ctx context.Context) (*machineapi.RollbackResponse, error) {
+	resp, err := c.MachineClient.Rollback(ctx, &machineapi.RollbackRequest{})
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
+	return resp, err
+}
+
 // Bootstrap implements the proto.MachineServiceClient interface.
 func (c *Client) Bootstrap(ctx context.Context, req *machineapi.BootstrapRequest) (err error) {
 	resp, err := c.MachineClient.Bootstrap(ctx, req)

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -4152,6 +4152,7 @@ The messages message containing the restart status.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | metadata | [common.Metadata](#common.Metadata) |  |  |
+| actor_id | [string](#string) |  |  |
 
 
 

--- a/website/content/v1.15/reference/cli.md
+++ b/website/content/v1.15/reference/cli.md
@@ -134,7 +134,7 @@ talosctl cluster create dev [flags]
       --bad-rtc                                  launch VM with bad RTC state
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                     search path for CNI binaries (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/cad26b5/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                     CNI cache directory path (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (default "/home/user/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
@@ -3229,11 +3229,15 @@ talosctl rollback [flags]
 ```
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
+      --debug                      debug operation from kernel logs. --wait is set to true when this flag is set
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for rollback
   -n, --nodes strings              target the specified nodes
+      --progress string            output mode for rollback progress. Values: [auto plain] (default "auto")
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
+      --timeout duration           time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
+      --wait                       wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
 ```
 
 ### SEE ALSO
@@ -3471,7 +3475,7 @@ talosctl upgrade [flags]
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for upgrade
-  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-beta.1")
+  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:cad26b5")
       --legacy                     force use of legacy upgrade method
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
       --no-reboot                  do not reboot the node after upgrade (skip reboot and drain)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

This PR updates `talosctl rollback` to be capable of waiting for ready state. This required adding an actor ID to the rollback API and then adjusting the `talosctl rollback` subcommand to connect to the action tracker, matching behavior for `talosctl reboot` or `talosctl upgrade`.

Includes the following flag additions to match upgrade/reboot, with the same defaults:

    - `--wait`: This defaults to true, which matches behavior of other subcommands that already wait for a ready state, but may be considered breaking existing behavior since the current rollback is fire and forget. I think this comes down to whether the current behavior is intended and this is a supplemental feature, or if current behavior is a bug that this is resolving. 
    - `--debug`
    - `--progress`

I haven't currently added any new unit tests, let me know if that should be done. However, I've built Talos and talosctl with these changes and confirmed that I could upgrade and rollback successfully, with auto progress output and waiting until it was complete.

## Why? (reasoning)

Fixes #14061

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
