### PR TITLE
fix: drop lockdown=confidentiality default for 1.14+

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -38,6 +38,15 @@ If you require IPVS support, you can enable it by loading the following kernel m
 * `xt_ipvs` (nftables/iptables match)
 """
 
+    [notes.lockdown]
+        title = "Secure Boot images no longer have lockdown=confidentiality enabled by default"
+        description = """\
+Secure Boot images no longer have `lockdown=confidentiality` enabled by default.
+This change was made to improve compatibility with eBPF tooling under default schematic.
+This means that Secure Boot images will now have `lockdown=integrity` enabled by default (implicitly), which is the recommended setting for most users.
+Users can override it by adding `lockdown=confidentiality` to the kernel command line through Image Factory if they require it.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/pkg/uki/generate.go
+++ b/internal/pkg/uki/generate.go
@@ -254,14 +254,6 @@ func (builder *Builder) generateProfiles() error {
 func (builder *Builder) generateKernel() error {
 	path := builder.KernelPath
 
-	if builder.peSigner != nil {
-		path := filepath.Join(builder.scratchDir, "kernel")
-
-		if err := builder.peSigner.Sign(builder.KernelPath, path); err != nil {
-			return err
-		}
-	}
-
 	builder.sections = append(
 		builder.sections,
 		section{

--- a/pkg/machinery/imager/quirks/quirks.go
+++ b/pkg/machinery/imager/quirks/quirks.go
@@ -377,3 +377,15 @@ func (q Quirks) NvmeCoreIoTimeoutAWSOnly() bool {
 
 	return q.v.GTE(minTalosVersionNvmeCoreIoTimeoutAWSOnly)
 }
+
+var maxTalosVersionForceLockdownConfidentiality = semver.MustParse("1.14.0")
+
+// ForcesLockdownConfidentiality returns true if the Talos version should have lockdown=confidentiality by default.
+func (q Quirks) ForcesLockdownConfidentiality() bool {
+	// if the version doesn't parse, we assume it's latest Talos
+	if q.v == nil {
+		return false
+	}
+
+	return q.v.LT(maxTalosVersionForceLockdownConfidentiality)
+}

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -79,10 +79,14 @@ func DefaultArgs(quirks quirks.Quirks) []string {
 }
 
 // SecureBootArgs returns the kernel commandline options required for secure boot.
-func SecureBootArgs(quirks.Quirks) []string {
-	return []string{
-		"lockdown=confidentiality",
+func SecureBootArgs(q quirks.Quirks) []string {
+	args := []string{}
+
+	if q.ForcesLockdownConfidentiality() {
+		args = append(args, "lockdown=confidentiality")
 	}
+
+	return args
 }
 
 // Param represents a kernel system property.

--- a/pkg/machinery/kernel/kernel_test.go
+++ b/pkg/machinery/kernel/kernel_test.go
@@ -179,9 +179,21 @@ func TestSecureBootArgs(t *testing.T) {
 		{
 			name: "latest",
 
-			expected: []string{
-				"lockdown=confidentiality",
-			},
+			expected: []string{},
+		},
+		{
+			name: "v1.13",
+
+			quirks: quirks.New("v1.13.0"),
+
+			expected: []string{"lockdown=confidentiality"},
+		},
+		{
+			name: "v1.14",
+
+			quirks: quirks.New("v1.14.0"),
+
+			expected: []string{},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
lockdown=confidentiality was forced unconditionally in SecureBootArgs;
gate it behind a new quirks.ForcesLockdownConfidentiality (true only
for Talos <1.14.0), since 1.14+ no longer needs it.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
