### PR TITLE
fix: watch IPv6 route changes in RouteSpecController

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_spec.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec.go
@@ -53,7 +53,7 @@ func (ctrl *RouteSpecController) Outputs() []controller.Output {
 //nolint:gocyclo
 func (ctrl *RouteSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	// watch link changes as some routes might need to be re-applied if the link appears
-	watcher, err := watch.NewRtNetlink(trigger.NewDefaultRateLimitedTrigger(ctx, r), unix.RTMGRP_LINK|unix.RTMGRP_IPV4_ROUTE)
+	watcher, err := watch.NewRtNetlink(trigger.NewDefaultRateLimitedTrigger(ctx, r), unix.RTMGRP_LINK|unix.RTMGRP_IPV4_ROUTE|unix.RTMGRP_IPV6_ROUTE)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

`RouteSpecController` subscribes to `RTMGRP_LINK|RTMGRP_IPV4_ROUTE`. Its reconcile loop lists **all** `RouteSpec` resources and syncs them regardless of address family, but nothing wakes it when an IPv6 route disappears from the kernel.

On an IPv6-only network a route that came from the machine config and is then deleted out of band stays missing until some unrelated event triggers the controller. The sibling controllers (`AddressSpecController`, `LinkSpecController`) watch `RTMGRP_LINK` only, so this asymmetry exists specifically in `route_spec.go`.

## Reproduction

Observed on Talos v1.13 on a host whose fabric is IPv6-only:

1. Configure an IPv6 route via `LinkConfig` and apply it — the route appears with `proto static`, and `talosctl get routespecs` shows it with `layer: configuration`.
2. `ip -6 route del <that route>` — it is **not** restored (waited 60s).
3. `ip -4 route add/del` anything — the IPv6 route is restored immediately.

Step 3 shows the sync logic itself is fine; the controller simply never gets woken for the IPv6 family.

## Fix

Add `unix.RTMGRP_IPV6_ROUTE` to the watch mask so both families behave the same.

The watcher is already wrapped in `trigger.NewDefaultRateLimitedTrigger`, so subscribing to the second family does not increase the reconciliation rate under routing churn.

## Testing

`go build` and `go vet` pass for `./internal/app/machined/pkg/controllers/network/...` with `GOOS=linux`. I could not run the package's tests locally (macOS host, Linux-only netlink code) — relying on CI for those.