### PR TITLE
fix: name diskSelector in UnattendedInstallConfig validation errors

### DIFF
--- a/pkg/machinery/config/types/runtime/unattended_install.go
+++ b/pkg/machinery/config/types/runtime/unattended_install.go
@@ -112,11 +112,11 @@ func (s ProvisioningSpec) IsZero() bool {
 // Validate parses selector without mutating stored config.
 func (s ProvisioningSpec) Validate() error {
 	if s.DiskSelector.Match.IsZero() {
-		return errors.New("provisioning.volumeSelector.match is required")
+		return errors.New("provisioning.diskSelector.match is required")
 	}
 
 	if err := s.DiskSelector.Match.ParseBool(celenv.DiskLocator()); err != nil {
-		return fmt.Errorf("provisioning.volumeSelector.match: %w", err)
+		return fmt.Errorf("provisioning.diskSelector.match: %w", err)
 	}
 
 	return nil

--- a/pkg/machinery/config/types/runtime/unattended_install_test.go
+++ b/pkg/machinery/config/types/runtime/unattended_install_test.go
@@ -90,7 +90,7 @@ func TestUnattendedInstallValidate(t *testing.T) {
 		{
 			name:          "empty",
 			cfg:           runtime.NewUnattendedInstallConfigV1Alpha1,
-			expectedError: "provisioning.volumeSelector.match is required",
+			expectedError: "provisioning.diskSelector.match is required",
 			expectedWarnings: []string{
 				"installer.image is not set, if Talos is not booted from asset built by Image Factory, installation will fail",
 			},
@@ -108,14 +108,14 @@ func TestUnattendedInstallValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "no volume selector match",
+			name: "no disk selector match",
 			cfg: func() *runtime.UnattendedInstallConfigV1Alpha1 {
 				cfg := runtime.NewUnattendedInstallConfigV1Alpha1()
 				cfg.Installer.Image = "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.0.0"
 
 				return cfg
 			},
-			expectedError: "provisioning.volumeSelector.match is required",
+			expectedError: "provisioning.diskSelector.match is required",
 		},
 		{
 			name: "invalid match expression",
@@ -131,7 +131,7 @@ func TestUnattendedInstallValidate(t *testing.T) {
 
 				return cfg
 			},
-			expectedError: "provisioning.volumeSelector.match: expression output type is int, expected bool",
+			expectedError: "provisioning.diskSelector.match: expression output type is int, expected bool",
 		},
 		{
 			name: "valid config",


### PR DESCRIPTION
## What? (description)

`ProvisioningSpec.Validate` names `provisioning.volumeSelector.match`, but the field is `provisioning.diskSelector` — there is no `volumeSelector` key anywhere in `UnattendedInstallConfig`.

Changes the two strings, the three test assertions covering them, and one subtest name. No behaviour change.

## Why? (reasoning)

Fixes #14213.

Both strings are byte-identical to the ones in `LVMVolumeGroupConfig` and `RAIDArrayConfig`, where `volumeSelector` *is* the correct field name. This type looks to have been derived from one of those and the field renamed to `diskSelector` without the messages following. Present since 416073748, the type's first commit.

**Backport to `release-1.14`?** This is the first error some people will meet on 1.14 — [at least one config generator currently emits](https://github.com/postfinance/topf/pull/128#issuecomment-5501074383) `provisioning: {}`, so the message lands before anything else does. It would be good to have in 1.14.0 rather than waiting for 1.15. Happy to open the backport PR if you want it.

## Acceptance

- [x] you linked an issue (if applicable) — #14213
- [x] you included tests (if applicable) — updated the three existing assertions. Changing those first made all three subtests fail against the old strings, which confirmed they cover every site this PR touches.
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
