### PR TITLE
fix: skip selinux label for read-only/detached/external mounts

### DIFF
--- a/internal/app/machined/pkg/controllers/block/mount.go
+++ b/internal/app/machined/pkg/controllers/block/mount.go
@@ -594,6 +594,12 @@ func (ctrl *MountController) handleDiskMountOperation(
 			fsOpts []fsopen.Option
 		)
 
+		// Read-only volumes preserve their existing metadata, detached mounts have no target,
+		// and external volume metadata is owned by the host.
+		shouldUpdateTargetSettings := !mountRequest.TypedSpec().ReadOnly &&
+			!mountRequest.TypedSpec().Detached &&
+			volumeStatus.TypedSpec().Type != block.VolumeTypeExternal
+
 		fsOpts = append(
 			fsOpts,
 			fsopen.WithSource(mountSource),
@@ -631,10 +637,9 @@ func (ctrl *MountController) handleDiskMountOperation(
 			}
 		}
 
-		opts = append(
-			opts,
-			mount.WithSelinuxLabel(volumeStatus.TypedSpec().MountSpec.SelinuxLabel),
-		)
+		if shouldUpdateTargetSettings {
+			opts = append(opts, mount.WithSelinuxLabel(volumeStatus.TypedSpec().MountSpec.SelinuxLabel))
+		}
 
 		if mountRequest.TypedSpec().DisableAccessTime {
 			opts = append(opts, mount.WithDisableAccessTime())
@@ -673,11 +678,7 @@ func (ctrl *MountController) handleDiskMountOperation(
 			return fmt.Errorf("failed to mount %q: %w", mountRequest.Metadata().ID(), err)
 		}
 
-		// external volumes are provided by the host (e.g. virtiofs): the mode and ownership of the mount root
-		// belong to the host, not to Talos, and the SELinux label is already applied by the mount itself.
-		if !mountRequest.TypedSpec().ReadOnly &&
-			!mountRequest.TypedSpec().Detached &&
-			volumeStatus.TypedSpec().Type != block.VolumeTypeExternal {
+		if shouldUpdateTargetSettings {
 			if err = ctrl.updateTargetSettings(mountTarget, volumeStatus.TypedSpec().Filesystem, volumeStatus.TypedSpec().MountSpec); err != nil {
 				manager.Unmount() //nolint:errcheck
 

--- a/internal/integration/api/volumes.go
+++ b/internal/integration/api/volumes.go
@@ -1490,7 +1490,8 @@ func (suite *VolumesSuite) TestExistingVolumes() {
 		),
 	)
 
-	// create existing volume
+	// mount the existing volume read-only from the start
+	existingVolumeDoc.MountSpec.MountReadOnly = new(true)
 	suite.PatchMachineConfig(ctx, existingVolumeDoc)
 
 	// wait for the existing volume to be discovered
@@ -1502,7 +1503,16 @@ func (suite *VolumesSuite) TestExistingVolumes() {
 		},
 	)
 
-	// check that the volume is mounted
+	// check that the volume is mounted read-only
+	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []resource.ID{existingVolumeID},
+		func(vs *block.MountStatus, asrt *assert.Assertions) {
+			asrt.True(vs.TypedSpec().ReadOnly)
+		})
+
+	// switch the existing volume to read-write
+	existingVolumeDoc.MountSpec.MountReadOnly = new(false)
+	suite.PatchMachineConfig(ctx, existingVolumeDoc)
+
 	rtestutils.AssertResources(ctx, suite.T(), suite.Client.COSI, []resource.ID{existingVolumeID},
 		func(vs *block.MountStatus, asrt *assert.Assertions) {
 			asrt.False(vs.TypedSpec().ReadOnly)


### PR DESCRIPTION
SELinux label was applied unconditionally on mount, ignoring the same
read-only/detached/external exclusions already used for target
settings. For a read-only existing volume this attempted to relabel a
target it must not touch. Unify both checks under one
shouldUpdateTargetSettings gate.

Fixes https://github.com/siderolabs/talos/issues/14118

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
