### PR TITLE
fix: handle Akamai/Linode metadata without IPv6

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai.go
@@ -105,39 +105,43 @@ func (a *Akamai) ParseMetadata(
 		)
 	}
 
-	networkConfig.Addresses = append(
-		networkConfig.Addresses,
-		network.AddressSpecSpec{
+	// only add IPv6 link-local address and gateway route if IPv6 is supported
+	// (VPC interfaces don't support IPv6, so the metadata doesn't include it)
+	if interfaceAddresses.IPv6.LinkLocal.IsValid() {
+		networkConfig.Addresses = append(
+			networkConfig.Addresses,
+			network.AddressSpecSpec{
+				ConfigLayer: network.ConfigPlatform,
+				LinkName:    "eth0",
+				Address:     interfaceAddresses.IPv6.LinkLocal,
+				Scope:       nethelpers.ScopeLink,
+				Family:      nethelpers.FamilyInet6,
+			},
+		)
+
+		ipv6gw, err := netip.ParseAddr(
+			strings.Split(interfaceAddresses.IPv6.LinkLocal.String(), ":")[0] + "::1",
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		route := network.RouteSpecSpec{
 			ConfigLayer: network.ConfigPlatform,
-			LinkName:    "eth0",
-			Address:     interfaceAddresses.IPv6.LinkLocal,
-			Scope:       nethelpers.ScopeLink,
+			Gateway:     ipv6gw,
+			OutLinkName: "eth0",
+			Destination: interfaceAddresses.IPv6.LinkLocal,
+			Table:       nethelpers.TableMain,
+			Protocol:    nethelpers.ProtocolStatic,
+			Type:        nethelpers.TypeUnicast,
 			Family:      nethelpers.FamilyInet6,
-		},
-	)
+			Priority:    1024,
+		}
 
-	ipv6gw, err := netip.ParseAddr(
-		strings.Split(interfaceAddresses.IPv6.LinkLocal.String(), ":")[0] + "::1",
-	)
-	if err != nil {
-		return nil, err
+		route.Normalize()
+
+		networkConfig.Routes = append(networkConfig.Routes, route)
 	}
-
-	route := network.RouteSpecSpec{
-		ConfigLayer: network.ConfigPlatform,
-		Gateway:     ipv6gw,
-		OutLinkName: "eth0",
-		Destination: interfaceAddresses.IPv6.LinkLocal,
-		Table:       nethelpers.TableMain,
-		Protocol:    nethelpers.ProtocolStatic,
-		Type:        nethelpers.TypeUnicast,
-		Family:      nethelpers.FamilyInet6,
-		Priority:    1024,
-	}
-
-	route.Normalize()
-
-	networkConfig.Routes = append(networkConfig.Routes, route)
 
 	for _, ipStr := range publicIPs {
 		if ip, err := netip.ParseAddr(ipStr); err == nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/akamai_test.go
@@ -26,27 +26,42 @@ var rawInstanceWithTags []byte
 //go:embed testdata/network.json
 var rawNetwork []byte
 
+//go:embed testdata/network-vpc.json
+var rawNetworkVPC []byte
+
 //go:embed testdata/expected-no-tags.yaml
 var expectedNoTags string
 
 //go:embed testdata/expected-with-tags.yaml
 var expectedWithTags string
 
+//go:embed testdata/expected-vpc.yaml
+var expectedVPC string
+
 func TestParseMetadata(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		instance []byte
+		network  []byte
 		expected string
 	}{
 		{
 			name:     "no tags",
 			instance: rawInstanceNoTags,
+			network:  rawNetwork,
 			expected: expectedNoTags,
 		},
 		{
 			name:     "with tags",
 			instance: rawInstanceWithTags,
+			network:  rawNetwork,
 			expected: expectedWithTags,
+		},
+		{
+			name:     "vpc interface (no IPv6)",
+			instance: rawInstanceNoTags,
+			network:  rawNetworkVPC,
+			expected: expectedVPC,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,7 +72,7 @@ func TestParseMetadata(t *testing.T) {
 			var interfaceConfig akametadata.NetworkData
 
 			require.NoError(t, json.Unmarshal(tt.instance, &metadata))
-			require.NoError(t, json.Unmarshal(rawNetwork, &interfaceConfig))
+			require.NoError(t, json.Unmarshal(tt.network, &interfaceConfig))
 
 			networkConfig, err := p.ParseMetadata(&metadata, &interfaceConfig)
 			require.NoError(t, err)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/testdata/expected-vpc.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/testdata/expected-vpc.yaml
@@ -1,0 +1,25 @@
+addresses:
+    - address: 172.234.1.2/32
+      linkName: eth0
+      family: inet4
+      scope: global
+      flags: permanent
+      layer: platform
+links: []
+routes: []
+hostnames:
+    - hostname: talos
+      domainname: ""
+      layer: platform
+resolvers: []
+timeServers: []
+operators: []
+externalIPs:
+    - 172.234.1.2
+metadata:
+    platform: akamai
+    hostname: talos
+    region: us-east
+    instanceType: g6-standard-1
+    instanceId: "123456"
+    providerId: linode://123456

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/testdata/network-vpc.json
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/akamai/testdata/network-vpc.json
@@ -1,0 +1,33 @@
+{
+    "interfaces": [
+        {
+            "id": 123456,
+            "purpose": "vpc",
+            "label": null,
+            "ipam_address": null,
+            "vpc": {
+                "id": 123456,
+                "label": "talos-devl",
+                "subnet": {
+                    "id": 123456,
+                    "label": "talos-devl",
+                    "ipv4": {
+                        "subnet_range": "10.239.96.0/20",
+                        "instance_address": "10.239.111.253/32",
+                        "nat_1_1": "172.234.1.2/32",
+                        "instance_ranges": []
+                    },
+                    "ipv6": null
+                }
+            }
+        }
+    ],
+    "ipv4": {
+        "public": [
+            "172.234.1.2/32"
+        ],
+        "private": [],
+        "shared": []
+    },
+    "ipv6": null
+}


### PR DESCRIPTION
## What? (description)

Fix the Akamai/Linode platform metadata parsing for nodes with VPC interfaces (no IPv6). VPC interfaces don't support IPv6, so the network metadata has no link-local data — the IPv6 gateway derivation ran on the invalid zero prefix and crashed `ParseMetadata`, causing a restart loop:

```
[talos] restarting platform network config {"component": "controller-runtime", "controller": "network.PlatformConfigController", "error": "parse metadata: ParseAddr(\"invalid Prefix::1\"): each colon-separated field must have at least one digit"}
```

With this fix, when the metadata has no IPv6, the link-local address spec and the IPv6 gateway route are simply not produced — the IPv4 public address and external IP are still configured as before.

## Why? (reasoning)

Fixes #13578. Linode VPCs don't support IPv6; the reporter's node has only a VPC interface (public IPv4 + VPC subnet address), and the parsing assumed IPv6 always exists. The maintainers explicitly invited the fix on the issue: *"grab the metadata, add it to the test case for Akamai, and ensure Talos translates that into proper network config"*.

The reporter's metadata is captured verbatim in `testdata/network-vpc.json` (VPC interface with `"ipv6": null` — the exact shape from the upstream go-metadata repro in linode/go-metadata#146).

## Notes

- The IPv6 link-local address spec and the gateway route are now only added when `IPv6.LinkLocal` is a valid prefix. `netip.Prefix{}.String()` is `"invalid Prefix"`, so the old code built `"invalid Prefix::1"` — the exact error from the report. Empty-string, `null`, and omitted `link_local` all decode to the same invalid zero prefix, so all three shapes are covered by the one guard.
- The VPC subnet address itself (`ipam_address`/`instance_address`) isn't exposed by `go-metadata` v0.3.0 (the `InterfaceData` struct has no VPC fields — tracked upstream at linode/go-metadata#146), so it can't be translated here; as the maintainer noted, DHCP still configures it.
- The IPv6 gateway derivation (`<first-hextet>::1`) is otherwise unchanged.

## Tests

- `TestParseMetadata` gains a **"vpc interface (no IPv6)"** case: the reporter's `network-vpc.json` + existing instance data → golden `expected-vpc.yaml` (IPv4 address + external IP only, no IPv6 addresses, no routes). The test fails on the pre-fix code with the exact `invalid Prefix::1` error.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

## Review follow-ups

- **Test proven to catch the bug**: temporarily reverted the fix and confirmed the new case fails with the exact reported error (`ParseAddr("invalid Prefix::1")`), then passes with the fix.
- **Scope boundary documented**: VPC address data is dropped by `go-metadata` upstream (linode/go-metadata#146, assigned to an Akamai maintainer) — out of talos's reach; this fix addresses the talos-side crash loop and translates everything the library does expose.
