### PR TITLE
doc: fix `ContainerConfig.dependsOn` examples

### DIFF
--- a/pkg/machinery/config/types/container/container_config.go
+++ b/pkg/machinery/config/types/container/container_config.go
@@ -159,7 +159,9 @@ func exampleContainerConfigV1Alpha1() *ContainerConfigV1Alpha1 {
 		},
 	}
 	cfg.DependsOnConfig = &ContainerDependsOn{
+		PathsConfig:    []string{"/var/mnt/web-content"},
 		NetworksConfig: []string{"addresses"},
+		TimeConfig:     new(true),
 	}
 
 	return cfg

--- a/website/content/v1.15/reference/configuration/container/containerconfig.md
+++ b/website/content/v1.15/reference/configuration/container/containerconfig.md
@@ -51,13 +51,13 @@ resources:
         memory: 512MiB # Memory ceiling, mapped onto cgroup v2 `memory.max`.
 # Conditions which must be satisfied before the container is started.
 dependsOn:
+    # Host paths which must exist before the container starts.
+    paths:
+        - /var/mnt/web-content
     # Network readiness conditions which must be satisfied.
     networks:
         - addresses
-
-    # # Host paths which must exist before the container starts.
-    # paths:
-    #     - /var/mnt/web-content
+    time: true # Whether the clock must be synchronized before the container starts.
 {{< /highlight >}}
 
 


### PR DESCRIPTION
I've noticed the example rendering is wonky in the [published reference](https://docs.siderolabs.com/talos/v1.14/reference/configuration/container/containerconfig).

This PR fixes the `dependsOn.paths` example and adds `dependsOn.time` to it.
