### PR TITLE
feat: Talos Containers support for talosctl

### DIFF
--- a/api/common/common.proto
+++ b/api/common/common.proto
@@ -96,6 +96,8 @@ enum ContainerdNamespace {
   NS_UNKNOWN = 0;
   NS_SYSTEM = 1;
   NS_CRI = 2;
+  // NS_TALOSCONTAINERS is the namespace for containers declared via a ContainerConfig document.
+  NS_TALOSCONTAINERS = 3;
 }
 
 message ContainerdInstance {

--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -16,15 +16,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var containersCmdFlags struct {
-	kubernetesNamespaceFlag
+	containerNamespaceFlag
 }
 
 // containersCmd represents the processes command.
@@ -44,17 +42,9 @@ var containersCmd = &cobra.Command{
 
 		defer clientFactory.Close() //nolint:errcheck
 
-		var (
-			namespace string
-			driver    common.ContainerDriver
-		)
-
-		if containersCmdFlags.kubernetes {
-			namespace = constants.K8sContainerdNamespace
-			driver = common.ContainerDriver_CRI
-		} else {
-			namespace = constants.SystemContainerdNamespace
-			driver = common.ContainerDriver_CONTAINERD
+		namespace, driver, err := containersCmdFlags.resolveContainerNamespace()
+		if err != nil {
+			return err
 		}
 
 		responseChan := multiplex.UnaryViaFactory(
@@ -110,7 +100,7 @@ var containersCmd = &cobra.Command{
 }
 
 func init() {
-	containersCmd.Flags().BoolVarP(&containersCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	addContainerNamespaceFlags(containersCmd, &containersCmdFlags.containerNamespaceFlag)
 
 	containersCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	containersCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -57,6 +57,10 @@ var debugCmd = &cobra.Command{
 
 	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if debugCmdFlags.namespace == constants.TalosContainersContainerdNamespace {
+			return fmt.Errorf("talosctl debug does not support the %q namespace", constants.TalosContainersContainerdNamespace)
+		}
+
 		ctx := cmd.Context()
 
 		clientFactory, err := NewClientFactory(ctx, nil)

--- a/cmd/talosctl/cmd/talos/debug_test.go
+++ b/cmd/talosctl/cmd/talos/debug_test.go
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !windows
+
+package talos //nolint:testpackage // to test the unexported debugCmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// TestDebugRejectsTalosContainersNamespace covers talosctl debug refusing --namespace taloscontainers.
+//
+// The check runs before any client/network setup, so RunE can be called directly and is expected to
+// fail on the namespace alone, without needing a reachable cluster.
+func TestDebugRejectsTalosContainersNamespace(t *testing.T) {
+	oldNamespace := debugCmdFlags.namespace
+
+	t.Cleanup(func() { debugCmdFlags.namespace = oldNamespace })
+
+	debugCmdFlags.namespace = constants.TalosContainersContainerdNamespace
+
+	err := debugCmd.RunE(debugCmd, []string{"docker.io/library/alpine:latest"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), constants.TalosContainersContainerdNamespace)
+}
+
+// TestDebugAcceptsOtherNamespaces is the other half: the rejection has to be specific to
+// taloscontainers, not a namespace check that would also reject the namespaces debug does support.
+//
+// Talosconfig is pointed at a path that can't exist so that, once the namespace check passes,
+// NewClientFactory fails deterministically on a missing config rather than reaching for a real
+// cluster - that failure (not a namespace rejection) is what proves the guard didn't fire.
+func TestDebugAcceptsOtherNamespaces(t *testing.T) {
+	oldTalosconfig := GlobalArgs.Talosconfig
+
+	t.Cleanup(func() { GlobalArgs.Talosconfig = oldTalosconfig })
+
+	GlobalArgs.Talosconfig = filepath.Join(t.TempDir(), "nonexistent-talosconfig")
+
+	for _, ns := range []string{"inmem", "system", "cri"} {
+		t.Run(ns, func(t *testing.T) {
+			oldNamespace := debugCmdFlags.namespace
+
+			t.Cleanup(func() { debugCmdFlags.namespace = oldNamespace })
+
+			debugCmdFlags.namespace = ns
+
+			err := debugCmd.RunE(debugCmd, []string{"docker.io/library/alpine:latest"})
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "does not support")
+			assert.NotContains(t, err.Error(), constants.TalosContainersContainerdNamespace)
+		})
+	}
+}

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -68,6 +68,8 @@ func (flags imageCmdFlagsType) apiNamespace() (common.ContainerdNamespace, error
 		return common.ContainerdNamespace_NS_CRI, nil
 	case "system":
 		return common.ContainerdNamespace_NS_SYSTEM, nil
+	case constants.TalosContainersContainerdNamespace:
+		return common.ContainerdNamespace_NS_TALOSCONTAINERS, nil
 	default:
 		return 0, fmt.Errorf("unsupported namespace %q", flags.namespace)
 	}
@@ -90,8 +92,29 @@ func (flags imageCmdFlagsType) containerdInstance() (*common.ContainerdInstance,
 			Driver:    common.ContainerDriver_CONTAINERD,
 			Namespace: common.ContainerdNamespace_NS_SYSTEM,
 		}, nil
+	case constants.TalosContainersContainerdNamespace:
+		return &common.ContainerdInstance{
+			Driver:    common.ContainerDriver_CONTAINERD,
+			Namespace: common.ContainerdNamespace_NS_TALOSCONTAINERS,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported namespace %q", flags.namespace)
+	}
+}
+
+// containerNamespace resolves the raw containerd namespace and driver used by the container-listing
+// RPCs (containers, logs, stats, restart), which take the namespace as a string directly rather than
+// through the ContainerdNamespace enum used by the image and debug commands.
+func (flags imageCmdFlagsType) containerNamespace() (string, common.ContainerDriver, error) {
+	switch flags.namespace {
+	case "cri":
+		return constants.K8sContainerdNamespace, common.ContainerDriver_CRI, nil
+	case "system":
+		return constants.SystemContainerdNamespace, common.ContainerDriver_CONTAINERD, nil
+	case constants.TalosContainersContainerdNamespace:
+		return constants.TalosContainersContainerdNamespace, common.ContainerDriver_CONTAINERD, nil
+	default:
+		return "", 0, fmt.Errorf("namespace %q is not supported by this command", flags.namespace)
 	}
 }
 
@@ -1048,7 +1071,8 @@ var imageCacheCertGenCmdFlags struct {
 func init() {
 	imageCmd.PersistentFlags().StringVar(
 		&imageCmdFlags.namespace, "namespace", "cri",
-		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance",
+		"namespace to use: \"system\" (etcd and kubelet images), \"cri\" for all Kubernetes workloads, \"inmem\" for in-memory containerd instance, \""+
+			constants.TalosContainersContainerdNamespace+"\" for containers declared via ContainerConfig",
 	)
 	addCommand(imageCmd)
 

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -11,13 +11,13 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -26,7 +26,7 @@ import (
 
 var logsCmdFlags struct {
 	global.InsecureFlags
-	kubernetesNamespaceFlag
+	containerNamespaceFlag
 
 	follow bool
 	tail   int32
@@ -40,6 +40,10 @@ var logsCmd = &cobra.Command{
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if logsCmdFlags.namespace == constants.TalosContainersContainerdNamespace {
+			return getTalosContainerLogs(cmd.Context(), &logsCmdFlags), cobra.ShellCompDirectiveNoFileComp
 		}
 
 		if logsCmdFlags.kubernetes {
@@ -62,17 +66,9 @@ var logsCmd = &cobra.Command{
 
 		defer clientFactory.Close() //nolint:errcheck
 
-		var (
-			namespace string
-			driver    common.ContainerDriver
-		)
-
-		if logsCmdFlags.kubernetes {
-			namespace = constants.K8sContainerdNamespace
-			driver = common.ContainerDriver_CRI
-		} else {
-			namespace = constants.SystemContainerdNamespace
-			driver = common.ContainerDriver_CONTAINERD
+		namespace, driver, err := logsCmdFlags.resolveContainerNamespace()
+		if err != nil {
+			return err
 		}
 
 		responseChan := multiplex.StreamingViaFactory(
@@ -170,8 +166,32 @@ func getLogsContainers(ctx context.Context, flags any) []string {
 	return result
 }
 
+// getTalosContainerLogs suggests the containers declared via ContainerConfig which have logs.
+//
+// A container that has never started has no buffer, and so does not appear.
+func getTalosContainerLogs(ctx context.Context, flags any) []string {
+	return stripTalosContainerLogPrefix(getLogsContainers(ctx, flags))
+}
+
+// stripTalosContainerLogPrefix keeps only the ids carrying the taloscontainers log prefix, with the
+// prefix removed.
+//
+// The registered identifiers carry the namespace prefix, but the command takes the container name, so
+// the prefix is stripped back off.
+func stripTalosContainerLogPrefix(ids []string) []string {
+	var result []string
+
+	for _, id := range ids {
+		if name, ok := strings.CutPrefix(id, constants.TalosContainersLogPrefix); ok {
+			result = append(result, name)
+		}
+	}
+
+	return result
+}
+
 func init() {
-	logsCmd.Flags().BoolVarP(&logsCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	addContainerNamespaceFlags(logsCmd, &logsCmdFlags.containerNamespaceFlag)
 	logsCmd.Flags().BoolVarP(&logsCmdFlags.follow, "follow", "f", false, "specify if the logs should be streamed")
 	logsCmd.Flags().Int32VarP(&logsCmdFlags.tail, "tail", "", -1, "lines of log file to display (default is to show from the beginning)")
 

--- a/cmd/talosctl/cmd/talos/namespace_test.go
+++ b/cmd/talosctl/cmd/talos/namespace_test.go
@@ -1,0 +1,221 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos //nolint:testpackage // to test unexported commands and helpers
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// namespaceSelectorCommands are the commands which let the namespace be chosen.
+//
+// Listed by name as well so that a failure says which command is missing the wiring rather than
+// pointing at an anonymous entry.
+func namespaceSelectorCommands() []struct {
+	name string
+	cmd  *cobra.Command
+} {
+	return []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"logs", logsCmd},
+		{"containers", containersCmd},
+		{"stats", statsCmd},
+		{"restart", restartCmd},
+	}
+}
+
+// resetNamespaceFlags restores the namespace selectors to their defaults once the test is done.
+//
+// The commands are package-level singletons whose flags are bound to package-level variables, so a
+// parsed flag would otherwise leak into every test that runs afterwards. Setting each flag back to its
+// default drives that through the bound variable as well, and clearing Changed is what makes a later
+// parse look like a first one to the flag-group validation.
+func resetNamespaceFlags(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		for _, name := range []string{"kubernetes", "namespace"} {
+			flag := cmd.Flags().Lookup(name)
+			require.NotNil(t, flag)
+			require.NoError(t, flag.Value.Set(flag.DefValue))
+
+			flag.Changed = false
+		}
+	})
+}
+
+// TestNamespaceFlagsAreMutuallyExclusive covers --kubernetes and --namespace being refused together.
+//
+// They are two ways of naming one containerd namespace, so accepting both would leave the command
+// reading one namespace while the operator had asked for another. cobra checks flag groups after the
+// arguments but before RunE, so validating the group directly is the same check the command performs,
+// without connecting to anything.
+func TestNamespaceFlagsAreMutuallyExclusive(t *testing.T) {
+	for _, tc := range namespaceSelectorCommands() {
+		t.Run(tc.name, func(t *testing.T) {
+			resetNamespaceFlags(t, tc.cmd)
+
+			require.NoError(t, tc.cmd.ParseFlags([]string{
+				"--kubernetes",
+				"--namespace", constants.TalosContainersContainerdNamespace,
+			}))
+
+			err := tc.cmd.ValidateFlagGroups()
+
+			require.Error(t, err, "expected --kubernetes and --namespace to be refused together")
+			assert.Contains(t, err.Error(), "kubernetes")
+			assert.Contains(t, err.Error(), "namespace")
+		})
+	}
+}
+
+// TestNamespaceFlagsAreAcceptedSeparately is the other half: the exclusion has to reject only the
+// combination, not either flag on its own.
+//
+// Asserting the rejection alone would also pass if the flags were somehow always in conflict.
+func TestNamespaceFlagsAreAcceptedSeparately(t *testing.T) {
+	for _, tc := range namespaceSelectorCommands() {
+		for _, args := range [][]string{
+			{"--kubernetes"},
+			{"--namespace", constants.TalosContainersContainerdNamespace},
+			{},
+		} {
+			t.Run(tc.name+" "+argsName(args), func(t *testing.T) {
+				resetNamespaceFlags(t, tc.cmd)
+
+				require.NoError(t, tc.cmd.ParseFlags(args))
+				assert.NoError(t, tc.cmd.ValidateFlagGroups())
+			})
+		}
+	}
+}
+
+func argsName(args []string) string {
+	if len(args) == 0 {
+		return "no flags"
+	}
+
+	return args[0]
+}
+
+// TestResolveContainerNamespace pins the namespace and driver each selector resolves to.
+//
+// The driver is the half that is easy to get wrong and hard to notice: asking for the taloscontainers
+// namespace through the CRI driver is refused by the server outright, and the mapping is what the
+// --namespace flag exists to reach.
+func TestResolveContainerNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		flags         containerNamespaceFlag
+		wantNamespace string
+		wantDriver    common.ContainerDriver
+		wantErr       bool
+	}{
+		{
+			name:          "system namespace",
+			flags:         containerNamespaceFlag{imageCmdFlagsType: imageCmdFlagsType{namespace: "system"}},
+			wantNamespace: constants.SystemContainerdNamespace,
+			wantDriver:    common.ContainerDriver_CONTAINERD,
+		},
+		{
+			name:          "cri symbol resolves to the k8s.io namespace via the CRI driver",
+			flags:         containerNamespaceFlag{imageCmdFlagsType: imageCmdFlagsType{namespace: "cri"}},
+			wantNamespace: constants.K8sContainerdNamespace,
+			wantDriver:    common.ContainerDriver_CRI,
+		},
+		{
+			name:          "deprecated --kubernetes behaves like --namespace cri",
+			flags:         containerNamespaceFlag{kubernetes: true},
+			wantNamespace: constants.K8sContainerdNamespace,
+			wantDriver:    common.ContainerDriver_CRI,
+		},
+		{
+			name:          "taloscontainers is read through containerd",
+			flags:         containerNamespaceFlag{imageCmdFlagsType: imageCmdFlagsType{namespace: constants.TalosContainersContainerdNamespace}},
+			wantNamespace: constants.TalosContainersContainerdNamespace,
+			wantDriver:    common.ContainerDriver_CONTAINERD,
+		},
+		{
+			name:    "inmem is not supported by this command",
+			flags:   containerNamespaceFlag{imageCmdFlagsType: imageCmdFlagsType{namespace: "inmem"}},
+			wantErr: true,
+		},
+		{
+			name:    "an unrecognized namespace errors",
+			flags:   containerNamespaceFlag{imageCmdFlagsType: imageCmdFlagsType{namespace: "bogus"}},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace, driver, err := tc.flags.resolveContainerNamespace()
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNamespace, namespace)
+			assert.Equal(t, tc.wantDriver, driver)
+		})
+	}
+}
+
+// TestKubernetesFlagIsDeprecated covers --kubernetes being marked deprecated in favor of --namespace
+// cri, on every command that carries the namespace selector.
+func TestKubernetesFlagIsDeprecated(t *testing.T) {
+	for _, tc := range namespaceSelectorCommands() {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := tc.cmd.Flags().Lookup("kubernetes")
+
+			require.NotNil(t, flag)
+			assert.NotEmpty(t, flag.Deprecated, "expected --kubernetes to be marked deprecated")
+		})
+	}
+}
+
+// TestStripTalosContainerLogPrefix covers turning taloscontainers log-buffer ids back into bare
+// container names for shell completion.
+func TestStripTalosContainerLogPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  []string
+		want []string
+	}{
+		{
+			name: "nil input",
+			ids:  nil,
+			want: nil,
+		},
+		{
+			name: "mixed prefixed and unprefixed ids",
+			ids:  []string{constants.TalosContainersLogPrefix + "foo", "apid", constants.TalosContainersLogPrefix + "bar"},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "id equal to the bare prefix strips to an empty name",
+			ids:  []string{constants.TalosContainersLogPrefix},
+			want: []string{""},
+		},
+		{
+			name: "no prefixed ids",
+			ids:  []string{"apid", "kubelet"},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripTalosContainerLogPrefix(tc.ids))
+		})
+	}
+}

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -11,14 +11,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var restartCmdFlags struct {
-	kubernetesNamespaceFlag
+	containerNamespaceFlag
 }
 
 // restartCmd represents the restart command.
@@ -44,17 +42,9 @@ var restartCmd = &cobra.Command{
 
 		defer clientFactory.Close() //nolint:errcheck
 
-		var (
-			namespace string
-			driver    common.ContainerDriver
-		)
-
-		if restartCmdFlags.kubernetes {
-			namespace = constants.K8sContainerdNamespace
-			driver = common.ContainerDriver_CRI
-		} else {
-			namespace = constants.SystemContainerdNamespace
-			driver = common.ContainerDriver_CONTAINERD
+		namespace, driver, err := restartCmdFlags.resolveContainerNamespace()
+		if err != nil {
+			return err
 		}
 
 		responseChan := multiplex.UnaryViaFactory(
@@ -77,7 +67,7 @@ var restartCmd = &cobra.Command{
 }
 
 func init() {
-	restartCmd.Flags().BoolVarP(&restartCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	addContainerNamespaceFlags(restartCmd, &restartCmdFlags.containerNamespaceFlag)
 
 	restartCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	restartCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -31,21 +31,49 @@ import (
 // GlobalArgs is the common arguments for the root command.
 var GlobalArgs global.Args
 
-// kubernetesNamespaceFlag is embedded into command flag structs that select between
-// the system and Kubernetes containerd namespaces via the --kubernetes flag.
-type kubernetesNamespaceFlag struct {
+// containerNamespaceFlag is embedded into command flag structs that select which containerd
+// namespace to address, via the same --namespace flag and vocabulary shared with talosctl
+// image/debug/upgrade, or, for backwards compatibility, via the deprecated --kubernetes/-k alias for
+// --namespace cri.
+type containerNamespaceFlag struct {
+	imageCmdFlagsType
+
 	kubernetes bool
 }
 
-// useKubernetesNamespace reports whether the Kubernetes containerd namespace is selected.
-func (f kubernetesNamespaceFlag) useKubernetesNamespace() bool {
-	return f.kubernetes
+// resolveContainerNamespace returns the containerd namespace to address and the driver to read it
+// with.
+//
+// The CRI driver exists only for Kubernetes pods, where it is what groups containers under the pod
+// they belong to; every other namespace, taloscontainers included, is read through the containerd
+// driver. Which containerd socket that means follows from the namespace itself, and the server works
+// that out, so there is nothing to select for here.
+func (f containerNamespaceFlag) resolveContainerNamespace() (string, common.ContainerDriver, error) {
+	if f.kubernetes {
+		return constants.K8sContainerdNamespace, common.ContainerDriver_CRI, nil
+	}
+
+	return f.containerNamespace()
 }
 
-// containerNamespaceFlags is implemented by command flag structs carrying the
-// --kubernetes namespace selector; used by the container completion helpers.
+// addContainerNamespaceFlags registers the namespace selectors on cmd.
+//
+// Both flags are registered together, along with their mutual exclusion, because they are two ways of
+// naming the same thing: accepting both would leave the command addressing one namespace while the
+// operator had asked for another.
+func addContainerNamespaceFlags(cmd *cobra.Command, flags *containerNamespaceFlag) {
+	cmd.Flags().BoolVarP(&flags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	cmd.Flags().MarkDeprecated("kubernetes", "use --namespace cri instead") //nolint:errcheck
+	cmd.Flags().StringVar(&flags.namespace, "namespace", "system",
+		"namespace to use: \"system\" (default, Talos service containers), \"cri\" for Kubernetes workloads, \""+
+			constants.TalosContainersContainerdNamespace+"\" for containers declared via ContainerConfig")
+	cmd.MarkFlagsMutuallyExclusive("kubernetes", "namespace")
+}
+
+// containerNamespaceFlags is implemented by command flag structs carrying the namespace selectors;
+// used by the container completion helpers.
 type containerNamespaceFlags interface {
-	useKubernetesNamespace() bool
+	resolveContainerNamespace() (string, common.ContainerDriver, error)
 }
 
 const pathAutoCompleteLimit = 500
@@ -243,19 +271,11 @@ func getContainersFromNode(ctx context.Context, flags containerNamespaceFlags) [
 
 	defer clientFactory.Close() //nolint:errcheck
 
-	kubernetes := flags.useKubernetesNamespace()
+	namespace, driver, err := flags.resolveContainerNamespace()
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("error resolving namespace: %v", err))
 
-	var (
-		namespace string
-		driver    common.ContainerDriver
-	)
-
-	if kubernetes {
-		namespace = constants.K8sContainerdNamespace
-		driver = common.ContainerDriver_CRI
-	} else {
-		namespace = constants.SystemContainerdNamespace
-		driver = common.ContainerDriver_CONTAINERD
+		return nil
 	}
 
 	responseChan := multiplex.UnaryViaFactory(
@@ -280,7 +300,9 @@ func getContainersFromNode(ctx context.Context, flags containerNamespaceFlags) [
 					continue
 				}
 
-				if kubernetes && p.Id == p.PodId {
+				// Only the CRI driver reports pod sandboxes, and a sandbox is not something to name on
+				// the command line, so it is left out of the suggestions.
+				if driver == common.ContainerDriver_CRI && p.Id == p.PodId {
 					continue
 				}
 

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -16,15 +16,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 var statsCmdFlags struct {
-	kubernetesNamespaceFlag
+	containerNamespaceFlag
 }
 
 // statsCmd represents the stats command.
@@ -43,17 +41,9 @@ var statsCmd = &cobra.Command{
 
 		defer clientFactory.Close() //nolint:errcheck
 
-		var (
-			namespace string
-			driver    common.ContainerDriver
-		)
-
-		if statsCmdFlags.kubernetes {
-			namespace = constants.K8sContainerdNamespace
-			driver = common.ContainerDriver_CRI
-		} else {
-			namespace = constants.SystemContainerdNamespace
-			driver = common.ContainerDriver_CONTAINERD
+		namespace, driver, err := statsCmdFlags.resolveContainerNamespace()
+		if err != nil {
+			return err
 		}
 
 		responseChan := multiplex.UnaryViaFactory(
@@ -109,7 +99,7 @@ var statsCmd = &cobra.Command{
 }
 
 func init() {
-	statsCmd.Flags().BoolVarP(&statsCmdFlags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	addContainerNamespaceFlags(statsCmd, &statsCmdFlags.containerNamespaceFlag)
 
 	statsCmd.Flags().Bool("use-cri", false, "use the CRI driver")
 	statsCmd.Flags().MarkHidden("use-cri") //nolint:errcheck

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -53,6 +53,16 @@ Users can override it by adding `lockdown=confidentiality` to the kernel command
 A new `talosctl diskfree` command (aliased to `df`) reports storage and inode usage for mounted volumes.
 """
 
+    [notes.containers_namespace]
+        title = "Unified --namespace Flag"
+        description = """\
+`talosctl containers`, `logs`, `stats` and `restart` now select the containerd namespace through the same `--namespace` flag and vocabulary already used by `talosctl image` and `talosctl debug`: `system` (the default), `cri` for Kubernetes workloads, and `taloscontainers` for containers declared via a `ContainerConfig` document.
+
+The `--kubernetes`/`-k` flag is deprecated in favor of `--namespace cri`.
+
+`talosctl image list` also supports `--namespace taloscontainers`, to inspect images pulled for `ContainerConfig` containers. `talosctl debug` does not support the `taloscontainers` namespace.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/internal/ctrhelper/ctrhelper.go
+++ b/internal/app/internal/ctrhelper/ctrhelper.go
@@ -24,29 +24,14 @@ import (
 //   - detached (context.Background()) context with the appropriate containerd namespace
 //   - containerd client
 func ContainerdInstanceHelper(ctx context.Context, req *common.ContainerdInstance) (context.Context, context.Context, *containerdapi.Client, error) {
-	var (
-		containerdAddress   string
-		containerdNamespace string
-	)
-
-	switch req.GetDriver() {
-	case common.ContainerDriver_CONTAINERD:
-		containerdAddress = constants.SystemContainerdAddress
-	case common.ContainerDriver_CRI:
-		containerdAddress = constants.CRIContainerdAddress
-	default:
-		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "invalid containerd driver %s", req.GetDriver())
+	containerdAddress, err := ContainerdInstanceAddress(req.GetDriver(), req.GetNamespace())
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	switch req.GetNamespace() {
-	case common.ContainerdNamespace_NS_CRI:
-		containerdNamespace = constants.K8sContainerdNamespace
-	case common.ContainerdNamespace_NS_SYSTEM:
-		containerdNamespace = constants.SystemContainerdNamespace
-	case common.ContainerdNamespace_NS_UNKNOWN:
-		fallthrough
-	default:
-		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "invalid containerd namespace %s", req.GetNamespace())
+	containerdNamespace, err := ContainerdInstanceNamespace(req.GetNamespace())
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	if req.GetDriver() == common.ContainerDriver_CONTAINERD && req.GetNamespace() == common.ContainerdNamespace_NS_CRI {
@@ -59,4 +44,38 @@ func ContainerdInstanceHelper(ctx context.Context, req *common.ContainerdInstanc
 	}
 
 	return namespaces.WithNamespace(ctx, containerdNamespace), namespaces.WithNamespace(context.Background(), containerdNamespace), client, nil
+}
+
+// ContainerdInstanceAddress resolves which containerd instance's socket a driver addresses.
+func ContainerdInstanceAddress(driver common.ContainerDriver, namespace common.ContainerdNamespace) (string, error) {
+	switch driver {
+	case common.ContainerDriver_CONTAINERD:
+		// The containerd instance backing every non-system namespace (taloscontainers included) is
+		// the same one CRI uses; only the system namespace lives in Talos's own containerd instance.
+		if namespace == common.ContainerdNamespace_NS_SYSTEM {
+			return constants.SystemContainerdAddress, nil
+		}
+
+		return constants.CRIContainerdAddress, nil
+	case common.ContainerDriver_CRI:
+		return constants.CRIContainerdAddress, nil
+	default:
+		return "", status.Errorf(codes.InvalidArgument, "invalid containerd driver %s", driver)
+	}
+}
+
+// ContainerdInstanceNamespace resolves the enum namespace selector to the raw containerd namespace name.
+func ContainerdInstanceNamespace(namespace common.ContainerdNamespace) (string, error) {
+	switch namespace {
+	case common.ContainerdNamespace_NS_CRI:
+		return constants.K8sContainerdNamespace, nil
+	case common.ContainerdNamespace_NS_SYSTEM:
+		return constants.SystemContainerdNamespace, nil
+	case common.ContainerdNamespace_NS_TALOSCONTAINERS:
+		return constants.TalosContainersContainerdNamespace, nil
+	case common.ContainerdNamespace_NS_UNKNOWN:
+		fallthrough
+	default:
+		return "", status.Errorf(codes.InvalidArgument, "invalid containerd namespace %s", namespace)
+	}
 }

--- a/internal/app/internal/ctrhelper/ctrhelper_test.go
+++ b/internal/app/internal/ctrhelper/ctrhelper_test.go
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ctrhelper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/app/internal/ctrhelper"
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// TestContainerdInstanceAddress pins which containerd socket each driver/namespace pair resolves to.
+//
+// The containerd driver is namespace-sensitive (system lives in Talos's own containerd instance,
+// everything else shares the one CRI uses), unlike the CRI driver, which always addresses the CRI
+// instance regardless of namespace - that asymmetry is the part most likely to regress silently.
+func TestContainerdInstanceAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		driver      common.ContainerDriver
+		namespace   common.ContainerdNamespace
+		wantAddress string
+		wantErr     bool
+	}{
+		{
+			name:        "containerd driver with system namespace uses the system containerd instance",
+			driver:      common.ContainerDriver_CONTAINERD,
+			namespace:   common.ContainerdNamespace_NS_SYSTEM,
+			wantAddress: constants.SystemContainerdAddress,
+		},
+		{
+			name:        "containerd driver with taloscontainers namespace uses the CRI containerd instance",
+			driver:      common.ContainerDriver_CONTAINERD,
+			namespace:   common.ContainerdNamespace_NS_TALOSCONTAINERS,
+			wantAddress: constants.CRIContainerdAddress,
+		},
+		{
+			name:        "containerd driver with cri namespace also uses the CRI containerd instance",
+			driver:      common.ContainerDriver_CONTAINERD,
+			namespace:   common.ContainerdNamespace_NS_CRI,
+			wantAddress: constants.CRIContainerdAddress,
+		},
+		{
+			name:        "cri driver uses the CRI containerd instance regardless of namespace",
+			driver:      common.ContainerDriver_CRI,
+			namespace:   common.ContainerdNamespace_NS_SYSTEM,
+			wantAddress: constants.CRIContainerdAddress,
+		},
+		{
+			name:      "unsupported driver errors",
+			driver:    common.ContainerDriver(99),
+			namespace: common.ContainerdNamespace_NS_SYSTEM,
+			wantErr:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			address, err := ctrhelper.ContainerdInstanceAddress(tc.driver, tc.namespace)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAddress, address)
+		})
+	}
+}
+
+// TestContainerdInstanceNamespace pins the raw containerd namespace name each enum value resolves to.
+func TestContainerdInstanceNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		namespace     common.ContainerdNamespace
+		wantNamespace string
+		wantErr       bool
+	}{
+		{
+			name:          "cri",
+			namespace:     common.ContainerdNamespace_NS_CRI,
+			wantNamespace: constants.K8sContainerdNamespace,
+		},
+		{
+			name:          "system",
+			namespace:     common.ContainerdNamespace_NS_SYSTEM,
+			wantNamespace: constants.SystemContainerdNamespace,
+		},
+		{
+			name:          "taloscontainers",
+			namespace:     common.ContainerdNamespace_NS_TALOSCONTAINERS,
+			wantNamespace: constants.TalosContainersContainerdNamespace,
+		},
+		{
+			name:      "unknown namespace errors",
+			namespace: common.ContainerdNamespace_NS_UNKNOWN,
+			wantErr:   true,
+		},
+		{
+			name:      "unrecognized namespace value errors",
+			namespace: common.ContainerdNamespace(99),
+			wantErr:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace, err := ctrhelper.ContainerdInstanceNamespace(tc.namespace)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNamespace, namespace)
+		})
+	}
+}

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_images.go
@@ -30,6 +30,8 @@ func containerdNamespaceHelper(ctx context.Context, ns common.ContainerdNamespac
 		namespaceName = constants.K8sContainerdNamespace
 	case common.ContainerdNamespace_NS_SYSTEM:
 		namespaceName = constants.SystemContainerdNamespace
+	case common.ContainerdNamespace_NS_TALOSCONTAINERS:
+		namespaceName = constants.TalosContainersContainerdNamespace
 	case common.ContainerdNamespace_NS_UNKNOWN:
 		fallthrough
 	default:

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -1319,40 +1319,29 @@ func (s *Server) Kubeconfig(empty *emptypb.Empty, obj machine.MachineService_Kub
 // Logs provides a service or container logs can be requested and the contents of the
 // log file are streamed in chunks.
 func (s *Server) Logs(req *machine.LogsRequest, l machine.MachineService_LogsServer) (err error) {
-	var chunk chunker.Chunker
+	var (
+		chunk chunker.Chunker
+		file  io.Closer
+	)
 
 	switch {
 	case req.Namespace == constants.SystemContainerdNamespace || req.Id == "kubelet":
-		var options []runtime.LogOption
-
-		if req.Follow {
-			options = append(options, runtime.WithFollow())
-		}
-
-		if req.TailLines >= 0 {
-			options = append(options, runtime.WithTailLines(int(req.TailLines)))
-		}
-
-		var logR io.ReadCloser
-
-		logR, err = s.Controller.Runtime().Logging().ServiceLog(req.Id).Reader(options...)
-		if err != nil {
-			return err
-		}
-
-		//nolint:errcheck
-		defer logR.Close()
-
-		chunk = stream.NewChunker(l.Context(), logR)
+		chunk, file, err = s.serviceLogChunker(l.Context(), req, req.Id)
+	case req.Namespace == constants.TalosContainersContainerdNamespace:
+		// Containers declared via ContainerConfig log to a buffer keyed by container, not by
+		// instance, so that successive restarts append to one buffer and logs outlive the
+		// container: see containers.RuntimeController.
+		chunk, file, err = s.serviceLogChunker(l.Context(), req, constants.TalosContainersLogPrefix+req.Id)
 	default:
-		var file io.Closer
-
-		if chunk, file, err = k8slogs(l.Context(), req); err != nil {
-			return err
-		}
-		//nolint:errcheck
-		defer file.Close()
+		chunk, file, err = k8slogs(l.Context(), req)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	//nolint:errcheck
+	defer file.Close()
 
 	for data := range chunk.Read() {
 		if err = l.Send(&common.Data{Bytes: data}); err != nil {
@@ -1361,6 +1350,26 @@ func (s *Server) Logs(req *machine.LogsRequest, l machine.MachineService_LogsSer
 	}
 
 	return nil
+}
+
+// serviceLogChunker opens the named entry in the in-memory service log buffer for streaming.
+func (s *Server) serviceLogChunker(ctx context.Context, req *machine.LogsRequest, id string) (chunker.Chunker, io.Closer, error) {
+	var options []runtime.LogOption
+
+	if req.Follow {
+		options = append(options, runtime.WithFollow())
+	}
+
+	if req.TailLines >= 0 {
+		options = append(options, runtime.WithTailLines(int(req.TailLines)))
+	}
+
+	logR, err := s.Controller.Runtime().Logging().ServiceLog(id).Reader(options...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return stream.NewChunker(ctx, logR), logR, nil
 }
 
 // LogsContainers provide a list of registered log containers.

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -7,11 +7,68 @@
 package cli
 
 import (
+	"encoding/json"
 	"regexp"
+	"testing"
+	"time"
 
 	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
+
+// talosContainerStartTimeout covers a cold pull of a small, likely-cached image plus the controller
+// chain that starts it.
+const talosContainerStartTimeout = 3 * time.Minute
+
+// applyTalosContainer declares a container via a ContainerConfig document on node, and returns a
+// cleanup func that removes it again.
+//
+// entrypoint and args may be nil to use the image's own entrypoint. A distinct name per caller keeps
+// the new namespace tests from clobbering each other if they ever run concurrently against the same
+// node.
+func applyTalosContainer(suite *base.CLISuite, node, name, image string, entrypoint, args []string) func() {
+	patch := map[string]any{
+		"apiVersion": "v1alpha1",
+		"kind":       "ContainerConfig",
+		"name":       name,
+		"image":      image,
+	}
+
+	if len(entrypoint) > 0 {
+		patch["entrypoint"] = entrypoint
+	}
+
+	if len(args) > 0 {
+		patch["args"] = args
+	}
+
+	data, err := json.Marshal(patch)
+	suite.Require().NoError(err)
+
+	suite.RunCLI(
+		[]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot"},
+		base.StdoutEmpty(), base.StderrNotEmpty(),
+	)
+
+	return func() {
+		removePatch := map[string]any{
+			"apiVersion": "v1alpha1",
+			"kind":       "ContainerConfig",
+			"name":       name,
+			"$patch":     "delete",
+		}
+
+		data, err := json.Marshal(removePatch)
+		suite.Require().NoError(err)
+
+		suite.RunCLI(
+			[]string{"patch", "--nodes", node, "--patch", string(data), "machineconfig", "--mode=no-reboot"},
+			base.StdoutEmpty(), base.StderrNotEmpty(),
+		)
+	}
+}
 
 // ContainersSuite verifies dmesg command.
 type ContainersSuite struct {
@@ -36,10 +93,64 @@ func (suite *ContainersSuite) TestContainerd() {
 func (suite *ContainersSuite) TestCRI() {
 	suite.RunCLI(
 		[]string{
+			"containers", "--namespace", "cri", "--nodes",
+			suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane),
+		},
+		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
+	)
+}
+
+// TestKubernetesFlagDeprecated covers the deprecated -k/--kubernetes alias: it still has to behave
+// exactly like --namespace cri, and using it has to warn, not just silently keep working forever.
+func (suite *ContainersSuite) TestKubernetesFlagDeprecated() {
+	suite.RunCLI(
+		[]string{
 			"containers", "-k", "--nodes",
 			suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane),
 		},
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
+		base.StderrShouldMatch(regexp.MustCompile(`(?i)deprecated`)),
+		base.StderrShouldMatch(regexp.MustCompile(`--namespace cri`)),
+	)
+}
+
+// TestTalosContainers inspects a container declared via a ContainerConfig document, addressed through
+// --namespace taloscontainers.
+func (suite *ContainersSuite) TestTalosContainers() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	if suite.Airgapped {
+		suite.T().Skip("skipping test in airgapped mode, the test pulls an image")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP()
+	name := "talosctl-it-containers"
+
+	cleanup := applyTalosContainer(&suite.CLISuite, node, name, images.DefaultSandboxImage, nil, nil)
+	defer cleanup()
+
+	suite.RunAndWaitForMatch(
+		[]string{"containers", "--namespace", constants.TalosContainersContainerdNamespace, "--nodes", node},
+		regexp.MustCompile(name),
+		talosContainerStartTimeout,
+	)
+}
+
+// TestNamespaceFlagsMutuallyExclusive verifies that --kubernetes and --namespace are refused together
+// by the actual binary, end to end with the unit-level check in namespace_test.go which only exercises
+// cobra's flag-group validation directly.
+func (suite *ContainersSuite) TestNamespaceFlagsMutuallyExclusive() {
+	suite.RunCLI(
+		[]string{
+			"containers", "--kubernetes", "--namespace", constants.TalosContainersContainerdNamespace,
+			"--nodes", suite.RandomDiscoveredNodeInternalIP(),
+		},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(`kubernetes`)),
+		base.StderrShouldMatch(regexp.MustCompile(`namespace`)),
 	)
 }
 

--- a/internal/integration/cli/image.go
+++ b/internal/integration/cli/image.go
@@ -17,7 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 )
 
@@ -204,6 +206,30 @@ func (suite *ImageSuite) TestCacheCreateFlat() {
 
 	assert.DirExistsf(suite.T(), cacheDir+"/blob", "blob directory should exist in the image cache directory")
 	assert.DirExistsf(suite.T(), cacheDir+"/manifests", "manifests directory should exist in the image cache directory")
+}
+
+// TestListTalosContainers verifies that the image pulled for a container declared via a
+// ContainerConfig document is visible through --namespace taloscontainers.
+func (suite *ImageSuite) TestListTalosContainers() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	if suite.Airgapped {
+		suite.T().Skip("skipping test in airgapped mode, the test pulls an image")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP()
+	name := "talosctl-it-image-list"
+
+	cleanup := applyTalosContainer(&suite.CLISuite, node, name, images.DefaultSandboxImage, nil, nil)
+	defer cleanup()
+
+	suite.RunAndWaitForMatch(
+		[]string{"image", "list", "--namespace", constants.TalosContainersContainerdNamespace, "--nodes", node},
+		regexp.MustCompile("pause"),
+		talosContainerStartTimeout,
+	)
 }
 
 func init() {

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -7,12 +7,22 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-retry/retry"
 
 	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
+
+// talosContainerLogImage has a shell, which the pause image used for the other taloscontainers tests
+// lacks, so it can be told to print something the test can look for in its logs.
+const talosContainerLogImage = "docker.io/library/alpine:3.23"
 
 // LogsSuite verifies logs command.
 type LogsSuite struct {
@@ -58,6 +68,67 @@ func (suite *LogsSuite) TestServiceNotFound() {
 		base.StderrShouldMatch(regexp.MustCompile(`error.+ log "servicenotfound" was not registered`)),
 		base.ShouldFail(),
 	)
+}
+
+// TestKubernetesFlagDeprecated covers the deprecated -k/--kubernetes alias reaching the CRI driver, and
+// warning while it does.
+//
+// A nonexistent container id keeps this from depending on a specific pod being present, while still
+// proving the request reached the CRI driver: the server's "not found" here is container-inspector
+// text distinct from the ServiceLog "was not registered" text TestServiceNotFound checks for the
+// system namespace, so a match confirms -k routed to the CRI path rather than falling back to system.
+func (suite *LogsSuite) TestKubernetesFlagDeprecated() {
+	suite.RunCLI(
+		[]string{"logs", "-k", "--nodes", suite.RandomDiscoveredNodeInternalIP(), "talosctl-it-nonexistent"},
+		base.StdoutEmpty(),
+		base.ShouldFail(),
+		base.StderrShouldMatch(regexp.MustCompile(`(?i)deprecated`)),
+		base.StderrShouldMatch(regexp.MustCompile(`--namespace cri`)),
+		base.StderrShouldMatch(regexp.MustCompile(`not found`)),
+	)
+}
+
+// TestTalosContainerLogs verifies that logs for a container declared via a ContainerConfig document
+// are readable through --namespace taloscontainers.
+func (suite *LogsSuite) TestTalosContainerLogs() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	if suite.Airgapped {
+		suite.T().Skip("skipping test in airgapped mode, the test pulls an image")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP()
+	name := "talosctl-it-logs"
+	marker := "talosctl-it-logs-marker"
+
+	cleanup := applyTalosContainer(&suite.CLISuite, node, name, talosContainerLogImage,
+		[]string{"/bin/sh", "-c"}, []string{"echo " + marker})
+	defer cleanup()
+
+	args := suite.MakeCMDFn([]string{
+		"logs", "--namespace", constants.TalosContainersContainerdNamespace, "--nodes", node, name,
+	})
+
+	// unlike containers/stats, logs errors out until the container's log buffer exists, so a plain
+	// command failure has to be retried too, not just a content mismatch.
+	suite.Require().NoError(retry.Constant(talosContainerStartTimeout, retry.WithUnits(time.Second)).Retry(func() error {
+		var stdout bytes.Buffer
+
+		cmd := args()
+		cmd.Stdout = &stdout
+
+		if err := cmd.Run(); err != nil {
+			return retry.ExpectedErrorf("logs command failed: %s", err)
+		}
+
+		if !regexp.MustCompile(marker).MatchString(stdout.String()) {
+			return retry.ExpectedErrorf("stdout doesn't match %q: %q", marker, stdout.String())
+		}
+
+		return nil
+	}))
 }
 
 func init() {

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -42,6 +42,25 @@ func (suite *RestartSuite) TestSystem() {
 	suite.RunAndWaitForMatch([]string{"service", "-n", node, "trustd"}, regexp.MustCompile(`EVENTS\s+\[Running\]: Health check successful`), 30*time.Second)
 }
 
+// TestKubernetesFlagDeprecated covers the deprecated -k/--kubernetes alias reaching the CRI driver, and
+// warning while it does.
+//
+// A nonexistent container id avoids restarting a real Kubernetes workload container, while still
+// proving the request reached the CRI driver via its "not found" response.
+func (suite *RestartSuite) TestKubernetesFlagDeprecated() {
+	suite.RunCLI(
+		[]string{
+			"restart", "-k", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane),
+			"talosctl-it-nonexistent",
+		},
+		base.StdoutEmpty(),
+		base.ShouldFail(),
+		base.StderrShouldMatch(regexp.MustCompile(`(?i)deprecated`)),
+		base.StderrShouldMatch(regexp.MustCompile(`--namespace cri`)),
+		base.StderrShouldMatch(regexp.MustCompile(`not found`)),
+	)
+}
+
 func init() {
 	allSuites = append(allSuites, new(RestartSuite))
 }

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -8,9 +8,12 @@ package cli
 
 import (
 	"regexp"
+	"testing"
 
 	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
 // StatsSuite verifies dmesg command.
@@ -35,10 +38,50 @@ func (suite *StatsSuite) TestContainerd() {
 // TestCRI inspects stats via CRI driver.
 func (suite *StatsSuite) TestCRI() {
 	suite.RunCLI(
-		[]string{"stats", "-k", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
+		[]string{"stats", "--namespace", "cri", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),
+	)
+}
+
+// TestKubernetesFlagDeprecated covers the deprecated -k/--kubernetes alias: it still has to behave
+// exactly like --namespace cri, and using it has to warn, not just silently keep working forever.
+func (suite *StatsSuite) TestKubernetesFlagDeprecated() {
+	suite.RunCLI(
+		[]string{"stats", "-k", "--nodes", suite.RandomDiscoveredNodeInternalIP(machine.TypeControlPlane)},
+		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
+		base.StderrShouldMatch(regexp.MustCompile(`(?i)deprecated`)),
+		base.StderrShouldMatch(regexp.MustCompile(`--namespace cri`)),
+	)
+}
+
+// TestTalosContainers inspects stats for a container declared via a ContainerConfig document,
+// addressed through --namespace taloscontainers.
+func (suite *StatsSuite) TestTalosContainers() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
+	if suite.Airgapped {
+		suite.T().Skip("skipping test in airgapped mode, the test pulls an image")
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP()
+	name := "talosctl-it-stats"
+
+	cleanup := applyTalosContainer(&suite.CLISuite, node, name, images.DefaultSandboxImage, nil, nil)
+	defer cleanup()
+
+	suite.RunAndWaitForMatch(
+		[]string{"stats", "--namespace", constants.TalosContainersContainerdNamespace, "--nodes", node},
+		regexp.MustCompile(name),
+		talosContainerStartTimeout,
+	)
+	suite.RunCLI(
+		[]string{"stats", "--namespace", constants.TalosContainersContainerdNamespace, "--nodes", node},
+		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 	)
 }
 

--- a/pkg/machinery/api/common/common.pb.go
+++ b/pkg/machinery/api/common/common.pb.go
@@ -126,6 +126,8 @@ const (
 	ContainerdNamespace_NS_UNKNOWN ContainerdNamespace = 0
 	ContainerdNamespace_NS_SYSTEM  ContainerdNamespace = 1
 	ContainerdNamespace_NS_CRI     ContainerdNamespace = 2
+	// NS_TALOSCONTAINERS is the namespace for containers declared via a ContainerConfig document.
+	ContainerdNamespace_NS_TALOSCONTAINERS ContainerdNamespace = 3
 )
 
 // Enum value maps for ContainerdNamespace.
@@ -134,11 +136,13 @@ var (
 		0: "NS_UNKNOWN",
 		1: "NS_SYSTEM",
 		2: "NS_CRI",
+		3: "NS_TALOSCONTAINERS",
 	}
 	ContainerdNamespace_value = map[string]int32{
-		"NS_UNKNOWN": 0,
-		"NS_SYSTEM":  1,
-		"NS_CRI":     2,
+		"NS_UNKNOWN":         0,
+		"NS_SYSTEM":          1,
+		"NS_CRI":             2,
+		"NS_TALOSCONTAINERS": 3,
 	}
 )
 
@@ -1028,13 +1032,14 @@ const file_common_common_proto_rawDesc = "" +
 	"\x0fContainerDriver\x12\x0e\n" +
 	"\n" +
 	"CONTAINERD\x10\x00\x12\a\n" +
-	"\x03CRI\x10\x01*@\n" +
+	"\x03CRI\x10\x01*X\n" +
 	"\x13ContainerdNamespace\x12\x0e\n" +
 	"\n" +
 	"NS_UNKNOWN\x10\x00\x12\r\n" +
 	"\tNS_SYSTEM\x10\x01\x12\n" +
 	"\n" +
-	"\x06NS_CRI\x10\x02:]\n" +
+	"\x06NS_CRI\x10\x02\x12\x16\n" +
+	"\x12NS_TALOSCONTAINERS\x10\x03:]\n" +
 	"\x19remove_deprecated_message\x12\x1f.google.protobuf.MessageOptions\x18\xbd\xd7\x05 \x01(\tR\x17removeDeprecatedMessage:W\n" +
 	"\x17remove_deprecated_field\x12\x1d.google.protobuf.FieldOptions\x18\xbd\xd7\x05 \x01(\tR\x15removeDeprecatedField:T\n" +
 	"\x16remove_deprecated_enum\x12\x1c.google.protobuf.EnumOptions\x18\xbd\xd7\x05 \x01(\tR\x14removeDeprecatedEnum:d\n" +

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -991,6 +991,7 @@ description: Talos gRPC API reference.
 | NS_UNKNOWN | 0 |  |
 | NS_SYSTEM | 1 |  |
 | NS_CRI | 2 |  |
+| NS_TALOSCONTAINERS | 3 | NS_TALOSCONTAINERS is the namespace for containers declared via a ContainerConfig document. |
 
 
  <!-- end enums -->

--- a/website/content/v1.15/reference/cli.md
+++ b/website/content/v1.15/reference/cli.md
@@ -1128,7 +1128,7 @@ talosctl containers [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for containers
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2259,7 +2259,7 @@ talosctl image cache-cert-gen [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2311,7 +2311,7 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2350,7 +2350,7 @@ talosctl image cache-serve [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2385,7 +2385,7 @@ talosctl image k8s-bundle [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2415,7 +2415,7 @@ talosctl image list [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2445,7 +2445,7 @@ talosctl image pull <image> [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2475,7 +2475,7 @@ talosctl image remove <image> [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2507,7 +2507,7 @@ talosctl image talos-bundle [talos-version] [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2528,7 +2528,7 @@ Manage container images
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for image
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2737,7 +2737,7 @@ talosctl logs <service name> [flags]
   -f, --follow                     specify if the logs should be streamed
   -h, --help                       help for logs
   -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --tail int32                 lines of log file to display (default is to show from the beginning) (default -1)
@@ -3243,7 +3243,7 @@ talosctl restart <id> [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for restart
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -3395,7 +3395,7 @@ talosctl stats [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for stats
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order


### PR DESCRIPTION
Resolves https://github.com/siderolabs/talos/issues/14069

Adds a `--namespace` option to `talosctl {containers,logs,stats,restart}` and `talosctl image list`, letting operators target the `taloscontainers` namespace. Unifies namespace selection across these commands (and `debug`) with the same `--namespace` flag/vocabulary already used by `image`/`debug`, and deprecates `--kubernetes`/`-k` in favor of `--namespace cri`. `debug` rejects `taloscontainers`.

Best to wait for https://github.com/siderolabs/talos/pull/14089 before merging. That way, we can re-test this PR under an actually running container, fetch logs, etc.

---

As tested locally, with the following `nginx` container:
```yaml
apiVersion: v1alpha1
kind: ContainerConfig
name: nginx
image: nginx
network:
  mode: host
security:
  profile: privileged
```

Retrieving logs (with -f for follow):
```sh
_out/talosctl-linux-amd64 -n 172.20.0.2 logs nginx --namespace taloscontainers -f  14:16:49
172.20.0.2: /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
172.20.0.2: /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
172.20.0.2: 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
172.20.0.2: 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
172.20.0.2: /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
172.20.0.2: /docker-entrypoint.sh: Configuration complete; ready for start up
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: using the "epoll" event method
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: nginx/1.31.4
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: built by gcc 14.2.0 (Debian 14.2.0-19)
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: OS: Linux 6.18.46-talos
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1024:1024
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: start worker processes
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: start worker process 29
172.20.0.2: 2026/08/25 11:51:09 [notice] 1#1: start worker process 30
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: signal 15 (SIGTERM) received, exiting
172.20.0.2: 2026/08/25 11:52:57 [notice] 30#30: exiting
172.20.0.2: 2026/08/25 11:52:57 [notice] 29#29: exiting
172.20.0.2: 2026/08/25 11:52:57 [notice] 29#29: exit
172.20.0.2: 2026/08/25 11:52:57 [notice] 30#30: exit
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: signal 17 (SIGCHLD) received from 29
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: worker process 29 exited with code 0
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: signal 29 (SIGIO) received
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: signal 17 (SIGCHLD) received from 30
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: worker process 30 exited with code 0
172.20.0.2: 2026/08/25 11:52:57 [notice] 1#1: exit
172.20.0.2: /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
172.20.0.2: /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
172.20.0.2: 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
172.20.0.2: 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
172.20.0.2: /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
172.20.0.2: /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
172.20.0.2: /docker-entrypoint.sh: Configuration complete; ready for start up
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: using the "epoll" event method
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: nginx/1.31.4
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: built by gcc 14.2.0 (Debian 14.2.0-19)
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: OS: Linux 6.18.46-talos
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1024:1024
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: start worker processes
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: start worker process 29
172.20.0.2: 2026/08/25 11:53:02 [notice] 1#1: start worker process 30
172.20.0.2: 172.20.0.1 - - [25/Aug/2026:12:17:08 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:154.0) Gecko/20100101 Firefox/154.0" "-"
172.20.0.2: 172.20.0.1 - - [25/Aug/2026:12:17:09 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:154.0) Gecko/20100101 Firefox/154.0" "-"
```


Retrieving stats:
```sh
_out/talosctl-linux-amd64 -n 172.20.0.2 stats --namespace taloscontainers
NODE         NAMESPACE         ID        MEMORY(MB)   CPU
172.20.0.2   taloscontainers   nginx-1   3.49         75712000
```

Listing containers:
```sh
_out/talosctl-linux-amd64 -n 172.20.0.2 containers --namespace taloscontainers
NODE         NAMESPACE         ID        IMAGE                                                                                             PID    STATUS
172.20.0.2   taloscontainers   nginx-1   docker.io/library/nginx@sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   1218   RUNNING
```

Listing images:
```sh
_out/talosctl-linux-amd64 image list  --nodes 172.20.0.2  --namespace taloscontainers
NODE         IMAGE                                                                                             DIGEST                                                                    SIZE    LABELS   CREATED
172.20.0.2   docker.io/library/nginx:latest                                                                    sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   63 MB            2026-08-25T11:51:08Z
172.20.0.2   docker.io/library/nginx@sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   63 MB            2026-08-25T11:51:08Z
172.20.0.2   sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0                           sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   63 MB            2026-08-25T11:51:08Z
```

Restarting:
```sh
# First grab the identifier
_out/talosctl-linux-amd64 containers --nodes 172.20.0.2 --namespace taloscontainers
NODE         NAMESPACE         ID        IMAGE                                                                                             PID    STATUS
172.20.0.2   taloscontainers   nginx-1   docker.io/library/nginx@sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   1218   RUNNING

# Doesn't output anything, but I added the echo to show the exit code
_out/talosctl-linux-amd64 restart --nodes 172.20.0.2 --namespace taloscontainers nginx-1
echo $?
0

_out/talosctl-linux-amd64 containers --nodes 172.20.0.2 --namespace taloscontainers
NODE         NAMESPACE         ID        IMAGE                                                                                             PID    STATUS
172.20.0.2   taloscontainers   nginx-2   docker.io/library/nginx@sha256:b34848eff6db786b6b1282d3a9c3fd0b5563dfb6d261df4923378b419e0d24f0   1374   RUNNING
```

---

On another note, perhaps we should add a ContainerConfig-level `restart`? The current behavior of `talosctl restart` SIGTERMs the literal running container ([src](https://github.com/siderolabs/talos/blob/f4662e930ea37b3be44150be0fdecb1781211812/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go#L1662-L1663)). This is fine on its own, but for Talos Containers, this will cause the container to be recreated with a new generation, hence with a new container ID (`nginx-1` --restart-> `nginx-2`). Should the user want to restart it again, they'd have to lookup the new container ID (new generation). 

Instead, it would be nice to have a "restart container for this ContainerConfig", which would always expect the `ContainerConfig` name, and automatically resolve the actual container (name+generation) to restart. 
