### PR TITLE
fix: hostns etc mount

### DIFF
--- a/internal/app/debug/hostns.go
+++ b/internal/app/debug/hostns.go
@@ -94,13 +94,10 @@ func runHostNsContainer( //nolint:gocyclo
 
 	defer teardown() //nolint:errcheck
 
-	// 4. Seed /etc files the squashfs lower doesn't carry.
-	seedEtcFiles(merged)
-
-	// 5. gRPC I/O streams.
+	// 4. gRPC I/O streams.
 	grpcStreamer, stdinR, stdoutW := newGrpcStreamWriter(srv)
 
-	// 6. Command + args: with explicit args, args[0] is the executable (resolved
+	// 5. Command + args: with explicit args, args[0] is the executable (resolved
 	// against PATH in launchInHostNs); otherwise default to the Nix bash.
 	const defaultShell = "/nix/var/nix/profiles/default/bin/bash"
 
@@ -117,11 +114,13 @@ func runHostNsContainer( //nolint:gocyclo
 		cmdArgs = []string{defaultShell}
 	}
 
-	// 7. Env: Nix profile on PATH (per-user profile first so nix-env installs win),
-	// plus caller-supplied overrides.
+	// 6. Env: Nix profile on PATH (per-user profile first so nix-env installs win),
+	// plus caller-supplied overrides. NIX_CONFIG carries settings that cannot be written
+	// under the live, read-only host /etc bind.
 	env := []string{
 		"PATH=/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt",
+		"NIX_CONFIG=build-users-group =\nsandbox = false\nexperimental-features = nix-command flakes",
 		"TERM=xterm-256color",
 		"HOME=/root",
 	}
@@ -130,14 +129,14 @@ func runHostNsContainer( //nolint:gocyclo
 		env = append(env, k+"="+v)
 	}
 
-	// 8. Per-session cgroup dir as an fd: SysProcAttr.CgroupFD places the child into
+	// 7. Per-session cgroup dir as an fd: SysProcAttr.CgroupFD places the child into
 	// the cgroup atomically at fork, avoiding a post-fork cgroup.procs write race.
 	cgroupFd, err := os.Open(filepath.Join("/sys/fs/cgroup", cgroupPath))
 	if err != nil {
 		return fmt.Errorf("host-ns: open cgroup dir %s: %w", cgroupPath, err)
 	}
 
-	// 9. Control channel: carries signals and pty-resize events from the gRPC recv
+	// 8. Control channel: carries signals and pty-resize events from the gRPC recv
 	// loop into the goroutine that owns the child. Buffered so recv never blocks.
 	controlC := make(chan hostNsControl, 16)
 
@@ -173,28 +172,6 @@ func runHostNsContainer( //nolint:gocyclo
 	<-launchDone
 
 	return streamErr
-}
-
-// seedEtcFiles writes into the overlay's /etc the files the raw squashfs lower does
-// not carry: the host's live resolv.conf (otherwise DNS is broken), and a nix.conf so
-// the package manager works without the nixbld build-users group or a sandbox.
-func seedEtcFiles(merged string) {
-	if hostResolv, readErr := os.ReadFile("/etc/resolv.conf"); readErr == nil && len(hostResolv) > 0 {
-		resolvDst := filepath.Join(merged, "etc", "resolv.conf")
-
-		if mkErr := os.MkdirAll(filepath.Dir(resolvDst), 0o755); mkErr == nil {
-			os.WriteFile(resolvDst, hostResolv, 0o644) //nolint:errcheck
-		}
-	}
-
-	nixConfDst := filepath.Join(merged, "etc", "nix", "nix.conf")
-	if mkErr := os.MkdirAll(filepath.Dir(nixConfDst), 0o755); mkErr == nil {
-		os.WriteFile(nixConfDst, []byte( //nolint:errcheck
-			"build-users-group =\n"+
-				"sandbox = false\n"+
-				"experimental-features = nix-command flakes\n",
-		), 0o644)
-	}
 }
 
 // launchInHostNs execs the requested command chrooted into the prepared root (merged),

--- a/internal/pkg/hostns/hostns.go
+++ b/internal/pkg/hostns/hostns.go
@@ -26,16 +26,16 @@ import (
 
 // HostBinds are the live host mounts bind-mounted into the debug root so tools can
 // reach the running node: devices, kernel filesystems, runtime sockets (/run,
-// /system) and data (/var). They are recursively bind-mounted and made shared, so a
-// mount a session creates under them (e.g. `zpool create -m /var/tank`) propagates to
-// the host, and unmounts propagate back — the session manages host mounts as if it
-// were in the host namespace (which it is). Flags (nodev, nosuid, noexec) are inherited
+// /system), live configuration (/etc), and data (/var). They are recursively bind-mounted
+// and made shared, so a mount a session creates under them (e.g. `zpool create -m /var/tank`)
+// propagates to the host, and unmounts propagate back. The session manages host mounts as
+// if it were in the host namespace (which it is). Flags (nodev, nosuid, noexec) are inherited
 // from the already-compliant host mounts.
 //
 // /var is bound even though the session's own scratch (merged, image, overlay uppers)
 // lives under it: Setup marks those scratch mounts MS_UNBINDABLE, so the recursive /var
 // bind skips them and cannot nest merged into itself.
-var HostBinds = []string{"dev", "proc", "sys", "run", "system", "var"}
+var HostBinds = []string{"dev", "proc", "sys", "run", "system", "var", "etc"}
 
 // Setup builds the debug chroot root in the CURRENT (host) mount namespace:
 //   - the image snapshot mounted read-only at baseDir/image (via fsopen, so the many-
@@ -89,8 +89,9 @@ func Setup(snapshotMounts []mount.Mount, baseDir, varBase string) (merged string
 	}
 
 	// Overlay root: host / as lower, disk-backed upper/work under varBase (mountv3
-	// creates the target and the upper/work dirs). The upper lets the session create
-	// /nix, /etc/nix, etc. without touching Talos's immutable squashfs, on disk.
+	// creates the target and the upper/work dirs). The upper gives the session writable
+	// root paths not replaced by the live host binds below, without touching Talos's
+	// immutable squashfs.
 	if _, err = mountv3.NewOverlayWithBasePath([]string{"/"}, merged, varBase, nil).Mount(); err != nil {
 		return "", nil, fmt.Errorf("mount overlay root: %w", err)
 	}

--- a/internal/pkg/hostns/hostns_test.go
+++ b/internal/pkg/hostns/hostns_test.go
@@ -44,6 +44,14 @@ func TestSetupTeardownNoLeak(t *testing.T) {
 
 	tmp := t.TempDir()
 
+	// Replace /etc inside this private mount namespace with a marker-bearing host mount.
+	// The overlay lowerdir=/ sees only the underlying mount-point directory, so the marker
+	// is visible in the debug root only when Setup explicitly bind-mounts the live /etc.
+	hostEtc := filepath.Join(tmp, "host-etc")
+	require.NoError(t, os.MkdirAll(hostEtc, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hostEtc, "hostns-marker"), []byte("host-etc"), 0o644))
+	require.NoError(t, unix.Mount(hostEtc, "/etc", "", unix.MS_BIND|unix.MS_REC, ""))
+
 	// Fake image snapshot: overlayfs needs at least two lower layers (a real Nix image
 	// has ~70). The top layer carries /nix/bin/tool.
 	imgUpperLayer := filepath.Join(tmp, "img1")
@@ -74,6 +82,10 @@ func TestSetupTeardownNoLeak(t *testing.T) {
 	_, err = os.Stat(filepath.Join(merged, "nix", "bin", "tool"))
 	assert.NoError(t, err, "image /nix overlaid into merged")
 
+	marker, err := os.ReadFile(filepath.Join(merged, "etc", "hostns-marker"))
+	require.NoError(t, err)
+	assert.Equal(t, "host-etc", string(marker), "live host /etc bound into merged")
+
 	// The overlay root and every host bind are mounted.
 	assert.True(t, isMounted(t, merged), "overlay root mounted")
 
@@ -101,6 +113,10 @@ func TestSetupTeardownNoLeak(t *testing.T) {
 	assert.Zero(t, countUnder(t, baseDir), "no scratch mounts remain under baseDir")
 	assert.True(t, isMounted(t, "/proc"), "host /proc survived teardown")
 	assert.True(t, isMounted(t, "/sys"), "host /sys survived teardown")
+
+	marker, err = os.ReadFile("/etc/hostns-marker")
+	require.NoError(t, err)
+	assert.Equal(t, "host-etc", string(marker), "host /etc survived teardown")
 	assert.Equal(t, baseline, len(mountTargets(t)), "mount table returned to baseline — nothing leaked")
 }
 


### PR DESCRIPTION
Talos `/etc` is a bind mount, so we need to explicitly mount it up for hostns, otherwise `EtcFileConfig` files would be missed.

This means we can drop the etc seeding.