### PR TITLE
fix: escape output in the talosctl dashboard

### DIFF
--- a/internal/pkg/dashboard/components/components.go
+++ b/internal/pkg/dashboard/components/components.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rivo/tview"
 	"github.com/siderolabs/gen/xslices"
 )
 
@@ -62,29 +63,31 @@ func padRight(s string, width int) string {
 
 func toHealthStatus(healthy bool) string {
 	if healthy {
-		return formatStatus("Healthy")
+		return FormatStatus("Healthy")
 	}
 
-	return formatStatus("Unhealthy")
+	return FormatStatus("Unhealthy")
 }
 
-func formatStatus(status any) string {
-	statusStr := capitalizeFirst(fmt.Sprintf("%v", status))
+func FormatStatus(status any) string {
+	statusStr := tview.Escape(capitalizeFirst(fmt.Sprintf("%v", status)))
 
 	switch strings.ToLower(statusStr) {
 	case "running", "healthy", "true":
-		return formatText(statusStr, true)
+		return FormatText(statusStr, true)
 	case "stopped", "unhealthy", "false":
-		return formatText(statusStr, false)
+		return FormatText(statusStr, false)
 	default:
 		return statusStr
 	}
 }
 
-func formatText(text string, ok bool) string {
+func FormatText(text string, ok bool) string {
 	if text == "" {
 		return ""
 	}
+
+	text = tview.Escape(text)
 
 	if ok {
 		return fmt.Sprintf("[green]√ %s[-]", text)

--- a/internal/pkg/dashboard/components/escape_test.go
+++ b/internal/pkg/dashboard/components/escape_test.go
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/dashboard/components"
+	"github.com/siderolabs/talos/internal/pkg/dashboard/resourcedata"
+	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
+	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/siderolink"
+)
+
+// The dashboard renders through tcell, which never lets a terminal control
+// character reach the terminal - it draws runes into cells. What it does read out
+// of the text is tview's own markup, so a node putting "[red]" or a region tag
+// into any string it serves repaints or hides part of the operator's dashboard.
+//
+// tview.Escape turns "[red]" into "[red[]", which prints as the literal text.
+const (
+	payload = "node[red]INJECTED[-]value"
+	escaped = "node[red[]INJECTED[-[]value"
+)
+
+// assertInert checks that the widget's text carries the payload only in its
+// escaped form, i.e. tview will print it rather than act on it.
+func assertInert(t *testing.T, text string) {
+	t.Helper()
+
+	require.Contains(t, text, "INJECTED", "the payload did not reach the widget, so this test proves nothing")
+	assert.Contains(t, text, escaped)
+	assert.NotContains(t, strings.ReplaceAll(text, escaped, ""), "[red]")
+}
+
+func TestTalosInfoEscapesAPIData(t *testing.T) {
+	t.Parallel()
+
+	const node = "10.0.0.1"
+
+	for name, res := range map[string]resourcedata.Data{
+		"uuid": {Node: node, Resource: func() *hardware.SystemInformation {
+			r := hardware.NewSystemInformation("systeminformation")
+			r.TypedSpec().UUID = payload
+
+			return r
+		}()},
+		"cluster name": {Node: node, Resource: func() *cluster.Info {
+			r := cluster.NewInfo()
+			r.TypedSpec().ClusterName = payload
+
+			return r
+		}()},
+		"siderolink host": {Node: node, Resource: func() *siderolink.Status {
+			r := siderolink.NewStatus()
+			r.TypedSpec().Host = payload
+			r.TypedSpec().Connected = true
+
+			return r
+		}()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			widget := components.NewTalosInfo()
+			widget.OnNodeSelect(node)
+			widget.OnResourceDataChange(res)
+
+			assertInert(t, widget.GetText(false))
+		})
+	}
+}
+
+func TestNetworkInfoEscapesAPIData(t *testing.T) {
+	t.Parallel()
+
+	const node = "10.0.0.1"
+
+	hostname := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostname.TypedSpec().Hostname = payload
+
+	timeservers := network.NewTimeServerStatus(network.NamespaceName, network.TimeServerID)
+	timeservers.TypedSpec().NTPServers = []string{payload}
+
+	for name, res := range map[string]resourcedata.Data{
+		"hostname":    {Node: node, Resource: hostname},
+		"ntp servers": {Node: node, Resource: timeservers},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			widget := components.NewNetworkInfo()
+			widget.OnNodeSelect(node)
+			widget.OnResourceDataChange(res)
+
+			assertInert(t, widget.GetText(false))
+		})
+	}
+}
+
+func TestHeaderEscapesAPIData(t *testing.T) {
+	t.Parallel()
+
+	const node = "10.0.0.1"
+
+	hostname := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostname.TypedSpec().Hostname = payload
+
+	versionRes := runtime.NewVersion()
+	versionRes.TypedSpec().Version = payload
+	versionRes.TypedSpec().Name = payload
+
+	for name, res := range map[string]resourcedata.Data{
+		"hostname": {Node: node, Resource: hostname},
+		"version":  {Node: node, Resource: versionRes},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			widget := components.NewHeader()
+			widget.OnNodeSelect(node)
+			widget.OnResourceDataChange(res)
+
+			assertInert(t, widget.GetText(false))
+		})
+	}
+}
+
+// TestFormattersEscapeTheirText: formatStatus and formatText wrap node text in
+// tview tags, so they have to escape the text and not the tags.
+func TestFormattersEscapeTheirText(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Node[red[]injected[-[]", components.FormatStatus("node[red]injected[-]"))
+	assert.Equal(t, "[green]√ node[red[]x[-[][-]", components.FormatText("node[red]x[-]", true))
+
+	// the ordinary values still render exactly as before.
+	assert.Equal(t, "[green]√ Running[-]", components.FormatStatus("running"))
+	assert.Equal(t, "[red]× Stopped[-]", components.FormatStatus("stopped"))
+	assert.Equal(t, "Unknown", components.FormatStatus("unknown"))
+}

--- a/internal/pkg/dashboard/components/header.go
+++ b/internal/pkg/dashboard/components/header.go
@@ -74,15 +74,15 @@ func (widget *Header) OnResourceDataChange(data resourcedata.Data) {
 		if data.Deleted {
 			nodeData.hostname = noHostname
 		} else {
-			nodeData.hostname = res.TypedSpec().Hostname
+			nodeData.hostname = tview.Escape(res.TypedSpec().Hostname)
 		}
 	case *runtime.Version:
 		if data.Deleted {
 			nodeData.name = version.Name
 			nodeData.version = notAvailable
 		} else {
-			nodeData.name = res.TypedSpec().Name
-			nodeData.version = res.TypedSpec().Version
+			nodeData.name = tview.Escape(res.TypedSpec().Name)
+			nodeData.version = tview.Escape(res.TypedSpec().Version)
 
 			if nodeData.name == "" {
 				nodeData.name = version.Name

--- a/internal/pkg/dashboard/components/kubernetesinfo.go
+++ b/internal/pkg/dashboard/components/kubernetesinfo.go
@@ -117,7 +117,7 @@ func (widget *KubernetesInfo) updateNodeData(data resourcedata.Data) {
 			nodeData.typ = notAvailable
 		} else {
 			nodeData.isControlPlane = res.MachineType() == machine.TypeControlPlane
-			nodeData.typ = res.MachineType().String()
+			nodeData.typ = tview.Escape(res.MachineType().String())
 		}
 	}
 }
@@ -133,7 +133,7 @@ func kubernetesVersion(deleted bool, image string) string {
 		return notAvailable
 	}
 
-	return version
+	return tview.Escape(version)
 }
 
 func (widget *KubernetesInfo) updateNodeAPIData(node string, data *apidata.Node) {

--- a/internal/pkg/dashboard/components/networkinfo.go
+++ b/internal/pkg/dashboard/components/networkinfo.go
@@ -105,7 +105,7 @@ func (widget *NetworkInfo) updateNodeData(data resourcedata.Data) {
 		if data.Deleted {
 			nodeData.hostname = notAvailable
 		} else {
-			nodeData.hostname = res.TypedSpec().Hostname
+			nodeData.hostname = tview.Escape(res.TypedSpec().Hostname)
 		}
 	case *network.RouteStatus:
 		if data.Deleted {
@@ -257,7 +257,7 @@ func (widget *NetworkInfo) timeservers(status *network.TimeServerStatus) string 
 		return none
 	}
 
-	return strings.Join(status.TypedSpec().NTPServers, ", ")
+	return strings.Join(xslices.Map(status.TypedSpec().NTPServers, tview.Escape), ", ")
 }
 
 func (widget *NetworkInfo) connectivity(status *network.Status) string {

--- a/internal/pkg/dashboard/components/talosinfo.go
+++ b/internal/pkg/dashboard/components/talosinfo.go
@@ -77,34 +77,34 @@ func (widget *TalosInfo) updateNodeData(data resourcedata.Data) {
 		if data.Deleted {
 			nodeData.uuid = notAvailable
 		} else {
-			nodeData.uuid = res.TypedSpec().UUID
+			nodeData.uuid = tview.Escape(res.TypedSpec().UUID)
 		}
 	case *cluster.Info:
 		clusterName := res.TypedSpec().ClusterName
 		if data.Deleted || clusterName == "" {
 			nodeData.clusterName = notAvailable
 		} else {
-			nodeData.clusterName = clusterName
+			nodeData.clusterName = tview.Escape(clusterName)
 		}
 	case *siderolink.Status:
 		if data.Deleted {
 			nodeData.siderolink = notAvailable
 		} else {
-			nodeData.siderolink = formatText(res.TypedSpec().Host, res.TypedSpec().Connected)
+			nodeData.siderolink = FormatText(res.TypedSpec().Host, res.TypedSpec().Connected)
 		}
 	case *runtime.MachineStatus:
 		if data.Deleted {
 			nodeData.stage = notAvailable
 			nodeData.ready = notAvailable
 		} else {
-			nodeData.stage = formatStatus(res.TypedSpec().Stage.String())
-			nodeData.ready = formatStatus(res.TypedSpec().Status.Ready)
+			nodeData.stage = FormatStatus(res.TypedSpec().Stage.String())
+			nodeData.ready = FormatStatus(res.TypedSpec().Status.Ready)
 		}
 	case *runtime.SecurityState:
 		if data.Deleted {
 			nodeData.secureBootState = notAvailable
 		} else {
-			nodeData.secureBootState = formatStatus(res.TypedSpec().SecureBoot)
+			nodeData.secureBootState = FormatStatus(res.TypedSpec().SecureBoot)
 		}
 	case *cluster.Member:
 		if data.Deleted {

--- a/internal/pkg/dashboard/configurl.go
+++ b/internal/pkg/dashboard/configurl.go
@@ -80,7 +80,7 @@ func NewConfigURLGrid(ctx context.Context, dashboard *Dashboard) *ConfigURLGrid 
 
 		err := dashboard.cli.MetaWrite(ctx, meta.DownloadURLCode, []byte(value))
 		if err != nil {
-			grid.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", err))
+			grid.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", tview.Escape(err.Error())))
 
 			return
 		}
@@ -100,7 +100,7 @@ func NewConfigURLGrid(ctx context.Context, dashboard *Dashboard) *ConfigURLGrid 
 				return
 			}
 
-			grid.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", err))
+			grid.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", tview.Escape(err.Error())))
 
 			return
 		}
@@ -180,7 +180,7 @@ func (widget *ConfigURLGrid) updateNodeData(data resourcedata.Data) {
 					val = "(empty)"
 				}
 
-				nodeData.existingCode = fmt.Sprintf("[blue]%s[-]", val)
+				nodeData.existingCode = fmt.Sprintf("[blue]%s[-]", tview.Escape(val))
 			}
 		}
 	}

--- a/internal/pkg/dashboard/networkconfig.go
+++ b/internal/pkg/dashboard/networkconfig.go
@@ -314,7 +314,7 @@ func (widget *NetworkConfigGrid) redraw() {
 
 		err := encoder.Encode(data.existingConfig)
 		if err != nil {
-			widget.existingConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", err))
+			widget.existingConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", tview.Escape(err.Error())))
 		}
 
 		widget.existingConfigView.SetText(fmt.Sprintf("[lightblue]%s[-]", tview.Escape(buf.String())))
@@ -323,7 +323,7 @@ func (widget *NetworkConfigGrid) redraw() {
 	}
 
 	if data.newConfigError != nil {
-		widget.newConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", data.newConfigError))
+		widget.newConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", tview.Escape(data.newConfigError.Error())))
 	} else if data.newConfig != nil {
 		var buf strings.Builder
 
@@ -332,7 +332,7 @@ func (widget *NetworkConfigGrid) redraw() {
 
 		err := encoder.Encode(data.newConfig)
 		if err != nil {
-			widget.newConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", err))
+			widget.newConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", tview.Escape(err.Error())))
 		}
 
 		widget.newConfigView.SetText(fmt.Sprintf("[green]%s[-]", tview.Escape(buf.String())))
@@ -387,7 +387,7 @@ func (widget *NetworkConfigGrid) updateNodeData(data resourcedata.Data) {
 				cfg := runtime.PlatformNetworkConfig{}
 
 				if err := yaml.Unmarshal([]byte(res.TypedSpec().Value), &cfg); err != nil {
-					widget.existingConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", err))
+					widget.existingConfigView.SetText(fmt.Sprintf("[red]error: %v[-]", tview.Escape(err.Error())))
 
 					return
 				}
@@ -437,7 +437,7 @@ func (widget *NetworkConfigGrid) save(ctx context.Context) {
 
 	configBytes, err := yaml.Marshal(nodeData.newConfig)
 	if err != nil {
-		widget.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", err))
+		widget.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", tview.Escape(err.Error())))
 
 		return
 	}
@@ -445,7 +445,7 @@ func (widget *NetworkConfigGrid) save(ctx context.Context) {
 	ctx = utils.NodeContext(ctx, widget.selectedNode)
 
 	if err = widget.dashboard.cli.MetaWrite(ctx, meta.MetalNetworkPlatformConfig, configBytes); err != nil {
-		widget.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", err))
+		widget.infoView.SetText(fmt.Sprintf("[red]Error: %v[-]", tview.Escape(err.Error())))
 
 		return
 	}

--- a/internal/pkg/dashboard/resourceexplorer.go
+++ b/internal/pkg/dashboard/resourceexplorer.go
@@ -298,7 +298,7 @@ func (widget *ResourceExplorerGrid) loadResourceTypes() {
 			widget.app.QueueUpdateDraw(func() {
 				widget.initTypesTableHeader()
 				widget.typesTable.SetCell(1, 0, &tview.TableCell{
-					Text:          fmt.Sprintf("[red]%s[-]", formatError(err)),
+					Text:          fmt.Sprintf("[red]%s[-]", tview.Escape(formatError(err))),
 					NotSelectable: true,
 				})
 			})
@@ -361,19 +361,19 @@ func (widget *ResourceExplorerGrid) renderTypesTable() {
 		}
 
 		widget.typesTable.SetCell(row, 0, &tview.TableCell{
-			Text:      spec.Type,
+			Text:      tview.Escape(spec.Type),
 			Align:     tview.AlignLeft,
 			Color:     tcell.ColorDefault,
 			Reference: rd, // used by selectResourceType to retrieve the RD
 			Expansion: 1,
 		})
 		widget.typesTable.SetCell(row, 1, &tview.TableCell{
-			Text:  spec.DefaultNamespace,
+			Text:  tview.Escape(spec.DefaultNamespace),
 			Align: tview.AlignLeft,
 			Color: tcell.ColorDefault,
 		})
 		widget.typesTable.SetCell(row, 2, &tview.TableCell{
-			Text:  strings.Join(spec.Aliases, ", "),
+			Text:  tview.Escape(strings.Join(spec.Aliases, ", ")),
 			Align: tview.AlignLeft,
 			Color: tcell.ColorGray,
 		})
@@ -694,16 +694,16 @@ func (widget *ResourceExplorerGrid) selectResource(row int) {
 func (widget *ResourceExplorerGrid) showResourceYAML(res resource.Resource) {
 	out, err := resource.MarshalYAML(res)
 	if err != nil {
-		widget.yamlView.SetText(fmt.Sprintf("Error marshaling resource: %v", err))
+		widget.yamlView.SetText(tview.Escape(fmt.Sprintf("Error marshaling resource: %v", err)))
 	} else {
 		outBytes, marshalErr := yaml.Marshal(out)
 		if marshalErr != nil {
-			widget.yamlView.SetText(fmt.Sprintf("Error encoding YAML: %v", marshalErr))
+			widget.yamlView.SetText(tview.Escape(fmt.Sprintf("Error encoding YAML: %v", marshalErr)))
 		} else {
 			var node yaml.Node
 
 			if unmarshalErr := yaml.Unmarshal(outBytes, &node); unmarshalErr != nil {
-				widget.yamlView.SetText(fmt.Sprintf("Error encoding YAML: %v", unmarshalErr))
+				widget.yamlView.SetText(tview.Escape(fmt.Sprintf("Error encoding YAML: %v", unmarshalErr)))
 			} else {
 				var sb strings.Builder
 


### PR DESCRIPTION
The output to tview might be re-processed by tview for its own color tags, so ensure any input data is escaped before drawn into tview.
