### PR TITLE
docs: update CRI customization example

### DIFF
--- a/pkg/machinery/config/types/cri/customization.go
+++ b/pkg/machinery/config/types/cri/customization.go
@@ -76,7 +76,7 @@ func NewCRICustomizationConfigV1Alpha1(name string) *CRICustomizationConfigV1Alp
 
 func exampleCRICustomizationConfigV1Alpha1() *CRICustomizationConfigV1Alpha1 {
 	cfg := NewCRICustomizationConfigV1Alpha1("enable-metrics")
-	cfg.CustomizationContent = `[metrics]
+	cfg.CustomizationContent = `[plugins."io.containerd.server.v1.metrics"]
   address = "0.0.0.0:11234"
 `
 

--- a/pkg/machinery/config/types/cri/customization_test.go
+++ b/pkg/machinery/config/types/cri/customization_test.go
@@ -20,7 +20,7 @@ import (
 //go:embed testdata/cricustomizationconfig.yaml
 var expectedCRICustomizationConfigDocument []byte
 
-const customizationContent = `[metrics]
+const customizationContent = `[plugins."io.containerd.server.v1.metrics"]
   address = "0.0.0.0:11234"
 `
 

--- a/pkg/machinery/config/types/cri/testdata/cricustomizationconfig.yaml
+++ b/pkg/machinery/config/types/cri/testdata/cricustomizationconfig.yaml
@@ -2,5 +2,5 @@ apiVersion: v1alpha1
 kind: CRICustomizationConfig
 name: enable-metrics
 content: |
-    [metrics]
+    [plugins."io.containerd.server.v1.metrics"]
       address = "0.0.0.0:11234"

--- a/website/content/v1.15/reference/configuration/cri/cricustomizationconfig.md
+++ b/website/content/v1.15/reference/configuration/cri/cricustomizationconfig.md
@@ -18,7 +18,7 @@ apiVersion: v1alpha1
 kind: CRICustomizationConfig
 name: enable-metrics # Name of the CRI customization.
 content: | # CRI containerd configuration fragment in TOML format.
-    [metrics]
+    [plugins."io.containerd.server.v1.metrics"]
       address = "0.0.0.0:11234"
 {{< /highlight >}}
 


### PR DESCRIPTION
In containerd v4 config format, the `[metrics]` was deprecated - update to the new name in the examples.
