### PR TITLE
test: isolate base OCI spec test in BGP CLOS runs

### DIFF
--- a/internal/integration/api/common.go
+++ b/internal/integration/api/common.go
@@ -236,7 +236,14 @@ func (suite *CommonSuite) TestBaseOCISpec() {
 		suite.T().Skip("skipping ulimits test since provisioner is docker")
 	}
 
-	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+	nodeType := machine.TypeWorker
+
+	if suite.BGPCLOSEnabled {
+		// Keep the CRI restart away from the worker used by the BGP CLOS tests.
+		nodeType = machine.TypeControlPlane
+	}
+
+	node := suite.RandomDiscoveredNodeInternalIP(nodeType)
 
 	k8sNode, err := suite.GetK8sNodeByInternalIP(suite.ctx, node)
 	suite.Require().NoError(err)


### PR DESCRIPTION
Keep the normal worker placement outside BGP CLOS runs. When BGP CLOS is enabled, run the test on a control plane so its CRI restart and exec checks do not use the worker exercised by BGP and MetalLB tests.