### PR TITLE
feat: load config patches from an http(s) URL

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -102,7 +102,7 @@ func addWorkersMemoryFlag(flagset *pflag.FlagSet, bind *bytesize.ByteSize, flagN
 }
 
 func addConfigPatchFlag(flagset *pflag.FlagSet, bind *[]string, flagName string) {
-	flagset.StringArrayVar(bind, flagName, nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file")
+	flagset.StringArrayVar(bind, flagName, nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it")
 }
 
 func addConfigPatchControlPlaneFlag(flagset *pflag.FlagSet, bind *[]string, flagName string) {

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -442,7 +442,7 @@ func init() {
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.configVersion, "version", "v1alpha1", "the desired machine config version to generate")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
-	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatch, "config-patch", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file")
+	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatch, "config-patch", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it")
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatchControlPlane, "config-patch-control-plane", nil, "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatchWorker, "config-patch-worker", nil, "patch generated machineconfigs (applied to 'worker' type)")
 	genConfigCmd.Flags().StringSliceVar(&genConfigCmdFlags.registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")

--- a/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
+++ b/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
@@ -30,7 +30,7 @@ var patchCmd = &cobra.Command{
 			return err
 		}
 
-		patches, err := configpatcher.LoadPatches(patchCmdFlags.patches)
+		patches, err := configpatcher.LoadPatchesWithContext(cmd.Context(), patchCmdFlags.patches)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ var patchCmd = &cobra.Command{
 
 func init() {
 	// use StringArrayVarP instead of StringSliceVarP to prevent cobra from splitting the patch string on commas
-	patchCmd.Flags().StringArrayVarP(&patchCmdFlags.patches, "patch", "p", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file")
+	patchCmd.Flags().StringArrayVarP(&patchCmdFlags.patches, "patch", "p", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it")
 	patchCmd.Flags().StringVarP(&patchCmdFlags.output, "output", "o", "", "output destination. if not specified, output will be printed to stdout")
 
 	Cmd.AddCommand(patchCmd)

--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -78,7 +78,7 @@ var applyConfigCmd = &cobra.Command{
 				patches []configpatcher.Patch
 			)
 
-			patches, err = configpatcher.LoadPatches(applyConfigCmdFlags.patches)
+			patches, err = configpatcher.LoadPatchesWithContext(cmd.Context(), applyConfigCmdFlags.patches)
 			if err != nil {
 				return err
 			}

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -129,7 +129,7 @@ var patchCmd = &cobra.Command{
 			return errors.New("either --patch or --patch-file should be defined")
 		}
 
-		patches, err := configpatcher.LoadPatches(patchCmdFlags.patch)
+		patches, err := configpatcher.LoadPatchesWithContext(cmd.Context(), patchCmdFlags.patch)
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ var patchCmd = &cobra.Command{
 func init() {
 	patchCmd.Flags().StringVar(&patchCmdFlags.namespace, "namespace", "", "resource namespace (default is to use default namespace per resource)")
 	patchCmd.Flags().StringVar(&patchCmdFlags.patchFile, "patch-file", "", "a file containing a patch to be applied to the resource.")
-	patchCmd.Flags().StringArrayVarP(&patchCmdFlags.patch, "patch", "p", nil, "the patch to be applied to the resource file, use @file to read a patch from file.")
+	patchCmd.Flags().StringArrayVarP(&patchCmdFlags.patch, "patch", "p", nil, "the patch to be applied to the resource file, use @file to read a patch from file, or an http(s) URL to fetch it.")
 	patchCmd.Flags().BoolVar(&patchCmdFlags.dryRun, "dry-run", false, "print the change summary and patch preview without applying the changes")
 	patchCmd.Flags().DurationVar(&patchCmdFlags.configTryTimeout, "timeout", constants.ConfigTryTimeout, "the config will be rolled back after specified timeout (if try mode is selected)")
 	helpers.AddModeFlags(&patchCmdFlags.Mode, patchCmd)

--- a/pkg/machinery/config/configpatcher/load.go
+++ b/pkg/machinery/config/configpatcher/load.go
@@ -6,14 +6,28 @@ package configpatcher
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+)
+
+const (
+	// remotePatchTimeout bounds a single fetch of a patch over http/https.
+	remotePatchTimeout = 30 * time.Second
+	// remotePatchSizeLimit bounds how much of a remote response is read; a config patch
+	// that does not fit is a mistake or a hostile response, not a patch.
+	remotePatchSizeLimit = 1 << 20 // 1 MiB
 )
 
 type patch []map[string]any
@@ -70,12 +84,71 @@ func LoadPatch(in []byte) (Patch, error) {
 	return p, nil
 }
 
-// LoadPatches loads the JSON patch either from value literal or from a file if the patch starts with '@'.
+// isRemotePatch reports whether the patch source is an absolute http/https URL.
+//
+// Only those two schemes are recognized: anything else keeps the pre-existing meaning of the
+// argument (a filename, or an inline patch).
+func isRemotePatch(source string) bool {
+	u, err := url.Parse(source)
+	if err != nil {
+		return false
+	}
+
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// loadRemotePatch fetches a patch over http/https.
+func loadRemotePatch(ctx context.Context, source string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, remotePatchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error building request for patch %q: %w", source, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching patch %q: %w", source, err)
+	}
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error fetching patch %q: unexpected status %s", source, resp.Status)
+	}
+
+	// read one byte past the limit, so that a response which is exactly at the limit is
+	// accepted and a longer one is reported instead of being silently truncated
+	contents, err := io.ReadAll(io.LimitReader(resp.Body, remotePatchSizeLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("error reading patch %q: %w", source, err)
+	}
+
+	if len(contents) > remotePatchSizeLimit {
+		return nil, fmt.Errorf("error reading patch %q: response exceeds %d bytes", source, remotePatchSizeLimit)
+	}
+
+	return contents, nil
+}
+
+// LoadPatches loads the JSON patch either from value literal, from a file if the patch starts
+// with '@', or over http/https if the patch is a URL.
 //
 // It also tries to guess if the filename was given without '@' prefix.
 //
-//nolint:gocyclo
+// It is LoadPatchesWithContext with a background context; a remote patch is still bounded by
+// its own timeout, but cannot be cancelled by the caller.
 func LoadPatches(in []string) ([]Patch, error) {
+	return LoadPatchesWithContext(context.Background(), in)
+}
+
+// LoadPatchesWithContext is LoadPatches with a context governing any http/https fetch it does.
+//
+// The context is not used for patches read from the local filesystem or supplied inline.
+//
+//nolint:gocyclo
+func LoadPatchesWithContext(ctx context.Context, in []string) ([]Patch, error) {
 	var result []Patch
 
 	for _, patchString := range in {
@@ -85,11 +158,17 @@ func LoadPatches(in []string) ([]Patch, error) {
 			err      error
 		)
 
-		switch {
-		case strings.HasPrefix(patchString, "@"):
-			filename := patchString[1:]
+		// '@' means "not an inline patch"; what follows is a filename or a URL
+		source, explicitRef := strings.CutPrefix(patchString, "@")
 
-			contents, err = os.ReadFile(filename)
+		switch {
+		case isRemotePatch(source):
+			contents, err = loadRemotePatch(ctx, source)
+			if err != nil {
+				return result, err
+			}
+		case explicitRef:
+			contents, err = os.ReadFile(source)
 			if err != nil {
 				return result, err
 			}

--- a/pkg/machinery/config/configpatcher/load_test.go
+++ b/pkg/machinery/config/configpatcher/load_test.go
@@ -5,7 +5,12 @@
 package configpatcher_test
 
 import (
+	"bytes"
+	"context"
 	_ "embed"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -130,4 +135,125 @@ func TestLoadStraightFilename(t *testing.T) {
 
 	assert.Implements(t, (*configpatcher.StrategicMergePatch)(nil), patchList[0])
 	assert.IsType(t, jsonpatch.Patch{}, patchList[1])
+}
+
+// remotePatchSizeLimit mirrors the package's own cap on a remote patch response; it is
+// duplicated here because the test lives outside the package.
+const remotePatchSizeLimit = 1 << 20
+
+// remotePatchServer serves the same testdata the local-file tests use, over http.
+func remotePatchServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	for path, contents := range map[string][]byte{
+		"/patch.json":     jsonPatch,
+		"/patch.yaml":     yamlPatch,
+		"/strategic.yaml": strategicPatch,
+	} {
+		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+			w.Write(contents) //nolint:errcheck
+		})
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestLoadRemotePatches(t *testing.T) {
+	server := remotePatchServer(t)
+
+	patchList, err := configpatcher.LoadPatches([]string{
+		server.URL + "/patch.json",
+		"@" + server.URL + "/strategic.yaml",
+		server.URL + "/patch.yaml",
+		`[{"op":"replace","path":"/some","value": []}]`,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, patchList, 3)
+
+	assert.IsType(t, jsonpatch.Patch{}, patchList[0])
+	assert.Implements(t, (*configpatcher.StrategicMergePatch)(nil), patchList[1])
+
+	merged, ok := patchList[2].(jsonpatch.Patch)
+	require.True(t, ok)
+	assert.Len(t, merged, 2)
+}
+
+func TestLoadRemoteAndLocalPatches(t *testing.T) {
+	server := remotePatchServer(t)
+
+	patchList, err := configpatcher.LoadPatches([]string{
+		"@testdata/patch.json",
+		server.URL + "/patch.yaml",
+	})
+	require.NoError(t, err)
+
+	// both are JSON patches, so they are merged into one exactly as two local ones are
+	require.Len(t, patchList, 1)
+
+	merged, ok := patchList[0].(jsonpatch.Patch)
+	require.True(t, ok)
+	assert.Len(t, merged, 2)
+}
+
+func TestLoadRemotePatchStatus(t *testing.T) {
+	server := remotePatchServer(t)
+
+	_, err := configpatcher.LoadPatches([]string{server.URL + "/no-such-patch.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestLoadRemotePatchAtSizeLimit(t *testing.T) {
+	// a patch exactly at the limit is accepted, and is not truncated: a truncated
+	// strategic merge patch would either fail to parse or, worse, apply partially
+	padded := append(append([]byte{}, strategicPatch...), '\n')
+	padded = append(padded, bytes.Repeat([]byte("#"), remotePatchSizeLimit-len(padded))...)
+	require.Len(t, padded, remotePatchSizeLimit)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(padded) //nolint:errcheck
+	}))
+	t.Cleanup(server.Close)
+
+	patchList, err := configpatcher.LoadPatches([]string{server.URL + "/strategic.yaml"})
+	require.NoError(t, err)
+
+	require.Len(t, patchList, 1)
+	assert.Implements(t, (*configpatcher.StrategicMergePatch)(nil), patchList[0])
+}
+
+func TestLoadRemotePatchOverSizeLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(bytes.Repeat([]byte("#"), remotePatchSizeLimit+1)) //nolint:errcheck
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := configpatcher.LoadPatches([]string{server.URL + "/strategic.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestLoadRemotePatchContext(t *testing.T) {
+	server := remotePatchServer(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := configpatcher.LoadPatchesWithContext(ctx, []string{server.URL + "/patch.json"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLoadUnknownSchemeIsAFilename(t *testing.T) {
+	// only http and https are fetched; anything else keeps its previous meaning, which
+	// for a single word with no spaces is "a filename"
+	_, err := configpatcher.LoadPatches([]string{"file://testdata/strategic.yaml"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/website/content/v1.15/reference/cli.md
+++ b/website/content/v1.15/reference/cli.md
@@ -138,7 +138,7 @@ talosctl cluster create dev [flags]
       --cni-cache-dir string                     CNI cache directory path (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (default "/home/user/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
-      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it
       --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
       --control-plane-port int                   control plane port (load balancer and local API port) (default 6443)
@@ -253,7 +253,7 @@ talosctl cluster create docker [flags]
 ### Options
 
 ```
-      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it
       --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
       --cpus-controlplanes string                the share of CPUs as fraction for each control plane/VM (default "2.0")
@@ -309,7 +309,7 @@ talosctl cluster create qemu [flags]
 
 ```
       --cidr string                              CIDR of the cluster network (default "10.5.0.0/24")
-      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it
       --config-patch-controlplanes stringArray   patch generated machineconfigs (applied to 'controlplane' type)
       --config-patch-workers stringArray         patch generated machineconfigs (applied to 'worker' type)
       --controlplanes int                        the number of controlplanes to create (default 1)
@@ -1836,7 +1836,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
 
 ```
       --additional-sans strings                  additional Subject-Alt-Names for the APIServer certificate
-      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it
       --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
       --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
@@ -2749,7 +2749,7 @@ talosctl machineconfig patch <machineconfig-file> [flags]
 ```
   -h, --help                help for patch
   -o, --output string       output destination. if not specified, output will be printed to stdout
-  -p, --patch stringArray   patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+  -p, --patch stringArray   patch generated machineconfigs (applied to all node types), use @file to read a patch from file, or an http(s) URL to fetch it
 ```
 
 ### SEE ALSO
@@ -2970,7 +2970,7 @@ talosctl patch machineconfig [flags]
   -m, --mode auto, no-reboot, staged, try   apply config mode (default auto)
       --namespace string                    resource namespace (default is to use default namespace per resource)
   -n, --nodes strings                       target the specified nodes
-  -p, --patch stringArray                   the patch to be applied to the resource file, use @file to read a patch from file.
+  -p, --patch stringArray                   the patch to be applied to the resource file, use @file to read a patch from file, or an http(s) URL to fetch it.
       --patch-file string                   a file containing a patch to be applied to the resource.
       --siderov1-keys-dir string            the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string                  the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order


### PR DESCRIPTION
Closes #12966.

## What? (description)

`--config-patch` / `-p` now accepts an `http(s)` URL wherever it accepts a file, so the
example in the issue works:

```
talosctl apply-config -f control-plane.yaml -p https://example.com/v1.12/cilium.yaml
```

`@`-prefixed URLs work too (`-p @https://...`), because `@` already means "this is not an
inline patch" and erroring with *no such file* on one is not useful to anybody.

## Why? (reasoning)

On `main` @3b3e0e9 a bare URL is already being handled — as a filename. `LoadPatches`
treats any argument with no space, no newline and no leading `[`/`{{` as a path, so
`-p https://example.com/patch.yaml` reaches `os.ReadFile` and comes back:

```
open https://example.com/patch.yaml: no such file or directory
```

So this is not a new argument shape, it is a branch for a shape that already lands here.

## What it deliberately does not do

* **Only `http` and `https`.** Any other scheme keeps the meaning it has today — for a
  single bare word, "a filename". There is a test pinning that `file://...` still reaches
  `os.ReadFile`.
* **Patches only, not machine configs.** The issue raises this directly ("we wouldn't want
  to apply certificates from untrusted sources") and I agree, so `--file`/`-f` is
  untouched. Only the patch loader learned about URLs.
* **No new trust.** A patch fetched over http(s) is applied exactly like a local one; there
  is no signature check and none is implied. The operator chooses the URL the same way they
  choose a path.

## Bounds, since this makes a CLI reach the network

* a **30s** timeout per fetch, on a context;
* a **1 MiB** response cap, read as `LimitReader(limit+1)` so a response exactly at the
  cap is accepted and a longer one is an error instead of being **silently truncated** — a
  truncated strategic merge patch is the bad case, because it can still parse;
* a non-200 is an error naming the status, rather than a parse failure on an HTML error
  page.

## API

`LoadPatches` keeps its signature — `pkg/machinery` is a published module and third parties
call it. The new `LoadPatchesWithContext(ctx, in)` is the same function with a context, and
`LoadPatches` delegates to it with `context.Background()`. The three `talosctl` commands
that already sit in a `RunE` pass `cmd.Context()`, so `^C` cancels a fetch;
`GenerateConfigBundle` and the cluster-create maker keep the old entry point, because both
are library helpers whose signatures I did not want to break.

## Tests

`pkg/machinery/config/configpatcher/load_test.go` gains 7 cases over the same `testdata/`
the local-file tests use, served by `httptest`. **5 of them fail on the
unmodified `load.go`** — proved by restoring the pristine file and re-running, not assumed:

```
--- FAIL: TestLoadRemotePatches
    Error: open http://127.0.0.1:41863/patch.json: no such file or directory
--- FAIL: TestLoadRemoteAndLocalPatches
--- FAIL: TestLoadRemotePatchStatus
--- FAIL: TestLoadRemotePatchAtSizeLimit
--- FAIL: TestLoadRemotePatchOverSizeLimit
```

Two do not appear in that list and both are deliberate:

* `TestLoadUnknownSchemeIsAFilename` **passes on both sides**. It is the guard that a
  non-http scheme still means what it meant before; a guard that only passes after the
  change would not be guarding anything.
* `TestLoadRemotePatchContext` **cannot be run against the pristine file at all** — it
  names `LoadPatchesWithContext`, so that tree does not compile. Rather than count it, I am
  telling you it is unmeasured by this method.

## What was run, on `go1.26.6` / linux amd64

| | pristine `main` @3b3e0e9 | with this patch |
| --- | --- | --- |
| `go test ./config/configpatcher/` | 6 passed, 0 failed | 13 passed, 0 failed |

`go build ./cmd/talosctl/... ./pkg/machinery/config/...` rc=0. `gofmt -l` empty over both
trees. `go vet ./pkg/machinery/config/configpatcher/...` clean. `website/.../cli.md` was
updated by hand to match the four flag descriptions this changes — the six generated lines
are a text-only substitution and nothing else in that file moved.

**What I did not run, so it is not being claimed:** `make conformance`, `make lint`,
`make docs` and `make unit-tests`. All four run in containers and there is no Docker on the
machine this was written on, and `make lint` builds a custom `golangci-lint` with your own
`loglinter`/`kubeimportlinter` plugins, which I cannot reproduce either. The full `./...`
suite was not run: 2 cores and 3 GB. If CI turns anything up I will fix it.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above is a run on the machine
that wrote it rather than an inference: the baseline was run on pristine `main` first, and
the failing count was produced by restoring the pristine `load.go` and re-running, which is
also why one test is reported as unmeasurable by that method instead of being counted.

</details>
