### PR TITLE
fix: separate node taint updates from cordon/labels sync

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/node_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_apply.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
 
 	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/kubernetes"
@@ -166,23 +167,29 @@ func (ctrl *NodeApplyController) getNodeCordoned(ctx context.Context, r controll
 	return items.Len() > 0, nil
 }
 
-func (ctrl *NodeApplyController) getK8sClient(ctx context.Context, r controller.Runtime, logger *zap.Logger) (*kubernetes.Client, error) {
+func (ctrl *NodeApplyController) getK8sClient(ctx context.Context, r controller.Runtime, logger *zap.Logger) (*kubernetes.Client, bool, error) {
 	machineType, err := safe.ReaderGet[*config.MachineType](ctx, r, resource.NewMetadata(config.NamespaceName, config.MachineTypeType, config.MachineTypeID, resource.VersionUndefined))
 	if err != nil {
-		return nil, fmt.Errorf("error getting machine type: %w", err)
+		return nil, false, fmt.Errorf("error getting machine type: %w", err)
 	}
 
 	if machineType.MachineType().IsControlPlane() {
-		return kubernetes.NewTemporaryClientControlPlane(ctx, r)
+		client, err := kubernetes.NewTemporaryClientControlPlane(ctx, r)
+
+		// control plane nodes use a temporary admin client which can modify node taints
+		return client, true, err
 	}
 
 	logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
 
 	if err := conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return kubernetes.NewClientFromKubeletKubeconfig()
+	client, err := kubernetes.NewClientFromKubeletKubeconfig()
+
+	// worker nodes use the kubelet identity, which is not allowed to modify taints (NodeRestriction)
+	return client, false, err
 }
 
 func (ctrl *NodeApplyController) reconcileWithK8s(
@@ -206,7 +213,7 @@ func (ctrl *NodeApplyController) reconcileWithK8s(
 
 	nodename := nodenameResource.TypedSpec().Nodename
 
-	k8sClient, err := ctrl.getK8sClient(ctx, r, logger)
+	k8sClient, canManageTaints, err := ctrl.getK8sClient(ctx, r, logger)
 	if err != nil {
 		return fmt.Errorf("error building kubernetes client: %w", err)
 	}
@@ -238,21 +245,22 @@ func (ctrl *NodeApplyController) reconcileWithK8s(
 		return err
 	}
 
-	return ctrl.sync(ctx, logger, k8sClient, nodename, nodeLabelSpecs, nodeAnnotationSpecs, nodeTaintSpecs, nodeShouldCordon)
+	return ctrl.sync(ctx, logger, k8sClient, nodename, nodeLabelSpecs, nodeAnnotationSpecs, nodeTaintSpecs, nodeShouldCordon, canManageTaints)
 }
 
 func (ctrl *NodeApplyController) sync(
 	ctx context.Context,
 	logger *zap.Logger,
-	k8sClient *kubernetes.Client,
+	k8sClient k8sclient.Interface,
 	nodeName string,
 	nodeLabelSpecs, nodeAnnotationSpecs map[string]string,
 	nodeTaintSpecs []k8s.NodeTaintSpecSpec,
 	nodeShouldCordon bool,
+	canManageTaints bool,
 ) error {
 	// run several attempts retrying conflict errors
 	return retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(ctx, func(ctx context.Context) error {
-		err := ctrl.syncOnce(ctx, logger, k8sClient, nodeName, nodeLabelSpecs, nodeAnnotationSpecs, nodeTaintSpecs, nodeShouldCordon)
+		err := ctrl.syncOnce(ctx, logger, k8sClient, nodeName, nodeLabelSpecs, nodeAnnotationSpecs, nodeTaintSpecs, nodeShouldCordon, canManageTaints)
 		if err != nil && (apierrors.IsConflict(err) || apierrors.IsForbidden(err)) {
 			return retry.ExpectedError(err)
 		}
@@ -301,11 +309,12 @@ func marshalOwnedAnnotation(node *corev1.Node, annotation string, ownedMap map[s
 func (ctrl *NodeApplyController) syncOnce(
 	ctx context.Context,
 	logger *zap.Logger,
-	k8sClient *kubernetes.Client,
+	k8sClient k8sclient.Interface,
 	nodeName string,
 	nodeLabelSpecs, nodeAnnotationSpecs map[string]string,
 	nodeTaintSpecs []k8s.NodeTaintSpecSpec,
 	nodeShouldCordon bool,
+	canManageTaints bool,
 ) error {
 	node, err := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -326,14 +335,8 @@ func (ctrl *NodeApplyController) syncOnce(
 		return fmt.Errorf("error unmarshaling owned annotations: %w", err)
 	}
 
-	ownedTaintsMap, err := umarshalOwnedAnnotation(node, constants.AnnotationOwnedTaints)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling owned taints: %w", err)
-	}
-
 	ctrl.ApplyLabels(logger, node, ownedLabelsMap, nodeLabelSpecs)
 	ctrl.ApplyAnnotations(logger, node, ownedAnnotationsMap, nodeAnnotationSpecs)
-	ctrl.ApplyTaints(logger, node, ownedTaintsMap, nodeTaintSpecs)
 	ctrl.ApplyCordoned(logger, node, nodeShouldCordon)
 
 	if err = marshalOwnedAnnotation(node, constants.AnnotationOwnedLabels, ownedLabelsMap); err != nil {
@@ -343,6 +346,32 @@ func (ctrl *NodeApplyController) syncOnce(
 	if err = marshalOwnedAnnotation(node, constants.AnnotationOwnedAnnotations, ownedAnnotationsMap); err != nil {
 		return fmt.Errorf("error marshaling owned annotations: %w", err)
 	}
+
+	node, err = k8sClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error updating node: %w", err)
+	}
+
+	if !canManageTaints {
+		// nodes using the kubelet identity are not allowed to modify taints (NodeRestriction),
+		// so taints can't be managed here; in particular taint changes must not be sent in
+		// the same update as the cordon, or the whole update would be rejected (and the node
+		// would never get cordoned, blocking drain during upgrades)
+		if len(nodeTaintSpecs) > 0 {
+			logger.Debug("skipping taint updates, node identity is not allowed to modify taints")
+		}
+
+		return nil
+	}
+
+	// apply taints in a separate update, so that taint changes never poison the
+	// labels/annotations/cordon update
+	ownedTaintsMap, err := umarshalOwnedAnnotation(node, constants.AnnotationOwnedTaints)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling owned taints: %w", err)
+	}
+
+	ctrl.ApplyTaints(logger, node, ownedTaintsMap, nodeTaintSpecs)
 
 	if err = marshalOwnedAnnotation(node, constants.AnnotationOwnedTaints, ownedTaintsMap); err != nil {
 		return fmt.Errorf("error marshaling owned taints: %w", err)
@@ -396,6 +425,22 @@ func (ctrl *NodeApplyController) applyNodeKV(logger *zap.Logger, nodeKV map[stri
 // This method is exported for testing purposes.
 func (ctrl *NodeApplyController) ApplyLabels(logger *zap.Logger, node *corev1.Node, ownedLabels map[string]struct{}, nodeLabelSpecs map[string]string) {
 	ctrl.applyNodeKV(logger, node.Labels, ownedLabels, nodeLabelSpecs)
+}
+
+// SyncOnceForTest runs a single sync against the provided (fake) client.
+//
+// This method is exported for testing purposes.
+func (ctrl *NodeApplyController) SyncOnceForTest(
+	ctx context.Context,
+	logger *zap.Logger,
+	k8sClient k8sclient.Interface,
+	nodeName string,
+	nodeLabelSpecs, nodeAnnotationSpecs map[string]string,
+	nodeTaintSpecs []k8s.NodeTaintSpecSpec,
+	nodeShouldCordon bool,
+	canManageTaints bool,
+) error {
+	return ctrl.syncOnce(ctx, logger, k8sClient, nodeName, nodeLabelSpecs, nodeAnnotationSpecs, nodeTaintSpecs, nodeShouldCordon, canManageTaints)
 }
 
 // ApplyAnnotations performs the inner loop of the node annotation reconciliation.

--- a/internal/app/machined/pkg/controllers/k8s/node_apply_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_apply_test.go
@@ -5,14 +5,18 @@
 package k8s_test
 
 import (
+	"context"
 	"slices"
 	"testing"
 
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -523,4 +527,120 @@ func TestApplyCordoned(t *testing.T) {
 			assert.Equal(t, tt.expectedAnnotations, node.Annotations)
 		})
 	}
+}
+
+func TestSyncOnceWorkerSkipsTaintUpdates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := zaptest.NewLogger(t)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "worker-1",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{
+					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+					Value:  "true",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	fakeClient := k8sfake.NewSimpleClientset(node)
+
+	ctrl := &k8sctrl.NodeApplyController{}
+
+	err := ctrl.SyncOnceForTest(
+		ctx,
+		logger,
+		fakeClient,
+		"worker-1",
+		map[string]string{"example.com/tainted": "true"},
+		map[string]string{"example.com/annotation": "value"},
+		[]k8s.NodeTaintSpecSpec{
+			{
+				Key:    "talos.dev/taint",
+				Value:  "true",
+				Effect: "NoSchedule",
+			},
+		},
+		true,  // shouldCordon
+		false, // canManageTaints (worker -> kubelet identity)
+	)
+	require.NoError(t, err)
+
+	updated, err := fakeClient.CoreV1().Nodes().Get(ctx, "worker-1", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// cordon (unschedulable) must be applied even though taint changes are requested
+	assert.True(t, updated.Spec.Unschedulable)
+	assert.Equal(t, "true", updated.Annotations[constants.AnnotationCordonedKey])
+
+	// labels and annotations must be applied
+	assert.Equal(t, "true", updated.Labels["example.com/tainted"])
+	assert.Equal(t, "value", updated.Annotations["example.com/annotation"])
+
+	// taints must NOT be modified: the pre-existing taint stays, the requested one is not added
+	assert.Equal(t, []corev1.Taint{node.Spec.Taints[0]}, updated.Spec.Taints)
+
+	// Talos must not claim ownership of taints it can't manage
+	_, ownedTaints := updated.Annotations[constants.AnnotationOwnedTaints]
+	assert.False(t, ownedTaints)
+}
+
+func TestSyncOnceControlPlaneAppliesTaints(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := zaptest.NewLogger(t)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cp-1",
+		},
+	}
+
+	fakeClient := k8sfake.NewSimpleClientset(node)
+
+	ctrl := &k8sctrl.NodeApplyController{}
+
+	err := ctrl.SyncOnceForTest(
+		ctx,
+		logger,
+		fakeClient,
+		"cp-1",
+		nil,
+		nil,
+		[]k8s.NodeTaintSpecSpec{
+			{
+				Key:    "talos.dev/taint",
+				Value:  "true",
+				Effect: "NoSchedule",
+			},
+		},
+		true, // shouldCordon
+		true, // canManageTaints (control plane -> temporary admin client)
+	)
+	require.NoError(t, err)
+
+	updated, err := fakeClient.CoreV1().Nodes().Get(ctx, "cp-1", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.True(t, updated.Spec.Unschedulable)
+
+	// the requested taint must be applied in the separate update
+	assert.Equal(t, []corev1.Taint{
+		{
+			Key:    "talos.dev/taint",
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}, updated.Spec.Taints)
+
+	assert.Equal(t, `["talos.dev/taint"]`, updated.Annotations[constants.AnnotationOwnedTaints])
 }


### PR DESCRIPTION
## What? (description)

Split the `k8s.NodeApplyController` node sync so that taint changes are applied in a **separate Node update** from labels/annotations/cordon, and **not attempted at all** for nodes using the kubelet identity (workers).

Before: `syncOnce` applied labels, annotations, taints and the cordon state into the in-memory node and submitted them in a **single** `Nodes().Update`.

## Why? (reasoning)

Fixes #13681: worker nodes with `machine.nodeTaints` fail to upgrade.

`NodeRestriction` (kubernetes admission) forbids a node from modifying its own taints:

```go
// Don't allow a node to update its own taints. This would allow a node to remove or modify its
// taints in a way that would let it steer disallowed workloads to itself.
if !apiequality.Semantic.DeepEqual(node.Spec.Taints, oldNode.Spec.Taints) {
    return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to modify taints", nodeName))
}
```

Workers talk to the API server with the kubelet identity, so any desired taint change (e.g. a `machine.nodeTaints` entry that differs from the current node taints — like a bootstrap taint the cloud controller already removed) made the **entire** Node update forbidden — including the cordon (`spec.unschedulable`), which the kubelet *is* allowed to set. During `talosctl upgrade`, the drain phase cordons the node; with the update always rejected, the cordon never applied and drain hung until the upgrade failed.

Control plane nodes were unaffected because they use a temporary admin client (can modify taints).

## The fix

- `getK8sClient` now also reports whether the client can manage taints (control plane → temporary admin client → yes; workers → kubelet identity → no).
- `syncOnce` applies labels/annotations/cordon in the first update, then taints in a **second, separate** update.
- When the client cannot manage taints (workers), taint reconciliation is skipped with a debug log instead of failing the whole sync — taints on workers are managed at registration (`registerWithTaints`), by the cluster's cloud controller, or by an admin; Talos cannot modify them with kubelet credentials.
- `sync`/`syncOnce` now take client-go's `kubernetes.Interface` instead of the concrete client wrapper, so the split behavior is unit-testable with a fake clientset.

## Tests

- `TestSyncOnceWorkerSkipsTaintUpdates` — worker (kubelet identity) with a desired taint that differs from the node's: asserts the cordon **is** applied, labels/annotations **are** applied, taints are **untouched**, and Talos does not claim taint ownership.
- `TestSyncOnceControlPlaneAppliesTaints` — control plane: asserts the cordon is applied and the desired taint is added (in the separate update), with ownership recorded.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
