### PR TITLE
feat: add KmsgLogConfig extraTags support

### DIFF
--- a/api/resource/definitions/runtime/runtime.proto
+++ b/api/resource/definitions/runtime/runtime.proto
@@ -117,7 +117,16 @@ message KernelParamStatusSpec {
 
 // KmsgLogConfigSpec describes configuration for kmsg log streaming.
 message KmsgLogConfigSpec {
+  // Destinations is retained for compatibility with clients which do not support tagged destinations.
   repeated common.URL destinations = 1;
+  // TaggedDestinations associates each endpoint with its dedicated extra tags.
+  repeated KmsgLogDestination tagged_destinations = 2;
+}
+
+// KmsgLogDestination configures a destination for kernel message logs.
+message KmsgLogDestination {
+  common.URL endpoint = 1;
+  map<string, string> extra_tags = 2;
 }
 
 // LoadedKernelModuleSpec describes loaded Linux kernel modules.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -144,6 +144,27 @@ addresses:
 ```
 """
 
+    [notes.kmsg_log_extra_tags]
+        title = "Kernel Log Extra Tags"
+        description = """\
+The `KmsgLogConfig` document now supports an `extraTags` field which attaches additional key-value pairs
+to every kernel log message sent to that destination:
+
+```yaml
+apiVersion: v1alpha1
+kind: KmsgLogConfig
+name: apiSink
+url: https://kmsglog.api/logs
+extraTags:
+  cluster: staging-west
+  node: worker-1
+```
+
+Tags are scoped to the destination they are configured on, so different endpoints can receive different tags.
+The keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time` and `talos-level` are reserved and rejected,
+as they are set by Talos itself.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log.go
@@ -105,7 +105,7 @@ func (ctrl *KmsgLogDeliveryController) Run(ctx context.Context, r controller.Run
 			continue
 		}
 
-		if err = ctrl.deliverLogs(ctx, r, logger, kmsgCh, cfg.TypedSpec().Destinations); err != nil {
+		if err = ctrl.deliverLogs(ctx, r, logger, kmsgCh, cfg.TypedSpec().TaggedDestinations); err != nil {
 			return fmt.Errorf("error delivering logs: %w", err)
 		}
 
@@ -114,7 +114,8 @@ func (ctrl *KmsgLogDeliveryController) Run(ctx context.Context, r controller.Run
 }
 
 type logConfig struct {
-	endpoint *url.URL
+	endpoint  *url.URL
+	extraTags map[string]string
 }
 
 func (c logConfig) Format() string {
@@ -126,19 +127,25 @@ func (c logConfig) Endpoint() *url.URL {
 }
 
 func (c logConfig) ExtraTags() map[string]string {
-	return nil
+	return c.extraTags
 }
 
 //nolint:gocyclo
-func (ctrl *KmsgLogDeliveryController) deliverLogs(ctx context.Context, r controller.Runtime, logger *zap.Logger, kmsgCh <-chan kmsg.Packet, destURLs []*url.URL) error {
+func (ctrl *KmsgLogDeliveryController) deliverLogs(
+	ctx context.Context,
+	r controller.Runtime,
+	logger *zap.Logger,
+	kmsgCh <-chan kmsg.Packet,
+	taggedDestinations []runtime.KmsgLogDestination,
+) error {
 	if ctrl.drainSub == nil {
 		ctrl.drainSub = ctrl.Drainer.Subscribe()
 	}
 
-	// initialize all log senders
-	destLogConfigs := xslices.Map(destURLs, func(u *url.URL) config.LoggingDestination {
-		return logConfig{endpoint: u}
+	destLogConfigs := xslices.Map(taggedDestinations, func(destination runtime.KmsgLogDestination) config.LoggingDestination {
+		return logConfig{endpoint: destination.Endpoint, extraTags: destination.ExtraTags}
 	})
+
 	senders := xslices.Map(destLogConfigs, logging.NewJSONLines)
 
 	defer func() {

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_config.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_config.go
@@ -7,8 +7,8 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
-	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -66,7 +66,36 @@ func (ctrl *KmsgLogConfigController) Run(ctx context.Context, r controller.Runti
 		case <-r.EventCh():
 		}
 
-		var destinations []*url.URL
+		var taggedDestinations []runtime.KmsgLogDestination
+
+		destinationIdx := map[string]int{}
+
+		// addDestination deduplicates the destinations by the endpoint: if the same endpoint is specified
+		// more than once (e.g. both in the kernel args and the machine config), a single destination is kept
+		// with the extra tags merged together.
+		addDestination := func(endpoint *url.URL, extraTags map[string]string) {
+			idx, ok := destinationIdx[endpoint.String()]
+			if !ok {
+				destinationIdx[endpoint.String()] = len(taggedDestinations)
+
+				taggedDestinations = append(taggedDestinations, runtime.KmsgLogDestination{
+					Endpoint:  endpoint,
+					ExtraTags: maps.Clone(extraTags),
+				})
+
+				return
+			}
+
+			if len(extraTags) == 0 {
+				return
+			}
+
+			if taggedDestinations[idx].ExtraTags == nil {
+				taggedDestinations[idx].ExtraTags = map[string]string{}
+			}
+
+			maps.Copy(taggedDestinations[idx].ExtraTags, extraTags)
+		}
 
 		if ctrl.Cmdline != nil {
 			if val := ctrl.Cmdline.Get(constants.KernelParamLoggingKernel).First(); val != nil {
@@ -75,7 +104,7 @@ func (ctrl *KmsgLogConfigController) Run(ctx context.Context, r controller.Runti
 					return fmt.Errorf("error parsing %q: %w", constants.KernelParamLoggingKernel, err)
 				}
 
-				destinations = append(destinations, destURL)
+				addDestination(destURL, nil)
 			}
 		}
 
@@ -85,20 +114,19 @@ func (ctrl *KmsgLogConfigController) Run(ctx context.Context, r controller.Runti
 		}
 
 		if cfg != nil {
-			// remove duplicate URLs in case same destination is specified in both machine config and kernel args
-			destinations = append(destinations, xslices.Filter(cfg.Config().Runtime().KmsgLogURLs(),
-				func(u *url.URL) bool {
-					return !slices.ContainsFunc(destinations, func(v *url.URL) bool {
-						return v.String() == u.String()
-					})
-				})...)
+			for _, destination := range cfg.Config().Runtime().KmsgLogDestinations() {
+				addDestination(destination.Endpoint, destination.ExtraTags)
+			}
 		}
 
 		r.StartTrackingOutputs()
 
-		if len(destinations) > 0 {
+		if len(taggedDestinations) > 0 {
 			if err = safe.WriterModify(ctx, r, runtime.NewKmsgLogConfig(), func(cfg *runtime.KmsgLogConfig) error {
-				cfg.TypedSpec().Destinations = destinations
+				// Keep the legacy destination list populated for older clients. Newer clients
+				// prefer TaggedDestinations to retain the tags associated with each endpoint.
+				cfg.TypedSpec().Destinations = xslices.Map(taggedDestinations, func(d runtime.KmsgLogDestination) *url.URL { return d.Endpoint })
+				cfg.TypedSpec().TaggedDestinations = taggedDestinations
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_config_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_config_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
-	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-procfs/procfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -52,6 +51,7 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 		KmsgLogURL: meta.URL{
 			URL: must(url.Parse("https://10.0.0.2:4444/logs")),
 		},
+		ExtraTags: map[string]string{"cluster": "staging-west"},
 	}
 
 	kmsgLogConfig2 := &runtimecfg.KmsgLogV1Alpha1{
@@ -59,6 +59,7 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 		KmsgLogURL: meta.URL{
 			URL: must(url.Parse("https://10.0.0.1:3333/logs")),
 		},
+		ExtraTags: map[string]string{"node": "worker-1"},
 	}
 
 	cfg, err := container.New(kmsgLogConfig1, kmsgLogConfig2)
@@ -68,13 +69,16 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigMachineConfig() {
 
 	rtestutils.AssertResources[*runtime.KmsgLogConfig](suite.Ctx(), suite.T(), suite.State(), []resource.ID{runtime.KmsgLogConfigID},
 		func(cfg *runtime.KmsgLogConfig, asrt *assert.Assertions) {
-			asrt.Equal(
-				[]string{
-					"https://10.0.0.1:3333/logs",
-					"https://10.0.0.2:4444/logs",
-				},
-				xslices.Map(cfg.TypedSpec().Destinations, func(u *url.URL) string { return u.String() }),
-			)
+			// the destination from the kernel args is also specified in the machine config, so it is
+			// deduplicated, and the extra tags from the machine config are merged into it
+			asrt.Equal([]*url.URL{
+				must(url.Parse("https://10.0.0.1:3333/logs")),
+				must(url.Parse("https://10.0.0.2:4444/logs")),
+			}, cfg.TypedSpec().Destinations)
+			asrt.Equal([]runtime.KmsgLogDestination{
+				{Endpoint: must(url.Parse("https://10.0.0.1:3333/logs")), ExtraTags: map[string]string{"node": "worker-1"}},
+				{Endpoint: must(url.Parse("https://10.0.0.2:4444/logs")), ExtraTags: map[string]string{"cluster": "staging-west"}},
+			}, cfg.TypedSpec().TaggedDestinations)
 		})
 }
 
@@ -88,10 +92,8 @@ func (suite *KmsgLogConfigSuite) TestKmsgLogConfigCmdline() {
 
 	rtestutils.AssertResources[*runtime.KmsgLogConfig](suite.Ctx(), suite.T(), suite.State(), []resource.ID{runtime.KmsgLogConfigID},
 		func(cfg *runtime.KmsgLogConfig, asrt *assert.Assertions) {
-			asrt.Equal(
-				[]string{"https://10.0.0.1:3333/logs"},
-				xslices.Map(cfg.TypedSpec().Destinations, func(u *url.URL) string { return u.String() }),
-			)
+			asrt.Equal([]*url.URL{must(url.Parse("https://10.0.0.1:3333/logs"))}, cfg.TypedSpec().Destinations)
+			asrt.Equal([]runtime.KmsgLogDestination{{Endpoint: must(url.Parse("https://10.0.0.1:3333/logs"))}}, cfg.TypedSpec().TaggedDestinations)
 		})
 }
 

--- a/internal/app/machined/pkg/controllers/runtime/kmsg_log_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kmsg_log_test.go
@@ -28,6 +28,7 @@ import (
 type logHandler struct {
 	mu    sync.Mutex
 	count int
+	logs  []map[string]any
 }
 
 // HandleLog implements logreceiver.Handler.
@@ -36,6 +37,20 @@ func (s *logHandler) HandleLog(srcAddr netip.Addr, msg map[string]any) {
 	defer s.mu.Unlock()
 
 	s.count++
+	s.logs = append(s.logs, msg)
+}
+
+func (s *logHandler) hasTag(key, value string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, log := range s.logs {
+		if log[key] == value {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *logHandler) getCount() int {
@@ -60,11 +75,8 @@ type KmsgLogDeliverySuite struct {
 
 func (suite *KmsgLogDeliverySuite) TestDeliverySingleDestination() {
 	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
-	kmsgLogConfig.TypedSpec().Destinations = []*url.URL{
-		{
-			Scheme: "tcp",
-			Host:   suite.listener1.Addr().String(),
-		},
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()}},
 	}
 
 	suite.Create(kmsgLogConfig)
@@ -75,15 +87,9 @@ func (suite *KmsgLogDeliverySuite) TestDeliverySingleDestination() {
 
 func (suite *KmsgLogDeliverySuite) TestDeliveryMultipleDestinations() {
 	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
-	kmsgLogConfig.TypedSpec().Destinations = []*url.URL{
-		{
-			Scheme: "tcp",
-			Host:   suite.listener1.Addr().String(),
-		},
-		{
-			Scheme: "tcp",
-			Host:   suite.listener2.Addr().String(),
-		},
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()}},
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener2.Addr().String()}},
 	}
 
 	suite.Create(kmsgLogConfig)
@@ -93,20 +99,30 @@ func (suite *KmsgLogDeliverySuite) TestDeliveryMultipleDestinations() {
 	suite.assertLogsSeen(suite.handler2)
 }
 
+func (suite *KmsgLogDeliverySuite) TestDeliveryExtraTags() {
+	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{
+			Endpoint:  &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()},
+			ExtraTags: map[string]string{"cluster": "staging-west"},
+		},
+	}
+
+	suite.Create(kmsgLogConfig)
+
+	suite.Require().EventuallyWithT(func(collect *assert.CollectT) {
+		assert.True(collect, suite.handler1.hasTag("cluster", "staging-west"))
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
 func (suite *KmsgLogDeliverySuite) TestDeliveryOneDeadDestination() {
 	// stop one listener
 	suite.Require().NoError(suite.listener1.Close())
 
 	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
-	kmsgLogConfig.TypedSpec().Destinations = []*url.URL{
-		{
-			Scheme: "tcp",
-			Host:   suite.listener1.Addr().String(),
-		},
-		{
-			Scheme: "tcp",
-			Host:   suite.listener2.Addr().String(),
-		},
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()}},
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener2.Addr().String()}},
 	}
 
 	suite.Create(kmsgLogConfig)
@@ -121,15 +137,9 @@ func (suite *KmsgLogDeliverySuite) TestDeliveryAllDeadDestinations() {
 	suite.Require().NoError(suite.listener2.Close())
 
 	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
-	kmsgLogConfig.TypedSpec().Destinations = []*url.URL{
-		{
-			Scheme: "tcp",
-			Host:   suite.listener1.Addr().String(),
-		},
-		{
-			Scheme: "tcp",
-			Host:   suite.listener2.Addr().String(),
-		},
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()}},
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener2.Addr().String()}},
 	}
 
 	suite.Create(kmsgLogConfig)
@@ -137,11 +147,8 @@ func (suite *KmsgLogDeliverySuite) TestDeliveryAllDeadDestinations() {
 
 func (suite *KmsgLogDeliverySuite) TestDrain() {
 	kmsgLogConfig := runtimeres.NewKmsgLogConfig()
-	kmsgLogConfig.TypedSpec().Destinations = []*url.URL{
-		{
-			Scheme: "tcp",
-			Host:   suite.listener1.Addr().String(),
-		},
+	kmsgLogConfig.TypedSpec().TaggedDestinations = []runtimeres.KmsgLogDestination{
+		{Endpoint: &url.URL{Scheme: "tcp", Host: suite.listener1.Addr().String()}},
 	}
 
 	suite.Create(kmsgLogConfig)

--- a/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime.pb.go
@@ -893,10 +893,13 @@ func (x *KernelParamStatusSpec) GetUnsupported() bool {
 
 // KmsgLogConfigSpec describes configuration for kmsg log streaming.
 type KmsgLogConfigSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Destinations  []*common.URL          `protobuf:"bytes,1,rep,name=destinations,proto3" json:"destinations,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Destinations is retained for compatibility with clients which do not support tagged destinations.
+	Destinations []*common.URL `protobuf:"bytes,1,rep,name=destinations,proto3" json:"destinations,omitempty"`
+	// TaggedDestinations associates each endpoint with its dedicated extra tags.
+	TaggedDestinations []*KmsgLogDestination `protobuf:"bytes,2,rep,name=tagged_destinations,json=taggedDestinations,proto3" json:"tagged_destinations,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *KmsgLogConfigSpec) Reset() {
@@ -936,6 +939,66 @@ func (x *KmsgLogConfigSpec) GetDestinations() []*common.URL {
 	return nil
 }
 
+func (x *KmsgLogConfigSpec) GetTaggedDestinations() []*KmsgLogDestination {
+	if x != nil {
+		return x.TaggedDestinations
+	}
+	return nil
+}
+
+// KmsgLogDestination configures a destination for kernel message logs.
+type KmsgLogDestination struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Endpoint      *common.URL            `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	ExtraTags     map[string]string      `protobuf:"bytes,2,rep,name=extra_tags,json=extraTags,proto3" json:"extra_tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KmsgLogDestination) Reset() {
+	*x = KmsgLogDestination{}
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KmsgLogDestination) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KmsgLogDestination) ProtoMessage() {}
+
+func (x *KmsgLogDestination) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KmsgLogDestination.ProtoReflect.Descriptor instead.
+func (*KmsgLogDestination) Descriptor() ([]byte, []int) {
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *KmsgLogDestination) GetEndpoint() *common.URL {
+	if x != nil {
+		return x.Endpoint
+	}
+	return nil
+}
+
+func (x *KmsgLogDestination) GetExtraTags() map[string]string {
+	if x != nil {
+		return x.ExtraTags
+	}
+	return nil
+}
+
 // LoadedKernelModuleSpec describes loaded Linux kernel modules.
 //
 // Deprecated: use KernelModuleStatus instead.
@@ -954,7 +1017,7 @@ type LoadedKernelModuleSpec struct {
 
 func (x *LoadedKernelModuleSpec) Reset() {
 	*x = LoadedKernelModuleSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[17]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -966,7 +1029,7 @@ func (x *LoadedKernelModuleSpec) String() string {
 func (*LoadedKernelModuleSpec) ProtoMessage() {}
 
 func (x *LoadedKernelModuleSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[17]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -979,7 +1042,7 @@ func (x *LoadedKernelModuleSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadedKernelModuleSpec.ProtoReflect.Descriptor instead.
 func (*LoadedKernelModuleSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{17}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *LoadedKernelModuleSpec) GetSize() int64 {
@@ -1028,7 +1091,7 @@ type MachineStatusSpec struct {
 
 func (x *MachineStatusSpec) Reset() {
 	*x = MachineStatusSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[18]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1103,7 @@ func (x *MachineStatusSpec) String() string {
 func (*MachineStatusSpec) ProtoMessage() {}
 
 func (x *MachineStatusSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[18]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1116,7 @@ func (x *MachineStatusSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineStatusSpec.ProtoReflect.Descriptor instead.
 func (*MachineStatusSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{18}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *MachineStatusSpec) GetStage() enums.RuntimeMachineStage {
@@ -1081,7 +1144,7 @@ type MachineStatusStatus struct {
 
 func (x *MachineStatusStatus) Reset() {
 	*x = MachineStatusStatus{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[19]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1093,7 +1156,7 @@ func (x *MachineStatusStatus) String() string {
 func (*MachineStatusStatus) ProtoMessage() {}
 
 func (x *MachineStatusStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[19]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1106,7 +1169,7 @@ func (x *MachineStatusStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineStatusStatus.ProtoReflect.Descriptor instead.
 func (*MachineStatusStatus) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{19}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *MachineStatusStatus) GetReady() bool {
@@ -1134,7 +1197,7 @@ type MaintenanceServiceConfigSpec struct {
 
 func (x *MaintenanceServiceConfigSpec) Reset() {
 	*x = MaintenanceServiceConfigSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[20]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1146,7 +1209,7 @@ func (x *MaintenanceServiceConfigSpec) String() string {
 func (*MaintenanceServiceConfigSpec) ProtoMessage() {}
 
 func (x *MaintenanceServiceConfigSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[20]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1159,7 +1222,7 @@ func (x *MaintenanceServiceConfigSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MaintenanceServiceConfigSpec.ProtoReflect.Descriptor instead.
 func (*MaintenanceServiceConfigSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{20}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *MaintenanceServiceConfigSpec) GetListenAddress() string {
@@ -1186,7 +1249,7 @@ type MetaKeySpec struct {
 
 func (x *MetaKeySpec) Reset() {
 	*x = MetaKeySpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[21]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1198,7 +1261,7 @@ func (x *MetaKeySpec) String() string {
 func (*MetaKeySpec) ProtoMessage() {}
 
 func (x *MetaKeySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[21]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1211,7 +1274,7 @@ func (x *MetaKeySpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaKeySpec.ProtoReflect.Descriptor instead.
 func (*MetaKeySpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{21}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *MetaKeySpec) GetValue() string {
@@ -1231,7 +1294,7 @@ type MetaLoadedSpec struct {
 
 func (x *MetaLoadedSpec) Reset() {
 	*x = MetaLoadedSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[22]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1243,7 +1306,7 @@ func (x *MetaLoadedSpec) String() string {
 func (*MetaLoadedSpec) ProtoMessage() {}
 
 func (x *MetaLoadedSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[22]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1256,7 +1319,7 @@ func (x *MetaLoadedSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaLoadedSpec.ProtoReflect.Descriptor instead.
 func (*MetaLoadedSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{22}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MetaLoadedSpec) GetDone() bool {
@@ -1281,7 +1344,7 @@ type MountStatusSpec struct {
 
 func (x *MountStatusSpec) Reset() {
 	*x = MountStatusSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[23]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1293,7 +1356,7 @@ func (x *MountStatusSpec) String() string {
 func (*MountStatusSpec) ProtoMessage() {}
 
 func (x *MountStatusSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[23]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1306,7 +1369,7 @@ func (x *MountStatusSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountStatusSpec.ProtoReflect.Descriptor instead.
 func (*MountStatusSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{23}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *MountStatusSpec) GetSource() string {
@@ -1363,7 +1426,7 @@ type OOMActionSpec struct {
 
 func (x *OOMActionSpec) Reset() {
 	*x = OOMActionSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[24]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1375,7 +1438,7 @@ func (x *OOMActionSpec) String() string {
 func (*OOMActionSpec) ProtoMessage() {}
 
 func (x *OOMActionSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[24]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1388,7 +1451,7 @@ func (x *OOMActionSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OOMActionSpec.ProtoReflect.Descriptor instead.
 func (*OOMActionSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{24}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *OOMActionSpec) GetTriggerContext() string {
@@ -1432,7 +1495,7 @@ type PlatformMetadataSpec struct {
 
 func (x *PlatformMetadataSpec) Reset() {
 	*x = PlatformMetadataSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[25]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1444,7 +1507,7 @@ func (x *PlatformMetadataSpec) String() string {
 func (*PlatformMetadataSpec) ProtoMessage() {}
 
 func (x *PlatformMetadataSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[25]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1457,7 +1520,7 @@ func (x *PlatformMetadataSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlatformMetadataSpec.ProtoReflect.Descriptor instead.
 func (*PlatformMetadataSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{25}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PlatformMetadataSpec) GetPlatform() string {
@@ -1552,7 +1615,7 @@ type SBOMItemSpec struct {
 
 func (x *SBOMItemSpec) Reset() {
 	*x = SBOMItemSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[26]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1564,7 +1627,7 @@ func (x *SBOMItemSpec) String() string {
 func (*SBOMItemSpec) ProtoMessage() {}
 
 func (x *SBOMItemSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[26]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1577,7 +1640,7 @@ func (x *SBOMItemSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SBOMItemSpec.ProtoReflect.Descriptor instead.
 func (*SBOMItemSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{26}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SBOMItemSpec) GetName() string {
@@ -1638,7 +1701,7 @@ type SecurityStateSpec struct {
 
 func (x *SecurityStateSpec) Reset() {
 	*x = SecurityStateSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[27]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1650,7 +1713,7 @@ func (x *SecurityStateSpec) String() string {
 func (*SecurityStateSpec) ProtoMessage() {}
 
 func (x *SecurityStateSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[27]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1663,7 +1726,7 @@ func (x *SecurityStateSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityStateSpec.ProtoReflect.Descriptor instead.
 func (*SecurityStateSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{27}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SecurityStateSpec) GetSecureBoot() bool {
@@ -1728,7 +1791,7 @@ type ServicePIDSpec struct {
 
 func (x *ServicePIDSpec) Reset() {
 	*x = ServicePIDSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[28]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1740,7 +1803,7 @@ func (x *ServicePIDSpec) String() string {
 func (*ServicePIDSpec) ProtoMessage() {}
 
 func (x *ServicePIDSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[28]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1753,7 +1816,7 @@ func (x *ServicePIDSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServicePIDSpec.ProtoReflect.Descriptor instead.
 func (*ServicePIDSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{28}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ServicePIDSpec) GetPid() int32 {
@@ -1782,7 +1845,7 @@ type UnattendedInstallStatusSpec struct {
 
 func (x *UnattendedInstallStatusSpec) Reset() {
 	*x = UnattendedInstallStatusSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[29]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1794,7 +1857,7 @@ func (x *UnattendedInstallStatusSpec) String() string {
 func (*UnattendedInstallStatusSpec) ProtoMessage() {}
 
 func (x *UnattendedInstallStatusSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[29]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1807,7 +1870,7 @@ func (x *UnattendedInstallStatusSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnattendedInstallStatusSpec.ProtoReflect.Descriptor instead.
 func (*UnattendedInstallStatusSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{29}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UnattendedInstallStatusSpec) GetImage() string {
@@ -1841,7 +1904,7 @@ type UniqueMachineTokenSpec struct {
 
 func (x *UniqueMachineTokenSpec) Reset() {
 	*x = UniqueMachineTokenSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[30]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1853,7 +1916,7 @@ func (x *UniqueMachineTokenSpec) String() string {
 func (*UniqueMachineTokenSpec) ProtoMessage() {}
 
 func (x *UniqueMachineTokenSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[30]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1866,7 +1929,7 @@ func (x *UniqueMachineTokenSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UniqueMachineTokenSpec.ProtoReflect.Descriptor instead.
 func (*UniqueMachineTokenSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{30}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UniqueMachineTokenSpec) GetToken() string {
@@ -1887,7 +1950,7 @@ type UnmetCondition struct {
 
 func (x *UnmetCondition) Reset() {
 	*x = UnmetCondition{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[31]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1899,7 +1962,7 @@ func (x *UnmetCondition) String() string {
 func (*UnmetCondition) ProtoMessage() {}
 
 func (x *UnmetCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[31]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1912,7 +1975,7 @@ func (x *UnmetCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnmetCondition.ProtoReflect.Descriptor instead.
 func (*UnmetCondition) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{31}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *UnmetCondition) GetName() string {
@@ -1940,7 +2003,7 @@ type VersionSpec struct {
 
 func (x *VersionSpec) Reset() {
 	*x = VersionSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[32]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1952,7 +2015,7 @@ func (x *VersionSpec) String() string {
 func (*VersionSpec) ProtoMessage() {}
 
 func (x *VersionSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[32]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1965,7 +2028,7 @@ func (x *VersionSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionSpec.ProtoReflect.Descriptor instead.
 func (*VersionSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{32}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *VersionSpec) GetVersion() string {
@@ -1993,7 +2056,7 @@ type WatchdogTimerConfigSpec struct {
 
 func (x *WatchdogTimerConfigSpec) Reset() {
 	*x = WatchdogTimerConfigSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[33]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2005,7 +2068,7 @@ func (x *WatchdogTimerConfigSpec) String() string {
 func (*WatchdogTimerConfigSpec) ProtoMessage() {}
 
 func (x *WatchdogTimerConfigSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[33]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2018,7 +2081,7 @@ func (x *WatchdogTimerConfigSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchdogTimerConfigSpec.ProtoReflect.Descriptor instead.
 func (*WatchdogTimerConfigSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{33}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *WatchdogTimerConfigSpec) GetDevice() string {
@@ -2047,7 +2110,7 @@ type WatchdogTimerStatusSpec struct {
 
 func (x *WatchdogTimerStatusSpec) Reset() {
 	*x = WatchdogTimerStatusSpec{}
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[34]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2059,7 +2122,7 @@ func (x *WatchdogTimerStatusSpec) String() string {
 func (*WatchdogTimerStatusSpec) ProtoMessage() {}
 
 func (x *WatchdogTimerStatusSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[34]
+	mi := &file_resource_definitions_runtime_runtime_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2072,7 +2135,7 @@ func (x *WatchdogTimerStatusSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchdogTimerStatusSpec.ProtoReflect.Descriptor instead.
 func (*WatchdogTimerStatusSpec) Descriptor() ([]byte, []int) {
-	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{34}
+	return file_resource_definitions_runtime_runtime_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *WatchdogTimerStatusSpec) GetDevice() string {
@@ -2153,9 +2216,17 @@ const file_resource_definitions_runtime_runtime_proto_rawDesc = "" +
 	"\x15KernelParamStatusSpec\x12\x18\n" +
 	"\acurrent\x18\x01 \x01(\tR\acurrent\x12\x18\n" +
 	"\adefault\x18\x02 \x01(\tR\adefault\x12 \n" +
-	"\vunsupported\x18\x03 \x01(\bR\vunsupported\"D\n" +
+	"\vunsupported\x18\x03 \x01(\bR\vunsupported\"\xad\x01\n" +
 	"\x11KmsgLogConfigSpec\x12/\n" +
-	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\"\xad\x01\n" +
+	"\fdestinations\x18\x01 \x03(\v2\v.common.URLR\fdestinations\x12g\n" +
+	"\x13tagged_destinations\x18\x02 \x03(\v26.talos.resource.definitions.runtime.KmsgLogDestinationR\x12taggedDestinations\"\xe1\x01\n" +
+	"\x12KmsgLogDestination\x12'\n" +
+	"\bendpoint\x18\x01 \x01(\v2\v.common.URLR\bendpoint\x12d\n" +
+	"\n" +
+	"extra_tags\x18\x02 \x03(\v2E.talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntryR\textraTags\x1a<\n" +
+	"\x0eExtraTagsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xad\x01\n" +
 	"\x16LoadedKernelModuleSpec\x12\x12\n" +
 	"\x04size\x18\x01 \x01(\x03R\x04size\x12'\n" +
 	"\x0freference_count\x18\x02 \x01(\x03R\x0ereferenceCount\x12\"\n" +
@@ -2257,7 +2328,7 @@ func file_resource_definitions_runtime_runtime_proto_rawDescGZIP() []byte {
 	return file_resource_definitions_runtime_runtime_proto_rawDescData
 }
 
-var file_resource_definitions_runtime_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_resource_definitions_runtime_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_resource_definitions_runtime_runtime_proto_goTypes = []any{
 	(*APIServiceConfigSpec)(nil),             // 0: talos.resource.definitions.runtime.APIServiceConfigSpec
 	(*BootIDSpec)(nil),                       // 1: talos.resource.definitions.runtime.BootIDSpec
@@ -2276,56 +2347,61 @@ var file_resource_definitions_runtime_runtime_proto_goTypes = []any{
 	(*KernelParamSpecSpec)(nil),              // 14: talos.resource.definitions.runtime.KernelParamSpecSpec
 	(*KernelParamStatusSpec)(nil),            // 15: talos.resource.definitions.runtime.KernelParamStatusSpec
 	(*KmsgLogConfigSpec)(nil),                // 16: talos.resource.definitions.runtime.KmsgLogConfigSpec
-	(*LoadedKernelModuleSpec)(nil),           // 17: talos.resource.definitions.runtime.LoadedKernelModuleSpec
-	(*MachineStatusSpec)(nil),                // 18: talos.resource.definitions.runtime.MachineStatusSpec
-	(*MachineStatusStatus)(nil),              // 19: talos.resource.definitions.runtime.MachineStatusStatus
-	(*MaintenanceServiceConfigSpec)(nil),     // 20: talos.resource.definitions.runtime.MaintenanceServiceConfigSpec
-	(*MetaKeySpec)(nil),                      // 21: talos.resource.definitions.runtime.MetaKeySpec
-	(*MetaLoadedSpec)(nil),                   // 22: talos.resource.definitions.runtime.MetaLoadedSpec
-	(*MountStatusSpec)(nil),                  // 23: talos.resource.definitions.runtime.MountStatusSpec
-	(*OOMActionSpec)(nil),                    // 24: talos.resource.definitions.runtime.OOMActionSpec
-	(*PlatformMetadataSpec)(nil),             // 25: talos.resource.definitions.runtime.PlatformMetadataSpec
-	(*SBOMItemSpec)(nil),                     // 26: talos.resource.definitions.runtime.SBOMItemSpec
-	(*SecurityStateSpec)(nil),                // 27: talos.resource.definitions.runtime.SecurityStateSpec
-	(*ServicePIDSpec)(nil),                   // 28: talos.resource.definitions.runtime.ServicePIDSpec
-	(*UnattendedInstallStatusSpec)(nil),      // 29: talos.resource.definitions.runtime.UnattendedInstallStatusSpec
-	(*UniqueMachineTokenSpec)(nil),           // 30: talos.resource.definitions.runtime.UniqueMachineTokenSpec
-	(*UnmetCondition)(nil),                   // 31: talos.resource.definitions.runtime.UnmetCondition
-	(*VersionSpec)(nil),                      // 32: talos.resource.definitions.runtime.VersionSpec
-	(*WatchdogTimerConfigSpec)(nil),          // 33: talos.resource.definitions.runtime.WatchdogTimerConfigSpec
-	(*WatchdogTimerStatusSpec)(nil),          // 34: talos.resource.definitions.runtime.WatchdogTimerStatusSpec
-	nil,                                      // 35: talos.resource.definitions.runtime.PlatformMetadataSpec.TagsEntry
-	(enums.RuntimeKernelModuleType)(0),       // 36: talos.resource.definitions.enums.RuntimeKernelModuleType
-	(enums.RuntimeKernelModuleState)(0),      // 37: talos.resource.definitions.enums.RuntimeKernelModuleState
-	(*common.URL)(nil),                       // 38: common.URL
-	(enums.RuntimeMachineStage)(0),           // 39: talos.resource.definitions.enums.RuntimeMachineStage
-	(*common.NetIP)(nil),                     // 40: common.NetIP
-	(enums.RuntimeSELinuxState)(0),           // 41: talos.resource.definitions.enums.RuntimeSELinuxState
-	(enums.RuntimeFIPSState)(0),              // 42: talos.resource.definitions.enums.RuntimeFIPSState
-	(enums.RuntimeUnattendedInstallPhase)(0), // 43: talos.resource.definitions.enums.RuntimeUnattendedInstallPhase
-	(*durationpb.Duration)(nil),              // 44: google.protobuf.Duration
+	(*KmsgLogDestination)(nil),               // 17: talos.resource.definitions.runtime.KmsgLogDestination
+	(*LoadedKernelModuleSpec)(nil),           // 18: talos.resource.definitions.runtime.LoadedKernelModuleSpec
+	(*MachineStatusSpec)(nil),                // 19: talos.resource.definitions.runtime.MachineStatusSpec
+	(*MachineStatusStatus)(nil),              // 20: talos.resource.definitions.runtime.MachineStatusStatus
+	(*MaintenanceServiceConfigSpec)(nil),     // 21: talos.resource.definitions.runtime.MaintenanceServiceConfigSpec
+	(*MetaKeySpec)(nil),                      // 22: talos.resource.definitions.runtime.MetaKeySpec
+	(*MetaLoadedSpec)(nil),                   // 23: talos.resource.definitions.runtime.MetaLoadedSpec
+	(*MountStatusSpec)(nil),                  // 24: talos.resource.definitions.runtime.MountStatusSpec
+	(*OOMActionSpec)(nil),                    // 25: talos.resource.definitions.runtime.OOMActionSpec
+	(*PlatformMetadataSpec)(nil),             // 26: talos.resource.definitions.runtime.PlatformMetadataSpec
+	(*SBOMItemSpec)(nil),                     // 27: talos.resource.definitions.runtime.SBOMItemSpec
+	(*SecurityStateSpec)(nil),                // 28: talos.resource.definitions.runtime.SecurityStateSpec
+	(*ServicePIDSpec)(nil),                   // 29: talos.resource.definitions.runtime.ServicePIDSpec
+	(*UnattendedInstallStatusSpec)(nil),      // 30: talos.resource.definitions.runtime.UnattendedInstallStatusSpec
+	(*UniqueMachineTokenSpec)(nil),           // 31: talos.resource.definitions.runtime.UniqueMachineTokenSpec
+	(*UnmetCondition)(nil),                   // 32: talos.resource.definitions.runtime.UnmetCondition
+	(*VersionSpec)(nil),                      // 33: talos.resource.definitions.runtime.VersionSpec
+	(*WatchdogTimerConfigSpec)(nil),          // 34: talos.resource.definitions.runtime.WatchdogTimerConfigSpec
+	(*WatchdogTimerStatusSpec)(nil),          // 35: talos.resource.definitions.runtime.WatchdogTimerStatusSpec
+	nil,                                      // 36: talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntry
+	nil,                                      // 37: talos.resource.definitions.runtime.PlatformMetadataSpec.TagsEntry
+	(enums.RuntimeKernelModuleType)(0),       // 38: talos.resource.definitions.enums.RuntimeKernelModuleType
+	(enums.RuntimeKernelModuleState)(0),      // 39: talos.resource.definitions.enums.RuntimeKernelModuleState
+	(*common.URL)(nil),                       // 40: common.URL
+	(enums.RuntimeMachineStage)(0),           // 41: talos.resource.definitions.enums.RuntimeMachineStage
+	(*common.NetIP)(nil),                     // 42: common.NetIP
+	(enums.RuntimeSELinuxState)(0),           // 43: talos.resource.definitions.enums.RuntimeSELinuxState
+	(enums.RuntimeFIPSState)(0),              // 44: talos.resource.definitions.enums.RuntimeFIPSState
+	(enums.RuntimeUnattendedInstallPhase)(0), // 45: talos.resource.definitions.enums.RuntimeUnattendedInstallPhase
+	(*durationpb.Duration)(nil),              // 46: google.protobuf.Duration
 }
 var file_resource_definitions_runtime_runtime_proto_depIdxs = []int32{
 	7,  // 0: talos.resource.definitions.runtime.ExtensionServiceConfigSpec.files:type_name -> talos.resource.definitions.runtime.ExtensionServiceConfigFile
-	36, // 1: talos.resource.definitions.runtime.KernelModuleStatusSpec.type:type_name -> talos.resource.definitions.enums.RuntimeKernelModuleType
-	37, // 2: talos.resource.definitions.runtime.KernelModuleStatusSpec.state:type_name -> talos.resource.definitions.enums.RuntimeKernelModuleState
-	38, // 3: talos.resource.definitions.runtime.KmsgLogConfigSpec.destinations:type_name -> common.URL
-	39, // 4: talos.resource.definitions.runtime.MachineStatusSpec.stage:type_name -> talos.resource.definitions.enums.RuntimeMachineStage
-	19, // 5: talos.resource.definitions.runtime.MachineStatusSpec.status:type_name -> talos.resource.definitions.runtime.MachineStatusStatus
-	31, // 6: talos.resource.definitions.runtime.MachineStatusStatus.unmet_conditions:type_name -> talos.resource.definitions.runtime.UnmetCondition
-	40, // 7: talos.resource.definitions.runtime.MaintenanceServiceConfigSpec.reachable_addresses:type_name -> common.NetIP
-	35, // 8: talos.resource.definitions.runtime.PlatformMetadataSpec.tags:type_name -> talos.resource.definitions.runtime.PlatformMetadataSpec.TagsEntry
-	41, // 9: talos.resource.definitions.runtime.SecurityStateSpec.se_linux_state:type_name -> talos.resource.definitions.enums.RuntimeSELinuxState
-	42, // 10: talos.resource.definitions.runtime.SecurityStateSpec.fips_state:type_name -> talos.resource.definitions.enums.RuntimeFIPSState
-	43, // 11: talos.resource.definitions.runtime.UnattendedInstallStatusSpec.phase:type_name -> talos.resource.definitions.enums.RuntimeUnattendedInstallPhase
-	44, // 12: talos.resource.definitions.runtime.WatchdogTimerConfigSpec.timeout:type_name -> google.protobuf.Duration
-	44, // 13: talos.resource.definitions.runtime.WatchdogTimerStatusSpec.timeout:type_name -> google.protobuf.Duration
-	44, // 14: talos.resource.definitions.runtime.WatchdogTimerStatusSpec.feed_interval:type_name -> google.protobuf.Duration
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	38, // 1: talos.resource.definitions.runtime.KernelModuleStatusSpec.type:type_name -> talos.resource.definitions.enums.RuntimeKernelModuleType
+	39, // 2: talos.resource.definitions.runtime.KernelModuleStatusSpec.state:type_name -> talos.resource.definitions.enums.RuntimeKernelModuleState
+	40, // 3: talos.resource.definitions.runtime.KmsgLogConfigSpec.destinations:type_name -> common.URL
+	17, // 4: talos.resource.definitions.runtime.KmsgLogConfigSpec.tagged_destinations:type_name -> talos.resource.definitions.runtime.KmsgLogDestination
+	40, // 5: talos.resource.definitions.runtime.KmsgLogDestination.endpoint:type_name -> common.URL
+	36, // 6: talos.resource.definitions.runtime.KmsgLogDestination.extra_tags:type_name -> talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntry
+	41, // 7: talos.resource.definitions.runtime.MachineStatusSpec.stage:type_name -> talos.resource.definitions.enums.RuntimeMachineStage
+	20, // 8: talos.resource.definitions.runtime.MachineStatusSpec.status:type_name -> talos.resource.definitions.runtime.MachineStatusStatus
+	32, // 9: talos.resource.definitions.runtime.MachineStatusStatus.unmet_conditions:type_name -> talos.resource.definitions.runtime.UnmetCondition
+	42, // 10: talos.resource.definitions.runtime.MaintenanceServiceConfigSpec.reachable_addresses:type_name -> common.NetIP
+	37, // 11: talos.resource.definitions.runtime.PlatformMetadataSpec.tags:type_name -> talos.resource.definitions.runtime.PlatformMetadataSpec.TagsEntry
+	43, // 12: talos.resource.definitions.runtime.SecurityStateSpec.se_linux_state:type_name -> talos.resource.definitions.enums.RuntimeSELinuxState
+	44, // 13: talos.resource.definitions.runtime.SecurityStateSpec.fips_state:type_name -> talos.resource.definitions.enums.RuntimeFIPSState
+	45, // 14: talos.resource.definitions.runtime.UnattendedInstallStatusSpec.phase:type_name -> talos.resource.definitions.enums.RuntimeUnattendedInstallPhase
+	46, // 15: talos.resource.definitions.runtime.WatchdogTimerConfigSpec.timeout:type_name -> google.protobuf.Duration
+	46, // 16: talos.resource.definitions.runtime.WatchdogTimerStatusSpec.timeout:type_name -> google.protobuf.Duration
+	46, // 17: talos.resource.definitions.runtime.WatchdogTimerStatusSpec.feed_interval:type_name -> google.protobuf.Duration
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_resource_definitions_runtime_runtime_proto_init() }
@@ -2339,7 +2415,7 @@ func file_resource_definitions_runtime_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_definitions_runtime_runtime_proto_rawDesc), len(file_resource_definitions_runtime_runtime_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/runtime/runtime_vtproto.pb.go
@@ -841,6 +841,18 @@ func (m *KmsgLogConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TaggedDestinations) > 0 {
+		for iNdEx := len(m.TaggedDestinations) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.TaggedDestinations[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
 	if len(m.Destinations) > 0 {
 		for iNdEx := len(m.Destinations) - 1; iNdEx >= 0; iNdEx-- {
 			if vtmsg, ok := interface{}(m.Destinations[iNdEx]).(interface {
@@ -864,6 +876,80 @@ func (m *KmsgLogConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *KmsgLogDestination) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *KmsgLogDestination) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *KmsgLogDestination) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ExtraTags) > 0 {
+		for k := range m.ExtraTags {
+			v := m.ExtraTags[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Endpoint != nil {
+		if vtmsg, ok := interface{}(m.Endpoint).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Endpoint)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -2266,6 +2352,40 @@ func (m *KmsgLogConfigSpec) SizeVT() (n int) {
 				l = proto.Size(e)
 			}
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.TaggedDestinations) > 0 {
+		for _, e := range m.TaggedDestinations {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *KmsgLogDestination) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Endpoint != nil {
+		if size, ok := interface{}(m.Endpoint).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Endpoint)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.ExtraTags) > 0 {
+		for k, v := range m.ExtraTags {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
 	}
 	n += len(m.unknownFields)
@@ -4526,6 +4646,262 @@ func (m *KmsgLogConfigSpec) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TaggedDestinations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TaggedDestinations = append(m.TaggedDestinations, &KmsgLogDestination{})
+			if err := m.TaggedDestinations[len(m.TaggedDestinations)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *KmsgLogDestination) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: KmsgLogDestination: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: KmsgLogDestination: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Endpoint", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Endpoint == nil {
+				m.Endpoint = &common.URL{}
+			}
+			if unmarshal, ok := interface{}(m.Endpoint).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Endpoint); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExtraTags", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ExtraTags == nil {
+				m.ExtraTags = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.ExtraTags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/config/config/runtime.go
+++ b/pkg/machinery/config/config/runtime.go
@@ -19,8 +19,14 @@ import (
 // RuntimeConfig defines the interface to access Talos runtime configuration.
 type RuntimeConfig interface {
 	EventsEndpoint() *string
-	KmsgLogURLs() []*url.URL
+	KmsgLogDestinations() []KmsgLogDestination
 	WatchdogTimer() WatchdogTimerConfig
+}
+
+// KmsgLogDestination configures a destination for kernel message logs.
+type KmsgLogDestination struct {
+	Endpoint  *url.URL
+	ExtraTags map[string]string
 }
 
 // EnvironmentConfig defines the interface to access Talos environment configuration.
@@ -115,9 +121,9 @@ func (w runtimeConfigWrapper) EventsEndpoint() *string {
 	})
 }
 
-func (w runtimeConfigWrapper) KmsgLogURLs() []*url.URL {
-	return aggregateValues(w, func(c RuntimeConfig) []*url.URL {
-		return c.KmsgLogURLs()
+func (w runtimeConfigWrapper) KmsgLogDestinations() []KmsgLogDestination {
+	return aggregateValues(w, func(c RuntimeConfig) []KmsgLogDestination {
+		return c.KmsgLogDestinations()
 	})
 }
 

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -6858,6 +6858,18 @@
           "description": "The URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.\n",
           "markdownDescription": "The URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.",
           "x-intellij-html-description": "\u003cp\u003eThe URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.\u003c/p\u003e\n"
+        },
+        "extraTags": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "title": "extraTags",
+          "description": "Extra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys facility, seq, clock, priority, msg, talos-time, and talos-level are reserved and rejected.\n",
+          "markdownDescription": "Extra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time`, and `talos-level` are reserved and rejected.",
+          "x-intellij-html-description": "\u003cp\u003eExtra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys \u003ccode\u003efacility\u003c/code\u003e, \u003ccode\u003eseq\u003c/code\u003e, \u003ccode\u003eclock\u003c/code\u003e, \u003ccode\u003epriority\u003c/code\u003e, \u003ccode\u003emsg\u003c/code\u003e, \u003ccode\u003etalos-time\u003c/code\u003e, and \u003ccode\u003etalos-level\u003c/code\u003e are reserved and rejected.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/runtime/deep_copy.generated.go
+++ b/pkg/machinery/config/types/runtime/deep_copy.generated.go
@@ -39,6 +39,12 @@ func (o *KmsgLogV1Alpha1) DeepCopy() *KmsgLogV1Alpha1 {
 			*cp.KmsgLogURL.URL.User = *o.KmsgLogURL.URL.User
 		}
 	}
+	if o.ExtraTags != nil {
+		cp.ExtraTags = make(map[string]string, len(o.ExtraTags))
+		for k2, v2 := range o.ExtraTags {
+			cp.ExtraTags[k2] = v2
+		}
+	}
 	return &cp
 }
 

--- a/pkg/machinery/config/types/runtime/event_sink.go
+++ b/pkg/machinery/config/types/runtime/event_sink.go
@@ -9,7 +9,6 @@ package runtime
 import (
 	"fmt"
 	"net"
-	"net/url"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/internal/registry"
@@ -87,8 +86,8 @@ func (s *EventSinkV1Alpha1) EventsEndpoint() *string {
 	return new(s.Endpoint)
 }
 
-// KmsgLogURLs implements config.RuntimeConfig interface.
-func (s *EventSinkV1Alpha1) KmsgLogURLs() []*url.URL {
+// KmsgLogDestinations implements config.RuntimeConfig interface.
+func (s *EventSinkV1Alpha1) KmsgLogDestinations() []config.KmsgLogDestination {
 	return nil
 }
 

--- a/pkg/machinery/config/types/runtime/kmsg_log.go
+++ b/pkg/machinery/config/types/runtime/kmsg_log.go
@@ -8,6 +8,7 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 
 	"github.com/siderolabs/gen/ensure"
@@ -64,6 +65,10 @@ type KmsgLogV1Alpha1 struct {
 	//     type: string
 	//     pattern: "^(tcp|udp)://"
 	KmsgLogURL meta.URL `yaml:"url"`
+	//   description: |
+	//     Extra tags (key-value) pairs to attach to every kernel log message sent.
+	//     The keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time`, and `talos-level` are reserved and rejected.
+	ExtraTags map[string]string `yaml:"extraTags,omitempty"`
 }
 
 // NewKmsgLogV1Alpha1 creates a new eventsink config document.
@@ -80,6 +85,10 @@ func exampleKmsgLogV1Alpha1() *KmsgLogV1Alpha1 {
 	cfg := NewKmsgLogV1Alpha1()
 	cfg.MetaName = "remote-log"
 	cfg.KmsgLogURL.URL = ensure.Value(url.Parse("tcp://192.168.3.7:3478/"))
+	cfg.ExtraTags = map[string]string{
+		"cluster": "staging-west",
+		"node":    "worker-1",
+	}
 
 	return cfg
 }
@@ -104,9 +113,12 @@ func (s *KmsgLogV1Alpha1) EventsEndpoint() *string {
 	return nil
 }
 
-// KmsgLogURLs implements config.RuntimeConfig interface.
-func (s *KmsgLogV1Alpha1) KmsgLogURLs() []*url.URL {
-	return []*url.URL{s.KmsgLogURL.URL}
+// KmsgLogDestinations implements config.RuntimeConfig interface.
+func (s *KmsgLogV1Alpha1) KmsgLogDestinations() []config.KmsgLogDestination {
+	return []config.KmsgLogDestination{{
+		Endpoint:  s.KmsgLogURL.URL,
+		ExtraTags: s.ExtraTags,
+	}}
 }
 
 // WatchdogTimer implements config.RuntimeConfig interface.
@@ -142,5 +154,20 @@ func (s *KmsgLogV1Alpha1) Validate(validation.RuntimeMode, ...validation.Option)
 		return nil, errors.New("url port is required")
 	}
 
+	for key := range s.ExtraTags {
+		if isReservedKmsgLogField(key) {
+			return nil, fmt.Errorf("extra tag %q is reserved", key)
+		}
+	}
+
 	return nil, nil
+}
+
+func isReservedKmsgLogField(key string) bool {
+	switch key {
+	case "facility", "seq", "clock", "priority", "msg", "talos-time", "talos-level":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/machinery/config/types/runtime/kmsg_log_test.go
+++ b/pkg/machinery/config/types/runtime/kmsg_log_test.go
@@ -24,6 +24,7 @@ func TestKmsgLogMarshalStability(t *testing.T) {
 	cfg := runtime.NewKmsgLogV1Alpha1()
 	cfg.MetaName = "apiSink"
 	cfg.KmsgLogURL.URL = ensure.Value(url.Parse("https://kmsglog.api/logs"))
+	cfg.ExtraTags = map[string]string{"cluster": "staging-west", "node": "worker-1"}
 
 	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
 	require.NoError(t, err)
@@ -102,6 +103,7 @@ func TestKmsgLogValidate(t *testing.T) {
 				cfg := runtime.NewKmsgLogV1Alpha1()
 				cfg.MetaName = "name3"
 				cfg.KmsgLogURL.URL = ensure.Value(url.Parse("tcp://10.2.3.4:5000/"))
+				cfg.ExtraTags = map[string]string{"cluster": "staging-west"}
 
 				return cfg
 			},
@@ -129,6 +131,24 @@ func TestKmsgLogValidate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestKmsgLogRejectsReservedExtraTags(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{"facility", "seq", "clock", "priority", "msg", "talos-time", "talos-level"} {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := runtime.NewKmsgLogV1Alpha1()
+			cfg.MetaName = "name"
+			cfg.KmsgLogURL.URL = ensure.Value(url.Parse("tcp://10.2.3.4:5000/"))
+			cfg.ExtraTags = map[string]string{key: "overridden"}
+
+			_, err := cfg.Validate(validationMode{})
+			assert.EqualError(t, err, "extra tag \""+key+"\" is reserved")
 		})
 	}
 }

--- a/pkg/machinery/config/types/runtime/runtime_doc.go
+++ b/pkg/machinery/config/types/runtime/runtime_doc.go
@@ -34,6 +34,13 @@ func (KmsgLogV1Alpha1) Doc() *encoder.Doc {
 				Description: "The URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "The URL encodes the log destination." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "extraTags",
+				Type:        "map[string]string",
+				Note:        "",
+				Description: "Extra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time`, and `talos-level` are reserved and rejected.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Extra tags (key-value) pairs to attach to every kernel log message sent." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/pkg/machinery/config/types/runtime/testdata/kmsglog.yaml
+++ b/pkg/machinery/config/types/runtime/testdata/kmsglog.yaml
@@ -2,3 +2,6 @@ apiVersion: v1alpha1
 kind: KmsgLogConfig
 name: apiSink
 url: https://kmsglog.api/logs
+extraTags:
+    cluster: staging-west
+    node: worker-1

--- a/pkg/machinery/config/types/runtime/watchdog_timer.go
+++ b/pkg/machinery/config/types/runtime/watchdog_timer.go
@@ -8,7 +8,6 @@ package runtime
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -104,8 +103,8 @@ func (s *WatchdogTimerV1Alpha1) EventsEndpoint() *string {
 	return nil
 }
 
-// KmsgLogURLs implements config.RuntimeConfig interface.
-func (s *WatchdogTimerV1Alpha1) KmsgLogURLs() []*url.URL {
+// KmsgLogDestinations implements config.RuntimeConfig interface.
+func (s *WatchdogTimerV1Alpha1) KmsgLogDestinations() []config.KmsgLogDestination {
 	return nil
 }
 

--- a/pkg/machinery/resources/runtime/deep_copy.generated.go
+++ b/pkg/machinery/resources/runtime/deep_copy.generated.go
@@ -142,6 +142,26 @@ func (o KmsgLogConfigSpec) DeepCopy() KmsgLogConfigSpec {
 			}
 		}
 	}
+	if o.TaggedDestinations != nil {
+		cp.TaggedDestinations = make([]KmsgLogDestination, len(o.TaggedDestinations))
+		copy(cp.TaggedDestinations, o.TaggedDestinations)
+		for i2 := range o.TaggedDestinations {
+			if o.TaggedDestinations[i2].Endpoint != nil {
+				cp.TaggedDestinations[i2].Endpoint = new(url.URL)
+				*cp.TaggedDestinations[i2].Endpoint = *o.TaggedDestinations[i2].Endpoint
+				if o.TaggedDestinations[i2].Endpoint.User != nil {
+					cp.TaggedDestinations[i2].Endpoint.User = new(url.Userinfo)
+					*cp.TaggedDestinations[i2].Endpoint.User = *o.TaggedDestinations[i2].Endpoint.User
+				}
+			}
+			if o.TaggedDestinations[i2].ExtraTags != nil {
+				cp.TaggedDestinations[i2].ExtraTags = make(map[string]string, len(o.TaggedDestinations[i2].ExtraTags))
+				for k4, v4 := range o.TaggedDestinations[i2].ExtraTags {
+					cp.TaggedDestinations[i2].ExtraTags[k4] = v4
+				}
+			}
+		}
+	}
 	return cp
 }
 

--- a/pkg/machinery/resources/runtime/kmsg_log_config.go
+++ b/pkg/machinery/resources/runtime/kmsg_log_config.go
@@ -28,7 +28,18 @@ const KmsgLogConfigID resource.ID = "kmsg-log"
 //
 //gotagsrewrite:gen
 type KmsgLogConfigSpec struct {
+	// Destinations is retained for compatibility with clients which do not support tagged destinations.
 	Destinations []*url.URL `yaml:"destinations" protobuf:"1"`
+	// TaggedDestinations associates each endpoint with its dedicated extra tags.
+	TaggedDestinations []KmsgLogDestination `yaml:"taggedDestinations" protobuf:"2"`
+}
+
+// KmsgLogDestination configures a destination for kernel message logs.
+//
+//gotagsrewrite:gen
+type KmsgLogDestination struct {
+	Endpoint  *url.URL          `yaml:"endpoint" protobuf:"1"`
+	ExtraTags map[string]string `yaml:"extraTags,omitempty" protobuf:"2"`
 }
 
 // NewKmsgLogConfig initializes a KmsgLogConfig resource.

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -554,6 +554,8 @@ description: Talos gRPC API reference.
     - [KernelParamSpecSpec](#talos.resource.definitions.runtime.KernelParamSpecSpec)
     - [KernelParamStatusSpec](#talos.resource.definitions.runtime.KernelParamStatusSpec)
     - [KmsgLogConfigSpec](#talos.resource.definitions.runtime.KmsgLogConfigSpec)
+    - [KmsgLogDestination](#talos.resource.definitions.runtime.KmsgLogDestination)
+    - [KmsgLogDestination.ExtraTagsEntry](#talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntry)
     - [MachineStatusSpec](#talos.resource.definitions.runtime.MachineStatusSpec)
     - [MachineStatusStatus](#talos.resource.definitions.runtime.MachineStatusStatus)
     - [MaintenanceServiceConfigSpec](#talos.resource.definitions.runtime.MaintenanceServiceConfigSpec)
@@ -9648,7 +9650,40 @@ KmsgLogConfigSpec describes configuration for kmsg log streaming.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| destinations | [common.URL](#common.URL) | repeated |  |
+| destinations | [common.URL](#common.URL) | repeated | Destinations is retained for compatibility with clients which do not support tagged destinations. |
+| tagged_destinations | [KmsgLogDestination](#talos.resource.definitions.runtime.KmsgLogDestination) | repeated | TaggedDestinations associates each endpoint with its dedicated extra tags. |
+
+
+
+
+
+
+<a name="talos.resource.definitions.runtime.KmsgLogDestination"></a>
+
+### KmsgLogDestination
+KmsgLogDestination configures a destination for kernel message logs.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| endpoint | [common.URL](#common.URL) |  |  |
+| extra_tags | [KmsgLogDestination.ExtraTagsEntry](#talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntry) | repeated |  |
+
+
+
+
+
+
+<a name="talos.resource.definitions.runtime.KmsgLogDestination.ExtraTagsEntry"></a>
+
+### KmsgLogDestination.ExtraTagsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 

--- a/website/content/v1.15/reference/configuration/runtime/kmsglogconfig.md
+++ b/website/content/v1.15/reference/configuration/runtime/kmsglogconfig.md
@@ -18,6 +18,10 @@ apiVersion: v1alpha1
 kind: KmsgLogConfig
 name: remote-log # Name of the config document.
 url: tcp://192.168.3.7:3478/ # The URL encodes the log destination.
+# Extra tags (key-value) pairs to attach to every kernel log message sent.
+extraTags:
+    cluster: staging-west
+    node: worker-1
 {{< /highlight >}}
 
 
@@ -27,6 +31,7 @@ url: tcp://192.168.3.7:3478/ # The URL encodes the log destination.
 |`url` |URL |The URL encodes the log destination.<br>The scheme must be tcp:// or udp://.<br>The path must be empty.<br>The port is required. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 url: udp://10.3.7.3:2810
 {{< /highlight >}}</details> | |
+|`extraTags` |map[string]string |Extra tags (key-value) pairs to attach to every kernel log message sent.<br>The keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time`, and `talos-level` are reserved and rejected.  | |
 
 
 

--- a/website/content/v1.15/schemas/config.schema.json
+++ b/website/content/v1.15/schemas/config.schema.json
@@ -6858,6 +6858,18 @@
           "description": "The URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.\n",
           "markdownDescription": "The URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.",
           "x-intellij-html-description": "\u003cp\u003eThe URL encodes the log destination.\nThe scheme must be tcp:// or udp://.\nThe path must be empty.\nThe port is required.\u003c/p\u003e\n"
+        },
+        "extraTags": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "title": "extraTags",
+          "description": "Extra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys facility, seq, clock, priority, msg, talos-time, and talos-level are reserved and rejected.\n",
+          "markdownDescription": "Extra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys `facility`, `seq`, `clock`, `priority`, `msg`, `talos-time`, and `talos-level` are reserved and rejected.",
+          "x-intellij-html-description": "\u003cp\u003eExtra tags (key-value) pairs to attach to every kernel log message sent.\nThe keys \u003ccode\u003efacility\u003c/code\u003e, \u003ccode\u003eseq\u003c/code\u003e, \u003ccode\u003eclock\u003c/code\u003e, \u003ccode\u003epriority\u003c/code\u003e, \u003ccode\u003emsg\u003c/code\u003e, \u003ccode\u003etalos-time\u003c/code\u003e, and \u003ccode\u003etalos-level\u003c/code\u003e are reserved and rejected.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Add `extraTags` support to `KmsgLogConfig`.

The extra tags are attached to every log forwarded by the kmsg log service. It allows to set node metadata, such as cluster or environment, to be included in logs alongside other tags.

As discussed in #14073 added extra tags support to KmsgLogConfig:

```yaml
apiVersion: v1alpha1
kind: KmsgLogConfig
name: kmsg
url: tcp://127.0.0.1:6050/
extraTags:
  cluster: staging-west
  node: worker-1
  environment: dev
```

## Why? (reasoning)

Metadata must be available even when a node is degraded or unable to run workloads. Suggested approach that injects tags from a running workload depend on the node being healthy enough to schedule and run that workload.

Configuring the tags in KmsgLogConfig makes log metadata available directly to the kmsg log service, including during node failures and early boot, and avoids healthy runtime dependencies to send logs.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
