### PR TITLE
feat: add KubeSpan peer endpoint filters

### DIFF
--- a/api/resource/definitions/kubespan/kubespan.proto
+++ b/api/resource/definitions/kubespan/kubespan.proto
@@ -28,6 +28,8 @@ message ConfigSpec {
   repeated common.NetIPPort extra_endpoints = 9;
   // If not empty, filter advertised networks using the list of CIDRs.
   repeated common.NetIPPrefix exclude_advertised_networks = 10;
+  // If not empty, filter peer endpoints to connect to using the list of CIDRs.
+  repeated string peer_endpoint_filters = 11;
 }
 
 // EndpointSpec describes Endpoint state.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -26,6 +26,17 @@ CoreDNS: 1.14.7
 Talos is built with Go 1.26.7.
 """
 
+    [notes.kubespan_peer_endpoint_filters]
+        title = "KubeSpan Peer Endpoint Filters"
+        description = """\
+KubeSpan now supports filtering the endpoints received from other peers via `filters.peerEndpoints` in the `KubeSpanConfig` document.
+
+While `filters.endpoints` filters the addresses a node advertises to the whole cluster, `filters.peerEndpoints` filters the endpoints
+received from other peers before the node connects to them, affecting only that node. This allows excluding peer-advertised endpoints
+which are known to be unreachable from a node (e.g., addresses of a private network the node is not connected to), so that KubeSpan
+endpoint rotation never attempts them.
+"""
+
     [notes.ipvs]
         title = "IPVS Support"
         description = """\

--- a/internal/app/machined/pkg/controllers/kubespan/config.go
+++ b/internal/app/machined/pkg/controllers/kubespan/config.go
@@ -56,6 +56,7 @@ func NewConfigController() *ConfigController {
 
 						if c.NetworkKubeSpanConfig().Filters() != nil {
 							res.TypedSpec().EndpointFilters = c.NetworkKubeSpanConfig().Filters().Endpoints()
+							res.TypedSpec().PeerEndpointFilters = c.NetworkKubeSpanConfig().Filters().PeerEndpoints()
 							res.TypedSpec().ExcludeAdvertisedNetworks = c.NetworkKubeSpanConfig().Filters().ExcludeAdvertisedNetworks()
 						}
 					}

--- a/internal/app/machined/pkg/controllers/kubespan/config_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/config_test.go
@@ -99,6 +99,7 @@ func (suite *ConfigSuite) TestReconcileMultiDoc() {
 	kubeSpanCfg.ConfigMTU = new(uint32(1380))
 	kubeSpanCfg.ConfigFilters = &network.KubeSpanFiltersConfig{
 		ConfigEndpoints:                 []string{"0.0.0.0/0", "::/0"},
+		ConfigPeerEndpoints:             []string{"0.0.0.0/0", "!192.168.0.0/16", "::/0"},
 		ConfigExcludeAdvertisedNetworks: []meta.Prefix{{Prefix: netip.MustParsePrefix("10.0.0.0/8")}},
 	}
 
@@ -127,6 +128,7 @@ func (suite *ConfigSuite) TestReconcileMultiDoc() {
 			asrt.Equal("test-cluster-secret-multi-doc", spec.SharedSecret)
 			asrt.Equal(uint32(1380), spec.MTU)
 			asrt.Equal([]string{"0.0.0.0/0", "::/0"}, spec.EndpointFilters)
+			asrt.Equal([]string{"0.0.0.0/0", "!192.168.0.0/16", "::/0"}, spec.PeerEndpointFilters)
 			asrt.Equal([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}, spec.ExcludeAdvertisedNetworks)
 		},
 	)

--- a/internal/app/machined/pkg/controllers/kubespan/peer_spec.go
+++ b/internal/app/machined/pkg/controllers/kubespan/peer_spec.go
@@ -7,6 +7,7 @@ package kubespan
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -15,6 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/gen/xslices"
+	sideronet "github.com/siderolabs/net"
 	"go.uber.org/zap"
 	"go4.org/netipx"
 
@@ -164,11 +166,20 @@ func (ctrl *PeerSpecController) Run(ctx context.Context, r controller.Runtime, l
 
 				peerIPSets[spec.KubeSpan.PublicKey] = ipSet
 
+				endpoints := slices.Clone(spec.KubeSpan.Endpoints)
+
+				if len(cfg.TypedSpec().PeerEndpointFilters) > 0 {
+					endpoints, err = filterPeerEndpoints(endpoints, cfg.TypedSpec().PeerEndpointFilters)
+					if err != nil {
+						return fmt.Errorf("error filtering endpoints for peer %q: %w", spec.KubeSpan.PublicKey, err)
+					}
+				}
+
 				if err = safe.WriterModify(ctx, r, kubespan.NewPeerSpec(kubespan.NamespaceName, spec.KubeSpan.PublicKey), func(res *kubespan.PeerSpec) error {
 					*res.TypedSpec() = kubespan.PeerSpecSpec{
 						Address:    spec.KubeSpan.Address,
 						AllowedIPs: ipSet.Prefixes(),
-						Endpoints:  slices.Clone(spec.KubeSpan.Endpoints),
+						Endpoints:  endpoints,
 						Label:      spec.Nodename,
 					}
 
@@ -206,4 +217,20 @@ func (ctrl *PeerSpecController) Run(ctx context.Context, r controller.Runtime, l
 // dumpSet converts IPSet to a form suitable for logging.
 func dumpSet(set *netipx.IPSet) []string {
 	return xslices.Map(set.Ranges(), netipx.IPRange.String)
+}
+
+// filterPeerEndpoints filters peer endpoints by the list of CIDR filters, preserving the original endpoint order.
+func filterPeerEndpoints(endpoints []netip.AddrPort, filters []string) ([]netip.AddrPort, error) {
+	filteredAddrs, err := sideronet.FilterIPs(xslices.Map(endpoints, netip.AddrPort.Addr), filters)
+	if err != nil {
+		return nil, err
+	}
+
+	allowedAddrs := xslices.ToSet(filteredAddrs)
+
+	return xslices.Filter(endpoints, func(endpoint netip.AddrPort) bool {
+		_, ok := allowedAddrs[endpoint.Addr()]
+
+		return ok
+	}), nil
 }

--- a/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
@@ -226,3 +226,65 @@ func TestPeerSpecSuite(t *testing.T) {
 		},
 	})
 }
+
+type PeerSpecFilterSuite struct {
+	ctest.DefaultSuite
+}
+
+func (suite *PeerSpecFilterSuite) TestPeerEndpointFilters() {
+	cfg := kubespan.NewConfig(config.NamespaceName, kubespan.ConfigID)
+	cfg.TypedSpec().Enabled = true
+	cfg.TypedSpec().PeerEndpointFilters = []string{"0.0.0.0/0", "!172.20.0.0/24", "::/0"}
+	suite.Create(cfg)
+
+	nodeIdentity := cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity)
+	suite.Require().NoError(clusteradapter.IdentitySpec(nodeIdentity.TypedSpec()).Generate())
+	suite.Create(nodeIdentity)
+
+	affiliate := cluster.NewAffiliate(cluster.NamespaceName, "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:    "node-1",
+		Nodename:    "node-1",
+		MachineType: machine.TypeWorker,
+		Addresses:   []netip.Addr{netip.MustParseAddr("172.20.0.2")},
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey: "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+			Address:   netip.MustParseAddr("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			Endpoints: []netip.AddrPort{
+				netip.MustParseAddrPort("172.20.0.2:51820"),
+				netip.MustParseAddrPort("1.2.3.4:51820"),
+				netip.MustParseAddrPort("[2001:db8::1]:51820"),
+			},
+		},
+	}
+	suite.Create(affiliate)
+
+	// the endpoint in the excluded subnet should be filtered out, preserving the order of the others
+	ctest.AssertResource(
+		suite,
+		affiliate.TypedSpec().KubeSpan.PublicKey,
+		func(res *kubespan.PeerSpec, asrt *assert.Assertions) {
+			asrt.Equal(
+				[]netip.AddrPort{
+					netip.MustParseAddrPort("1.2.3.4:51820"),
+					netip.MustParseAddrPort("[2001:db8::1]:51820"),
+				},
+				res.TypedSpec().Endpoints,
+			)
+		},
+	)
+}
+
+func TestPeerSpecFilterSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &PeerSpecFilterSuite{
+		DefaultSuite: ctest.DefaultSuite{
+			Timeout: 5 * time.Second,
+			AfterSetup: func(suite *ctest.DefaultSuite) {
+				suite.Require().NoError(suite.Runtime().RegisterController(&kubespanctrl.PeerSpecController{}))
+			},
+		},
+	})
+}

--- a/pkg/machinery/api/resource/definitions/kubespan/kubespan.pb.go
+++ b/pkg/machinery/api/resource/definitions/kubespan/kubespan.pb.go
@@ -46,8 +46,10 @@ type ConfigSpec struct {
 	ExtraEndpoints []*common.NetIPPort `protobuf:"bytes,9,rep,name=extra_endpoints,json=extraEndpoints,proto3" json:"extra_endpoints,omitempty"`
 	// If not empty, filter advertised networks using the list of CIDRs.
 	ExcludeAdvertisedNetworks []*common.NetIPPrefix `protobuf:"bytes,10,rep,name=exclude_advertised_networks,json=excludeAdvertisedNetworks,proto3" json:"exclude_advertised_networks,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// If not empty, filter peer endpoints to connect to using the list of CIDRs.
+	PeerEndpointFilters []string `protobuf:"bytes,11,rep,name=peer_endpoint_filters,json=peerEndpointFilters,proto3" json:"peer_endpoint_filters,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ConfigSpec) Reset() {
@@ -146,6 +148,13 @@ func (x *ConfigSpec) GetExtraEndpoints() []*common.NetIPPort {
 func (x *ConfigSpec) GetExcludeAdvertisedNetworks() []*common.NetIPPrefix {
 	if x != nil {
 		return x.ExcludeAdvertisedNetworks
+	}
+	return nil
+}
+
+func (x *ConfigSpec) GetPeerEndpointFilters() []string {
+	if x != nil {
+		return x.PeerEndpointFilters
 	}
 	return nil
 }
@@ -457,7 +466,7 @@ var File_resource_definitions_kubespan_kubespan_proto protoreflect.FileDescripto
 
 const file_resource_definitions_kubespan_kubespan_proto_rawDesc = "" +
 	"\n" +
-	",resource/definitions/kubespan/kubespan.proto\x12#talos.resource.definitions.kubespan\x1a\x13common/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&resource/definitions/enums/enums.proto\"\xd9\x03\n" +
+	",resource/definitions/kubespan/kubespan.proto\x12#talos.resource.definitions.kubespan\x1a\x13common/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&resource/definitions/enums/enums.proto\"\x8d\x04\n" +
 	"\n" +
 	"ConfigSpec\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1d\n" +
@@ -471,7 +480,8 @@ const file_resource_definitions_kubespan_kubespan_proto_rawDesc = "" +
 	"\x17harvest_extra_endpoints\x18\b \x01(\bR\x15harvestExtraEndpoints\x12:\n" +
 	"\x0fextra_endpoints\x18\t \x03(\v2\x11.common.NetIPPortR\x0eextraEndpoints\x12S\n" +
 	"\x1bexclude_advertised_networks\x18\n" +
-	" \x03(\v2\x13.common.NetIPPrefixR\x19excludeAdvertisedNetworks\"`\n" +
+	" \x03(\v2\x13.common.NetIPPrefixR\x19excludeAdvertisedNetworks\x122\n" +
+	"\x15peer_endpoint_filters\x18\v \x03(\tR\x13peerEndpointFilters\"`\n" +
 	"\fEndpointSpec\x12!\n" +
 	"\faffiliate_id\x18\x01 \x01(\tR\vaffiliateId\x12-\n" +
 	"\bendpoint\x18\x02 \x01(\v2\x11.common.NetIPPortR\bendpoint\"\xaa\x01\n" +

--- a/pkg/machinery/api/resource/definitions/kubespan/kubespan_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/kubespan/kubespan_vtproto.pb.go
@@ -55,6 +55,15 @@ func (m *ConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PeerEndpointFilters) > 0 {
+		for iNdEx := len(m.PeerEndpointFilters) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.PeerEndpointFilters[iNdEx])
+			copy(dAtA[i:], m.PeerEndpointFilters[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PeerEndpointFilters[iNdEx])))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
 	if len(m.ExcludeAdvertisedNetworks) > 0 {
 		for iNdEx := len(m.ExcludeAdvertisedNetworks) - 1; iNdEx >= 0; iNdEx-- {
 			if vtmsg, ok := interface{}(m.ExcludeAdvertisedNetworks[iNdEx]).(interface {
@@ -615,6 +624,12 @@ func (m *ConfigSpec) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if len(m.PeerEndpointFilters) > 0 {
+		for _, s := range m.PeerEndpointFilters {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1087,6 +1102,38 @@ func (m *ConfigSpec) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PeerEndpointFilters", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PeerEndpointFilters = append(m.PeerEndpointFilters, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/machinery/config/config/network.go
+++ b/pkg/machinery/config/config/network.go
@@ -393,6 +393,7 @@ type NetworkKubeSpanConfig interface {
 // NetworkKubeSpanFilters configures KubeSpan filters.
 type NetworkKubeSpanFilters interface {
 	Endpoints() []string
+	PeerEndpoints() []string
 	ExcludeAdvertisedNetworks() []netip.Prefix
 }
 

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -5073,6 +5073,16 @@
           "markdownDescription": "Filter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections.\n\nBy default, all addresses are advertised, and KubeSpan cycles through all endpoints until it finds one that works.\n\nDefault value: no filtering.",
           "x-intellij-html-description": "\u003cp\u003eFilter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections.\u003c/p\u003e\n\n\u003cp\u003eBy default, all addresses are advertised, and KubeSpan cycles through all endpoints until it finds one that works.\u003c/p\u003e\n\n\u003cp\u003eDefault value: no filtering.\u003c/p\u003e\n"
         },
+        "peerEndpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "peerEndpoints",
+          "description": "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.\n\nThis filter is the opposite of the endpoints filter: endpoints filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while peerEndpoints\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\n\nUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\n\nDefault value: no filtering.\n",
+          "markdownDescription": "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.\n\nThis filter is the opposite of the `endpoints` filter: `endpoints` filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while `peerEndpoints`\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\n\nUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\n\nDefault value: no filtering.",
+          "x-intellij-html-description": "\u003cp\u003eFilter endpoints received from other KubeSpan peers before this node attempts to connect to them.\u003c/p\u003e\n\n\u003cp\u003eThis filter is the opposite of the \u003ccode\u003eendpoints\u003c/code\u003e filter: \u003ccode\u003eendpoints\u003c/code\u003e filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while \u003ccode\u003epeerEndpoints\u003c/code\u003e\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\u003c/p\u003e\n\n\u003cp\u003eUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\u003c/p\u003e\n\n\u003cp\u003eDefault value: no filtering.\u003c/p\u003e\n"
+        },
         "excludeAdvertisedNetworks": {
           "items": {
             "type": "string",

--- a/pkg/machinery/config/types/network/deep_copy.generated.go
+++ b/pkg/machinery/config/types/network/deep_copy.generated.go
@@ -544,6 +544,10 @@ func (o *KubeSpanConfigV1Alpha1) DeepCopy() *KubeSpanConfigV1Alpha1 {
 			cp.ConfigFilters.ConfigEndpoints = make([]string, len(o.ConfigFilters.ConfigEndpoints))
 			copy(cp.ConfigFilters.ConfigEndpoints, o.ConfigFilters.ConfigEndpoints)
 		}
+		if o.ConfigFilters.ConfigPeerEndpoints != nil {
+			cp.ConfigFilters.ConfigPeerEndpoints = make([]string, len(o.ConfigFilters.ConfigPeerEndpoints))
+			copy(cp.ConfigFilters.ConfigPeerEndpoints, o.ConfigFilters.ConfigPeerEndpoints)
+		}
 		if o.ConfigFilters.ConfigExcludeAdvertisedNetworks != nil {
 			cp.ConfigFilters.ConfigExcludeAdvertisedNetworks = make([]meta.Prefix, len(o.ConfigFilters.ConfigExcludeAdvertisedNetworks))
 			copy(cp.ConfigFilters.ConfigExcludeAdvertisedNetworks, o.ConfigFilters.ConfigExcludeAdvertisedNetworks)

--- a/pkg/machinery/config/types/network/kubespan.go
+++ b/pkg/machinery/config/types/network/kubespan.go
@@ -117,6 +117,26 @@ type KubeSpanFiltersConfig struct {
 	ConfigEndpoints []string `yaml:"endpoints,omitempty"`
 
 	//   description: |
+	//     Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.
+	//
+	//     This filter is the opposite of the `endpoints` filter: `endpoints` filters the addresses this node
+	//     advertises to the whole cluster, affecting how every peer connects to this node, while `peerEndpoints`
+	//     filters the endpoints received from other peers, affecting only outgoing connections of this node.
+	//
+	//     Use it to exclude endpoints which are known to be unreachable from this node
+	//     (e.g., addresses of a private network this node is not connected to), so they are never attempted.
+	//
+	//     Default value: no filtering.
+	//   examples:
+	//     - name: Exclude peer endpoints in the 192.168.0.0/16 subnet.
+	//       value: '[]string{"0.0.0.0/0", "!192.168.0.0/16", "::/0"}'
+	//   schema:
+	//     type: array
+	//     items:
+	//       type: string
+	ConfigPeerEndpoints []string `yaml:"peerEndpoints,omitempty"`
+
+	//   description: |
 	//     Filter networks (e.g., host addresses, pod CIDRs if enabled) which will be advertised over KubeSpan.
 	//
 	//     By default, all networks are advertised.
@@ -183,6 +203,14 @@ func (s *KubeSpanConfigV1Alpha1) Validate(validation.RuntimeMode, ...validation.
 				errs = errors.Join(errs, fmt.Errorf("KubeSpan endpoint filter is not valid: %q", cidr))
 			}
 		}
+
+		for _, cidr := range s.ConfigFilters.ConfigPeerEndpoints {
+			cidr = strings.TrimPrefix(cidr, "!")
+
+			if _, err := sideronet.ParseSubnetOrAddress(cidr); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("KubeSpan peer endpoint filter is not valid: %q", cidr))
+			}
+		}
 	}
 
 	return nil, errs
@@ -240,6 +268,11 @@ func (s *KubeSpanConfigV1Alpha1) Filters() config.NetworkKubeSpanFilters {
 // Endpoints implements config.NetworkKubeSpanFilters interface.
 func (f *KubeSpanFiltersConfig) Endpoints() []string {
 	return f.ConfigEndpoints
+}
+
+// PeerEndpoints implements config.NetworkKubeSpanFilters interface.
+func (f *KubeSpanFiltersConfig) PeerEndpoints() []string {
+	return f.ConfigPeerEndpoints
 }
 
 // ExcludeAdvertisedNetworks implements config.NetworkKubeSpanFilters interface.

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -1528,6 +1528,13 @@ func (KubeSpanFiltersConfig) Doc() *encoder.Doc {
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Filter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{
+				Name:        "peerEndpoints",
+				Type:        "[]string",
+				Note:        "",
+				Description: "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.\n\nThis filter is the opposite of the `endpoints` filter: `endpoints` filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while `peerEndpoints`\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\n\nUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\n\nDefault value: no filtering.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
+			{
 				Name:        "excludeAdvertisedNetworks",
 				Type:        "[]Prefix",
 				Note:        "",
@@ -1538,7 +1545,8 @@ func (KubeSpanFiltersConfig) Doc() *encoder.Doc {
 	}
 
 	doc.Fields[0].AddExample("Exclude addresses in 192.168.0.0/16 subnet.", []string{"0.0.0.0/0", "!192.168.0.0/16", "::/0"})
-	doc.Fields[1].AddExample("Exclude private networks from being advertised.", []meta.Prefix{{netip.MustParsePrefix("192.168.1.0/24")}})
+	doc.Fields[1].AddExample("Exclude peer endpoints in the 192.168.0.0/16 subnet.", []string{"0.0.0.0/0", "!192.168.0.0/16", "::/0"})
+	doc.Fields[2].AddExample("Exclude private networks from being advertised.", []meta.Prefix{{netip.MustParsePrefix("192.168.1.0/24")}})
 
 	return doc
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1170,6 +1170,13 @@ func (k *KubeSpanFilters) Endpoints() []string {
 	return k.KubeSpanFiltersEndpoints
 }
 
+// PeerEndpoints implements the config.KubeSpanFilters interface.
+//
+// Peer endpoint filters are only supported in the KubeSpanConfig document.
+func (k *KubeSpanFilters) PeerEndpoints() []string {
+	return nil
+}
+
 // ExcludeAdvertisedNetworks implements the config.KubeSpanFilters interface.
 func (k *KubeSpanFilters) ExcludeAdvertisedNetworks() []netip.Prefix {
 	if len(k.KubeSpanFiltersExcludeAdvertisedNetworks) == 0 {

--- a/pkg/machinery/resources/kubespan/config.go
+++ b/pkg/machinery/resources/kubespan/config.go
@@ -42,6 +42,8 @@ type ConfigSpec struct {
 	MTU uint32 `yaml:"mtu,omitempty" protobuf:"6"`
 	// If not empty, filter advertised endpoints using the list of CIDRs.
 	EndpointFilters []string `yaml:"endpointFilters,omitempty" protobuf:"7"`
+	// If not empty, filter peer endpoints to connect to using the list of CIDRs.
+	PeerEndpointFilters []string `yaml:"peerEndpointFilters,omitempty" protobuf:"11"`
 	// Harvest endpoints from the peer statuses.
 	HarvestExtraEndpoints bool `yaml:"harvestExtraEndpoints" protobuf:"8"`
 	// Extra endpoints to announce.

--- a/pkg/machinery/resources/kubespan/deep_copy.generated.go
+++ b/pkg/machinery/resources/kubespan/deep_copy.generated.go
@@ -17,6 +17,10 @@ func (o ConfigSpec) DeepCopy() ConfigSpec {
 		cp.EndpointFilters = make([]string, len(o.EndpointFilters))
 		copy(cp.EndpointFilters, o.EndpointFilters)
 	}
+	if o.PeerEndpointFilters != nil {
+		cp.PeerEndpointFilters = make([]string, len(o.PeerEndpointFilters))
+		copy(cp.PeerEndpointFilters, o.PeerEndpointFilters)
+	}
 	if o.ExtraEndpoints != nil {
 		cp.ExtraEndpoints = make([]netip.AddrPort, len(o.ExtraEndpoints))
 		copy(cp.ExtraEndpoints, o.ExtraEndpoints)

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -9300,6 +9300,7 @@ ConfigSpec describes KubeSpan configuration..
 | harvest_extra_endpoints | [bool](#bool) |  | Harvest endpoints from the peer statuses. |
 | extra_endpoints | [common.NetIPPort](#common.NetIPPort) | repeated | Extra endpoints to announce. |
 | exclude_advertised_networks | [common.NetIPPrefix](#common.NetIPPrefix) | repeated | If not empty, filter advertised networks using the list of CIDRs. |
+| peer_endpoint_filters | [string](#string) | repeated | If not empty, filter peer endpoints to connect to using the list of CIDRs. |
 
 
 

--- a/website/content/v1.15/reference/configuration/network/kubespanconfig.md
+++ b/website/content/v1.15/reference/configuration/network/kubespanconfig.md
@@ -31,6 +31,14 @@ filters:
     excludeAdvertisedNetworks:
         - 192.168.1.0/24
         - 2003::/16
+
+    # # Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.
+
+    # # Exclude peer endpoints in the 192.168.0.0/16 subnet.
+    # peerEndpoints:
+    #     - 0.0.0.0/0
+    #     - '!192.168.0.0/16'
+    #     - ::/0
 {{< /highlight >}}
 
 
@@ -57,6 +65,12 @@ KubeSpanFiltersConfig configures KubeSpan endpoint filters.
 |-------|------|-------------|----------|
 |`endpoints` |[]string |Filter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections.<br><br>By default, all addresses are advertised, and KubeSpan cycles through all endpoints until it finds one that works.<br><br>Default value: no filtering. <details><summary>Show example(s)</summary>Exclude addresses in 192.168.0.0/16 subnet.:{{< highlight yaml >}}
 endpoints:
+    - 0.0.0.0/0
+    - '!192.168.0.0/16'
+    - ::/0
+{{< /highlight >}}</details> | |
+|`peerEndpoints` |[]string |Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.<br><br>This filter is the opposite of the `endpoints` filter: `endpoints` filters the addresses this node<br>advertises to the whole cluster, affecting how every peer connects to this node, while `peerEndpoints`<br>filters the endpoints received from other peers, affecting only outgoing connections of this node.<br><br>Use it to exclude endpoints which are known to be unreachable from this node<br>(e.g., addresses of a private network this node is not connected to), so they are never attempted.<br><br>Default value: no filtering. <details><summary>Show example(s)</summary>Exclude peer endpoints in the 192.168.0.0/16 subnet.:{{< highlight yaml >}}
+peerEndpoints:
     - 0.0.0.0/0
     - '!192.168.0.0/16'
     - ::/0

--- a/website/content/v1.15/schemas/config.schema.json
+++ b/website/content/v1.15/schemas/config.schema.json
@@ -5073,6 +5073,16 @@
           "markdownDescription": "Filter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections.\n\nBy default, all addresses are advertised, and KubeSpan cycles through all endpoints until it finds one that works.\n\nDefault value: no filtering.",
           "x-intellij-html-description": "\u003cp\u003eFilter node addresses which will be advertised as KubeSpan endpoints for peer-to-peer Wireguard connections.\u003c/p\u003e\n\n\u003cp\u003eBy default, all addresses are advertised, and KubeSpan cycles through all endpoints until it finds one that works.\u003c/p\u003e\n\n\u003cp\u003eDefault value: no filtering.\u003c/p\u003e\n"
         },
+        "peerEndpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "peerEndpoints",
+          "description": "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.\n\nThis filter is the opposite of the endpoints filter: endpoints filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while peerEndpoints\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\n\nUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\n\nDefault value: no filtering.\n",
+          "markdownDescription": "Filter endpoints received from other KubeSpan peers before this node attempts to connect to them.\n\nThis filter is the opposite of the `endpoints` filter: `endpoints` filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while `peerEndpoints`\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\n\nUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\n\nDefault value: no filtering.",
+          "x-intellij-html-description": "\u003cp\u003eFilter endpoints received from other KubeSpan peers before this node attempts to connect to them.\u003c/p\u003e\n\n\u003cp\u003eThis filter is the opposite of the \u003ccode\u003eendpoints\u003c/code\u003e filter: \u003ccode\u003eendpoints\u003c/code\u003e filters the addresses this node\nadvertises to the whole cluster, affecting how every peer connects to this node, while \u003ccode\u003epeerEndpoints\u003c/code\u003e\nfilters the endpoints received from other peers, affecting only outgoing connections of this node.\u003c/p\u003e\n\n\u003cp\u003eUse it to exclude endpoints which are known to be unreachable from this node\n(e.g., addresses of a private network this node is not connected to), so they are never attempted.\u003c/p\u003e\n\n\u003cp\u003eDefault value: no filtering.\u003c/p\u003e\n"
+        },
         "excludeAdvertisedNetworks": {
           "items": {
             "type": "string",


### PR DESCRIPTION
## Motivation

KubeSpan peers advertise all of their (filtered) addresses as candidate WireGuard endpoints, and endpoint rotation on each node tries them in turn. In hybrid clusters it is common for some peers to advertise addresses of a private network (e.g. a datacenter-private L2) which other nodes — e.g. cloud-provider nodes — are not connected to.

Previously, such endpoints were merely wasted rotation attempts: dialing them failed, and rotation moved on to a reachable endpoint.

However, when such a subnet is covered by a **user-managed route via the KubeSpan link itself** (a setup used to steer pod traffic toward those subnets *through* KubeSpan — for example with CNIs whose eBPF datapath performs FIB lookups directly and therefore bypasses KubeSpan's nftables fwmark rules), WireGuard's own outer packets toward those endpoints are routed **back into the KubeSpan interface**. The handshake to the "unreachable" endpoint then *succeeds through an existing tunnel*, and the result is stable nested encapsulation (tunnel-in-tunnel):

- every packet pays double encryption, each nesting layer costs ~80 bytes of path capacity, and full-size packets hit hard-to-diagnose MTU failures while handshakes and small packets keep working — a partial outage that is very hard to attribute (observed in the wild as cross-network TCP connections stuck in reconnect loops);
- the state is stable precisely because the handshake works: rotation has no reason to fail over to the reachable (public) endpoint anymore.

The existing advertise-side filter (`filters.endpoints`) cannot address this: the private-network addresses must remain advertised for the peers which *are* connected to that network. The missing primitive is **dial-side** filtering, per node.

## What this PR does

Adds `filters.peerEndpoints` to the KubeSpan configuration — in the `KubeSpanConfig` document and the legacy `machine.network.kubespan.filters` — filtering which peer-advertised endpoints *this node* will attempt to connect to. Syntax and semantics match the existing `filters.endpoints` (CIDR list with `!` exclusions, applied via `net.FilterIPs`); filtering is applied in `kubespan.PeerSpecController` when building `KubeSpanPeerSpecs` from affiliates, preserving the advertised endpoint order for the remaining endpoints.

Example — a node not connected to the `172.20.0.0/24` network will never dial endpoints in it:

```yaml
apiVersion: v1alpha1
kind: KubeSpanConfig
enabled: true
filters:
  peerEndpoints:
    - "!172.20.0.0/24"
    - 0.0.0.0/0
    - ::/0
```

Validation mirrors `filters.endpoints` (both config flavors).

A peer whose advertised endpoints are all filtered out is configured without an endpoint: it is not dialed from this node, but inbound connections from it still work and WireGuard roaming learns the source as usual.

## Testing

- new `TestPeerSpecFilterSuite/TestPeerEndpointFilters` covering filtering and order preservation (IPv4 + IPv6 endpoints);
- `TestConfigSuite/TestReconcileMultiDoc` extended for the new field plumbing;
- existing kubespan controller and machinery config tests pass.

## Related

- siderolabs/docs#553 — KubeSpan with Cilium native routing is the setup class where user-managed routes via the KubeSpan link arise; this PR closes the loop hazard those routes create.
- #9044 — a dedicated KubeSpan IPv4 comes from the same setup class; dial-side endpoint filtering is complementary (it protects the underlay regardless of how the overlay is addressed).

## Notes for reviewers

Generated artifacts (dpgen config structs, deep-copy, docgen, config schema, resource proto + pb.go, website reference) are included; they were produced with the individual generators (`go generate` on the affected machinery packages, `structprotogen`, `buf generate` scoped to the changed proto) rather than one full `make generate && make docs` run — if CI's regeneration check shows any formatting delta, happy to fix it up.


