### PR TITLE
feat: add host extension pre-shutdown hooks

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -265,10 +265,7 @@ func (*Sequencer) Reboot(r runtime.Runtime, in *machineapi.RebootRequest) []runt
 				"cleanup",
 				StopAllPods,
 			).
-			Append(
-				"dbus",
-				StopDBus,
-			).
+			AppendList(preShutdownPhaselist()).
 			AppendList(stopAllPhaselist(r, true))
 	}
 
@@ -324,9 +321,8 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 			!in.GetGraceful(),
 			"cleanup",
 			taskErrorHandler(logError, StopAllPods),
-		).Append(
-			"dbus",
-			StopDBus,
+		).AppendList(
+			preShutdownPhaselist(),
 		).AppendWhen(
 			in.GetGraceful() && (r.Config().Machine().Type() != machine.TypeWorker),
 			"leave",
@@ -379,9 +375,8 @@ func (*Sequencer) Shutdown(r runtime.Runtime, in *machineapi.ShutdownRequest) []
 	).Append(
 		"cleanup",
 		StopAllPods,
-	).Append(
-		"dbus",
-		StopDBus,
+	).AppendList(
+		preShutdownPhaselist(),
 	).
 		AppendList(stopAllPhaselist(r, false)).
 		Append("shutdown", Shutdown)
@@ -400,9 +395,8 @@ func (*Sequencer) StageUpgrade(r runtime.Runtime, in *machineapi.UpgradeRequest)
 		phases = phases.Append(
 			"cleanup",
 			StopAllPods,
-		).Append(
-			"dbus",
-			StopDBus,
+		).AppendList(
+			preShutdownPhaselist(),
 		).AppendList(
 			stopAllPhaselist(r, in.GetRebootMode() == machineapi.UpgradeRequest_DEFAULT),
 		).Append(
@@ -464,9 +458,8 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 		).Append(
 			"cleanup",
 			StopAllPods,
-		).Append(
-			"dbus",
-			StopDBus,
+		).AppendList(
+			preShutdownPhaselist(),
 		).Append(
 			"stopContainers",
 			TeardownContainerLifecycle,
@@ -508,6 +501,12 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 	}
 
 	return phases
+}
+
+func preShutdownPhaselist() PhaseList {
+	return PhaseList{}.
+		Append("preShutdown", PreShutdownServices).
+		Append("dbus", StopDBus)
 }
 
 func stopAllPhaselist(r runtime.Runtime, enableKexec bool) PhaseList {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -443,6 +443,13 @@ func StartAllServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string)
 	}, "startAllServices"
 }
 
+// PreShutdownServices runs node shutdown hooks while services are still running.
+func PreShutdownServices(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
+	return func(ctx context.Context, _ *log.Logger, r runtime.Runtime) error {
+		return system.Services(r).PreShutdown(ctx)
+	}, "preShutdownServices"
+}
+
 // StopServicesEphemeral represents the StopServicesEphemeral task.
 func StopServicesEphemeral(runtime.Sequence, any) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_test.go
@@ -6,11 +6,18 @@
 package v1alpha1
 
 import (
+	"log"
 	"reflect"
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/logging"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/metal"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 )
 
 func TestNewSequencer(t *testing.T) {
@@ -29,6 +36,114 @@ func TestNewSequencer(t *testing.T) {
 			if got := NewSequencer(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewSequencer() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+type resetOptions struct{}
+
+func (resetOptions) GetGraceful() bool {
+	return false
+}
+
+func (resetOptions) GetReboot() bool {
+	return true
+}
+
+func (resetOptions) GetMode() machineapi.ResetRequest_WipeMode {
+	return machineapi.ResetRequest_ALL
+}
+
+func (resetOptions) GetUserDisksToWipe() []string {
+	return nil
+}
+
+func (resetOptions) GetSystemDiskTargets() []runtime.PartitionTarget {
+	return nil
+}
+
+func (resetOptions) GetSystemDiskPaths() []string {
+	return nil
+}
+
+func TestPreShutdownPhaseOrdering(t *testing.T) {
+	t.Setenv("PLATFORM", "container")
+
+	state, err := NewState()
+	require.NoError(t, err)
+
+	metalPlatform := &metal.Metal{}
+	state.platform = metalPlatform
+	state.machine.platform = metalPlatform
+
+	rt := NewRuntime(
+		state,
+		NewEvents(1000, 10),
+		logging.NewCircularBufferLoggingManager(log.New(t.Output(), "fallback logger: ", log.Flags())),
+	)
+	sequencer := NewSequencer()
+
+	for _, tt := range []struct {
+		name     string
+		phases   []runtime.Phase
+		expected bool
+	}{
+		{
+			name:     "reboot",
+			phases:   sequencer.Reboot(rt, &machineapi.RebootRequest{}),
+			expected: true,
+		},
+		{
+			name:     "reset",
+			phases:   sequencer.Reset(rt, resetOptions{}),
+			expected: true,
+		},
+		{
+			name:     "shutdown",
+			phases:   sequencer.Shutdown(rt, &machineapi.ShutdownRequest{}),
+			expected: true,
+		},
+		{
+			name:     "stage upgrade",
+			phases:   sequencer.StageUpgrade(rt, &machineapi.UpgradeRequest{}),
+			expected: true,
+		},
+		{
+			name:     "upgrade",
+			phases:   sequencer.Upgrade(rt, &machineapi.UpgradeRequest{}),
+			expected: true,
+		},
+		{
+			name: "forced reboot",
+			phases: sequencer.Reboot(rt, &machineapi.RebootRequest{
+				Mode: machineapi.RebootRequest_FORCE,
+			}),
+		},
+		{
+			name:   "maintenance upgrade",
+			phases: sequencer.MaintenanceUpgrade(rt, &machineapi.UpgradeRequest{}),
+		},
+		{
+			name:   "emergency cleanup",
+			phases: sequencer.EmergencyVolumeCleanup(rt),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			names := make([]string, 0, len(tt.phases))
+			for _, phase := range tt.phases {
+				names = append(names, phase.Name)
+			}
+
+			preShutdown := slices.Index(names, "preShutdown")
+			if !tt.expected {
+				assert.Equal(t, -1, preShutdown)
+
+				return
+			}
+
+			require.NotEqual(t, -1, preShutdown)
+			require.Less(t, preShutdown+1, len(names))
+			assert.Equal(t, "dbus", names[preShutdown+1])
 		})
 	}
 }

--- a/internal/app/machined/pkg/system/integration_test.go
+++ b/internal/app/machined/pkg/system/integration_test.go
@@ -6,10 +6,14 @@ package system_test
 
 import (
 	"context"
+	"errors"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
@@ -72,6 +76,98 @@ func (TestService) DependsOn(runtime.Runtime) []string {
 
 func (TestService) Volumes(runtime.Runtime) []string {
 	return nil
+}
+
+type preShutdownTestService struct {
+	TestService
+
+	id      string
+	started chan struct{}
+	running atomic.Bool
+	hook    func() error
+}
+
+func (service *preShutdownTestService) ID(runtime.Runtime) string {
+	return service.id
+}
+
+func (service *preShutdownTestService) Runner(r runtime.Runtime) (runner.Runner, error) {
+	return goroutine.NewRunner(r, service.id, func(ctx context.Context, _ runtime.Runtime, _ io.Writer) error {
+		service.running.Store(true)
+
+		close(service.started)
+		defer service.running.Store(false)
+
+		<-ctx.Done()
+
+		return nil
+	}), nil
+}
+
+func (service *preShutdownTestService) Condition(runtime.Runtime) conditions.Condition {
+	return nil
+}
+
+func (service *preShutdownTestService) PreShutdownFunc(context.Context, runtime.Runtime) error {
+	if !service.running.Load() {
+		return errors.New("main service stopped before pre-shutdown hook")
+	}
+
+	return service.hook()
+}
+
+func TestPreShutdownServices(t *testing.T) {
+	ctx := t.Context()
+	services := system.NewServices(newRuntime(t))
+
+	var (
+		mu    sync.Mutex
+		calls []string
+	)
+
+	record := func(id string, err error) func() error {
+		return func() error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			calls = append(calls, id)
+
+			return err
+		}
+	}
+
+	serviceA := &preShutdownTestService{id: "a", started: make(chan struct{}), hook: record("a", errors.New("a failed"))}
+	serviceZ := &preShutdownTestService{id: "z", started: make(chan struct{}), hook: record("z", nil)}
+
+	services.Load(serviceZ, serviceA)
+	require.NoError(t, services.Start("z", "a"))
+	require.NoError(t, system.WaitForServiceWithInstance(services, system.StateEventUp, "z").Wait(ctx))
+	require.NoError(t, system.WaitForServiceWithInstance(services, system.StateEventUp, "a").Wait(ctx))
+
+	for _, service := range []*preShutdownTestService{serviceA, serviceZ} {
+		select {
+		case <-service.started:
+		case <-ctx.Done():
+			t.Fatal("service did not start before test context expired")
+		}
+	}
+
+	err := services.PreShutdown(ctx)
+	require.ErrorContains(t, err, `service "a" pre-shutdown hook failed: a failed`)
+	assert.Equal(t, []string{"a", "z"}, calls)
+	assert.True(t, serviceA.running.Load())
+	assert.True(t, serviceZ.running.Load())
+
+	require.Error(t, services.PreShutdown(ctx))
+	assert.Equal(t, []string{"a", "z", "a", "z"}, calls, "hooks should be retryable")
+
+	require.NoError(t, services.Stop(ctx, "a"))
+	assert.Equal(t, []string{"a", "z", "a", "z"}, calls, "service stop must not run node-shutdown hooks")
+
+	require.NoError(t, services.PreShutdown(ctx))
+	assert.Equal(t, []string{"a", "z", "a", "z", "z"}, calls, "stopped services must be skipped")
+
+	services.Shutdown(ctx)
 }
 
 func TestRestartService(t *testing.T) {

--- a/internal/app/machined/pkg/system/service.go
+++ b/internal/app/machined/pkg/system/service.go
@@ -33,6 +33,11 @@ type Service interface {
 	Volumes(runtime.Runtime) []string
 }
 
+// PreShutdownService is a service which performs work before node shutdown.
+type PreShutdownService interface {
+	PreShutdownFunc(context.Context, runtime.Runtime) error
+}
+
 // HealthcheckedService is a service which provides health check.
 type HealthcheckedService interface {
 	// HealtFunc provides function that checks health of the service

--- a/internal/app/machined/pkg/system/services/export_test.go
+++ b/internal/app/machined/pkg/system/services/export_test.go
@@ -41,6 +41,11 @@ func (svc *Extension) HostProcessArgs() (runner.Args, error) {
 	return svc.hostProcessArgs(nil)
 }
 
+// SetPreShutdownRunnerFactory replaces the pre-shutdown process runner factory for tests.
+func (svc *Extension) SetPreShutdownRunnerFactory(factory func(bool, *runner.Args, ...runner.Option) runner.Runner) {
+	svc.preShutdownRunnerFn = factory
+}
+
 // ApplyExtensionServiceConfig exposes applyExtensionServiceConfig for tests.
 func (svc *Extension) ApplyExtensionServiceConfig(
 	spec *runtimeres.ExtensionServiceConfigSpec,

--- a/internal/app/machined/pkg/system/services/extension.go
+++ b/internal/app/machined/pkg/system/services/extension.go
@@ -42,7 +42,8 @@ import (
 type Extension struct {
 	Spec extservices.Spec
 
-	overlayUnmounter func() error
+	overlayUnmounter    func() error
+	preShutdownRunnerFn func(bool, *runner.Args, ...runner.Option) runner.Runner
 }
 
 // ID implements the Service interface.
@@ -83,6 +84,95 @@ func (svc *Extension) PostFunc(r runtime.Runtime, state events.ServiceState) (er
 	}
 
 	return svc.overlayUnmounter()
+}
+
+// PreShutdownFunc runs the configured node shutdown hook while the service is still running.
+func (svc *Extension) PreShutdownFunc(ctx context.Context, r runtime.Runtime) error {
+	if svc.Spec.PreShutdown == nil {
+		return nil
+	}
+
+	envVars, err := svc.preShutdownEnvironment(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	hookCtx, cancel := context.WithTimeout(ctx, svc.Spec.PreShutdown.Timeout)
+	defer cancel()
+
+	hookRunner := svc.preShutdownRunner(r, envVars)
+	if err = hookRunner.Open(); err != nil {
+		return fmt.Errorf("failed to open pre-shutdown hook runner: %w", err)
+	}
+
+	defer hookRunner.Close() //nolint:errcheck
+
+	_, err = hookRunner.Run(hookCtx, events.NullRecorder, nil)
+
+	return svc.preShutdownError(err, hookCtx.Err())
+}
+
+func (svc *Extension) preShutdownEnvironment(ctx context.Context, r runtime.Runtime) ([]string, error) {
+	envVars, err := svc.parseEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	configSpec, err := safe.StateGetByID[*runtimeres.ExtensionServiceConfig](ctx, r.State().V1Alpha2().Resources(), svc.Spec.Name)
+	if state.IsNotFoundError(err) {
+		return slices.Concat(envVars, environment.Get(r.Config())), nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, envVars, err = svc.applyExtensionServiceConfig(configSpec.TypedSpec(), nil, envVars)
+	if err != nil {
+		return nil, err
+	}
+
+	return slices.Concat(envVars, environment.Get(r.Config())), nil
+}
+
+func (svc *Extension) preShutdownRunner(r runtime.Runtime, envVars []string) runner.Runner {
+	logToConsole := svc.Spec.LogToConsole
+	if r.Config() != nil && r.Config().Debug() {
+		logToConsole = true
+	}
+
+	runnerFn := svc.preShutdownRunnerFn
+	if runnerFn == nil {
+		runnerFn = process.NewRunner
+	}
+
+	return runnerFn(
+		logToConsole,
+		&runner.Args{
+			ID:          svc.ID(r) + "-pre-shutdown",
+			ProcessArgs: append([]string{svc.Spec.PreShutdown.Entrypoint}, svc.Spec.PreShutdown.Args...),
+		},
+		runner.WithLoggingManager(r.Logging()),
+		runner.WithEnv(envVars),
+		runner.WithCgroupPath(filepath.Join(constants.CgroupExtensions, svc.Spec.Name)),
+		runner.WithGracefulShutdownTimeout(0),
+		runner.WithOOMScoreAdj(-600),
+	)
+}
+
+func (svc *Extension) preShutdownError(runErr, contextErr error) error {
+	switch contextErr {
+	case context.DeadlineExceeded:
+		return fmt.Errorf("pre-shutdown hook timed out after %s: %w", svc.Spec.PreShutdown.Timeout, contextErr)
+	case context.Canceled:
+		return fmt.Errorf("pre-shutdown hook canceled: %w", contextErr)
+	}
+
+	if runErr != nil {
+		return fmt.Errorf("pre-shutdown hook failed: %w", runErr)
+	}
+
+	return nil
 }
 
 // Condition implements the Service interface.

--- a/internal/app/machined/pkg/system/services/extension_test.go
+++ b/internal/app/machined/pkg/system/services/extension_test.go
@@ -5,8 +5,13 @@
 package services_test
 
 import (
+	"context"
+	"errors"
+	"log"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -16,14 +21,59 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime/logging"
+	runtimev1alpha1 "github.com/siderolabs/talos/internal/app/machined/pkg/runtime/v1alpha1"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/system/events"
+	"github.com/siderolabs/talos/internal/app/machined/pkg/system/runner"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services/mocks"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	extservices "github.com/siderolabs/talos/pkg/machinery/extensions/services"
 	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 )
 
 type MockClient struct {
 	controller *gomock.Controller
+}
+
+type preShutdownRunner struct {
+	run    func(context.Context) error
+	opened bool
+	closed bool
+}
+
+func (mock *preShutdownRunner) String() string {
+	return "pre-shutdown-test-runner"
+}
+
+func (mock *preShutdownRunner) Open() error {
+	mock.opened = true
+
+	return nil
+}
+
+func (mock *preShutdownRunner) Run(ctx context.Context, _ events.Recorder, _ runner.OnStart) (runner.Status, error) {
+	return runner.Status{Started: true}, mock.run(ctx)
+}
+
+func (mock *preShutdownRunner) Close() error {
+	mock.closed = true
+
+	return nil
+}
+
+func newExtensionRuntime(t *testing.T) runtime.Runtime {
+	t.Helper()
+	t.Setenv("PLATFORM", "container")
+
+	state, err := runtimev1alpha1.NewState()
+	require.NoError(t, err)
+
+	eventSink := runtimev1alpha1.NewEvents(1000, 10)
+	loggingManager := logging.NewCircularBufferLoggingManager(log.New(t.Output(), "fallback logger: ", log.Flags()))
+
+	return runtimev1alpha1.NewRuntime(state, eventSink, loggingManager)
 }
 
 func (c *MockClient) SnapshotService(snapshotterName string) snapshots.Snapshotter {
@@ -209,6 +259,101 @@ func TestExtensionHostRunnerMode(t *testing.T) {
 	assert.Equal(t, []string{"/usr/local/bin/hello", "--log=debug"}, args.ProcessArgs)
 	assert.Equal(t, []string{"networkd"}, svc.DependsOn(nil))
 	assert.NoError(t, svc.PostFunc(nil, 0))
+}
+
+func TestExtensionPreShutdown(t *testing.T) {
+	rt := newExtensionRuntime(t)
+	mockRunner := &preShutdownRunner{run: func(context.Context) error { return nil }}
+
+	var (
+		gotArgs runner.Args
+		gotOpts runner.Options
+	)
+
+	svc := &services.Extension{
+		Spec: extservices.Spec{
+			Name:       "hello",
+			RunnerMode: extservices.RunnerModeHost,
+			Container: extservices.Container{
+				Environment: []string{"MODE=host"},
+			},
+			PreShutdown: &extservices.Command{
+				Entrypoint: "/usr/local/bin/hello-shutdown",
+				Args:       []string{"--graceful"},
+				Timeout:    time.Minute,
+			},
+		},
+	}
+
+	svc.SetPreShutdownRunnerFactory(func(_ bool, args *runner.Args, setters ...runner.Option) runner.Runner {
+		gotArgs = *args
+
+		opts := runner.DefaultOptions()
+		for _, setter := range setters {
+			setter(opts)
+		}
+
+		gotOpts = *opts
+
+		return mockRunner
+	})
+
+	require.NoError(t, svc.PreShutdownFunc(t.Context(), rt))
+	assert.True(t, mockRunner.opened)
+	assert.True(t, mockRunner.closed)
+	assert.Equal(t, "ext-hello-pre-shutdown", gotArgs.ID)
+	assert.Equal(t, []string{"/usr/local/bin/hello-shutdown", "--graceful"}, gotArgs.ProcessArgs)
+	assert.Contains(t, gotOpts.Env, "MODE=host")
+	assert.Equal(t, filepath.Join(constants.CgroupExtensions, "hello"), gotOpts.CgroupPath)
+	assert.Zero(t, gotOpts.GracefulShutdownTimeout)
+}
+
+func TestExtensionPreShutdownFailure(t *testing.T) {
+	rt := newExtensionRuntime(t)
+	svc := &services.Extension{
+		Spec: extservices.Spec{
+			Name:       "hello",
+			RunnerMode: extservices.RunnerModeHost,
+			PreShutdown: &extservices.Command{
+				Entrypoint: "/usr/local/bin/hello-shutdown",
+				Timeout:    time.Minute,
+			},
+		},
+	}
+
+	mockRunner := &preShutdownRunner{run: func(context.Context) error { return errors.New("exit 1") }}
+
+	svc.SetPreShutdownRunnerFactory(func(bool, *runner.Args, ...runner.Option) runner.Runner { return mockRunner })
+
+	err := svc.PreShutdownFunc(t.Context(), rt)
+	require.ErrorContains(t, err, "pre-shutdown hook failed: exit 1")
+	assert.True(t, mockRunner.closed)
+}
+
+func TestExtensionPreShutdownTimeout(t *testing.T) {
+	rt := newExtensionRuntime(t)
+	svc := &services.Extension{
+		Spec: extservices.Spec{
+			Name:       "hello",
+			RunnerMode: extservices.RunnerModeHost,
+			PreShutdown: &extservices.Command{
+				Entrypoint: "/usr/local/bin/hello-shutdown",
+				Timeout:    time.Nanosecond,
+			},
+		},
+	}
+
+	mockRunner := &preShutdownRunner{run: func(ctx context.Context) error {
+		<-ctx.Done()
+
+		return nil
+	}}
+
+	svc.SetPreShutdownRunnerFactory(func(bool, *runner.Args, ...runner.Option) runner.Runner { return mockRunner })
+
+	err := svc.PreShutdownFunc(t.Context(), rt)
+	require.ErrorContains(t, err, "pre-shutdown hook timed out after 1ns: context deadline exceeded")
+	assert.True(t, mockRunner.closed)
 }
 
 func TestExtensionHostRunnerConfig(t *testing.T) {

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -246,6 +246,28 @@ func (s *singleton) Shutdown(ctx context.Context) {
 	_ = s.stopServices(ctx, nil, true) //nolint:errcheck
 }
 
+// PreShutdown runs node shutdown hooks for all running services.
+func (s *singleton) PreShutdown(ctx context.Context) error {
+	var multiErr *multierror.Error
+
+	for _, svcrunner := range s.List() {
+		if svcrunner.GetState() != events.StateRunning {
+			continue
+		}
+
+		service, ok := svcrunner.service.(PreShutdownService)
+		if !ok {
+			continue
+		}
+
+		if err := service.PreShutdownFunc(ctx, s.runtime); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("service %q pre-shutdown hook failed: %w", svcrunner.id, err))
+		}
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
 // Stop will initiate a shutdown of the specified service.
 func (s *singleton) Stop(ctx context.Context, serviceIDs ...string) (err error) {
 	if len(serviceIDs) == 0 {

--- a/pkg/machinery/extensions/services/services.go
+++ b/pkg/machinery/extensions/services/services.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -37,8 +38,20 @@ type Spec struct {
 	Depends []Dependency `yaml:"depends"`
 	// Restart configuration.
 	Restart RestartKind `yaml:"restart"`
+	// PreShutdown specifies a command to run before node shutdown.
+	PreShutdown *Command `yaml:"preShutdown,omitempty"`
 	// LogToConsole enables sending service logs to the console.
 	LogToConsole bool `yaml:"logToConsole"`
+}
+
+// Command specifies a bounded host command to run during a service lifecycle hook.
+type Command struct {
+	// Entrypoint is the absolute host path to execute.
+	Entrypoint string `yaml:"entrypoint"`
+	// Args are passed to the entrypoint.
+	Args []string `yaml:"args,omitempty"`
+	// Timeout bounds command execution.
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 // Container specifies service container to run.
@@ -116,6 +129,14 @@ func (spec *Spec) Validate() error {
 		multiErr = multierror.Append(multiErr, spec.validateHostMode())
 	}
 
+	if spec.PreShutdown != nil {
+		if spec.RunnerMode != RunnerModeHost {
+			multiErr = multierror.Append(multiErr, errors.New("pre-shutdown hook is only supported in host runner mode"))
+		}
+
+		multiErr = multierror.Append(multiErr, spec.PreShutdown.Validate())
+	}
+
 	for _, dep := range spec.Depends {
 		multiErr = multierror.Append(multiErr, dep.Validate())
 	}
@@ -137,6 +158,21 @@ func (spec *Spec) validateHostMode() error {
 
 	if !filepath.IsAbs(spec.Container.Entrypoint) {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("container entrypoint must be an absolute host path in host runner mode: %q", spec.Container.Entrypoint))
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+// Validate the command spec.
+func (command *Command) Validate() error {
+	var multiErr *multierror.Error
+
+	if !filepath.IsAbs(command.Entrypoint) {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("pre-shutdown entrypoint must be an absolute host path: %q", command.Entrypoint))
+	}
+
+	if command.Timeout <= 0 {
+		multiErr = multierror.Append(multiErr, errors.New("pre-shutdown timeout must be positive"))
 	}
 
 	return multiErr.ErrorOrNil()

--- a/pkg/machinery/extensions/services/services_test.go
+++ b/pkg/machinery/extensions/services/services_test.go
@@ -7,6 +7,7 @@ package services_test
 import (
 	_ "embed"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,11 @@ func TestUnmarshalHostRunnerMode(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(helloHostYAML, &spec))
 
 	assert.Equal(t, services.RunnerModeHost, spec.RunnerMode)
+	assert.Equal(t, &services.Command{
+		Entrypoint: "/usr/local/bin/hello-shutdown",
+		Args:       []string{"--graceful"},
+		Timeout:    30 * time.Second,
+	}, spec.PreShutdown)
 	assert.NoError(t, spec.Validate())
 }
 
@@ -165,6 +171,52 @@ func TestValidate(t *testing.T) {
 				Restart:    services.RestartAlways,
 			},
 			expectedError: "1 error occurred:\n\t* container entrypoint must be an absolute host path in host runner mode: \"usr/local/bin/foo\"\n\n",
+		},
+		{
+			name: "container runner with pre-shutdown hook",
+			spec: services.Spec{
+				Name: "foo",
+				Container: services.Container{
+					Entrypoint: "foo",
+				},
+				Restart: services.RestartAlways,
+				PreShutdown: &services.Command{
+					Entrypoint: "/usr/local/bin/foo-shutdown",
+					Timeout:    time.Minute,
+				},
+			},
+			expectedError: "1 error occurred:\n\t* pre-shutdown hook is only supported in host runner mode\n\n",
+		},
+		{
+			name: "pre-shutdown hook with relative entrypoint",
+			spec: services.Spec{
+				Name: "foo",
+				Container: services.Container{
+					Entrypoint: "/usr/local/bin/foo",
+				},
+				RunnerMode: services.RunnerModeHost,
+				Restart:    services.RestartAlways,
+				PreShutdown: &services.Command{
+					Entrypoint: "usr/local/bin/foo-shutdown",
+					Timeout:    time.Minute,
+				},
+			},
+			expectedError: "1 error occurred:\n\t* pre-shutdown entrypoint must be an absolute host path: \"usr/local/bin/foo-shutdown\"\n\n",
+		},
+		{
+			name: "pre-shutdown hook without timeout",
+			spec: services.Spec{
+				Name: "foo",
+				Container: services.Container{
+					Entrypoint: "/usr/local/bin/foo",
+				},
+				RunnerMode: services.RunnerModeHost,
+				Restart:    services.RestartAlways,
+				PreShutdown: &services.Command{
+					Entrypoint: "/usr/local/bin/foo-shutdown",
+				},
+			},
+			expectedError: "1 error occurred:\n\t* pre-shutdown timeout must be positive\n\n",
 		},
 		{
 			name: "invalid deps",

--- a/pkg/machinery/extensions/services/testdata/hello-host.yaml
+++ b/pkg/machinery/extensions/services/testdata/hello-host.yaml
@@ -7,3 +7,8 @@ container:
   args:
     - --log=debug
 restart: always
+preShutdown:
+  entrypoint: /usr/local/bin/hello-shutdown
+  args:
+    - --graceful
+  timeout: 30s


### PR DESCRIPTION
Allow host extension services to run bounded commands before graceful node teardown while their dependencies and D-Bus are still available. This prevents surviving child processes from blocking EPHEMERAL teardown without changing API stop or restart semantics.

Run hooks for reboot, reset, shutdown, staged upgrade, and upgrade. Skip forced and maintenance paths where graceful cleanup is unavailable.