### PR TITLE
fix: use default terminal theme colors in talosctl dashboard

### DIFF
--- a/internal/pkg/dashboard/components/footer.go
+++ b/internal/pkg/dashboard/components/footer.go
@@ -75,7 +75,7 @@ func NewFooter(screenKeyToName map[string]string, nodes []string) *Footer {
 					j,
 					tview.BoxDrawingsLightHorizontal,
 					nil,
-					tcell.StyleDefault.Foreground(tcell.ColorWhite),
+					tcell.StyleDefault,
 				)
 			}
 		}

--- a/internal/pkg/dashboard/components/horizontalline.go
+++ b/internal/pkg/dashboard/components/horizontalline.go
@@ -34,7 +34,7 @@ func NewHorizontalLine(label string) *HorizontalLine {
 				if j == y && i >= leftGap && i-leftGap < labelLength {
 					screen.SetContent(i, j, widget.label[i-leftGap], nil, tcell.StyleDefault.Foreground(tcell.ColorYellow))
 				} else {
-					screen.SetContent(i, j, tview.BoxDrawingsLightHorizontal, nil, tcell.StyleDefault.Foreground(tcell.ColorWhite))
+					screen.SetContent(i, j, tview.BoxDrawingsLightHorizontal, nil, tcell.StyleDefault)
 				}
 			}
 		}

--- a/internal/pkg/dashboard/dashboard.go
+++ b/internal/pkg/dashboard/dashboard.go
@@ -28,8 +28,19 @@ import (
 )
 
 func init() {
-	// set background to be left as the default color of the terminal
+	// Inherit the color scheme from the terminal: leave the foreground and background
+	// at the terminal defaults, so that the dashboard is readable on both dark and
+	// light themes without any detection or configuration.
+	//
+	// Accent colors elsewhere in the dashboard are ANSI-16 names (red, green, yellow,
+	// gray, ...) on purpose: tcell renders those as palette indices, so the terminal
+	// remaps them to the theme the user picked. Absolute (RGB) colors bypass the
+	// palette and must not be used.
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
+	tview.Styles.PrimaryTextColor = tcell.ColorDefault
+	tview.Styles.BorderColor = tcell.ColorDefault
+	tview.Styles.TitleColor = tcell.ColorDefault
+	tview.Styles.GraphicsColor = tcell.ColorDefault
 }
 
 // Screen is a dashboard screen.

--- a/internal/pkg/dashboard/networkconfig.go
+++ b/internal/pkg/dashboard/networkconfig.go
@@ -66,6 +66,18 @@ type NetworkConfigGrid struct {
 	nodeMap      map[string]*networkConfigData
 }
 
+// dropdownListStyles returns the styles for the drop-down popup list.
+//
+// The popup keeps a background of its own so that it stands out from whatever it
+// covers, but the text color is left at the terminal default, and the selected entry
+// is marked with reverse video rather than a hardcoded color pair, so that both work
+// on dark and light terminals alike.
+func dropdownListStyles() (unselected, selected tcell.Style) {
+	unselected = tcell.StyleDefault.Background(tview.Styles.MoreContrastBackgroundColor)
+
+	return unselected, unselected.Attributes(tcell.AttrReverse)
+}
+
 // NewNetworkConfigGrid initializes NetworkConfigGrid.
 func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkConfigGrid {
 	widget := &NetworkConfigGrid{
@@ -117,10 +129,7 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 	widget.interfaceDropdown.SetOptions([]string{interfaceNone}, func(_ string, _ int) {
 		widget.formEdited()
 	})
-	widget.interfaceDropdown.SetListStyles(
-		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.MoreContrastBackgroundColor),
-		tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tview.Styles.PrimaryTextColor),
-	)
+	widget.interfaceDropdown.SetListStyles(dropdownListStyles())
 
 	widget.vlanIDField = tview.NewInputField().SetLabel(formItemVLANID).SetAcceptanceFunc(tview.InputFieldInteger)
 	widget.vlanIDField.SetBlurFunc(widget.formEdited)
@@ -130,10 +139,7 @@ func NewNetworkConfigGrid(ctx context.Context, dashboard *Dashboard) *NetworkCon
 	widget.modeDropdown.SetOptions([]string{ModeDHCP, ModeStatic}, func(_ string, _ int) {
 		widget.formEdited()
 	})
-	widget.modeDropdown.SetListStyles(
-		tcell.StyleDefault.Foreground(tview.Styles.PrimitiveBackgroundColor).Background(tview.Styles.MoreContrastBackgroundColor),
-		tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tview.Styles.PrimaryTextColor),
-	)
+	widget.modeDropdown.SetListStyles(dropdownListStyles())
 
 	widget.addressesField = tview.NewInputField().SetLabel(formItemAddresses)
 	widget.addressesField.SetBlurFunc(widget.formEdited)

--- a/internal/pkg/dashboard/resourceexplorer.go
+++ b/internal/pkg/dashboard/resourceexplorer.go
@@ -363,14 +363,14 @@ func (widget *ResourceExplorerGrid) renderTypesTable() {
 		widget.typesTable.SetCell(row, 0, &tview.TableCell{
 			Text:      spec.Type,
 			Align:     tview.AlignLeft,
-			Color:     tcell.ColorWhite,
+			Color:     tcell.ColorDefault,
 			Reference: rd, // used by selectResourceType to retrieve the RD
 			Expansion: 1,
 		})
 		widget.typesTable.SetCell(row, 1, &tview.TableCell{
 			Text:  spec.DefaultNamespace,
 			Align: tview.AlignLeft,
-			Color: tcell.ColorWhite,
+			Color: tcell.ColorDefault,
 		})
 		widget.typesTable.SetCell(row, 2, &tview.TableCell{
 			Text:  strings.Join(spec.Aliases, ", "),
@@ -491,17 +491,15 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 		md := res.Metadata()
 
 		phaseText := tview.Escape(md.Phase().String())
-		phaseColor := tcell.ColorWhite
 
 		if md.Phase() == resource.PhaseTearingDown {
 			phaseText = "[red]" + phaseText + "[-]"
-			phaseColor = tcell.ColorDefault
 		}
 
 		widget.resourceTable.SetCell(i+1, 0, &tview.TableCell{
 			Text:      tview.Escape(md.ID()),
 			Align:     tview.AlignLeft,
-			Color:     tcell.ColorWhite,
+			Color:     tcell.ColorDefault,
 			Expansion: 1,
 		})
 		widget.resourceTable.SetCell(i+1, 1, &tview.TableCell{
@@ -512,7 +510,7 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 		widget.resourceTable.SetCell(i+1, 2, &tview.TableCell{
 			Text:  phaseText,
 			Align: tview.AlignLeft,
-			Color: phaseColor,
+			Color: tcell.ColorDefault,
 		})
 		widget.resourceTable.SetCell(i+1, 3, &tview.TableCell{
 			Text:  tview.Escape(md.Owner()),
@@ -532,7 +530,7 @@ func (widget *ResourceExplorerGrid) renderResourceTable() {
 				widget.resourceTable.SetCell(i+1, 4+j, &tview.TableCell{
 					Text:  tview.Escape(text),
 					Align: tview.AlignLeft,
-					Color: tcell.ColorWhite,
+					Color: tcell.ColorDefault,
 				})
 			}
 		}
@@ -868,6 +866,6 @@ func headerCell(text string) *tview.TableCell {
 		Text:          "[::b]" + text,
 		Align:         tview.AlignLeft,
 		NotSelectable: true,
-		Color:         tcell.ColorWhite,
+		Color:         tcell.ColorDefault,
 	}
 }

--- a/internal/pkg/dashboard/theme_test.go
+++ b/internal/pkg/dashboard/theme_test.go
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package dashboard_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	// imported for the side effect of applying the terminal-inherited theme to tview.Styles.
+	_ "github.com/siderolabs/talos/internal/pkg/dashboard"
+	"github.com/siderolabs/talos/internal/pkg/dashboard/components"
+)
+
+// themeSafe reports whether a color rendered by the dashboard adapts to the terminal theme.
+//
+// Colors are theme-safe when they are either the terminal default, or one of the ANSI-16
+// palette colors, which tcell emits as palette indices for the terminal to remap. Absolute
+// (RGB) colors bypass the palette altogether, and the grayscale entries of the palette
+// (black, silver, gray, white) are indistinguishable from a light or a dark background, so
+// none of those may be used unconditionally.
+func themeSafe(c tcell.Color) bool {
+	if c == tcell.ColorDefault || c == tcell.ColorReset {
+		return true
+	}
+
+	if !c.Valid() || c.IsRGB() {
+		return false
+	}
+
+	idx := c & 0xFFFFFFFF
+
+	if idx >= 16 {
+		return false
+	}
+
+	// black, silver, gray, white
+	return idx != 0 && idx != 7 && idx != 8 && idx != 15
+}
+
+func describeColor(c tcell.Color) string {
+	switch {
+	case c == tcell.ColorDefault:
+		return "default"
+	case c == tcell.ColorReset:
+		return "reset"
+	case c.IsRGB():
+		return "rgb" + c.CSS()
+	case c.Valid():
+		return fmt.Sprintf("palette(%d)", c&0xFFFFFFFF)
+	default:
+		return fmt.Sprintf("invalid(%d)", uint64(c))
+	}
+}
+
+// TestStylesInheritTerminalTheme asserts that the global tview theme leaves the foreground
+// and background at the terminal defaults.
+func TestStylesInheritTerminalTheme(t *testing.T) {
+	for name, color := range map[string]tcell.Color{
+		"PrimitiveBackgroundColor": tview.Styles.PrimitiveBackgroundColor,
+		"PrimaryTextColor":         tview.Styles.PrimaryTextColor,
+		"BorderColor":              tview.Styles.BorderColor,
+		"TitleColor":               tview.Styles.TitleColor,
+		"GraphicsColor":            tview.Styles.GraphicsColor,
+	} {
+		if color != tcell.ColorDefault {
+			t.Errorf("tview.Styles.%s is %s, want the terminal default", name, describeColor(color))
+		}
+	}
+}
+
+// TestComponentsInheritTerminalTheme renders every dashboard component and asserts that it
+// only paints colors which follow the terminal's own color scheme, so that the dashboard
+// stays readable on both dark and light terminals.
+func TestComponentsInheritTerminalTheme(t *testing.T) {
+	const width, height = 120, 30
+
+	app := tview.NewApplication()
+
+	for name, primitive := range map[string]tview.Primitive{
+		"cpugraph":       components.NewCPUGraph(),
+		"cpuinfo":        components.NewCPUInfo(),
+		"diagnostics":    components.NewDiagnostics(),
+		"disksparkline":  components.NewDiskSparkline(),
+		"footer":         components.NewFooter(map[string]string{"F1": "Summary"}, []string{"node1"}),
+		"gauges":         components.NewSystemGauges(),
+		"header":         components.NewHeader(),
+		"horizontalline": components.NewHorizontalLine("LOGS"),
+		"kubernetesinfo": components.NewKubernetesInfo(),
+		"loadavggraph":   components.NewLoadAvgGraph(),
+		"loadavginfo":    components.NewLoadAvgInfo(),
+		"logviewer":      components.NewLogViewer(app),
+		"meminfo":        components.NewMemInfo(),
+		"memgraph":       components.NewMemGraph(),
+		"netsparkline":   components.NewNetSparkline(),
+		"networkinfo":    components.NewNetworkInfo(),
+		"processtable":   components.NewProcessTable(),
+		"procsinfo":      components.NewProcsInfo(),
+		"talosinfo":      components.NewTalosInfo(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			screen := tcell.NewSimulationScreen("UTF-8")
+
+			if err := screen.Init(); err != nil {
+				t.Fatalf("init simulation screen: %v", err)
+			}
+
+			t.Cleanup(screen.Fini)
+
+			screen.SetSize(width, height)
+
+			primitive.SetRect(0, 0, width, height)
+			primitive.Draw(screen)
+			screen.Show()
+
+			cells, w, _ := screen.GetContents()
+
+			reported := map[string]struct{}{}
+
+			for i, cell := range cells {
+				fg, bg, _ := cell.Style.Decompose()
+
+				if themeSafe(fg) && themeSafe(bg) {
+					continue
+				}
+
+				problem := fmt.Sprintf("fg=%s bg=%s", describeColor(fg), describeColor(bg))
+				if _, ok := reported[problem]; ok {
+					continue
+				}
+
+				reported[problem] = struct{}{}
+
+				t.Errorf("row %d, col %d (%q) does not follow the terminal theme: %s",
+					i/w, i%w, string(cell.Runes), problem)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of hardcoding specific colors, use the default colors and the "palette" colors which are mapped into the terminal theme.

This way dashboard looks native in any terminal theme.

We might implement actual theming later, but this should be good enough to adapt the dashboard to the terminal for now.
