### PR TITLE
chore: add SPD5118 driver to squashfs

### DIFF
--- a/hack/modules-amd64.txt
+++ b/hack/modules-amd64.txt
@@ -99,6 +99,7 @@ kernel/drivers/hwmon/k10temp.ko
 kernel/drivers/hwmon/k8temp.ko
 kernel/drivers/hwmon/nct6683.ko
 kernel/drivers/hwmon/nct6775.ko
+kernel/drivers/hwmon/spd5118.ko
 kernel/drivers/i2c/algos/i2c-algo-bit.ko
 kernel/drivers/i2c/busses/i2c-i801.ko
 kernel/drivers/i2c/i2c-smbus.ko

--- a/hack/modules-arm64.txt
+++ b/hack/modules-arm64.txt
@@ -66,6 +66,7 @@ kernel/drivers/hv/hv_utils.ko
 kernel/drivers/hwmon/acpi_power_meter.ko
 kernel/drivers/hwmon/drivetemp.ko
 kernel/drivers/hwmon/i5k_amb.ko
+kernel/drivers/hwmon/spd5118.ko
 kernel/drivers/i2c/algos/i2c-algo-bit.ko
 kernel/drivers/i2c/busses/i2c-i801.ko
 kernel/drivers/i2c/i2c-mux.ko


### PR DESCRIPTION
SPD5118 enables temperature monitoring on DDR5 DIMMs.
