### PR TITLE
feat: add light/dark theme support to talosctl dashboard

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard.go
+++ b/cmd/talosctl/cmd/talos/dashboard.go
@@ -14,6 +14,7 @@ import (
 
 var dashboardCmdFlags struct {
 	interval time.Duration
+	theme    string
 }
 
 // dashboardCmd represents the monitor command.
@@ -55,11 +56,13 @@ Keyboard shortcuts:
 			dashboard.WithScreens(dashboard.ScreenSummary, dashboard.ScreenMonitor, dashboard.ScreenResourceExplorer),
 			dashboard.WithAllowExitKeys(true),
 			dashboard.WithNodes(clientFactory.Nodes()...),
+			dashboard.WithTheme(dashboard.Theme(dashboardCmdFlags.theme)),
 		)
 	},
 }
 
 func init() {
 	dashboardCmd.Flags().DurationVarP(&dashboardCmdFlags.interval, "update-interval", "d", 3*time.Second, "interval between updates")
+	dashboardCmd.Flags().StringVarP(&dashboardCmdFlags.theme, "theme", "t", "dark", "color theme (dark, light)")
 	addCommand(dashboardCmd)
 }

--- a/internal/pkg/dashboard/components/footer.go
+++ b/internal/pkg/dashboard/components/footer.go
@@ -75,7 +75,7 @@ func NewFooter(screenKeyToName map[string]string, nodes []string) *Footer {
 					j,
 					tview.BoxDrawingsLightHorizontal,
 					nil,
-					tcell.StyleDefault.Foreground(tcell.ColorWhite),
+					tcell.StyleDefault.Foreground(CurrentColors().LineColor).Background(CurrentColors().BackgroundColor),
 				)
 			}
 		}

--- a/internal/pkg/dashboard/components/gauges.go
+++ b/internal/pkg/dashboard/components/gauges.go
@@ -7,7 +7,6 @@ package components
 import (
 	"math"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/navidys/tvxwidgets"
 	"github.com/rivo/tview"
 
@@ -34,7 +33,7 @@ func NewSystemGauges() *SystemGauges {
 
 	cpuFrame := tview.NewFrame(cpuGauge)
 	cpuFrame.SetBorders(0, 0, 0, 0, 0, 0).
-		AddText("[::b]CPU", true, tview.AlignLeft, tcell.ColorDefault)
+		AddText("[::b]CPU", true, tview.AlignLeft, tview.Styles.PrimaryTextColor)
 
 	root.AddItem(cpuFrame, 0, 0, 1, 1, 0, 0, false)
 
@@ -45,7 +44,7 @@ func NewSystemGauges() *SystemGauges {
 
 	memFrame := tview.NewFrame(memGauge)
 	memFrame.SetBorders(0, 0, 0, 0, 0, 0).
-		AddText("[::b]MEM", true, tview.AlignLeft, tcell.ColorDefault)
+		AddText("[::b]MEM", true, tview.AlignLeft, tview.Styles.PrimaryTextColor)
 
 	root.AddItem(memFrame, 1, 0, 1, 1, 0, 0, false)
 

--- a/internal/pkg/dashboard/components/graphs.go
+++ b/internal/pkg/dashboard/components/graphs.go
@@ -33,7 +33,7 @@ func NewBaseGraph(title string, labels []string) *BaseGraph {
 
 	root := tview.NewFrame(widget.plot).
 		SetBorders(0, 0, 0, 0, 0, 0).
-		AddText(title, true, tview.AlignCenter, tcell.ColorDefault)
+		AddText(title, true, tview.AlignCenter, tview.Styles.PrimaryTextColor)
 
 	widget.plot.SetBorder(false)
 	widget.plot.SetLineColor([]tcell.Color{

--- a/internal/pkg/dashboard/components/horizontalline.go
+++ b/internal/pkg/dashboard/components/horizontalline.go
@@ -27,14 +27,15 @@ func NewHorizontalLine(label string) *HorizontalLine {
 
 	// set the background to be a horizontal line
 	widget.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		colors := CurrentColors()
 		labelLength := len(widget.label)
 
 		for i := x; i < x+width; i++ {
 			for j := y; j < y+height; j++ {
 				if j == y && i >= leftGap && i-leftGap < labelLength {
-					screen.SetContent(i, j, widget.label[i-leftGap], nil, tcell.StyleDefault.Foreground(tcell.ColorYellow))
+					screen.SetContent(i, j, widget.label[i-leftGap], nil, tcell.StyleDefault.Foreground(tcell.ColorYellow).Background(colors.BackgroundColor))
 				} else {
-					screen.SetContent(i, j, tview.BoxDrawingsLightHorizontal, nil, tcell.StyleDefault.Foreground(tcell.ColorWhite))
+					screen.SetContent(i, j, tview.BoxDrawingsLightHorizontal, nil, tcell.StyleDefault.Foreground(colors.LineColor).Background(colors.BackgroundColor))
 				}
 			}
 		}

--- a/internal/pkg/dashboard/components/sparklines.go
+++ b/internal/pkg/dashboard/components/sparklines.go
@@ -25,7 +25,7 @@ func NewBaseSparklineGroup(title string, labels, dataLabels []string) *BaseSpark
 	flex := tview.NewFlex().SetDirection(tview.FlexRow)
 	root := tview.NewFrame(flex).
 		SetBorders(0, 0, 0, 0, 0, 0).
-		AddText(title, true, tview.AlignLeft, tcell.ColorDefault)
+		AddText(title, true, tview.AlignLeft, tview.Styles.PrimaryTextColor)
 
 	colors := []tcell.Color{tcell.ColorRed, tcell.ColorGreen}
 
@@ -35,7 +35,7 @@ func NewBaseSparklineGroup(title string, labels, dataLabels []string) *BaseSpark
 		sparklines[i] = tvxwidgets.NewSparkline()
 		sparklines[i].SetBorder(false)
 		sparklines[i].SetDataTitle(labels[i])
-		sparklines[i].SetTitleColor(tcell.ColorDefault)
+		sparklines[i].SetTitleColor(tview.Styles.PrimaryTextColor)
 		sparklines[i].SetLineColor(colors[i%len(colors)])
 
 		flex.AddItem(sparklines[i], 0, 1, false)

--- a/internal/pkg/dashboard/components/tables.go
+++ b/internal/pkg/dashboard/components/tables.go
@@ -44,15 +44,42 @@ func NewProcessTable() *ProcessTable {
 	widget.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse))
 
 	// Header cells are created once and never replaced.
-	widget.SetCell(0, 0, &tview.TableCell{Text: "[::b]PID", Align: tview.AlignRight, MaxWidth: pidWidth, NotSelectable: true})
-	widget.SetCell(0, 1, &tview.TableCell{Text: "[::b]S", Align: tview.AlignCenter, MaxWidth: stateWidth, NotSelectable: true})
-	widget.SetCell(0, 2, &tview.TableCell{Text: "[::b]CPU%", Align: tview.AlignRight, MaxWidth: cpuWidth, NotSelectable: true})
-	widget.SetCell(0, 3, &tview.TableCell{Text: "[::b]MEM%", Align: tview.AlignRight, MaxWidth: memWidth, NotSelectable: true})
-	widget.SetCell(0, 4, &tview.TableCell{Text: "[::b]VIRT", Align: tview.AlignRight, MaxWidth: virtWidth, NotSelectable: true})
-	widget.SetCell(0, 5, &tview.TableCell{Text: "[::b]RES", Align: tview.AlignRight, MaxWidth: resWidth, NotSelectable: true})
-	widget.SetCell(0, 6, &tview.TableCell{Text: "[::b]TIME+", Align: tview.AlignRight, MaxWidth: timeWidth, NotSelectable: true})
-	widget.SetCell(0, 7, &tview.TableCell{Text: "[::b]THR", Align: tview.AlignRight, MaxWidth: threadsWidth, NotSelectable: true})
-	widget.SetCell(0, 8, &tview.TableCell{Text: "[::b]COMMAND", Align: tview.AlignLeft, NotSelectable: true, Expansion: 1})
+	widget.SetCell(0, 0, &tview.TableCell{
+		Text: "[::b]PID", Align: tview.AlignRight, MaxWidth: pidWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 1, &tview.TableCell{
+		Text: "[::b]S", Align: tview.AlignCenter, MaxWidth: stateWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 2, &tview.TableCell{
+		Text: "[::b]CPU%", Align: tview.AlignRight, MaxWidth: cpuWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 3, &tview.TableCell{
+		Text: "[::b]MEM%", Align: tview.AlignRight, MaxWidth: memWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 4, &tview.TableCell{
+		Text: "[::b]VIRT", Align: tview.AlignRight, MaxWidth: virtWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 5, &tview.TableCell{
+		Text: "[::b]RES", Align: tview.AlignRight, MaxWidth: resWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 6, &tview.TableCell{
+		Text: "[::b]TIME+", Align: tview.AlignRight, MaxWidth: timeWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 7, &tview.TableCell{
+		Text: "[::b]THR", Align: tview.AlignRight, MaxWidth: threadsWidth, NotSelectable: true,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
+	widget.SetCell(0, 8, &tview.TableCell{
+		Text: "[::b]COMMAND", Align: tview.AlignLeft, NotSelectable: true, Expansion: 1,
+		Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+	})
 
 	// Pre-allocate the noData placeholder in row 1.
 	widget.ensureDataRows(1)
@@ -83,15 +110,15 @@ func (widget *ProcessTable) ensureDataRows(n int) {
 
 		var cells [processTableCols]*tview.TableCell
 
-		cells[0] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: pidWidth}
-		cells[1] = &tview.TableCell{Align: tview.AlignCenter, MaxWidth: stateWidth}
-		cells[2] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: cpuWidth}
-		cells[3] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: memWidth}
-		cells[4] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: virtWidth}
-		cells[5] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: resWidth}
-		cells[6] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: timeWidth}
-		cells[7] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: threadsWidth}
-		cells[8] = &tview.TableCell{Align: tview.AlignLeft, Expansion: 1}
+		cells[0] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: pidWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[1] = &tview.TableCell{Align: tview.AlignCenter, MaxWidth: stateWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[2] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: cpuWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[3] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: memWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[4] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: virtWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[5] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: resWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[6] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: timeWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[7] = &tview.TableCell{Align: tview.AlignRight, MaxWidth: threadsWidth, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
+		cells[8] = &tview.TableCell{Align: tview.AlignLeft, Expansion: 1, Color: tview.Styles.PrimaryTextColor, BackgroundColor: tview.Styles.PrimitiveBackgroundColor}
 
 		widget.dataCells = append(widget.dataCells, cells)
 

--- a/internal/pkg/dashboard/components/theme.go
+++ b/internal/pkg/dashboard/components/theme.go
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// Theme defines the color theme for the dashboard.
+type Theme string
+
+const (
+	ThemeDark  Theme = "dark"
+	ThemeLight Theme = "light"
+)
+
+// themeColors holds the color palette for a given theme.
+type themeColors struct {
+	TextColor       tcell.Color
+	LineColor       tcell.Color
+	BackgroundColor tcell.Color
+}
+
+var darkTheme = themeColors{
+	TextColor:       tcell.ColorWhite,
+	LineColor:       tcell.ColorWhite,
+	BackgroundColor: tcell.ColorBlack,
+}
+
+var lightTheme = themeColors{
+	TextColor:       tcell.ColorBlack,
+	LineColor:       tcell.ColorBlack,
+	BackgroundColor: tcell.ColorWhite,
+}
+
+// currentTheme is the active theme, set by SetTheme.
+var currentTheme = ThemeDark
+
+// CurrentColors returns the color palette for the active theme.
+func CurrentColors() themeColors {
+	if currentTheme == ThemeLight {
+		return lightTheme
+	}
+
+	return darkTheme
+}
+
+// SetTheme sets the active theme and applies theme-specific styles.
+func SetTheme(theme Theme) {
+	currentTheme = theme
+
+	colors := CurrentColors()
+
+	tview.Styles.PrimitiveBackgroundColor = colors.BackgroundColor
+	tview.Styles.ContrastBackgroundColor = colors.BackgroundColor
+	tview.Styles.MoreContrastBackgroundColor = colors.TextColor
+	tview.Styles.PrimaryTextColor = colors.TextColor
+	tview.Styles.BorderColor = colors.TextColor
+	tview.Styles.TitleColor = colors.TextColor
+	tview.Styles.GraphicsColor = colors.TextColor
+}

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -139,7 +139,7 @@ func buildDashboard(ctx context.Context, cli *client.Client, opts ...Option) (*D
 	}
 
 	nodes := getSortedNodeAliases(options.nodes)
-
+	components.SetTheme(components.Theme(options.theme))
 	dashboard := &Dashboard{
 		cli:      cli,
 		interval: options.interval,

--- a/internal/pkg/dashboard/networkconfig.go
+++ b/internal/pkg/dashboard/networkconfig.go
@@ -119,7 +119,7 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 	})
 	widget.interfaceDropdown.SetListStyles(
 		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.MoreContrastBackgroundColor),
-		tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tview.Styles.PrimaryTextColor),
+		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.PrimaryTextColor),
 	)
 
 	widget.vlanIDField = tview.NewInputField().SetLabel(formItemVLANID).SetAcceptanceFunc(tview.InputFieldInteger)
@@ -132,7 +132,7 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 	})
 	widget.modeDropdown.SetListStyles(
 		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.MoreContrastBackgroundColor),
-		tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tview.Styles.PrimaryTextColor),
+		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.PrimaryTextColor),
 	)
 
 	widget.addressesField = tview.NewInputField().SetLabel(formItemAddresses)

--- a/internal/pkg/dashboard/options.go
+++ b/internal/pkg/dashboard/options.go
@@ -9,11 +9,20 @@ import (
 	"time"
 )
 
+// Theme defines the color theme for the dashboard.
+type Theme string
+
+const (
+	ThemeDark  Theme = "dark"
+	ThemeLight Theme = "light"
+)
+
 type options struct {
 	interval      time.Duration
 	allowExitKeys bool
 	screens       []Screen
 	nodes         []string
+	theme         Theme
 }
 
 func defaultOptions() *options {
@@ -26,6 +35,7 @@ func defaultOptions() *options {
 			ScreenNetworkConfig,
 		},
 		nodes: []string{""}, // use "local" node by default
+		theme: ThemeDark,
 	}
 }
 
@@ -58,5 +68,12 @@ func WithScreens(screens ...Screen) Option {
 func WithNodes(nodes ...string) Option {
 	return func(o *options) {
 		o.nodes = slices.Clone(nodes)
+	}
+}
+
+// WithTheme sets the color theme for the dashboard.
+func WithTheme(theme Theme) Option {
+	return func(o *options) {
+		o.theme = theme
 	}
 }

--- a/internal/pkg/dashboard/resourceexplorer.go
+++ b/internal/pkg/dashboard/resourceexplorer.go
@@ -102,7 +102,7 @@ func NewResourceExplorerGrid(ctx context.Context, dashboard *Dashboard) *Resourc
 	widget.filterInput = tview.NewInputField()
 	widget.filterInput.SetLabel("filter: ")
 	widget.filterInput.SetLabelColor(tcell.ColorYellow)
-	widget.filterInput.SetFieldBackgroundColor(tcell.ColorDefault)
+	widget.filterInput.SetFieldBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
 	widget.filterInput.SetChangedFunc(func(text string) {
 		widget.filterText = text
 		widget.renderTypesTable()
@@ -286,8 +286,10 @@ func (widget *ResourceExplorerGrid) deactivateFilter(clearText bool) {
 func (widget *ResourceExplorerGrid) loadResourceTypes() {
 	widget.initTypesTableHeader()
 	widget.typesTable.SetCell(1, 0, &tview.TableCell{
-		Text:          "[gray]Loading...[-]",
-		NotSelectable: true,
+		Text:            "[gray]Loading...[-]",
+		NotSelectable:   true,
+		Color:           tview.Styles.PrimaryTextColor,
+		BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 	})
 
 	ctx := utils.NodeContext(widget.ctx, widget.selectedNode)
@@ -298,8 +300,10 @@ func (widget *ResourceExplorerGrid) loadResourceTypes() {
 			widget.app.QueueUpdateDraw(func() {
 				widget.initTypesTableHeader()
 				widget.typesTable.SetCell(1, 0, &tview.TableCell{
-					Text:          fmt.Sprintf("[red]%s[-]", formatError(err)),
-					NotSelectable: true,
+					Text:            fmt.Sprintf("[red]%s[-]", formatError(err)),
+					NotSelectable:   true,
+					Color:           tview.Styles.PrimaryTextColor,
+					BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 				})
 			})
 
@@ -361,21 +365,24 @@ func (widget *ResourceExplorerGrid) renderTypesTable() {
 		}
 
 		widget.typesTable.SetCell(row, 0, &tview.TableCell{
-			Text:      spec.Type,
-			Align:     tview.AlignLeft,
-			Color:     tcell.ColorWhite,
-			Reference: rd, // used by selectResourceType to retrieve the RD
-			Expansion: 1,
+			Text:            spec.Type,
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+			Reference:       rd,
+			Expansion:       1,
 		})
 		widget.typesTable.SetCell(row, 1, &tview.TableCell{
-			Text:  spec.DefaultNamespace,
-			Align: tview.AlignLeft,
-			Color: tcell.ColorWhite,
+			Text:            spec.DefaultNamespace,
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 		})
 		widget.typesTable.SetCell(row, 2, &tview.TableCell{
-			Text:  strings.Join(spec.Aliases, ", "),
-			Align: tview.AlignLeft,
-			Color: tcell.ColorGray,
+			Text:            strings.Join(spec.Aliases, ", "),
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 		})
 
 		row++
@@ -465,8 +472,10 @@ func (widget *ResourceExplorerGrid) initResourceTableHeader() {
 	}
 
 	widget.resourceTable.SetCell(1, 0, &tview.TableCell{
-		Text:          "[gray]Loading...[-]",
-		NotSelectable: true,
+		Text:            "[gray]Loading...[-]",
+		NotSelectable:   true,
+		Color:           tview.Styles.PrimaryTextColor,
+		BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 	})
 }
 
@@ -491,7 +500,7 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 		md := res.Metadata()
 
 		phaseText := tview.Escape(md.Phase().String())
-		phaseColor := tcell.ColorWhite
+		phaseColor := tview.Styles.PrimaryTextColor
 
 		if md.Phase() == resource.PhaseTearingDown {
 			phaseText = "[red]" + phaseText + "[-]"
@@ -499,25 +508,29 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 		}
 
 		widget.resourceTable.SetCell(i+1, 0, &tview.TableCell{
-			Text:      tview.Escape(md.ID()),
-			Align:     tview.AlignLeft,
-			Color:     tcell.ColorWhite,
-			Expansion: 1,
+			Text:            tview.Escape(md.ID()),
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
+			Expansion:       1,
 		})
 		widget.resourceTable.SetCell(i+1, 1, &tview.TableCell{
-			Text:  tview.Escape(md.Version().String()),
-			Align: tview.AlignLeft,
-			Color: tcell.ColorGray,
+			Text:            tview.Escape(md.Version().String()),
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 		})
 		widget.resourceTable.SetCell(i+1, 2, &tview.TableCell{
-			Text:  phaseText,
-			Align: tview.AlignLeft,
-			Color: phaseColor,
+			Text:            phaseText,
+			Align:           tview.AlignLeft,
+			Color:           phaseColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 		})
 		widget.resourceTable.SetCell(i+1, 3, &tview.TableCell{
-			Text:  tview.Escape(md.Owner()),
-			Align: tview.AlignLeft,
-			Color: tcell.ColorGray,
+			Text:            tview.Escape(md.Owner()),
+			Align:           tview.AlignLeft,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 		})
 
 		if len(widget.dynamicColumns) > 0 {
@@ -530,9 +543,10 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 				}
 
 				widget.resourceTable.SetCell(i+1, 4+j, &tview.TableCell{
-					Text:  tview.Escape(text),
-					Align: tview.AlignLeft,
-					Color: tcell.ColorWhite,
+					Text:            tview.Escape(text),
+					Align:           tview.AlignLeft,
+					Color:           tview.Styles.PrimaryTextColor,
+					BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 				})
 			}
 		}
@@ -670,9 +684,11 @@ func (widget *ResourceExplorerGrid) marshalSpec(res resource.Resource) any {
 func (widget *ResourceExplorerGrid) showResourceTableError(msg string) {
 	widget.initResourceTableHeader()
 	widget.resourceTable.SetCell(1, 0, &tview.TableCell{
-		Text:          fmt.Sprintf("[red]%s[-]", tview.Escape(msg)),
-		NotSelectable: true,
-		Expansion:     1,
+		Text:            fmt.Sprintf("[red]%s[-]", tview.Escape(msg)),
+		NotSelectable:   true,
+		Expansion:       1,
+		Color:           tview.Styles.PrimaryTextColor,
+		BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 	})
 }
 
@@ -865,9 +881,10 @@ func writeScalar(sb *strings.Builder, node *yaml.Node) {
 // headerCell creates a bold header cell for tables.
 func headerCell(text string) *tview.TableCell {
 	return &tview.TableCell{
-		Text:          "[::b]" + text,
-		Align:         tview.AlignLeft,
-		NotSelectable: true,
-		Color:         tcell.ColorWhite,
+		Text:            "[::b]" + text,
+		Align:           tview.AlignLeft,
+		NotSelectable:   true,
+		Color:           tview.Styles.PrimaryTextColor,
+		BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 	}
 }


### PR DESCRIPTION
# Pull Request

Fixes #13524


## What? (description)

Add `--theme` flag (dark/light) that sets tview global styles. All dashboard components now use theme-aware colors instead of hardcoded `tcell.ColorWhite/ColorDefault`.
There was another option to auto detect the system theme but that gets a bit tricky/difficult we could either use a env variable like `COLORFGBG` but it is not used everywhere or use Operating System Command escape sequences (OSC 11) but seems far fetched for this task.
Currently the dashboard defaults to dark mode, unless a theme is mentioned like:
`talosctl dashboard -n 192.168.31.133 -e 192.168.31.133 -t light`

## Why? (reasoning)

Add Support for light theme.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.


<img width="1916" height="1072" alt="Screenshot from 2026-08-21 12-30-52" src="https://github.com/user-attachments/assets/266b0052-fc31-4f46-9302-ec3f25d10a2d" />
<img width="1916" height="1072" alt="Screenshot from 2026-08-21 12-32-10" src="https://github.com/user-attachments/assets/c4ddb02b-7c9b-41ab-835e-f2c589ae64a4" />
<img width="1916" height="1072" alt="Screenshot from 2026-08-21 12-31-12" src="https://github.com/user-attachments/assets/2836f66d-7d0c-46d8-b4ba-ac1528507c57" />
<img width="1916" height="1072" alt="Screenshot from 2026-08-21 12-31-52" src="https://github.com/user-attachments/assets/bb211eb4-1396-4f8f-b8d3-6c738fba74bc" />
<img width="1916" height="1072" alt="Screenshot from 2026-08-21 12-32-01" src="https://github.com/user-attachments/assets/8f3edcce-7d06-4b6f-9d00-a602b8877615" />
