### PR TITLE
fix: drop libssl from the rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -783,7 +783,7 @@ COPY --link --from=pkg-zlib-amd64 /usr/lib /rootfs/usr/lib
 # NOTE: amd64 ships igzip, but arm64 ships pigz (see https://github.com/siderolabs/extensions/discussions/931)
 COPY --link --exclude=usr/lib/pkgconfig --exclude=usr/include --from=pkg-igzip-amd64 / /rootfs
 COPY --link --from=pkg-pcre2-amd64 / /rootfs
-COPY --link --from=pkg-openssl-amd64 / /rootfs
+COPY --link --from=pkg-openssl-amd64 --exclude=usr/lib/libssl* / /rootfs
 COPY --link --from=pkg-lvm2-amd64 / /rootfs
 COPY --link --from=pkg-libaio-amd64 / /rootfs
 COPY --link --from=pkg-mdadm-amd64 / /rootfs
@@ -870,7 +870,7 @@ COPY --link --from=pkg-liburcu-arm64 / /rootfs
 COPY --link --from=pkg-libsepol-arm64 / /rootfs
 COPY --link --from=pkg-libselinux-arm64 / /rootfs
 COPY --link --from=pkg-pcre2-arm64 / /rootfs
-COPY --link --from=pkg-openssl-arm64 / /rootfs
+COPY --link --from=pkg-openssl-arm64 --exclude=usr/lib/libssl* / /rootfs
 COPY --link --from=pkg-lvm2-arm64 / /rootfs
 COPY --link --from=pkg-libaio-arm64 / /rootfs
 COPY --link --from=pkg-mdadm-arm64 / /rootfs
@@ -1230,7 +1230,7 @@ COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=
 COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --from=pkg-libburn / /
 COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --from=pkg-libisoburn / /
 COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --from=pkg-libisofs / /
-COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --exclude=usr/lib/cmake --from=pkg-openssl / /
+COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --exclude=usr/lib/cmake --exclude=usr/lib/libssl* --from=pkg-openssl / /
 COPY --link --from=pkg-open-vmdk / /
 COPY --link --exclude=**/*.a --exclude=**/*.la  --exclude=usr/include --exclude=usr/lib/pkgconfig --from=pkg-pcre2 / /
 COPY --link --from=pkg-pigz / /


### PR DESCRIPTION
OpenSSL ships two libraries:

* libcrypto
* libssl

The libcrypto is consumed is e.g. by cryptsetup, but libssl is not consumed by anything in the rootfs. Drop it to reduce the initramfs size, and security surface.
