### PR TITLE
fix: make talosctl time use the node's configured NTP servers

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -164,7 +164,10 @@ func (s *Server) Register(obj *grpc.Server) {
 	storage.RegisterStorageServiceServer(obj, &storaged.Server{Controller: s.Controller})
 	machine.RegisterLVMServiceServer(obj, lvmd.NewService(s.Controller, s.Logger))
 	machine.RegisterMDServiceServer(obj, mdd.NewService(s.Controller, s.Logger))
-	timeapi.RegisterTimeServiceServer(obj, &TimeServer{ConfigProvider: s.Controller.Runtime()})
+	timeapi.RegisterTimeServiceServer(obj, &TimeServer{
+		ConfigProvider: s.Controller.Runtime(),
+		State:          resourceState,
+	})
 }
 
 // modeWrapper overrides RequiresInstall() based on actual installed status.

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	ntpclient "github.com/beevik/ntp"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,6 +23,7 @@ import (
 	timeapi "github.com/siderolabs/talos/pkg/machinery/api/time"
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
 // ConfigProvider defines an interface sufficient for the TimeServer.
@@ -32,6 +36,7 @@ type TimeServer struct {
 	timeapi.UnimplementedTimeServiceServer
 
 	ConfigProvider ConfigProvider
+	State          state.State
 }
 
 // Register implements the factory.Registrator interface.
@@ -41,20 +46,42 @@ func (r *TimeServer) Register(s *grpc.Server) {
 
 // Time issues a query to the configured ntp server and displays the results.
 func (r *TimeServer) Time(ctx context.Context, in *emptypb.Empty) (reply *timeapi.TimeResponse, err error) {
-	var timeServers []string
+	var timeServer string
 
-	if r.ConfigProvider.Config() != nil {
-		if cfg := r.ConfigProvider.Config().NetworkTimeSyncConfig(); cfg != nil {
-			timeServers = cfg.Servers()
+	// prefer the node's runtime NTP server list, which includes servers
+	// provided via DHCP (the static time.servers config is a subset of it)
+	if r.State != nil {
+		timeServersStatus, err := safe.ReaderGet[*network.TimeServerStatus](
+			ctx,
+			r.State,
+			resource.NewMetadata(network.NamespaceName, network.TimeServerStatusType, network.TimeServerID, resource.VersionUndefined),
+		)
+		if err != nil {
+			if !state.IsNotFoundError(err) {
+				return nil, fmt.Errorf("error getting time server status: %w", err)
+			}
+		} else if timeServers := timeServersStatus.TypedSpec().NTPServers; len(timeServers) > 0 {
+			timeServer = timeServers[0]
 		}
 	}
 
-	if len(timeServers) == 0 {
-		timeServers = []string{constants.DefaultNTPServer}
+	// fall back to the static time.servers config
+	if timeServer == "" {
+		if r.ConfigProvider.Config() != nil {
+			if cfg := r.ConfigProvider.Config().NetworkTimeSyncConfig(); cfg != nil {
+				if servers := cfg.Servers(); len(servers) > 0 {
+					timeServer = servers[0]
+				}
+			}
+		}
+	}
+
+	if timeServer == "" {
+		timeServer = constants.DefaultNTPServer
 	}
 
 	return r.TimeCheck(ctx, &timeapi.TimeRequest{
-		Server: timeServers[0],
+		Server: timeServer,
 	})
 }
 

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
@@ -6,11 +6,15 @@ package runtime_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -24,6 +28,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 )
 
 type TimedSuite struct {
@@ -53,34 +58,37 @@ func (provider *mockConfigProvider) Config() config.Config {
 func (suite *TimedSuite) TestTime() {
 	testServer := "time.cloudflare.com"
 
-	// Create gRPC server
-	api := &runtime.TimeServer{
+	nClient := suite.newTimeClient(&runtime.TimeServer{
 		ConfigProvider: &mockConfigProvider{timeServer: testServer},
-	}
-	server := factory.NewServer(api)
-	listener, err := fakeTimedRPC(suite.T())
-	suite.Assert().NoError(err)
+	})
 
-	defer server.Stop()
-
-	//nolint:errcheck
-	defer os.Remove(listener.Addr().String())
-
-	//nolint:errcheck
-	go server.Serve(listener)
-
-	conn, err := grpc.NewClient(
-		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer.DialUnix()),
-	)
-	suite.Require().NoError(err)
-	suite.T().Cleanup(func() { conn.Close() }) //nolint:errcheck
-
-	nClient := timeapi.NewTimeServiceClient(conn)
 	reply, err := nClient.Time(context.Background(), &emptypb.Empty{})
 	suite.Require().NoError(err)
 	suite.Assert().Equal(reply.Messages[0].Server, testServer)
+}
+
+func (suite *TimedSuite) TestTimeUsesRuntimeTimeServers() {
+	// fake NTP server so the test doesn't depend on the network
+	ntpAddr := fakeNTPServer(suite.T())
+
+	ctx := context.Background()
+
+	st := state.WrapCore(inmem.NewStateWithOptions()(network.NamespaceName))
+
+	timeServersStatus := network.NewTimeServerStatus(network.NamespaceName, network.TimeServerID)
+	timeServersStatus.TypedSpec().NTPServers = []string{ntpAddr}
+
+	suite.Require().NoError(st.Create(ctx, timeServersStatus))
+
+	// the static config has a different server; the runtime list (e.g. from DHCP) should win
+	nClient := suite.newTimeClient(&runtime.TimeServer{
+		ConfigProvider: &mockConfigProvider{timeServer: "time.cloudflare.com"},
+		State:          st,
+	})
+
+	reply, err := nClient.Time(ctx, &emptypb.Empty{})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(reply.Messages[0].Server, ntpAddr)
 }
 
 func (suite *TimedSuite) TestTimeCheck() {
@@ -90,16 +98,20 @@ func (suite *TimedSuite) TestTimeCheck() {
 	// so we can check that we explicitly check the time of the
 	// specified server ( testserver )
 
-	// Create gRPC server
-	api := &runtime.TimeServer{}
+	nClient := suite.newTimeClient(&runtime.TimeServer{})
+
+	reply, err := nClient.TimeCheck(context.Background(), &timeapi.TimeRequest{Server: testServer})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(reply.Messages[0].Server, testServer)
+}
+
+func (suite *TimedSuite) newTimeClient(api *runtime.TimeServer) timeapi.TimeServiceClient {
 	server := factory.NewServer(api)
 	listener, err := fakeTimedRPC(suite.T())
 	suite.Assert().NoError(err)
 
-	defer server.Stop()
-
-	//nolint:errcheck
-	defer os.Remove(listener.Addr().String())
+	suite.T().Cleanup(server.Stop)                                    //nolint:errcheck
+	suite.T().Cleanup(func() { os.Remove(listener.Addr().String()) }) //nolint:errcheck
 
 	//nolint:errcheck
 	go server.Serve(listener)
@@ -112,10 +124,62 @@ func (suite *TimedSuite) TestTimeCheck() {
 	suite.Require().NoError(err)
 	suite.T().Cleanup(func() { conn.Close() }) //nolint:errcheck
 
-	nClient := timeapi.NewTimeServiceClient(conn)
-	reply, err := nClient.TimeCheck(context.Background(), &timeapi.TimeRequest{Server: testServer})
-	suite.Require().NoError(err)
-	suite.Assert().Equal(reply.Messages[0].Server, testServer)
+	return timeapi.NewTimeServiceClient(conn)
+}
+
+// ntpEpochOffset is the number of seconds between the NTP epoch (1900-01-01) and the Unix epoch.
+const ntpEpochOffset = 2208988800
+
+// fakeNTPServer starts a minimal UDP NTP responder on loopback and returns its address.
+func fakeNTPServer(t *testing.T) string {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { conn.Close() }) //nolint:errcheck
+
+	go func() {
+		buf := make([]byte, 512)
+
+		for {
+			n, raddr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+
+			if n < 48 {
+				continue
+			}
+
+			resp := make([]byte, 48)
+
+			now := uint64(time.Now().Unix()) + ntpEpochOffset
+
+			resp[0] = 0x24 // leap 0, version 4, mode 4 (server)
+			resp[1] = 1    // stratum 1
+
+			// reference time: now - 1s, so the response is fresh
+			putNTPTime(resp[16:24], now-1)
+			// origin time: echo the request's transmit timestamp
+			copy(resp[24:32], buf[40:48])
+			// receive and transmit times
+			putNTPTime(resp[32:40], now)
+			putNTPTime(resp[40:48], now)
+
+			_, err = conn.WriteTo(resp, raddr)
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return conn.LocalAddr().String()
+}
+
+// putNTPTime writes a 64-bit NTP timestamp (seconds since the NTP epoch, zero fraction) into b.
+func putNTPTime(b []byte, secs uint64) {
+	binary.BigEndian.PutUint64(b, secs<<32)
 }
 
 func fakeTimedRPC(t *testing.T) (net.Listener, error) {


### PR DESCRIPTION
## What? (description)

Make `talosctl time` check the node time against the node's *actual* NTP servers instead of always defaulting to `time.cloudflare.com`.

The node's effective NTP server list (static `time.servers` config + DHCP-provided servers, e.g. from the local router) is tracked in the `TimeServerStatus` resource — the same list the time sync controller actually uses. The `time` gRPC server now:

1. reads `TimeServerStatus` and uses its first server (this is what `talosctl get timeserver` shows),
2. falls back to the static `time.servers` config,
3. falls back to the Talos default (`time.cloudflare.com`) only when neither exists.

For the reporter's node, `talosctl time` now queries `192.168.8.9` (DHCP-provided) instead of `time.cloudflare.com`:

```
NODE           NTP-SERVER   NODE-TIME ...   NTP-SERVER-TIME ...
192.168.8.44   192.168.8.9  ...
```

`talosctl time --check SERVER` (explicit override) is unchanged.

## Why? (reasoning)

Fixes #13341. `talosctl time` displayed the node time vs `time.cloudflare.com` even on nodes that sync against a DHCP-provided server, so the check didn't reflect the node's reality. The issue discussion confirms the intent: `time` should default to the node's current NTP server, with `--check` remaining the explicit-override path.

## Notes

- The `TimeServer` gRPC server gains a `state.State` reference (the same wrapped resource state used by the rest of the API) to read `TimeServerStatus`.
- Precedence is exact: runtime resource → static config → default. The static config is a subset of the runtime resource (the config controller feeds it), so behavior for static-config-only nodes is unchanged — only DHCP-provided servers become visible.
- Early boot (resource not yet reconciled) degrades gracefully to the config/default path.

## Tests

- `TestTimeUsesRuntimeTimeServers` — new: `TimeServerStatus` in an in-memory resource state points at a fake local NTP server while the static config names `time.cloudflare.com`; asserts `Time` queries the runtime server (and that the reply echoes it). Uses a minimal in-test UDP NTP responder, so the test is deterministic and network-free.
- `TestTime` / `TestTimeCheck` — existing coverage for the config path and the explicit `--check` override, refactored onto a shared client helper.
- Regression-proven: with the resource read disabled, the new test fails (the config server wins).

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

## Review follow-ups

- **Deterministic NTP in tests**: the new test spins a minimal UDP NTP responder on loopback (mode 4, stratum 1, echoes the request's transmit timestamp) rather than depending on outbound network — the fake NTP server also makes the test ~5s faster than it would be querying an unroutable address.
- **No CLI changes**: the fix lives in the `Time` gRPC handler, so `talosctl time` needs no flags or plumbing; the `NTP-SERVER` column now shows the server actually queried.
- **State-read failures are loud**: if reading `TimeServerStatus` returns a non-NotFound error, `Time` fails with that error instead of silently degrading to the config fallback. The state read is cheap and a broken state would break the NTP query itself anyway, so failing loudly felt right — happy to degrade gracefully instead if preferred.
