### PR TITLE
fix: filter the output in talosctl

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ output:
 linters:
   default: all
   enable:
+    - forbidigo
     - loglinter
     - kubeimportlinter
   disable:
@@ -28,7 +29,6 @@ linters:
     - err113
     - errorlint
     - exhaustruct
-    - forbidigo
     - forcetypeassert
     - funcorder
     - funlen
@@ -63,6 +63,22 @@ linters:
     - wrapcheck
     - wsl # replaced by wsl_v5
   settings:
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.(Print|Printf|Println)$
+          msg: >-
+            talosctl renders text received from the node it is talking to, and a terminal acts on
+            control sequences in it.
+            Print through cmd/talosctl/pkg/talos/safeout instead.
+        - pattern: ^cli\.(Warning|Fatalf)$
+          msg: >-
+            these write to the raw stderr, so a warning quoting a node bypasses the filter.
+            Print through cmd/talosctl/pkg/talos/safeout instead.
+        - pattern: ^os\.(Stdout|Stderr)$
+          msg: >-
+            use safeout.Stdout / safeout.Stderr so node-supplied text cannot drive the
+            operator's terminal. A stream which must stay raw - a
+            file, a pcap, an interactive pty - needs //nolint:forbidigo saying which.
     custom:
       loglinter:
         type: module
@@ -168,6 +184,10 @@ linters:
         - fmt.Fprintln
         - fmt.Fprintf
         - fmt.Fprint
+        - github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout.Fprintf
+        - github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout.Printf
+        - github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout.Println
+        - github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout.Print
     exhaustive:
       default-signifies-exhaustive: false
     goconst:
@@ -268,6 +288,14 @@ linters:
   exclusions:
     generated: lax
     rules:
+      # forbidigo guards the code which renders responses from a node; the offline
+      # config and local cluster commands do not have that input.
+      - linters:
+          - forbidigo
+        path-except: ^cmd/talosctl/(cmd/talos|pkg/talos)/
+      - linters:
+          - forbidigo
+        path: cmd/talosctl/pkg/talos/safeout
       - linters:
           - dupl
         path: cmd/talosctl/cmd

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/providers"
@@ -86,7 +87,7 @@ func init() {
 	destroyCmd.PersistentFlags().StringVarP(&destroyCmdFlags.saveSupportArchivePath, "save-support-archive-path", "", "", "save support archive to the specified file on destroy")
 	destroyCmd.PersistentFlags().StringVarP(&destroyCmdFlags.saveClusterLogsArchivePath, "save-cluster-logs-archive-path", "", "", "save cluster logs archive to the specified file on destroy")
 	AddProvisionerFlag(destroyCmd)
-	cli.Should(destroyCmd.Flags().MarkDeprecated(ProvisionerFlagName, "the provisioner is inferred automatically"))
+	cli.Should(helpers.MarkFlagDeprecated(destroyCmd.Flags(), ProvisionerFlagName, "the provisioner is inferred automatically"))
 
 	Cmd.AddCommand(destroyCmd)
 }

--- a/cmd/talosctl/cmd/root.go
+++ b/cmd/talosctl/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	_ "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create" // import to get the command registered via the init() function.
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/cli"
 )
 
@@ -33,16 +34,23 @@ var rootCmd = &cobra.Command{
 // Execute invokes the user-entered command in a cancellable context (with Ctrl^C).
 // Handles errors related to incorrect usage and prints the error message to stderr.
 func Execute() error {
+	// a partial UTF-8 sequence held back by the last write is released here, and
+	// the tail of the output is lost without it.
+	defer safeout.Flush() //nolint:errcheck
+
 	cmd, err := cli.WithContextC(context.Background(), rootCmd.ExecuteContextC)
 	if err != nil && !common.SuppressErrors {
-		fmt.Fprintln(os.Stderr, err.Error())
-
 		errorString := err.Error()
+
+		safeout.Flush() //nolint:errcheck
+
+		fmt.Fprintln(os.Stderr, safeout.String(errorString)) //nolint:forbidigo // the error message is filtered explicitly
+
 		// TODO: this is a nightmare, but arg-flag related validation returns simple `fmt.Errorf`, no way to distinguish
 		//       these errors
 		if strings.Contains(errorString, "arg(s)") || strings.Contains(errorString, "flag") || strings.Contains(errorString, "command") {
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, cmd.UsageString())
+			fmt.Fprintln(safeout.Stderr())
+			fmt.Fprintln(safeout.Stderr(), cmd.UsageString())
 		}
 	}
 
@@ -56,6 +64,13 @@ func init() {
 		mgmtGroup    = "mgmt"
 		clusterGroup = "cluster"
 	)
+
+	// cobra's own writers, so that anything printed through cmd.Print or cmd.OutOrStdout
+	// is filtered too. The out writer is stdout, as it is where cobra renders the help
+	// output; the messages cobra prints through it which belong on stderr are handled
+	// explicitly - see helpers.MarkFlagDeprecated.
+	rootCmd.SetOut(safeout.Stdout())
+	rootCmd.SetErr(safeout.Stderr())
 
 	rootCmd.AddGroup(&cobra.Group{ID: talosGroup, Title: "Manage running Talos clusters:"})
 	rootCmd.AddGroup(&cobra.Group{ID: mgmtGroup, Title: "Commands to generate and manage machine configuration offline:"})

--- a/cmd/talosctl/cmd/talos/bootstrap.go
+++ b/cmd/talosctl/cmd/talos/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	snapshot "go.etcd.io/etcd/etcdutl/v3/snapshot"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/logging"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 )
@@ -49,14 +50,14 @@ Talos etcd cluster can be recovered from a known snapshot with '--recover-from='
 		}
 
 		if bootstrapCmdFlags.recoverFrom != "" {
-			manager := snapshot.NewV3(logging.Wrap(os.Stderr))
+			manager := snapshot.NewV3(logging.Wrap(os.Stderr)) //nolint:forbidigo // a zap sink, not a render path
 
 			status, err := manager.Status(bootstrapCmdFlags.recoverFrom)
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("recovering from snapshot %q: hash %08x, revision %d, total keys %d, total size %d\n",
+			safeout.Printf("recovering from snapshot %q: hash %08x, revision %d, total keys %d, total size %d\n",
 				bootstrapCmdFlags.recoverFrom, status.Hash, status.Revision, status.TotalKey, status.TotalSize)
 
 			snapshot, err := os.Open(bootstrapCmdFlags.recoverFrom)

--- a/cmd/talosctl/cmd/talos/cgroups.go
+++ b/cmd/talosctl/cmd/talos/cgroups.go
@@ -21,8 +21,8 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/cgroupsprinter"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/internal/pkg/cgroups"
-	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -137,7 +137,7 @@ To see schema examples, refer to https://github.com/siderolabs/talos/tree/main/c
 			}
 		})
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 
 		defer w.Flush() //nolint:errcheck
 
@@ -161,7 +161,7 @@ func buildCgroupResolveMap(ctx context.Context, c *client.Client) map[string]str
 
 	containersResp, err := c.Containers(ctx, constants.K8sContainerdNamespace, common.ContainerDriver_CRI)
 	if err != nil {
-		cli.Warning("error getting containers: %s", err)
+		safeout.Warningf("error getting containers: %s", err)
 	} else {
 		for _, ctr := range containersResp.Messages[0].Containers {
 			if ctr.Uid != "" && ctr.PodId != "" {
@@ -186,7 +186,7 @@ func buildProcessResolveMap(ctx context.Context, c *client.Client) map[string]st
 
 	processesResp, err := c.Processes(ctx)
 	if err != nil {
-		cli.Warning("error getting processes: %s", err)
+		safeout.Warningf("error getting processes: %s", err)
 
 		return processResolveMap
 	}
@@ -219,7 +219,7 @@ func buildDevicesResolveMap(ctx context.Context, c *client.Client) map[string]st
 
 	r, err := c.Copy(ctx, "/sys/dev/block")
 	if err != nil {
-		cli.Warning("error copying devices: %s", err)
+		safeout.Warningf("error copying devices: %s", err)
 
 		return devicesResolveMap
 	}
@@ -228,7 +228,7 @@ func buildDevicesResolveMap(ctx context.Context, c *client.Client) map[string]st
 
 	gzR, err := gzip.NewReader(r)
 	if err != nil {
-		cli.Warning("error reading devices: %s", err)
+		safeout.Warningf("error reading devices: %s", err)
 
 		return devicesResolveMap
 	}

--- a/cmd/talosctl/cmd/talos/cgroupsprinter/schema.go
+++ b/cmd/talosctl/cmd/talos/cgroupsprinter/schema.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 	"text/template"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 )
 
 // Schema defines columns for cgroups printer.
@@ -46,16 +48,21 @@ func (s *Schema) HeaderLine() string {
 
 // Render returns the row line.
 func (s *Schema) Render(data any) (string, error) {
-	var rowLine strings.Builder
+	var rowLine, cell strings.Builder
 
 	for i, c := range s.Columns {
 		if i > 0 {
 			rowLine.WriteString("\t")
 		}
 
-		if err := c.Render(&rowLine, data); err != nil {
+		// the column is rendered into a buffer of its own and escaped
+		cell.Reset()
+
+		if err := c.Render(&cell, data); err != nil {
 			return "", err
 		}
+
+		rowLine.WriteString(safeout.Cell(cell.String()))
 	}
 
 	return rowLine.String(), nil

--- a/cmd/talosctl/cmd/talos/cgroupsprinter/tree.go
+++ b/cmd/talosctl/cmd/talos/cgroupsprinter/tree.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/internal/pkg/cgroups"
 )
 
@@ -62,7 +63,7 @@ func PrintNode(name string, w io.Writer, schema *Schema, node, parent *cgroups.N
 		return err
 	}
 
-	_, err = fmt.Fprintf(w, "%s%s%s\t%s\n", prefix.String(), edge, name, rowData)
+	_, err = fmt.Fprintf(w, "%s%s%s\t%s\n", prefix.String(), edge, safeout.Cell(name), rowData)
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -282,7 +283,7 @@ var configRemoveCmd = &cobra.Command{
 		for _, match := range matches {
 			if match == c.Context {
 				fmt.Fprintf(
-					os.Stderr,
+					safeout.Stderr(),
 					"skipping removal of current context %q, please change it to another before removing\n",
 					match,
 				)
@@ -297,7 +298,7 @@ var configRemoveCmd = &cobra.Command{
 					continue
 				}
 			} else {
-				fmt.Fprintf(os.Stderr, "removing context %q\n", match)
+				fmt.Fprintf(safeout.Stderr(), "removing context %q\n", match)
 			}
 
 			noChanges = false
@@ -369,7 +370,7 @@ var configGetContextsCmd = &cobra.Command{
 		keys := maps.Keys(c.Contexts)
 		slices.Sort(keys)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "CURRENT\tNAME\tENDPOINTS\tNODES")
 
 		for _, name := range keys {
@@ -393,7 +394,7 @@ var configGetContextsCmd = &cobra.Command{
 				nodes = strings.Join(context.Nodes, ",")
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", current, name, endpoints, nodes)
+			safeout.Fprintf(w, "%s\t%s\t%s\t%s\n", current, name, endpoints, nodes)
 		}
 
 		return w.Flush()
@@ -421,7 +422,7 @@ var configMergeCmd = &cobra.Command{
 
 		renames := c.Merge(secondConfig)
 		for _, rename := range renames {
-			fmt.Fprintf(os.Stderr, "renamed talosconfig context %s\n", rename.String())
+			fmt.Fprintf(safeout.Stderr(), "renamed talosconfig context %s\n", rename.String())
 		}
 
 		if err := c.Save(GlobalArgs.Talosconfig); err != nil {
@@ -604,7 +605,7 @@ var configInfoCmd = &cobra.Command{
 				return err
 			}
 
-			fmt.Print(res)
+			safeout.Print(res)
 
 			return nil
 		case "json":
@@ -613,7 +614,7 @@ var configInfoCmd = &cobra.Command{
 				return err
 			}
 
-			enc := json.NewEncoder(os.Stdout)
+			enc := json.NewEncoder(os.Stdout) //nolint:forbidigo // the encoder escapes control characters itself
 			enc.SetIndent("", "  ")
 
 			return enc.Encode(&info)
@@ -623,7 +624,7 @@ var configInfoCmd = &cobra.Command{
 				return err
 			}
 
-			return yaml.NewEncoder(os.Stdout).Encode(&info)
+			return yaml.NewEncoder(os.Stdout).Encode(&info) //nolint:forbidigo // the encoder escapes control characters itself
 		default:
 			return fmt.Errorf("unknown output format: %q", configInfoCmdFlags.output)
 		}

--- a/cmd/talosctl/cmd/talos/containers.go
+++ b/cmd/talosctl/cmd/talos/containers.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -54,7 +54,7 @@ var containersCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tIMAGE\tPID\tSTATUS")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -84,7 +84,7 @@ var containersCmd = &cobra.Command{
 								display = "└─ " + display
 							}
 
-							fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Node, p.Namespace, display, p.Image, p.Pid, p.Status)
+							safeout.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Node, p.Namespace, display, p.Image, p.Pid, p.Status)
 						}
 					}
 				}

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -64,7 +64,7 @@ captures ownership and permission bits.`,
 		localPath := args[1]
 
 		if localPath == "-" {
-			_, err = io.Copy(os.Stdout, r)
+			_, err = io.Copy(os.Stdout, r) //nolint:forbidigo // a tar stream, not text.
 
 			return err
 		}

--- a/cmd/talosctl/cmd/talos/debug.go
+++ b/cmd/talosctl/cmd/talos/debug.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -75,7 +76,7 @@ var debugCmd = &cobra.Command{
 			return err
 		}
 
-		rep := reporter.New()
+		rep := reporter.New(reporter.WithLineFilter(safeout.String))
 
 		ctrdInstance, err := debugCmdFlags.containerdInstance()
 		if err != nil {
@@ -222,7 +223,9 @@ func runContainer(
 			switch msg.Resp.(type) {
 			case *machine.DebugContainerRunResponse_StdoutData:
 				if stdoutData := msg.GetStdoutData(); stdoutData != nil {
-					os.Stdout.Write(stdoutData) //nolint:errcheck
+					// an interactive session with a pty on the node: the escape sequences
+					// are the point, exactly as they are for ssh.
+					os.Stdout.Write(stdoutData) //nolint:errcheck,forbidigo
 				}
 
 			case *machine.DebugContainerRunResponse_ExitCode:
@@ -233,7 +236,7 @@ func runContainer(
 				return
 
 			default:
-				fmt.Fprintf(os.Stderr, "unknown message type %T\n", msg.Resp)
+				fmt.Fprintf(safeout.Stderr(), "unknown message type %T\n", msg.Resp)
 			}
 		}
 	}()
@@ -244,7 +247,7 @@ func runContainer(
 	select {
 	case err := <-stdinDone:
 		if err != nil && err != io.EOF {
-			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			fmt.Fprintf(safeout.Stderr(), "%s\n", err.Error())
 		}
 
 		cancel() // cancels sigHandler, stdinReader goroutines
@@ -258,7 +261,7 @@ func runContainer(
 		// close send stream and wait for the server to exit
 		// which will cause recvLoop to return
 		if err := stream.CloseSend(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close send stream: %v\n", err)
+			fmt.Fprintf(safeout.Stderr(), "Warning: failed to close send stream: %v\n", err)
 		}
 
 		if recvErr := <-recvDone; recvErr != nil && recvErr != io.EOF {

--- a/cmd/talosctl/cmd/talos/diskfree.go
+++ b/cmd/talosctl/cmd/talos/diskfree.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -18,6 +17,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -74,7 +74,7 @@ This is a per-volume view rather than the node's full mount table: use
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		defer w.Flush() //nolint:errcheck
 
 		var (
@@ -193,13 +193,13 @@ func printDiskFreeRow(w *tabwriter.Writer, node string, row dfRow) {
 	info := row.statfs
 
 	if dfCmdFlags.inodes {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		safeout.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			node, row.volume, row.source,
 			stringifyCount(info.Inodes), stringifyCount(info.InodesUsed), stringifyCount(info.InodesFree),
 			percent(info.InodesUsed, info.Inodes), row.target,
 		)
 	} else {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		safeout.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			node, row.volume, row.source,
 			stringifySize(info.Size), stringifySize(info.Used), stringifySize(info.Available),
 			percent(info.Used, info.Used+info.Available), row.target,

--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strconv"
 	"text/tabwriter"
@@ -16,6 +15,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -81,7 +81,7 @@ var duCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		defer w.Flush() //nolint:errcheck
 
 		stringifySize := func(s int64) string {
@@ -133,7 +133,7 @@ var duCmd = &cobra.Command{
 				outputArgs = slices.Insert(outputArgs, 0, any(resp.Node))
 			}
 
-			fmt.Fprintf(w, pattern, outputArgs...)
+			safeout.Fprintf(w, pattern, outputArgs...)
 		}
 
 		return errs

--- a/cmd/talosctl/cmd/talos/dmesg.go
+++ b/cmd/talosctl/cmd/talos/dmesg.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -57,7 +58,7 @@ var dmesgCmd = &cobra.Command{
 			}
 
 			if resp.Payload.Bytes != nil {
-				fmt.Printf("%s: %s", resp.Node, resp.Payload.Bytes)
+				safeout.Printf("%s: %s", resp.Node, resp.Payload.Bytes)
 			}
 		}
 

--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util/editor/crlf"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/yamlstrip"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -109,13 +110,13 @@ func editFn() func(ctx context.Context, c *client.Client, node string, mc resour
 			}
 
 			if len(bytes.TrimSpace(bytes.TrimSpace(yamlstrip.Comments(edited)))) == 0 {
-				fmt.Fprintln(os.Stderr, "Apply was skipped: empty file.")
+				fmt.Fprintln(safeout.Stderr(), "Apply was skipped: empty file.")
 
 				break
 			}
 
 			if bytes.Equal(edited, body) {
-				fmt.Fprintln(os.Stderr, "Apply was skipped: no changes detected.")
+				fmt.Fprintln(safeout.Stderr(), "Apply was skipped: no changes detected.")
 
 				break
 			}

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	snapshot "go.etcd.io/etcd/etcdutl/v3/snapshot"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/logging"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -63,7 +64,7 @@ var etcdAlarmListCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 
 		flushTimer := time.NewTimer(outputFlushInterval)
 		defer flushTimer.Stop()
@@ -93,7 +94,7 @@ var etcdAlarmListCmd = &cobra.Command{
 								headerPrinted = true
 							}
 
-							fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+							safeout.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
 						}
 					}
 				}
@@ -131,7 +132,7 @@ var etcdAlarmDisarmCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 
 		flushTimer := time.NewTimer(outputFlushInterval)
 		defer flushTimer.Stop()
@@ -161,7 +162,7 @@ var etcdAlarmDisarmCmd = &cobra.Command{
 								headerPrinted = true
 							}
 
-							fmt.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
+							safeout.Fprintf(w, "%s\t%s\t%s\n", resp.Node, etcdresource.FormatMemberID(alarm.GetMemberId()), alarm.GetAlarm().String())
 						}
 					}
 				}
@@ -331,7 +332,7 @@ var etcdMemberListCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS\tLEARNER")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -353,7 +354,7 @@ var etcdMemberListCmd = &cobra.Command{
 				} else {
 					for _, message := range resp.Payload.Messages {
 						for _, member := range message.Members {
-							fmt.Fprintf(
+							safeout.Fprintf(
 								w, "%s\t%s\t%s\t%s\t%s\t%v\n",
 								resp.Node,
 								etcdresource.FormatMemberID(member.Id),
@@ -398,7 +399,7 @@ var etcdStatusCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tMEMBER\tDB SIZE\tIN USE\tLEADER\tRAFT INDEX\tRAFT TERM\tRAFT APPLIED INDEX\tLEARNER\tPROTOCOL\tSTORAGE\tERRORS")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -425,7 +426,7 @@ var etcdStatusCmd = &cobra.Command{
 							ratio = float64(message.GetMemberStatus().GetDbSizeInUse()) / float64(message.GetMemberStatus().GetDbSize()) * 100.0
 						}
 
-						fmt.Fprintf(
+						safeout.Fprintf(
 							w, "%s\t%s\t%s\t%s (%.2f%%)\t%s\t%d\t%d\t%d\t%v\t%s\t%s\t%s\n",
 							resp.Node,
 							etcdresource.FormatMemberID(message.GetMemberStatus().GetMemberId()),
@@ -515,16 +516,16 @@ var etcdSnapshotCmd = &cobra.Command{
 			return fmt.Errorf("error renaming to final location: %w", err)
 		}
 
-		fmt.Printf("etcd snapshot saved to %q (%d bytes)\n", dbPath, size)
+		safeout.Printf("etcd snapshot saved to %q (%d bytes)\n", dbPath, size)
 
-		manager := snapshot.NewV3(logging.Wrap(os.Stderr))
+		manager := snapshot.NewV3(logging.Wrap(os.Stderr)) //nolint:forbidigo // a zap sink, not a render path
 
 		status, err := manager.Status(dbPath)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("snapshot info: hash %08x, revision %d, total keys %d, total size %d\n",
+		safeout.Printf("snapshot info: hash %08x, revision %d, total keys %d, total size %d\n",
 			status.Hash, status.Revision, status.TotalKey, status.TotalSize)
 
 		return nil
@@ -569,7 +570,7 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 			return err
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		pattern := etcdDowngradePattern
 		header := etcdDowngradeHeader
 
@@ -578,7 +579,7 @@ var etcdDowngradeValidateCmd = &cobra.Command{
 				fmt.Fprintln(w, header)
 			}
 
-			fmt.Fprintf(
+			safeout.Fprintf(
 				w, pattern, node,
 				fmt.Sprintf(
 					"downgrade validate success, cluster version %s",
@@ -618,7 +619,7 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 			return err
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		pattern := etcdDowngradePattern
 		header := etcdDowngradeHeader
 
@@ -627,7 +628,7 @@ var etcdDowngradeEnableCmd = &cobra.Command{
 				fmt.Fprintln(w, header)
 			}
 
-			fmt.Fprintf(
+			safeout.Fprintf(
 				w, pattern,
 				node,
 				fmt.Sprintf(
@@ -666,7 +667,7 @@ var etcdDowngradeCancelCmd = &cobra.Command{
 			return err
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		pattern := etcdDowngradePattern
 		header := etcdDowngradeHeader
 
@@ -675,7 +676,7 @@ var etcdDowngradeCancelCmd = &cobra.Command{
 				fmt.Fprintln(w, header)
 			}
 
-			fmt.Fprintf(
+			safeout.Fprintf(
 				w, pattern, node,
 				fmt.Sprintf(
 					"downgrade cancel success, cluster version %s",

--- a/cmd/talosctl/cmd/talos/events.go
+++ b/cmd/talosctl/cmd/talos/events.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -68,7 +68,7 @@ var eventsCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tID\tEVENT\tACTOR\tSOURCE\tMESSAGE")
 
 		const format = "%s\t%s\t%s\n%s\t%s\t%s\n"
@@ -104,17 +104,17 @@ var eventsCmd = &cobra.Command{
 					eventArgs = append(eventArgs, msg.GetAction().String())
 				}
 			case *machine.PhaseEvent:
-				eventArgs = []any{msg.GetPhase(), msg.GetAction().String()}
+				eventArgs = []any{safeout.Cell(msg.GetPhase()), msg.GetAction().String()}
 			case *machine.TaskEvent:
-				eventArgs = []any{msg.GetTask(), msg.GetAction().String()}
+				eventArgs = []any{safeout.Cell(msg.GetTask()), msg.GetAction().String()}
 			case *machine.ServiceStateEvent:
-				eventArgs = []any{msg.GetService(), fmt.Sprintf("%s: %s", msg.GetAction(), msg.GetMessage())}
+				eventArgs = []any{safeout.Cell(msg.GetService()), fmt.Sprintf("%s: %s", msg.GetAction(), safeout.Cell(msg.GetMessage()))}
 			case *machine.ConfigLoadErrorEvent:
-				eventArgs = []any{"error", msg.GetError()}
+				eventArgs = []any{"error", safeout.Cell(msg.GetError())}
 			case *machine.ConfigValidationErrorEvent:
-				eventArgs = []any{"error", msg.GetError()}
+				eventArgs = []any{"error", safeout.Cell(msg.GetError())}
 			case *machine.AddressEvent:
-				eventArgs = []any{msg.GetHostname(), fmt.Sprintf("ADDRESSES: %s", strings.Join(msg.GetAddresses(), ","))}
+				eventArgs = []any{safeout.Cell(msg.GetHostname()), fmt.Sprintf("ADDRESSES: %s", safeout.Cell(strings.Join(msg.GetAddresses(), ",")))}
 			case *machine.MachineStatusEvent:
 				eventArgs = []any{
 					msg.GetStage().String(),
@@ -124,7 +124,7 @@ var eventsCmd = &cobra.Command{
 						xslices.Map(
 							msg.GetStatus().GetUnmetConditions(),
 							func(c *machine.MachineStatusEvent_MachineStatus_UnmetCondition) string {
-								return c.Name
+								return safeout.Cell(c.Name)
 							},
 						),
 					),
@@ -132,7 +132,7 @@ var eventsCmd = &cobra.Command{
 			}
 
 			eventArgs = append([]any{resp.Node, event.ID, event.TypeURL, event.ActorID}, eventArgs...)
-			fmt.Fprintf(w, format, eventArgs...)
+			safeout.Fprintf(w, format, eventArgs...)
 
 			if err := w.Flush(); err != nil {
 				errs = errors.Join(errs, fmt.Errorf("error flushing output: %w", err))

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
@@ -70,7 +71,7 @@ func getResources(ctx context.Context, args []string, clientFactory *global.Clie
 		return err
 	}
 
-	out, err := output.NewWriter(getCmdFlags.output)
+	out, err := output.NewWriter(getCmdFlags.output, os.Stdout) //nolint:forbidigo // wrapped per format below
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
 	"github.com/siderolabs/talos/pkg/cluster/hydrophone"
@@ -24,6 +24,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	clusterres "github.com/siderolabs/talos/pkg/machinery/resources/cluster"
+	"github.com/siderolabs/talos/pkg/reporter"
 )
 
 type clusterNodes struct {
@@ -158,7 +159,12 @@ func healthOnClient(ctx context.Context, clientFactory *global.ClientFactory) er
 	checkCtx, checkCtxCancel := context.WithTimeout(ctx, healthCmdFlags.clusterWaitTimeout)
 	defer checkCtxCancel()
 
-	return check.Wait(checkCtx, &state, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
+	// the condition lines are assembled from node names, service states and API
+	// errors the nodes chose, and the reporter colorizes them and writes to the
+	// terminal itself, so the text is filtered on its way in.
+	rep := check.StderrReporter(reporter.WithLineFilter(safeout.String))
+
+	return check.Wait(checkCtx, &state, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), rep)
 }
 
 func healthOnServer(ctx context.Context, clientFactory *global.ClientFactory) error {
@@ -195,7 +201,7 @@ func healthOnServer(ctx context.Context, clientFactory *global.ClientFactory) er
 			return err
 		}
 
-		fmt.Fprintln(os.Stderr, msg.GetMessage())
+		fmt.Fprintln(safeout.Stderr(), msg.GetMessage())
 	}
 }
 

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -36,6 +36,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/artifacts"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/internal/app/machined/pkg/system/services/registry"
 	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/imager/cache"
@@ -164,7 +165,7 @@ func imageList(ctx context.Context) error {
 		},
 	)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	headerWritten := false
 
 	var errs error
@@ -187,7 +188,7 @@ func imageList(ctx context.Context) error {
 			fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tLABELS\tCREATED")
 		}
 
-		fmt.Fprintf(
+		safeout.Fprintf(
 			w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			resp.Node,
 			resp.Payload.GetName(),
@@ -217,7 +218,7 @@ func imageListLegacy(ctx context.Context, clientFactory *global.ClientFactory) e
 		},
 	)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tIMAGE\tDIGEST\tSIZE\tCREATED")
 
 	var errs error
@@ -229,7 +230,7 @@ func imageListLegacy(ctx context.Context, clientFactory *global.ClientFactory) e
 			continue
 		}
 
-		fmt.Fprintf(
+		safeout.Fprintf(
 			w, "%s\t%s\t%s\t%s\t%s\n",
 			resp.Node,
 			resp.Payload.Name,
@@ -263,7 +264,7 @@ func imagePull(ctx context.Context, imageRef string) error {
 
 	defer clientFactory.Close() //nolint:errcheck
 
-	rep := reporter.New()
+	rep := reporter.New(reporter.WithLineFilter(safeout.String))
 
 	containerdInstance, err := imageCmdFlags.containerdInstance()
 	if err != nil {
@@ -335,7 +336,7 @@ func imagePullInternal(
 		var sb strings.Builder
 
 		for node, imageName := range finishedPulls {
-			fmt.Fprintf(&sb, "%s: pulled image %s\n", node, imageName)
+			fmt.Fprintf(&sb, "%s: pulled image %s\n", node, safeout.String(imageName))
 		}
 
 		rep.Report(reporter.Update{
@@ -564,16 +565,16 @@ var imageK8sBundleCmd = &cobra.Command{
 			},
 		)
 
-		fmt.Printf("%s\n", images.Flannel)
-		fmt.Printf("%s\n", images.CoreDNS)
-		fmt.Printf("%s\n", images.Etcd)
-		fmt.Printf("%s\n", images.Pause)
-		fmt.Printf("%s\n", images.KubeAPIServer)
-		fmt.Printf("%s\n", images.KubeControllerManager)
-		fmt.Printf("%s\n", images.KubeScheduler)
-		fmt.Printf("%s\n", images.KubeProxy)
-		fmt.Printf("%s\n", images.Kubelet)
-		fmt.Printf("%s\n", images.KubeNetworkPolicies)
+		safeout.Printf("%s\n", images.Flannel)
+		safeout.Printf("%s\n", images.CoreDNS)
+		safeout.Printf("%s\n", images.Etcd)
+		safeout.Printf("%s\n", images.Pause)
+		safeout.Printf("%s\n", images.KubeAPIServer)
+		safeout.Printf("%s\n", images.KubeControllerManager)
+		safeout.Printf("%s\n", images.KubeScheduler)
+		safeout.Printf("%s\n", images.KubeProxy)
+		safeout.Printf("%s\n", images.Kubelet)
+		safeout.Printf("%s\n", images.KubeNetworkPolicies)
 
 		return nil
 	},
@@ -652,15 +653,15 @@ var imageTalosBundleCmd = &cobra.Command{
 		sources := images.ListSourcesFor(tag)
 
 		if semTag.LT(talosLegacyInstallerMaximumVersion) {
-			fmt.Printf("%s\n", sources.Installer)
+			safeout.Printf("%s\n", sources.Installer)
 		}
 
-		fmt.Printf("%s\n", sources.InstallerBase)
-		fmt.Printf("%s\n", sources.Imager)
-		fmt.Printf("%s\n", sources.Talos)
-		fmt.Printf("%s\n", sources.TalosctlAll)
-		fmt.Printf("%s\n", sources.Overlays)
-		fmt.Printf("%s\n", sources.Extensions)
+		safeout.Printf("%s\n", sources.InstallerBase)
+		safeout.Printf("%s\n", sources.Imager)
+		safeout.Printf("%s\n", sources.Talos)
+		safeout.Printf("%s\n", sources.TalosctlAll)
+		safeout.Printf("%s\n", sources.Overlays)
+		safeout.Printf("%s\n", sources.Extensions)
 
 		digestedReferences := []string{}
 
@@ -689,7 +690,7 @@ var imageTalosBundleCmd = &cobra.Command{
 		slices.Sort(digestedReferences)
 
 		for _, ref := range slices.Compact(digestedReferences) {
-			fmt.Printf("%s\n", ref)
+			safeout.Printf("%s\n", ref)
 		}
 
 		return nil
@@ -784,7 +785,7 @@ var imageIntegrationCmd = &cobra.Command{
 		imageNames = slices.Compact(imageNames)
 
 		for _, img := range imageNames {
-			fmt.Println(img)
+			safeout.Println(img)
 		}
 
 		return nil

--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -6,11 +6,10 @@ package talos
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/formatters"
 )
 
@@ -58,10 +57,10 @@ to render the graph:
 				return fmt.Errorf("error getting controller runtime dependencies: %s", err)
 			}
 
-			cli.Warning("%s", err)
+			safeout.Warningf("%s", err)
 		}
 
-		return formatters.RenderGraph(ctx, c, resp, os.Stdout, inspectDependenciesCmdFlags.withResources)
+		return formatters.RenderGraph(ctx, c, resp, safeout.Stdout(), inspectDependenciesCmdFlags.withResources)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -19,6 +19,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	taloskubeconfig "github.com/siderolabs/talos/pkg/kubeconfig"
 )
 
@@ -129,7 +130,8 @@ If merge flag is false and [local-path] is "-", config will be written to stdout
 		}
 
 		if localPath == stdoutOutput {
-			_, err = os.Stdout.Write(data)
+			// a kubeconfig written for a program to read back.
+			_, err = os.Stdout.Write(data) //nolint:forbidigo
 
 			return err
 		}
@@ -144,12 +146,12 @@ func mergeKubeconfig(config *clientcmdapi.Config, localPath string) error {
 		return err
 	}
 
-	interactive := isatty.IsTerminal(os.Stdout.Fd())
+	interactive := isatty.IsTerminal(os.Stdout.Fd()) //nolint:forbidigo // asking about the stream, not writing to it
 
 	err = merger.Merge(config, kubeconfig.MergeOptions{
 		ActivateContext:  true,
 		ForceContextName: kubeconfigFlags.forceContextName,
-		OutputWriter:     os.Stdout,
+		OutputWriter:     os.Stdout, //nolint:forbidigo // a kubeconfig written for a program to read back
 		ConflictHandler: func(component kubeconfig.ConfigComponent, name string) (kubeconfig.ConflictDecision, error) {
 			if kubeconfigFlags.force {
 				return kubeconfig.OverwriteDecision, nil
@@ -173,7 +175,7 @@ func askOverwriteOrRename(prompt string) (kubeconfig.ConflictDecision, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s [(r)ename/(o)verwrite]: ", prompt)
+		safeout.Printf("%s [(r)ename/(o)verwrite]: ", prompt)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {

--- a/cmd/talosctl/cmd/talos/list.go
+++ b/cmd/talosctl/cmd/talos/list.go
@@ -18,6 +18,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -108,7 +109,7 @@ var lsCmd = &cobra.Command{
 		)
 
 		if !lsCmdFlags.long {
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+			w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 			defer w.Flush() //nolint:errcheck
 
 			var (
@@ -132,7 +133,7 @@ var lsCmd = &cobra.Command{
 				}
 
 				if !multipleNodes {
-					fmt.Println(info.RelativeName)
+					safeout.Println(info.RelativeName)
 
 					continue
 				}
@@ -143,7 +144,7 @@ var lsCmd = &cobra.Command{
 					headerWritten = true
 				}
 
-				fmt.Fprintf(
+				safeout.Fprintf(
 					w, "%s\t%s\n",
 					resp.Node,
 					info.RelativeName,
@@ -153,7 +154,7 @@ var lsCmd = &cobra.Command{
 			return errs
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		defer w.Flush() //nolint:errcheck
 
 		var (
@@ -218,7 +219,7 @@ var lsCmd = &cobra.Command{
 				}
 			}
 
-			fmt.Fprintf(
+			safeout.Fprintf(
 				w, "%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n",
 				resp.Node,
 				os.FileMode(info.Mode).String(),

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -84,7 +85,7 @@ var logsCmd = &cobra.Command{
 		lineBuffers := map[string][]byte{}
 
 		emit := func(node string, line []byte) error {
-			_, err := fmt.Printf("%s: %s\n", node, line)
+			_, err := safeout.Printf("%s: %s\n", node, line)
 
 			return err
 		}

--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -59,7 +59,7 @@ var memoryCmd = &cobra.Command{
 }
 
 func renderBrief(responseChan <-chan multiplex.Response[*machineapi.MemoryResponse]) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tTOTAL\tUSED\tFREE\tSHARED\tBUFFERS\tCACHE\tAVAILABLE")
 
 	flushTimer := time.NewTimer(outputFlushInterval)
@@ -81,7 +81,7 @@ func renderBrief(responseChan <-chan multiplex.Response[*machineapi.MemoryRespon
 			} else {
 				for _, msg := range resp.Payload.Messages {
 					// Default to displaying output as MB
-					fmt.Fprintf(
+					safeout.Fprintf(
 						w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
 						resp.Node,
 						msg.Meminfo.Memtotal/1024,
@@ -116,55 +116,55 @@ func renderVerbose(responseChan <-chan multiplex.Response[*machineapi.MemoryResp
 
 		// Dump as /proc/meminfo
 		for _, msg := range resp.Payload.Messages {
-			fmt.Printf("%s: %s\n", "NODE", resp.Node)
-			fmt.Printf("%s: %d %s\n", "MemTotal", msg.Meminfo.Memtotal, "kB")
-			fmt.Printf("%s: %d %s\n", "MemFree", msg.Meminfo.Memfree, "kB")
-			fmt.Printf("%s: %d %s\n", "MemAvailable", msg.Meminfo.Memavailable, "kB")
-			fmt.Printf("%s: %d %s\n", "Buffers", msg.Meminfo.Buffers, "kB")
-			fmt.Printf("%s: %d %s\n", "Cached", msg.Meminfo.Cached, "kB")
-			fmt.Printf("%s: %d %s\n", "SwapCached", msg.Meminfo.Swapcached, "kB")
-			fmt.Printf("%s: %d %s\n", "Active", msg.Meminfo.Active, "kB")
-			fmt.Printf("%s: %d %s\n", "Inactive", msg.Meminfo.Inactive, "kB")
-			fmt.Printf("%s: %d %s\n", "ActiveAnon", msg.Meminfo.Activeanon, "kB")
-			fmt.Printf("%s: %d %s\n", "InactiveAnon", msg.Meminfo.Inactiveanon, "kB")
-			fmt.Printf("%s: %d %s\n", "ActiveFile", msg.Meminfo.Activefile, "kB")
-			fmt.Printf("%s: %d %s\n", "InactiveFile", msg.Meminfo.Inactivefile, "kB")
-			fmt.Printf("%s: %d %s\n", "Unevictable", msg.Meminfo.Unevictable, "kB")
-			fmt.Printf("%s: %d %s\n", "Mlocked", msg.Meminfo.Mlocked, "kB")
-			fmt.Printf("%s: %d %s\n", "SwapTotal", msg.Meminfo.Swaptotal, "kB")
-			fmt.Printf("%s: %d %s\n", "SwapFree", msg.Meminfo.Swapfree, "kB")
-			fmt.Printf("%s: %d %s\n", "Dirty", msg.Meminfo.Dirty, "kB")
-			fmt.Printf("%s: %d %s\n", "Writeback", msg.Meminfo.Writeback, "kB")
-			fmt.Printf("%s: %d %s\n", "AnonPages", msg.Meminfo.Anonpages, "kB")
-			fmt.Printf("%s: %d %s\n", "Mapped", msg.Meminfo.Mapped, "kB")
-			fmt.Printf("%s: %d %s\n", "Shmem", msg.Meminfo.Shmem, "kB")
-			fmt.Printf("%s: %d %s\n", "Slab", msg.Meminfo.Slab, "kB")
-			fmt.Printf("%s: %d %s\n", "SReclaimable", msg.Meminfo.Sreclaimable, "kB")
-			fmt.Printf("%s: %d %s\n", "SUnreclaim", msg.Meminfo.Sunreclaim, "kB")
-			fmt.Printf("%s: %d %s\n", "KernelStack", msg.Meminfo.Kernelstack, "kB")
-			fmt.Printf("%s: %d %s\n", "PageTables", msg.Meminfo.Pagetables, "kB")
-			fmt.Printf("%s: %d %s\n", "NFSUnstable", msg.Meminfo.Nfsunstable, "kB")
-			fmt.Printf("%s: %d %s\n", "Bounce", msg.Meminfo.Bounce, "kB")
-			fmt.Printf("%s: %d %s\n", "WritebackTmp", msg.Meminfo.Writebacktmp, "kB")
-			fmt.Printf("%s: %d %s\n", "CommitLimit", msg.Meminfo.Commitlimit, "kB")
-			fmt.Printf("%s: %d %s\n", "CommittedAS", msg.Meminfo.Committedas, "kB")
-			fmt.Printf("%s: %d %s\n", "VmallocTotal", msg.Meminfo.Vmalloctotal, "kB")
-			fmt.Printf("%s: %d %s\n", "VmallocUsed", msg.Meminfo.Vmallocused, "kB")
-			fmt.Printf("%s: %d %s\n", "VmallocChunk", msg.Meminfo.Vmallocchunk, "kB")
-			fmt.Printf("%s: %d %s\n", "HardwareCorrupted", msg.Meminfo.Hardwarecorrupted, "kB")
-			fmt.Printf("%s: %d %s\n", "AnonHugePages", msg.Meminfo.Anonhugepages, "kB")
-			fmt.Printf("%s: %d %s\n", "ShmemHugePages", msg.Meminfo.Shmemhugepages, "kB")
-			fmt.Printf("%s: %d %s\n", "ShmemPmdMapped", msg.Meminfo.Shmempmdmapped, "kB")
-			fmt.Printf("%s: %d %s\n", "CmaTotal", msg.Meminfo.Cmatotal, "kB")
-			fmt.Printf("%s: %d %s\n", "CmaFree", msg.Meminfo.Cmafree, "kB")
-			fmt.Printf("%s: %d\n", "HugePagesTotal", msg.Meminfo.Hugepagestotal)
-			fmt.Printf("%s: %d\n", "HugePagesFree", msg.Meminfo.Hugepagesfree)
-			fmt.Printf("%s: %d\n", "HugePagesRsvd", msg.Meminfo.Hugepagesrsvd)
-			fmt.Printf("%s: %d\n", "HugePagesSurp", msg.Meminfo.Hugepagessurp)
-			fmt.Printf("%s: %d %s\n", "Hugepagesize", msg.Meminfo.Hugepagesize, "kB")
-			fmt.Printf("%s: %d %s\n", "DirectMap4k", msg.Meminfo.Directmap4K, "kB")
-			fmt.Printf("%s: %d %s\n", "DirectMap2M", msg.Meminfo.Directmap2M, "kB")
-			fmt.Printf("%s: %d %s\n", "DirectMap1G", msg.Meminfo.Directmap1G, "kB")
+			safeout.Printf("%s: %s\n", "NODE", resp.Node)
+			safeout.Printf("%s: %d %s\n", "MemTotal", msg.Meminfo.Memtotal, "kB")
+			safeout.Printf("%s: %d %s\n", "MemFree", msg.Meminfo.Memfree, "kB")
+			safeout.Printf("%s: %d %s\n", "MemAvailable", msg.Meminfo.Memavailable, "kB")
+			safeout.Printf("%s: %d %s\n", "Buffers", msg.Meminfo.Buffers, "kB")
+			safeout.Printf("%s: %d %s\n", "Cached", msg.Meminfo.Cached, "kB")
+			safeout.Printf("%s: %d %s\n", "SwapCached", msg.Meminfo.Swapcached, "kB")
+			safeout.Printf("%s: %d %s\n", "Active", msg.Meminfo.Active, "kB")
+			safeout.Printf("%s: %d %s\n", "Inactive", msg.Meminfo.Inactive, "kB")
+			safeout.Printf("%s: %d %s\n", "ActiveAnon", msg.Meminfo.Activeanon, "kB")
+			safeout.Printf("%s: %d %s\n", "InactiveAnon", msg.Meminfo.Inactiveanon, "kB")
+			safeout.Printf("%s: %d %s\n", "ActiveFile", msg.Meminfo.Activefile, "kB")
+			safeout.Printf("%s: %d %s\n", "InactiveFile", msg.Meminfo.Inactivefile, "kB")
+			safeout.Printf("%s: %d %s\n", "Unevictable", msg.Meminfo.Unevictable, "kB")
+			safeout.Printf("%s: %d %s\n", "Mlocked", msg.Meminfo.Mlocked, "kB")
+			safeout.Printf("%s: %d %s\n", "SwapTotal", msg.Meminfo.Swaptotal, "kB")
+			safeout.Printf("%s: %d %s\n", "SwapFree", msg.Meminfo.Swapfree, "kB")
+			safeout.Printf("%s: %d %s\n", "Dirty", msg.Meminfo.Dirty, "kB")
+			safeout.Printf("%s: %d %s\n", "Writeback", msg.Meminfo.Writeback, "kB")
+			safeout.Printf("%s: %d %s\n", "AnonPages", msg.Meminfo.Anonpages, "kB")
+			safeout.Printf("%s: %d %s\n", "Mapped", msg.Meminfo.Mapped, "kB")
+			safeout.Printf("%s: %d %s\n", "Shmem", msg.Meminfo.Shmem, "kB")
+			safeout.Printf("%s: %d %s\n", "Slab", msg.Meminfo.Slab, "kB")
+			safeout.Printf("%s: %d %s\n", "SReclaimable", msg.Meminfo.Sreclaimable, "kB")
+			safeout.Printf("%s: %d %s\n", "SUnreclaim", msg.Meminfo.Sunreclaim, "kB")
+			safeout.Printf("%s: %d %s\n", "KernelStack", msg.Meminfo.Kernelstack, "kB")
+			safeout.Printf("%s: %d %s\n", "PageTables", msg.Meminfo.Pagetables, "kB")
+			safeout.Printf("%s: %d %s\n", "NFSUnstable", msg.Meminfo.Nfsunstable, "kB")
+			safeout.Printf("%s: %d %s\n", "Bounce", msg.Meminfo.Bounce, "kB")
+			safeout.Printf("%s: %d %s\n", "WritebackTmp", msg.Meminfo.Writebacktmp, "kB")
+			safeout.Printf("%s: %d %s\n", "CommitLimit", msg.Meminfo.Commitlimit, "kB")
+			safeout.Printf("%s: %d %s\n", "CommittedAS", msg.Meminfo.Committedas, "kB")
+			safeout.Printf("%s: %d %s\n", "VmallocTotal", msg.Meminfo.Vmalloctotal, "kB")
+			safeout.Printf("%s: %d %s\n", "VmallocUsed", msg.Meminfo.Vmallocused, "kB")
+			safeout.Printf("%s: %d %s\n", "VmallocChunk", msg.Meminfo.Vmallocchunk, "kB")
+			safeout.Printf("%s: %d %s\n", "HardwareCorrupted", msg.Meminfo.Hardwarecorrupted, "kB")
+			safeout.Printf("%s: %d %s\n", "AnonHugePages", msg.Meminfo.Anonhugepages, "kB")
+			safeout.Printf("%s: %d %s\n", "ShmemHugePages", msg.Meminfo.Shmemhugepages, "kB")
+			safeout.Printf("%s: %d %s\n", "ShmemPmdMapped", msg.Meminfo.Shmempmdmapped, "kB")
+			safeout.Printf("%s: %d %s\n", "CmaTotal", msg.Meminfo.Cmatotal, "kB")
+			safeout.Printf("%s: %d %s\n", "CmaFree", msg.Meminfo.Cmafree, "kB")
+			safeout.Printf("%s: %d\n", "HugePagesTotal", msg.Meminfo.Hugepagestotal)
+			safeout.Printf("%s: %d\n", "HugePagesFree", msg.Meminfo.Hugepagesfree)
+			safeout.Printf("%s: %d\n", "HugePagesRsvd", msg.Meminfo.Hugepagesrsvd)
+			safeout.Printf("%s: %d\n", "HugePagesSurp", msg.Meminfo.Hugepagessurp)
+			safeout.Printf("%s: %d %s\n", "Hugepagesize", msg.Meminfo.Hugepagesize, "kB")
+			safeout.Printf("%s: %d %s\n", "DirectMap4k", msg.Meminfo.Directmap4K, "kB")
+			safeout.Printf("%s: %d %s\n", "DirectMap2M", msg.Meminfo.Directmap2M, "kB")
+			safeout.Printf("%s: %d %s\n", "DirectMap1G", msg.Meminfo.Directmap1G, "kB")
 		}
 	}
 

--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -45,12 +45,12 @@ var mountsCmd = &cobra.Command{
 			},
 		)
 
-		return renderMounts(os.Stdout, responseChan)
+		return RenderMounts(safeout.Stdout(), responseChan)
 	},
 }
 
-// renderMounts renders the mounts output for a stream of multiplexed responses.
-func renderMounts(output io.Writer, responseChan <-chan multiplex.Response[*machineapi.MountsResponse]) error {
+// RenderMounts renders the mounts output for a stream of multiplexed responses.
+func RenderMounts(output io.Writer, responseChan <-chan multiplex.Response[*machineapi.MountsResponse]) error {
 	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tFILESYSTEM\tSIZE(GB)\tUSED(GB)\tAVAILABLE(GB)\tPERCENT USED\tMOUNTED ON")
 
@@ -79,7 +79,7 @@ func renderMounts(output io.Writer, responseChan <-chan multiplex.Response[*mach
 							continue
 						}
 
-						fmt.Fprintf(
+						safeout.Fprintf(
 							w, "%s\t%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n",
 							resp.Node,
 							r.Filesystem,

--- a/cmd/talosctl/cmd/talos/mounts_test.go
+++ b/cmd/talosctl/cmd/talos/mounts_test.go
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
+)
+
+// TestRenderMountsEscapesNodeStrings drives a whole command's render path:
+// the tabwriter sits between the command and the escaped output, and
+// it consumes a tab or a newline in a value before any writer can see it.
+func TestRenderMountsEscapesNodeStrings(t *testing.T) {
+	t.Parallel()
+
+	// everything a compromised node controls in this response.
+	const (
+		clipboard  = "\x1b]52;c;RjMtQ0xJUEJPQVJELUhJSkFDSw==\x07"
+		repaint    = "\x1b[2J\x1b[HREPAINTED"
+		lineRewind = "junk\rOVERWRITTEN"
+		columns    = "a\tb\nNODE\tfake\trow"
+	)
+
+	responseChan := make(chan multiplex.Response[*machineapi.MountsResponse], 1)
+	responseChan <- multiplex.Response[*machineapi.MountsResponse]{
+		Node: "10.0.0.1",
+		Payload: &machineapi.MountsResponse{
+			Messages: []*machineapi.Mounts{
+				{
+					Stats: []*machineapi.MountStat{
+						{Filesystem: clipboard, MountedOn: repaint, Size: 100, Available: 50},
+						{Filesystem: lineRewind, MountedOn: columns, Size: 100, Available: 50},
+					},
+				},
+			},
+		},
+	}
+
+	close(responseChan)
+
+	var buf bytes.Buffer
+
+	require.NoError(t, talos.RenderMounts(&buf, responseChan))
+
+	out := buf.String()
+
+	for _, r := range out {
+		assert.True(t, r == '\n' || unicode.IsPrint(r), "rune %U reached the terminal", r)
+	}
+
+	// the escaped text is still there to be read, just inert.
+	assert.Contains(t, out, `\x1b]52;c;`)
+	assert.Contains(t, out, `\x0dOVERWRITTEN`)
+
+	// a node cannot forge extra rows or columns: one header plus one row per stat.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	assert.Len(t, lines, 3)
+	assert.NotContains(t, lines[1], "fake")
+}

--- a/cmd/talosctl/cmd/talos/namespace_test.go
+++ b/cmd/talosctl/cmd/talos/namespace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
@@ -180,7 +181,7 @@ func TestKubernetesFlagIsDeprecated(t *testing.T) {
 			flag := tc.cmd.Flags().Lookup("kubernetes")
 
 			require.NotNil(t, flag)
-			assert.NotEmpty(t, flag.Deprecated, "expected --kubernetes to be marked deprecated")
+			assert.NotEmpty(t, helpers.DeprecationMessage(flag), "expected --kubernetes to be marked deprecated")
 		})
 	}
 }

--- a/cmd/talosctl/cmd/talos/netstat.go
+++ b/cmd/talosctl/cmd/talos/netstat.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -16,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -121,7 +120,7 @@ If you don't pass an argument, the command will show host connections.`,
 		}
 
 		printer := &netstatPrinter{
-			w:             tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0),
+			w:             tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0),
 			nodeNetNSPods: nodeNetNSPods,
 		}
 
@@ -131,7 +130,7 @@ If you don't pass an argument, the command will show host connections.`,
 			foundNode, foundNetNs := findPodNetNs(nodeNetNSPods, args[0])
 
 			if foundNetNs == "" {
-				cli.Fatalf("pod %s not found", args[0])
+				return fmt.Errorf("pod %s not found", args[0])
 			}
 
 			req.Netns.Netns = []string{foundNetNs}
@@ -148,7 +147,7 @@ If you don't pass an argument, the command will show host connections.`,
 					return err
 				}
 
-				cli.Warning("%s", err)
+				safeout.Warningf("%s", err)
 			}
 
 			printer.printResponse(foundNode, response)
@@ -380,7 +379,7 @@ func (p *netstatPrinter) printResponse(node string, response *machine.NetstatRes
 			pattern := strings.Repeat("%s\t", len(args))
 			pattern = strings.TrimSpace(pattern) + "\n"
 
-			fmt.Fprintf(p.w, pattern, args...)
+			safeout.Fprintf(p.w, pattern, args...)
 		}
 	}
 }

--- a/cmd/talosctl/cmd/talos/output/output.go
+++ b/cmd/talosctl/cmd/talos/output/output.go
@@ -7,7 +7,7 @@ package output
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -15,6 +15,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/jsonpath"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 )
 
 // Writer interface.
@@ -24,17 +26,23 @@ type Writer interface {
 	Flush() error
 }
 
-// NewWriter builds writer from type.
-func NewWriter(format string) (Writer, error) {
-	writer := os.Stdout
+// NewWriter builds a writer over out, taking the raw stream so that the choice of
+// which formats are filtered is testable.
+//
+// A resource comes from the node, so its ID, its spec and even the print columns
+// of its definition are node-supplied. The JSON and YAML encoders escape control
+// characters themselves and are handed the raw stream; the table and jsonpath
+// writers render values verbatim and are handed the filtered one.
+func NewWriter(format string, out io.Writer) (Writer, error) {
+	filtered := safeout.NewWriter(out)
 
 	switch {
 	case format == "table":
-		return NewTable(writer), nil
+		return filterFlusher{NewTable(filtered), filtered}, nil
 	case format == "yaml":
-		return NewYAML(writer), nil
+		return NewYAML(out), nil
 	case format == "json":
-		return NewJSON(writer), nil
+		return NewJSON(out), nil
 	case strings.HasPrefix(format, "jsonpath="):
 		path := format[len("jsonpath="):]
 
@@ -44,10 +52,29 @@ func NewWriter(format string) (Writer, error) {
 			return nil, fmt.Errorf("error parsing jsonpath: %w", err)
 		}
 
-		return NewJSONPath(writer, jp), nil
+		// a jsonpath expression selecting a scalar renders it verbatim, unlike the
+		// JSON branch of the same writer. The filter is the identity on printable
+		// UTF-8, so `-o jsonpath=` stays usable from a script.
+		return filterFlusher{NewJSONPath(filtered, jp), filtered}, nil
 	default:
 		return nil, fmt.Errorf("output format %q is not supported", format)
 	}
+}
+
+// filterFlusher extends Flush down to the escaping stream, which otherwise holds
+// on to the trailing bytes of a value that ends mid-rune.
+type filterFlusher struct {
+	Writer
+
+	filter *safeout.Writer
+}
+
+func (f filterFlusher) Flush() error {
+	if err := f.Writer.Flush(); err != nil {
+		return err
+	}
+
+	return f.filter.Flush()
 }
 
 // CompleteOutputArg represents tab completion for `--output` argument.

--- a/cmd/talosctl/cmd/talos/output/output_test.go
+++ b/cmd/talosctl/cmd/talos/output/output_test.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package output_test
+
+import (
+	"bytes"
+	"testing"
+	"unicode"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/talos/output"
+	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
+)
+
+// TestNoFormatRendersControlCharacters pins the decision in newWriter about which
+// output formats are filtered.
+//
+// A resource is served by the node, so its ID is node-supplied. The JSON and YAML
+// encoders escape control characters themselves; the table and jsonpath writers
+// render values verbatim and need the filter. Every format has to come out inert,
+// however it gets there.
+func TestNoFormatRendersControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	// OSC 52 writes the operator's clipboard; the bare CR overwrites the line
+	// talosctl printed itself.
+	const payload = "cpu\x1b]52;c;RjM=\x07\x1b[2Jjunk\rOVERWRITTEN"
+
+	for _, format := range []string{"table", "yaml", "json", "jsonpath={.metadata.id}"} {
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			out, err := output.NewWriter(format, &buf)
+			require.NoError(t, err)
+
+			require.NoError(t, out.WriteResource("10.0.0.1", hardware.NewProcessorInfo(payload), state.Created))
+			require.NoError(t, out.Flush())
+
+			assert.NotEmpty(t, buf.String())
+
+			for _, r := range buf.String() {
+				assert.True(t, r == '\n' || r == '\t' || unicode.IsPrint(r), "rune %U reached the terminal in %s output", r, format)
+			}
+		})
+	}
+}
+
+// TestJSONPathScalarEscaped: the scalar branch of the jsonpath writer prints the
+// value with no encoder in front of it, which is the branch the JSON one does not
+// cover.
+func TestJSONPathScalarEscaped(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	out, err := output.NewWriter("jsonpath={.metadata.id}", &buf)
+	require.NoError(t, err)
+
+	require.NoError(t, out.WriteResource("10.0.0.1", hardware.NewProcessorInfo("cpu\x1b[2Jwiped"), state.Created))
+	require.NoError(t, out.Flush())
+
+	assert.Equal(t, `cpu\x1b[2Jwiped`+"\n", buf.String())
+}
+
+// TestJSONPathPassthrough: an ordinary value is untouched, so `-o jsonpath=` stays
+// usable from a script.
+func TestJSONPathPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	out, err := output.NewWriter("jsonpath={.metadata.id}", &buf)
+	require.NoError(t, err)
+
+	require.NoError(t, out.WriteResource("10.0.0.1", hardware.NewProcessorInfo("CPU0"), state.Created))
+	require.NoError(t, out.Flush())
+
+	assert.Equal(t, "CPU0\n", buf.String())
+}

--- a/cmd/talosctl/cmd/talos/output/table.go
+++ b/cmd/talosctl/cmd/talos/output/table.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.yaml.in/yaml/v4"
 	"k8s.io/client-go/util/jsonpath"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 )
 
 // Table outputs resources in Table view.
@@ -46,12 +48,14 @@ func (table *Table) WriteHeader(definition *meta.ResourceDefinition, withEvents 
 		fields = slices.Insert(fields, 0, "*")
 	}
 
-	table.displayType = definition.TypedSpec().DisplayType
+	// the resource definition is served by the node, so the display type and the
+	// column names are node-supplied too, not just the rows.
+	table.displayType = safeout.Cell(definition.TypedSpec().DisplayType)
 
 	for _, column := range definition.TypedSpec().PrintColumns {
 		name := column.Name
 
-		fields = append(fields, strings.ToUpper(name))
+		fields = append(fields, safeout.Cell(strings.ToUpper(name)))
 
 		expr := jsonpath.New(name)
 		if err := expr.Parse(column.JSONPath); err != nil {
@@ -80,7 +84,7 @@ func (table *Table) WriteHeader(definition *meta.ResourceDefinition, withEvents 
 
 // WriteResource implements output.Writer interface.
 func (table *Table) WriteResource(node string, r resource.Resource, event state.EventType) error {
-	values := []string{r.Metadata().Namespace(), table.displayType, r.Metadata().ID(), r.Metadata().Version().String()}
+	values := []string{safeout.Cell(r.Metadata().Namespace()), table.displayType, safeout.Cell(r.Metadata().ID()), r.Metadata().Version().String()}
 
 	if table.withEvents {
 		var label string
@@ -118,7 +122,11 @@ func (table *Table) WriteResource(node string, r resource.Resource, event state.
 			return err
 		}
 
-		values = append(values, value)
+		// every cell is escaped rather than only filtered on the way out, because a
+		// tab in a value is read by the tabwriter as a column separator and a newline
+		// ends the row: a node choosing either one rewrites the shape of the table
+		// around it, and the tabwriter has consumed both before any writer sees them.
+		values = append(values, safeout.Cell(value))
 	}
 
 	values = slices.Insert(values, 0, node)

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -19,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/yamlstrip"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -97,13 +97,13 @@ func patchFn(patches []configpatcher.Patch) func(context.Context, *client.Client
 			bytes.TrimSpace(yamlstrip.Comments(patched)),
 			bytes.TrimSpace(yamlstrip.Comments(body)),
 		) {
-			fmt.Fprintln(os.Stderr, "Apply was skipped: no changes detected.")
+			fmt.Fprintln(safeout.Stderr(), "Apply was skipped: no changes detected.")
 
 			return nil
 		}
 
 		fmt.Fprintf(
-			os.Stderr, "patched %s/%s at the node %s\n",
+			safeout.Stderr(), "patched %s/%s at the node %s\n",
 			mc.Metadata().Type(),
 			mc.Metadata().ID(),
 			node,

--- a/cmd/talosctl/cmd/talos/pcap.go
+++ b/cmd/talosctl/cmd/talos/pcap.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
@@ -107,7 +109,7 @@ e.g. by excluding packets with the port 50000.
 		var out io.Writer
 
 		if pcapCmdFlags.output == "-" {
-			out = os.Stdout
+			out = os.Stdout //nolint:forbidigo // a pcap file, not text
 		} else {
 			out, err = os.Create(pcapCmdFlags.output)
 			if err != nil {
@@ -150,9 +152,9 @@ func dumpPackets(ctx context.Context, r io.Reader) error {
 		func(packet gopacket.Packet, err error) {
 			switch err {
 			case nil:
-				fmt.Println(packet)
+				safeout.Println(packet)
 			default:
-				fmt.Println("packet capture error:", err)
+				safeout.Println("packet capture error:", err)
 			}
 		},
 	)
@@ -207,7 +209,7 @@ func init() {
 	pcapCmd.Flags().StringVarP(&pcapCmdFlags.output, "output", "o", "", "if not set, decode packets to stdout; if set write raw pcap data to a file, use '-' for stdout")
 	pcapCmd.Flags().StringVar(&pcapCmdFlags.bpfFilter, "bpf-filter", "", "bpf filter to apply, tcpdump -dd format")
 	pcapCmd.Flags().DurationVar(&pcapCmdFlags.duration, "duration", 0, "duration of the capture")
-	pcapCmd.Flags().MarkDeprecated("snaplen", "support of snap length is removed") //nolint:errcheck
+	helpers.MarkFlagDeprecated(pcapCmd.Flags(), "snaplen", "support of snap length is removed") //nolint:errcheck
 
 	addCommand(pcapCmd)
 }

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -51,7 +51,7 @@ var processesCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tPID\tSTATE\tTHREADS\tCPU-TIME\tVIRTMEM\tRESMEM\tLABEL\tCOMMAND")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -82,7 +82,7 @@ var processesCmd = &cobra.Command{
 						}
 
 						for _, p := range procs {
-							fmt.Fprintf(
+							safeout.Fprintf(
 								w, "%s\t%d\t%s\t%d\t%.2f\t%s\t%s\t%s\t%s\n",
 								resp.Node, p.Pid, p.State, p.Threads, p.CpuTime,
 								humanize.Bytes(p.VirtualMemory), humanize.Bytes(p.ResidentMemory),

--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -48,7 +48,9 @@ var readCmd = &cobra.Command{
 
 		defer r.Close() //nolint:errcheck
 
-		_, err = io.Copy(os.Stdout, r)
+		// the file is arbitrary bytes, not text: it is routinely redirected to a
+		// file, so it is passed through unmodified.
+		_, err = io.Copy(os.Stdout, r) //nolint:forbidigo
 		if err != nil {
 			return fmt.Errorf("error reading: %w", err)
 		}

--- a/cmd/talosctl/cmd/talos/reboot.go
+++ b/cmd/talosctl/cmd/talos/reboot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -69,6 +70,7 @@ func rebootRun(ctx context.Context, opts []client.RebootMode) (retErr error) {
 
 	rep := reporter.New(
 		reporter.WithOutputMode(rebootCmdFlags.progress.Value()),
+		reporter.WithLineFilter(safeout.String),
 	)
 
 	if !rebootCmdFlags.drain {

--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -63,7 +64,7 @@ func (f containerNamespaceFlag) resolveContainerNamespace() (string, common.Cont
 // operator had asked for another.
 func addContainerNamespaceFlags(cmd *cobra.Command, flags *containerNamespaceFlag) {
 	cmd.Flags().BoolVarP(&flags.kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
-	cmd.Flags().MarkDeprecated("kubernetes", "use --namespace cri instead") //nolint:errcheck
+	helpers.MarkFlagDeprecated(cmd.Flags(), "kubernetes", "use --namespace cri instead") //nolint:errcheck
 	cmd.Flags().StringVar(&flags.namespace, "namespace", "system",
 		"namespace to use: \"system\" (default, Talos service containers), \"cri\" for Kubernetes workloads, \""+
 			constants.TalosContainersContainerdNamespace+"\" for containers declared via ContainerConfig")

--- a/cmd/talosctl/cmd/talos/rotate-ca.go
+++ b/cmd/talosctl/cmd/talos/rotate-ca.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
@@ -141,7 +142,7 @@ func rotateTalosCA(ctx context.Context, oldClient *client.Client, encoderOpt enc
 
 		EncoderOption: encoderOpt,
 
-		Printf: func(format string, args ...any) { fmt.Printf(format, args...) },
+		Printf: func(format string, args ...any) { safeout.Printf(format, args...) },
 	}
 
 	newTalosconfig, err := talos.Rotate(ctx, options)
@@ -150,12 +151,12 @@ func rotateTalosCA(ctx context.Context, oldClient *client.Client, encoderOpt enc
 	}
 
 	if rotateCACmdFlags.dryRun {
-		fmt.Println("> Dry-run mode enabled, no changes were made to the cluster, re-run with `--dry-run=false` to apply the changes.")
+		safeout.Println("> Dry-run mode enabled, no changes were made to the cluster, re-run with `--dry-run=false` to apply the changes.")
 
 		return nil, nil
 	}
 
-	fmt.Printf("> Writing new talosconfig to %q\n", rotateCACmdFlags.output)
+	safeout.Printf("> Writing new talosconfig to %q\n", rotateCACmdFlags.output)
 
 	return newTalosconfig, newTalosconfig.Save(rotateCACmdFlags.output)
 }
@@ -173,7 +174,7 @@ func rotateKubernetesCA(ctx context.Context, c *client.Client, encoderOpt encode
 
 		EncoderOption: encoderOpt,
 
-		Printf: func(format string, args ...any) { fmt.Printf(format, args...) },
+		Printf: func(format string, args ...any) { safeout.Printf(format, args...) },
 	}
 
 	if err := kubernetes.Rotate(ctx, options); err != nil {
@@ -181,12 +182,12 @@ func rotateKubernetesCA(ctx context.Context, c *client.Client, encoderOpt encode
 	}
 
 	if rotateCACmdFlags.dryRun {
-		fmt.Println("> Dry-run mode enabled, no changes were made to the cluster, re-run with `--dry-run=false` to apply the changes.")
+		safeout.Println("> Dry-run mode enabled, no changes were made to the cluster, re-run with `--dry-run=false` to apply the changes.")
 
 		return nil
 	}
 
-	fmt.Printf("> Kubernetes CA rotation done, new 'kubeconfig' can be fetched with `talosctl kubeconfig`.\n")
+	safeout.Printf("> Kubernetes CA rotation done, new 'kubeconfig' can be fetched with `talosctl kubeconfig`.\n")
 
 	return nil
 }

--- a/cmd/talosctl/cmd/talos/service.go
+++ b/cmd/talosctl/cmd/talos/service.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -92,7 +92,7 @@ func serviceList(ctx context.Context, clientFactory *global.ClientFactory) error
 		},
 	)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tSERVICE\tSTATE\tHEALTH\tLAST CHANGE\tLAST EVENT")
 
 	var errs error
@@ -108,7 +108,7 @@ func serviceList(ctx context.Context, clientFactory *global.ClientFactory) error
 			for _, s := range msg.Services {
 				svc := serviceInfoWrapper{s}
 
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s\n", resp.Node, svc.Id, svc.State, svc.healthStatus(), svc.lastUpdated(), svc.lastEvent())
+				safeout.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s\n", resp.Node, svc.Id, svc.State, svc.healthStatus(), svc.lastUpdated(), svc.lastEvent())
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func serviceInfo(ctx context.Context, clientFactory *global.ClientFactory, id st
 		},
 	)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 
 	var (
 		errs  error
@@ -160,13 +160,13 @@ func serviceInfo(ctx context.Context, clientFactory *global.ClientFactory, id st
 func renderServiceInfo(w *tabwriter.Writer, node string, s *machineapi.ServiceInfo) {
 	svc := serviceInfoWrapper{s}
 
-	fmt.Fprintf(w, "NODE\t%s\n", node)
-	fmt.Fprintf(w, "ID\t%s\n", svc.Id)
-	fmt.Fprintf(w, "STATE\t%s\n", svc.State)
-	fmt.Fprintf(w, "HEALTH\t%s\n", svc.healthStatus())
+	safeout.Fprintf(w, "NODE\t%s\n", node)
+	safeout.Fprintf(w, "ID\t%s\n", svc.Id)
+	safeout.Fprintf(w, "STATE\t%s\n", svc.State)
+	safeout.Fprintf(w, "HEALTH\t%s\n", svc.healthStatus())
 
 	if svc.Health.LastMessage != "" {
-		fmt.Fprintf(w, "LAST HEALTH MESSAGE\t%s\n", svc.Health.LastMessage)
+		safeout.Fprintf(w, "LAST HEALTH MESSAGE\t%s\n", svc.Health.LastMessage)
 	}
 
 	label := "EVENTS"
@@ -175,7 +175,7 @@ func renderServiceInfo(w *tabwriter.Writer, node string, s *machineapi.ServiceIn
 		event := svc.Events.Events[len(svc.Events.Events)-1-i]
 
 		ts := event.Ts.AsTime()
-		fmt.Fprintf(w, "%s\t[%s]: %s (%s ago)\n", label, event.State, event.Msg, time.Since(ts).Round(time.Second))
+		safeout.Fprintf(w, "%s\t[%s]: %s (%s ago)\n", label, event.State, event.Msg, time.Since(ts).Round(time.Second))
 		label = ""
 	}
 }
@@ -225,7 +225,7 @@ func serviceActionRun[RespT any](
 ) error {
 	responseChan := multiplex.UnaryViaFactory(ctx, clientFactory, call)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tRESPONSE")
 
 	var errs error
@@ -238,7 +238,7 @@ func serviceActionRun[RespT any](
 		}
 
 		for _, r := range responses(resp.Payload) {
-			fmt.Fprintf(w, "%s\t%s\n", resp.Node, r)
+			safeout.Fprintf(w, "%s\t%s\n", resp.Node, r)
 		}
 	}
 

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -53,7 +53,7 @@ var statsCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tNAMESPACE\tID\tMEMORY(MB)\tCPU")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -83,7 +83,7 @@ var statsCmd = &cobra.Command{
 								display = "└─ " + display
 							}
 
-							fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
+							safeout.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
 						}
 					}
 				}

--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/kubeconfig"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clusterresource "github.com/siderolabs/talos/pkg/machinery/resources/cluster"
@@ -99,10 +100,10 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 
 			encryptionOpts = opts
 
-			fmt.Fprintln(os.Stderr, "Encrypting support bundle to the following recipients:")
+			fmt.Fprintln(safeout.Stderr(), "Encrypting support bundle to the following recipients:")
 
 			for _, r := range recipients {
-				fmt.Fprintf(os.Stderr, "  - %s\n", r)
+				fmt.Fprintf(safeout.Stderr(), "  - %s\n", r)
 			}
 		}
 
@@ -165,7 +166,7 @@ Default encryption recipients can be removed by setting --encryption-no-default-
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "Support bundle is written to %s\n", supportCmdFlags.output)
+		fmt.Fprintf(safeout.Stderr(), "Support bundle is written to %s\n", supportCmdFlags.output)
 
 		return collectErr
 	},
@@ -314,7 +315,7 @@ func openArchive(ctx context.Context, clientFactory *global.ClientFactory) (*os.
 	} else {
 		buf := bufio.NewReader(os.Stdin)
 
-		fmt.Printf("%s already exists, overwrite? [y/N]: ", supportCmdFlags.output)
+		safeout.Printf("%s already exists, overwrite? [y/N]: ", supportCmdFlags.output)
 
 		choice, err := buf.ReadString('\n')
 		if err != nil {
@@ -354,13 +355,19 @@ func (sbe *supportBundleErrors) print() error {
 
 	var wroteHeader bool
 
-	w := tabwriter.NewWriter(os.Stderr, 0, 0, 3, ' ', 0)
+	// the rows are colorized, and a color escape written through the filter would be
+	// escaped into literal text, so the stream stays raw and every cell coming from
+	// a node is escaped by hand below.
+	w := tabwriter.NewWriter(os.Stderr, 0, 0, 3, ' ', 0) //nolint:forbidigo // see above
 
 	for _, err := range sbe.errors {
 		if !wroteHeader {
 			wroteHeader = true
 
-			fmt.Fprintln(os.Stderr, "Processed with errors:")
+			// the header goes through the tabwriter too, so that it keeps its place
+			// in the output: a line without a tab is a block of its own and is
+			// written out unchanged.
+			fmt.Fprintln(w, "Processed with errors:")
 			fmt.Fprintln(w, "\tSOURCE\tERROR")
 		}
 
@@ -369,11 +376,11 @@ func (sbe *supportBundleErrors) print() error {
 			details[i] = strings.TrimSpace(d)
 		}
 
-		fmt.Fprintf(w, "\t%s\t%s\n", err.source, color.RedString(details[0]))
+		fmt.Fprintf(w, "\t%s\t%s\n", safeout.Cell(err.source), color.RedString("%s", safeout.Cell(details[0])))
 
 		if len(details) > 1 {
 			for _, line := range details[1:] {
-				fmt.Fprintf(w, "\t\t%s\n", color.RedString(line))
+				fmt.Fprintf(w, "\t\t%s\n", color.RedString("%s", safeout.Cell(line)))
 			}
 		}
 	}

--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	timeapi "github.com/siderolabs/talos/pkg/machinery/api/time"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -50,7 +50,7 @@ var timeCmd = &cobra.Command{
 			},
 		)
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 		fmt.Fprintln(w, "NODE\tNTP-SERVER\tNODE-TIME\tNTP-SERVER-TIME")
 
 		flushTimer := time.NewTimer(outputFlushInterval)
@@ -83,7 +83,7 @@ var timeCmd = &cobra.Command{
 							continue
 						}
 
-						fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.Node, msg.Server, msg.Localtime.AsTime().String(), msg.Remotetime.AsTime().String())
+						safeout.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.Node, msg.Server, msg.Localtime.AsTime().String(), msg.Remotetime.AsTime().String())
 					}
 				}
 

--- a/cmd/talosctl/cmd/talos/upgrade.go
+++ b/cmd/talosctl/cmd/talos/upgrade.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -23,7 +22,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/flags"
 	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -101,7 +100,7 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 	}
 
 	if upgradeCmdFlags.legacy {
-		cli.Warning("Forcing use of legacy upgrade method. This flag is deprecated and will be removed in Talos 1.18.")
+		safeout.Warningf("Forcing use of legacy upgrade method. This flag is deprecated and will be removed in Talos 1.18.")
 
 		return upgradeLegacy(ctx, clientFactory)
 	}
@@ -117,6 +116,7 @@ func upgradeViaLifecycleService(ctx context.Context, clientFactory *global.Clien
 
 	rep := reporter.New(
 		reporter.WithOutputMode(upgradeCmdFlags.progress.Value()),
+		reporter.WithLineFilter(safeout.String),
 	)
 
 	if err = helpers.TalosVersionCheck(ctx, clientFactory, talosUpgradeAPIVersionRange); err != nil {
@@ -310,14 +310,14 @@ func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, o
 				}
 
 				// partial success: the upgrade was acknowledged but some non-fatal error occurred
-				cli.Warning("%s", err)
+				safeout.Warningf("%s", err)
 			}
 
 			return resp, nil
 		},
 	)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(safeout.Stdout(), 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NODE\tACK\tSTARTED")
 
 	var errs error
@@ -330,7 +330,7 @@ func doUpgradeLegacy(ctx context.Context, clientFactory *global.ClientFactory, o
 		}
 
 		for _, msg := range resp.Payload.Messages {
-			fmt.Fprintf(w, "%s\t%s\t%s\t\n", resp.Node, msg.Ack, time.Now())
+			safeout.Fprintf(w, "%s\t%s\t%s\t\n", resp.Node, msg.Ack, time.Now())
 		}
 	}
 
@@ -385,7 +385,7 @@ func init() {
 	upgradeCmd.Flags().BoolVarP(&upgradeCmdFlags.stage, "stage", "s", false, "stage the upgrade to perform it after a reboot")
 
 	for _, flag := range []string{"force", "insecure", "preserve", "stage"} {
-		upgradeCmd.Flags().MarkDeprecated(flag, "legacy flag for MachineService.Upgrade fallback, to be removed in Talos 1.18") //nolint:errcheck
+		helpers.MarkFlagDeprecated(upgradeCmd.Flags(), flag, "legacy flag for MachineService.Upgrade fallback, to be removed in Talos 1.18") //nolint:errcheck
 	}
 
 	addCommand(upgradeCmd)

--- a/cmd/talosctl/cmd/talos/version.go
+++ b/cmd/talosctl/cmd/talos/version.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/global"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/cli"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -38,7 +39,7 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !versionCmdFlags.json {
-			fmt.Println("Client:")
+			safeout.Println("Client:")
 
 			if versionCmdFlags.shortVersion {
 				version.PrintShortVersion()
@@ -51,7 +52,7 @@ var versionCmd = &cobra.Command{
 				return nil
 			}
 
-			fmt.Println("Server:")
+			safeout.Println("Server:")
 		}
 
 		ctx := cmd.Context()
@@ -89,16 +90,26 @@ var versionCmd = &cobra.Command{
 func printVersionResponse(node string, resp *machine.VersionResponse) error {
 	for _, msg := range resp.Messages {
 		if !versionCmdFlags.json {
-			fmt.Printf("\t%s:        %s\n", "NODE", node)
+			safeout.Printf("\t%s:        %s\n", "NODE", node)
 
-			version.PrintLongVersionFromExisting(msg.Version)
+			// the fields are the node's own strings rendered into talosctl's layout,
+			// so each one is escaped as a cell: a newline in any of them would
+			// otherwise fake a line of the version block.
+			version.WriteLongVersionFromExisting(safeout.Stdout(), &machine.VersionInfo{
+				Tag:       safeout.Cell(msg.Version.GetTag()),
+				Sha:       safeout.Cell(msg.Version.GetSha()),
+				Built:     safeout.Cell(msg.Version.GetBuilt()),
+				GoVersion: safeout.Cell(msg.Version.GetGoVersion()),
+				Os:        safeout.Cell(msg.Version.GetOs()),
+				Arch:      safeout.Cell(msg.Version.GetArch()),
+			})
 
 			var enabledFeatures []string
 			if msg.Features.GetRbac() {
 				enabledFeatures = append(enabledFeatures, "RBAC")
 			}
 
-			fmt.Printf("\tEnabled:     %s\n", strings.Join(enabledFeatures, ", "))
+			safeout.Printf("\tEnabled:     %s\n", strings.Join(enabledFeatures, ", "))
 
 			continue
 		}
@@ -108,7 +119,7 @@ func printVersionResponse(node string, resp *machine.VersionResponse) error {
 			return err
 		}
 
-		fmt.Printf("%s\n", b)
+		safeout.Printf("%s\n", b)
 	}
 
 	return nil

--- a/cmd/talosctl/pkg/talos/action/node.go
+++ b/cmd/talosctl/pkg/talos/action/node.go
@@ -11,12 +11,14 @@ import (
 	"io"
 	"strings"
 
+	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-circular"
 	"github.com/siderolabs/go-retry/retry"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -148,7 +150,7 @@ func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 				}
 
 				a.update(reporter.Update{
-					Message: fmt.Sprintf("actor ID: %v", actorID),
+					Message: fmt.Sprintf("actor ID: %v", safeout.String(actorID)),
 					Status:  reporter.StatusRunning,
 				})
 
@@ -175,7 +177,7 @@ func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 
 		if err != nil {
 			a.update(reporter.Update{
-				Message: fmt.Sprintf("error: %v", err),
+				Message: fmt.Sprintf("error: %v", safeout.String(err.Error())),
 				Status:  reporter.StatusError,
 			})
 		}
@@ -257,13 +259,13 @@ func (a *nodeTracker) handleEvent(event client.Event) error {
 	switch msg := event.Payload.(type) {
 	case *machineapi.PhaseEvent:
 		a.update(reporter.Update{
-			Message: fmt.Sprintf("phase: %s action: %v", msg.GetPhase(), msg.GetAction()),
+			Message: fmt.Sprintf("phase: %s action: %v", safeout.String(msg.GetPhase()), msg.GetAction()),
 			Status:  reporter.StatusRunning,
 		})
 
 	case *machineapi.TaskEvent:
 		a.update(reporter.Update{
-			Message: fmt.Sprintf("task: %s action: %v", msg.GetTask(), msg.GetAction()),
+			Message: fmt.Sprintf("task: %s action: %v", safeout.String(msg.GetTask()), msg.GetAction()),
 			Status:  reporter.StatusRunning,
 		})
 
@@ -276,13 +278,13 @@ func (a *nodeTracker) handleEvent(event client.Event) error {
 		if msg.GetError().GetMessage() != "" {
 			errStr = fmt.Sprintf(
 				" error: [code: %v message: %v]",
-				msg.GetError().GetMessage(),
 				msg.GetError().GetCode(),
+				safeout.String(msg.GetError().GetMessage()),
 			)
 		}
 
 		a.update(reporter.Update{
-			Message: fmt.Sprintf("sequence: %s action: %v%v", msg.GetSequence(), msg.GetAction(), errStr),
+			Message: fmt.Sprintf("sequence: %s action: %v%v", safeout.String(msg.GetSequence()), msg.GetAction(), errStr),
 			Status:  reporter.StatusRunning,
 		})
 
@@ -291,18 +293,21 @@ func (a *nodeTracker) handleEvent(event client.Event) error {
 		}
 
 		if errStr != "" {
-			return fmt.Errorf("sequence error: %s", msg.GetError().GetMessage())
+			return fmt.Errorf("sequence error: %s", safeout.String(msg.GetError().GetMessage()))
 		}
 
 	case *machineapi.MachineStatusEvent:
 		a.update(reporter.Update{
-			Message: fmt.Sprintf("stage: %v ready: %v unmetCond: %v", msg.GetStage(), msg.GetStatus().GetReady(), msg.GetStatus().GetUnmetConditions()),
-			Status:  reporter.StatusRunning,
+			Message: fmt.Sprintf("stage: %v ready: %v unmetCond: %v", msg.GetStage(), msg.GetStatus().GetReady(),
+				xslices.Map(msg.GetStatus().GetUnmetConditions(), func(c *machineapi.MachineStatusEvent_MachineStatus_UnmetCondition) string {
+					return safeout.String(c.GetName())
+				})),
+			Status: reporter.StatusRunning,
 		})
 
 	case *machineapi.ServiceStateEvent:
 		a.update(reporter.Update{
-			Message: fmt.Sprintf("service: %v message: %v healthy: %v", msg.GetService(), msg.GetMessage(), msg.GetHealth().GetHealthy()),
+			Message: fmt.Sprintf("service: %v message: %v healthy: %v", safeout.String(msg.GetService()), safeout.String(msg.GetMessage()), msg.GetHealth().GetHealthy()),
 			Status:  reporter.StatusRunning,
 		})
 	}

--- a/cmd/talosctl/pkg/talos/action/tracker.go
+++ b/cmd/talosctl/pkg/talos/action/tracker.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
@@ -156,9 +157,9 @@ func NewTracker(
 		expectedEventFn:          expectedEventFn,
 		actionFn:                 actionFn,
 		nodeToLatestStatusUpdate: make(map[string]reporter.Update, len(clientFactory.Nodes())),
-		reporter:                 reporter.New(),
+		reporter:                 reporter.New(reporter.WithLineFilter(safeout.String)),
 		reportCh:                 make(chan nodeUpdate),
-		isTerminal:               isatty.IsTerminal(os.Stderr.Fd()),
+		isTerminal:               isatty.IsTerminal(os.Stderr.Fd()), //nolint:forbidigo // asking about the stream, not writing to it
 		clientExecutor:           clientFactory,
 	}
 
@@ -239,7 +240,7 @@ func (a *Tracker) Run(ctx context.Context) error {
 				}
 
 				tracker.update(reporter.Update{
-					Message: trackErr.Error(),
+					Message: safeout.String(trackErr.Error()),
 					Status:  reporter.StatusError,
 				})
 			}
@@ -271,14 +272,14 @@ func (a *Tracker) Run(ctx context.Context) error {
 	if len(failedNodes) > 0 {
 		slices.Sort(failedNodes)
 
-		fmt.Fprintf(os.Stderr, "console logs for nodes %q:\n", failedNodes)
+		fmt.Fprintf(safeout.Stderr(), "console logs for nodes %q:\n", failedNodes)
 
 		for _, node := range failedNodes {
 			dmesgReader, _ := failedNodesToDmesgs.Get(node)
 
-			_, copyErr := io.Copy(os.Stderr, dmesgReader)
+			_, copyErr := io.Copy(safeout.Stderr(), dmesgReader)
 			if copyErr != nil {
-				fmt.Fprintf(os.Stderr, "%q: failed to print debug logs: %v\n", node, copyErr)
+				fmt.Fprintf(safeout.Stderr(), "%q: failed to print debug logs: %v\n", node, copyErr)
 			}
 		}
 	}
@@ -312,7 +313,7 @@ func (a *Tracker) runReporter(ctx context.Context) error {
 
 		case update = <-a.reportCh:
 			if !a.isTerminal {
-				fmt.Fprintf(os.Stderr, "%q: %v\n", update.node, update.update.Message)
+				fmt.Fprintf(safeout.Stderr(), "%q: %v\n", update.node, update.update.Message)
 
 				continue
 			}

--- a/cmd/talosctl/pkg/talos/helpers/checks.go
+++ b/cmd/talosctl/pkg/talos/helpers/checks.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/siderolabs/gen/xerrors"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/client/multiplex"
@@ -105,7 +105,7 @@ func ClientVersionCheck(ctx context.Context, clientFactory ClientFactory) error 
 	}
 
 	if warnings != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: %s\n", strings.Join(warnings, ", "))
+		fmt.Fprintf(safeout.Stderr(), "WARNING: %s\n", strings.Join(warnings, ", "))
 	}
 
 	return errs

--- a/cmd/talosctl/pkg/talos/helpers/confirm.go
+++ b/cmd/talosctl/pkg/talos/helpers/confirm.go
@@ -7,6 +7,8 @@ package helpers
 import (
 	"fmt"
 	"strings"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 )
 
 var okays = []string{"y", "yes"}
@@ -16,7 +18,7 @@ var okays = []string{"y", "yes"}
 func Confirm(prompt string) bool {
 	var inp string
 
-	fmt.Printf("%s (y/N): ", prompt)
+	safeout.Printf("%s (y/N): ", prompt)
 	fmt.Scanf("%s", &inp) //nolint:errcheck
 	inp = strings.TrimSpace(inp)
 

--- a/cmd/talosctl/pkg/talos/helpers/deprecated.go
+++ b/cmd/talosctl/pkg/talos/helpers/deprecated.go
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
+)
+
+type deprecatedFlag struct {
+	flag    *pflag.Flag
+	message string
+}
+
+// deprecatedFlags is filled in by [MarkFlagDeprecated] from the init functions registering the flags.
+var deprecatedFlags []deprecatedFlag
+
+func init() {
+	// cobra runs the initializers once the command line is parsed and before the command itself
+	// runs, so the warning comes out ahead of the command output.
+	cobra.OnInitialize(func() { warnOnDeprecatedFlags(safeout.Stderr()) })
+}
+
+// MarkFlagDeprecated marks the named flag as deprecated: it is hidden from the help output, and
+// using it prints a warning.
+//
+// It replaces pflag's own MarkDeprecated, which leaves the warning for cobra to print via
+// cmd.Print, i.e. to the command's output stream. That stream is stdout for talosctl (the help
+// output goes there), so the warning would land in the middle of the command output instead of
+// on stderr.
+func MarkFlagDeprecated(flags *pflag.FlagSet, name, message string) error {
+	flag := flags.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %q does not exist", name)
+	}
+
+	if message == "" {
+		return fmt.Errorf("deprecation message for flag %q must be set", name)
+	}
+
+	flag.Hidden = true
+
+	deprecatedFlags = append(deprecatedFlags, deprecatedFlag{flag: flag, message: message})
+
+	return nil
+}
+
+// warnOnDeprecatedFlags prints a warning for every deprecated flag used on the command line.
+//
+// The wording matches pflag's own, as it is the message talosctl printed before the warnings were
+// taken over here.
+func warnOnDeprecatedFlags(w io.Writer) {
+	for _, deprecated := range deprecatedFlags {
+		if deprecated.flag.Changed {
+			fmt.Fprintf(w, "Flag --%s has been deprecated, %s\n", deprecated.flag.Name, deprecated.message) //nolint:errcheck
+		}
+	}
+}
+
+// DeprecationMessage returns the message registered for the flag by [MarkFlagDeprecated], or an
+// empty string if the flag is not deprecated.
+//
+// It stands in for pflag's own Flag.Deprecated field, which is left unset so that pflag does not
+// print the warning itself.
+func DeprecationMessage(flag *pflag.Flag) string {
+	for _, deprecated := range deprecatedFlags {
+		if deprecated.flag == flag {
+			return deprecated.message
+		}
+	}
+
+	return ""
+}

--- a/cmd/talosctl/pkg/talos/helpers/deprecated_internal_test.go
+++ b/cmd/talosctl/pkg/talos/helpers/deprecated_internal_test.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarkFlagDeprecated asserts that the warning about a deprecated flag stays off the command
+// output stream: cobra prints its own flag deprecation warnings there, and for talosctl that
+// stream is stdout, where they would be mixed into the output of the command.
+func TestMarkFlagDeprecated(t *testing.T) {
+	registered := len(deprecatedFlags)
+
+	t.Cleanup(func() { deprecatedFlags = deprecatedFlags[:registered] })
+
+	var out, stderr bytes.Buffer
+
+	cmd := &cobra.Command{Use: "test", Run: func(*cobra.Command, []string) {}}
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Flags().BoolP("kubernetes", "k", false, "use the k8s.io containerd namespace")
+
+	require.NoError(t, MarkFlagDeprecated(cmd.Flags(), "kubernetes", "use --namespace cri instead"))
+
+	assert.True(t, cmd.Flags().Lookup("kubernetes").Hidden)
+
+	warnOnDeprecatedFlags(&stderr)
+	assert.Empty(t, stderr.String(), "the flag was not used")
+
+	cmd.SetArgs([]string{"-k"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Empty(t, out.String(), "cobra should not print the warning itself")
+
+	warnOnDeprecatedFlags(&stderr)
+	assert.Equal(t, "Flag --kubernetes has been deprecated, use --namespace cri instead\n", stderr.String())
+}
+
+func TestMarkFlagDeprecatedErrors(t *testing.T) {
+	registered := len(deprecatedFlags)
+
+	t.Cleanup(func() { deprecatedFlags = deprecatedFlags[:registered] })
+
+	flags := &cobra.Command{Use: "test"}
+
+	flags.Flags().Bool("flag", false, "")
+
+	assert.Error(t, MarkFlagDeprecated(flags.Flags(), "missing", "gone"))
+	assert.Error(t, MarkFlagDeprecated(flags.Flags(), "flag", ""))
+}

--- a/cmd/talosctl/pkg/talos/helpers/error.go
+++ b/cmd/talosctl/pkg/talos/helpers/error.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/gertd/go-pluralize"
 	"github.com/hashicorp/go-multierror"
 )
@@ -26,7 +25,11 @@ func AppendErrors(err error, errs ...error) error {
 
 		count := pluralize.NewClient().Pluralize("error", len(lines), true)
 
-		return color.RedString(fmt.Sprintf("%s occurred:\n%s", count, strings.Join(lines, "\n")))
+		// plain text: the aggregated message is mostly chosen by the node, so it is
+		// escaped before it reaches the terminal, and an escape sequence in it would
+		// be escaped along with everything else. Whoever prints the error colorizes
+		// it - see cmd.Execute.
+		return fmt.Sprintf("%s occurred:\n%s", count, strings.Join(lines, "\n"))
 	}
 
 	return res

--- a/cmd/talosctl/pkg/talos/helpers/error_test.go
+++ b/cmd/talosctl/pkg/talos/helpers/error_test.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package helpers_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
+)
+
+// TestAppendErrorsIsPlainText guards the aggregated message against carrying
+// terminal styling: it is escaped before it is printed, so a color escape in it
+// would reach the operator as literal text instead of a color.
+func TestAppendErrorsIsPlainText(t *testing.T) {
+	colorized := color.NoColor
+	color.NoColor = false
+
+	t.Cleanup(func() { color.NoColor = colorized })
+
+	err := helpers.AppendErrors(nil, errors.New("node said boom"), errors.New("and again"))
+
+	assert.Equal(t, "2 errors occurred:\n node said boom\n and again", err.Error())
+}

--- a/cmd/talosctl/pkg/talos/helpers/mode.go
+++ b/cmd/talosctl/pkg/talos/helpers/mode.go
@@ -6,14 +6,13 @@ package helpers
 
 import (
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
 	"github.com/siderolabs/gen/maps"
 	"github.com/spf13/cobra"
 
-	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 )
 
@@ -84,11 +83,11 @@ func AddModeFlags(mode *Mode, command *cobra.Command) {
 func PrintApplyResults(resp *machine.ApplyConfigurationResponse) {
 	for _, m := range resp.GetMessages() {
 		for _, w := range m.GetWarnings() {
-			cli.Warning("%s", w)
+			safeout.Warningf("%s", w)
 		}
 
 		if m.ModeDetails != "" {
-			fmt.Fprintln(os.Stderr, m.ModeDetails)
+			fmt.Fprintln(safeout.Stderr(), m.ModeDetails)
 		}
 	}
 }

--- a/cmd/talosctl/pkg/talos/safeout/safeout.go
+++ b/cmd/talosctl/pkg/talos/safeout/safeout.go
@@ -1,0 +1,385 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package safeout renders untrusted text safely to a terminal.
+//
+// Everything talosctl prints about a node - log lines, resource fields, service
+// states, hostnames, error messages - is chosen by that node. A compromised node
+// can therefore put terminal control sequences into any of it, and a terminal
+// acts on them: OSC 52 writes the operator's clipboard, a bare CR overwrites the
+// line prefix talosctl printed itself, CSI sequences repaint the screen, and
+// bidirectional overrides reorder what the operator reads. The node is the
+// attacker, the operator's terminal emulator is the vulnerable interpreter, and
+// the only place the two can be separated is here, on the client, at the point
+// where talosctl renders.
+//
+// The filter is the identity transformation on printable UTF-8: well-behaved
+// output passes through byte for byte, so piping talosctl into jq, grep or a
+// file keeps working and only malicious or malformed content is rewritten. That
+// property is what makes it safe to filter unconditionally rather than only when
+// stdout is a terminal - node logs are routinely redirected to a file or captured
+// by CI and rendered on a terminal much later, which is precisely when a
+// terminal-detection check would have already waved the payload through.
+//
+// The filter deliberately does not escape a literal backslash, so an escape it
+// emits is indistinguishable from that same text appearing literally in the
+// source data. Preserving the identity property is worth more than that
+// ambiguity: neither form can drive a terminal.
+//
+// Escaping is not the right answer for every kind of output, and this package is
+// not meant for all of it:
+//
+//   - Structured output (-o json, -o yaml) is already safe, because the encoders
+//     escape control characters themselves. Do not filter it again.
+//   - Byte streams that are not text at all (talosctl read, pcap, copy, support
+//     bundles) must reach their destination unmodified. Protect those by refusing
+//     to write raw bytes to a terminal, not by escaping them.
+//   - Escape sequences talosctl emits itself - colors, spinners, the dashboard -
+//     must be written outside this filter, otherwise talosctl escapes its own
+//     styling. Filter the untrusted field with [String] before interpolating it
+//     into a line that is styled later.
+package safeout
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+// RawOutputEnvVar disables filtering of the stdout and stderr streams when set
+// to a true value, for an operator who needs the original bytes from a node
+// (a service which legitimately colorizes its own log output, say).
+//
+// It does not disable [String] and [Cell]: a field interpolated into a line
+// talosctl formats and colorizes itself is escaped either way, as leaving that
+// one field raw is the injection this package exists to prevent.
+const RawOutputEnvVar = "TALOSCTL_RAW_OUTPUT"
+
+// rawOutput reports whether the stdout and stderr streams should pass through
+// unfiltered.
+var rawOutput = sync.OnceValue(func() bool {
+	raw, err := strconv.ParseBool(os.Getenv(RawOutputEnvVar))
+
+	return err == nil && raw
+})
+
+// allowed reports whether r may reach a terminal as itself.
+//
+// unicode.IsPrint is false for exactly the runes which are dangerous or invisible
+// here: the C0 controls including ESC, BEL, CR and DEL, the C1 controls including
+// the single-byte CSI U+009B, the bidirectional overrides and isolates
+// U+202A-U+202E and U+2066-U+2069, the zero-width formatting characters, the byte
+// order mark, and the line and paragraph separators U+2028 and U+2029.
+//
+// Explicitly allow `\n` and `\t` as they are used in table formatting.
+func allowed(r rune) bool {
+	switch r {
+	case '\n', '\t':
+		return true
+	default:
+		return unicode.IsPrint(r)
+	}
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendEscapedByte appends a byte which is not part of a valid UTF-8 sequence.
+func appendEscapedByte(dst []byte, b byte) []byte {
+	return append(dst, '\\', 'x', hexDigits[b>>4], hexDigits[b&0xf])
+}
+
+// appendEscapedRune appends the visible representation of a disallowed rune.
+//
+// The escapes are uniform rather than using the short Go forms such as \r, so
+// that everything this package rewrites can be found with a single search for
+// \x or \u, and so that no rewritten rune can be mistaken for one which was
+// allowed through.
+func appendEscapedRune(dst []byte, r rune) []byte {
+	switch {
+	case r < 0x100:
+		return appendEscapedByte(dst, byte(r))
+	case r < 0x10000:
+		dst = append(dst, '\\', 'u')
+
+		for shift := 12; shift >= 0; shift -= 4 {
+			dst = append(dst, hexDigits[(r>>shift)&0xf])
+		}
+
+		return dst
+	default:
+		dst = append(dst, '\\', 'U')
+
+		for shift := 28; shift >= 0; shift -= 4 {
+			dst = append(dst, hexDigits[(r>>shift)&0xf])
+		}
+
+		return dst
+	}
+}
+
+// escape appends the filtered form of src to dst.
+//
+// It returns the number of trailing bytes of src which were not consumed because
+// they are the start of a UTF-8 sequence which src is too short to complete. A
+// streaming caller holds those back for the next chunk; a caller with the whole
+// string in hand escapes them as individual bytes.
+func escape(dst, src []byte, allowed func(rune) bool) ([]byte, int) {
+	for len(src) > 0 {
+		r, size := utf8.DecodeRune(src)
+
+		// DecodeRune reports (RuneError, 1) both for a byte which can never be part
+		// of a valid sequence and for a valid prefix which is cut short; a genuine
+		// U+FFFD in the input decodes with size 3 and is not confused with either.
+		if r == utf8.RuneError && size <= 1 {
+			if !utf8.FullRune(src) {
+				return dst, len(src)
+			}
+
+			dst = appendEscapedByte(dst, src[0])
+			src = src[1:]
+
+			continue
+		}
+
+		if allowed(r) {
+			dst = append(dst, src[:size]...)
+		} else {
+			dst = appendEscapedRune(dst, r)
+		}
+
+		src = src[size:]
+	}
+
+	return dst, 0
+}
+
+// Writer filters everything written through it before passing it on.
+//
+// It is safe for concurrent use, and it is stream oriented: log output arrives
+// from the API in arbitrary chunks, so a multi-byte rune split across two Write
+// calls is held back until the following call completes it rather than being
+// mangled into escapes. [Writer.Flush] releases such a remainder when no further
+// call is coming.
+type Writer struct {
+	w io.Writer
+
+	mu sync.Mutex
+	// pending holds an incomplete trailing UTF-8 sequence, at most utf8.UTFMax-1 bytes.
+	pending []byte
+	joined  []byte
+	out     []byte
+
+	raw bool
+}
+
+// NewWriter returns a Writer filtering everything written to w.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w: w}
+}
+
+// Write implements io.Writer.
+func (w *Writer) Write(p []byte) (int, error) {
+	if w.raw {
+		return w.w.Write(p)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	src := p
+
+	if len(w.pending) > 0 {
+		w.joined = append(append(w.joined[:0], w.pending...), p...)
+		src = w.joined
+		w.pending = w.pending[:0]
+	}
+
+	out, held := escape(w.out[:0], src, allowed)
+	w.out = out
+	w.pending = append(w.pending[:0], src[len(src)-held:]...)
+
+	if _, err := w.w.Write(out); err != nil {
+		return 0, err
+	}
+
+	// report the caller's length: the filtered form has a different one, and a
+	// short write would make fmt and io.Copy believe the write failed.
+	return len(p), nil
+}
+
+// Flush escapes and writes out an incomplete UTF-8 sequence held back by the
+// last Write. It must be called before the process exits, or a truncated
+// trailing rune is silently dropped.
+func (w *Writer) Flush() error {
+	if w.raw {
+		return nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(w.pending) == 0 {
+		return nil
+	}
+
+	out := w.out[:0]
+
+	for _, b := range w.pending {
+		out = appendEscapedByte(out, b)
+	}
+
+	w.pending = w.pending[:0]
+	w.out = out
+
+	_, err := w.w.Write(out)
+
+	return err
+}
+
+var (
+	stdout = sync.OnceValue(func() *Writer { return &Writer{w: os.Stdout, raw: rawOutput()} })
+	stderr = sync.OnceValue(func() *Writer { return &Writer{w: os.Stderr, raw: rawOutput()} })
+)
+
+// Stdout returns the filtered standard output stream.
+//
+// Anything rendering node-supplied text for a human writes here instead of to
+// os.Stdout, including as the writer underneath a tabwriter.
+func Stdout() io.Writer { return stdout() }
+
+// Stderr returns the filtered standard error stream.
+func Stderr() io.Writer { return stderr() }
+
+// Fprintf is fmt.Fprintf with every string and error argument escaped as a table
+// cell by [Cell].
+//
+// Use it for a row handed to a tabwriter. The format string stays untouched
+// because it is talosctl's own literal, so the tabs which separate the columns
+// keep their meaning; the values interpolated into it come from the node, and a
+// tab in one of those is read by the tabwriter as a column separator before any
+// writer underneath it can see the byte.
+func Fprintf(w io.Writer, format string, a ...any) (int, error) {
+	escaped := a
+
+	for i, v := range a {
+		var cell string
+
+		switch v := v.(type) {
+		case string:
+			cell = Cell(v)
+		case error:
+			// fmt renders an error whose Error method panics on a nil receiver as
+			// <nil>, so the rendering goes through fmt here too rather than calling
+			// the method directly.
+			cell = Cell(fmt.Sprint(v))
+		default:
+			continue
+		}
+
+		// copy on first write: a caller passing a slice with `args...` keeps
+		// ownership of it.
+		if &escaped[0] == &a[0] {
+			escaped = slices.Clone(a)
+		}
+
+		escaped[i] = cell
+	}
+
+	return fmt.Fprintf(w, format, escaped...)
+}
+
+// Print is fmt.Print against the filtered standard output stream.
+func Print(a ...any) (int, error) { return fmt.Fprint(Stdout(), a...) }
+
+// Printf is fmt.Printf against the filtered standard output stream.
+func Printf(format string, a ...any) (int, error) { return fmt.Fprintf(Stdout(), format, a...) }
+
+// Println is fmt.Println against the filtered standard output stream.
+func Println(a ...any) (int, error) { return fmt.Fprintln(Stdout(), a...) }
+
+// Warningf prints a warning to the filtered standard error stream, escaping every
+// string and error argument as a table cell by [Cell].
+//
+// It replaces cli.Warning for the commands which talk to a node: a warning is a
+// single line prefixed with WARNING:, and its text is usually chosen by the node
+// - a config validation warning, a partially failed request - so a newline in it
+// would let the node write a line of its own without that prefix.
+func Warningf(format string, a ...any) {
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+
+	Fprintf(Stderr(), "WARNING: "+format, a...) //nolint:errcheck
+}
+
+// Flush releases any partial rune held by the shared streams.
+func Flush() error {
+	if err := stdout().Flush(); err != nil {
+		return err
+	}
+
+	return stderr().Flush()
+}
+
+// String returns s with anything a terminal would act on replaced by a visible
+// escape, preserving newlines and tabs.
+//
+// Use it for an untrusted field which is interpolated into a line that something
+// other than [Stdout] renders - a reporter message, a colorized status line - so
+// that talosctl's own escape sequences survive while the node's do not.
+func String(s string) string {
+	return escapeString(s, allowed)
+}
+
+// Cell returns s escaped for a single field of a table or a one-line summary,
+// additionally escaping newlines and tabs.
+//
+// A tab in a value handed to a tabwriter is read as a column separator and a
+// newline ends the row, so a node choosing either one silently rewrites the shape
+// of the table around it.
+func Cell(s string) string {
+	return escapeString(s, unicode.IsPrint)
+}
+
+func escapeString(s string, allowed func(rune) bool) string {
+	// ranging over a string yields utf8.RuneError for a byte which is not part of
+	// a valid sequence, so this catches malformed input as well as disallowed
+	// runes. A genuine U+FFFD sends a well-formed string down the slow path, where
+	// it is allowed through unchanged.
+	clean := true
+
+	for _, r := range s {
+		if r == utf8.RuneError || !allowed(r) {
+			clean = false
+
+			break
+		}
+	}
+
+	if clean {
+		return s
+	}
+
+	src := []byte(s)
+
+	out, held := escape(make([]byte, 0, len(s)+escapeGrowth), src, allowed)
+
+	// nothing further is coming, so a truncated trailing sequence is escaped
+	// rather than held back for a chunk which will never arrive.
+	for _, b := range src[len(src)-held:] {
+		out = appendEscapedByte(out, b)
+	}
+
+	return string(out)
+}
+
+// escapeGrowth is the slack left in the escaped buffer, enough for a couple of
+// escapes before it has to grow.
+const escapeGrowth = 16

--- a/cmd/talosctl/pkg/talos/safeout/safeout_test.go
+++ b/cmd/talosctl/pkg/talos/safeout/safeout_test.go
@@ -1,0 +1,311 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package safeout_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
+)
+
+// payloads that can put into any string talosctl renders.
+var payloads = map[string]struct {
+	in       string
+	expected string
+}{
+	"OSC 0 window title": {
+		in:       "\x1b]0;F3-OSC-TITLE-INJECTED\x07",
+		expected: `\x1b]0;F3-OSC-TITLE-INJECTED\x07`,
+	},
+	"OSC 52 clipboard write": {
+		in:       "\x1b]52;c;RjMtQ0xJUEJPQVJELUhJSkFDSw==\x07",
+		expected: `\x1b]52;c;RjMtQ0xJUEJPQVJELUhJSkFDSw==\x07`,
+	},
+	"CSI screen repaint": {
+		in:       "\x1b[2J\x1b[HF3-SCREEN-REPAINTED-BY-NODE",
+		expected: `\x1b[2J\x1b[HF3-SCREEN-REPAINTED-BY-NODE`,
+	},
+	"bare CR overwriting the line prefix": {
+		in:       "junk\rF3-LINE-PREFIX-OVERWRITTEN",
+		expected: `junk\x0dF3-LINE-PREFIX-OVERWRITTEN`,
+	},
+	"SGR color in a hostname": {
+		in:       "\x1b[1;31mF3-HOSTNAME-IS-A-SINK\x1b[0m",
+		expected: `\x1b[1;31mF3-HOSTNAME-IS-A-SINK\x1b[0m`,
+	},
+	// U+009B is a single byte CSI on a terminal which decodes C1, and arrives as
+	// a two byte UTF-8 sequence rather than as ESC.
+	"C1 single byte CSI": {
+		in:       "before\u009b2Jcsi",
+		expected: `before\x9b2Jcsi`,
+	},
+	"bidirectional override": {
+		in:       "safe\u202eesrever\u202c",
+		expected: `safe\u202eesrever\u202c`,
+	},
+	"bidirectional isolate": {
+		in:       "a\u2066b\u2069c",
+		expected: `a\u2066b\u2069c`,
+	},
+	"zero width space": {
+		in:       "ad\u200bmin",
+		expected: `ad\u200bmin`,
+	},
+	"byte order mark": {
+		in:       "\ufeffvalue",
+		expected: `\ufeffvalue`,
+	},
+	"line and paragraph separators": {
+		in:       "a\u2028b\u2029c",
+		expected: `a\u2028b\u2029c`,
+	},
+	"DEL and backspace": {
+		in:       "pass\x7fword\x08\x08",
+		expected: `pass\x7fword\x08\x08`,
+	},
+	"BEL": {
+		in:       "beep\a",
+		expected: `beep\x07`,
+	},
+	"vertical tab and form feed": {
+		in:       "a\vb\fc",
+		expected: `a\x0bb\x0cc`,
+	},
+	"NUL": {
+		in:       "a\x00b",
+		expected: `a\x00b`,
+	},
+	"invalid UTF-8": {
+		in:       "bad\xffbyte\xc3",
+		expected: `bad\xffbyte\xc3`,
+	},
+	"surrogate half encoded as UTF-8": {
+		in:       "a\xed\xa0\x80b",
+		expected: `a\xed\xa0\x80b`,
+	},
+	"unassigned plane 15 code point": {
+		in:       "a\U000f0000b",
+		expected: `a\U000f0000b`,
+	},
+}
+
+// content which must survive untouched: the filter is the identity
+// transformation on printable UTF-8.
+var passthrough = []string{
+	"",
+	"kubelet: starting",
+	"[   12.345678] kernel: nvme nvme0: pci function",
+	`{"ts":1234,"msg":"hello","level":"info"}`,
+	"column\tseparated\tvalues\n",
+	"multi\nline\noutput\n",
+	"ünïcode ÿ ß 日本語 emoji \U0001f389 combining é", //nolint:gosmopolitan // intentionally testing non-ASCII UTF-8
+	`path/with\backslash and \x1b written literally`,
+	"replacement \ufffd character",
+}
+
+func TestStringEscapes(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, safeout.String(tc.in))
+		})
+	}
+}
+
+func TestStringPassthrough(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range passthrough {
+		assert.Equal(t, in, safeout.String(in), "printable UTF-8 must pass through unchanged")
+	}
+}
+
+func TestWriterMatchesString(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			w := safeout.NewWriter(&buf)
+
+			n, err := w.Write([]byte(tc.in))
+			require.NoError(t, err)
+			// a filtering writer changes the byte count, but must report the caller's
+			// length or fmt and io.Copy treat the write as short and failed.
+			assert.Equal(t, len(tc.in), n)
+
+			require.NoError(t, w.Flush())
+
+			assert.Equal(t, tc.expected, buf.String())
+		})
+	}
+}
+
+func TestWriterPassthrough(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range passthrough {
+		var buf bytes.Buffer
+
+		w := safeout.NewWriter(&buf)
+
+		_, err := w.Write([]byte(in))
+		require.NoError(t, err)
+		require.NoError(t, w.Flush())
+
+		assert.Equal(t, in, buf.String())
+	}
+}
+
+// TestWriterSplitRune covers the case a stream filter gets wrong: node output
+// arrives in arbitrary chunks, so a multi-byte rune is routinely cut in half by
+// the transport. Every split of every input must produce the same bytes as
+// writing it in one go.
+func TestWriterSplitRune(t *testing.T) {
+	t.Parallel()
+
+	inputs := append([]string{}, passthrough...)
+
+	for _, tc := range payloads {
+		inputs = append(inputs, tc.in)
+	}
+
+	for _, in := range inputs {
+		for split := range len(in) + 1 {
+			var buf bytes.Buffer
+
+			w := safeout.NewWriter(&buf)
+
+			_, err := w.Write([]byte(in[:split]))
+			require.NoError(t, err)
+
+			_, err = w.Write([]byte(in[split:]))
+			require.NoError(t, err)
+
+			require.NoError(t, w.Flush())
+
+			assert.Equal(t, safeout.String(in), buf.String(), "input %q split at %d", in, split)
+		}
+	}
+}
+
+// TestWriterByteAtATime is the degenerate case of the above: every rune split at
+// every boundary at once.
+func TestWriterByteAtATime(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range passthrough {
+		var buf bytes.Buffer
+
+		w := safeout.NewWriter(&buf)
+
+		for i := range len(in) {
+			_, err := w.Write([]byte(in[i : i+1]))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, w.Flush())
+
+		assert.Equal(t, in, buf.String())
+	}
+}
+
+// TestFlushReleasesTruncatedRune: a stream ending mid-rune must still render the
+// bytes it did receive, rather than dropping them.
+func TestFlushReleasesTruncatedRune(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	w := safeout.NewWriter(&buf)
+
+	_, err := w.Write([]byte("ok\xe6\x97"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "ok", buf.String(), "an incomplete rune is held back, not guessed at")
+
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, `ok\xe6\x97`, buf.String())
+}
+
+func TestCellEscapesTabAndNewline(t *testing.T) {
+	t.Parallel()
+
+	// a tab is a column separator to tabwriter and a newline ends the row, so a
+	// node choosing either rewrites the shape of the table around it.
+	assert.Equal(t, `a\x09b\x0ac`, safeout.Cell("a\tb\nc"))
+	assert.Equal(t, "a\tb\nc", safeout.String("a\tb\nc"))
+	assert.Equal(t, "plain value", safeout.Cell("plain value"))
+	assert.Equal(t, `\x1b[2Jwiped`, safeout.Cell("\x1b[2Jwiped"))
+}
+
+// TestNoControlRunesSurvive asserts the property the advisory is about directly,
+// rather than through golden strings.
+func TestNoControlRunesSurvive(t *testing.T) {
+	t.Parallel()
+
+	var all strings.Builder
+
+	for _, tc := range payloads {
+		all.WriteString(tc.in)
+	}
+
+	for _, out := range []string{safeout.String(all.String()), safeout.Cell(all.String())} {
+		for _, r := range out {
+			assert.True(t, r == '\n' || r == '\t' || unicode.IsPrint(r), "rune %U reached the terminal", r)
+		}
+	}
+}
+
+type nilError struct {
+	msg string
+}
+
+func (e *nilError) Error() string { return e.msg }
+
+func TestFprintfEscapesArguments(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	args := []any{"a\tb", errors.New("\x1b[2Jwiped"), 42}
+
+	_, err := safeout.Fprintf(&buf, "%s|%s|%d\n", args...)
+	require.NoError(t, err)
+
+	assert.Equal(t, `a\x09b|\x1b[2Jwiped|42`+"\n", buf.String())
+	// the caller keeps ownership of a slice passed with args...
+	assert.Equal(t, "a\tb", args[0])
+}
+
+func TestFprintfTypedNilError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		buf bytes.Buffer
+		e   *nilError
+	)
+
+	// a nil pointer with an Error method whose receiver it dereferences: fmt
+	// renders it as <nil>, and neither may this panic.
+	_, err := safeout.Fprintf(&buf, "%s\n", error(e))
+	require.NoError(t, err)
+
+	assert.Equal(t, "<nil>\n", buf.String())
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -752,7 +752,6 @@ func (ctrl *Controller) MakeLogger(serviceName string) (*zap.Logger, error) {
 	return logging.ZapLogger(
 		logging.NewLogDestination(
 			logWriter, zapcore.DebugLevel,
-			logging.WithColoredLevels(),
 		),
 		logging.NewLogDestination(
 			logging.StdWriter, ctrl.consoleLogLevel,

--- a/pkg/cluster/check/reporter.go
+++ b/pkg/cluster/check/reporter.go
@@ -23,9 +23,9 @@ func (r *ConditionReporter) Update(condition conditions.Condition) {
 }
 
 // StderrReporter returns console reporter with stderr output.
-func StderrReporter() *ConditionReporter {
+func StderrReporter(opts ...reporter.Option) *ConditionReporter {
 	return &ConditionReporter{
-		w: reporter.New(),
+		w: reporter.New(opts...),
 	}
 }
 

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -45,6 +45,7 @@ type Reporter struct {
 	w                 *os.File
 	lastLine          string
 	lastLineTemporary bool
+	lineFilter        func(string) string
 
 	colorized  bool
 	spinnerIdx int
@@ -100,6 +101,19 @@ func WithOutputMode(mode OutputMode) Option {
 	}
 }
 
+// WithLineFilter returns an Option that sets a filter applied to every message
+// before it is rendered.
+//
+// A message assembled from data a Talos node supplied can carry terminal control
+// sequences, and the reporter writes to the terminal directly and adds its own
+// colors and cursor movement, so such a message has to be filtered as text here
+// rather than on the stream underneath the reporter.
+func WithLineFilter(filter func(string) string) Option {
+	return func(r *Reporter) {
+		r.lineFilter = filter
+	}
+}
+
 // New returns a console reporter with stderr output.
 func New(opts ...Option) *Reporter {
 	rep := &Reporter{
@@ -126,6 +140,10 @@ func (r *Reporter) Report(update Update) {
 	line := strings.TrimSpace(update.Message)
 	// replace tabs with spaces to get consistent output length
 	line = strings.ReplaceAll(line, "\t", "    ")
+
+	if r.lineFilter != nil {
+		line = r.lineFilter(line)
+	}
 
 	if !r.colorized {
 		if line != r.lastLine {


### PR DESCRIPTION
In general, any output received via Talos API should be filtered when printed back to the console with the exception of binary output - e.g. recieving a .tar.gz from `talosctl copy`.

For example, `talosctl logs` returns the logs of the provided service/pod/container, and it might contain any symbols produced by the running program, so when printed back to the terminal, it might produce unexpected output, so it should be filtered.

The filtering applied is similar to e.g. what `less` does.
