### PR TITLE
test: revert disabling PS/2 in QEMU

### DIFF
--- a/internal/integration/provision/external_triggers.go
+++ b/internal/integration/provision/external_triggers.go
@@ -94,6 +94,8 @@ func (suite *ExternalTriggerSuite) TestTriggers() {
 	})
 
 	suite.Run("trigger Ctrl+Alt+Delete", func() {
+		suite.T().Logf("using node %s", suite.Cluster.Info().Nodes[0].Name)
+
 		// using machine 0 for this test
 		c := maintenanceClients[0]
 
@@ -125,6 +127,8 @@ func (suite *ExternalTriggerSuite) TestTriggers() {
 	})
 
 	suite.Run("trigger poweroff", func() {
+		suite.T().Logf("using node %s", suite.Cluster.Info().Nodes[1].Name)
+
 		// using machine 1 for this test
 		c := maintenanceClients[1]
 

--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -255,13 +255,6 @@ func (arch Arch) getMachineArgs(iommu bool) []string {
 
 	if arch == ArchAmd64 {
 		args += ",smm=on"
-
-		// the VMs are driven over the serial console, so the emulated PS/2 controller is never used,
-		// while tearing down `psmouse` in the kernel shutdown path is a known source of hangs on
-		// reboot/kexec
-		//
-		// note: requires QEMU >= 7.0
-		args += ",i8042=off"
 	}
 
 	return []string{"-machine", args}


### PR DESCRIPTION
It kills the external triggers test, as it can't send Ctrl+Alt+Del - the plan is to ship this way for 1.14, and 1.15 switch to virtio keyboard instead - that'd be better as it works on arm64/amd64.
