### PR TITLE
fix: drop gRPC client keepalive aggressive settings in the tracker

### DIFF
--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
@@ -83,10 +82,6 @@ func GRPCDialOptions() []grpc.DialOption {
 			// disable grpc backoff
 			Backoff:           backoff.Config{},
 			MinConnectTimeout: 20 * time.Second,
-		}),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:    10 * time.Second,
-			Timeout: 5 * time.Second,
 		}),
 	}
 }


### PR DESCRIPTION
They were introduced long ago to fight the problem of "dead" connections, but:

* it breaks on live, but idle connections as Talos server-side drops the connection as it goes above the server-side budget of keepalives
* it applies only to the connection to the endpoint, not to the actual connection to the node (when going via proxying), or to the connection e.g. to Omni if using against Talos cluster behind Omni
* I don't see problems in my smoke tests today - connections are closed gracefully, and the client sees it
* Talos integration tests were fine without it always (when using direct API calls)

The first point is the real issue: image pull process might take a while for images first created by the Image Factory, and the Talos API will sit idle while waiting for the image to start pulling, while this agressive keep-alive actually kills the perfectly valid API call by blowing up the server-side budget.
