### PR TITLE
refactor: log filter stays enabled on enter press

### DIFF
--- a/internal/pkg/dashboard/components/logviewer.go
+++ b/internal/pkg/dashboard/components/logviewer.go
@@ -80,14 +80,12 @@ func NewLogViewer(app *tview.Application) *LogViewer {
 		widget.renderLogs()
 	})
 	widget.filterInput.SetDoneFunc(func(key tcell.Key) {
-		if key == tcell.KeyEscape {
-			widget.deactivateSearch()
-		}
+		widget.deactivateSearch(key == tcell.KeyEscape)
 	})
 
 	widget.SetRows(1, 0).SetColumns(0)
 
-	widget.AddItem(NewHorizontalLine("Logs"), 0, 0, 1, 1, 0, 0, false)
+	widget.AddItem(NewHorizontalLine("Logs (/: filter)"), 0, 0, 1, 1, 0, 0, false)
 	widget.AddItem(&widget.logs, 1, 0, 1, 1, 0, 0, true)
 
 	return widget
@@ -108,22 +106,33 @@ func (widget *LogViewer) activateSearch() {
 	widget.app.SetFocus(widget.filterInput)
 }
 
-// deactivateSearch hides the search input and clears the filter.
-func (widget *LogViewer) deactivateSearch() {
-	if widget.filterText != "" {
-		widget.filterText = ""
-		widget.filterInput.SetText("")
-		widget.renderLogs()
+// deactivateSearch hides the search input. If clearText is true, the filter is also cleared.
+func (widget *LogViewer) deactivateSearch(clearText bool) {
+	if !widget.filterActive {
+		if clearText && widget.filterText != "" {
+			widget.filterText = ""
+			widget.filterInput.SetText("")
+			widget.renderLogs()
+		}
+
+		return
 	}
 
-	if !widget.filterActive {
-		return
+	hadFilter := widget.filterText != ""
+
+	if clearText {
+		widget.filterText = ""
+		widget.filterInput.SetText("")
 	}
 
 	widget.filterActive = false
 	widget.RemoveItem(widget.filterInput)
 	widget.SetRows(1, 0)
 	widget.app.SetFocus(&widget.logs)
+
+	if clearText && hadFilter {
+		widget.renderLogs()
+	}
 }
 
 // WriteLog writes the log line to the widget.

--- a/internal/pkg/dashboard/components/logviewer_test.go
+++ b/internal/pkg/dashboard/components/logviewer_test.go
@@ -8,6 +8,8 @@ package components
 import (
 	"testing"
 	"unicode/utf8"
+
+	"github.com/rivo/tview"
 )
 
 // TestFormatLogEntry covers the two responsibilities of formatLogEntry: deciding
@@ -180,6 +182,112 @@ func TestFormatLogEntryKeepsTextValid(t *testing.T) {
 
 	if !utf8.ValidString(actual) {
 		t.Fatalf("output is not valid UTF-8: %q", actual)
+	}
+}
+
+// TestDeactivateSearchKeepFilter verifies that Enter (clearText=false) hides the
+// input row while preserving the filter text for next activation.
+func TestDeactivateSearchKeepFilter(t *testing.T) {
+	app := tview.NewApplication()
+	defer app.Stop()
+
+	viewer := NewLogViewer(app)
+
+	// Manually set up the filtered state as activateSearch would.
+	viewer.filterText = "test"
+	viewer.filterActive = true
+	viewer.filterInput.SetText("test")
+	viewer.SetRows(1, 0, 1)
+	viewer.AddItem(viewer.filterInput, 2, 0, 1, 1, 0, 0, true)
+
+	// Simulate Enter: keep the filter but hide the input row.
+	viewer.deactivateSearch(false)
+
+	if viewer.filterActive {
+		t.Fatalf("filterActive = %v, expected false (input row should be hidden)", viewer.filterActive)
+	}
+
+	if viewer.filterText != "test" {
+		t.Fatalf("filterText = %q, expected %q (filter text should be preserved for next /)", viewer.filterText, "test")
+	}
+}
+
+// TestDeactivateSearchClearFilter verifies that Escape (clearText=true) clears
+// the filter and hides the input row.
+func TestDeactivateSearchClearFilter(t *testing.T) {
+	app := tview.NewApplication()
+	defer app.Stop()
+
+	viewer := NewLogViewer(app)
+
+	// Manually set up the filtered state.
+	viewer.filterText = "test"
+	viewer.filterActive = true
+	viewer.filterInput.SetText("test")
+	viewer.SetRows(1, 0, 1)
+	viewer.AddItem(viewer.filterInput, 2, 0, 1, 1, 0, 0, true)
+
+	// Add a log entry so renderLogs has something to process.
+	viewer.entries = append(viewer.entries, logEntry{text: "test line", isError: false})
+
+	// Simulate Escape: clear the filter and hide the input row.
+	viewer.deactivateSearch(true)
+
+	if viewer.filterActive {
+		t.Fatalf("filterActive = %v, expected false", viewer.filterActive)
+	}
+
+	if viewer.filterText != "" {
+		t.Fatalf("filterText = %q, expected empty", viewer.filterText)
+	}
+
+	if viewer.filterInput.GetText() != "" {
+		t.Fatalf("filterInput text = %q, expected empty", viewer.filterInput.GetText())
+	}
+}
+
+// TestDeactivateSearchWhenInactive verifies that calling deactivateSearch when
+// the input is not active clears the text only if clearText=true.
+func TestDeactivateSearchWhenInactive(t *testing.T) {
+	app := tview.NewApplication()
+	defer app.Stop()
+
+	viewer := NewLogViewer(app)
+	viewer.filterText = "old"
+	viewer.filterActive = false
+
+	// clearText=false: should not clear.
+	viewer.deactivateSearch(false)
+
+	if viewer.filterText != "old" {
+		t.Fatalf("filterText = %q, expected %q", viewer.filterText, "old")
+	}
+
+	// clearText=true: should clear and re-render.
+	viewer.entries = append(viewer.entries, logEntry{text: "line", isError: false})
+	viewer.deactivateSearch(true)
+
+	if viewer.filterText != "" {
+		t.Fatalf("filterText = %q, expected empty", viewer.filterText)
+	}
+}
+
+// TestDeactivateSearchEscapeWithoutFilterKeepsNoData verifies that pressing Esc
+// immediately after opening the filter (without typing) does not clear the
+// initial noData placeholder.
+func TestDeactivateSearchEscapeWithoutFilterKeepsNoData(t *testing.T) {
+	app := tview.NewApplication()
+	defer app.Stop()
+
+	viewer := NewLogViewer(app)
+	// Manually activate the filter input (as activateSearch would).
+	viewer.filterActive = true
+	viewer.SetRows(1, 0, 1)
+	viewer.AddItem(viewer.filterInput, 2, 0, 1, 1, 0, 0, true)
+	viewer.deactivateSearch(true)
+
+	if text := viewer.logs.GetText(true); text != noData {
+		t.Fatalf("logs text = %q, expected %q", text, noData)
 	}
 }
 


### PR DESCRIPTION
I've recently added log filtering support to the talosctl dashboard, in https://github.com/siderolabs/talos/pull/14066. I've realized it can be improved and aligned with how pre-existing filtering features work.

This PR aligns the log filter behavior with the "Resources" page (`F3`). That is, on the "Summary"  page (`F1`):
- Pressing `/` opens the filter input (as it already does).
- When the filter input is opened, it can be hidden and kept (enabled) by pressing `Enter`.
- When the filter is enabled, it can be disabled by re-opening the filter input (press `/`), and then pressing `Esc`.
- Documents the filter option key in the page's header, "Logs" horizontal line (similar to the resource view).

Enabling able to "apply" the filter via `Enter` and hide the text prompt, allows the user to navigate the logs up/down, which currently isn't possible with log filtering enabled.

<img width="843" height="392" alt="image" src="https://github.com/user-attachments/assets/ef535205-8d0a-42c5-9e3c-3f079a2f1c63" />

"Resources" page for reference:
<img width="843" height="392" alt="image" src="https://github.com/user-attachments/assets/6fd940e1-a94a-43b8-be01-75f5b405ea8a" />
