### PR TITLE
fix: drop dead legacy registries init from worker generation

### DIFF
--- a/pkg/machinery/config/generate/generate_test.go
+++ b/pkg/machinery/config/generate/generate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	mc "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	blockcfg "github.com/siderolabs/talos/pkg/machinery/config/types/block"
@@ -166,6 +167,31 @@ func TestGenerateRegistryMirrorsOrder(t *testing.T) {
 	named, ok = registryConfigs[1].(mc.NamedDocument)
 	require.True(t, ok)
 	assert.Equal(t, "b.com", named.Name())
+}
+
+// TestGenerateNoLegacyRegistries asserts that no empty legacy `.machine.registries` stanza is
+// generated for machine types which use the multi-doc registry configuration.
+func TestGenerateNoLegacyRegistries(t *testing.T) {
+	t.Parallel()
+
+	input, err := generate.NewInput("test", "https://10.0.1.5", constants.DefaultKubernetesVersion)
+	require.NoError(t, err)
+
+	for _, machineType := range []machine.Type{machine.TypeControlPlane, machine.TypeWorker} {
+		t.Run(machineType.String(), func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := input.Config(machineType)
+			require.NoError(t, err)
+
+			// the legacy stanza is only rendered by the commented encoder, which is what
+			// `talosctl gen config` uses by default.
+			out, err := cfg.EncodeBytes(encoder.WithComments(encoder.CommentsAll))
+			require.NoError(t, err)
+
+			assert.NotContains(t, string(out), "registries:")
+		})
+	}
 }
 
 func TestGenerateEphemeralVolumeConfig(t *testing.T) {

--- a/pkg/machinery/config/generate/worker.go
+++ b/pkg/machinery/config/generate/worker.go
@@ -145,21 +145,6 @@ func (in *Input) worker() ([]config.Document, error) {
 		}
 	}
 
-	if machine.MachineRegistries.RegistryMirrors == nil { //nolint:staticcheck // backwards compatibility
-		machine.MachineRegistries.RegistryMirrors = map[string]*v1alpha1.RegistryMirrorConfig{} //nolint:staticcheck // backwards compatibility
-	}
-
-	if in.Options.VersionContract.KubernetesAlternateImageRegistries() {
-		if _, ok := machine.MachineRegistries.RegistryMirrors["k8s.gcr.io"]; !ok { //nolint:staticcheck // backwards compatibility Talos v1.1->1.2
-			machine.MachineRegistries.RegistryMirrors["k8s.gcr.io"] = &v1alpha1.RegistryMirrorConfig{ //nolint:staticcheck // backwards compatibility Talos v1.1->1.2
-				MirrorEndpoints: []string{
-					"https://registry.k8s.io",
-					"https://k8s.gcr.io",
-				},
-			}
-		}
-	}
-
 	if in.Options.VersionContract.ClusterNameForWorkers() && !in.Options.VersionContract.MultidocKubernetesConfigSupported() {
 		cluster.ClusterName = in.ClusterName //nolint:staticcheck // legacy configuration
 	}


### PR DESCRIPTION
`worker()` pre-initialized `.machine.registries.mirrors` to an empty
map before calling `generateRegistryConfigs`, which reassigns the whole
`RegistriesConfig` on legacy contracts and leaves it untouched on
multi-doc ones. The two contract predicates are disjoint
(`KubernetesAlternateImageRegistries` covers only v1.2,
`MultidocNetworkConfigSupported` starts after v1.11), so the block never
contributed a mirror — it only left a non-nil empty map behind.

The commented encoder's `isEmpty` falls back to `reflect.Value.IsZero()`
for structs, which is false for a struct holding a non-nil empty map, so
`talosctl gen config` rendered a spurious `registries: {}` in
worker.yaml while controlplane.yaml, which has no such block, stayed
clean. `--with-docs=false --with-examples=false` hid it because plain
`yaml.Marshal` recurses into the struct and treats it as zero.

Closes #14161

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
