### PR TITLE
fix: add checks for meta key in the API path

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_meta.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_meta.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/meta"
 )
 
 // MetaWrite implements the machine.MachineServer interface.
@@ -22,11 +23,17 @@ func (s *Server) MetaWrite(ctx context.Context, req *machine.MetaWriteRequest) (
 		return nil, err
 	}
 
-	if uint32(uint8(req.Key)) != req.Key {
+	metaKey := uint8(req.Key)
+
+	if uint32(metaKey) != req.Key {
 		return nil, status.Errorf(codes.InvalidArgument, "key must be a uint8")
 	}
 
-	ok, err := s.Controller.Runtime().State().Machine().Meta().SetTagBytes(ctx, uint8(req.Key), req.Value)
+	if !meta.IsAPIWriteable(metaKey) {
+		return nil, status.Errorf(codes.PermissionDenied, "meta key is not writeable via the API")
+	}
+
+	ok, err := s.Controller.Runtime().State().Machine().Meta().SetTagBytes(ctx, metaKey, req.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +62,17 @@ func (s *Server) MetaDelete(ctx context.Context, req *machine.MetaDeleteRequest)
 		return nil, err
 	}
 
-	if uint32(uint8(req.Key)) != req.Key {
+	metaKey := uint8(req.Key)
+
+	if uint32(metaKey) != req.Key {
 		return nil, status.Errorf(codes.InvalidArgument, "key must be a uint8")
 	}
 
-	ok, err := s.Controller.Runtime().State().Machine().Meta().DeleteTag(ctx, uint8(req.Key))
+	if !meta.IsAPIWriteable(metaKey) {
+		return nil, status.Errorf(codes.PermissionDenied, "meta key is not writeable via the API")
+	}
+
+	ok, err := s.Controller.Runtime().State().Machine().Meta().DeleteTag(ctx, metaKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/api/meta.go
+++ b/internal/integration/api/meta.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_api
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talos/internal/integration/base"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/meta"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+)
+
+// MetaSuite ...
+type MetaSuite struct {
+	base.APISuite
+
+	ctx       context.Context //nolint:containedctx
+	ctxCancel context.CancelFunc
+}
+
+// SuiteName ...
+func (suite *MetaSuite) SuiteName() string {
+	return "api.MetaSuite"
+}
+
+// SetupTest ...
+func (suite *MetaSuite) SetupTest() {
+	if !suite.Capabilities().SupportsMETA {
+		suite.T().Skip("META APIs not supported on this node")
+	}
+
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 15*time.Second)
+}
+
+// TearDownTest ...
+func (suite *MetaSuite) TearDownTest() {
+	if suite.ctxCancel != nil {
+		suite.ctxCancel()
+	}
+}
+
+// TestMetaWriteDelete verifies META APIs.
+func (suite *MetaSuite) TestMetaWriteDelete() {
+	node := suite.RandomDiscoveredNodeInternalIP()
+	ctx := client.WithNode(suite.ctx, node)
+
+	const (
+		metaValue  = "test-value"
+		metaValue2 = "test-value-2"
+	)
+
+	suite.Run("regular operations", func() {
+		// no value in the initial state
+		rtestutils.AssertNoResource[*runtime.MetaKey](ctx, suite.T(), suite.Client.COSI, runtime.MetaKeyTagToID(meta.UserReserved1))
+
+		suite.Require().NoError(suite.Client.MetaWrite(ctx, meta.UserReserved1, []byte(metaValue)))
+
+		// value should appear after write
+		rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI, runtime.MetaKeyTagToID(meta.UserReserved1), func(mt *runtime.MetaKey, asrt *assert.Assertions) {
+			asrt.Equal(metaValue, mt.TypedSpec().Value)
+		})
+
+		// overwrite value
+		suite.Require().NoError(suite.Client.MetaWrite(ctx, meta.UserReserved1, []byte(metaValue2)))
+
+		rtestutils.AssertResource(ctx, suite.T(), suite.Client.COSI, runtime.MetaKeyTagToID(meta.UserReserved1), func(mt *runtime.MetaKey, asrt *assert.Assertions) {
+			asrt.Equal(metaValue2, mt.TypedSpec().Value)
+		})
+
+		// delete value
+		suite.Require().NoError(suite.Client.MetaDelete(ctx, meta.UserReserved1))
+
+		rtestutils.AssertNoResource[*runtime.MetaKey](ctx, suite.T(), suite.Client.COSI, runtime.MetaKeyTagToID(meta.UserReserved1))
+	})
+
+	suite.Run("invalid key", func() {
+		const invalidKey = 0x100 // above uint8
+
+		// using direct client here as the wrapper limits to uint8
+		_, err := suite.Client.MachineClient.MetaWrite(ctx, &machine.MetaWriteRequest{Key: invalidKey, Value: []byte(metaValue)})
+		suite.Require().Error(err)
+		suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+
+		_, err = suite.Client.MachineClient.MetaDelete(ctx, &machine.MetaDeleteRequest{Key: invalidKey})
+		suite.Require().Error(err)
+		suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+	})
+
+	suite.Run("disallowed keys", func() {
+		for metaKey := range 256 {
+			metaKey := uint8(metaKey)
+
+			if meta.IsAPIWriteable(metaKey) {
+				continue
+			}
+
+			suite.Run(fmt.Sprintf("key=%02x", metaKey), func() {
+				err := suite.Client.MetaWrite(ctx, metaKey, []byte(metaValue))
+				suite.Require().Error(err)
+				suite.Assert().Equal(codes.PermissionDenied, status.Code(err))
+
+				err = suite.Client.MetaDelete(ctx, metaKey)
+				suite.Require().Error(err)
+				suite.Assert().Equal(codes.PermissionDenied, status.Code(err))
+			})
+		}
+	})
+}
+
+func init() {
+	allSuites = append(allSuites, new(MetaSuite))
+}

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -169,6 +169,7 @@ type Capabilities struct {
 	SupportsReboot  bool
 	SupportsRecover bool
 	SupportsVolumes bool
+	SupportsMETA    bool
 	SecureBooted    bool
 }
 
@@ -186,6 +187,7 @@ func (apiSuite *APISuite) Capabilities() Capabilities {
 			caps.RunsTalosKernel = true
 			caps.SupportsReboot = true
 			caps.SupportsRecover = true
+			caps.SupportsMETA = true
 			caps.SupportsVolumes = true
 		}
 	}

--- a/pkg/machinery/meta/constants.go
+++ b/pkg/machinery/meta/constants.go
@@ -30,3 +30,15 @@ const (
 	// DiskImageBootloader stores the bootloader used for the disk image, this key is wiped on first boot.
 	DiskImageBootloader
 )
+
+// IsAPIWriteable returns true if the given key is writeable via the API.
+func IsAPIWriteable(key uint8) bool {
+	switch key {
+	case 0:
+		return false // used internally as empty slot marker, not settable
+	case Upgrade, StagedUpgradeImageRef, StagedUpgradeInstallOptions, StateEncryptionConfig, DiskImageBootloader:
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/machinery/meta/meta.go
+++ b/pkg/machinery/meta/meta.go
@@ -39,6 +39,10 @@ func (v *Value) Parse(s string) error {
 		return fmt.Errorf("invalid key %q", k)
 	}
 
+	if key == 0 { // reserved value, used as a sentinel for "no key"
+		return fmt.Errorf("invalid key %q: key cannot be 0", k)
+	}
+
 	v.Key = uint8(key)
 	v.Value = vv
 


### PR DESCRIPTION
Protect some META keys which are completely owned by Talos itself to be not writeable via the API.

Also block writes for zero value, as it used internally in the META format and it will provide inconsistent output.

Add integration tests.
