### PR TITLE
fix: exclude scheduler config from apiserver config version

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_config_static_pods.go
@@ -241,8 +241,7 @@ func (ctrl *RenderConfigsStaticPodController) Run(ctx context.Context, r control
 			r.TypedSpec().Ready = true
 			r.TypedSpec().Version = admissionRes.Metadata().Version().String() +
 				auditRes.Metadata().Version().String() +
-				authorizerConfigRes.Metadata().Version().String() +
-				kubeSchedulerRes.Metadata().Version().String()
+				authorizerConfigRes.Metadata().Version().String()
 
 			if authenticationConfigRes != nil {
 				r.TypedSpec().Version += authenticationConfigRes.Metadata().Version().String()


### PR DESCRIPTION
ConfigStatus.Version only feeds the kube-apiserver static pod, through the
`talos.dev/config-file-version` annotation. Mixing the SchedulerConfig
resource version into it meant every scheduler change rewrote the
kube-apiserver manifest, so the scheduler phase of `talosctl upgrade-k8s`
restarted the apiserver too. That phase watches `k8s-app = kube-scheduler`
only, so it moved on to the next control plane node while the apiserver was
still starting, and all apiservers could end up unready at once.

The scheduler pod carries its own SchedulerConfig version in
`talos.dev/config-version`, so it still restarts when its config changes.

Closes #14152

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
