### PR TITLE
fix: cache filemap layers on disk

### DIFF
--- a/pkg/imager/cache/cache.go
+++ b/pkg/imager/cache/cache.go
@@ -155,7 +155,15 @@ func Generate(images []string, platforms []string, insecure bool, imageLayerCach
 		return fmt.Errorf("walking filesystem: %w", err)
 	}
 
-	artifactsLayer, err := filemap.Layer(artifacts)
+	// staged outside tmpDir, which is the tree the layer is built from.
+	layerDir, err := os.MkdirTemp("", "talos-image-cache-layer")
+	if err != nil {
+		return fmt.Errorf("creating layer staging directory: %w", err)
+	}
+
+	defer os.RemoveAll(layerDir) //nolint:errcheck
+
+	artifactsLayer, err := filemap.Layer(layerDir, artifacts)
 	if err != nil {
 		return fmt.Errorf("creating artifacts layer: %w", err)
 	}

--- a/pkg/imager/filemap/filemap.go
+++ b/pkg/imager/filemap/filemap.go
@@ -7,7 +7,9 @@ package filemap
 
 import (
 	"archive/tar"
+	"bufio"
 	"cmp"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -146,15 +148,62 @@ func handleDir(w *tar.Writer, path string, mode int64) error {
 // These layers are reproducible and consistent.
 //
 // A filemap is a path -> file content map representing a file system.
-func Layer(filemap []File) (v1.Layer, error) {
+//
+// The compressed layer is staged as a file under tempDir, which must outlive the returned
+// layer: go-containerregistry re-opens the layer contents for every digest and write access.
+// Removing tempDir reclaims the temporary file.
+func Layer(tempDir string, filemap []File) (v1.Layer, error) {
 	slices.SortFunc(filemap, func(a, b File) int { return cmp.Compare(a.ImagePath, b.ImagePath) })
 
-	// Return a new copy of the buffer each time it's opened.
-	//
-	// WithCompressedCaching memoizes the compressed bytes after the first read, so the gzip
-	// pipeline is spun up exactly once instead of being re-created for each digest/diffID/write
-	// access.
+	path, err := buildCompressed(tempDir, filemap)
+	if err != nil {
+		return nil, err
+	}
+
 	return tarball.LayerFromOpener(func() (io.ReadCloser, error) {
-		return Build(filemap), nil
-	}, tarball.WithMediaType(types.OCILayer), tarball.WithCompressedCaching)
+		return os.Open(path)
+	}, tarball.WithMediaType(types.OCILayer))
+}
+
+// buildCompressed writes the gzipped filemap tarball to a new file under tempDir, returning
+// its path.
+//
+// The compression level matches the one go-containerregistry applies to an uncompressed
+// opener, so staging the layer here leaves its digest unchanged (see TestLayerDigestParity).
+func buildCompressed(tempDir string, filemap []File) (string, error) {
+	out, err := os.CreateTemp(tempDir, "layer-*.tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("error creating layer file: %w", err)
+	}
+
+	defer out.Close() //nolint:errcheck
+
+	tarReader := Build(filemap)
+	defer tarReader.Close() //nolint:errcheck
+
+	// use bufio to avoid many small writes to the underlying file
+	bw := bufio.NewWriterSize(out, 2<<16)
+
+	zw, err := gzip.NewWriterLevel(bw, gzip.BestSpeed)
+	if err != nil {
+		return "", fmt.Errorf("error creating gzip writer: %w", err)
+	}
+
+	if _, err = io.Copy(zw, tarReader); err != nil {
+		return "", fmt.Errorf("error compressing layer: %w", err)
+	}
+
+	if err = zw.Close(); err != nil {
+		return "", fmt.Errorf("error finishing layer compression: %w", err)
+	}
+
+	if err = bw.Flush(); err != nil {
+		return "", fmt.Errorf("error flushing layer file: %w", err)
+	}
+
+	if err = out.Close(); err != nil {
+		return "", fmt.Errorf("error closing layer file: %w", err)
+	}
+
+	return out.Name(), nil
 }

--- a/pkg/imager/filemap/filemap_test.go
+++ b/pkg/imager/filemap/filemap_test.go
@@ -5,11 +5,16 @@
 package filemap_test
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -86,7 +91,7 @@ func TestLayer(t *testing.T) {
 	artifacts, err := filemap.Walk(tempDir, "")
 	require.NoError(t, err)
 
-	layer, err := filemap.Layer(artifacts)
+	layer, err := filemap.Layer(t.TempDir(), artifacts)
 	require.NoError(t, err)
 
 	_, err = layer.Digest()
@@ -105,4 +110,85 @@ func TestLayer(t *testing.T) {
 
 		require.NoError(t, rc.Close())
 	}
+}
+
+// TestLayerDigestParity pins the staged layer against the one go-containerregistry builds from an
+// uncompressed opener.
+//
+// Layer compresses ahead of time at a level picked to match go-containerregistry's private default,
+// and a dependency bump which changed that default would otherwise silently change the digest
+// of every artifacts layer we publish.
+func TestLayerDigestParity(t *testing.T) {
+	tempDir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "a/b"), 0o755))
+	// compressible, so that the compression level is what decides the digest.
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a/b/file"), bytes.Repeat([]byte("hello world"), 4096), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a/executable"), []byte("payload"), 0o755))
+
+	artifacts, err := filemap.Walk(tempDir, "")
+	require.NoError(t, err)
+
+	// sorts artifacts in place, so the reference layer below sees the same entry order.
+	staged, err := filemap.Layer(t.TempDir(), artifacts)
+	require.NoError(t, err)
+
+	reference, err := tarball.LayerFromOpener(
+		func() (io.ReadCloser, error) { return filemap.Build(artifacts), nil },
+		tarball.WithMediaType(types.OCILayer),
+	)
+	require.NoError(t, err)
+
+	stagedDigest, err := staged.Digest()
+	require.NoError(t, err)
+
+	referenceDigest, err := reference.Digest()
+	require.NoError(t, err)
+
+	assert.Equal(t, referenceDigest, stagedDigest)
+
+	stagedSize, err := staged.Size()
+	require.NoError(t, err)
+
+	referenceSize, err := reference.Size()
+	require.NoError(t, err)
+
+	assert.Equal(t, referenceSize, stagedSize)
+}
+
+// TestLayerHeapUsage guards against the layer memoizing its compressed contents on the heap,
+// the way tarball.WithCompressedCaching does.
+func TestLayerHeapUsage(t *testing.T) {
+	const payloadSize = 32 << 20
+
+	sourceDir := t.TempDir()
+
+	// random, hence incompressible: the layer cannot end up much smaller than the payload.
+	payload := make([]byte, payloadSize)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "payload"), payload, 0o644))
+
+	artifacts, err := filemap.Walk(sourceDir, "")
+	require.NoError(t, err)
+
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	layer, err := filemap.Layer(t.TempDir(), artifacts)
+	require.NoError(t, err)
+
+	size, err := layer.Size()
+	require.NoError(t, err)
+	require.Greater(t, size, int64(payloadSize/2), "payload compressed further than expected, test is not measuring anything")
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+
+	runtime.KeepAlive(layer)
+
+	assert.Less(t, after.HeapAlloc, before.HeapAlloc+payloadSize/2, "layer retains its compressed contents on the heap")
 }

--- a/pkg/imager/out.go
+++ b/pkg/imager/out.go
@@ -579,7 +579,7 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 		)
 	}
 
-	artifactsLayer, err := filemap.Layer(artifacts)
+	artifactsLayer, err := filemap.Layer(i.tempDir, artifacts)
 	if err != nil {
 		return xerrors.NewTaggedf[DependencyTag]("failed to create artifacts layer: %w", err)
 	}
@@ -646,7 +646,7 @@ func (i *Imager) outInstaller(ctx context.Context, path string, report *reporter
 			overlayArtifacts = append(overlayArtifacts, extraFiles...)
 		}
 
-		overlayArtifactsLayer, internalErr := filemap.Layer(overlayArtifacts)
+		overlayArtifactsLayer, internalErr := filemap.Layer(i.tempDir, overlayArtifacts)
 		if internalErr != nil {
 			return xerrors.NewTaggedf[DependencyTag]("failed to create overlay artifacts layer: %w", internalErr)
 		}


### PR DESCRIPTION
With one of the earlier changes we introduced in-memory layer caching for the filemap layers, but this puts a high toll on Image Factory when building multiple installer images in parallel.

Use scratch directory/disk instead of memory.


(cherry picked from commit 4f56e5f44466333dd07be4f7f6c2fba96a1e8543)

PR: #14133 