### PR TITLE
fix: normalize image reference when passing to image verification flow

### DIFF
--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -750,6 +750,7 @@ var imageIntegrationCmd = &cobra.Command{
 			imgs.Pause.String(),
 			imgs.KubeNetworkPolicies.String(),
 			"registry.k8s.io/conformance:v" + constants.DefaultKubernetesVersion,
+			"docker.io/alpine/socat:1.8.1.3",
 			"docker.io/library/alpine:latest",
 			"ghcr.io/siderolabs/talosctl:v1.13.5",
 			"registry.k8s.io/kube-apiserver:v1.27.0",

--- a/internal/app/machined/pkg/controllers/security/image_verification_config.go
+++ b/internal/app/machined/pkg/controllers/security/image_verification_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/talos/internal/pkg/containers/image/imageref"
 	configres "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/security"
 )
@@ -73,7 +74,9 @@ func (ctrl *ImageVerificationConfigController) Run(ctx context.Context, r contro
 					if err := safe.WriterModify(
 						ctx, r, security.NewImageVerificationRule(fmt.Sprintf("%04d", idx)),
 						func(r *security.ImageVerificationRule) error {
-							r.TypedSpec().ImagePattern = rule.ImagePattern()
+							// store the pattern in its normalized form, so that `talosctl get
+							// imageverificationrules` shows the pattern which is actually matched
+							r.TypedSpec().ImagePattern = imageref.NormalizePattern(rule.ImagePattern())
 							r.TypedSpec().Skip = rule.Skip()
 							r.TypedSpec().Deny = rule.Deny()
 

--- a/internal/integration/api/containers.go
+++ b/internal/integration/api/containers.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -39,14 +40,20 @@ import (
 const (
 	// containerPauseImage never writes anything and never exits, which is what the lifecycle tests
 	// want.
+	//
+	// Note: this image is part of the default image cache in `talosctl image integration`.
 	containerPauseImage = images.DefaultSandboxImage
 
 	// containerShellImage is used wherever a test needs the container to run a command and say
 	// something about itself. The pause image has no shell and produces no output, so it cannot
 	// carry any assertion about what the container actually got.
+	//
+	// Note: this image is part of the default image cache in `talosctl image integration`.
 	containerShellImage = "docker.io/library/alpine:3.23"
 
 	// containerSocatImage carries a unix-socket client, needed for machined socket access testing.
+	//
+	// Note: this image is part of the default image cache in `talosctl image integration`.
 	containerSocatImage = "docker.io/alpine/socat:1.8.1.3"
 )
 
@@ -80,10 +87,6 @@ func (suite *ContainersSuite) SuiteName() string {
 
 // SetupTest ...
 func (suite *ContainersSuite) SetupTest() {
-	if suite.Airgapped {
-		suite.T().Skip("skipping test in airgapped mode, the tests pull images")
-	}
-
 	// Enough for an image pull; the reboot test extends its own deadline.
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 10*time.Minute)
 }
@@ -141,6 +144,10 @@ func (suite *ContainersSuite) TestContainerLifecycle() {
 // TestSurvivesReboot verifies that a declared container is stopped on the way down and started again
 // as a new task on the way up.
 func (suite *ContainersSuite) TestSurvivesReboot() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	if !suite.Capabilities().SupportsReboot {
 		suite.T().Skip("cluster doesn't support reboots")
 	}
@@ -223,6 +230,10 @@ func (suite *ContainersSuite) TestRestartAfterTermination() {
 // TestUnresolvableImage verifies that a container whose image cannot be pulled is withheld while the
 // pull keeps retrying, and starts once the reference is corrected.
 func (suite *ContainersSuite) TestUnresolvableImage() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	ctx, name, _ := suite.setupContainer("bad-image")
 
 	// Built off the pause image rather than the shell one: the corrected container has to stay up
@@ -626,6 +637,10 @@ func (suite *ContainersSuite) TestHostPathMount() {
 // TestDependsOnPaths verifies that a container declaring dependsOn.paths waits for the path to exist
 // and starts once it does.
 func (suite *ContainersSuite) TestDependsOnPaths() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	// Redeclaring the container against a path that exists, rather than making the original path
 	// appear. This covers the gate being re-evaluated when the spec changes; the subtest below covers
 	// an unmet path being noticed without any config change.
@@ -907,6 +922,10 @@ func (suite *ContainersSuite) TestUserVolumeMountWritableByDefault() {
 // The pause image is used because it is already on every node, so nothing here waits on a pull; what
 // is being timed is the gate, not the registry.
 func (suite *ContainersSuite) TestUserVolumeMountGate() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	ctx, name, node := suite.setupContainer("volume-gate")
 
 	// Named but not declared: the volume config is applied only further down.
@@ -950,6 +969,10 @@ func (suite *ContainersSuite) TestUserVolumeMountGate() {
 // happens when it is left unset.
 func (suite *ContainersSuite) TestAllowMachinedAccess() {
 	suite.Run("enabled", func() {
+		if testing.Short() {
+			suite.T().Skip("skipping the test in short mode")
+		}
+
 		ctx, name, _ := suite.setupContainer("allow-machined-enabled")
 		script := fmt.Sprintf(
 			`if [ -S %s ]; then echo SOCKET_OK; else echo SOCKET_MISSING; fi
@@ -1009,6 +1032,10 @@ sleep 3600`,
 // TestAllowMachinedSocketConnect verifies that a container granted security.machinedAccess can
 // actually connect() to the machined socket, not merely see it.
 func (suite *ContainersSuite) TestAllowMachinedSocketConnect() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	ctx, name, _ := suite.setupContainer("allow-machined-connect")
 
 	script := fmt.Sprintf(
@@ -1433,6 +1460,10 @@ func (suite *ContainersSuite) assertContainerdImages(ctx context.Context, namesp
 // covered by TestImageGCTalosContainers in the controller's own tests, on synthetic time. This is
 // the same kind of blind spot as the one assertNoContainerdContainer documents.
 func (suite *ContainersSuite) TestImageNotGarbageCollectedWhileReferenced() {
+	if testing.Short() {
+		suite.T().Skip("skipping the test in short mode")
+	}
+
 	ctx, name, _ := suite.setupContainer("image-gc")
 
 	suite.applyContainers(ctx, suite.shellContainer(name, "sleep 3600"))

--- a/internal/integration/api/images.go
+++ b/internal/integration/api/images.go
@@ -252,6 +252,12 @@ func (suite *ImagesSuite) TestVerify() {
 			RuleImagePattern: "localhost:4444/*",
 			RuleDeny:         new(true),
 		},
+		{
+			// a pattern written against the Docker Hub host the way the configuration
+			// reference shows it
+			RuleImagePattern: "docker.io/library/busybox*",
+			RuleDeny:         new(true),
+		},
 	}
 
 	suite.PatchMachineConfig(ctx, imageVerificationConfig)
@@ -259,7 +265,7 @@ func (suite *ImagesSuite) TestVerify() {
 	// wait for the configuration to be applied
 	rtestutils.AssertResources(
 		ctx, suite.T(), suite.Client.COSI,
-		[]resource.ID{"0000", "0001", "0002"},
+		[]resource.ID{"0000", "0001", "0002", "0003"},
 		func(rule *securityres.ImageVerificationRule, asrt *assert.Assertions) {
 			switch rule.Metadata().ID() {
 			case "0000":
@@ -268,6 +274,8 @@ func (suite *ImagesSuite) TestVerify() {
 				asrt.Equal("registry.k8s.io/*", rule.TypedSpec().ImagePattern)
 			case "0002":
 				asrt.Equal("localhost:4444/*", rule.TypedSpec().ImagePattern)
+			case "0003":
+				asrt.Equal("docker.io/library/busybox*", rule.TypedSpec().ImagePattern)
 			}
 		},
 	)
@@ -299,6 +307,21 @@ func (suite *ImagesSuite) TestVerify() {
 	suite.Require().Error(err)
 	suite.Assert().Equal(codes.PermissionDenied, status.Code(err), "expected image verification to be denied according to our config")
 	suite.Assert().Equal("verification denied by matched rule (0002)", status.Convert(err).Message())
+
+	// the reference is normalized before it is matched, so neither a different spelling of the
+	// registry domain nor a different spelling of the Docker Hub repository evades a deny rule
+	for _, deniedRef := range []string{
+		"LOCALHOST:4444/myimage:latest",
+		"docker.io/library/busybox:1.36",
+		"index.docker.io/library/busybox:1.36",
+		"busybox:1.36",
+	} {
+		_, err = suite.Client.ImageClient.Verify(ctx, &machine.ImageServiceVerifyRequest{
+			ImageRef: deniedRef,
+		})
+		suite.Require().Error(err, "expected %q to be denied", deniedRef)
+		suite.Assert().Equal(codes.PermissionDenied, status.Code(err), "expected %q to be denied according to our config", deniedRef)
+	}
 
 	// now test via the image pull flow
 	rcv, err := suite.Client.ImageClient.Pull(ctx, &machine.ImageServicePullRequest{

--- a/internal/pkg/containers/image/imageref/imageref.go
+++ b/internal/pkg/containers/image/imageref/imageref.go
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package imageref provides canonical normalization of container image references.
+//
+// Talos parses an image reference in several places on a single pull: to match it against the
+// image verification policy, to look up the registry mirror, auth and TLS configuration, and to
+// hand it to containerd for the actual pull. All of those have to agree on a single spelling of
+// the reference, otherwise the policy decision can be made about one image while a different one
+// is pulled.
+package imageref
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/distribution/reference"
+)
+
+const (
+	// dockerHubDomain is the canonical Docker Hub domain as produced by
+	// github.com/distribution/reference and understood by containerd.
+	dockerHubDomain = "docker.io"
+
+	// legacyDockerHubDomain is the legacy Docker Hub domain. It is also the spelling
+	// github.com/google/go-containerregistry canonicalizes Docker Hub to, so references and
+	// patterns do show up written this way.
+	legacyDockerHubDomain = "index.docker.io"
+
+	// endpointDockerHubDomain is the Docker Hub registry endpoint, the host `docker.io` is an
+	// alias for (see containerd's docker.DefaultHost). A reference written this way points at
+	// the very same image as one written against `docker.io`.
+	endpointDockerHubDomain = "registry-1.docker.io"
+
+	// officialRepoPrefix is the implicit namespace of the official Docker Hub images.
+	officialRepoPrefix = "library/"
+
+	// localhostDomain is always a registry domain, never a repository namespace.
+	localhostDomain = "localhost"
+)
+
+// Parse parses a container image reference and returns it in the canonical form used throughout
+// Talos.
+//
+// On top of the normalization done by github.com/distribution/reference (defaulting the domain,
+// adding the implicit `library/` namespace on Docker Hub, defaulting the tag to `latest` and
+// dropping the tag from a reference carrying both a tag and a digest), the registry domain is
+// lower-cased, as registry domains are DNS names and DNS is case-insensitive, and the alternative
+// spellings of the Docker Hub domain, `index.docker.io` and `registry-1.docker.io`, are folded
+// into `docker.io`.
+//
+// Normalization is idempotent: parsing the result again yields the same reference.
+func Parse(imageRef string) (reference.Named, error) {
+	namedRef, err := reference.ParseDockerRef(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	domain := reference.Domain(namedRef)
+
+	normalizedDomain := normalizeDomain(domain)
+	if normalizedDomain == domain {
+		return namedRef, nil
+	}
+
+	if !isExplicitDomain(normalizedDomain) {
+		// A single-label component is taken for a registry domain only because it is not
+		// lower-case: lower-casing it would turn the registry into a Docker Hub namespace and
+		// point the reference at a completely different image, so reject it instead.
+		return nil, fmt.Errorf("invalid reference format: registry domain %q must be lowercase", domain)
+	}
+
+	path := reference.Path(namedRef)
+
+	// the implicit `library/` namespace applies once the domain is folded into `docker.io`,
+	// e.g. `INDEX.DOCKER.IO/alpine` is `docker.io/library/alpine`
+	if normalizedDomain == dockerHubDomain && !strings.ContainsRune(path, '/') {
+		path = officialRepoPrefix + path
+	}
+
+	// build the reference explicitly rather than re-parsing the normalized string: re-parsing
+	// would re-run the domain/repository heuristics, which are case-sensitive
+	trimmedRef, err := reference.WithName(normalizedDomain + "/" + path)
+	if err != nil {
+		return nil, err
+	}
+
+	switch ref := namedRef.(type) {
+	case reference.Canonical:
+		return reference.WithDigest(trimmedRef, ref.Digest())
+	case reference.NamedTagged:
+		return reference.WithTag(trimmedRef, ref.Tag())
+	default:
+		return trimmedRef, nil
+	}
+}
+
+// RepositoryKey returns the canonical `<registry>/<repository>` form of the reference, with the
+// tag and the digest stripped.
+//
+// This is the key image verification rules are matched against.
+func RepositoryKey(namedRef reference.Named) string {
+	return reference.TrimNamed(namedRef).String()
+}
+
+// NormalizePattern normalizes the registry domain of an image reference glob pattern, so that the
+// pattern is matched in the same namespace the output of [RepositoryKey] is in.
+//
+// Only the domain part of the pattern is normalized: the repository part of a canonical reference
+// is always lower-case already, so folding its case would make a pattern match references it was
+// not written for.
+func NormalizePattern(pattern string) string {
+	domain, repository, hasRepository := strings.Cut(pattern, "/")
+
+	// a pattern which carries no `/` yet is still a pattern on the domain: the domain is the
+	// first thing the normalized reference starts with, so `index.docker.io*` has to be folded
+	// just like `index.docker.io/*` is
+	normalizedDomain := normalizeDomainPattern(domain)
+
+	if !hasRepository {
+		return normalizedDomain
+	}
+
+	return normalizedDomain + "/" + repository
+}
+
+// normalizeDomainPattern normalizes the glob pattern matched against a registry domain.
+func normalizeDomainPattern(domain string) string {
+	globIdx := strings.IndexRune(domain, '*')
+	if globIdx < 0 {
+		return normalizeDomain(domain)
+	}
+
+	// the glob matcher anchors the literal in front of the first `*` at the start of the
+	// reference, so that literal is normalized, while whatever the glob itself covers is matched
+	// as written
+	return normalizeDomain(domain[:globIdx]) + domain[globIdx:]
+}
+
+// normalizeDomain normalizes a registry domain to its canonical spelling.
+func normalizeDomain(domain string) string {
+	domain = strings.ToLower(domain)
+
+	switch domain {
+	case legacyDockerHubDomain, endpointDockerHubDomain:
+		return dockerHubDomain
+	default:
+		return domain
+	}
+}
+
+// isExplicitDomain reports whether the component is recognized as a registry domain by
+// github.com/distribution/reference independently of its case.
+func isExplicitDomain(domain string) bool {
+	return strings.ContainsAny(domain, ".:") || domain == localhostDomain
+}

--- a/internal/pkg/containers/image/imageref/imageref_test.go
+++ b/internal/pkg/containers/image/imageref/imageref_test.go
@@ -1,0 +1,244 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package imageref_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/imageref"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		imageRef string
+
+		expected      string
+		expectedKey   string
+		expectedError string
+	}{
+		{
+			imageRef: "registry.k8s.io/pause:3.9",
+
+			expected:    "registry.k8s.io/pause:3.9",
+			expectedKey: "registry.k8s.io/pause",
+		},
+		{ // the registry domain is a DNS name, so its case is not significant
+			imageRef: "REGISTRY.K8S.IO/pause:3.9",
+
+			expected:    "registry.k8s.io/pause:3.9",
+			expectedKey: "registry.k8s.io/pause",
+		},
+		{
+			imageRef: "Registry.K8s.IO:5000/pause:3.9",
+
+			expected:    "registry.k8s.io:5000/pause:3.9",
+			expectedKey: "registry.k8s.io:5000/pause",
+		},
+		{
+			imageRef: "docker.io/library/alpine:3.19",
+
+			expected:    "docker.io/library/alpine:3.19",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{ // the legacy Docker Hub domain folds into docker.io
+			imageRef: "index.docker.io/library/alpine:3.19",
+
+			expected:    "docker.io/library/alpine:3.19",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{
+			imageRef: "INDEX.DOCKER.IO/library/alpine:3.19",
+
+			expected:    "docker.io/library/alpine:3.19",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{ // the Docker Hub registry endpoint is the same registry as docker.io, so a
+			// reference written against it must not evade a rule written for docker.io
+			imageRef: "registry-1.docker.io/library/alpine:3.19",
+
+			expected:    "docker.io/library/alpine:3.19",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{
+			imageRef: "Registry-1.Docker.IO/alpine",
+
+			expected:    "docker.io/library/alpine:latest",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{ // the implicit library/ namespace is applied after the domain is normalized
+			imageRef: "INDEX.DOCKER.IO/alpine",
+
+			expected:    "docker.io/library/alpine:latest",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{
+			imageRef: "DOCKER.IO/alpine:3.19",
+
+			expected:    "docker.io/library/alpine:3.19",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{
+			imageRef: "alpine",
+
+			expected:    "docker.io/library/alpine:latest",
+			expectedKey: "docker.io/library/alpine",
+		},
+		{
+			imageRef: "GHCR.IO/siderolabs/kubelet@sha256:3fc16b37247f6f154d0ebf7428a28f89079a0a138c92c91fe975803d2e19ef2b",
+
+			expected:    "ghcr.io/siderolabs/kubelet@sha256:3fc16b37247f6f154d0ebf7428a28f89079a0a138c92c91fe975803d2e19ef2b",
+			expectedKey: "ghcr.io/siderolabs/kubelet",
+		},
+		{ // a reference carrying both a tag and a digest keeps only the digest
+			imageRef: "GHCR.IO/siderolabs/kubelet:v1.34.1@sha256:3fc16b37247f6f154d0ebf7428a28f89079a0a138c92c91fe975803d2e19ef2b",
+
+			expected:    "ghcr.io/siderolabs/kubelet@sha256:3fc16b37247f6f154d0ebf7428a28f89079a0a138c92c91fe975803d2e19ef2b",
+			expectedKey: "ghcr.io/siderolabs/kubelet",
+		},
+		{
+			imageRef: "LOCALHOST:5000/foo",
+
+			expected:    "localhost:5000/foo:latest",
+			expectedKey: "localhost:5000/foo",
+		},
+		{ // an uppercase repository path is not a valid reference, and lower-casing the
+			// domain must not turn one into a valid reference
+			imageRef: "registry.k8s.io/Pause:3.9",
+
+			expectedError: "invalid reference format: repository name (Pause) must be lowercase",
+		},
+		{ // a single-label component is only taken for a registry domain because it is not
+			// lower-case; it has no canonical spelling, so it is rejected outright
+			imageRef: "Foo/bar",
+
+			expectedError: `invalid reference format: registry domain "Foo" must be lowercase`,
+		},
+		{
+			imageRef: "LOCALHOST/foo",
+
+			expected:    "localhost/foo:latest",
+			expectedKey: "localhost/foo",
+		},
+		{
+			imageRef: "",
+
+			expectedError: "invalid reference format",
+		},
+	} {
+		t.Run(test.imageRef, func(t *testing.T) {
+			t.Parallel()
+
+			namedRef, err := imageref.Parse(test.imageRef)
+
+			if test.expectedError != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedError)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, namedRef.String())
+			assert.Equal(t, test.expectedKey, imageref.RepositoryKey(namedRef))
+
+			// normalization is idempotent: whichever spelling of the reference reaches the
+			// policy check, the pull and the registry configuration lookup, it is the same one
+			reparsed, err := imageref.Parse(namedRef.String())
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, reparsed.String())
+			assert.Equal(t, test.expectedKey, imageref.RepositoryKey(reparsed))
+		})
+	}
+}
+
+func TestNormalizePattern(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		pattern string
+
+		expected string
+	}{
+		{
+			pattern:  "registry.k8s.io/*",
+			expected: "registry.k8s.io/*",
+		},
+		{
+			pattern:  "REGISTRY.K8S.IO/*",
+			expected: "registry.k8s.io/*",
+		},
+		{ // the pattern shape given as the first example in the config reference
+			pattern:  "docker.io/library/nginx",
+			expected: "docker.io/library/nginx",
+		},
+		{
+			pattern:  "index.docker.io/library/alpine*",
+			expected: "docker.io/library/alpine*",
+		},
+		{
+			pattern:  "Index.Docker.IO/library/alpine*",
+			expected: "docker.io/library/alpine*",
+		},
+		{
+			pattern:  "*",
+			expected: "*",
+		},
+		{ // a glob in the domain is matched as written
+			pattern:  "*.docker.io/library/*",
+			expected: "*.docker.io/library/*",
+		},
+		{
+			pattern:  "*/library/*",
+			expected: "*/library/*",
+		},
+		{
+			pattern:  "nginx*",
+			expected: "nginx*",
+		},
+		{ // a pattern carrying no `/` is still anchored at the registry domain, so the
+			// domain literal in front of the glob is folded just as it is with a `/`
+			pattern:  "index.docker.io*",
+			expected: "docker.io*",
+		},
+		{
+			pattern:  "registry-1.docker.io/library/alpine*",
+			expected: "docker.io/library/alpine*",
+		},
+		{
+			pattern:  "REGISTRY-1.DOCKER.IO*",
+			expected: "docker.io*",
+		},
+		{
+			pattern:  "docker.io*",
+			expected: "docker.io*",
+		},
+		{ // the literal in front of the glob is not a complete domain, so there is nothing
+			// to fold, only to lower-case
+			pattern:  "INDEX.DOCKER.I*",
+			expected: "index.docker.i*",
+		},
+		{
+			pattern:  "REGISTRY.K8S.IO",
+			expected: "registry.k8s.io",
+		},
+		{
+			pattern:  "localhost:5000/*",
+			expected: "localhost:5000/*",
+		},
+	} {
+		t.Run(test.pattern, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, imageref.NormalizePattern(test.pattern))
+			assert.Equal(t, test.expected, imageref.NormalizePattern(test.expected), "normalization should be idempotent")
+		})
+	}
+}

--- a/internal/pkg/containers/image/pull.go
+++ b/internal/pkg/containers/image/pull.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/talos/internal/pkg/containers/image/imageref"
 	"github.com/siderolabs/talos/internal/pkg/containers/image/progress"
 	"github.com/siderolabs/talos/internal/pkg/containers/image/verify"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -54,7 +55,7 @@ func Pull(
 		o(&opts)
 	}
 
-	namedRef, err := reference.ParseDockerRef(ref)
+	namedRef, err := imageref.Parse(ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
 	}
@@ -82,7 +83,7 @@ func PullWithRetriesAndTimeout(
 		o(&opts)
 	}
 
-	namedRef, err := reference.ParseDockerRef(ref)
+	namedRef, err := imageref.Parse(ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
 	}
@@ -131,7 +132,9 @@ func pullInternal(
 	namedRef reference.Named,
 	opts PullOptions,
 ) (img containerd.Image, err error) {
-	// normalize reference
+	// the canonical form of the reference, as produced by imageref.Parse: this is the single
+	// spelling used for the verification policy match, for the registry configuration lookup and
+	// for the pull itself
 	ref := namedRef.String()
 
 	if opts.SkipIfAlreadyPulled {

--- a/internal/pkg/containers/image/tagfetch.go
+++ b/internal/pkg/containers/image/tagfetch.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/errdefs"
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -47,14 +47,16 @@ var tagFetchAccept = strings.Join([]string{
 func NewTagFetcher(reg cri.Registries) verify.TagFetcher {
 	hosts := RegistryHosts(reg)
 
-	return func(ctx context.Context, repo name.Repository, tag string, expectedDigest digest.Digest) ([]byte, error) {
-		registryHosts, err := hosts(repo.RegistryStr())
+	return func(ctx context.Context, repo reference.Named, tag string, expectedDigest digest.Digest) ([]byte, error) {
+		registryDomain := reference.Domain(repo)
+
+		registryHosts, err := hosts(registryDomain)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get registry hosts for %q: %w", repo.RegistryStr(), err)
+			return nil, fmt.Errorf("failed to get registry hosts for %q: %w", registryDomain, err)
 		}
 
 		if len(registryHosts) == 0 {
-			return nil, fmt.Errorf("no registry hosts for %q: %w", repo.RegistryStr(), errdefs.ErrNotFound)
+			return nil, fmt.Errorf("no registry hosts for %q: %w", registryDomain, errdefs.ErrNotFound)
 		}
 
 		var firstErr error
@@ -80,7 +82,7 @@ func NewTagFetcher(reg cri.Registries) verify.TagFetcher {
 // manifest, performs the same 401/Authorize handshake the docker resolver does,
 // and validates the returned content against expectedDigest.
 func fetchManifestByTagFromHost(
-	ctx context.Context, host docker.RegistryHost, repo name.Repository, tag string, expectedDigest digest.Digest,
+	ctx context.Context, host docker.RegistryHost, repo reference.Named, tag string, expectedDigest digest.Digest,
 ) ([]byte, error) {
 	reqURL := buildTagManifestURL(host, repo, tag)
 
@@ -210,8 +212,8 @@ func checkTagManifestStatus(status int, reqURL string) error {
 // buildTagManifestURL mirrors how containerd's dockerBase builds a manifests URL:
 // <scheme>://<host>/<host.Path>/<repo>/manifests/<tag>, with the proxy-namespace
 // query argument added when the configured host is not the image's registry.
-func buildTagManifestURL(host docker.RegistryHost, repo name.Repository, tag string) string {
-	p := path.Join("/", host.Path, repo.RepositoryStr(), "manifests", tag)
+func buildTagManifestURL(host docker.RegistryHost, repo reference.Named, tag string) string {
+	p := path.Join("/", host.Path, reference.Path(repo), "manifests", tag)
 
 	u := url.URL{
 		Scheme: host.Scheme,
@@ -223,7 +225,7 @@ func buildTagManifestURL(host docker.RegistryHost, repo name.Repository, tag str
 	// the upstream namespace as ?ns=<registry> so they know what to proxy.
 	// docker.DefaultHost handles aliases such as docker.io → registry-1.docker.io,
 	// so we don't have to duplicate that mapping here.
-	refHost := repo.RegistryStr()
+	refHost := reference.Domain(repo)
 
 	canonicalRefHost, err := docker.DefaultHost(refHost)
 	if err != nil {

--- a/internal/pkg/containers/image/tagfetch_test.go
+++ b/internal/pkg/containers/image/tagfetch_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/containerd/errdefs"
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,7 +142,7 @@ func TestTagFetcher(t *testing.T) {
 
 			fetcher := image.NewTagFetcher(cfg)
 
-			repo, err := name.NewRepository("example.com/" + repoStr)
+			repo, err := reference.WithName("example.com/" + repoStr)
 			require.NoError(t, err)
 
 			body, err := fetcher(t.Context(), repo, tag, expectedDigest)
@@ -199,7 +199,7 @@ func TestTagFetcherMaxBodySize(t *testing.T) {
 
 	fetcher := image.NewTagFetcher(cfg)
 
-	repo, err := name.NewRepository("example.com/" + repoStr)
+	repo, err := reference.WithName("example.com/" + repoStr)
 	require.NoError(t, err)
 
 	_, err = fetcher(t.Context(), repo, tag, advertisedDigest)

--- a/internal/pkg/containers/image/verify/internal/cosign/cosign.go
+++ b/internal/pkg/containers/image/verify/internal/cosign/cosign.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/distribution/reference"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -52,7 +52,7 @@ type VerifyResult struct {
 // NotFound, working around CDNs (notably registry.k8s.io) where the HEAD-by-tag
 // and GET-by-digest requests can land on different regional backends with
 // inconsistent replication. When nil, the fallback is skipped.
-type TagFetcher func(ctx context.Context, repository name.Repository, tag string, expectedDigest digest.Digest) ([]byte, error)
+type TagFetcher func(ctx context.Context, repository reference.Named, tag string, expectedDigest digest.Digest) ([]byte, error)
 
 // VerifyImage verifies the given image reference and digest against the provided verification configuration.
 //
@@ -67,11 +67,11 @@ type TagFetcher func(ctx context.Context, repository name.Repository, tag string
 //
 // The verifiers are in opts, if any of the verifiers returns true for bundle verification, the image is considered verified.
 func VerifyImage(
-	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher, imageRef name.Digest, co cosign.CheckOpts,
+	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher, imageRef reference.Canonical, co cosign.CheckOpts,
 ) (*VerifyResult, error) {
 	logger = logger.With(zap.Stringer("image", imageRef))
 
-	imageDigest, err := v1.NewHash(imageRef.DigestStr())
+	imageDigest, err := v1.NewHash(imageRef.Digest().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image digest: %w", err)
 	}
@@ -84,13 +84,13 @@ func VerifyImage(
 	artifactPolicyOption := verify.WithArtifactDigest(imageDigest.Algorithm, digestBytes)
 
 	// Step 1: try OCI referrers for new-style sigstore bundles.
-	fetcher, err := resolver.Fetcher(ctx, imageRef.Name())
+	fetcher, err := resolver.Fetcher(ctx, imageRef.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fetcher: %w", err)
 	}
 
 	if refFetcher, ok := fetcher.(remotes.ReferrersFetcher); ok {
-		referrers, err := refFetcher.FetchReferrers(ctx, digest.Digest(imageRef.DigestStr()),
+		referrers, err := refFetcher.FetchReferrers(ctx, imageRef.Digest(),
 			remotes.WithReferrerArtifactTypes(sigstoreBundleV03ArtifactType))
 		if err == nil {
 			bundleRefs := filterBundleReferrers(referrers)
@@ -184,13 +184,15 @@ func verifyBundleReferrers(
 //nolint:gocyclo
 func verifyFromBundleTag(
 	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher,
-	imageRef name.Digest, artifactPolicyOption verify.ArtifactPolicyOption, co cosign.CheckOpts,
+	imageRef reference.Canonical, artifactPolicyOption verify.ArtifactPolicyOption, co cosign.CheckOpts,
 ) (bool, *VerifyResult, error) {
-	bundleTag := strings.ReplaceAll(imageRef.DigestStr(), ":", "-")
+	bundleTag := strings.ReplaceAll(imageRef.Digest().String(), ":", "-")
 
 	logger.Debug("resolving bundle tag", zap.String("bundleTag", bundleTag))
 
-	resolvedName, desc, err := resolver.Resolve(ctx, imageRef.Repository.Name()+":"+bundleTag)
+	repository := reference.TrimNamed(imageRef)
+
+	resolvedName, desc, err := resolver.Resolve(ctx, repository.Name()+":"+bundleTag)
 	if err != nil {
 		logger.Debug("bundle tag not found", zap.String("bundleTag", bundleTag), zap.Error(err))
 
@@ -212,7 +214,7 @@ func verifyFromBundleTag(
 
 	switch desc.MediaType {
 	case ocispec.MediaTypeImageManifest:
-		manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, bundleTag)
+		manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, repository, bundleTag)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to fetch bundle manifest: %w", err)
 		}
@@ -225,7 +227,7 @@ func verifyFromBundleTag(
 	case ocispec.MediaTypeImageIndex:
 		// The bundle tag may be an OCI image index wrapping individual bundle manifests.
 		// Walk each manifest entry and collect bundle layers from all of them.
-		index, err := fetchIndexWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, bundleTag)
+		index, err := fetchIndexWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, repository, bundleTag)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to fetch bundle index: %w", err)
 		}
@@ -271,13 +273,15 @@ func verifyFromBundleTag(
 // cosign signature layers.
 func verifyFromLegacySigTag(
 	ctx context.Context, logger *zap.Logger, resolver remotes.Resolver, tagFetcher TagFetcher,
-	imageRef name.Digest, imageDigest v1.Hash, co cosign.CheckOpts,
+	imageRef reference.Canonical, imageDigest v1.Hash, co cosign.CheckOpts,
 ) (*VerifyResult, error) {
-	signatureTag := strings.ReplaceAll(imageRef.DigestStr(), ":", "-") + ".sig"
+	signatureTag := strings.ReplaceAll(imageRef.Digest().String(), ":", "-") + ".sig"
 
 	logger.Debug("resolving .sig tag", zap.String("signatureTag", signatureTag))
 
-	resolvedName, desc, err := resolver.Resolve(ctx, imageRef.Repository.Name()+":"+signatureTag)
+	repository := reference.TrimNamed(imageRef)
+
+	resolvedName, desc, err := resolver.Resolve(ctx, repository.Name()+":"+signatureTag)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("legacy signature tag not found")
@@ -297,7 +301,7 @@ func verifyFromLegacySigTag(
 		return nil, fmt.Errorf("failed to get fetcher for .sig manifest: %w", err)
 	}
 
-	manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, imageRef.Repository, signatureTag)
+	manifest, err := fetchManifestWithTagFallback(ctx, logger, fetcher, tagFetcher, desc, repository, signatureTag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch .sig manifest: %w", err)
 	}
@@ -431,7 +435,7 @@ func fetchIndex(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descr
 //nolint:dupl // not a duplicate of fetchIndexWithTagFallback - decodes a different type
 func fetchManifestWithTagFallback(
 	ctx context.Context, logger *zap.Logger, fetcher remotes.Fetcher, tagFetcher TagFetcher,
-	desc ocispec.Descriptor, repo name.Repository, tag string,
+	desc ocispec.Descriptor, repo reference.Named, tag string,
 ) (ocispec.Manifest, error) {
 	manifest, err := fetchManifest(ctx, fetcher, desc)
 	if err == nil {
@@ -462,7 +466,7 @@ func fetchManifestWithTagFallback(
 //nolint:dupl // not a duplicate of fetchManifestWithTagFallback - decodes a different type
 func fetchIndexWithTagFallback(
 	ctx context.Context, logger *zap.Logger, fetcher remotes.Fetcher, tagFetcher TagFetcher,
-	desc ocispec.Descriptor, repo name.Repository, tag string,
+	desc ocispec.Descriptor, repo reference.Named, tag string,
 ) (ocispec.Index, error) {
 	index, err := fetchIndex(ctx, fetcher, desc)
 	if err == nil {

--- a/internal/pkg/containers/image/verify/internal/cosign/cosign_test.go
+++ b/internal/pkg/containers/image/verify/internal/cosign/cosign_test.go
@@ -9,7 +9,7 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/distribution/reference"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -186,8 +186,11 @@ func TestVerifyImage(t *testing.T) {
 
 			logger := zaptest.NewLogger(t)
 
-			imageRef, err := name.NewDigest(test.imageRef)
+			namedRef, err := reference.ParseDockerRef(test.imageRef)
 			require.NoError(t, err)
+
+			imageRef, ok := namedRef.(reference.Canonical)
+			require.True(t, ok, "image reference must be digested")
 
 			result, err := ourcosign.VerifyImage(t.Context(), logger, resolver, tagFetcher, imageRef, test.checkOpts)
 

--- a/internal/pkg/containers/image/verify/rules.go
+++ b/internal/pkg/containers/image/verify/rules.go
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verify
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/ryanuber/go-glob"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/imageref"
+	"github.com/siderolabs/talos/pkg/machinery/resources/security"
+)
+
+// RuleMatchFunc matches an image reference against the image verification rules.
+//
+// The image reference is normalized before it is matched, and the returned rule is the first one
+// whose (also normalized) pattern matches; a nil rule means no rule matched.
+type RuleMatchFunc func(imageRef string) (*security.ImageVerificationRule, error)
+
+// NewRuleMatcher builds a matcher for the image verification rules present in the state.
+//
+// Both the image reference and the rule patterns are normalized with [imageref], so that a rule is
+// matched against the very reference which is going to be pulled: matching a reference in one
+// spelling while pulling another would let a rule be evaded by, say, upper-casing the registry
+// domain.
+func NewRuleMatcher(ctx context.Context, st state.State) (RuleMatchFunc, error) {
+	rules, err := safe.StateListAll[*security.ImageVerificationRule](ctx, st)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list image verification rules: %w", err)
+	}
+
+	type normalizedRule struct {
+		rule    *security.ImageVerificationRule
+		pattern string
+	}
+
+	normalizedRules := make([]normalizedRule, 0, rules.Len())
+
+	for rule := range rules.All() {
+		if rule.TypedSpec().ImagePattern == "" {
+			continue
+		}
+
+		normalizedRules = append(normalizedRules, normalizedRule{
+			rule:    rule,
+			pattern: imageref.NormalizePattern(rule.TypedSpec().ImagePattern),
+		})
+	}
+
+	return func(imageRef string) (*security.ImageVerificationRule, error) {
+		namedRef, err := imageref.Parse(imageRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
+		}
+
+		// rules match on the registry and the repository only, never on the tag or the digest
+		repositoryKey := imageref.RepositoryKey(namedRef)
+
+		for _, normalized := range normalizedRules {
+			if glob.Glob(normalized.pattern, repositoryKey) {
+				return normalized.rule, nil
+			}
+		}
+
+		return nil, nil
+	}, nil
+}

--- a/internal/pkg/containers/image/verify/rules_test.go
+++ b/internal/pkg/containers/image/verify/rules_test.go
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verify_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/internal/pkg/containers/image/verify"
+	"github.com/siderolabs/talos/pkg/machinery/resources/security"
+)
+
+func TestRuleMatcher(t *testing.T) {
+	t.Parallel()
+
+	patterns := []string{
+		"registry.k8s.io/*",
+		"docker.io/library/busybox*",
+		"index.docker.io/library/alpine*",
+		"ghcr.io/siderolabs/*",
+		"index.docker.io*",
+	}
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	for idx, pattern := range patterns {
+		rule := security.NewImageVerificationRule(fmt.Sprintf("%04d", idx))
+		rule.TypedSpec().ImagePattern = pattern
+		rule.TypedSpec().Deny = true
+
+		require.NoError(t, st.Create(t.Context(), rule))
+	}
+
+	matcher, err := verify.NewRuleMatcher(t.Context(), st)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		imageRef string
+
+		expectedRuleID string
+		expectedError  string
+	}{
+		{
+			imageRef:       "registry.k8s.io/pause:3.9",
+			expectedRuleID: "0000",
+		},
+		{ // the registry domain is a DNS name, so upper-casing it must not evade the rule
+			imageRef:       "REGISTRY.K8S.IO/pause:3.9",
+			expectedRuleID: "0000",
+		},
+		{
+			imageRef:       "registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097",
+			expectedRuleID: "0000",
+		},
+		{ // a rule written the way the configuration reference shows it matches Docker Hub
+			imageRef:       "docker.io/library/busybox:1.36",
+			expectedRuleID: "0001",
+		},
+		{
+			imageRef:       "busybox:1.36",
+			expectedRuleID: "0001",
+		},
+		{
+			imageRef:       "index.docker.io/library/busybox:1.36",
+			expectedRuleID: "0001",
+		},
+		{ // registry-1.docker.io is the Docker Hub endpoint docker.io itself resolves to, so a
+			// reference written that way must not evade a rule written for docker.io
+			imageRef:       "registry-1.docker.io/library/busybox:1.36",
+			expectedRuleID: "0001",
+		},
+		{
+			imageRef:       "REGISTRY-1.DOCKER.IO/busybox:1.36",
+			expectedRuleID: "0001",
+		},
+		{ // and so does a rule written against the legacy Docker Hub domain
+			imageRef:       "docker.io/library/alpine:3.19",
+			expectedRuleID: "0002",
+		},
+		{
+			imageRef:       "DOCKER.IO/library/alpine:3.19",
+			expectedRuleID: "0002",
+		},
+		{
+			imageRef:       "ghcr.io/siderolabs/kubelet:v1.34.1",
+			expectedRuleID: "0003",
+		},
+		{ // a rule pattern carrying no `/` is anchored at the registry domain and is folded
+			// just like one written as `index.docker.io/*`
+			imageRef:       "nginx:latest",
+			expectedRuleID: "0004",
+		},
+		{
+			imageRef: "quay.io/some/image:v1.0.0",
+		},
+		{ // the tag is never part of the match
+			imageRef: "quay.io/registry.k8s.io:latest",
+		},
+		{
+			imageRef:      "registry.k8s.io/Pause:3.9",
+			expectedError: `failed to parse image reference "registry.k8s.io/Pause:3.9": invalid reference format: repository name (Pause) must be lowercase`,
+		},
+	} {
+		t.Run(test.imageRef, func(t *testing.T) {
+			t.Parallel()
+
+			rule, err := matcher(test.imageRef)
+
+			if test.expectedError != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedError)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			if test.expectedRuleID == "" {
+				assert.Nil(t, rule)
+
+				return
+			}
+
+			require.NotNil(t, rule)
+			assert.Equal(t, test.expectedRuleID, rule.Metadata().ID())
+		})
+	}
+}

--- a/internal/pkg/containers/image/verify/verify.go
+++ b/internal/pkg/containers/image/verify/verify.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/distribution/reference"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/talos/internal/pkg/containers/image/imageref"
 	ourcosign "github.com/siderolabs/talos/internal/pkg/containers/image/verify/internal/cosign"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/resources/security"
@@ -34,6 +35,10 @@ type TagFetcher = ourcosign.TagFetcher
 
 // ImageSignature verifies image signature within Talos source code.
 //
+// The image reference is normalized with [imageref] before anything else: the verification rules
+// are matched against the canonical reference, and the digested reference returned on success is
+// in the same namespace, so that the image which was verified is the image which gets pulled.
+//
 // tagFetcher (optional) is invoked when the resolver's digest-based manifest
 // fetch returns NotFound — see [TagFetcher].
 //
@@ -43,21 +48,29 @@ func ImageSignature(
 ) (*machine.ImageServiceVerifyResponse, error) {
 	logger = logger.With(zap.String("image_ref", imageRef))
 
-	inRef, err := name.ParseReference(imageRef)
+	namedRef, err := imageref.Parse(imageRef)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "image reference is invalid: %s", err)
 	}
 
-	ruleMatcher, err := security.ImageVerificationRuleMatcher(ctx, resources)
+	normalizedRef := namedRef.String()
+
+	logger = logger.With(zap.String("normalized_image_ref", normalizedRef))
+
+	ruleMatcher, err := NewRuleMatcher(ctx, resources)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create image verification rule matcher: %s", err)
 	}
 
-	logger.Debug("finding matching image verification rule for image reference", zap.Stringer("image_ref_context", inRef.Context()))
+	logger.Debug("finding matching image verification rule for image reference")
 
-	matchedRule := ruleMatcher(inRef.Context().String())
+	matchedRule, err := ruleMatcher(normalizedRef)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to match image verification rules: %s", err)
+	}
+
 	if matchedRule == nil {
-		logger.Info("no matched image verification rule, allowing by default", zap.Stringer("image_ref_context", inRef.Context()))
+		logger.Info("no matched image verification rule, allowing by default")
 
 		return &machine.ImageServiceVerifyResponse{
 			Verified: false,
@@ -81,13 +94,9 @@ func ImageSignature(
 	}
 
 	// resolve the image reference to a digest reference if needed
-	var (
-		digestRef name.Digest
-		ok        bool
-	)
-
-	if digestRef, ok = inRef.(name.Digest); !ok {
-		_, desc, err := resolver.Resolve(ctx, inRef.String())
+	digestRef, ok := namedRef.(reference.Canonical)
+	if !ok {
+		_, desc, err := resolver.Resolve(ctx, normalizedRef)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				logger.Info("image reference not found during resolution", zap.Error(err))
@@ -98,7 +107,7 @@ func ImageSignature(
 			return nil, status.Errorf(codes.Internal, "failed to resolve image reference: %s", err)
 		}
 
-		digestRef, err = name.NewDigest(inRef.Context().Name() + "@" + desc.Digest.String())
+		digestRef, err = reference.WithDigest(reference.TrimNamed(namedRef), desc.Digest)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to construct digest reference: %s", err)
 		}

--- a/pkg/machinery/config/types/security/image_verification.go
+++ b/pkg/machinery/config/types/security/image_verification.go
@@ -96,6 +96,11 @@ type ImageVerificationRuleV1Alpha1 struct {
 	//   description: |
 	//     Image reference pattern to match for this rule.
 	//     Supports glob patterns, matches only on the image registry and repository, not on the tag or digest.
+	//
+	//     The pattern is matched against the normalized image reference, which always starts with a registry
+	//     domain: `docker.io/library/nginx*` matches `nginx:latest`, while `library/nginx*` matches nothing.
+	//     The Docker Hub domain is always normalized to `docker.io`, so a pattern written against
+	//     `index.docker.io` or `registry-1.docker.io` matches the same images a `docker.io` one does.
 	//   examples:
 	//     - value: >
 	//         "docker.io/library/nginx"
@@ -175,7 +180,7 @@ func exampleImageVerificationConfigV1Alpha1() *ImageVerificationConfigV1Alpha1 {
 			},
 		},
 		{
-			RuleImagePattern: "my-registry/*",
+			RuleImagePattern: "my-registry.example.com/*",
 			RulePublicKeyVerifier: &ImagePublicKeyVerifierV1Alpha1{
 				ConfigCertificate: `-----BEGIN CERTIFICATE-----
 MII--Sample Value--
@@ -183,7 +188,7 @@ MII--Sample Value--
 			},
 		},
 		{
-			RuleImagePattern: "locahost:3000/*",
+			RuleImagePattern: "localhost:3000/*",
 			RuleDeny:         new(true),
 		},
 	}
@@ -223,8 +228,10 @@ func (s *ImageVerificationConfigV1Alpha1) Validate(validation.RuntimeMode, ...va
 			}
 		}
 
-		if !strings.ContainsRune(rule.RuleImagePattern, '/') && rule.RuleImagePattern != "*" && rule.RuleImagePattern != "" {
-			warnings = append(warnings, fmt.Sprintf("rule %d: imagePattern does not contain a '/', image references like 'nginx' are matched as 'docker.io/nginx' (normalized)", i))
+		if pattern := rule.RuleImagePattern; pattern != "" && patternMatchesNoImage(pattern) {
+			warnings = append(warnings,
+				fmt.Sprintf("rule %d: imagePattern %q cannot match any image: references are matched in their normalized "+
+					"'<registry domain>/<repository>' form, e.g. 'nginx' is matched as 'docker.io/library/nginx'", i, pattern))
 		}
 
 		skip := pointer.SafeDeref(rule.RuleSkip)
@@ -268,6 +275,28 @@ func (s *ImageVerificationConfigV1Alpha1) Validate(validation.RuntimeMode, ...va
 	}
 
 	return warnings, errs
+}
+
+// patternMatchesNoImage reports whether the pattern cannot match any image reference at all.
+//
+// Image references are matched in their normalized `<registry domain>/<repository>` form, and the
+// glob matcher anchors the pattern's leading literal at the start of the reference. So a pattern
+// whose leading literal reaches past the domain separator without being a registry domain can
+// never match — `library/nginx*` does not match `docker.io/library/nginx` — and neither can a
+// pattern which has no glob and no `/`, as every normalized reference has one.
+func patternMatchesNoImage(pattern string) bool {
+	// the literal which the glob matcher anchors at the start of the reference
+	prefix, _, hasGlob := strings.Cut(pattern, "*")
+
+	domain, _, hasSeparator := strings.Cut(prefix, "/")
+	if !hasSeparator {
+		// the literal stops short of the domain separator, so it can still be extended into a
+		// registry domain by a glob
+		return !hasGlob
+	}
+
+	// the domain of a pattern is matched case-insensitively, just like the domain of a reference
+	return !strings.ContainsAny(domain, ".:") && !strings.EqualFold(domain, "localhost")
 }
 
 // Rules implements config.ImageVerificationConfig interface.

--- a/pkg/machinery/config/types/security/image_verification_test.go
+++ b/pkg/machinery/config/types/security/image_verification_test.go
@@ -345,6 +345,35 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 						RuleImagePattern: "nginx",
 						RuleSkip:         new(true),
 					},
+					{
+						RuleImagePattern: "library/nginx*",
+						RuleSkip:         new(true),
+					},
+					{ // a pattern which does start with a registry domain draws no warning
+						RuleImagePattern: "docker.io/library/nginx*",
+						RuleSkip:         new(true),
+					},
+					{
+						RuleImagePattern: "localhost:5000/*",
+						RuleSkip:         new(true),
+					},
+					{ // the domain of a pattern is normalized before it is matched, so its
+						// case is not significant here either
+						RuleImagePattern: "LOCALHOST/*",
+						RuleSkip:         new(true),
+					},
+					{
+						RuleImagePattern: "*/library/nginx*",
+						RuleSkip:         new(true),
+					},
+					{ // a glob can still be extended into a registry domain, e.g. 'nginx.io/foo'
+						RuleImagePattern: "nginx*",
+						RuleSkip:         new(true),
+					},
+					{
+						RuleImagePattern: "*",
+						RuleSkip:         new(true),
+					},
 				}
 
 				return c
@@ -353,7 +382,10 @@ func TestImageVerificationConfigValidate(t *testing.T) {
 			expectedWarnings: []string{
 				"rule 0: imagePattern contains ':' but matching only applies to the image registry and repository, not the tag or digest",
 				"rule 1: imagePattern contains '@' but matching only applies to the image registry and repository, not the tag or digest",
-				"rule 2: imagePattern does not contain a '/', image references like 'nginx' are matched as 'docker.io/nginx' (normalized)",
+				"rule 2: imagePattern \"nginx\" cannot match any image: references are matched in their normalized " +
+					"'<registry domain>/<repository>' form, e.g. 'nginx' is matched as 'docker.io/library/nginx'",
+				"rule 3: imagePattern \"library/nginx*\" cannot match any image: references are matched in their normalized " +
+					"'<registry domain>/<repository>' form, e.g. 'nginx' is matched as 'docker.io/library/nginx'",
 			},
 		},
 	} {

--- a/pkg/machinery/config/types/security/security_doc.go
+++ b/pkg/machinery/config/types/security/security_doc.go
@@ -83,7 +83,7 @@ func (ImageVerificationRuleV1Alpha1) Doc() *encoder.Doc {
 				Name:        "image",
 				Type:        "string",
 				Note:        "",
-				Description: "Image reference pattern to match for this rule.\nSupports glob patterns, matches only on the image registry and repository, not on the tag or digest.",
+				Description: "Image reference pattern to match for this rule.\nSupports glob patterns, matches only on the image registry and repository, not on the tag or digest.\n\nThe pattern is matched against the normalized image reference, which always starts with a registry\ndomain: `docker.io/library/nginx*` matches `nginx:latest`, while `library/nginx*` matches nothing.\nThe Docker Hub domain is always normalized to `docker.io`, so a pattern written against\n`index.docker.io` or `registry-1.docker.io` matches the same images a `docker.io` one does.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Image reference pattern to match for this rule." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
 			{

--- a/pkg/machinery/resources/security/image_verification_rule.go
+++ b/pkg/machinery/resources/security/image_verification_rule.go
@@ -6,16 +6,10 @@
 package security
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/resource/typed"
-	"github.com/cosi-project/runtime/pkg/safe"
-	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/ryanuber/go-glob"
 
 	"github.com/siderolabs/talos/pkg/machinery/proto"
 )
@@ -94,27 +88,6 @@ func (ImageVerificationRuleExtension) ResourceDefinition() meta.ResourceDefiniti
 			},
 		},
 	}
-}
-
-// ImageVerificationRuleMatchFunc is a function type for matching image references to verification rules.
-type ImageVerificationRuleMatchFunc func(imageRef string) *ImageVerificationRule
-
-// ImageVerificationRuleMatcher creates the matcher for the given image reference against the provided rules and returns the first matching rule.
-func ImageVerificationRuleMatcher(ctx context.Context, st state.State) (ImageVerificationRuleMatchFunc, error) {
-	rules, err := safe.StateListAll[*ImageVerificationRule](ctx, st)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list image verification rules: %w", err)
-	}
-
-	return func(imageRef string) *ImageVerificationRule {
-		for rule := range rules.All() {
-			if rule.TypedSpec().ImagePattern != "" && glob.Glob(rule.TypedSpec().ImagePattern, imageRef) {
-				return rule
-			}
-		}
-
-		return nil
-	}, nil
 }
 
 func init() {

--- a/website/content/v1.15/reference/configuration/security/imageverificationconfig.md
+++ b/website/content/v1.15/reference/configuration/security/imageverificationconfig.md
@@ -26,14 +26,14 @@ rules:
 
         # # Regex pattern for subject matching.
         # subjectRegex: .*@example\.com
-    - image: my-registry/* # Image reference pattern to match for this rule.
+    - image: my-registry.example.com/* # Image reference pattern to match for this rule.
       # Public key verifier configuration to use for this rule.
       publicKey:
         certificate: |- # A public certificate in PEM format accepted for image signature verification.
             -----BEGIN CERTIFICATE-----
             MII--Sample Value--
             -----END CERTIFICATE-----
-    - image: locahost:3000/* # Image reference pattern to match for this rule.
+    - image: localhost:3000/* # Image reference pattern to match for this rule.
       deny: true # Deny pulling images matching the pattern (default: false).
 {{< /highlight >}}
 
@@ -54,7 +54,7 @@ ImageVerificationRuleV1Alpha1 defines a verification rule.
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`image` |string |Image reference pattern to match for this rule.<br>Supports glob patterns, matches only on the image registry and repository, not on the tag or digest. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
+|`image` |string |Image reference pattern to match for this rule.<br>Supports glob patterns, matches only on the image registry and repository, not on the tag or digest.<br><br>The pattern is matched against the normalized image reference, which always starts with a registry<br>domain: `docker.io/library/nginx*` matches `nginx:latest`, while `library/nginx*` matches nothing.<br>The Docker Hub domain is always normalized to `docker.io`, so a pattern written against<br>`index.docker.io` or `registry-1.docker.io` matches the same images a `docker.io` one does. <details><summary>Show example(s)</summary>{{< highlight yaml >}}
 image: docker.io/library/nginx
 {{< /highlight >}}{{< highlight yaml >}}
 image: registry.k8s.io/*


### PR DESCRIPTION
When image verification config is enabled, it's important to ensure that the rule matching for verification matches exactly further pull attempt, so make sure that before anything else happens, image reference is normalized to match the normalization during the actual image pull flow.
