### PR TITLE
fix: stop churning gatewayless IPv6 routes

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_spec.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec.go
@@ -142,6 +142,16 @@ func routePriorityMatches(actual uint32, expected *network.RouteSpecSpec) bool {
 		actual == network.DefaultRouteMetric
 }
 
+func routeScopeMatches(actual uint8, expected *network.RouteSpecSpec) bool {
+	if actual == uint8(expected.Scope) {
+		return true
+	}
+
+	// The IPv6 kernel has no per-route scope: it ignores rtm_scope on add and reports
+	// every route as universe, so a link-scoped spec would never match what it reads back.
+	return expected.Family == nethelpers.FamilyInet6 && actual == uint8(nethelpers.ScopeGlobal)
+}
+
 func findMatchingRoutes(existingRoutes []rtnetlink.RouteMessage, expected *network.RouteSpecSpec) []*rtnetlink.RouteMessage {
 	var result []*rtnetlink.RouteMessage //nolint:prealloc
 
@@ -355,7 +365,7 @@ func (ctrl *RouteSpecController) syncRoute(ctx context.Context, r controller.Run
 			}
 
 			// check if existing route matches the spec: if it does, skip update
-			if existing.Scope == uint8(route.TypedSpec().Scope) && nethelpers.RouteFlags(existing.Flags).Equal(route.TypedSpec().Flags) &&
+			if routeScopeMatches(existing.Scope, route.TypedSpec()) && nethelpers.RouteFlags(existing.Flags).Equal(route.TypedSpec().Flags) &&
 				existing.Protocol == uint8(route.TypedSpec().Protocol) &&
 				// when no out-link is requested, accept whatever egress device the kernel resolved
 				(linkIndex == 0 || existing.Attributes.OutIface == linkIndex) &&

--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/mdlayher/netlink"
 	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sys/unix"
@@ -642,6 +643,113 @@ func (suite *RouteSpecSuite) TestLinkLocalRouteAlias() {
 		suite.assertNoRoute(
 			netip.MustParsePrefix("169.254.169.254/32"),
 			netip.MustParseAddr("10.28.0.1"),
+		),
+	)
+}
+
+func (suite *RouteSpecSuite) TestIPv6GatewaylessRouteNoChurn() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(
+		conn.Link.New(
+			&rtnetlink.LinkMessage{
+				Type:   unix.ARPHRD_ETHER,
+				Flags:  unix.IFF_UP,
+				Change: unix.IFF_UP,
+				Attributes: &rtnetlink.LinkAttributes{
+					Name: dummyInterface,
+					Info: &rtnetlink.LinkInfo{Kind: "dummy"},
+				},
+			},
+		),
+	)
+
+	iface, err := net.InterfaceByName(dummyInterface)
+	suite.Require().NoError(err)
+
+	defer conn.Link.Delete(uint32(iface.Index)) //nolint:errcheck
+
+	localIP := net.ParseIP("2001:db8:1399:5::2").To16()
+
+	suite.Require().NoError(
+		conn.Address.New(
+			&rtnetlink.AddressMessage{
+				Family:       unix.AF_INET6,
+				PrefixLength: 64,
+				Scope:        unix.RT_SCOPE_UNIVERSE,
+				Index:        uint32(iface.Index),
+				Attributes: &rtnetlink.AddressAttributes{
+					Address: localIP,
+					Local:   localIP,
+				},
+			},
+		),
+	)
+
+	destination := netip.MustParsePrefix("2001:db8:1399:6::/64")
+	route := network.NewRouteSpec(network.NamespaceName, "ipv6-gatewayless-no-churn")
+	*route.TypedSpec() = network.RouteSpecSpec{
+		Family:      nethelpers.FamilyInet6,
+		Destination: destination,
+		Table:       nethelpers.TableMain,
+		OutLinkName: dummyInterface,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+	// Normalize is what assigns the link scope this test is about.
+	route.TypedSpec().Normalize()
+
+	suite.Create(route)
+
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				return suite.assertRoute(destination, netip.Addr{}, func(rtnetlink.RouteMessage) error { return nil })
+			},
+		),
+	)
+
+	// the IPv6 kernel reports every route as universe, so a link-scoped spec would be
+	// deleted and recreated on every reconcile, forever.
+	monitor, err := rtnetlink.Dial(&netlink.Config{Groups: unix.RTMGRP_IPV6_ROUTE})
+	suite.Require().NoError(err)
+
+	defer monitor.Close() //nolint:errcheck
+
+	suite.Require().NoError(monitor.SetReadDeadline(time.Now().Add(time.Second)))
+
+	for {
+		rtmsgs, msgs, recvErr := monitor.Receive()
+		if recvErr != nil {
+			break
+		}
+
+		for i, msg := range msgs {
+			if msg.Header.Type != unix.RTM_DELROUTE {
+				continue
+			}
+
+			deleted, ok := rtmsgs[i].(*rtnetlink.RouteMessage)
+			if !ok {
+				continue
+			}
+
+			if deleted.Attributes.Dst.Equal(destination.Addr().AsSlice()) {
+				suite.FailNow(fmt.Sprintf("route to %s was deleted by the controller", destination))
+			}
+		}
+	}
+
+	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), route.Metadata()))
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error { return suite.assertNoRoute(destination, netip.Addr{}) },
 		),
 	)
 }


### PR DESCRIPTION
## What? (description)

`syncRoute` compares the kernel's routes against the spec field by field, and
`scope` is one of those fields. IPv6 has no per-route scope: the kernel accepts
`rtm_scope` on `RTM_NEWROUTE`, drops it, and reports every route back as
`RT_SCOPE_UNIVERSE`. `RouteSpecSpec.Normalize()` assigns `ScopeLink` to any route
with a destination and no gateway regardless of family, so for such an IPv6 route
the comparison is `0 == 253` on every pass and the controller deletes and
recreates the route it just wrote.

This adds a `routeScopeMatches` helper that accepts `RT_SCOPE_UNIVERSE` from the
kernel when the spec is IPv6, in the same shape as `routePriorityMatches`
directly above it, which already special-cases the metric the IPv6 kernel
assigns on its own.

The regression test subscribes to `RTMGRP_IPV6_ROUTE` once the route has settled
and fails on the first `RTM_DELROUTE` for it. It is red without the change and
green with it.

## Why? (reasoning)

Since 7ac3cad5e the controller also watches `RTMGRP_IPV6_ROUTE`, so its own write
wakes it up and the mismatch became a self-sustaining loop at the rate limiter's
10 events/s, with a window with no route on every cycle. Details, reproduction on
two nodes and the ruled-out alternatives are in #14164.

Applies to `release-1.14` unchanged.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable) — #14164
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`) — n/a, no schema change
- [x] you ran unit-tests (`make unit-tests`)

## AI Disclosure

I investigated this and wrote the patch with an AI coding assistant; I have read
the diff and I stand behind it. Same disclosure as the issue.
