### PR TITLE
feat: adopt ImageGCController for containers

### DIFF
--- a/internal/app/machined/pkg/controllers/cri/image_gc.go
+++ b/internal/app/machined/pkg/controllers/cri/image_gc.go
@@ -18,30 +18,44 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/siderolabs/gen/optional"
-	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/containers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 )
 
-// ImageCleanupInterval is the interval at which the image GC controller runs.
-const ImageCleanupInterval = 15 * time.Minute
+// DefaultImageCleanupInterval is the default interval at which the image GC controller runs.
+const DefaultImageCleanupInterval = 15 * time.Minute
 
-// ImageGCGracePeriod is the minimum age of an image before it can be deleted.
-const ImageGCGracePeriod = 4 * ImageCleanupInterval
+// DefaultImageGCGracePeriod is the default minimum age of an image before it can be deleted.
+const DefaultImageGCGracePeriod = 4 * DefaultImageCleanupInterval
+
+// RefsToRetainFunc returns the image references which must be preserved.
+//
+// It may return an empty set before its underlying resources have synced (e.g. right after boot).
+// That is safe: cleanup only deletes an image once it has looked unreferenced continuously for a full
+// GCGracePeriod, tracked per-image from the first time the controller ever observed it as such (see
+// imageFirstSeenUnreferenced in cleanup below) — which is reliably longer than resources take to sync.
+type RefsToRetainFunc func(ctx context.Context, reader controller.Reader) ([]string, error)
 
 // NewImageGCController creates a new ImageGCController.
-func NewImageGCController(containerdName string, buildExpectedImages bool) *ImageGCController {
-	controllerName := "cri." + containerdName + "ImageGCController"
+//
+// containerdName selects the containerd instance (and the v1alpha1.Service gating on it), and
+// namespace is the containerd namespace to collect. A nil refsToRetain means nothing is retained,
+// i.e. every image in the namespace is eligible for cleanup.
+func NewImageGCController(containerdName, namespace string, refsToRetainFunc RefsToRetainFunc) *ImageGCController {
+	controllerName := fmt.Sprintf("%s.%s.ImageGCController", containerdName, namespace)
 
 	return &ImageGCController{
 		containerdName:      containerdName,
+		containerdNamespace: namespace,
 		controllerName:      controllerName,
-		buildExpectedImages: buildExpectedImages,
+		refsToRetain:        refsToRetainFunc,
 	}
 }
 
@@ -49,9 +63,19 @@ func NewImageGCController(containerdName string, buildExpectedImages bool) *Imag
 type ImageGCController struct {
 	ImageServiceProvider func() (ImageServiceProvider, error)
 
-	containerdName             string
+	// CleanupInterval and GCGracePeriod default to DefaultImageCleanupInterval and DefaultImageGCGracePeriod.
+	//
+	// They are fields rather than constants so that tests can run a cleanup cycle without waiting
+	// out the production timing; nothing in Talos overrides them.
+	CleanupInterval time.Duration
+	GCGracePeriod   time.Duration
+
+	containerdName      string
+	containerdNamespace string
+	// refsToRetain computes the images to preserve; nil retains nothing.
+	refsToRetain RefsToRetainFunc
+
 	controllerName             string
-	buildExpectedImages        bool
 	imageFirstSeenUnreferenced map[string]time.Time
 }
 
@@ -67,35 +91,43 @@ func (ctrl *ImageGCController) Name() string {
 }
 
 // Inputs implements controller.Controller interface.
+//
+// Only the containerd service is an input: it is the one thing the controller has to wake for.
+// Everything else is read on the cleanup tick, see RefsToRetainFunc.
 func (ctrl *ImageGCController) Inputs() []controller.Input {
-	inputs := []controller.Input{
+	return []controller.Input{
 		{
 			Namespace: v1alpha1.NamespaceName,
 			Type:      v1alpha1.ServiceType,
 			ID:        optional.Some(ctrl.containerdName),
 			Kind:      controller.InputWeak,
 		},
+		{
+			Namespace: containers.NamespaceName,
+			Type:      containers.ContainerSpecType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: containers.NamespaceName,
+			Type:      containers.ContainerImageStatusType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: containers.NamespaceName,
+			Type:      containers.ContainerInstanceSpecType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: k8s.NamespaceName,
+			Type:      k8s.KubeletSpecType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: etcd.NamespaceName,
+			Type:      etcd.SpecType,
+			Kind:      controller.InputWeak,
+		},
 	}
-
-	if ctrl.buildExpectedImages {
-		inputs = append(
-			inputs,
-			controller.Input{
-				Namespace: k8s.NamespaceName,
-				Type:      k8s.KubeletSpecType,
-				ID:        optional.Some(k8s.KubeletID),
-				Kind:      controller.InputWeak,
-			},
-			controller.Input{
-				Namespace: etcd.NamespaceName,
-				Type:      etcd.SpecType,
-				ID:        optional.Some(etcd.SpecID),
-				Kind:      controller.InputWeak,
-			},
-		)
-	}
-
-	return inputs
 }
 
 // Outputs implements controller.Controller interface.
@@ -140,24 +172,15 @@ func (s *containerdImageServiceProvider) Close() error {
 }
 
 // Run implements controller.Controller interface.
-//
-//nolint:gocyclo,cyclop
 func (ctrl *ImageGCController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
-	if ctrl.ImageServiceProvider == nil {
-		ctrl.ImageServiceProvider = defaultImageServiceProvider(ctrl.containerdName)
-	}
-
-	if ctrl.imageFirstSeenUnreferenced == nil {
-		ctrl.imageFirstSeenUnreferenced = map[string]time.Time{}
-	}
+	ctrl.ensureDefaults()
 
 	var (
 		containerdIsUp       bool
-		expectedImages       []string
 		imageServiceProvider ImageServiceProvider
 	)
 
-	ticker := time.NewTicker(ImageCleanupInterval)
+	ticker := time.NewTicker(ctrl.CleanupInterval)
 	defer ticker.Stop()
 
 	defer func() {
@@ -171,50 +194,22 @@ func (ctrl *ImageGCController) Run(ctx context.Context, r controller.Runtime, lo
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if !containerdIsUp || (ctrl.buildExpectedImages && len(expectedImages) == 0) {
+			if !containerdIsUp {
 				continue
 			}
 
-			if imageServiceProvider == nil {
-				var err error
+			var err error
 
-				imageServiceProvider, err = ctrl.ImageServiceProvider()
-				if err != nil {
-					return fmt.Errorf("error creating image service provider: %w", err)
-				}
-			}
-
-			if err := ctrl.cleanup(ctx, logger, imageServiceProvider.ImageService(), expectedImages); err != nil {
-				return fmt.Errorf("error running image cleanup: %w", err)
+			imageServiceProvider, err = ctrl.runCleanup(ctx, logger, r, imageServiceProvider)
+			if err != nil {
+				return err
 			}
 		case <-r.EventCh():
-			containerdService, err := safe.ReaderGet[*v1alpha1.Service](ctx, r, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, ctrl.containerdName, resource.VersionUndefined))
-			if err != nil && !state.IsNotFoundError(err) {
-				return fmt.Errorf("error getting container service: %w", err)
-			}
+			var err error
 
-			containerdIsUp = containerdService != nil && containerdService.TypedSpec().Running && containerdService.TypedSpec().Healthy
-
-			expectedImages = nil
-
-			if ctrl.buildExpectedImages {
-				etcdSpec, err := safe.ReaderGet[*etcd.Spec](ctx, r, resource.NewMetadata(etcd.NamespaceName, etcd.SpecType, etcd.SpecID, resource.VersionUndefined))
-				if err != nil && !state.IsNotFoundError(err) {
-					return fmt.Errorf("error getting etcd spec: %w", err)
-				}
-
-				if etcdSpec != nil {
-					expectedImages = append(expectedImages, etcdSpec.TypedSpec().Image)
-				}
-
-				kubeletSpec, err := safe.ReaderGet[*k8s.KubeletSpec](ctx, r, resource.NewMetadata(k8s.NamespaceName, k8s.KubeletSpecType, k8s.KubeletID, resource.VersionUndefined))
-				if err != nil && !state.IsNotFoundError(err) {
-					return fmt.Errorf("error getting kubelet spec: %w", err)
-				}
-
-				if kubeletSpec != nil {
-					expectedImages = append(expectedImages, kubeletSpec.TypedSpec().Image)
-				}
+			containerdIsUp, err = ctrl.updateContainerdStatus(ctx, r)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -222,23 +217,106 @@ func (ctrl *ImageGCController) Run(ctx context.Context, r controller.Runtime, lo
 	}
 }
 
+// ensureDefaults fills in zero-value fields with their defaults.
+func (ctrl *ImageGCController) ensureDefaults() {
+	if ctrl.ImageServiceProvider == nil {
+		ctrl.ImageServiceProvider = defaultImageServiceProvider(ctrl.containerdName)
+	}
+
+	if ctrl.imageFirstSeenUnreferenced == nil {
+		ctrl.imageFirstSeenUnreferenced = map[string]time.Time{}
+	}
+
+	if ctrl.CleanupInterval == 0 {
+		ctrl.CleanupInterval = DefaultImageCleanupInterval
+	}
+
+	if ctrl.GCGracePeriod == 0 {
+		ctrl.GCGracePeriod = DefaultImageGCGracePeriod
+	}
+}
+
+// runCleanup runs a single cleanup cycle, lazily creating imageServiceProvider if it isn't set yet.
+//
+// It returns imageServiceProvider back (created or unchanged) so the caller can keep closing it on exit.
+func (ctrl *ImageGCController) runCleanup(ctx context.Context, logger *zap.Logger, reader controller.Reader, imageServiceProvider ImageServiceProvider) (ImageServiceProvider, error) {
+	retainRefs, err := ctrl.safeRefsToRetain(ctx, reader)
+	if err != nil {
+		return imageServiceProvider, fmt.Errorf("error computing images to retain: %w", err)
+	}
+
+	if imageServiceProvider == nil {
+		imageServiceProvider, err = ctrl.ImageServiceProvider()
+		if err != nil {
+			return nil, fmt.Errorf("error creating image service provider: %w", err)
+		}
+	}
+
+	if err := ctrl.cleanup(ctx, logger, imageServiceProvider.ImageService(), retainRefs); err != nil {
+		return imageServiceProvider, fmt.Errorf("error running image cleanup: %w", err)
+	}
+
+	return imageServiceProvider, nil
+}
+
+// updateContainerdStatus reports whether the watched containerd service is running and healthy.
+func (ctrl *ImageGCController) updateContainerdStatus(ctx context.Context, r controller.Runtime) (bool, error) {
+	containerdService, err := safe.ReaderGet[*v1alpha1.Service](ctx, r, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, ctrl.containerdName, resource.VersionUndefined))
+	if err != nil && !state.IsNotFoundError(err) {
+		return false, fmt.Errorf("error getting container service: %w", err)
+	}
+
+	return containerdService != nil && containerdService.TypedSpec().Running && containerdService.TypedSpec().Healthy, nil
+}
+
+// safeRefsToRetain calls RefsToRetain, treating a nil one as retaining nothing.
+func (ctrl *ImageGCController) safeRefsToRetain(ctx context.Context, reader controller.Reader) ([]string, error) {
+	if ctrl.refsToRetain == nil {
+		return nil, nil
+	}
+
+	return ctrl.refsToRetain(ctx, reader)
+}
+
+// buildExpectedDigests resolves the expected image references to the digests they name.
+//
+// An expectation is either a bare digest, which resolves to itself, or a reference, which either
+// carries its digest or has to be matched by name and tag against the images actually stored.
+//
 //nolint:gocyclo
 func buildExpectedDigests(logger *zap.Logger, actualImages []images.Image, expectedImages []string) (map[string]struct{}, error) {
-	var parseErrors error
+	var (
+		parseErrors        error
+		expectedReferences []reference.Named
+	)
 
-	expectedReferences := xslices.Map(expectedImages, func(ref string) reference.Named {
-		res, parseErr := reference.ParseNamed(ref)
+	expectedDigests := map[string]struct{}{}
 
-		parseErrors = errors.Join(parseErrors, parseErr)
+	for _, ref := range expectedImages {
+		// Bare digest, as ContainerImageStatus and ContainerInstanceSpec carry it: nothing to
+		// resolve.
+		if dgst, err := digest.Parse(ref); err == nil {
+			expectedDigests[dgst.String()] = struct{}{}
 
-		return res
-	})
+			continue
+		}
+
+		// ParseDockerRef rather than ParseNamed, because it is what the pull path normalizes with
+		// (see internal/pkg/containers/image.Pull), and the containerd image record is named after
+		// the result.
+		parsed, parseErr := reference.ParseDockerRef(ref)
+		if parseErr != nil {
+			parseErrors = errors.Join(parseErrors, parseErr)
+
+			continue
+		}
+
+		expectedReferences = append(expectedReferences, parsed)
+	}
 
 	if parseErrors != nil {
 		return nil, fmt.Errorf("error parsing expected images: %w", parseErrors)
 	}
-
-	expectedDigests := map[string]struct{}{}
 
 	for _, expectedRef := range expectedReferences {
 		// easy case: image ref has digest, record it
@@ -257,7 +335,7 @@ func buildExpectedDigests(logger *zap.Logger, actualImages []images.Image, expec
 				continue
 			}
 
-			digest := image.Target.Digest.String()
+			imageDigest := image.Target.Digest.String()
 
 			if ref, ok := imageRef.(reference.NamedTagged); ok {
 				if expectedRef.Name() != ref.Name() {
@@ -266,7 +344,7 @@ func buildExpectedDigests(logger *zap.Logger, actualImages []images.Image, expec
 
 				if expectedTagged, ok := expectedRef.(reference.Tagged); ok && ref.Tag() == expectedTagged.Tag() {
 					// this is expected image by tag, inject digest
-					expectedDigests[digest] = struct{}{}
+					expectedDigests[imageDigest] = struct{}{}
 
 					break
 				}
@@ -280,7 +358,7 @@ func buildExpectedDigests(logger *zap.Logger, actualImages []images.Image, expec
 func (ctrl *ImageGCController) cleanup(ctx context.Context, logger *zap.Logger, imageService images.Store, expectedImages []string) error {
 	logger.Debug("running image cleanup")
 
-	ctx = namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
+	ctx = namespaces.WithNamespace(ctx, ctrl.containerdNamespace)
 
 	actualImages, err := imageService.List(ctx)
 	if err != nil {
@@ -311,13 +389,13 @@ func (ctrl *ImageGCController) cleanup(ctx context.Context, logger *zap.Logger, 
 
 		// calculate image age two ways, and pick the minimum:
 		//  * as CRI reports it, which is the time image got pulled
-		//  * as we see it, this means the image won't be deleted until it reaches the age of ImageGCGracePeriod from the moment it became unreferenced
+		//  * as we see it, this means the image won't be deleted until it reaches the age of GCGracePeriod from the moment it became unreferenced
 		imageAgeCRI := time.Since(image.CreatedAt)
 		imageAgeInternal := time.Since(ctrl.imageFirstSeenUnreferenced[image.Name])
 
 		imageAge := min(imageAgeCRI, imageAgeInternal)
 
-		if imageAge < ImageGCGracePeriod {
+		if imageAge < ctrl.GCGracePeriod {
 			logger.Debug("skipping image cleanup, as it's below minimum age", zap.String("image", image.Name), zap.Duration("age", imageAge))
 
 			continue

--- a/internal/app/machined/pkg/controllers/cri/image_gc_retain.go
+++ b/internal/app/machined/pkg/controllers/cri/image_gc_retain.go
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cri
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/containers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
+)
+
+// KubernetesRefsToRetain preserves the images of the Kubernetes-related services Talos runs itself:
+// etcd and the kubelet.
+//
+// Images of Kubernetes pods are deliberately out of scope, as the kubelet garbage collects those.
+func KubernetesRefsToRetain(ctx context.Context, reader controller.Reader) ([]string, error) {
+	var retain []string
+
+	etcdSpec, err := safe.ReaderGet[*etcd.Spec](ctx, reader, resource.NewMetadata(etcd.NamespaceName, etcd.SpecType, etcd.SpecID, resource.VersionUndefined))
+	if err != nil && !state.IsNotFoundError(err) {
+		return nil, fmt.Errorf("error getting etcd spec: %w", err)
+	}
+
+	if etcdSpec != nil {
+		retain = append(retain, etcdSpec.TypedSpec().Image)
+	}
+
+	kubeletSpec, err := safe.ReaderGet[*k8s.KubeletSpec](ctx, reader, resource.NewMetadata(k8s.NamespaceName, k8s.KubeletSpecType, k8s.KubeletID, resource.VersionUndefined))
+	if err != nil && !state.IsNotFoundError(err) {
+		return nil, fmt.Errorf("error getting kubelet spec: %w", err)
+	}
+
+	if kubeletSpec != nil {
+		retain = append(retain, kubeletSpec.TypedSpec().Image)
+	}
+
+	return retain, nil
+}
+
+// TalosContainersRefsToRetain preserves the images of the containers declared in the machine
+// configuration.
+//
+// It covers all three views a container has of its image, because they can disagree and each one
+// alone leaves a window where an image in use looks collectable:
+//
+//   - ContainerSpec.Image.Ref is what is declared. It is a reference rather than a digest, so it
+//     only resolves once the image is actually stored, and a moving tag resolves to whatever is
+//     stored now rather than to what was pulled.
+//   - ContainerImageStatus.Digest is what was pulled for that container, which pins the bytes a
+//     moving tag resolved to at pull time.
+//   - ContainerInstanceSpec.Image is the digest a running instance was created against. An instance
+//     carries a resolved snapshot and is replaced rather than mutated, so after the reference is
+//     edited this is the only place the still-running image is named.
+func TalosContainersRefsToRetain(ctx context.Context, reader controller.Reader) ([]string, error) {
+	var retain []string
+
+	containerSpecs, err := safe.ReaderListAll[*containers.ContainerSpec](ctx, reader)
+	if err != nil {
+		return nil, fmt.Errorf("error listing container specs: %w", err)
+	}
+
+	for containerSpec := range containerSpecs.All() {
+		retain = append(retain, containerSpec.TypedSpec().Image.Ref)
+	}
+
+	imageStatuses, err := safe.ReaderListAll[*containers.ContainerImageStatus](ctx, reader)
+	if err != nil {
+		return nil, fmt.Errorf("error listing container image statuses: %w", err)
+	}
+
+	for imageStatus := range imageStatuses.All() {
+		// Empty until the pull completes; there is nothing to preserve before then.
+		if digest := imageStatus.TypedSpec().Digest; digest != "" {
+			retain = append(retain, digest)
+		}
+	}
+
+	instanceSpecs, err := safe.ReaderListAll[*containers.ContainerInstanceSpec](ctx, reader)
+	if err != nil {
+		return nil, fmt.Errorf("error listing container instance specs: %w", err)
+	}
+
+	for instanceSpec := range instanceSpecs.All() {
+		retain = append(retain, instanceSpec.TypedSpec().Image)
+	}
+
+	return retain, nil
+}

--- a/internal/app/machined/pkg/controllers/cri/image_gc_test.go
+++ b/internal/app/machined/pkg/controllers/cri/image_gc_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/siderolabs/gen/maps"
@@ -23,6 +24,8 @@ import (
 
 	crictrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/cri"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/containers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
@@ -33,15 +36,13 @@ func TestImageGC(t *testing.T) {
 		mockImageService := &mockImageService{}
 
 		// Create the controller inside synctest time function so it uses the controlled time
-		controller := crictrl.NewImageGCController("cri", true)
+		controller := crictrl.NewImageGCController("cri", constants.SystemContainerdNamespace, crictrl.KubernetesRefsToRetain)
 		controller.ImageServiceProvider = func() (crictrl.ImageServiceProvider, error) {
 			return mockImageService, nil
 		}
 
-		// Set up the test environment manually
 		suite := &ctest.DefaultSuite{
 			AfterSetup: func(suite *ctest.DefaultSuite) {
-				// Register the controller
 				suite.Require().NoError(suite.Runtime().RegisterController(controller))
 			},
 			// We need a long timeout here because we advance time manually in the test and we want the controller
@@ -60,7 +61,7 @@ func TestImageGC(t *testing.T) {
 		storedImages := []images.Image{
 			{
 				Name:      "registry.io/org/image1:v1.3.5@sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a",
-				CreatedAt: now.Add(-2 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-2 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a")),
 				},
@@ -68,42 +69,42 @@ func TestImageGC(t *testing.T) {
 			{
 				Name: "sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a",
 				// the image age is more than the grace period, but the controller won't remove due to the check on the last seen unreferenced timestamp
-				CreatedAt: now.Add(-4 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-4 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a")),
 				},
 			}, // ok to be gc'd, same as above, another ref
 			{
 				Name:      "registry.io/org/image1:v1.3.7",
-				CreatedAt: now.Add(-2 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-2 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135")),
 				},
 			}, // current image
 			{
 				Name:      "registry.io/org/image1@sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135",
-				CreatedAt: now.Add(-2 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-2 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135")),
 				},
 			}, // current image, canonical ref
 			{
 				Name:      "sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135",
-				CreatedAt: now.Add(-2 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-2 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135")),
 				},
 			}, // current image, digest ref
 			{
 				Name:      "registry.io/org/image1:v1.3.8",
-				CreatedAt: now.Add(crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:fd03335dd2e7163e5e36e933a0c735d7fec6f42b33ddafad0bc54f333e4a23c0")),
 				},
 			}, // not ok to clean up, too new
 			{
 				Name:      "registry.io/org/image2@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8",
-				CreatedAt: now.Add(-2 * crictrl.ImageGCGracePeriod),
+				CreatedAt: now.Add(-2 * crictrl.DefaultImageGCGracePeriod),
 				Target: v1.Descriptor{
 					Digest: must(digest.Parse("sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8")),
 				},
@@ -131,11 +132,11 @@ func TestImageGC(t *testing.T) {
 
 		// Advance time past the grace period to make old images eligible for cleanup
 		// Grace period is 60 minutes, so advance by 65 minutes to ensure cleanup
-		time.Sleep(crictrl.ImageGCGracePeriod + 5*time.Minute)
+		time.Sleep(crictrl.DefaultImageGCGracePeriod + 5*time.Minute)
 		synctest.Wait()
 
 		// Advance time to trigger the cleanup cycle (15 minutes)
-		time.Sleep(crictrl.ImageCleanupInterval)
+		time.Sleep(crictrl.DefaultImageCleanupInterval)
 		synctest.Wait() // Wait for cleanup to complete
 
 		// Images that should remain after cleanup:
@@ -149,12 +150,234 @@ func TestImageGC(t *testing.T) {
 			"registry.io/org/image2@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8", // etcd image
 		}
 
-		imageList, err := mockImageService.List(suite.Ctx())
-		require.NoError(t, err)
+		suite.Assert().Equal(expectedImages, mockImageService.imageNames(), "images after first GC run do not match expected")
 
-		actualImages := xslices.Map(imageList, func(i images.Image) string { return i.Name })
+		suite.Assert().Equal([]string{constants.SystemContainerdNamespace}, mockImageService.seenNamespaces(),
+			"controller must only touch the containerd namespace it was constructed with")
+	})
+}
 
-		suite.Assert().Equal(expectedImages, actualImages, "images after first GC run do not match expected")
+// TestImageGCTalosContainers covers the instance which collects the taloscontainers namespace, where
+// the expected set comes from the containers declared in the machine configuration.
+func TestImageGCTalosContainers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			cleanupInterval = time.Minute
+			gracePeriod     = 5 * time.Minute
+		)
+
+		mockImageService := &mockImageService{}
+
+		controller := crictrl.NewImageGCController("cri", constants.TalosContainersContainerdNamespace, crictrl.TalosContainersRefsToRetain)
+		controller.ImageServiceProvider = func() (crictrl.ImageServiceProvider, error) {
+			return mockImageService, nil
+		}
+		controller.CleanupInterval = cleanupInterval
+		controller.GCGracePeriod = gracePeriod
+
+		suite := &ctest.DefaultSuite{
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(controller))
+			},
+			Timeout: 2 * time.Hour,
+		}
+
+		suite.SetT(t)
+
+		suite.SetupTest()
+		defer suite.TearDownTest()
+
+		now := time.Now()
+
+		mockImageService.images = []images.Image{
+			{
+				// Referenced by a ContainerSpec below. Note the stored name uses the `docker.io`
+				// host produced by the pull path, while the spec carries the `index.docker.io`
+				// canonical form: the two must still match.
+				Name:      "docker.io/library/alpine:3.23",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target: v1.Descriptor{
+					Digest: must(digest.Parse("sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135")),
+				},
+			},
+			{
+				// Referenced by a ContainerSpec by digest.
+				Name:      "registry.k8s.io/pause@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target: v1.Descriptor{
+					Digest: must(digest.Parse("sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8")),
+				},
+			},
+			{
+				// Left over from a container which is no longer declared: this is the leak the
+				// controller exists to collect.
+				Name:      "docker.io/library/alpine:3.22",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target: v1.Descriptor{
+					Digest: must(digest.Parse("sha256:6b094bd0b063a1172eec7da249eccbb48cc48333800569363d67c747960cfa0a")),
+				},
+			},
+		}
+
+		criService := v1alpha1.NewService("cri")
+		criService.TypedSpec().Healthy = true
+		criService.TypedSpec().Running = true
+
+		require.NoError(t, suite.State().Create(suite.Ctx(), criService))
+
+		shell := containers.NewContainerSpec(containers.NamespaceName, "shell")
+		shell.TypedSpec().Image = containers.ContainerImageSpec{Ref: "index.docker.io/library/alpine:3.23"}
+		require.NoError(t, suite.State().Create(suite.Ctx(), shell))
+
+		pause := containers.NewContainerSpec(containers.NamespaceName, "pause")
+		pause.TypedSpec().Image = containers.ContainerImageSpec{
+			Ref: "registry.k8s.io/pause@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8",
+		}
+		require.NoError(t, suite.State().Create(suite.Ctx(), pause))
+
+		time.Sleep(gracePeriod + cleanupInterval)
+		synctest.Wait()
+
+		suite.Assert().Equal(
+			[]string{
+				"docker.io/library/alpine:3.23",
+				"registry.k8s.io/pause@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8",
+			},
+			mockImageService.imageNames(),
+			"images referenced by a ContainerSpec must survive, unreferenced ones must not",
+		)
+
+		// Removing the container's configuration makes its image collectable, but only after it has
+		// been seen unreferenced for the grace period.
+		require.NoError(t, suite.State().Destroy(suite.Ctx(), shell.Metadata()))
+
+		time.Sleep(cleanupInterval)
+		synctest.Wait()
+
+		suite.Assert().Contains(mockImageService.imageNames(), "docker.io/library/alpine:3.23",
+			"image must not be collected before the grace period elapses")
+
+		time.Sleep(gracePeriod + cleanupInterval)
+		synctest.Wait()
+
+		suite.Assert().Equal(
+			[]string{"registry.k8s.io/pause@sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8"},
+			mockImageService.imageNames(),
+			"image of a removed container must be collected",
+		)
+
+		suite.Assert().Equal([]string{constants.TalosContainersContainerdNamespace}, mockImageService.seenNamespaces(),
+			"controller must only touch the containerd namespace it was constructed with")
+	})
+}
+
+// TestImageGCTalosContainersResolvedDigests covers the two expectation sources which name an image by
+// digest rather than by reference: the pull result, and what a running instance was created against.
+//
+// Both matter when the declared reference no longer names the stored image: after the reference is
+// edited, or when it is a moving tag which has since been re-resolved.
+func TestImageGCTalosContainersResolvedDigests(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			cleanupInterval = time.Minute
+			gracePeriod     = 5 * time.Minute
+
+			runningDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+			pulledDigest  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+			orphanDigest  = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+		)
+
+		mockImageService := &mockImageService{}
+
+		controller := crictrl.NewImageGCController("cri", constants.TalosContainersContainerdNamespace, crictrl.TalosContainersRefsToRetain)
+		controller.ImageServiceProvider = func() (crictrl.ImageServiceProvider, error) {
+			return mockImageService, nil
+		}
+		controller.CleanupInterval = cleanupInterval
+		controller.GCGracePeriod = gracePeriod
+
+		suite := &ctest.DefaultSuite{
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(controller))
+			},
+			Timeout: 2 * time.Hour,
+		}
+
+		suite.SetT(t)
+
+		suite.SetupTest()
+		defer suite.TearDownTest()
+
+		now := time.Now()
+
+		mockImageService.images = []images.Image{
+			{
+				// Named by no reference in the expected set: the container's declared reference has
+				// been edited to a tag which has not been pulled yet, so only the still-running
+				// instance names these bytes.
+				Name:      "docker.io/library/nginx:1.29",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target:    v1.Descriptor{Digest: must(digest.Parse(runningDigest))},
+			},
+			{
+				// The container declares the moving tag `redis:8`, which does not match this record
+				// by name and tag. Only the pull result names these bytes.
+				Name:      "docker.io/library/redis:8.0",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target:    v1.Descriptor{Digest: must(digest.Parse(pulledDigest))},
+			},
+			{
+				Name:      "docker.io/library/mysql:9.0",
+				CreatedAt: now.Add(-2 * gracePeriod),
+				Target:    v1.Descriptor{Digest: must(digest.Parse(orphanDigest))},
+			},
+		}
+
+		criService := v1alpha1.NewService("cri")
+		criService.TypedSpec().Healthy = true
+		criService.TypedSpec().Running = true
+
+		require.NoError(t, suite.State().Create(suite.Ctx(), criService))
+
+		// web: reference edited to a tag whose pull is still in flight, so its image status carries
+		// no digest yet, and the running instance is the only thing naming the old image.
+		web := containers.NewContainerSpec(containers.NamespaceName, "web")
+		web.TypedSpec().Image = containers.ContainerImageSpec{Ref: "index.docker.io/library/nginx:1.30"}
+		require.NoError(t, suite.State().Create(suite.Ctx(), web))
+
+		webImage := containers.NewContainerImageStatus(containers.NamespaceName, "web")
+		webImage.TypedSpec().Phase = containers.ContainerImagePhasePulling
+		webImage.TypedSpec().Image = "index.docker.io/library/nginx:1.30"
+		require.NoError(t, suite.State().Create(suite.Ctx(), webImage))
+
+		webInstance := containers.NewContainerInstanceSpec(containers.NamespaceName, containers.InstanceID("web", 0))
+		webInstance.TypedSpec().ContainerID = "web"
+		webInstance.TypedSpec().Image = runningDigest
+		require.NoError(t, suite.State().Create(suite.Ctx(), webInstance))
+
+		// cache: declares a moving tag, which the stored record does not carry. The pull result is
+		// what pins the bytes that tag resolved to.
+		cache := containers.NewContainerSpec(containers.NamespaceName, "cache")
+		cache.TypedSpec().Image = containers.ContainerImageSpec{Ref: "index.docker.io/library/redis:8"}
+		require.NoError(t, suite.State().Create(suite.Ctx(), cache))
+
+		cacheImage := containers.NewContainerImageStatus(containers.NamespaceName, "cache")
+		cacheImage.TypedSpec().Phase = containers.ContainerImagePhaseReady
+		cacheImage.TypedSpec().Image = "index.docker.io/library/redis:8"
+		cacheImage.TypedSpec().Digest = pulledDigest
+		require.NoError(t, suite.State().Create(suite.Ctx(), cacheImage))
+
+		time.Sleep(gracePeriod + cleanupInterval)
+		synctest.Wait()
+
+		suite.Assert().Equal(
+			[]string{
+				"docker.io/library/nginx:1.29",
+				"docker.io/library/redis:8.0",
+			},
+			mockImageService.imageNames(),
+			"images named only by an instance spec or an image status must survive; one named by nothing must not",
+		)
 	})
 }
 
@@ -162,6 +385,10 @@ type mockImageService struct {
 	mu sync.Mutex
 
 	images []images.Image
+
+	// namespaces records every containerd namespace the controller operated in, so that a test can
+	// assert it collected the namespace it was constructed with and no other.
+	namespaces map[string]struct{}
 }
 
 func (m *mockImageService) ImageService() images.Store {
@@ -172,6 +399,31 @@ func (m *mockImageService) Close() error {
 	return nil
 }
 
+// recordNamespace notes the containerd namespace carried by ctx. Called with m.mu held.
+func (m *mockImageService) recordNamespace(ctx context.Context) {
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		ns = "<none>"
+	}
+
+	if m.namespaces == nil {
+		m.namespaces = map[string]struct{}{}
+	}
+
+	m.namespaces[ns] = struct{}{}
+}
+
+// seenNamespaces returns the containerd namespaces the controller has operated in so far.
+func (m *mockImageService) seenNamespaces() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	seen := maps.Keys(m.namespaces)
+	slices.Sort(seen)
+
+	return seen
+}
+
 func (m *mockImageService) Get(ctx context.Context, name string) (images.Image, error) {
 	panic("not implemented")
 }
@@ -179,6 +431,8 @@ func (m *mockImageService) Get(ctx context.Context, name string) (images.Image, 
 func (m *mockImageService) List(ctx context.Context, filters ...string) ([]images.Image, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	m.recordNamespace(ctx)
 
 	return slices.Clone(m.images), nil
 }
@@ -195,9 +449,22 @@ func (m *mockImageService) Delete(ctx context.Context, name string, opts ...imag
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.recordNamespace(ctx)
+
 	m.images = xslices.FilterInPlace(m.images, func(i images.Image) bool { return i.Name != name })
 
 	return nil
+}
+
+// imageNames returns the names of the images left in the store.
+//
+// It reads the store directly rather than through List, so that inspecting it from a test does not
+// count as the controller having operated in a namespace.
+func (m *mockImageService) imageNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return xslices.Map(m.images, func(i images.Image) string { return i.Name })
 }
 
 func TestBuildExpectedImageDigests(t *testing.T) {
@@ -244,6 +511,13 @@ func TestBuildExpectedImageDigests(t *testing.T) {
 				Digest: must(digest.Parse("sha256:2f794176e9bd8a28501fa185693dc1073013a048c51585022ebce4f84b469db8")),
 			},
 		},
+		{
+			// As the pull path names it: `docker.io`, not the `index.docker.io` canonical form.
+			Name: "docker.io/library/alpine:3.23",
+			Target: v1.Descriptor{
+				Digest: must(digest.Parse("sha256:ba0b7fbc85d67cf5b0d0c1e2b0b0eab0a5fa9b3b7c8b6e0a1a2b3c4d5e6f7081")),
+			},
+		},
 	}
 
 	logger := zaptest.NewLogger(t)
@@ -288,6 +562,29 @@ func TestBuildExpectedImageDigests(t *testing.T) {
 			name: "not found",
 			expectedImages: []string{
 				"registry.io/org/image1:v1.3.9",
+			},
+		},
+		{
+			// ContainerImageStatus and ContainerInstanceSpec name an image by bare digest, which
+			// resolves to itself: there is nothing to look up in the stored images.
+			name: "by bare digest",
+			expectedImages: []string{
+				"sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135",
+			},
+			expectedDigests: []string{
+				"sha256:7051a34bcd2522e58a2291d1aa065667f225fd07e4445590b091e86c6799b135",
+			},
+		},
+		{
+			// ContainerConfig canonicalizes Docker Hub references to the `index.docker.io` host,
+			// while the pull path stores the image record under `docker.io`. Both must resolve to
+			// the same digest, or every container image would look unreferenced.
+			name: "docker hub host normalization",
+			expectedImages: []string{
+				"index.docker.io/library/alpine:3.23",
+			},
+			expectedDigests: []string{
+				"sha256:ba0b7fbc85d67cf5b0d0c1e2b0b0eab0a5fa9b3b7c8b6e0a1a2b3c4d5e6f7081",
 			},
 		},
 	} {

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -262,8 +262,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			Runtime: ctrl.v1alpha1Runtime,
 		},
 		&cri.CustomizationConfigController{},
-		cri.NewImageGCController("containerd", false),
-		cri.NewImageGCController("cri", true),
+		cri.NewImageGCController("containerd", constants.SystemContainerdNamespace, nil),
+		cri.NewImageGCController("cri", constants.SystemContainerdNamespace, cri.KubernetesRefsToRetain),
+		cri.NewImageGCController("cri", constants.TalosContainersContainerdNamespace, cri.TalosContainersRefsToRetain),
 		&cri.RegistriesConfigController{},
 		&cri.ServiceController{
 			V1Alpha1Services: system.Services(ctrl.v1alpha1Runtime),

--- a/internal/integration/api/containers.go
+++ b/internal/integration/api/containers.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -24,6 +25,7 @@ import (
 	"github.com/siderolabs/talos/internal/integration/base"
 	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	configcontainer "github.com/siderolabs/talos/pkg/machinery/config/config"
 	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
@@ -1378,6 +1380,87 @@ func (suite *ContainersSuite) readContainerLog(ctx context.Context, containerNam
 	}
 
 	return string(body), nil
+}
+
+// containerdImages lists the names of the images stored in a containerd namespace.
+func (suite *ContainersSuite) containerdImages(ctx context.Context, namespace common.ContainerdNamespace) ([]string, error) {
+	driver := common.ContainerDriver_CONTAINERD
+	if namespace == common.ContainerdNamespace_NS_SYSTEM || namespace == common.ContainerdNamespace_NS_CRI {
+		driver = common.ContainerDriver_CRI
+	}
+
+	rcv, err := suite.Client.ImageClient.List(ctx, &machine.ImageServiceListRequest{
+		Containerd: &common.ContainerdInstance{
+			Driver:    driver,
+			Namespace: namespace,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var imageNames []string
+
+	for {
+		msg, err := rcv.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return imageNames, nil
+			}
+
+			return nil, err
+		}
+
+		imageNames = append(imageNames, msg.GetName())
+	}
+}
+
+// assertContainerdImages returns the image names in a containerd namespace, failing the test if
+// they cannot be read.
+func (suite *ContainersSuite) assertContainerdImages(ctx context.Context, namespace common.ContainerdNamespace) []string {
+	imageNames, err := suite.containerdImages(ctx, namespace)
+	suite.Require().NoError(err)
+
+	return imageNames
+}
+
+// TestImageNotGarbageCollectedWhileReferenced covers the image GC instance which collects the
+// taloscontainers namespace: a declared container's image lands there and not in the system
+// namespace, and is not collected out from under a container that is still using it.
+//
+// The deletion half cannot be covered here: an unreferenced image only becomes eligible after
+// cri.ImageGCGracePeriod, an hour, which is far longer than any node can be held for. That path is
+// covered by TestImageGCTalosContainers in the controller's own tests, on synthetic time. This is
+// the same kind of blind spot as the one assertNoContainerdContainer documents.
+func (suite *ContainersSuite) TestImageNotGarbageCollectedWhileReferenced() {
+	ctx, name, _ := suite.setupContainer("image-gc")
+
+	suite.applyContainers(ctx, suite.shellContainer(name, "sleep 3600"))
+
+	suite.assertContainerRunning(ctx, name, "before inspecting the image store")
+
+	suite.Assert().Contains(suite.assertContainerdImages(ctx, common.ContainerdNamespace_NS_TALOSCONTAINERS), containerShellImage,
+		"the container's image must be pulled into the taloscontainers namespace")
+
+	suite.Assert().NotContains(suite.assertContainerdImages(ctx, common.ContainerdNamespace_NS_SYSTEM), containerShellImage,
+		"the container's image must not leak into the system namespace, which is collected against a different expected set")
+
+	suite.T().Logf("removing container config %q", name)
+
+	suite.RemoveMachineConfigDocumentsByName(ctx, containercfg.ContainerConfigKind, name)
+
+	suite.assertNoContainerdContainer(ctx, name)
+
+	// The image is unreferenced from here on, and must survive until the grace period elapses.
+	suite.Require().Never(func() bool {
+		imageNames, err := suite.containerdImages(ctx, common.ContainerdNamespace_NS_TALOSCONTAINERS)
+		if err != nil {
+			// A failed read is not the image having been collected.
+			return false
+		}
+
+		return !slices.Contains(imageNames, containerShellImage)
+	}, 30*time.Second, 5*time.Second, "image was collected before the grace period elapsed")
 }
 
 // assertNoContainerdContainer verifies that containerd is running no task for containerName.


### PR DESCRIPTION
Resolves https://github.com/siderolabs/talos/issues/14025

- Refactors ImageGCController to facilitate reusability and testability.
- Runs a third copy of the ImageGCController, focused on the `taloscontainers` CRI namespace.
