### PR TITLE
fix: discover partitions on disks with a whole-disk filesystem signature

### DIFF
--- a/internal/app/machined/pkg/controllers/block/discovery.go
+++ b/internal/app/machined/pkg/controllers/block/discovery.go
@@ -16,7 +16,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/go-blockdevice/v2/blkid"
+	blockdev "github.com/siderolabs/go-blockdevice/v2/block"
 	"github.com/siderolabs/go-blockdevice/v2/partitioning"
+	"github.com/siderolabs/go-blockdevice/v2/partitioning/gpt"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
@@ -229,7 +231,30 @@ func (ctrl *DiscoveryController) rescan(ctx context.Context, r controller.Runtim
 
 		touchedIDs[id] = struct{}{}
 
-		for _, nested := range info.Parts {
+		parts := info.Parts
+
+		if len(parts) == 0 && info.Name != "" && info.Name != "gpt" && device.TypedSpec().Type == "disk" {
+			// The probe matched a whole-disk filesystem signature, so no partitions were discovered.
+			//
+			// On hybrid disk layouts (e.g. a Talos ISO written to a USB stick), a filesystem signature (ISO9660)
+			// coexists with a valid GPT, and the probe returns the first (filesystem) match without enumerating
+			// the partition table.
+			//
+			// The kernel parses the partition table independently of the filesystem signature: if it published
+			// partition devices for this disk, recover the partitions by reading the GPT directly, so that
+			// volumes on such disks are discoverable (e.g. a `metal-iso` machine configuration partition
+			// on the boot USB stick).
+			kernelPartitions, err := kernelPartitionsForDisk(ctx, r, id)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(kernelPartitions) > 0 {
+				parts = ctrl.probeHybridDiskPartitions(logger.With(zap.String("device", id)), id, kernelPartitions)
+			}
+		}
+
+		for _, nested := range parts {
 			partID := partitioning.DevName(id, nested.PartitionIndex)
 
 			if err = safe.WriterModify(ctx, r, block.NewDiscoveredVolume(block.NamespaceName, partID), func(dv *block.DiscoveredVolume) error {
@@ -326,4 +351,127 @@ func (ctrl *DiscoveryController) fillDiscoveredVolumeFromInfo(dv *block.Discover
 	dv.TypedSpec().BlockSize = info.BlockSize
 	dv.TypedSpec().FilesystemBlockSize = info.FilesystemBlockSize
 	dv.TypedSpec().ProbedSize = info.ProbedSize
+}
+
+// kernelPartitionsForDisk returns a map of partition numbers to partition device IDs published by the kernel for the given disk.
+func kernelPartitionsForDisk(ctx context.Context, r controller.Reader, diskID string) (map[uint]string, error) {
+	devices, err := safe.ReaderListAll[*block.Device](ctx, r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %w", err)
+	}
+
+	var kernelPartitions map[uint]string
+
+	for device := range devices.All() {
+		if device.TypedSpec().Type != "partition" || device.TypedSpec().Parent != diskID {
+			continue
+		}
+
+		if device.TypedSpec().PartitionNumber <= 0 {
+			continue
+		}
+
+		if kernelPartitions == nil {
+			kernelPartitions = map[uint]string{}
+		}
+
+		kernelPartitions[uint(device.TypedSpec().PartitionNumber)] = device.Metadata().ID()
+	}
+
+	return kernelPartitions, nil
+}
+
+// probeHybridDiskPartitions discovers partitions on a disk which carries both a whole-disk filesystem signature and a GPT.
+//
+// The partition entries are read directly from the GPT, while the filesystem on each partition is probed via the
+// kernel-published partition device (which handles the partition offset). Only partitions published by the kernel
+// are returned.
+//
+// Any error is treated as "no partitions discovered" (the behavior before the hybrid disk support), as a disk with
+// a whole-disk filesystem signature is not expected to have a partition table in the general case.
+func (ctrl *DiscoveryController) probeHybridDiskPartitions(logger *zap.Logger, id string, kernelPartitions map[uint]string) []blkid.NestedProbeResult {
+	parts, err := readGPTPartitions(filepath.Join("/dev", id), kernelPartitions)
+	if err != nil {
+		logger.Debug("failed to read GPT on a disk with a whole-disk filesystem signature", zap.Error(err))
+
+		return nil
+	}
+
+	for i := range parts {
+		partInfo, err := blkid.ProbePath(filepath.Join("/dev", kernelPartitions[parts[i].PartitionIndex]), blkid.WithProbeLogger(logger))
+		if err != nil {
+			logger.Debug("failed to probe partition device", zap.Uint("partition", parts[i].PartitionIndex), zap.Error(err))
+
+			continue
+		}
+
+		parts[i].ProbeResult = partInfo.ProbeResult
+		parts[i].Parts = partInfo.Parts
+	}
+
+	return parts
+}
+
+// readGPTPartitions opens the disk device and converts its GPT partition entries into nested probe results.
+func readGPTPartitions(devPath string, kernelPartitions map[uint]string) ([]blkid.NestedProbeResult, error) {
+	dev, err := blockdev.NewFromPath(devPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open device: %w", err)
+	}
+
+	defer dev.Close() //nolint:errcheck
+
+	if err = dev.TryLock(false); err != nil {
+		return nil, fmt.Errorf("failed to lock device: %w", err)
+	}
+
+	defer dev.Unlock() //nolint:errcheck
+
+	gptdev, err := gpt.DeviceFromBlockDevice(dev)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GPT device: %w", err)
+	}
+
+	return gptNestedProbeResults(gptdev, kernelPartitions)
+}
+
+// gptNestedProbeResults reads the GPT and converts partition entries into nested probe results,
+// matching the format of the results returned by the blkid GPT prober.
+//
+// Partitions not published by the kernel (not present in kernelPartitions) are skipped.
+func gptNestedProbeResults(gptdev gpt.Device, kernelPartitions map[uint]string) ([]blkid.NestedProbeResult, error) {
+	pt, err := gpt.Read(gptdev)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GPT: %w", err)
+	}
+
+	sectorSize := uint64(gptdev.GetSectorSize())
+
+	var parts []blkid.NestedProbeResult
+
+	for idx, part := range pt.Partitions() {
+		if part == nil {
+			continue
+		}
+
+		partitionIndex := uint(idx) + 1 // GPT partition index is 1-based
+
+		if _, ok := kernelPartitions[partitionIndex]; !ok {
+			continue
+		}
+
+		parts = append(parts, blkid.NestedProbeResult{
+			NestedResult: blkid.NestedResult{
+				PartitionUUID:  new(part.PartGUID),
+				PartitionType:  new(part.TypeGUID),
+				PartitionLabel: new(part.Name),
+				PartitionIndex: partitionIndex,
+
+				PartitionOffset: part.FirstLBA * sectorSize,
+				PartitionSize:   (part.LastLBA - part.FirstLBA + 1) * sectorSize,
+			},
+		})
+	}
+
+	return parts, nil
 }

--- a/internal/app/machined/pkg/controllers/block/discovery_test.go
+++ b/internal/app/machined/pkg/controllers/block/discovery_test.go
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package block_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/siderolabs/go-blockdevice/v2/partitioning/gpt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	blockctrls "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/block"
+)
+
+// TestGPTNestedProbeResults verifies recovering GPT partitions on a "hybrid" disk, where a whole-disk
+// filesystem signature (e.g. ISO9660 on a Talos ISO written to a USB stick) shadows the partition table
+// from the blkid probe, so the partitions have to be discovered by reading the GPT directly.
+func TestGPTNestedProbeResults(t *testing.T) {
+	t.Parallel()
+
+	const diskSize = 4 * 1024 * 1024
+
+	partType := uuid.MustParse("0FC63DAF-8483-4772-8E79-3D69D8477DE4") // Linux filesystem data
+
+	imagePath := filepath.Join(t.TempDir(), "image.raw")
+
+	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_RDWR, 0o644)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+	require.NoError(t, f.Truncate(diskSize))
+
+	gptdev, err := gpt.DeviceFromFile(f)
+	require.NoError(t, err)
+
+	// without a GPT on the disk, expect an error
+	_, err = blockctrls.GPTNestedProbeResults(gptdev, map[uint]string{1: "sda1"})
+	require.Error(t, err)
+
+	pt, err := gpt.New(gptdev)
+	require.NoError(t, err)
+
+	_, part1, err := pt.AllocatePartition(1024*1024, "metal-iso", partType)
+	require.NoError(t, err)
+
+	_, part2, err := pt.AllocatePartition(1024*1024, "", partType)
+	require.NoError(t, err)
+
+	require.NoError(t, pt.Write())
+
+	sectorSize := uint64(gptdev.GetSectorSize())
+
+	// both partitions published by the kernel
+	parts, err := blockctrls.GPTNestedProbeResults(gptdev, map[uint]string{1: "sda1", 2: "sda2"})
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+
+	assert.Equal(t, uint(1), parts[0].PartitionIndex)
+	require.NotNil(t, parts[0].PartitionLabel)
+	assert.Equal(t, "metal-iso", *parts[0].PartitionLabel)
+	require.NotNil(t, parts[0].PartitionUUID)
+	assert.Equal(t, part1.PartGUID, *parts[0].PartitionUUID)
+	require.NotNil(t, parts[0].PartitionType)
+	assert.Equal(t, partType, *parts[0].PartitionType)
+	assert.Equal(t, part1.FirstLBA*sectorSize, parts[0].PartitionOffset)
+	assert.Equal(t, (part1.LastLBA-part1.FirstLBA+1)*sectorSize, parts[0].PartitionSize)
+
+	assert.Equal(t, uint(2), parts[1].PartitionIndex)
+	require.NotNil(t, parts[1].PartitionLabel)
+	assert.Equal(t, "", *parts[1].PartitionLabel)
+	assert.Equal(t, part2.FirstLBA*sectorSize, parts[1].PartitionOffset)
+
+	// partitions not published by the kernel are skipped
+	parts, err = blockctrls.GPTNestedProbeResults(gptdev, map[uint]string{2: "sda2"})
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+
+	assert.Equal(t, uint(2), parts[0].PartitionIndex)
+
+	// no partitions published by the kernel
+	parts, err = blockctrls.GPTNestedProbeResults(gptdev, nil)
+	require.NoError(t, err)
+	assert.Empty(t, parts)
+}

--- a/internal/app/machined/pkg/controllers/block/export_test.go
+++ b/internal/app/machined/pkg/controllers/block/export_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package block
+
+import (
+	"github.com/siderolabs/go-blockdevice/v2/blkid"
+	"github.com/siderolabs/go-blockdevice/v2/partitioning/gpt"
+)
+
+// GPTNestedProbeResults is exported for testing purposes.
+func GPTNestedProbeResults(gptdev gpt.Device, kernelPartitions map[uint]string) ([]blkid.NestedProbeResult, error) {
+	return gptNestedProbeResults(gptdev, kernelPartitions)
+}


### PR DESCRIPTION

## What? (description)

Makes volume discovery work on "hybrid" disks where a whole-disk filesystem signature coexists with a valid GPT — most notably a Talos ISO `dd`'d to a USB stick with an extra config partition added.

`blkid.ProbePath` returns the first successful match of the prober chain, and the chain lists filesystems (including `iso9660`) before `gpt`. On a dd'd hybrid ISO the whole-disk probe therefore reports `iso9660` with **zero** partitions, and since `block.DiscoveryController` derives partition `DiscoveredVolumes` exclusively from the whole-disk probe's nested results, no partition on such a stick was ever discovered — even though the kernel parses the GPT fine and publishes `/dev/sdX1..sdXN`.

The fix: in `DiscoveryController.rescan`, when the whole-disk probe matches a filesystem (not `gpt`) but returns no partitions, and the kernel **has** published partition devices for that disk, fall back to reading the GPT directly (public `go-blockdevice` `partitioning/gpt` package, same pattern as `internal/.../volumes/disk.go`). Partition metadata comes from the GPT entries converted into the same `blkid.NestedProbeResult` shape the GPT prober would return, so the existing `DiscoveredVolume` population code is reused unchanged; per-partition filesystems are probed against the kernel-published partition devices; only kernel-published partitions are emitted. No behavior change for regular disks; any error in the fallback degrades to the previous behavior with a debug log.

An alternative would be to fix the prober-chain semantics in `go-blockdevice` itself (probe partition tables in a separate chain from superblocks, the util-linux `libblkid` model) — happy to pursue that instead if preferred; this PR fixes it on the Talos side without touching `go-blockdevice`.

**How to reproduce:**

1. `dd` a Talos metal ISO to a USB stick.
2. Add a config partition to the leftover space:

   ```sh
   sgdisk --move-second-header /dev/sdX
   sgdisk -n 0:0:+64MiB -c 0:metal-iso /dev/sdX
   mkfs.vfat /dev/sdX<N>   # copy config.yaml onto it
   ```

3. Boot with `talos.config=metal-iso`.

Before: `talosctl get discoveredvolumes` shows only the whole stick as `iso9660`; the machine waits forever for the `metal-iso` volume (`waiting -> missing` loop). After: the partitions are discovered with `PARTITION_LABEL` filled from the GPT, and the machine config is picked up.

## Why? (reasoning)

The documented `talos.config=metal-iso` flow (a `metal-iso`-labeled config partition supplying the machine config) silently cannot work when that partition lives on the boot stick itself — the most natural setup for bare-metal machines with a single USB port. The failure mode gives no hint of the cause: the volume matcher loops `waiting -> missing` forever while the kernel plainly lists the partition. Talos's view of the disk also diverges from the rest of the Linux stack (the kernel and util-linux `blkid` both recognize the partition table on such disks).

Fixes #14195

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`) (content passes while GPG and GPG identity does not)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
