### PR TITLE
fix: use os.Root in the talosctl extract path

### DIFF
--- a/cmd/talosctl/pkg/talos/helpers/archive.go
+++ b/cmd/talosctl/pkg/talos/helpers/archive.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/siderolabs/talos/pkg/safepath"
 )
@@ -56,6 +55,9 @@ func ExtractFileFromTarGz(filename string, r io.ReadCloser) ([]byte, error) {
 
 // ExtractTarGz extracts .tar.gz archive from r into filesystem under localPath.
 //
+// The archive is a dump of node's filesystem which might contain symlinks or
+// other special files, handle them in a safe way for the client.
+//
 //nolint:gocyclo
 func ExtractTarGz(localPath string, r io.ReadCloser) error {
 	defer r.Close() //nolint:errcheck
@@ -64,6 +66,13 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 	if err != nil {
 		return fmt.Errorf("error initializing gzip: %w", err)
 	}
+
+	root, err := os.OpenRoot(localPath)
+	if err != nil {
+		return fmt.Errorf("error opening local path %q: %w", localPath, err)
+	}
+
+	defer root.Close() //nolint:errcheck
 
 	tr := tar.NewReader(zr)
 
@@ -77,36 +86,36 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 			return fmt.Errorf("error reading tar header: %s", err)
 		}
 
-		hdrPath := safepath.CleanPath(hdr.Name)
-		if hdrPath == "" {
+		path := safepath.CleanPath(hdr.Name)
+		if path == "" {
 			return errors.New("empty tar header path")
 		}
 
-		path := filepath.Join(localPath, hdrPath)
-		// TODO: do we need to clean up any '..' references?
-
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			mode := hdr.FileInfo().Mode()
+			// Perm drops setuid, setgid and sticky along with the type bits.
+			mode := hdr.FileInfo().Mode().Perm()
 			mode |= 0o700 // make rwx for the owner
 
-			if err = os.Mkdir(path, mode); err != nil {
+			if err = root.Mkdir(path, mode); err != nil {
 				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)
 			}
 
-			if err = os.Chmod(path, mode); err != nil {
+			if err = root.Chmod(path, mode); err != nil {
 				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
 			}
 
 		case tar.TypeSymlink:
-			if err = os.Symlink(hdr.Linkname, path); err != nil {
+			if err = root.Symlink(hdr.Linkname, path); err != nil {
 				return fmt.Errorf("error creating symlink %q -> %q: %w", path, hdr.Linkname, err)
 			}
 
 		default:
-			mode := hdr.FileInfo().Mode()
+			// drop setuid, setgid and sticky along with the type bits, the owner
+			// of the file is not restored, so setuid and setgid bits are not useful.
+			mode := hdr.FileInfo().Mode().Perm()
 
-			fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
+			fp, err := root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
 			if err != nil {
 				return fmt.Errorf("error creating file %q mode %s: %w", path, mode, err)
 			}
@@ -120,7 +129,7 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 				return fmt.Errorf("error closing %q: %w", path, err)
 			}
 
-			if err = os.Chmod(path, mode); err != nil {
+			if err = root.Chmod(path, mode); err != nil {
 				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
 			}
 		}

--- a/cmd/talosctl/pkg/talos/helpers/archive_test.go
+++ b/cmd/talosctl/pkg/talos/helpers/archive_test.go
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+)
+
+// tarGz builds a .tar.gz from the given headers, with the body of each regular
+// file entry taken from bodies by name.
+func tarGz(t *testing.T, headers []*tar.Header, bodies map[string]string) io.ReadCloser {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	zw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(zw)
+
+	for _, hdr := range headers {
+		body := bodies[hdr.Name]
+		hdr.Size = int64(len(body))
+
+		require.NoError(t, tw.WriteHeader(hdr))
+
+		if body != "" {
+			_, err := tw.Write([]byte(body))
+			require.NoError(t, err)
+		}
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, zw.Close())
+
+	return io.NopCloser(&buf)
+}
+
+// TestExtractTarGzSymlinkEscape verifies symlink escape on extraction.
+func TestExtractTarGzSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		linkname func(outside string) string
+	}{
+		{
+			name:     "absolute link target",
+			linkname: func(outside string) string { return outside },
+		},
+		{
+			name:     "relative link target",
+			linkname: func(outside string) string { return "../outside" },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := t.TempDir()
+			root := filepath.Join(base, "root")
+			outside := filepath.Join(base, "outside")
+
+			require.NoError(t, os.Mkdir(root, 0o755))
+			require.NoError(t, os.Mkdir(outside, 0o755))
+
+			headers := []*tar.Header{
+				{
+					Name:     "esc",
+					Linkname: test.linkname(outside),
+					Typeflag: tar.TypeSymlink,
+					Mode:     0o777,
+				},
+				{
+					Name:     "esc/PWNED",
+					Typeflag: tar.TypeReg,
+					Mode:     0o4755,
+				},
+			}
+
+			archive := tarGz(t, headers, map[string]string{"esc/PWNED": "payload"})
+
+			err := helpers.ExtractTarGz(root, archive)
+
+			escaped := filepath.Join(outside, "PWNED")
+
+			_, statErr := os.Lstat(escaped)
+			assert.True(t, os.IsNotExist(statErr), "a tar entry wrote outside the extraction root: %s (extract error: %v)", escaped, err)
+
+			// and it fails loudly: reporting success while skipping the entry would
+			// leave the operator believing the copy completed.
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestExtractTarGzDropsSetuid verifies that setuid and setgid bits are dropped on extraction.
+func TestExtractTarGzSetuid(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	headers := []*tar.Header{{Name: "suid", Typeflag: tar.TypeReg, Mode: 0o4755}}
+
+	archive := tarGz(t, headers, map[string]string{"suid": "payload"})
+
+	require.NoError(t, helpers.ExtractTarGz(root, archive))
+
+	info, err := os.Stat(filepath.Join(root, "suid"))
+	require.NoError(t, err)
+
+	assert.Zero(t, info.Mode()&(os.ModeSetuid|os.ModeSetgid), "extracted file kept mode %s", info.Mode())
+}
+
+// TestExtractTarGzNormal: a well-formed archive still extracts.
+func TestExtractTarGzNormal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	headers := []*tar.Header{
+		{Name: "dir", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "dir/file", Typeflag: tar.TypeReg, Mode: 0o644},
+		{Name: "dir/link", Linkname: "file", Typeflag: tar.TypeSymlink, Mode: 0o777},
+	}
+
+	archive := tarGz(t, headers, map[string]string{"dir/file": "hello"})
+
+	require.NoError(t, helpers.ExtractTarGz(root, archive))
+
+	body, err := os.ReadFile(filepath.Join(root, "dir", "file"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(body))
+
+	target, err := os.Readlink(filepath.Join(root, "dir", "link"))
+	require.NoError(t, err)
+	assert.Equal(t, "file", target)
+
+	body, err = os.ReadFile(filepath.Join(root, "dir", "link"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(body))
+}


### PR DESCRIPTION
The fix is similar to #14117, but applied to the `talosctl` CLI path - when processing the tarball (received via Talos API), ensure that the extraction doesn't leave the extract root path, and avoid setting dangerous file mode bits (e.g. setuid), as it makes no sense, as extraction doesn't preserve the owner's uid.

The produced tarball still contains raw data, so it can be used to do full analysis without extraction as required.
