### PR TITLE
test: preserve valid BGP config during MetalLB cleanup

### DIFF
--- a/internal/integration/api/bgp_metallb.go
+++ b/internal/integration/api/bgp_metallb.go
@@ -246,10 +246,6 @@ func (suite *BGPMetalLBSuite) TestMetalLBVRFBGP() { //nolint:gocyclo
 
 	workloadHelper.assertFabricSessions(nodeCtx, fabricSessions)
 
-	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.BGPInstanceKind, metalLBWorkloadBGP)
-	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.VRFKind, metalLBWorkloadVRF)
-	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.VethKind, metalLBVethName)
-
 	bgpImportsRoutesDeletePatch := map[string]any{
 		"apiVersion": "v1alpha1",
 		"kind":       "BGPInstanceConfig",
@@ -259,6 +255,10 @@ func (suite *BGPMetalLBSuite) TestMetalLBVRFBGP() { //nolint:gocyclo
 		},
 	}
 	suite.PatchMachineConfig(nodeCtx, bgpImportsRoutesDeletePatch)
+
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.BGPInstanceKind, metalLBWorkloadBGP)
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.VRFKind, metalLBWorkloadVRF)
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.VethKind, metalLBVethName)
 
 	rtestutils.AssertNoResource[*networkres.BGPPeerStatus](
 		nodeCtx,

--- a/internal/integration/api/common.go
+++ b/internal/integration/api/common.go
@@ -268,6 +268,25 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 		"Running",
 	}
 
+	assertUlimit := func(exec func() (string, string, error), expected string) {
+		suite.Require().NoError(retry.Constant(30*time.Second, retry.WithUnits(time.Second)).Retry(func() error {
+			stdout, stderr, err := exec()
+			if err != nil {
+				return retry.ExpectedError(err)
+			}
+
+			if stderr != "" {
+				return retry.ExpectedErrorf("unexpected stderr: %s", stderr)
+			}
+
+			if stdout != expected {
+				return retry.ExpectedErrorf("expected ulimit %q, got %q", expected, stdout)
+			}
+
+			return nil
+		}))
+	}
+
 	// Capture the baseline before applying the config: CRI can emit Stopping before ApplyConfiguration returns.
 	ts := suite.LatestServiceEventTimestamp(suite.ctx, node, "cri")
 
@@ -285,14 +304,9 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 
 	defer func() { suite.Assert().NoError(ociUlimits1PodDef.Delete(suite.ctx)) }()
 
-	stdout, stderr, err := ociUlimits1PodDef.Exec(
-		suite.ctx,
-		"ulimit -n",
-	)
-	suite.Require().NoError(err)
-
-	suite.Require().Equal("", stderr)
-	suite.Require().Equal("1024\n", stdout)
+	assertUlimit(func() (string, string, error) {
+		return ociUlimits1PodDef.Exec(suite.ctx, "ulimit -n")
+	}, "1024\n")
 
 	// Delete immediately before removing the CRIBaseRuntimeSpecConfig document.
 	suite.Assert().NoError(ociUlimits1PodDef.Delete(suite.ctx))
@@ -312,14 +326,9 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 
 	defer func() { suite.Assert().NoError(ociUlimits2PodDef.Delete(suite.ctx)) }()
 
-	stdout, stderr, err = ociUlimits2PodDef.Exec(
-		suite.ctx,
-		"ulimit -n",
-	)
-	suite.Require().NoError(err)
-
-	suite.Require().Equal("", stderr)
-	suite.Require().Equal("1048576\n", stdout)
+	assertUlimit(func() (string, string, error) {
+		return ociUlimits2PodDef.Exec(suite.ctx, "ulimit -n")
+	}, "1048576\n")
 }
 
 func init() {


### PR DESCRIPTION
Remove the fabric route import before deleting its source BGP instance. The old order temporarily left the fabric configuration referring to a missing instance and made BGP reconciliation fail.

Validated with make integration-test and the BGP CLOS, MetalLB, cgroups, and base OCI integration sequence.