### PR TITLE
fix: RouteSpecController churning IPv6 routes every 100ms

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_spec.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec.go
@@ -142,6 +142,20 @@ func routePriorityMatches(actual uint32, expected *network.RouteSpecSpec) bool {
 		actual == network.DefaultRouteMetric
 }
 
+// RouteScopeMatches compares the actual rtm scope (as reported by the kernel), with the expected scope, as defined in the RouteSpec.
+//
+// The kernel accepts any scope on RTM_NEWROUTE. However, the route scope is an IPv4-only concept.
+// In the case of IPv6, the kernel ignores the provided scope, and the IPv6 FIB (fib6_info) doesn't even have an equivalent scope field.
+// When the route is read back, the kernel always fills the returned route's scope with RT_SCOPE_UNIVERSE (nethelpers.ScopeGlobal), in
+// rt6_fill_node(). That's why we only assert the scope in non-IPv6 scenarios.
+func RouteScopeMatches(actual uint8, expected *network.RouteSpecSpec) bool {
+	if expected.Family == nethelpers.FamilyInet6 {
+		return true
+	}
+
+	return actual == uint8(expected.Scope)
+}
+
 func findMatchingRoutes(existingRoutes []rtnetlink.RouteMessage, expected *network.RouteSpecSpec) []*rtnetlink.RouteMessage {
 	var result []*rtnetlink.RouteMessage //nolint:prealloc
 
@@ -355,7 +369,7 @@ func (ctrl *RouteSpecController) syncRoute(ctx context.Context, r controller.Run
 			}
 
 			// check if existing route matches the spec: if it does, skip update
-			if existing.Scope == uint8(route.TypedSpec().Scope) && nethelpers.RouteFlags(existing.Flags).Equal(route.TypedSpec().Flags) &&
+			if RouteScopeMatches(existing.Scope, route.TypedSpec()) && nethelpers.RouteFlags(existing.Flags).Equal(route.TypedSpec().Flags) &&
 				existing.Protocol == uint8(route.TypedSpec().Protocol) &&
 				// when no out-link is requested, accept whatever egress device the kernel resolved
 				(linkIndex == 0 || existing.Attributes.OutIface == linkIndex) &&

--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/mdlayher/netlink"
 	"github.com/siderolabs/go-retry/retry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sys/unix"
 
@@ -644,6 +646,300 @@ func (suite *RouteSpecSuite) TestLinkLocalRouteAlias() {
 			netip.MustParseAddr("10.28.0.1"),
 		),
 	)
+}
+
+// assertNoIPv6RouteChurn watches RTNLGRP_IPV6_ROUTE for the given duration and fails on the first
+// RTM_DELROUTE for the destination.
+//
+// A spec the kernel never reports back verbatim makes the controller delete and re-add the route on
+// every reconcile, and since the controller watches RTMGRP_IPV6_ROUTE, its own writes wake it up again.
+func (suite *RouteSpecSuite) assertNoIPv6RouteChurn(destination netip.Prefix, duration time.Duration) {
+	conn, err := rtnetlink.Dial(&netlink.Config{Groups: unix.RTMGRP_IPV6_ROUTE})
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(conn.SetReadDeadline(time.Now().Add(duration)))
+
+	for {
+		rtmsgs, msgs, err := conn.Receive()
+		if err != nil {
+			suite.Require().ErrorIs(err, os.ErrDeadlineExceeded)
+
+			return
+		}
+
+		for i, msg := range msgs {
+			if msg.Header.Type != unix.RTM_DELROUTE {
+				continue
+			}
+
+			route, ok := rtmsgs[i].(*rtnetlink.RouteMessage)
+			if !ok {
+				continue
+			}
+
+			if int(route.DstLength) == destination.Bits() && route.Attributes.Dst.Equal(destination.Addr().AsSlice()) {
+				suite.Require().Failf(
+					"route churn",
+					"unexpected RTM_DELROUTE for %s: the route is being rewritten on every reconcile",
+					destination,
+				)
+			}
+		}
+	}
+}
+
+func (suite *RouteSpecSuite) TestIPv6GatewaylessRoute() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(
+		conn.Link.New(
+			&rtnetlink.LinkMessage{
+				Type:   unix.ARPHRD_ETHER,
+				Flags:  unix.IFF_UP,
+				Change: unix.IFF_UP,
+				Attributes: &rtnetlink.LinkAttributes{
+					Name: dummyInterface,
+					Info: &rtnetlink.LinkInfo{Kind: "dummy"},
+				},
+			},
+		),
+	)
+
+	iface, err := net.InterfaceByName(dummyInterface)
+	suite.Require().NoError(err)
+
+	defer conn.Link.Delete(uint32(iface.Index)) //nolint:errcheck
+
+	localIP := net.ParseIP("2001:db8:1399:6::2").To16()
+
+	suite.Require().NoError(
+		conn.Address.New(
+			&rtnetlink.AddressMessage{
+				Family:       unix.AF_INET6,
+				PrefixLength: 64,
+				Scope:        unix.RT_SCOPE_UNIVERSE,
+				Index:        uint32(iface.Index),
+				Attributes: &rtnetlink.AddressAttributes{
+					Address: localIP,
+					Local:   localIP,
+				},
+			},
+		),
+	)
+
+	destination := netip.MustParsePrefix("2001:db8:1399:7::/64")
+
+	route := network.NewRouteSpec(network.NamespaceName, "ipv6-gatewayless")
+	*route.TypedSpec() = network.RouteSpecSpec{
+		Family:      nethelpers.FamilyInet6,
+		Destination: destination,
+		OutLinkName: dummyInterface,
+		Table:       nethelpers.TableMain,
+		Priority:    network.DefaultRouteMetric,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		// Normalize() assigns link scope to any route with a destination and no gateway, regardless of family
+		Scope:       nethelpers.ScopeLink,
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+
+	suite.Create(route)
+
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				return suite.assertRoute(destination, netip.Addr{}, func(message rtnetlink.RouteMessage) error {
+					// the IPv6 FIB doesn't store the scope, so a link-scoped spec is reported back as global
+					if message.Scope != uint8(nethelpers.ScopeGlobal) {
+						return retry.ExpectedErrorf(
+							"route scope expected %d, got %d",
+							nethelpers.ScopeGlobal,
+							message.Scope,
+						)
+					}
+
+					return nil
+				})
+			},
+		),
+	)
+
+	suite.assertNoIPv6RouteChurn(destination, time.Second)
+
+	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), route.Metadata()))
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error { return suite.assertNoRoute(destination, netip.Addr{}) },
+		),
+	)
+}
+
+// TestIPv4RouteScopeMismatch covers the other side of routeScopeMatches: for IPv4 the kernel does
+// store the scope, so a route already present with the wrong one must be rewritten.
+func (suite *RouteSpecSuite) TestIPv4RouteScopeMismatch() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(
+		conn.Link.New(
+			&rtnetlink.LinkMessage{
+				Type:   unix.ARPHRD_ETHER,
+				Flags:  unix.IFF_UP,
+				Change: unix.IFF_UP,
+				Attributes: &rtnetlink.LinkAttributes{
+					Name: dummyInterface,
+					Info: &rtnetlink.LinkInfo{Kind: "dummy"},
+				},
+			},
+		),
+	)
+
+	iface, err := net.InterfaceByName(dummyInterface)
+	suite.Require().NoError(err)
+
+	defer conn.Link.Delete(uint32(iface.Index)) //nolint:errcheck
+
+	localIP := net.ParseIP("10.28.0.2").To4()
+
+	suite.Require().NoError(
+		conn.Address.New(
+			&rtnetlink.AddressMessage{
+				Family:       unix.AF_INET,
+				PrefixLength: 24,
+				Scope:        unix.RT_SCOPE_UNIVERSE,
+				Index:        uint32(iface.Index),
+				Attributes: &rtnetlink.AddressAttributes{
+					Address:   localIP,
+					Local:     localIP,
+					Broadcast: net.ParseIP("10.28.0.255").To4(),
+				},
+			},
+		),
+	)
+
+	destination := netip.MustParsePrefix("10.29.0.0/24")
+
+	// install the route out of band with a global scope: everything else matches the spec below, so
+	// the scope is the only reason for the controller to rewrite it
+	suite.Require().NoError(
+		conn.Route.Add(
+			&rtnetlink.RouteMessage{
+				Family:    unix.AF_INET,
+				DstLength: 24,
+				Protocol:  unix.RTPROT_STATIC,
+				Scope:     unix.RT_SCOPE_UNIVERSE,
+				Type:      unix.RTN_UNICAST,
+				Attributes: rtnetlink.RouteAttributes{
+					Dst:      destination.Addr().AsSlice(),
+					OutIface: uint32(iface.Index),
+					Priority: network.DefaultRouteMetric,
+					Table:    unix.RT_TABLE_MAIN,
+				},
+			},
+		),
+	)
+
+	route := network.NewRouteSpec(network.NamespaceName, "ipv4-scope-mismatch")
+	*route.TypedSpec() = network.RouteSpecSpec{
+		Family:      nethelpers.FamilyInet4,
+		Destination: destination,
+		OutLinkName: dummyInterface,
+		Table:       nethelpers.TableMain,
+		Priority:    network.DefaultRouteMetric,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		Scope:       nethelpers.ScopeLink,
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+
+	suite.Create(route)
+
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error {
+				return suite.assertRoute(destination, netip.Addr{}, func(message rtnetlink.RouteMessage) error {
+					if message.Scope != uint8(nethelpers.ScopeLink) {
+						return retry.ExpectedErrorf(
+							"route scope expected %d, got %d",
+							nethelpers.ScopeLink,
+							message.Scope,
+						)
+					}
+
+					return nil
+				})
+			},
+		),
+	)
+
+	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), route.Metadata()))
+	suite.Require().NoError(
+		retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+			func() error { return suite.assertNoRoute(destination, netip.Addr{}) },
+		),
+	)
+}
+
+func TestRouteScopeMatches(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		family   nethelpers.Family
+		actual   nethelpers.Scope
+		expected nethelpers.Scope
+		matches  bool
+	}{
+		{
+			name:     "inet4 equal",
+			family:   nethelpers.FamilyInet4,
+			actual:   nethelpers.ScopeLink,
+			expected: nethelpers.ScopeLink,
+			matches:  true,
+		},
+		{
+			name:     "inet4 mismatch",
+			family:   nethelpers.FamilyInet4,
+			actual:   nethelpers.ScopeGlobal,
+			expected: nethelpers.ScopeLink,
+			matches:  false,
+		},
+		{
+			// the kernel reports every IPv6 route as global, whatever scope the spec asked for
+			name:     "inet6 link spec reported as global",
+			family:   nethelpers.FamilyInet6,
+			actual:   nethelpers.ScopeGlobal,
+			expected: nethelpers.ScopeLink,
+			matches:  true,
+		},
+		{
+			name:     "inet6 equal",
+			family:   nethelpers.FamilyInet6,
+			actual:   nethelpers.ScopeGlobal,
+			expected: nethelpers.ScopeGlobal,
+			matches:  true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.matches, netctrl.RouteScopeMatches(
+				uint8(test.actual),
+				&network.RouteSpecSpec{Family: test.family, Scope: test.expected},
+			))
+		})
+	}
 }
 
 func TestRouteSpecSuite(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/siderolabs/talos/issues/14164

Based on https://github.com/siderolabs/talos/commit/a705a384240b3539536799e4bfb80c132d0fe682 , but verified the root cause independently against both Talos and upstream Linux sources (version-matching, 6.18.36). Simplifies the original fix, and expands test coverage. 

63bd62c9c (cherry-picked to release-1.14 as 7ac3cad5e), introduces `RTMGRP_IPV6_ROUTE` to the controller's RtNetlink watcher, which triggers the controller's wake-ups.

As reported in pull #14085, before the controller was subscribed to `RTMGRP_IPV6_ROUTE` (through the watcher), deleting an IPv6 route out-of-band (not through Talos config documents), would leave the actual route missing until the subsequent controller wake-up. This however, combined with how Linux implicitly handles the scope field for the IPv6 family, created an unwanted side effect, resulting in the controller endlessly churning IPv6 route creation. This churn rate was capped only by the `RateLimitedTrigger`, which happens to be using the default configuration limits of 10 events/sec (with a burst of 5). This perfectly matches the observed behavior of IPv6 routes reconciling every 100ms.

Now about how the kernel handles route scope in the IPv6 family. The kernel accepts any scope on `RTM_NEWROUTE`, regardless of family type. However, the route scope is an IPv4-only concept, and this field is dropped when an IPv6 route is being stored into the FIB ([src](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n5199)). The IPv6 FIB (fib6_info struct) doesn't even have an equivalent scope field ([fib6_config src](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/net/ip6_fib.h?h=v6.18.46#n36)).

Then, when we read the routes back in the RouteSpecController, with the intent of comparing the actual route's scope against the desired one (as defined by the RouteSpec documents), the kernel always fills the returned route's scope with `RT_SCOPE_UNIVERSE` (`nethelpers.ScopeGlobal`) ([in rt6_fill_node()](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n5805)). Then, if the IPv6 RouteSpec's scope is not set to scope global, the actual route is considered out of sync, and the controller writes the route. Writing the IPv6 route causes a `RTMGRP_IPV6_ROUTE` event to be emitted, which triggers our RtNetlink watcher, which wakes up our controller, which leads to the same reconciliation, which completes the cycle and results in the endless IPv6 route creation loop.

To mitigate the above, we must only assert the route scope equality for non-IPv6 routes.

Moreover, the strict IPv6 single-route retrieval, `inet6_rtm_valid_getroute_req`, rejects any requests containing header fields that would have been dropped in the first place on a write, like the route scope ([src](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n6147)). This makes me wonder whether we should fail validation for IPv6 RouteSpec documents defining a route spec (and perhaps other fields that are dropped on write).

Below is a kernel source analysis done through Claude I've used to learn the route read/write paths through the kernel.

<details>

**1. Write path drops `rtm_scope` — `rtm_to_fib6_config()`.** The `fib6_config` initializer copies `rtm_table`, `rtm_dst_len`, `rtm_src_len`, `rtm_protocol`, `rtm_type`. Not scope.
- [v6.18.46 net/ipv6/route.c#n5199](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n5199)
- [v6.18 route.c#L5183-L5194](https://github.com/torvalds/linux/blob/v6.18/net/ipv6/route.c#L5183-L5194)

**2. No field to store it in — `struct fib6_config`, `struct fib6_info`.** Zero occurrences of `scope` in either. Contrast IPv4's `fc_scope` / `fib_scope`.
- [v6.18.46 ip6_fib.h#n36](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/net/ip6_fib.h?h=v6.18.46#n36) · [#n158](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/net/ip6_fib.h?h=v6.18.46#n158)
- [v6.18 ip6_fib.h#L36-L65](https://github.com/torvalds/linux/blob/v6.18/include/net/ip6_fib.h#L36-L65) · [#L158-L205](https://github.com/torvalds/linux/blob/v6.18/include/net/ip6_fib.h#L158-L205)

**3. Read path invents it — `rt6_fill_node()`.** The decisive line: `rtm->rtm_scope = RT_SCOPE_UNIVERSE;`, an unconditional literal, no branch in the function. Sitting between `rtm_type = rt->fib6_type` and `rtm_protocol = rt->fib6_protocol`, which do read stored state. Every dump and every notification carries scope 0.
- [v6.18.46 route.c#n5805](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n5805)
- [v6.18 route.c#L5789](https://github.com/torvalds/linux/blob/v6.18/net/ipv6/route.c#L5789)

**4. Accepted on add, refused on strict get — `inet6_rtm_valid_getroute_req()`.** Nonzero `rtm_scope` is an explicit `-EINVAL`, "Invalid values in header for get route request". The add path has no such check because it never reads the field. Silently ignored on write, actively rejected where the kernel does look.
- [v6.18.46 route.c#n6147](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv6/route.c?h=v6.18.46#n6147)
- [v6.18 route.c#L6129](https://github.com/torvalds/linux/blob/v6.18/net/ipv6/route.c#L6129)

**5. IPv4 round-trips — `net/ipv4/fib_semantics.c`.** Stored (`fib_create_info`), read back (`fib_dump_info`), and part of route identity (`fib_find_info`). Why the IPv4 half of the same Talos config is stable.
- v6.18.46: [#n1448 store](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv4/fib_semantics.c?h=v6.18.46#n1448) · [#n1780 dump](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv4/fib_semantics.c?h=v6.18.46#n1780) · [#n437 match](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv4/fib_semantics.c?h=v6.18.46#n437)
- v6.18: [#L1417](https://github.com/torvalds/linux/blob/v6.18/net/ipv4/fib_semantics.c#L1417) · [#L1749](https://github.com/torvalds/linux/blob/v6.18/net/ipv4/fib_semantics.c#L1749) · [#L437](https://github.com/torvalds/linux/blob/v6.18/net/ipv4/fib_semantics.c#L437)

**6. iproute2 guards the same heuristic on family — `ip/iproute.c`.** With `scope` omitted, `AF_INET6` short-circuits to `RT_SCOPE_UNIVERSE` before reaching the gatewayless→`RT_SCOPE_LINK` rule. Exactly the branch `Normalize()` lacks. Display side suppresses the field unless `!= RT_SCOPE_UNIVERSE`, so IPv6 routes never print a scope.
- [iproute2 main ip/iproute.c#L1616-L1625](https://github.com/iproute2/iproute2/blob/main/ip/iproute.c#L1616-L1625) · [#L916](https://github.com/iproute2/iproute2/blob/main/ip/iproute.c#L916)
</details>

