### PR TITLE
fix: treat desired roles empty as error in Talos API access

### DIFF
--- a/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
+++ b/internal/app/machined/pkg/controllers/kubeaccess/serviceaccount/crd_controller.go
@@ -323,7 +323,11 @@ func (t *CRDController) syncHandler(ctx context.Context, key string) error {
 	}
 
 	desiredRoles, found, err := unstructured.NestedStringSlice(talosSA.UnstructuredContent(), "spec", "roles")
-	if err != nil || !found {
+
+	// parse desiredRoles to see if they are empty.
+	desiredRoleSet, _ := role.Parse(desiredRoles)
+
+	if err != nil || !found || desiredRoleSet.Empty() {
 		msg := messageRolesNotFound
 
 		updateErr := t.updateTalosSAStatus(ctx, talosSA, msg)
@@ -340,8 +344,6 @@ func (t *CRDController) syncHandler(ctx context.Context, key string) error {
 		return errors.New(msg)
 	}
 
-	desiredRoleSet, _ := role.Parse(desiredRoles)
-
 	if !slices.ContainsFunc(t.allowedNamespaces, func(allowedNS string) bool {
 		return allowedNS == namespace
 	}) {
@@ -357,6 +359,7 @@ func (t *CRDController) syncHandler(ctx context.Context, key string) error {
 		return nil
 	}
 
+	// every requested role must appear in the allowlist; the empty desiredRoles list is handled above.
 	var unallowedRoles []string
 
 	for _, desiredRole := range desiredRoles {

--- a/pkg/machinery/config/generate/secrets/ca.go
+++ b/pkg/machinery/config/generate/secrets/ca.go
@@ -6,6 +6,7 @@ package secrets
 
 import (
 	stdx509 "crypto/x509"
+	"errors"
 	"time"
 
 	"github.com/siderolabs/crypto/x509"
@@ -64,6 +65,11 @@ func NewTalosCA(currentTime time.Time) (ca *x509.CertificateAuthority, err error
 
 // NewAdminCertificateAndKey generates the admin Talos certificate and key.
 func NewAdminCertificateAndKey(currentTime time.Time, ca *x509.PEMEncodedCertificateAndKey, roles role.Set, ttl time.Duration) (p *x509.PEMEncodedCertificateAndKey, err error) {
+	// A client certificate without any roles is no longer valid, as RBAC is now enabled by default (but it was valid in pre-RBAC days).
+	if roles.Empty() {
+		return nil, errors.New("at least one role is required to generate a Talos API certificate")
+	}
+
 	opts := []x509.Option{
 		x509.Organization(roles.Strings()...),
 		x509.NotAfter(currentTime.Add(ttl)),

--- a/pkg/machinery/config/generate/secrets/ca_test.go
+++ b/pkg/machinery/config/generate/secrets/ca_test.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets_test
+
+import (
+	stdx509 "crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/crypto/x509"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"github.com/siderolabs/talos/pkg/machinery/role"
+)
+
+func TestNewAdminCertificateAndKey(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	ca, err := secrets.NewTalosCA(now)
+	require.NoError(t, err)
+
+	talosCA := &x509.PEMEncodedCertificateAndKey{
+		Crt: ca.CrtPEM,
+		Key: ca.KeyPEM,
+	}
+
+	t.Run("roles land in the Subject Organization", func(t *testing.T) {
+		t.Parallel()
+
+		cert, err := secrets.NewAdminCertificateAndKey(now, talosCA, role.MakeSet(role.Reader), time.Hour)
+		require.NoError(t, err)
+
+		block, _ := pem.Decode(cert.Crt)
+		require.NotNil(t, block)
+
+		parsed, err := stdx509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"os:reader"}, parsed.Subject.Organization)
+	})
+
+	t.Run("an empty role set is refused", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := secrets.NewAdminCertificateAndKey(now, talosCA, role.Zero, time.Hour)
+		assert.ErrorContains(t, err, "at least one role is required")
+	})
+}

--- a/pkg/machinery/config/types/k8s/talos_api_access.go
+++ b/pkg/machinery/config/types/k8s/talos_api_access.go
@@ -97,6 +97,10 @@ func (s *KubeTalosAPIAccessConfigV1Alpha1) Validate(validation.RuntimeMode, ...v
 		warnings []string
 	)
 
+	if len(s.AccessAllowedRoles) == 0 {
+		warnings = append(warnings, "no roles are allowed in .allowedRoles, so access is blocked")
+	}
+
 	for _, r := range s.AccessAllowedRoles {
 		if !role.All.Includes(role.Role(r)) {
 			errs = errors.Join(errs, fmt.Errorf("invalid role %q in .allowedRoles", r))

--- a/pkg/machinery/config/types/k8s/talos_api_access_test.go
+++ b/pkg/machinery/config/types/k8s/talos_api_access_test.go
@@ -76,15 +76,17 @@ func TestKubeTalosAPIAccessConfigValidate(t *testing.T) {
 		name string
 		cfg  func() *k8s.KubeTalosAPIAccessConfigV1Alpha1
 
-		expectedError string
+		expectedError    string
+		expectedWarnings []string
 	}{
 		{
 			name: "valid",
 			cfg:  kubeTalosAPIAccessConfig,
 		},
 		{
-			name: "no roles",
-			cfg:  k8s.NewKubeTalosAPIAccessConfigV1Alpha1,
+			name:             "no roles",
+			cfg:              k8s.NewKubeTalosAPIAccessConfigV1Alpha1,
+			expectedWarnings: []string{"no roles are allowed in .allowedRoles, so access is blocked"},
 		},
 		{
 			name: "all roles",
@@ -128,7 +130,7 @@ func TestKubeTalosAPIAccessConfigValidate(t *testing.T) {
 			t.Parallel()
 
 			warnings, err := test.cfg().Validate(validationMode{})
-			assert.Nil(t, warnings)
+			assert.Equal(t, test.expectedWarnings, warnings)
 
 			if test.expectedError != "" {
 				assert.EqualError(t, err, test.expectedError)

--- a/pkg/machinery/role/role.go
+++ b/pkg/machinery/role/role.go
@@ -104,6 +104,14 @@ func (s Set) Strings() []string {
 	return res
 }
 
+// Empty returns true if the set contains no roles.
+//
+// A credential resolving to an empty set names no roles at all, and never authorizes
+// anything: it should be rejected rather than treated as a caller holding no roles.
+func (s Set) Empty() bool {
+	return len(s.roles) == 0
+}
+
 // IncludesAny returns true if there is a non-empty intersection between sets.
 //
 // Returns false if any set is empty.


### PR DESCRIPTION
In Talos API access from K8s, the empty desired roles on the service account CRD was treated as normal, which leads to talosconfig issues with no roles at all, which on its own makes no sense, as RBAC is enforced (and Talos API access from Kubernetes requires RBAC, and now RBAC is locked on always).
