### PR TITLE
fix: use os.Root in the untar path

### DIFF
--- a/pkg/archiver/untar.go
+++ b/pkg/archiver/untar.go
@@ -28,6 +28,13 @@ import (
 func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[string]string) error {
 	tr := tar.NewReader(r)
 
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("error opening root path %q: %w", rootPath, err)
+	}
+
+	defer root.Close() //nolint:errcheck
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -44,43 +51,45 @@ func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[stri
 			return fmt.Errorf("error reading tar header: %s", err)
 		}
 
-		hdrPath := safepath.CleanPath(hdr.Name)
-		if hdrPath == "" {
-			return errors.New("empty tar header path")
+		path := safepath.CleanPath(hdr.Name)
+		if filepath.IsAbs(path) {
+			path = path[1:]
 		}
 
-		path := filepath.Join(rootPath, hdrPath)
+		if path == "" {
+			return errors.New("empty tar header path")
+		}
 
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			mode := hdr.FileInfo().Mode() & os.ModePerm
 			mode |= 0o700 // make rwx for the owner
 
-			if err = os.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
+			if err = root.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)
 			}
 
-			if err = os.Chmod(path, mode); err != nil {
+			if err = root.Chmod(path, mode); err != nil {
 				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
 			}
 
 		case tar.TypeSymlink:
-			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			if err = root.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 				return fmt.Errorf("error creating parent directory for symlink %q: %w", path, err)
 			}
 
-			if err = os.Symlink(hdr.Linkname, path); err != nil {
+			if err = root.Symlink(hdr.Linkname, path); err != nil {
 				return fmt.Errorf("error creating symlink %q -> %q: %w", path, hdr.Linkname, err)
 			}
 
 		default:
 			mode := hdr.FileInfo().Mode()
 
-			if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			if err = root.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 				return fmt.Errorf("error creating parent directory for file %q: %w", path, err)
 			}
 
-			fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
+			fp, err := root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
 			if err != nil {
 				return fmt.Errorf("error creating file %q mode %s: %w", path, mode, err)
 			}
@@ -94,13 +103,13 @@ func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[stri
 				return fmt.Errorf("error closing %q: %w", path, err)
 			}
 
-			if err = os.Chmod(path, mode); err != nil {
+			if err = root.Chmod(path, mode); err != nil {
 				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
 			}
 		}
 
 		if hdr.PAXRecords[constants.TarPaxHeaderSELinux] != "" && xattrsMap != nil {
-			xattrsMap[path] = hdr.PAXRecords[constants.TarPaxHeaderSELinux]
+			xattrsMap[filepath.Join(rootPath, path)] = hdr.PAXRecords[constants.TarPaxHeaderSELinux]
 		}
 	}
 

--- a/pkg/archiver/untar_test.go
+++ b/pkg/archiver/untar_test.go
@@ -7,27 +7,140 @@ package archiver_test
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/archiver"
 )
 
-func TestUntarCreatesParentDirectories(t *testing.T) {
+func TestUntar(t *testing.T) {
+	t.Parallel()
+
+	type tarEntry struct {
+		header  tar.Header
+		payload []byte
+	}
+
+	for _, tc := range []struct {
+		name string
+
+		entries []tarEntry
+
+		verification func(t *testing.T, dir string, xattrs map[string]string)
+	}{
+		{
+			name: "nested paths",
+			entries: []tarEntry{
+				{
+					header: tar.Header{
+						Name: "nested/path/file.txt",
+						Mode: 0o644,
+					},
+					payload: []byte("hello"),
+				},
+			},
+			verification: func(t *testing.T, dir string, xattrs map[string]string) {
+				data, err := os.ReadFile(filepath.Join(dir, "nested/path/file.txt"))
+				require.NoError(t, err)
+
+				assert.Equal(t, []byte("hello"), data)
+				assert.Empty(t, xattrs)
+			},
+		},
+		{
+			name: "abs path",
+
+			entries: []tarEntry{
+				{
+					header: tar.Header{
+						Name: "/file.txt",
+						Mode: 0o644,
+					},
+					payload: []byte("abs"),
+				},
+			},
+			verification: func(t *testing.T, dir string, xattrs map[string]string) {
+				data, err := os.ReadFile(filepath.Join(dir, "file.txt"))
+				require.NoError(t, err)
+
+				assert.Equal(t, []byte("abs"), data)
+				assert.Empty(t, xattrs)
+			},
+		},
+		{
+			name: "xattrs",
+
+			entries: []tarEntry{
+				{
+					header: tar.Header{
+						Name:   "file.txt",
+						Mode:   0o644,
+						Xattrs: map[string]string{"security.selinux": "test_t"},
+					},
+					payload: []byte("xattrs"),
+				},
+			},
+			verification: func(t *testing.T, dir string, xattrs map[string]string) {
+				assert.Equal(
+					t, map[string]string{
+						filepath.Join(dir, "file.txt"): "test_t",
+					},
+					xattrs,
+				)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			tw := tar.NewWriter(&buf)
+
+			for _, entry := range tc.entries {
+				header := entry.header
+				header.Size = int64(len(entry.payload))
+
+				require.NoError(t, tw.WriteHeader(&header))
+				_, err := tw.Write(entry.payload)
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, tw.Close())
+
+			dir := t.TempDir()
+
+			xattrsMap := map[string]string{}
+
+			require.NoError(t, archiver.Untar(t.Context(), bytes.NewReader(buf.Bytes()), dir, xattrsMap))
+
+			tc.verification(t, dir, xattrsMap)
+		})
+	}
+}
+
+func TestUntarUnsafeSymlink(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 
 	tw := tar.NewWriter(&buf)
 
-	payload := []byte("hello")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "symlink",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "../passwd",
+		Mode:     0o644,
+	}))
+
+	payload := []byte("oops!")
 
 	require.NoError(t, tw.WriteHeader(&tar.Header{
-		Name: "nested/path/file.txt",
+		Name: "symlink/a.txt",
 		Mode: 0o644,
 		Size: int64(len(payload)),
 	}))
@@ -38,9 +151,14 @@ func TestUntarCreatesParentDirectories(t *testing.T) {
 
 	dir := t.TempDir()
 
-	require.NoError(t, archiver.Untar(context.Background(), bytes.NewReader(buf.Bytes()), dir, nil))
+	extractDir := filepath.Join(dir, "extract")
+	symlinkedDir := filepath.Join(dir, "symlink")
 
-	data, err := os.ReadFile(filepath.Join(dir, "nested/path/file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, payload, data)
+	require.NoError(t, os.MkdirAll(extractDir, 0o755))
+	require.NoError(t, os.MkdirAll(symlinkedDir, 0o755))
+
+	err = archiver.Untar(t.Context(), bytes.NewReader(buf.Bytes()), extractDir, nil)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "path escapes from parent")
 }


### PR DESCRIPTION
This should be defense-in-depth, as the untar is usually passed trusted input - either an extension image, or the Talos Read API result, but it's better to stay on the safe side, and protect from malicious tar structure by restricting the extraction to the provided root.
