### PR TITLE
feat: let a user volume declare no filesystem

### DIFF
--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes.go
@@ -42,6 +42,21 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 
 	for _, userVolumeConfig := range c.UserVolumeConfigs() {
 		volumeID := constants.UserVolumePrefix + userVolumeConfig.Name()
+
+		// A volume declared with no filesystem is a raw block device, for a
+		// consumer such as LVM. There is nothing to mount, and an empty
+		// TargetPath is how the volume manager already spells that: the
+		// FilesystemTypeNone branch in volumes.Format only probes for an
+		// existing filesystem when a target path is set, and would otherwise
+		// fail the volume for the absence of a filesystem that was
+		// deliberately not created.
+		mountOrNone := func(spec block.MountSpec) block.MountSpec {
+			if userVolumeConfig.Filesystem().Type() == block.FilesystemTypeNone {
+				return block.MountSpec{}
+			}
+
+			return spec
+		}
 		userVolumeResource := VolumeResource{
 			VolumeID:           volumeID,
 			Label:              block.UserVolumeLabel,
@@ -81,7 +96,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 						MinAllocationGroupSize: minAllocationGroupSize(userVolumeConfig.Filesystem()),
 					},
 				}).
-				WithMount(block.MountSpec{
+				WithMount(mountOrNone(block.MountSpec{
 					TargetPath:          userVolumeConfig.Name(),
 					ParentID:            constants.UserVolumeMountPoint,
 					SelinuxLabel:        constants.EphemeralSelinuxLabel,
@@ -89,7 +104,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 					UID:                 0,
 					GID:                 0,
 					ProjectQuotaSupport: userVolumeConfig.Filesystem().ProjectQuotaSupport(),
-				}).
+				})).
 				WithTrim(c, userVolumeConfig).
 				WithScrub(c, userVolumeConfig).
 				WithConvertEncryptionConfiguration(userVolumeConfig.Encryption()).
@@ -118,7 +133,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 						MinAllocationGroupSize: minAllocationGroupSize(userVolumeConfig.Filesystem()),
 					},
 				}).
-				WithMount(block.MountSpec{
+				WithMount(mountOrNone(block.MountSpec{
 					TargetPath:          userVolumeConfig.Name(),
 					ParentID:            constants.UserVolumeMountPoint,
 					SelinuxLabel:        constants.EphemeralSelinuxLabel,
@@ -126,7 +141,7 @@ func UserVolumeTransformer(c configconfig.Config) ([]VolumeResource, error) {
 					UID:                 0,
 					GID:                 0,
 					ProjectQuotaSupport: userVolumeConfig.Filesystem().ProjectQuotaSupport(),
-				}).
+				})).
 				WithTrim(c, userVolumeConfig).
 				WithScrub(c, userVolumeConfig).
 				WithConvertEncryptionConfiguration(userVolumeConfig.Encryption()).

--- a/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
+++ b/internal/app/machined/pkg/controllers/block/internal/volumes/volumeconfig/user_volumes_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,7 +52,7 @@ func TestUserVolumeTransformer(t *testing.T) {
 					MetaName:   "foo",
 					VolumeType: new(block.VolumeTypePartition),
 					FilesystemSpec: blockcfg.FilesystemSpec{
-						FilesystemType: block.FilesystemTypeXFS,
+						FilesystemType: pointer.To(block.FilesystemTypeXFS),
 					},
 				},
 			},
@@ -82,6 +83,66 @@ func TestUserVolumeTransformer(t *testing.T) {
 			},
 		},
 		{
+			// A whole-disk volume that declares no filesystem is a raw block
+			// device for a consumer such as LVM: it must NOT be coerced to xfs,
+			// and it must NOT be given a mount target, or the volume manager
+			// would probe it for a filesystem that was deliberately not created.
+			name: "disk volume, no filesystem",
+			cfg: []*blockcfg.UserVolumeConfigV1Alpha1{
+				{
+					Meta: meta.Meta{
+						MetaKind:       blockcfg.UserVolumeConfigKind,
+						MetaAPIVersion: "v1alpha1",
+					},
+					MetaName:   "lvmdata",
+					VolumeType: new(block.VolumeTypeDisk),
+					FilesystemSpec: blockcfg.FilesystemSpec{
+						FilesystemType: pointer.To(block.FilesystemTypeNone),
+					},
+				},
+			},
+			checkFunc: func(t *testing.T, resources []volumeconfig.VolumeResource, err error) {
+				require.NoError(t, err)
+				require.Len(t, resources, 1)
+
+				testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+					require.NoError(t, err)
+
+					assert.Equal(t, block.VolumeTypeDisk, vc.TypedSpec().Type)
+					assert.Equal(t, block.FilesystemTypeNone, vc.TypedSpec().Provisioning.FilesystemSpec.Type)
+					assert.Empty(t, vc.TypedSpec().Mount.TargetPath)
+				})
+			},
+		},
+		{
+			// The control for the case above: omitting the filesystem entirely
+			// still selects the documented xfs default and still mounts. Without
+			// this, making `none` expressible could silently stop formatting
+			// every user volume that does not name a filesystem.
+			name: "disk volume, filesystem unset, defaults to xfs",
+			cfg: []*blockcfg.UserVolumeConfigV1Alpha1{
+				{
+					Meta: meta.Meta{
+						MetaKind:       blockcfg.UserVolumeConfigKind,
+						MetaAPIVersion: "v1alpha1",
+					},
+					MetaName:   "plain",
+					VolumeType: new(block.VolumeTypeDisk),
+				},
+			},
+			checkFunc: func(t *testing.T, resources []volumeconfig.VolumeResource, err error) {
+				require.NoError(t, err)
+				require.Len(t, resources, 1)
+
+				testTransformFunc(t, resources[0].TransformFunc, func(t *testing.T, vc *block.VolumeConfig, err error) {
+					require.NoError(t, err)
+
+					assert.Equal(t, block.FilesystemTypeXFS, vc.TypedSpec().Provisioning.FilesystemSpec.Type)
+					assert.Equal(t, "plain", vc.TypedSpec().Mount.TargetPath)
+				})
+			},
+		},
+		{
 			name: "directory volume",
 			cfg: []*blockcfg.UserVolumeConfigV1Alpha1{{
 				Meta: meta.Meta{
@@ -91,7 +152,7 @@ func TestUserVolumeTransformer(t *testing.T) {
 				MetaName:   "bar",
 				VolumeType: new(block.VolumeTypeDirectory),
 				FilesystemSpec: blockcfg.FilesystemSpec{
-					FilesystemType: block.FilesystemTypeXFS,
+					FilesystemType: pointer.To(block.FilesystemTypeXFS),
 				},
 			}},
 			checkFunc: func(t *testing.T, resources []volumeconfig.VolumeResource, err error) {
@@ -147,7 +208,7 @@ func TestUserVolumeTransformer(t *testing.T) {
 				MetaName:   "foo",
 				VolumeType: new(block.VolumeTypePartition),
 				FilesystemSpec: blockcfg.FilesystemSpec{
-					FilesystemType: block.FilesystemTypeXFS,
+					FilesystemType: pointer.To(block.FilesystemTypeXFS),
 				},
 			}, {
 				Meta: meta.Meta{
@@ -157,7 +218,7 @@ func TestUserVolumeTransformer(t *testing.T) {
 				MetaName:   "bar",
 				VolumeType: new(block.VolumeTypeDirectory),
 				FilesystemSpec: blockcfg.FilesystemSpec{
-					FilesystemType: block.FilesystemTypeXFS,
+					FilesystemType: pointer.To(block.FilesystemTypeXFS),
 				},
 			}},
 			checkFunc: func(t *testing.T, resources []volumeconfig.VolumeResource, err error) {

--- a/pkg/machinery/config/types/block/deep_copy.generated.go
+++ b/pkg/machinery/config/types/block/deep_copy.generated.go
@@ -271,6 +271,10 @@ func (o *UserVolumeConfigV1Alpha1) DeepCopy() *UserVolumeConfigV1Alpha1 {
 			copy(cp.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw, o.ProvisioningSpec.ProvisioningMaxSize.ByteSize.raw)
 		}
 	}
+	if o.FilesystemSpec.FilesystemType != nil {
+		filesystemType := *o.FilesystemSpec.FilesystemType
+		cp.FilesystemSpec.FilesystemType = &filesystemType
+	}
 	if o.FilesystemSpec.ProjectQuotaSupportConfig != nil {
 		cp.FilesystemSpec.ProjectQuotaSupportConfig = new(bool)
 		*cp.FilesystemSpec.ProjectQuotaSupportConfig = *o.FilesystemSpec.ProjectQuotaSupportConfig

--- a/pkg/machinery/config/types/block/user_volume_config.go
+++ b/pkg/machinery/config/types/block/user_volume_config.go
@@ -138,7 +138,7 @@ func exampleUserVolumeConfigV1Alpha1Partition() *UserVolumeConfigV1Alpha1 {
 		ProvisioningMaxSize: MustSize("50GiB"),
 	}
 	cfg.FilesystemSpec = FilesystemSpec{
-		FilesystemType: block.FilesystemTypeXFS,
+		FilesystemType: pointer.To(block.FilesystemTypeXFS),
 	}
 	cfg.EncryptionSpec = EncryptionSpec{
 		EncryptionProvider: block.EncryptionProviderLUKS2,
@@ -177,7 +177,7 @@ func exampleUserVolumeConfigV1Alpha1Disk() *UserVolumeConfigV1Alpha1 {
 		},
 	}
 	cfg.FilesystemSpec = FilesystemSpec{
-		FilesystemType: block.FilesystemTypeXFS,
+		FilesystemType: pointer.To(block.FilesystemTypeXFS),
 	}
 	cfg.EncryptionSpec = EncryptionSpec{
 		EncryptionProvider: block.EncryptionProviderLUKS2,
@@ -379,11 +379,18 @@ func (s *UserVolumeConfigV1Alpha1) Scrub() config.VolumeScrubConfig {
 type FilesystemSpec struct {
 	//   description: |
 	//     Filesystem type. Default is `xfs`.
+	//
+	//     `none` leaves the volume unformatted and unmounted -- a raw block
+	//     device for a consumer such as LVM. That is distinct from omitting
+	//     this field, which selects the `xfs` default, and the two cannot be
+	//     told apart by value: `none` is the zero of the enum. Hence the
+	//     pointer.
 	//   values:
+	//     - none
 	//     - ext4
 	//     - xfs
 	//     - btrfs
-	FilesystemType block.FilesystemType `yaml:"type,omitempty"`
+	FilesystemType *block.FilesystemType `yaml:"type,omitempty"`
 	//   description: |
 	//     Enables project quota support, valid only for 'xfs' filesystem.
 	//
@@ -419,16 +426,16 @@ type XFSSpec struct {
 
 // IsZero checks if the filesystem spec is zero.
 func (s FilesystemSpec) IsZero() bool {
-	return s.FilesystemType == block.FilesystemTypeNone && s.ProjectQuotaSupportConfig == nil && s.XFSSpec == nil
+	return s.FilesystemType == nil && s.ProjectQuotaSupportConfig == nil && s.XFSSpec == nil
 }
 
 // Type implements config.FilesystemConfig interface.
 func (s FilesystemSpec) Type() block.FilesystemType {
-	if s.FilesystemType == block.FilesystemTypeNone {
+	if s.FilesystemType == nil {
 		return block.FilesystemTypeXFS
 	}
 
-	return s.FilesystemType
+	return *s.FilesystemType
 }
 
 // ProjectQuotaSupport implements config.FilesysteemConfig interface.
@@ -447,13 +454,13 @@ func (s FilesystemSpec) XFS() config.XFSFilesystemConfig {
 
 // Validate implements config.Validator interface.
 func (s FilesystemSpec) Validate() ([]string, error) {
-	switch s.FilesystemType { //nolint:exhaustive
+	switch pointer.SafeDeref(s.FilesystemType) { //nolint:exhaustive
 	case block.FilesystemTypeNone:
 	case block.FilesystemTypeXFS:
 	case block.FilesystemTypeEXT4:
 	case block.FilesystemTypeBtrfs:
 	default:
-		return nil, fmt.Errorf("unsupported filesystem type: %s", s.FilesystemType)
+		return nil, fmt.Errorf("unsupported filesystem type: %s", pointer.SafeDeref(s.FilesystemType))
 	}
 
 	if pointer.SafeDeref(s.ProjectQuotaSupportConfig) && s.Type() != block.FilesystemTypeXFS {

--- a/pkg/machinery/config/types/block/user_volume_config_test.go
+++ b/pkg/machinery/config/types/block/user_volume_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/go-pointer"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
@@ -40,7 +41,7 @@ func TestUserVolumeConfigMarshalUnmarshal(t *testing.T) {
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.transport == "nvme" && !system_disk`)))
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("100GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeXFS
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeXFS)
 
 				return c
 			},
@@ -81,7 +82,7 @@ func TestUserVolumeConfigMarshalUnmarshal(t *testing.T) {
 
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`!system_disk`)))
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeXFS
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeXFS)
 				c.FilesystemSpec.ProjectQuotaSupportConfig = new(true)
 
 				return c
@@ -227,7 +228,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("2.5TiB")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeISO9660
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeISO9660)
 
 				return c
 			},
@@ -309,7 +310,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`system_disk`)))
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 				c.FilesystemSpec.ProjectQuotaSupportConfig = new(true)
 
 				return c
@@ -326,7 +327,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`system_disk`)))
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 				c.FilesystemSpec.XFSSpec = &block.XFSSpec{
 					MinAllocationGroupSizeConfig: block.MustByteSize("128GiB"),
 				}
@@ -385,7 +386,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("2.5TiB")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 
 				return c
 			},
@@ -400,7 +401,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				c.MetaName = constants.EphemeralPartitionLabel
 				c.VolumeType = new(blockres.VolumeTypeDirectory)
 
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeVFAT
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeVFAT)
 
 				return c
 			},
@@ -467,7 +468,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("2.5TiB")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 
 				return c
 			},
@@ -483,7 +484,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
 				c.ProvisioningSpec.ProvisioningMaxSize = block.MustSize("2.5TiB")
 				c.ProvisioningSpec.ProvisioningMinSize = block.MustByteSize("10GiB")
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 
 				return c
 			},
@@ -508,7 +509,7 @@ func TestUserVolumeConfigValidate(t *testing.T) {
 				c.VolumeType = new(blockres.VolumeTypeDisk)
 
 				require.NoError(t, c.ProvisioningSpec.DiskSelectorSpec.Match.UnmarshalText([]byte(`disk.size > 120u * GiB`)))
-				c.FilesystemSpec.FilesystemType = blockres.FilesystemTypeEXT4
+				c.FilesystemSpec.FilesystemType = pointer.To(blockres.FilesystemTypeEXT4)
 
 				return c
 			},


### PR DESCRIPTION
A `UserVolumeConfig` currently cannot express "encrypted block device, nothing else". `filesystem: type: none` is accepted by `Validate` and then mapped to XFS by `FilesystemSpec.Type()`, so the volume is formatted and mounted, and a consumer such as LVM has nothing left to claim — the device an operator wanted as a physical volume comes back as a mounted XFS filesystem.

This is a proposal rather than a settled design, and I'd welcome direction on the shape before it goes any further.

## Why the default could not simply be dropped

`FilesystemTypeNone` is the **zero value** of the enum, so an omitted field and an explicit `none` are the same bits. Returning `None` for both would silently stop formatting every existing user volume that does not name a filesystem — a data-shaped change, not just a behavioural one.

Making the field a pointer is what separates the two: `nil` keeps the documented `xfs` default, an explicit `none` survives. It follows the pointer-for-optional style already used nearby (`VolumeType`, `ProjectQuotaSupportConfig`, `XFSSpec`), but it is an exported field on a public config type, so it is the part I am least sure about. If you would prefer a different mechanism — a distinct sentinel, a separate `raw: true`, presence tracked at unmarshal, or something else entirely — I am glad to rework it.

A volume with no filesystem is also not mountable, so it no longer gets a mount spec. An empty `TargetPath` is how the volume manager already spells this: the `FilesystemTypeNone` branch in `volumes.Format` only probes for an existing filesystem when a target path is set, and would otherwise fail the volume for the absence of a filesystem that was deliberately not created.

## A thing I would rather flag than hide

`deep_copy.generated.go` is hand-edited here for the new pointer, because I did not want to submit an unrelated regeneration diff. It should be regenerated with `make deep-copy` — happy to do that, or to drop the hand-edit, whichever you prefer.

## Testing

`go test` green across `pkg/machinery/config/types/block`, the `volumeconfig` transformer, and the block controllers.

The two new transformer cases are mutation-checked rather than assumed: restoring the `none → xfs` coercion turns `disk_volume,_no_filesystem` red, while the `filesystem_unset,_defaults_to_xfs` control stays green — so the pair covers both the new behaviour and the preserved default.

Beyond the unit tests, this was exercised on a booted node: a QEMU aarch64 machine with a two-disk mirror, LUKS2 on the whole array, and no filesystem — `md0` reports `luks`, the opened device reports `lvm2-pv`, nothing is mounted, and the volume group comes up writeable with one PV. That configuration is not expressible without this change.

## Related

Companion to #14145, but independent of it — different files, and either can land without the other. #14145 fixes LVM physical volumes being created on the ciphertext device; this makes the whole-disk form of that layout expressible.

## Anything I can provide

If it would help, I'm happy to add integration coverage in `VolumesSuite`, run this against a configuration or platform you'd like to see, or provide the venue details for the reproduction above. Please let me know what would be most useful.