### PR TITLE
feat(machined): fall back to sysfs for processor topology when SMBIOS is thin

### DIFF
--- a/internal/app/machined/pkg/controllers/hardware/system.go
+++ b/internal/app/machined/pkg/controllers/hardware/system.go
@@ -7,6 +7,9 @@ package hardware
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -14,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/prometheus/procfs"
+	"github.com/prometheus/procfs/sysfs"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-smbios/smbios"
 	"go.uber.org/zap"
@@ -74,6 +78,8 @@ func (ctrl *SystemInfoController) Outputs() []controller.Output {
 
 const memoryModuleUnknown = "UNKNOWN"
 
+const processorUnknown = "UNKNOWN"
+
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
@@ -116,7 +122,7 @@ func (ctrl *SystemInfoController) Run(ctx context.Context, r controller.Runtime,
 			return err
 		}
 
-		if err := ctrl.reconcileProcessors(ctx, r); err != nil {
+		if err := ctrl.reconcileProcessors(ctx, r, logger); err != nil {
 			return err
 		}
 
@@ -161,13 +167,35 @@ func (ctrl *SystemInfoController) reconcileSystemInformation(ctx context.Context
 	return nil
 }
 
-func (ctrl *SystemInfoController) reconcileProcessors(ctx context.Context, r controller.Runtime) error {
-	for _, p := range ctrl.SMBIOS.ProcessorInformation {
+func (ctrl *SystemInfoController) reconcileProcessors(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if len(ctrl.SMBIOS.ProcessorInformation) == 0 {
+		return ctrl.reconcileProcessorsFromSysfs(ctx, r, logger)
+	}
+
+	var topologies []cpuTopologyInfo
+
+	if slices.ContainsFunc(ctrl.SMBIOS.ProcessorInformation, processorNeedsTopologyFallback) {
+		logger.Debug("processor information incomplete, attempting to retrieve topology from sysfs")
+
+		var err error
+
+		topologies, err = cpuTopologyFallback()
+		if err != nil {
+			return err
+		}
+	}
+
+	for i, p := range ctrl.SMBIOS.ProcessorInformation {
 		// replaces `CPU 0` with `CPU-0`
 		id := strings.ReplaceAll(p.SocketDesignation, " ", "-")
+		populated := p.Status.SocketPopulated()
 
 		if err := safe.WriterModify(ctx, r, hardware.NewProcessorInfo(id), func(res *hardware.Processor) error {
 			hwadapter.Processor(res).Update(&p)
+
+			if populated {
+				applyTopologyFallback(res.TypedSpec(), topologies, i)
+			}
 
 			return nil
 		}); err != nil {
@@ -176,6 +204,188 @@ func (ctrl *SystemInfoController) reconcileProcessors(ctx context.Context, r con
 	}
 
 	return nil
+}
+
+// reconcileProcessorsFromSysfs populates Processor resources purely from
+// /sys/devices/system/cpu, for use when SMBIOS provides no processor
+// information at all. This happens on boards with thin or incomplete
+// firmware, e.g. some ARM SBCs booting through a minimal UEFI shim.
+func (ctrl *SystemInfoController) reconcileProcessorsFromSysfs(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	logger.Debug("no processor information found, attempting to retrieve topology from sysfs")
+
+	topologies, err := cpuTopologyFallback()
+	if err != nil {
+		return err
+	}
+
+	for i, t := range topologies {
+		id := processorUnknown
+		if len(topologies) > 1 {
+			id = fmt.Sprintf("%s-%d", processorUnknown, i)
+		}
+
+		if err := safe.WriterModify(ctx, r, hardware.NewProcessorInfo(id), func(res *hardware.Processor) error {
+			spec := res.TypedSpec()
+			spec.CoreCount = t.coreCount
+			spec.CoreEnabled = t.coreCount
+			spec.ThreadCount = t.threadCount
+			spec.MaxSpeed = t.maxSpeedMHz
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error updating objects: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// processorNeedsTopologyFallback reports whether a populated SMBIOS processor socket is missing
+// CoreCount, ThreadCount, or MaxSpeed, and would benefit from the sysfs-derived fallback.
+func processorNeedsTopologyFallback(p smbios.ProcessorInformation) bool {
+	return p.Status.SocketPopulated() && (p.CoreCount == 0 || p.ThreadCount == 0 || p.MaxSpeed == 0)
+}
+
+// applyTopologyFallback fills zero CoreCount/CoreEnabled/ThreadCount/MaxSpeed fields on spec
+// from the topology detected for the i-th SMBIOS processor entry, if any was detected.
+func applyTopologyFallback(spec *hardware.ProcessorSpec, topologies []cpuTopologyInfo, i int) {
+	if len(topologies) == 0 {
+		return
+	}
+
+	t := topologies[min(i, len(topologies)-1)]
+
+	if spec.CoreCount == 0 {
+		spec.CoreCount = t.coreCount
+		spec.CoreEnabled = t.coreCount
+	}
+
+	if spec.ThreadCount == 0 {
+		spec.ThreadCount = t.threadCount
+	}
+
+	if spec.MaxSpeed == 0 {
+		spec.MaxSpeed = t.maxSpeedMHz
+	}
+}
+
+// cpuTopologyInfo describes the topology of a single physical processor
+// package (socket), derived from /sys/devices/system/cpu.
+type cpuTopologyInfo struct {
+	coreCount   uint32
+	threadCount uint32
+	maxSpeedMHz uint32
+}
+
+// cpuPackageInfo accumulates the topology of a single physical processor
+// package while walking /sys/devices/system/cpu.
+type cpuPackageInfo struct {
+	coreIDs     map[string]struct{}
+	threadCount uint32
+	maxSpeedMHz uint32
+}
+
+// cpuTopologyFallback derives per-socket processor topology from
+// /sys/devices/system/cpu. Logical CPUs are grouped by physical_package_id,
+// so multi-socket systems are still split correctly. The result is sorted by
+// ascending package ID.
+func cpuTopologyFallback() ([]cpuTopologyInfo, error) {
+	fs, err := sysfs.NewDefaultFS()
+	if err != nil {
+		return nil, err
+	}
+
+	cpus, err := fs.CPUs()
+	if err != nil {
+		return nil, err
+	}
+
+	packages, order, cpuPackage := groupCPUsByPackage(cpus)
+
+	// best-effort: not all systems expose cpufreq (e.g. many VMs), so a
+	// missing/unreadable cpuinfo_max_freq just leaves MaxSpeed unset, same as
+	// the existing SMBIOS-derived path.
+	applyMaxSpeeds(fs, packages, cpuPackage)
+
+	sort.Slice(order, func(i, j int) bool {
+		a, errA := strconv.Atoi(order[i])
+		b, errB := strconv.Atoi(order[j])
+
+		if errA == nil && errB == nil {
+			return a < b
+		}
+
+		return order[i] < order[j]
+	})
+
+	result := make([]cpuTopologyInfo, 0, len(order))
+
+	for _, id := range order {
+		p := packages[id]
+
+		result = append(result, cpuTopologyInfo{
+			coreCount:   uint32(len(p.coreIDs)),
+			threadCount: p.threadCount,
+			maxSpeedMHz: p.maxSpeedMHz,
+		})
+	}
+
+	return result, nil
+}
+
+// groupCPUsByPackage walks the topology of every CPU, grouping them by physical package ID.
+// It also returns package IDs in first-seen order, and a logical-CPU-number -> package ID map.
+func groupCPUsByPackage(cpus []sysfs.CPU) (map[string]*cpuPackageInfo, []string, map[string]string) {
+	packages := map[string]*cpuPackageInfo{}
+	cpuPackage := map[string]string{}
+
+	var order []string
+
+	for _, cpu := range cpus {
+		topology, err := cpu.Topology()
+		if err != nil {
+			// topology info isn't available for this CPU (e.g. offline), skip it
+			continue
+		}
+
+		cpuPackage[cpu.Number()] = topology.PhysicalPackageID
+
+		p, ok := packages[topology.PhysicalPackageID]
+		if !ok {
+			p = &cpuPackageInfo{coreIDs: map[string]struct{}{}}
+			packages[topology.PhysicalPackageID] = p
+
+			order = append(order, topology.PhysicalPackageID)
+		}
+
+		p.coreIDs[topology.CoreID] = struct{}{}
+		p.threadCount++
+	}
+
+	return packages, order, cpuPackage
+}
+
+// applyMaxSpeeds fills in maxSpeedMHz per package from cpufreq, where available.
+func applyMaxSpeeds(fs sysfs.FS, packages map[string]*cpuPackageInfo, cpuPackage map[string]string) {
+	freqs, err := fs.SystemCpufreq()
+	if err != nil {
+		return
+	}
+
+	for _, f := range freqs {
+		if f.CpuinfoMaximumFrequency == nil {
+			continue
+		}
+
+		packageID, ok := cpuPackage[f.Name]
+		if !ok {
+			continue
+		}
+
+		if mhz := uint32(*f.CpuinfoMaximumFrequency / 1000); mhz > packages[packageID].maxSpeedMHz {
+			packages[packageID].maxSpeedMHz = mhz
+		}
+	}
 }
 
 func (ctrl *SystemInfoController) reconcileMemoryModules(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {

--- a/internal/app/machined/pkg/controllers/hardware/system_test.go
+++ b/internal/app/machined/pkg/controllers/hardware/system_test.go
@@ -181,6 +181,39 @@ func (suite *SystemInfoSuite) TestPopulateSystemInformationEmpty() {
 		asrt.Equal("UNKNOWN", r.TypedSpec().Manufacturer)
 		asrt.NotZero(r.TypedSpec().Size)
 	})
+
+	ctest.AssertResource(suite, "UNKNOWN", func(r *hardware.Processor, asrt *assert.Assertions) {
+		asrt.NotZero(r.TypedSpec().CoreCount)
+		asrt.NotZero(r.TypedSpec().ThreadCount)
+	})
+}
+
+// TestPopulateProcessorsFallbackForThinSMBIOS verifies that CoreCount/ThreadCount/MaxSpeed are
+// backfilled from /sys/devices/system/cpu when SMBIOS reports a populated socket but doesn't
+// provide topology data — as seen on some ARM SBCs booting through a minimal UEFI shim.
+func (suite *SystemInfoSuite) TestPopulateProcessorsFallbackForThinSMBIOS() {
+	s := &smbios.SMBIOS{
+		ProcessorInformation: []smbios.ProcessorInformation{
+			{
+				SocketDesignation:     "CPU 0",
+				ProcessorManufacturer: "Raspberry Pi",
+				Status:                0x40, // socket populated, all other bits unset
+			},
+		},
+	}
+
+	suite.Require().NoError(suite.Runtime().RegisterController(&hardwarectrl.SystemInfoController{
+		SMBIOS: s,
+	}))
+
+	suite.Create(runtime.NewMetaLoaded())
+
+	ctest.AssertResource(suite, "CPU-0", func(r *hardware.Processor, asrt *assert.Assertions) {
+		asrt.Equal("Raspberry Pi", r.TypedSpec().Manufacturer)
+		asrt.NotZero(r.TypedSpec().CoreCount)
+		asrt.NotZero(r.TypedSpec().CoreEnabled)
+		asrt.NotZero(r.TypedSpec().ThreadCount)
+	})
 }
 
 func (suite *SystemInfoSuite) TestUUIDOverwrite() {


### PR DESCRIPTION
## Summary

Closes #14171

On boards where firmware provides thin or incomplete SMBIOS data (e.g. Raspberry Pi CM4 and other ARM SBCs booting through a minimal UEFI shim), `hardware.Processor` comes back with a socket entry but no `CoreCount`/`ThreadCount`/`MaxSpeed` — even though the Linux kernel knows all three from CPU topology and cpufreq, independent of firmware.

This mirrors the existing `reconcileMemoryModules` fallback to `procfs.Meminfo()` (same file), which already falls back to kernel-derived data when SMBIOS is empty.

- When `SMBIOS.ProcessorInformation` is empty entirely, `hardware.Processor` resources are populated purely from `/sys/devices/system/cpu`.
- When a populated socket is present but missing `CoreCount`/`ThreadCount`/`MaxSpeed`, those specific zero fields are backfilled from the same sysfs data (SMBIOS-reported values, including manufacturer/model/serial, are left untouched).
- Logical CPUs are grouped by `physical_package_id` (falling back to `core_id` uniqueness for `CoreCount`, logical CPU count for `ThreadCount`), so multi-socket systems still split correctly.
- `MaxSpeedMHz` is derived from `cpufreq/cpuinfo_max_freq` where the driver exposes it (e.g. many VMs don't), left unset otherwise — same best-effort spirit as the existing SMBIOS path.

Manufacturer, ProductName, SerialNumber, AssetTag, PartNumber remain SMBIOS-only, as proposed in the issue — there's no kernel-exposed equivalent.

## Test plan

- [x] `go test ./internal/app/machined/pkg/controllers/hardware/...` — added `TestPopulateProcessorsFallbackForThinSMBIOS` (populated socket with zero fields gets backfilled) and extended `TestPopulateSystemInformationEmpty` (no SMBIOS processor info at all) to assert non-zero Core/ThreadCount
- [x] existing `TestPopulateSystemInformation` (full SMBIOS data) still passes unchanged, confirming the fallback doesn't kick in when SMBIOS is complete
- [ ] Manual verification on the reporter's Raspberry Pi CM4 hardware (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)