### PR TITLE
fix: preserve special modes when extracting files

### DIFF
--- a/pkg/archiver/untar.go
+++ b/pkg/archiver/untar.go
@@ -89,7 +89,7 @@ func Untar(ctx context.Context, r io.Reader, rootPath string, xattrsMap map[stri
 				return fmt.Errorf("error creating parent directory for file %q: %w", path, err)
 			}
 
-			fp, err := root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
+			fp, err := root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode.Perm())
 			if err != nil {
 				return fmt.Errorf("error creating file %q mode %s: %w", path, mode, err)
 			}

--- a/pkg/archiver/untar_test.go
+++ b/pkg/archiver/untar_test.go
@@ -93,6 +93,27 @@ func TestUntar(t *testing.T) {
 				)
 			},
 		},
+		{
+			name: "setuid file",
+
+			entries: []tarEntry{
+				{
+					header: tar.Header{
+						Name: "setuid-file",
+						Mode: 0o4755,
+					},
+					payload: []byte("setuid"),
+				},
+			},
+			verification: func(t *testing.T, dir string, xattrs map[string]string) {
+				info, err := os.Stat(filepath.Join(dir, "setuid-file"))
+				require.NoError(t, err)
+
+				assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+				assert.NotZero(t, info.Mode()&os.ModeSetuid)
+				assert.Empty(t, xattrs)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
OpenFile with the full mode (setuid/setgid/sticky) can fail inside
the chroot/imager extraction path. Apply only the permission bits at
creation and let the subsequent Chmod set the special bits.