### PR TITLE
fix: use the UKI command line when the config has no install section

### DIFF
--- a/cmd/installer/cmd/installer/install.go
+++ b/cmd/installer/cmd/installer/install.go
@@ -81,6 +81,13 @@ func runInstallCmd(ctx context.Context) (err error) {
 		// then we should set the option to true
 		grubUseUKICmdline := config.Machine() == nil || config.Machine().Install().GrubUseUKICmdline()
 
+		// A config with no .machine.install section has nowhere to hold extraKernelArgs, so there is no
+		// legacy command line to preserve and the UKI is the only source for the kernel arguments. The
+		// check above reads a missing setting the same as an explicit false, so look at the raw config.
+		if raw := config.RawV1Alpha1(); raw != nil && raw.MachineConfig != nil && raw.MachineConfig.MachineInstall == nil { //nolint:staticcheck // legacy configuration
+			grubUseUKICmdline = true
+		}
+
 		// the UnattendedInstallConfig document takes precedence over the deprecated .machine.install section.
 		if config.UnattendedInstallConfig() != nil {
 			// legacyBIOSSupport is not supported in the new config.


### PR DESCRIPTION
On a machine booted with GRUB, the kernel command line comes from the UKI only when grubUseUKICmdline is enabled. A configuration generated for Talos 1.14 or later has no install section at all, since the install disk moved to the unattended install document, and a missing setting reads as disabled without being distinguishable from a configuration that disables it deliberately. The command line of such a machine is then rebuilt from the platform defaults on every upgrade, and the kernel arguments baked into the installer image are dropped with no error reported.

A configuration with no install section has nowhere to hold extra kernel arguments, so it has no legacy command line to preserve and the UKI is the only source those arguments can have. Treat that case as enabled. Configurations that do carry an install section keep the behavior they have today, so machines that still rely on install-time kernel arguments are untouched.

This is reachable when the unattended install document is absent as well, which is the case for machines driven through the lifecycle API by a caller that does not submit it. Such a machine is installed with the UKI command line, because the lifecycle install call enables the setting explicitly, and then loses it on its first upgrade.
