### PR TITLE
fix: harden the code around kubelet's client certificate handling

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -195,11 +195,12 @@ message KubeletConfigSpec {
   map<string, string> register_with_taints = 16;
 }
 
-// KubeletKubeconfigSpec describes the current kubelet kubeconfig file.
+// KubeletKubeconfigSpec describes the current kubelet client credentials.
 message KubeletKubeconfigSpec {
-  // Hash is a content digest of the kubeconfig file. It changes whenever the
-  // file contents change, which is the signal consumers use to rebuild their
-  // Kubernetes clients.
+  // Hash is a content digest of the kubeconfig file and of the certificates it
+  // references on disk (kubelet rotates its client certificate without ever
+  // touching the kubeconfig). It changes whenever the credentials change, which
+  // is the signal consumers use to rebuild their Kubernetes clients.
   string hash = 1;
 }
 

--- a/hack/test/patches/kube-short-certs.yaml
+++ b/hack/test/patches/kube-short-certs.yaml
@@ -1,0 +1,10 @@
+# this patch is not wired in the CI, but it allows to shorten
+# the duration of the cluster signing certificates to 15 minutes,
+# which is useful for testing certificate rotation.
+#
+# apply this patch and let the cluster be idle for 15+ minutes -
+# Talos should not report any errors.
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+extraArgs:
+  cluster-signing-duration: 15m

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
@@ -24,6 +24,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 )
 
+// watchErrorsThreshold is the number of consecutive watch errors before the Kubernetes
+// client is rebuilt from scratch.
+const watchErrorsThreshold = 5
+
 // KubernetesPullController pulls list of Affiliate resource from the Kubernetes registry.
 type KubernetesPullController struct{}
 
@@ -47,6 +51,12 @@ func (ctrl *KubernetesPullController) Inputs() []controller.Input {
 			ID:        optional.Some(k8s.NodenameID),
 			Kind:      controller.InputWeak,
 		},
+		{
+			Namespace: k8s.NamespaceName,
+			Type:      k8s.KubeletKubeconfigType,
+			ID:        optional.Some(k8s.KubeletKubeconfigID),
+			Kind:      controller.InputWeak,
+		},
 	}
 }
 
@@ -65,26 +75,43 @@ func (ctrl *KubernetesPullController) Outputs() []controller.Output {
 //nolint:gocyclo,cyclop
 func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	var (
-		kubernetesClient   *kubernetes.Client
-		kubernetesRegistry *registry.Kubernetes
-		watchCtxCancel     context.CancelFunc
-		notifyCh           <-chan struct{}
-		notifyCloser       func()
+		kubernetesClient     *kubernetes.Client
+		kubernetesRegistry   *registry.Kubernetes
+		watchCtxCancel       context.CancelFunc
+		notifyCh             <-chan struct{}
+		watchErrCh           <-chan error
+		notifyCloser         func()
+		watchErrors          int
+		watchReady           bool
+		watcherKubeconfigVer string
 	)
 
-	defer func() {
+	closeWatcher := func() {
 		if watchCtxCancel != nil {
 			watchCtxCancel()
+			watchCtxCancel = nil
 		}
 
 		if notifyCloser != nil {
 			notifyCloser()
+			notifyCloser = nil
+			notifyCh = nil
+			watchErrCh = nil
 		}
 
 		if kubernetesClient != nil {
 			kubernetesClient.Close() //nolint:errcheck
+
+			kubernetesClient = nil
 		}
-	}()
+
+		kubernetesRegistry = nil
+		watchErrors = 0
+		watchReady = false
+		watcherKubeconfigVer = ""
+	}
+
+	defer closeWatcher()
 
 	for {
 		select {
@@ -92,6 +119,22 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 			return nil
 		case <-r.EventCh():
 		case <-notifyCh:
+			watchErrors = 0
+			watchReady = true
+		case watchErr := <-watchErrCh:
+			watchErrors++
+
+			logger.Error("kubernetes registry node watch error", zap.Error(watchErr), zap.Int("error_count", watchErrors))
+
+			if watchErrors < watchErrorsThreshold {
+				continue
+			}
+
+			// the client might be holding on to credentials which are no longer valid
+			// (e.g. kubelet rotated its client certificate), so rebuild it from scratch
+			logger.Info("restarting Kubernetes registry watch with a new client")
+
+			closeWatcher()
 		}
 
 		discoveryConfig, err := safe.ReaderGetByID[*cluster.Config](ctx, r, cluster.ConfigID)
@@ -125,6 +168,30 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 			continue
 		}
 
+		// Look up the current kubelet credentials hash: it changes both when the kubeconfig
+		// is rewritten and when kubelet rotates its client certificate, and either way the
+		// cached client is pinned to the credentials it read when it was built.
+		kubeconfigRes, err := safe.ReaderGetByID[*k8s.KubeletKubeconfig](ctx, r, k8s.KubeletKubeconfigID)
+		if err != nil {
+			if !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting kubelet kubeconfig: %w", err)
+			}
+
+			continue
+		}
+
+		currentKubeconfigVer := kubeconfigRes.TypedSpec().Hash
+
+		if kubernetesClient != nil && watcherKubeconfigVer != currentKubeconfigVer {
+			logger.Info(
+				"kubelet credentials changed, restarting Kubernetes registry watch",
+				zap.String("old_hash", watcherKubeconfigVer),
+				zap.String("new_hash", currentKubeconfigVer),
+			)
+
+			closeWatcher()
+		}
+
 		if kubernetesClient == nil {
 			kubernetesClient, err = kubernetes.NewClientFromKubeletKubeconfig()
 			if err != nil {
@@ -141,10 +208,19 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 
 			watchCtx, watchCtxCancel = context.WithCancel(ctx) //nolint:govet
 
-			notifyCh, notifyCloser, err = kubernetesRegistry.Watch(watchCtx, logger)
+			notifyCh, watchErrCh, notifyCloser, err = kubernetesRegistry.Watch(watchCtx)
 			if err != nil {
 				return fmt.Errorf("error setting up registry watcher: %w", err) //nolint:govet
 			}
+
+			watcherKubeconfigVer = currentKubeconfigVer
+		}
+
+		if !watchReady {
+			// The informer cache backing List() is empty until the watch delivers its first
+			// notification, so listing now would yield no affiliates and make cleanupAffiliates()
+			// destroy every affiliate this controller owns until the cache syncs.
+			continue
 		}
 
 		affiliateSpecs, err := kubernetesRegistry.List(nodename.TypedSpec().Nodename)

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
@@ -21,12 +21,14 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 )
 
 // KubernetesPushController pushes Affiliate resource to the Kubernetes registry.
 type KubernetesPushController struct {
-	localAffiliateID resource.ID
-	kubernetesClient *kubernetes.Client
+	localAffiliateID    resource.ID
+	kubernetesClient    *kubernetes.Client
+	clientKubeconfigVer string
 }
 
 // Name implements controller.Controller interface.
@@ -49,6 +51,12 @@ func (ctrl *KubernetesPushController) Inputs() []controller.Input {
 			ID:        optional.Some(cluster.LocalIdentity),
 			Kind:      controller.InputWeak,
 		},
+		{
+			Namespace: k8s.NamespaceName,
+			Type:      k8s.KubeletKubeconfigType,
+			ID:        optional.Some(k8s.KubeletKubeconfigID),
+			Kind:      controller.InputWeak,
+		},
 	}
 }
 
@@ -60,7 +68,7 @@ func (ctrl *KubernetesPushController) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 //
 //nolint:gocyclo
-func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
+func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	defer func() {
 		if ctrl.kubernetesClient != nil {
 			ctrl.kubernetesClient.Close() //nolint:errcheck
@@ -127,14 +135,16 @@ func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runt
 				continue
 			}
 
-			if ctrl.kubernetesClient == nil {
-				ctrl.kubernetesClient, err = kubernetes.NewClientFromKubeletKubeconfig()
-				if err != nil {
-					return fmt.Errorf("error building kubernetes client: %w", err)
-				}
+			client, err := ctrl.getKubernetesClient(ctx, r, logger)
+			if err != nil {
+				return err
 			}
 
-			if err = registry.NewKubernetes(ctrl.kubernetesClient).Push(ctx, affiliate); err != nil {
+			if client == nil {
+				continue
+			}
+
+			if err = registry.NewKubernetes(client).Push(ctx, affiliate); err != nil {
 				// reset client connection
 				ctrl.kubernetesClient.Close() //nolint:errcheck
 				ctrl.kubernetesClient = nil
@@ -145,4 +155,46 @@ func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runt
 
 		r.ResetRestartBackoff()
 	}
+}
+
+// getKubernetesClient returns the cached Kubernetes client, rebuilding it whenever the
+// kubelet credentials on disk have changed since the client was built.
+//
+// The credentials are read once when the client is created, so a client which outlives a
+// kubelet client certificate rotation would keep presenting an expired certificate.
+//
+// It returns a nil client if the kubelet credentials are not available yet.
+func (ctrl *KubernetesPushController) getKubernetesClient(ctx context.Context, r controller.Runtime, logger *zap.Logger) (*kubernetes.Client, error) {
+	kubeconfigRes, err := safe.ReaderGetByID[*k8s.KubeletKubeconfig](ctx, r, k8s.KubeletKubeconfigID)
+	if err != nil {
+		if !state.IsNotFoundError(err) {
+			return nil, fmt.Errorf("error getting kubelet kubeconfig: %w", err)
+		}
+
+		return nil, nil
+	}
+
+	currentKubeconfigVer := kubeconfigRes.TypedSpec().Hash
+
+	if ctrl.kubernetesClient != nil && ctrl.clientKubeconfigVer != currentKubeconfigVer {
+		logger.Info(
+			"kubelet credentials changed, rebuilding Kubernetes client",
+			zap.String("old_hash", ctrl.clientKubeconfigVer),
+			zap.String("new_hash", currentKubeconfigVer),
+		)
+
+		ctrl.kubernetesClient.Close() //nolint:errcheck
+		ctrl.kubernetesClient = nil
+	}
+
+	if ctrl.kubernetesClient == nil {
+		ctrl.kubernetesClient, err = kubernetes.NewClientFromKubeletKubeconfig()
+		if err != nil {
+			return nil, fmt.Errorf("error building kubernetes client: %w", err)
+		}
+
+		ctrl.clientKubeconfigVer = currentKubeconfigVer
+	}
+
+	return ctrl.kubernetesClient, nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/endpoint.go
+++ b/internal/app/machined/pkg/controllers/k8s/endpoint.go
@@ -297,7 +297,7 @@ func (ctrl *EndpointController) watchKubernetesEndpointSlices(ctx context.Contex
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	notifyCh, watchCloser, err := kubernetesEndpointSliceWatcher(ctx, logger, client)
+	notifyCh, watchErrCh, watchCloser, err := kubernetesEndpointSliceWatcher(ctx, client)
 	if err != nil {
 		return fmt.Errorf("error watching Kubernetes endpoint slice: %w", err)
 	}
@@ -308,11 +308,30 @@ func (ctrl *EndpointController) watchKubernetesEndpointSlices(ctx context.Contex
 		watchCloser()
 	}()
 
+	var watchErrors int
+
 	for {
 		select {
 		case endpoints := <-notifyCh:
+			watchErrors = 0
+
 			if err = ctrl.updateEndpointsResource(ctx, r, logger, endpoints); err != nil {
 				return err
+			}
+		case watchErr := <-watchErrCh:
+			watchErrors++
+
+			logger.Error("kubernetes endpoint watch error", zap.Error(watchErr), zap.Int("error_count", watchErrors))
+
+			if watchErrors >= watchErrorsThreshold {
+				// The watch is failing persistently: give up on this client and let the caller
+				// build a new one. On a worker that also re-reads the kubelet credentials off
+				// disk, which is what recovers a client pinned to a rotated client certificate.
+				logger.Info("restarting Kubernetes endpoint watch with a new client")
+
+				r.QueueReconcile()
+
+				return nil
 			}
 		case <-ctx.Done():
 			return nil
@@ -325,7 +344,7 @@ func (ctrl *EndpointController) watchKubernetesEndpointSlices(ctx context.Contex
 	}
 }
 
-func kubernetesEndpointSliceWatcher(ctx context.Context, logger *zap.Logger, client *kubernetes.Client) (chan *discoveryv1.EndpointSlice, func(), error) {
+func kubernetesEndpointSliceWatcher(ctx context.Context, client *kubernetes.Client) (chan *discoveryv1.EndpointSlice, <-chan error, func(), error) {
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(
 		client.Clientset, constants.KubernetesInformerDefaultResyncPeriod,
 		informers.WithNamespace(corev1.NamespaceDefault),
@@ -335,24 +354,39 @@ func kubernetesEndpointSliceWatcher(ctx context.Context, logger *zap.Logger, cli
 	)
 
 	notifyCh := make(chan *discoveryv1.EndpointSlice, 1)
+	watchErrCh := make(chan error, 1)
 
 	informer := informerFactory.Discovery().V1().EndpointSlices().Informer()
 
-	if err := informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
-		logger.Error("kubernetes endpoint watch error", zap.Error(err))
+	if err := informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		select {
+		case watchErrCh <- err:
+		default:
+		}
 	}); err != nil {
-		return nil, nil, fmt.Errorf("error setting watch error handler: %w", err)
+		return nil, nil, nil, fmt.Errorf("error setting watch error handler: %w", err)
+	}
+
+	// Every notification carries the endpoint slice itself, so a send can't be dropped the way
+	// a bare "something changed" notification could be; it is given up only once the watch
+	// context is canceled, as otherwise a handler blocked on a full channel with no reader left
+	// would deadlock the `informerFactory.Shutdown()` which follows the cancel.
+	notify := func(endpointSlice *discoveryv1.EndpointSlice) {
+		select {
+		case notifyCh <- endpointSlice:
+		case <-ctx.Done():
+		}
 	}
 
 	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj any) { notifyCh <- obj.(*discoveryv1.EndpointSlice) },
-		DeleteFunc: func(_ any) { notifyCh <- &discoveryv1.EndpointSlice{} },
-		UpdateFunc: func(_, obj any) { notifyCh <- obj.(*discoveryv1.EndpointSlice) },
+		AddFunc:    func(obj any) { notify(obj.(*discoveryv1.EndpointSlice)) },
+		DeleteFunc: func(_ any) { notify(&discoveryv1.EndpointSlice{}) },
+		UpdateFunc: func(_, obj any) { notify(obj.(*discoveryv1.EndpointSlice)) },
 	}); err != nil {
-		return nil, nil, fmt.Errorf("error adding watch event handler: %w", err)
+		return nil, nil, nil, fmt.Errorf("error adding watch event handler: %w", err)
 	}
 
 	informerFactory.Start(ctx.Done())
 
-	return notifyCh, informerFactory.Shutdown, nil
+	return notifyCh, watchErrCh, informerFactory.Shutdown, nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_kubeconfig.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_kubeconfig.go
@@ -8,17 +8,20 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
@@ -30,11 +33,22 @@ import (
 // directory exists.
 const kubeletKubeconfigPollInterval = 30 * time.Second
 
-// KubeletKubeconfigController watches the kubelet kubeconfig file on disk and
-// exposes its content hash via the [k8s.KubeletKubeconfig] resource. Consumers
+// errKubeconfigNotReady is reported when the kubeconfig on disk can't be parsed.
+//
+// Neither kubelet nor Talos write the kubeconfig atomically, so a read triggered by an
+// fsnotify event may catch a partially written file; this is a transient condition to be
+// retried, not a failure (see also [conditions.WaitForKubeconfigReady]).
+var errKubeconfigNotReady = errors.New("kubelet kubeconfig is not ready")
+
+// KubeletKubeconfigController watches the kubelet client credentials on disk and
+// exposes their content hash via the [k8s.KubeletKubeconfig] resource. Consumers
 // (e.g. [NodeStatusController]) rebuild their Kubernetes clients whenever the
-// hash changes, which is how we detect that a stale endpoint baked into an
-// existing client should be discarded.
+// hash changes, which is how we detect that a stale endpoint or an expired client
+// certificate baked into an existing client should be discarded.
+//
+// The credentials are not just the kubeconfig itself: the kubeconfig points at the
+// certificate kubelet rotates on its own (via the `kubelet-client-current.pem`
+// symlink), and that rotation never touches the kubeconfig file.
 type KubeletKubeconfigController struct {
 	// Path is the on-disk location of the kubelet kubeconfig. Defaults to
 	// [constants.KubeletKubeconfig] when empty; overridable for tests.
@@ -73,39 +87,21 @@ func (ctrl *KubeletKubeconfigController) Outputs() []controller.Output {
 //
 //nolint:gocyclo
 func (ctrl *KubeletKubeconfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := newCredentialsWatcher(ctrl.path())
 	if err != nil {
-		return fmt.Errorf("failed to create fsnotify watcher: %w", err)
+		return err
 	}
 
 	defer watcher.Close() //nolint:errcheck
 
-	kubeconfigDir := filepath.Dir(ctrl.path())
-	watchedDir := false
+	go watcher.run(ctx, r, logger)
 
-	// Forward fsnotify events and errors into the controller loop via QueueReconcile.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return
-				}
-
-				if filepath.Clean(event.Name) == ctrl.path() {
-					r.QueueReconcile()
-				}
-			case werr, ok := <-watcher.Errors:
-				if !ok {
-					return
-				}
-
-				logger.Warn("fsnotify error on kubelet kubeconfig", zap.Error(werr))
-			}
-		}
-	}()
+	// last successfully computed credentials, kept around to ride over a kubeconfig which
+	// can't be parsed at the moment
+	var (
+		lastHash string
+		lastRefs []string
+	)
 
 	for {
 		select {
@@ -115,22 +111,49 @@ func (ctrl *KubeletKubeconfigController) Run(ctx context.Context, r controller.R
 		case <-time.After(kubeletKubeconfigPollInterval):
 		}
 
-		if !watchedDir {
-			if _, statErr := os.Stat(kubeconfigDir); statErr == nil {
-				if addErr := watcher.Add(kubeconfigDir); addErr != nil {
-					return fmt.Errorf("failed to add %q to fsnotify watcher: %w", kubeconfigDir, addErr)
-				}
+		// Establish the watch before reading, so that a change landing while the credentials
+		// are being read is not lost.
+		watchAdded, err := watcher.watchDirs([]string{ctrl.path()})
+		if err != nil {
+			return err
+		}
 
-				watchedDir = true
-			}
+		hash, refs, err := kubeletCredentialsHash(ctrl.path())
+
+		switch {
+		case errors.Is(err, errKubeconfigNotReady):
+			// Both kubelet and Talos rewrite the kubeconfig in place, so a read might catch a
+			// partially written file: keep whatever was published so far (rather than hashing
+			// a torn file and making every consumer rebuild its client for nothing), and try
+			// again on the next event.
+			logger.Debug("kubelet kubeconfig is not parseable, retrying", zap.Error(err))
+
+			hash, refs = lastHash, lastRefs
+		case err != nil:
+			return fmt.Errorf("failed to hash kubelet credentials: %w", err)
+		default:
+			lastHash, lastRefs = hash, refs
+		}
+
+		paths := slices.Concat([]string{ctrl.path()}, refs)
+
+		refsAdded, err := watcher.watchDirs(paths)
+		if err != nil {
+			return err
+		}
+
+		// The tracked set is swapped only once the new one is known, so events for the files
+		// discovered by an earlier iteration keep queueing a reconcile in the meantime.
+		watcher.setTracked(paths)
+
+		if watchAdded || refsAdded {
+			// A directory has just come under watch: re-read the credentials, as a change
+			// which landed before the watch was established would otherwise go unnoticed
+			// until the next poll tick.
+			r.QueueReconcile()
 		}
 
 		r.StartTrackingOutputs()
-
-		hash, err := hashKubeletKubeconfig(ctrl.path())
-		if err != nil {
-			return fmt.Errorf("failed to hash kubelet kubeconfig: %w", err)
-		}
 
 		if hash != "" {
 			if err = safe.WriterModify(
@@ -152,25 +175,252 @@ func (ctrl *KubeletKubeconfigController) Run(ctx context.Context, r controller.R
 	}
 }
 
-// hashKubeletKubeconfig returns the hex-encoded SHA-256 hash of the file at the
-// given path. If the file does not exist, it returns an empty string and nil
-// error.
-func hashKubeletKubeconfig(path string) (string, error) {
-	f, err := os.Open(path)
+// credentialsWatcher watches the directories holding the kubelet credentials and queues a
+// reconcile whenever one of the tracked files changes.
+//
+// The files don't all live in the same directory (the kubeconfig sits in /etc/kubernetes,
+// while the certificates it points at live in kubelet's PKI directory), and which files to
+// track is only known once the kubeconfig has been parsed, so watches are established
+// incrementally via [credentialsWatcher.watchDirs], and the set of files to report on is
+// swapped in via [credentialsWatcher.setTracked].
+type credentialsWatcher struct {
+	watcher *fsnotify.Watcher
+
+	trackedMu sync.Mutex
+	tracked   map[string]struct{}
+}
+
+// newCredentialsWatcher creates a watcher tracking the given files to start with.
+func newCredentialsWatcher(paths ...string) (*credentialsWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
+		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+
+	w := &credentialsWatcher{
+		watcher: watcher,
+		tracked: map[string]struct{}{},
+	}
+
+	w.setTracked(paths)
+
+	return w, nil
+}
+
+// Close stops the watcher.
+func (w *credentialsWatcher) Close() error {
+	return w.watcher.Close()
+}
+
+// setTracked replaces the set of files changes are reported for.
+//
+// The swap is atomic with respect to [credentialsWatcher.isTracked], so a file which is
+// in both the old and the new set is never seen as untracked.
+func (w *credentialsWatcher) setTracked(paths []string) {
+	w.trackedMu.Lock()
+	defer w.trackedMu.Unlock()
+
+	clear(w.tracked)
+
+	for _, path := range paths {
+		w.tracked[path] = struct{}{}
+	}
+}
+
+// watchDirs establishes watches on the directories holding the given files.
+//
+// It reports whether a new directory watch was established.
+//
+// The set of already watched directories is queried from the watcher itself rather than
+// tracked here, as the kernel drops a watch when the directory it points at goes away
+// (kubelet's PKI directory is removed and recreated when the client certificate no longer
+// verifies), and such a directory has to be watched anew.
+func (w *credentialsWatcher) watchDirs(paths []string) (bool, error) {
+	watched := map[string]struct{}{}
+
+	for _, dir := range w.watcher.WatchList() {
+		watched[dir] = struct{}{}
+	}
+
+	var added bool
+
+	for _, path := range paths {
+		dir := filepath.Dir(path)
+
+		if _, ok := watched[dir]; ok {
+			continue
 		}
 
-		return "", err
+		if _, err := os.Stat(dir); err != nil {
+			// the directory is not there yet, retry on the next poll tick
+			continue
+		}
+
+		if err := w.watcher.Add(dir); err != nil {
+			return false, fmt.Errorf("failed to add %q to fsnotify watcher: %w", dir, err)
+		}
+
+		watched[dir] = struct{}{}
+
+		added = true
 	}
 
-	defer f.Close() //nolint:errcheck
+	return added, nil
+}
 
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+func (w *credentialsWatcher) isTracked(path string) bool {
+	w.trackedMu.Lock()
+	defer w.trackedMu.Unlock()
+
+	_, ok := w.tracked[path]
+
+	return ok
+}
+
+// run forwards fsnotify events and errors into the controller loop until the context is
+// canceled.
+func (w *credentialsWatcher) run(ctx context.Context, r controller.Runtime, logger *zap.Logger) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+
+			if w.isTracked(filepath.Clean(event.Name)) {
+				r.QueueReconcile()
+			}
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+
+			logger.Warn("fsnotify error on kubelet credentials", zap.Error(err))
+		}
+	}
+}
+
+// kubeletCredentialsHash returns the hex-encoded SHA-256 hash of the kubelet
+// kubeconfig combined with the certificates it references on disk, along with the
+// list of the referenced files.
+//
+// If the kubeconfig does not exist, it returns an empty hash and no error.
+func kubeletCredentialsHash(path string) (string, []string, error) {
+	kubeconfig, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil, nil
+		}
+
+		return "", nil, err
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), nil
+	refs, err := referencedFiles(path, kubeconfig)
+	if err != nil {
+		return "", nil, err
+	}
+
+	hash := sha256.New()
+
+	hash.Write(kubeconfig) //nolint:errcheck
+
+	for _, ref := range refs {
+		certs, err := certificatesFromFile(ref)
+		if err != nil {
+			return "", nil, err
+		}
+
+		// the path is part of the digest as well, so that repointing the kubeconfig to a
+		// different (but identical) file is still seen as a change
+		hash.Write([]byte(ref)) //nolint:errcheck
+		hash.Write(certs)       //nolint:errcheck
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), refs, nil
+}
+
+// referencedFiles returns the sorted list of PKI files the kubeconfig points at.
+//
+// Relative paths are resolved against the directory holding the kubeconfig, matching
+// the way client-go loads them.
+func referencedFiles(kubeconfigPath string, kubeconfig []byte) ([]string, error) {
+	cfg, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to parse kubeconfig %q: %w", errKubeconfigNotReady, kubeconfigPath, err)
+	}
+
+	// [clientcmd.Load] short-circuits on empty input and returns an empty config with no error,
+	// and a truncated file may still parse into a config which is missing the sections we hash.
+	// A kubeconfig is rewritten in place (`O_TRUNC`, which itself wakes the fsnotify watch), so a
+	// read is quite likely to catch it at zero length: treat that as "not ready" as well, rather
+	// than publishing the hash of an empty file.
+	if cfg.CurrentContext == "" || len(cfg.AuthInfos) == 0 || len(cfg.Clusters) == 0 {
+		return nil, fmt.Errorf("%w: kubeconfig %q has no credentials", errKubeconfigNotReady, kubeconfigPath)
+	}
+
+	base := filepath.Dir(kubeconfigPath)
+
+	var refs []string
+
+	appendRef := func(path string) {
+		if path == "" {
+			return
+		}
+
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(base, path)
+		}
+
+		refs = append(refs, filepath.Clean(path))
+	}
+
+	for _, authInfo := range cfg.AuthInfos {
+		appendRef(authInfo.ClientCertificate)
+		appendRef(authInfo.ClientKey)
+	}
+
+	for _, cluster := range cfg.Clusters {
+		appendRef(cluster.CertificateAuthority)
+	}
+
+	slices.Sort(refs)
+
+	return slices.Compact(refs), nil
+}
+
+// certificatesFromFile returns the DER bytes of the certificates found in the PEM file.
+//
+// Only certificates contribute to the digest: kubelet keeps the client key in the very
+// same file as the client certificate (`kubelet-client-current.pem`), and the digest is
+// exposed via the resource API, so private key material is deliberately left out.
+//
+// A file which doesn't exist (yet) contributes nothing.
+func certificatesFromFile(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	var certs []byte
+
+	for {
+		var block *pem.Block
+
+		block, raw = pem.Decode(raw)
+		if block == nil {
+			return certs, nil
+		}
+
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		certs = append(certs, block.Bytes...)
+	}
 }

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_kubeconfig_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_kubeconfig_test.go
@@ -8,14 +8,21 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/siderolabs/crypto/x509"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/siderolabs/talos/internal/app/machined/pkg/controllers/ctest"
 	k8sctrl "github.com/siderolabs/talos/internal/app/machined/pkg/controllers/k8s"
@@ -26,6 +33,10 @@ type KubeletKubeconfigSuite struct {
 	ctest.DefaultSuite
 
 	kubeconfigPath string
+
+	// logs captures controller errors, so that tests can assert that the controller rides
+	// over transient on-disk state instead of failing and being restarted
+	logs *observer.ObservedLogs
 }
 
 func TestKubeletKubeconfigSuite(t *testing.T) {
@@ -34,14 +45,20 @@ func TestKubeletKubeconfigSuite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kubeconfig-kubelet")
 
+	observerCore, logs := observer.New(zapcore.ErrorLevel)
+
 	s := &KubeletKubeconfigSuite{
 		kubeconfigPath: path,
+		logs:           logs,
 	}
 
 	s.DefaultSuite = ctest.DefaultSuite{
 		Timeout: 10 * time.Second,
+		Logger:  zap.New(observerCore),
 		AfterSetup: func(ds *ctest.DefaultSuite) {
-			// Reset filesystem state so tests don't leak into each other.
+			// Reset filesystem and log state so tests don't leak into each other.
+			logs.TakeAll()
+
 			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 				ds.Require().NoError(err)
 			}
@@ -67,12 +84,35 @@ func (suite *KubeletKubeconfigSuite) writeKubeconfig(data []byte) {
 	suite.Require().NoError(os.WriteFile(suite.kubeconfigPath, data, 0o600))
 }
 
+// completeKubeconfig builds a kubeconfig carrying everything the controller requires to
+// consider it fully written; the server URL is a handy way to get a different one.
+func completeKubeconfig(server string) []byte {
+	return fmt.Appendf(nil,
+		`apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    server: %s
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    user: default-auth
+current-context: default-context
+users:
+- name: default-auth
+  user:
+    token: bootstrap-token
+`, server)
+}
+
 func (suite *KubeletKubeconfigSuite) TestMissingFileNoResource() {
 	ctest.AssertNoResource[*k8s.KubeletKubeconfig](suite, k8s.KubeletKubeconfigID)
 }
 
 func (suite *KubeletKubeconfigSuite) TestCreateUpdateDelete() {
-	initial := []byte("apiVersion: v1\nkind: Config\nclusters: []\n")
+	initial := completeKubeconfig("https://localhost:6443")
 
 	suite.writeKubeconfig(initial)
 
@@ -84,7 +124,7 @@ func (suite *KubeletKubeconfigSuite) TestCreateUpdateDelete() {
 		},
 	)
 
-	updated := slices.Concat(initial, []byte("users: []\n"))
+	updated := completeKubeconfig("https://localhost:7445")
 
 	suite.writeKubeconfig(updated)
 
@@ -99,4 +139,294 @@ func (suite *KubeletKubeconfigSuite) TestCreateUpdateDelete() {
 	suite.Require().NoError(os.Remove(suite.kubeconfigPath))
 
 	ctest.AssertNoResource[*k8s.KubeletKubeconfig](suite, k8s.KubeletKubeconfigID)
+}
+
+// newCertificatePEM generates a self-signed certificate and its key in PEM format.
+func newCertificatePEM(t *testing.T) (crt, key []byte) {
+	t.Helper()
+
+	ca, err := x509.NewSelfSignedCertificateAuthority()
+	require.NoError(t, err)
+
+	return ca.CrtPEM, ca.KeyPEM
+}
+
+func (suite *KubeletKubeconfigSuite) writeKubeconfigWithClientCert(certPath string) []byte {
+	suite.T().Helper()
+
+	kubeconfig := kubeconfigWithClientCert(certPath)
+
+	suite.writeKubeconfig(kubeconfig)
+
+	return kubeconfig
+}
+
+func kubeconfigWithClientCert(certPath string) []byte {
+	return fmt.Appendf(nil,
+		`apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    server: https://localhost:6443
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    user: default-auth
+current-context: default-context
+users:
+- name: default-auth
+  user:
+    client-certificate: %s
+    client-key: %s
+`, certPath, certPath)
+}
+
+// hashWithoutCert is the hash the controller publishes for a kubeconfig whose referenced
+// certificate file is missing: only the kubeconfig and the path it points at are digested.
+func hashWithoutCert(kubeconfig []byte, certPath string) string {
+	sum := sha256.New()
+
+	sum.Write(kubeconfig)
+	sum.Write([]byte(certPath))
+
+	return hex.EncodeToString(sum.Sum(nil))
+}
+
+// TestClientCertificateRotation verifies that the hash follows the certificate the
+// kubeconfig points at: kubelet rotates it behind the `kubelet-client-current.pem`
+// symlink without ever rewriting the kubeconfig itself.
+func (suite *KubeletKubeconfigSuite) TestClientCertificateRotation() {
+	pkiDir := filepath.Join(filepath.Dir(suite.kubeconfigPath), "pki")
+	suite.Require().NoError(os.MkdirAll(pkiDir, 0o700))
+
+	// kubelet keeps the client key in the very same file as the client certificate
+	certPath := filepath.Join(pkiDir, "kubelet-client-current.pem")
+
+	crt, key := newCertificatePEM(suite.T())
+	suite.Require().NoError(os.WriteFile(certPath, slices.Concat(key, crt), 0o600))
+
+	suite.writeKubeconfigWithClientCert(certPath)
+
+	var initialHash string
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.NotEmpty(res.TypedSpec().Hash)
+
+			initialHash = res.TypedSpec().Hash
+		},
+	)
+
+	// rotate the certificate, keeping the kubeconfig untouched
+	rotatedCrt, rotatedKey := newCertificatePEM(suite.T())
+	suite.Require().NoError(os.WriteFile(certPath, slices.Concat(rotatedKey, rotatedCrt), 0o600))
+
+	var (
+		rotatedHash    string
+		rotatedVersion resource.Version
+	)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.NotEqual(initialHash, res.TypedSpec().Hash)
+
+			rotatedHash = res.TypedSpec().Hash
+			rotatedVersion = res.Metadata().Version()
+		},
+	)
+
+	// replacing the key alone should not be visible in the hash: private key material is
+	// deliberately left out of the digest
+	_, otherKey := newCertificatePEM(suite.T())
+	suite.Require().NoError(os.WriteFile(certPath, slices.Concat(otherKey, rotatedCrt), 0o600))
+
+	// give the fsnotify-driven reconcile a chance to run: an unchanged hash is a no-op
+	// write, so the resource version stays put as well
+	time.Sleep(time.Second)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(rotatedHash, res.TypedSpec().Hash)
+			assert.Equal(rotatedVersion.String(), res.Metadata().Version().String())
+		},
+	)
+}
+
+// TestPKIDirectoryRecreated verifies that the watch on kubelet's PKI directory survives the
+// directory being removed and recreated: Talos wipes it when the client certificate no
+// longer verifies against the accepted CAs, and the kernel drops the watch along with it.
+func (suite *KubeletKubeconfigSuite) TestPKIDirectoryRecreated() {
+	pkiDir := filepath.Join(filepath.Dir(suite.kubeconfigPath), "pki-recreated")
+	suite.Require().NoError(os.MkdirAll(pkiDir, 0o700))
+
+	certPath := filepath.Join(pkiDir, "kubelet-client-current.pem")
+
+	crt, key := newCertificatePEM(suite.T())
+	suite.Require().NoError(os.WriteFile(certPath, slices.Concat(key, crt), 0o600))
+
+	kubeconfig := suite.writeKubeconfigWithClientCert(certPath)
+
+	withoutCert := hashWithoutCert(kubeconfig, certPath)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.NotEqual(withoutCert, res.TypedSpec().Hash)
+		},
+	)
+
+	suite.Require().NoError(os.RemoveAll(pkiDir))
+	suite.Require().NoError(os.MkdirAll(pkiDir, 0o700))
+
+	// Rewrite the kubeconfig to get a reconcile in now that the directory is back: in
+	// production any reconcile does, and the poll tick guarantees one. Waiting for the
+	// certificate-less hash to be published pins down that the reconcile has happened, so
+	// that the watch, if it is going to be re-established at all, is in place by now.
+	suite.writeKubeconfigWithClientCert(certPath)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(withoutCert, res.TypedSpec().Hash)
+		},
+	)
+
+	// The kubeconfig is untouched from here on, so this is only picked up if the recreated
+	// directory got watched anew: nothing else reports a write to a file inside it.
+	newCrt, newKey := newCertificatePEM(suite.T())
+	suite.Require().NoError(os.WriteFile(certPath, slices.Concat(newKey, newCrt), 0o600))
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.NotEqual(withoutCert, res.TypedSpec().Hash)
+		},
+	)
+}
+
+// TestMalformedKubeconfigKeepsLastHash verifies that a partially written kubeconfig
+// doesn't get hashed: neither kubelet nor Talos rewrite the file atomically, and hashing a
+// torn file would make every consumer rebuild its Kubernetes client for nothing.
+func (suite *KubeletKubeconfigSuite) TestMalformedKubeconfigKeepsLastHash() {
+	initial := completeKubeconfig("https://localhost:6443")
+
+	suite.writeKubeconfig(initial)
+
+	var version resource.Version
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(hashOf(initial), res.TypedSpec().Hash)
+
+			version = res.Metadata().Version()
+		},
+	)
+
+	suite.writeKubeconfig([]byte("apiVersion: v1\nkind: Config\nclusters:\n- name: \"unterminated\n"))
+
+	// give the fsnotify-driven reconcile a chance to run: the hash published so far is kept,
+	// so the resource is neither updated nor destroyed
+	time.Sleep(time.Second)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(hashOf(initial), res.TypedSpec().Hash)
+			assert.Equal(version.String(), res.Metadata().Version().String())
+		},
+	)
+
+	suite.assertControllerDidNotFail()
+
+	// once the file is written completely, the hash follows it again
+	updated := completeKubeconfig("https://localhost:7445")
+
+	suite.writeKubeconfig(updated)
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(hashOf(updated), res.TypedSpec().Hash)
+		},
+	)
+}
+
+// TestIncompleteKubeconfigKeepsLastHash verifies that a kubeconfig which parses but carries
+// no credentials doesn't get hashed either: the file is rewritten in place with `O_TRUNC`,
+// and that truncation is itself an fsnotify event, so a read is quite likely to catch the
+// file at zero length — for which [clientcmd.Load] reports an empty config and no error.
+func (suite *KubeletKubeconfigSuite) TestIncompleteKubeconfigKeepsLastHash() {
+	initial := completeKubeconfig("https://localhost:6443")
+
+	suite.writeKubeconfig(initial)
+
+	var version resource.Version
+
+	ctest.AssertResource(
+		suite,
+		k8s.KubeletKubeconfigID,
+		func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+			assert.Equal(hashOf(initial), res.TypedSpec().Hash)
+
+			version = res.Metadata().Version()
+		},
+	)
+
+	for _, incomplete := range [][]byte{
+		// the file as `os.WriteFile` leaves it right after truncating
+		nil,
+		// a prefix of the kubeconfig which is valid YAML on its own
+		[]byte("apiVersion: v1\nkind: Config\nclusters: []\n"),
+	} {
+		suite.writeKubeconfig(incomplete)
+
+		// give the fsnotify-driven reconcile a chance to run: the hash published so far is
+		// kept, so the resource is neither updated nor destroyed
+		time.Sleep(time.Second)
+
+		ctest.AssertResource(
+			suite,
+			k8s.KubeletKubeconfigID,
+			func(res *k8s.KubeletKubeconfig, assert *assert.Assertions) {
+				assert.Equal(hashOf(initial), res.TypedSpec().Hash)
+				assert.Equal(version.String(), res.Metadata().Version().String())
+			},
+		)
+	}
+
+	suite.assertControllerDidNotFail()
+}
+
+// TestMalformedKubeconfigNoResource verifies that a kubeconfig which has never been
+// readable doesn't produce a resource at all: consumers should keep waiting instead of
+// rebuilding their clients around a half-written file.
+func (suite *KubeletKubeconfigSuite) TestMalformedKubeconfigNoResource() {
+	suite.writeKubeconfig([]byte("apiVersion: v1\nkind: Config\nclusters:\n- name: \"unterminated\n"))
+
+	ctest.AssertNoResource[*k8s.KubeletKubeconfig](suite, k8s.KubeletKubeconfigID)
+
+	suite.assertControllerDidNotFail()
+}
+
+// assertControllerDidNotFail asserts that the controller kept running rather than
+// returning an error and being restarted by the runtime.
+func (suite *KubeletKubeconfigSuite) assertControllerDidNotFail() {
+	suite.T().Helper()
+
+	suite.Assert().Empty(suite.logs.FilterMessage("controller failed").All())
 }

--- a/internal/app/machined/pkg/controllers/k8s/node_status.go
+++ b/internal/app/machined/pkg/controllers/k8s/node_status.go
@@ -171,7 +171,7 @@ func (ctrl *NodeStatusController) Run(ctx context.Context, r controller.Runtime,
 		if nodewatcher != nil && watcherKubeconfigVer != currentKubeconfigVer {
 			// kubelet kubeconfig on disk changed — the cached client may be pinned
 			// to a stale endpoint, so rebuild the watcher with a fresh client.
-			logger.Info(
+			logger.Debug(
 				"kubelet kubeconfig changed, restarting node watcher",
 				zap.String("old_hash", watcherKubeconfigVer),
 				zap.String("new_hash", currentKubeconfigVer),

--- a/internal/pkg/discovery/registry/kubernetes.go
+++ b/internal/pkg/discovery/registry/kubernetes.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/siderolabs/gen/value"
 	"github.com/siderolabs/gen/xslices"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,10 +267,15 @@ func (r *Kubernetes) List(localNodeName string) ([]*cluster.AffiliateSpec, error
 }
 
 // Watch starts watching Node state and notifies on updates via notify channel.
-func (r *Kubernetes) Watch(ctx context.Context, logger *zap.Logger) (<-chan struct{}, func(), error) {
+//
+// Watch errors are reported via the returned error channel, so that the caller can
+// rebuild the client (and with it, the credentials read off the disk) if the watch
+// keeps failing.
+func (r *Kubernetes) Watch(ctx context.Context) (<-chan struct{}, <-chan error, func(), error) {
 	informerFactory := informers.NewSharedInformerFactory(r.client.Clientset, constants.KubernetesInformerDefaultResyncPeriod)
 
 	notifyCh := make(chan struct{}, 1)
+	watchErrCh := make(chan error, 1)
 
 	notify := func(_ any) {
 		select {
@@ -282,10 +286,13 @@ func (r *Kubernetes) Watch(ctx context.Context, logger *zap.Logger) (<-chan stru
 
 	r.nodes = informerFactory.Core().V1().Nodes()
 
-	if err := r.nodes.Informer().SetWatchErrorHandler(func(r *cache.Reflector, err error) {
-		logger.Error("kubernetes registry node watch error", zap.Error(err))
+	if err := r.nodes.Informer().SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		select {
+		case watchErrCh <- err:
+		default:
+		}
 	}); err != nil {
-		return nil, nil, fmt.Errorf("failed to set watch error handler: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to set watch error handler: %w", err)
 	}
 
 	if _, err := r.nodes.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -293,10 +300,10 @@ func (r *Kubernetes) Watch(ctx context.Context, logger *zap.Logger) (<-chan stru
 		DeleteFunc: notify,
 		UpdateFunc: func(_, _ any) { notify(nil) },
 	}); err != nil {
-		return nil, nil, fmt.Errorf("failed to add event handler: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to add event handler: %w", err)
 	}
 
 	informerFactory.Start(ctx.Done())
 
-	return notifyCh, informerFactory.Shutdown, nil
+	return notifyCh, watchErrCh, informerFactory.Shutdown, nil
 }

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -1619,12 +1619,13 @@ func (x *KubeletConfigSpec) GetRegisterWithTaints() map[string]string {
 	return nil
 }
 
-// KubeletKubeconfigSpec describes the current kubelet kubeconfig file.
+// KubeletKubeconfigSpec describes the current kubelet client credentials.
 type KubeletKubeconfigSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Hash is a content digest of the kubeconfig file. It changes whenever the
-	// file contents change, which is the signal consumers use to rebuild their
-	// Kubernetes clients.
+	// Hash is a content digest of the kubeconfig file and of the certificates it
+	// references on disk (kubelet rotates its client certificate without ever
+	// touching the kubeconfig). It changes whenever the credentials change, which
+	// is the signal consumers use to rebuild their Kubernetes clients.
 	Hash          string `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/machinery/resources/k8s/kubelet_kubeconfig.go
+++ b/pkg/machinery/resources/k8s/kubelet_kubeconfig.go
@@ -19,19 +19,20 @@ const KubeletKubeconfigType = resource.Type("KubeletKubeconfigs.kubernetes.talos
 // KubeletKubeconfigID is a singleton resource ID for KubeletKubeconfig.
 const KubeletKubeconfigID = resource.ID("kubelet")
 
-// KubeletKubeconfig resource exposes the on-disk kubelet kubeconfig state so
-// that consumers can detect when the file has changed and rebuild their
-// Kubernetes clients (the informer's reflector doesn't bubble up
-// connection-refused errors against a stale endpoint).
+// KubeletKubeconfig resource exposes the on-disk kubelet client credentials state
+// so that consumers can detect when they have changed and rebuild their Kubernetes
+// clients (the informer's reflector doesn't bubble up connection-refused errors
+// against a stale endpoint, nor does it recover from expired credentials).
 type KubeletKubeconfig = typed.Resource[KubeletKubeconfigSpec, KubeletKubeconfigExtension]
 
-// KubeletKubeconfigSpec describes the current kubelet kubeconfig file.
+// KubeletKubeconfigSpec describes the current kubelet client credentials.
 //
 //gotagsrewrite:gen
 type KubeletKubeconfigSpec struct {
-	// Hash is a content digest of the kubeconfig file. It changes whenever the
-	// file contents change, which is the signal consumers use to rebuild their
-	// Kubernetes clients.
+	// Hash is a content digest of the kubeconfig file and of the certificates it
+	// references on disk (kubelet rotates its client certificate without ever
+	// touching the kubeconfig). It changes whenever the credentials change, which
+	// is the signal consumers use to rebuild their Kubernetes clients.
 	Hash string `yaml:"hash" protobuf:"1"`
 }
 

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -8794,12 +8794,12 @@ KubeletConfigSpec holds the source of kubelet configuration.
 <a name="talos.resource.definitions.k8s.KubeletKubeconfigSpec"></a>
 
 ### KubeletKubeconfigSpec
-KubeletKubeconfigSpec describes the current kubelet kubeconfig file.
+KubeletKubeconfigSpec describes the current kubelet client credentials.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| hash | [string](#string) |  | Hash is a content digest of the kubeconfig file. It changes whenever the file contents change, which is the signal consumers use to rebuild their Kubernetes clients. |
+| hash | [string](#string) |  | Hash is a content digest of the kubeconfig file and of the certificates it references on disk (kubelet rotates its client certificate without ever touching the kubeconfig). It changes whenever the credentials change, which is the signal consumers use to rebuild their Kubernetes clients. |
 
 
 


### PR DESCRIPTION
There are several fixes here:

* direct one - when hashing the kubelet's client kubeconfig we ignored the actual certificate data - when the kubelet rotates it, it rewrites the cert, not the kubeconfig

* use this hash in more controllers to proactively refresh the connection

* expand the pattern established in some controllers to re-establish the watch on 5 watch errors - this should handle any other kubeconfig-related issues when restarting the watch picks up kubeconfig from scratch

Fixes #14153
