### PR TITLE
fix: correct typos in talosctl output, comments and config example

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -228,7 +228,7 @@ func (m *Maker[T]) initVersionContract() error {
 	return nil
 }
 
-// GetClusterConfigs prepares and returns the cluster create request data. This method is ment to be called after the implemeting maker
+// GetClusterConfigs prepares and returns the cluster create request data. This method is meant to be called after the implementing maker
 // logic has been run.
 func (m *Maker[T]) GetClusterConfigs() (clusterops.ClusterConfigs, error) {
 	var configBundle *bundle.Bundle

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_docker.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_docker.go
@@ -23,7 +23,7 @@ func getDockerClusterRequest(cOps clusterops.Common, dOps clusterops.Docker, pro
 	_, err := config.ParseContractFromVersion(cOps.TalosVersion)
 	if err != nil {
 		currentVersion := helpers.GetTag()
-		fmt.Printf("failed to derrive Talos version from the docker image, defaulting to %s\n", currentVersion)
+		fmt.Printf("failed to derive Talos version from the docker image, defaulting to %s\n", currentVersion)
 		cOps.TalosVersion = currentVersion
 	}
 

--- a/cmd/talosctl/cmd/mgmt/gen/ca.go
+++ b/cmd/talosctl/cmd/mgmt/gen/ca.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package gen implements the genration of various artifacts.
+// Package gen implements the generation of various artifacts.
 package gen
 
 import (


### PR DESCRIPTION
Five spelling fixes. Two are user-visible:

- `talosctl cluster create` prints "failed to derrive Talos version from the docker image" -> "derive".
- The `ImageVerificationConfig` example used `locahost:3000/*` as its image pattern -> `localhost:3000/*`. Updated both the Go source in `pkg/machinery/config/types/security/image_verification.go` and the generated `website/content/v1.15/reference/configuration/security/imageverificationconfig.md` so the two stay in sync.

The other three are comments:

- `configmaker/internal/makers/common.go`: "is ment to be called after the implemeting maker" -> "is meant to be called after the implementing maker"
- `cmd/talosctl/cmd/mgmt/gen/ca.go`: package doc "genration" -> "generation"

No behaviour changes; nothing in the tree asserts on the old strings.