### PR TITLE
fix: capture packets correctly on VLANs

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_pcap_test.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_pcap_test.go
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime_test
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/afpacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtime "github.com/siderolabs/talos/internal/app/machined/internal/server/v1alpha1"
+	"github.com/siderolabs/talos/internal/pkg/pcap"
+)
+
+type captureStep struct {
+	data []byte
+	ci   gopacket.CaptureInfo
+	err  error
+}
+
+// fakeCaptureHandle replays a fixed sequence of [afpacket.TPacket.ZeroCopyReadPacketData] results.
+type fakeCaptureHandle struct {
+	steps  []captureStep
+	closed bool
+}
+
+// check that the fake implements the same interface as the real handle.
+var (
+	_ runtime.PacketCaptureHandle = (*fakeCaptureHandle)(nil)
+	_ runtime.PacketCaptureHandle = (*afpacket.TPacket)(nil)
+)
+
+func (h *fakeCaptureHandle) ZeroCopyReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
+	if len(h.steps) == 0 {
+		// unrecoverable error terminates the capture
+		return nil, gopacket.CaptureInfo{}, io.EOF
+	}
+
+	step := h.steps[0]
+	h.steps = h.steps[1:]
+
+	return step.data, step.ci, step.err
+}
+
+func (h *fakeCaptureHandle) Stats() (afpacket.Stats, error) {
+	return afpacket.Stats{}, nil
+}
+
+func (h *fakeCaptureHandle) SocketStats() (afpacket.SocketStats, afpacket.SocketStatsV3, error) {
+	return afpacket.SocketStats{}, afpacket.SocketStatsV3{}, nil
+}
+
+func (h *fakeCaptureHandle) Close() {
+	h.closed = true
+}
+
+func buildFrame(t *testing.T, vlanID uint16) []byte {
+	t.Helper()
+
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x00, 0x50, 0x56, 0x8f, 0xa5, 0xcb},
+		DstMAC:       net.HardwareAddr{0x00, 0x50, 0x56, 0x8f, 0xd0, 0xc3},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.IPv4(11, 0, 1, 1),
+		DstIP:    net.IPv4(11, 0, 1, 254),
+	}
+
+	icmp := &layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+		Id:       1,
+		Seq:      17,
+	}
+
+	serializable := []gopacket.SerializableLayer{eth, ip, icmp, gopacket.Payload(bytes.Repeat([]byte{0xaa}, 56))}
+
+	if vlanID != 0 {
+		eth.EthernetType = layers.EthernetTypeDot1Q
+
+		serializable = append(
+			[]gopacket.SerializableLayer{eth, &layers.Dot1Q{VLANIdentifier: vlanID, Type: layers.EthernetTypeIPv4}},
+			serializable[1:]...,
+		)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+
+	require.NoError(t, gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}, serializable...))
+
+	return buf.Bytes()
+}
+
+// TestCapturePacketsVLAN verifies that a frame with the VLAN header re-inserted by afpacket is captured.
+//
+// afpacket re-inserts the VLAN header stripped by the kernel into the packet data, but reports the wire length
+// as seen by the kernel, i.e. 4 bytes short, so the capture loop has to compensate for that.
+func TestCapturePacketsVLAN(t *testing.T) {
+	t.Parallel()
+
+	untagged := buildFrame(t, 0)
+	tagged := buildFrame(t, 2005)
+
+	require.Len(t, tagged, len(untagged)+4)
+
+	handle := &fakeCaptureHandle{
+		steps: []captureStep{
+			{
+				data: untagged,
+				ci:   gopacket.CaptureInfo{CaptureLength: len(untagged), Length: len(untagged)},
+			},
+			{
+				// poll timeouts are retried, not fatal
+				err: afpacket.ErrTimeout,
+			},
+			{
+				data: tagged,
+				// the kernel doesn't count the stripped VLAN header in the wire length
+				ci: gopacket.CaptureInfo{CaptureLength: len(tagged), Length: len(tagged) - 4},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+
+	err := runtime.CapturePackets(t.Context(), &out, handle, afpacket.DefaultFrameSize, pcap.LinkTypeEthernet)
+	require.ErrorIs(t, err, io.EOF)
+	assert.True(t, handle.closed)
+
+	reader, err := pcapgo.NewReader(&out)
+	require.NoError(t, err)
+
+	data, ci, err := reader.ReadPacketData()
+	require.NoError(t, err)
+	assert.Equal(t, untagged, data)
+	assert.Equal(t, len(untagged), ci.CaptureLength)
+	assert.Equal(t, len(untagged), ci.Length)
+
+	data, ci, err = reader.ReadPacketData()
+	require.NoError(t, err)
+	assert.Equal(t, tagged, data)
+	assert.Equal(t, len(tagged), ci.CaptureLength)
+	assert.Equal(t, len(tagged), ci.Length)
+
+	packet := gopacket.NewPacket(data, layers.LinkTypeEthernet, gopacket.Default)
+
+	dot1q, ok := packet.Layer(layers.LayerTypeDot1Q).(*layers.Dot1Q)
+	require.True(t, ok, "no Dot1Q layer in %s", packet)
+	assert.Equal(t, uint16(2005), dot1q.VLANIdentifier)
+
+	_, _, err = reader.ReadPacketData()
+	assert.ErrorIs(t, err, io.EOF)
+}

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/protobuf/server"
 	"github.com/google/uuid"
+	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/afpacket"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/nberlee/go-netstat/netstat"
@@ -2480,6 +2481,9 @@ func (s *Server) PacketCapture(in *machine.PacketCaptureRequest, srv machine.Mac
 		afpacket.OptInterface(in.Interface),
 		afpacket.OptPollTimeout(100*time.Millisecond),
 		afpacket.OptSocketType(unix.SOCK_RAW|unix.SOCK_CLOEXEC),
+		// the kernel strips the VLAN header off the ingress frames and reports the tag out-of-band,
+		// so ask afpacket to re-insert it into the packet data, the same way libpcap/tcpdump do
+		afpacket.OptAddVLANHeader(true),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating afpacket handle: %w", err)
@@ -2499,11 +2503,21 @@ func (s *Server) PacketCapture(in *machine.PacketCaptureRequest, srv machine.Mac
 		return fmt.Errorf("error setting promiscuous mode %v: %w", in.Promiscuous, err)
 	}
 
-	return capturePackets(srv.Context(), &packetStreamWriter{srv}, handle, in.SnapLen, linkType)
+	return CapturePackets(srv.Context(), &packetStreamWriter{srv}, handle, in.SnapLen, linkType)
 }
 
+// PacketCaptureHandle is a subset of [afpacket.TPacket] used for packet capture.
+type PacketCaptureHandle interface {
+	ZeroCopyReadPacketData() ([]byte, gopacket.CaptureInfo, error)
+	Stats() (afpacket.Stats, error)
+	SocketStats() (afpacket.SocketStats, afpacket.SocketStatsV3, error)
+	Close()
+}
+
+// CapturePackets handles the packet capture loop and writes packets to the provided writer in pcap format.
+//
 //nolint:gocyclo,cyclop
-func capturePackets(ctx context.Context, w io.Writer, handle *afpacket.TPacket, snapLen uint32, linkType pcap.LinkType) error {
+func CapturePackets(ctx context.Context, w io.Writer, handle PacketCaptureHandle, snapLen uint32, linkType pcap.LinkType) error {
 	defer handle.Close()
 
 	pcapw := pcap.NewWriter(w)
@@ -2537,6 +2551,11 @@ func capturePackets(ctx context.Context, w io.Writer, handle *afpacket.TPacket, 
 
 		data, captureData, err := handle.ZeroCopyReadPacketData()
 		if err == nil {
+			// afpacket re-inserts the VLAN header stripped by the kernel into the packet data (which bumps the
+			// capture length), but, unlike libpcap, it doesn't adjust the original wire length reported by the
+			// kernel, so compensate here: otherwise the pcap writer rejects the packet as capture length > length.
+			captureData.Length = max(captureData.Length, captureData.CaptureLength)
+
 			if err = pcapw.WritePacket(captureData, data); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #12860

The Linux kernel ships VLAN tags on ingress frames, so use gopacket's feature to re-insert them.

This has limitations though (mostly on gopacket's side), but still better than current behavior:

* packets with VLAN tag 0 will not have header re-attached
* packets will be with 802.1q frames no matter what the actual VLAN tag was
