### PR TITLE
fix: persist in-memory meta on fresh install

### DIFF
--- a/internal/app/lifecycle/container.go
+++ b/internal/app/lifecycle/container.go
@@ -31,6 +31,7 @@ import (
 	containerdrunner "github.com/siderolabs/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/siderolabs/talos/internal/pkg/capability"
 	"github.com/siderolabs/talos/internal/pkg/cgroup"
+	"github.com/siderolabs/talos/internal/pkg/environment"
 	"github.com/siderolabs/talos/internal/pkg/install"
 	"github.com/siderolabs/talos/internal/pkg/selinux"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -115,7 +116,7 @@ func runInstallerContainer(ctx context.Context, pidRecorder pid.Recorder, rc *co
 	// build container spec
 	mounts := buildMounts()
 	args := buildInstallerArgs(rc.disk, rc.platform, &options)
-	specOpts := buildSpecOpts(img, args, mounts, options.Environment(nil), cgroupPath)
+	specOpts := buildSpecOpts(img, args, mounts, options.Environment(environment.Get(nil)), cgroupPath)
 
 	// create container
 	ctr, err := c8dClient.NewContainer(

--- a/internal/app/lifecycle/lifecycle.go
+++ b/internal/app/lifecycle/lifecycle.go
@@ -135,6 +135,20 @@ func (s *Service) Install(req *machine.LifecycleServiceInstallRequest, ss grpc.S
 		return status.Error(codes.Internal, fmt.Sprintf("installation failed: %v", err))
 	}
 
+	// the installer created the META partition from scratch: merge the in-memory META with what the
+	// installer wrote and persist it, as there is no install sequence around this call to do it
+	// (and the reboot comes as a separate API call)
+	resources := s.runtime.State().V1Alpha2().Resources()
+	meta := s.runtime.State().Machine().Meta()
+
+	if err = install.ReloadMeta(ctx, resources, meta); err != nil {
+		return status.Error(codes.Internal, fmt.Sprintf("failed to reload META: %v", err))
+	}
+
+	if err = install.SyncMeta(ctx, resources, meta); err != nil {
+		return status.Error(codes.Internal, fmt.Sprintf("failed to sync META: %v", err))
+	}
+
 	return nil
 }
 

--- a/internal/app/machined/pkg/controllers/runtime/unattended_install.go
+++ b/internal/app/machined/pkg/controllers/runtime/unattended_install.go
@@ -88,6 +88,19 @@ func NewUnattendedInstallController(rt v1alpha1runtime.Runtime) *UnattendedInsta
 				return err
 			}
 
+			// the install sequence (which reloads/flushes META after the installer) is skipped when the
+			// UnattendedInstallConfig document drives the install, so merge the in-memory META with what
+			// the installer wrote into the partition it just created here
+			meta := rt.State().Machine().Meta()
+
+			if err := install.ReloadMeta(ctx, resources, meta); err != nil {
+				return err
+			}
+
+			if err := install.SyncMeta(ctx, resources, meta); err != nil {
+				return err
+			}
+
 			return crires.WaitForImageCacheCopy(ctx, resources)
 		},
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1810,11 +1810,7 @@ func ReloadMeta(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 func FlushMeta(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
 		// META partition should be created at this point.
-		if _, err := waitForVolumeReady(ctx, r, constants.MetaPartitionLabel); err != nil {
-			return err
-		}
-
-		return r.State().Machine().Meta().Flush()
+		return install.SyncMeta(ctx, r.State().V1Alpha2().Resources(), r.State().Machine().Meta())
 	}, "flushMeta"
 }
 
@@ -1964,8 +1960,4 @@ func logError(err error, logger *log.Logger) error {
 	logger.Printf("WARNING: task failed: %s", err)
 
 	return nil
-}
-
-func waitForVolumeReady(ctx context.Context, r runtime.Runtime, volumeID string) (*blockres.VolumeStatus, error) {
-	return blockres.WaitForVolumePhase(ctx, r.State().V1Alpha2().Resources(), volumeID, blockres.VolumePhaseReady)
 }

--- a/internal/integration/provision/maintenance_siderolink.go
+++ b/internal/integration/provision/maintenance_siderolink.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v4"
 	"google.golang.org/grpc/codes"
@@ -66,11 +67,25 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		DefaultSettings.CurrentVersion,
 	)
 
+	// A META value seeded via the kernel command line, the way the Image Factory does it for the
+	// images it builds with META customization: while the machine runs in maintenance mode the value
+	// is only kept in memory (the META partition doesn't exist yet), so it has to be persisted as
+	// part of the install performed via the LifecycleService.
+	const metaValueFromCmdline = "seeded-from-cmdline"
+
+	bootKernelArgs := procfs.NewCmdline("")
+	bootKernelArgs.Append(
+		constants.KernelParamEnvironment,
+		constants.MetaValuesEnvVar+"="+meta.Values{{Key: meta.UserReserved2, Value: metaValueFromCmdline}}.Encode(false),
+	)
+
 	suite.setupCluster(clusterOptions{
 		ClusterName: "maintenance-siderolink",
 
 		ControlplaneNodes: maintenanceControlplanes,
 		WorkerNodes:       maintenanceWorkers,
+
+		InjectBootKernelArgs: bootKernelArgs,
 
 		SourceKernelPath:     helpers.ArtifactPath(constants.KernelAssetWithArch),
 		SourceInitramfsPath:  helpers.ArtifactPath(constants.InitramfsAssetWithArch),
@@ -200,6 +215,28 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 				suite.Assert().Equal(DefaultSettings.CurrentVersion, version.GetMessages()[0].GetVersion().GetTag())
 			}
 		}, time.Minute, time.Second, "machines should listen on SideroLink IPs")
+	})
+
+	suite.Run("check META value seeded from the kernel cmdline", func() {
+		ctx, cancel := context.WithTimeout(suite.ctx, 15*time.Second)
+		defer cancel()
+
+		// the machines are not installed yet, so the value is only in memory at this point
+		for _, maintenanceClient := range sideroLinkMaintenanceClients {
+			rtestutils.AssertResource(
+				ctx, suite.T(), maintenanceClient.COSI, runtime.MetaKeyTagToID(meta.UserReserved2),
+				func(metaValue *runtime.MetaKey, asrt *assert.Assertions) {
+					asrt.Equal(metaValueFromCmdline, metaValue.TypedSpec().Value)
+				},
+			)
+
+			rtestutils.AssertResource(
+				ctx, suite.T(), maintenanceClient.COSI, constants.MetaPartitionLabel,
+				func(volumeStatus *block.VolumeStatus, asrt *assert.Assertions) {
+					asrt.Equal(block.VolumePhaseMissing, volumeStatus.TypedSpec().Phase)
+				},
+			)
+		}
 	})
 
 	suite.Run("wipe the disk", func() {
@@ -332,12 +369,6 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		}
 	})
 
-	suite.Run("write META value", func() {
-		maintenanceClient := sideroLinkMaintenanceClients[0]
-
-		suite.Require().NoError(maintenanceClient.MetaWrite(suite.ctx, meta.UserReserved1, []byte("provision")))
-	})
-
 	suite.Run("reboot one machine", func() {
 		maintenanceClient := sideroLinkMaintenanceClients[0]
 		insecureMaintenanceClient := maintenanceClients[0]
@@ -381,18 +412,27 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		suite.Assert().NotEqual(currentBootID, newBootID, "boot ID should change after reboot")
 	})
 
-	suite.Run("read back META value", func() {
+	// nothing has flushed META on this machine other than the install itself: the value has to have
+	// been carried from the kernel cmdline into the META partition the installer created
+	suite.Run("read back META value seeded from the kernel cmdline", func() {
 		ctx, cancel := context.WithTimeout(suite.ctx, 15*time.Second)
 		defer cancel()
 
 		maintenanceClient := sideroLinkMaintenanceClients[0]
 
 		rtestutils.AssertResource(
-			ctx, suite.T(), maintenanceClient.COSI, runtime.MetaKeyTagToID(meta.UserReserved1),
+			ctx, suite.T(), maintenanceClient.COSI, runtime.MetaKeyTagToID(meta.UserReserved2),
 			func(metaValue *runtime.MetaKey, asrt *assert.Assertions) {
-				asrt.Equal("provision", metaValue.TypedSpec().Value)
+				asrt.Equal(metaValueFromCmdline, metaValue.TypedSpec().Value)
 			},
 		)
+	})
+
+	// MetaWrite flushes the whole in-memory META, so this has to come after the assertion above
+	suite.Run("write META value", func() {
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+
+		suite.Require().NoError(maintenanceClient.MetaWrite(suite.ctx, meta.UserReserved1, []byte("provision")))
 	})
 
 	suite.Run("upgrade using legacy API", func() {
@@ -437,6 +477,25 @@ func (suite *MaintenanceSideroLinkSuite) TestAPI() {
 		// check that boot ID has changed after reboot
 		newBootID := suite.readBootID(maintenanceClient)
 		suite.Assert().NotEqual(currentBootID, newBootID, "boot ID should change after reboot")
+	})
+
+	suite.Run("read back META values after the upgrade", func() {
+		ctx, cancel := context.WithTimeout(suite.ctx, 15*time.Second)
+		defer cancel()
+
+		maintenanceClient := sideroLinkMaintenanceClients[0]
+
+		for tag, expected := range map[uint8]string{
+			meta.UserReserved1: "provision",
+			meta.UserReserved2: metaValueFromCmdline,
+		} {
+			rtestutils.AssertResource(
+				ctx, suite.T(), maintenanceClient.COSI, runtime.MetaKeyTagToID(tag),
+				func(metaValue *runtime.MetaKey, asrt *assert.Assertions) {
+					asrt.Equal(expected, metaValue.TypedSpec().Value)
+				},
+			)
+		}
 	})
 
 	suite.Run("apply config and have a cluster", func() {

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -768,7 +768,12 @@ type clusterOptions struct {
 	ControlplaneNodes int
 	WorkerNodes       int
 
+	// InjectExtraKernelArgs injects kernel args via the systemd-stub, i.e. they only take effect on
+	// the UKI boot of an installed machine.
 	InjectExtraKernelArgs *procfs.Cmdline
+	// InjectBootKernelArgs injects kernel args directly on the kernel command line, i.e. they take
+	// effect on the initial (pre-install) boot as well.
+	InjectBootKernelArgs *procfs.Cmdline
 
 	SourceKernelPath     string
 	SourceInitramfsPath  string
@@ -1047,6 +1052,7 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 					},
 				},
 				Config:              suite.configBundle.ControlPlane(),
+				ExtraKernelArgs:     options.InjectBootKernelArgs,
 				SDStubKernelArgs:    options.InjectExtraKernelArgs,
 				SkipInjectingConfig: options.WithSkipInjectingConfig,
 			},
@@ -1069,6 +1075,7 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 					},
 				},
 				Config:              suite.configBundle.Worker(),
+				ExtraKernelArgs:     options.InjectBootKernelArgs,
 				SDStubKernelArgs:    options.InjectExtraKernelArgs,
 				SkipInjectingConfig: options.WithSkipInjectingConfig,
 			},

--- a/internal/pkg/install/meta.go
+++ b/internal/pkg/install/meta.go
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+// metaWaitTimeout bounds the wait for the META partition created by the installer to become a ready
+// volume.
+const metaWaitTimeout = time.Minute
+
+// ReloadMeta reloads the in-memory META from the META partition created by the installer, merging
+// the in-memory values on top of the on-disk ones.
+func ReloadMeta(ctx context.Context, st state.State, meta runtime.Meta) error {
+	ctx, cancel := context.WithTimeout(ctx, metaWaitTimeout)
+	defer cancel()
+
+	if err := waitForMeta(ctx, st); err != nil {
+		return err
+	}
+
+	if err := meta.Reload(ctx); err != nil {
+		return fmt.Errorf("failed to reload META: %w", err)
+	}
+
+	return nil
+}
+
+// SyncMeta writes the in-memory META to the META partition created by the installer.
+//
+// The installer creates the META partition from scratch, so in-memory META values are lost unless
+// they are explicitly flushed: e.g. the values seeded from `talos.environment=INSTALLER_META_BASE64=...`
+// while the machine was running in maintenance mode, or any tag set at runtime via the META API.
+//
+// Call ReloadMeta first to merge in the values the installer itself has written, otherwise they are
+// overwritten by the in-memory contents.
+func SyncMeta(ctx context.Context, st state.State, meta runtime.Meta) error {
+	ctx, cancel := context.WithTimeout(ctx, metaWaitTimeout)
+	defer cancel()
+
+	if err := waitForMeta(ctx, st); err != nil {
+		return err
+	}
+
+	if err := meta.Flush(); err != nil {
+		return fmt.Errorf("failed to flush META: %w", err)
+	}
+
+	return nil
+}
+
+func waitForMeta(ctx context.Context, st state.State) error {
+	if _, err := blockres.WaitForVolumePhase(ctx, st, constants.MetaPartitionLabel, blockres.VolumePhaseReady); err != nil {
+		return fmt.Errorf("failed to wait for the META volume: %w", err)
+	}
+
+	return nil
+}

--- a/internal/pkg/install/meta_test.go
+++ b/internal/pkg/install/meta_test.go
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/install"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	blockres "github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+// fakeMeta records the operations performed on the META.
+type fakeMeta struct {
+	calls []string
+}
+
+func (m *fakeMeta) ReadTag(uint8) (string, bool)                             { return "", false }
+func (m *fakeMeta) ReadTagBytes(uint8) ([]byte, bool)                        { return nil, false }
+func (m *fakeMeta) SetTag(context.Context, uint8, string) (bool, error)      { return false, nil }
+func (m *fakeMeta) SetTagBytes(context.Context, uint8, []byte) (bool, error) { return false, nil }
+func (m *fakeMeta) DeleteTag(context.Context, uint8) (bool, error)           { return false, nil }
+
+func (m *fakeMeta) Reload(context.Context) error {
+	m.calls = append(m.calls, "reload")
+
+	return nil
+}
+
+func (m *fakeMeta) Flush() error {
+	m.calls = append(m.calls, "flush")
+
+	return nil
+}
+
+func stateWithMetaVolume(t *testing.T, ctx context.Context, phase blockres.VolumePhase) state.State { //nolint:revive
+	t.Helper()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	volumeStatus := blockres.NewVolumeStatus(blockres.NamespaceName, constants.MetaPartitionLabel)
+	volumeStatus.TypedSpec().Phase = phase
+
+	require.NoError(t, st.Create(ctx, volumeStatus))
+
+	return st
+}
+
+func TestReloadMeta(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	meta := &fakeMeta{}
+
+	require.NoError(t, install.ReloadMeta(ctx, stateWithMetaVolume(t, ctx, blockres.VolumePhaseReady), meta))
+	require.Equal(t, []string{"reload"}, meta.calls)
+}
+
+func TestSyncMeta(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	meta := &fakeMeta{}
+
+	require.NoError(t, install.SyncMeta(ctx, stateWithMetaVolume(t, ctx, blockres.VolumePhaseReady), meta))
+	require.Equal(t, []string{"flush"}, meta.calls)
+}
+
+func TestMetaVolumeNotReady(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	st := stateWithMetaVolume(t, ctx, blockres.VolumePhaseMissing)
+
+	reloadMeta := &fakeMeta{}
+	require.Error(t, install.ReloadMeta(ctx, st, reloadMeta))
+	require.Empty(t, reloadMeta.calls)
+
+	syncMeta := &fakeMeta{}
+	require.Error(t, install.SyncMeta(ctx, st, syncMeta))
+	require.Empty(t, syncMeta.calls)
+}


### PR DESCRIPTION
The installer creates the meta partition from scratch, so any in-memory
values are lost unless flushed: e.g. tags seeded via
talos.environment=INSTALLER_META_BASE64 while running in maintenance
mode, or values set at runtime via the meta api.

The normal install sequence handles this with its reload/flush tasks,
but lifecycle service installs and unattended installs skip it. add
install.ReloadMeta/install.SyncMeta helpers (wait for volume ready,
then reload/flush) and call them after the installer runs in both
paths; reuse SyncMeta for the sequencer flush task.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
