### PR TITLE
fix: container mount rootfs propagation on `rshared`

### DIFF
--- a/internal/app/machined/pkg/controllers/containers/containerd_runner.go
+++ b/internal/app/machined/pkg/controllers/containers/containerd_runner.go
@@ -212,6 +212,14 @@ func (r *containerdRunner) ociSpecOpts(spec containersres.ContainerInstanceSpecS
 		opts = append(opts, oci.WithMounts(mounts))
 	}
 
+	// An rshared bind can only join the host peer group when the container's
+	// rootfs propagation is shared: with the runc default (recursive slave),
+	// the bind lands in a new peer group slaved to the host, and mounts created
+	// inside the container never propagate back out.
+	if MountsRequestSharedPropagation(spec.Mounts) {
+		opts = append(opts, containerdrunner.WithRootfsPropagation("shared"))
+	}
+
 	if spec.Security.MachinedAccess {
 		opts = append(opts, func(_ context.Context, _ oci.Client, _ *ctrdcontainers.Container, s *specs.Spec) error {
 			if _, err := os.Stat(constants.MachineSocketPath); err != nil {
@@ -407,4 +415,17 @@ func MountsResolvedToOCI(mounts []containersres.ResolvedMountSpec) []specs.Mount
 	}
 
 	return out
+}
+
+// MountsRequestSharedPropagation reports whether any declared mount asks for
+// rshared propagation, which requires the rootfs itself to be shared
+// for the bind to join the host peer group (see ociSpecOpts).
+func MountsRequestSharedPropagation(mounts []containersres.ResolvedMountSpec) bool {
+	for _, mount := range mounts {
+		if slices.Contains(mount.Options, "rshared") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/app/machined/pkg/controllers/containers/containerd_runner_test.go
+++ b/internal/app/machined/pkg/controllers/containers/containerd_runner_test.go
@@ -181,6 +181,63 @@ func TestMountsResolvedToOCI(t *testing.T) {
 	}
 }
 
+// TestMountsRequestSharedPropagation covers detection of a mount asking for rshared
+// propagation: missing this flips the rootfs into slave propagation, so a container-created
+// mount never becomes visible on the host.
+func TestMountsRequestSharedPropagation(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		mounts   []containers.ResolvedMountSpec
+		expected bool
+	}{
+		{
+			name: "none",
+		},
+		{
+			name: "mount with no options",
+			mounts: []containers.ResolvedMountSpec{
+				{Kind: containers.MountKindHostPath, Source: "/var/log", Destination: "/host-log"},
+			},
+		},
+		{
+			name: "unrelated option only",
+			mounts: []containers.ResolvedMountSpec{
+				{Kind: containers.MountKindHostPath, Source: "/var/log", Destination: "/host-log", Options: []string{"ro"}},
+			},
+		},
+		{
+			name: "rshared option",
+			mounts: []containers.ResolvedMountSpec{
+				{Kind: containers.MountKindHostPath, Source: "/var/log", Destination: "/host-log", Options: []string{"rshared"}},
+			},
+			expected: true,
+		},
+		{
+			name: "later mount requests rshared",
+			mounts: []containers.ResolvedMountSpec{
+				{Kind: containers.MountKindHostPath, Source: "/var/log", Destination: "/host-log", Options: []string{"ro"}},
+				{Kind: containers.MountKindHostPath, Source: "/var/mnt", Destination: "/host-mnt", Options: []string{"rshared"}},
+			},
+			expected: true,
+		},
+		{
+			name: "rshared is not the first option",
+			mounts: []containers.ResolvedMountSpec{
+				{Kind: containers.MountKindHostPath, Source: "/var/log", Destination: "/host-log", Options: []string{"rbind", "rshared"}},
+			},
+			expected: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, containersctrl.MountsRequestSharedPropagation(test.mounts))
+		})
+	}
+}
+
 func TestWithProcessArgs(t *testing.T) {
 	// Test that WithProcessArgs returns an oci.SpecOpts (function)
 	// We can't easily test the full behavior without mocking the image,


### PR DESCRIPTION
Container runner now enables containerd shared rootfs propagation if the user provides a `rshared` mount option.

Depends on: https://github.com/siderolabs/talos/pull/14206 (disables ctr test skipping)
