### PR TITLE
chore: speed up unit-tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1281,11 +1281,12 @@ COPY --link --from=rootfs / /
 COPY --link --from=pkg-ca-certificates / /
 COPY --link --from=pkg-btrfsprogs / /
 ARG TESTPKGS
+ARG UNITTEST_PARALLELISM
 ENV PLATFORM=container
 ARG GO_LDFLAGS
 RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache,id=talos/.cache go test \
     -ldflags "${GO_LDFLAGS}" \
-    -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -p 4 ${TESTPKGS}
+    -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -p ${UNITTEST_PARALLELISM} ${TESTPKGS}
 FROM scratch AS unit-tests
 COPY --link --from=unit-tests-runner /src/coverage.txt /coverage.txt
 
@@ -1296,12 +1297,15 @@ COPY --link --from=rootfs / /
 COPY --link --from=pkg-ca-certificates / /
 COPY --link --from=pkg-btrfsprogs / /
 ARG TESTPKGS
+ARG UNITTEST_PARALLELISM
 ENV PLATFORM=container
 ENV CGO_ENABLED=1
+ # reduce the wait time of TSan to exit after the test is done
+ENV GORACE=atexit_sleep_ms=100
 ARG GO_LDFLAGS
 RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache,id=talos/.cache go test \
     -ldflags "${GO_LDFLAGS}" \
-    -race -p 4 ${TESTPKGS}
+    -race -p ${UNITTEST_PARALLELISM} ${TESTPKGS}
 
 # The unit-tests-fips target performs tests with FIPS strict mode.
 FROM base AS unit-tests-fips
@@ -1309,13 +1313,14 @@ COPY --link --from=rootfs / /
 COPY --link --from=pkg-ca-certificates / /
 COPY --link --from=pkg-btrfsprogs / /
 ARG TESTPKGS
+ARG UNITTEST_PARALLELISM
 ENV PLATFORM=container
 ENV GOFIPS140=latest
 ENV GODEBUG=fips140=only,tlsmlkem=0
 ARG GO_LDFLAGS
 RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache,id=talos/.cache go test \
     -ldflags "${GO_LDFLAGS}" \
-    -p 4 ${TESTPKGS}
+    -p ${UNITTEST_PARALLELISM} ${TESTPKGS}
 
 # The integration-test targets builds integration test binary.
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ KUBESTR_URL ?= https://github.com/kastenhq/kubestr/releases/download/$(KUBESTR_V
 HELM_URL ?= https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz
 CILIUM_CLI_URL ?= https://github.com/cilium/cilium-cli/releases/download/$(CILIUM_CLI_VERSION)/cilium-$(OPERATING_SYSTEM)-amd64.tar.gz
 TESTPKGS ?= github.com/siderolabs/talos/...
+UNITTEST_PARALLELISM ?= 8
 RELEASES ?= v1.12.9 v1.13.7
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
@@ -255,6 +256,7 @@ COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
+COMMON_ARGS += --build-arg=UNITTEST_PARALLELISM=$(UNITTEST_PARALLELISM)
 COMMON_ARGS += --build-arg=TOOLS_PREFIX=$(TOOLS_PREFIX)
 COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
 COMMON_ARGS += --build-arg=GENERATE_VEX_PREFIX=$(GENERATE_VEX_PREFIX)


### PR DESCRIPTION
Increase parallelism to 8 instances, and reduce a bit the time race detector sleeps after the test finishes (which is the price paid for each test package, andw ehave many).
