### PR TITLE
fix: improve resilience of the action tracker agains dropped conns

### DIFF
--- a/cmd/talosctl/pkg/talos/action/internal/stall/stall.go
+++ b/cmd/talosctl/pkg/talos/action/internal/stall/stall.go
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package stall detects a lack of progress in an operation which reports no error of its own.
+//
+// A Talos API connection whose peer went away without closing it gracefully stays `READY` and
+// delivers nothing: long-running calls are mostly server-streaming, so nothing is ever written
+// that could draw a RST back, and the caller blocks with no error to react to.
+//
+// Waiting on such a call has to be bounded by observing that nothing is arriving, which is what a Detector does.
+package stall
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// Detector invokes onStall unless it is poked at least once every timeout.
+//
+// It stops once it fires, or once its context is done.
+type Detector struct {
+	pokeCh chan struct{}
+	fired  atomic.Bool
+}
+
+// NewDetector starts a Detector which calls onStall if it is not poked within timeout.
+func NewDetector(ctx context.Context, timeout time.Duration, onStall func()) *Detector {
+	d := &Detector{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-d.pokeCh:
+				timer.Reset(timeout)
+			case <-timer.C:
+				d.fired.Store(true)
+
+				onStall()
+
+				return
+			}
+		}
+	}()
+
+	return d
+}
+
+// Poke records progress, restarting the countdown.
+func (d *Detector) Poke() {
+	select {
+	case d.pokeCh <- struct{}{}:
+	default:
+	}
+}
+
+// Stalled reports whether the detector has fired.
+//
+// It lets a caller tell an error caused by the detector's own onStall from an unrelated failure.
+func (d *Detector) Stalled() bool {
+	return d.fired.Load()
+}

--- a/cmd/talosctl/pkg/talos/action/internal/stall/stall_test.go
+++ b/cmd/talosctl/pkg/talos/action/internal/stall/stall_test.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package stall_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action/internal/stall"
+)
+
+func TestDetectorFires(t *testing.T) {
+	ctx := t.Context()
+
+	stalled := make(chan struct{})
+
+	d := stall.NewDetector(ctx, 50*time.Millisecond, func() { close(stalled) })
+
+	assert.False(t, d.Stalled())
+
+	select {
+	case <-stalled:
+	case <-time.After(time.Second):
+		t.Fatal("stall detector did not fire")
+	}
+
+	assert.True(t, d.Stalled())
+}
+
+func TestDetectorPokeDelaysFiring(t *testing.T) {
+	ctx := t.Context()
+
+	stalled := make(chan struct{})
+
+	const timeout = 100 * time.Millisecond
+
+	d := stall.NewDetector(ctx, timeout, func() { close(stalled) })
+
+	// keep poking for well over the timeout: the detector must not fire while there is progress
+	for range 10 {
+		time.Sleep(timeout / 4)
+
+		d.Poke()
+
+		require.False(t, d.Stalled(), "fired while being poked")
+	}
+
+	// stop poking, and it fires
+	select {
+	case <-stalled:
+	case <-time.After(time.Second):
+		t.Fatal("stall detector did not fire once the pokes stopped")
+	}
+}
+
+func TestDetectorStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	fired := make(chan struct{})
+
+	stall.NewDetector(ctx, 50*time.Millisecond, func() { close(fired) })
+
+	cancel()
+
+	select {
+	case <-fired:
+		t.Fatal("stall detector fired after its context was canceled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/cmd/talosctl/pkg/talos/action/node.go
+++ b/cmd/talosctl/pkg/talos/action/node.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-circular"
@@ -17,12 +18,33 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 
+	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action/internal/stall"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/reporter"
+)
+
+const (
+	// eventStallTimeout bounds how long the tracker waits on an event stream which was established
+	// successfully, but delivers nothing.
+	//
+	// The tracker's only liveness signal is an attempt returning an error, and a connection whose
+	// peer went away without closing it never produces one: EventsWatchV2 blocks in stream.Recv
+	// before it even returns, and retry only re-evaluates its deadline between attempts, so a
+	// single blocked attempt bypasses the retry loop entirely until the overall timeout fires.
+	//
+	// A reconnect resumes from the last observed event ID, so firing on a legitimate quiet period
+	// (an upgrade waiting on a slow image pull emits no events for minutes) neither misses nor
+	// replays events: it is invisible to the rest of the tracking logic, which is what allows the
+	// timeout to be shorter than the longest expected gap between events.
+	eventStallTimeout = 5 * time.Minute
+
+	// postCheckTimeout bounds a single post check attempt, which runs over the same connection and
+	// can block in the same way the event stream does.
+	postCheckTimeout = 2 * time.Minute
 )
 
 // nodeTracker tracks the actions of a single node.
@@ -120,22 +142,41 @@ func (a *nodeTracker) update(update reporter.Update) {
 	}
 }
 
+//nolint:gocyclo
 func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 	var (
 		tailEvents     int32
+		lastEventID    string
 		actorID        string
 		waitForActorID = true
 	)
 
 	return retry.Constant(a.tracker.timeout).RetryWithContext(a.ctx, func(ctx context.Context) error {
+		// each attempt runs under its own context so that the stall detector can abort an attempt
+		// which established a stream but is not receiving anything from it
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		detector := stall.NewDetector(ctx, eventStallTimeout, cancel)
+
+		// resume from the last observed event if the position is known: event IDs are ordered
+		// across reboots, so this replays whatever was missed while disconnected without
+		// re-delivering the events which were already handled
+		opts := []client.EventsOptionFunc{client.WithTailEvents(tailEvents)}
+		if lastEventID != "" {
+			opts = []client.EventsOptionFunc{client.WithTailID(lastEventID)}
+		}
+
 		// retryable function
 		err := func() error {
 			eventCh := make(chan client.EventResult)
 
-			err := a.cli.EventsWatchV2(ctx, eventCh, client.WithTailEvents(tailEvents))
+			err := a.cli.EventsWatchV2(ctx, eventCh, opts...)
 			if err != nil {
 				return err
 			}
+
+			detector.Poke()
 
 			if waitForActorID {
 				a.update(reporter.Update{
@@ -155,12 +196,26 @@ func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 				})
 
 				waitForActorID = false
+
+				detector.Poke()
 			}
 
-			return a.handleEvents(eventCh, actorID)
+			return a.handleEvents(ctx, eventCh, actorID, &lastEventID, detector.Poke)
 		}()
+		if err == nil {
+			return nil
+		}
 
 		// handle retryable errors
+
+		if detector.Stalled() {
+			a.update(reporter.Update{
+				Message: fmt.Sprintf("no events received in %s, reconnecting...", eventStallTimeout),
+				Status:  reporter.StatusRunning,
+			})
+
+			return retry.ExpectedError(err)
+		}
 
 		statusCode := client.StatusCode(err)
 		if errors.Is(err, io.EOF) || statusCode == codes.Unavailable || statusCode == codes.Canceled {
@@ -169,18 +224,21 @@ func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 				Status:  reporter.StatusError,
 			})
 
-			tailEvents = -1
-			actorID = ""
+			if lastEventID == "" {
+				// the position in the event stream is not known, so fall back to replaying the
+				// whole history, dropping the actor ID as the replay covers events which predate
+				// the action
+				tailEvents = -1
+				actorID = ""
+			}
 
 			return retry.ExpectedError(err)
 		}
 
-		if err != nil {
-			a.update(reporter.Update{
-				Message: fmt.Sprintf("error: %v", safeout.String(err.Error())),
-				Status:  reporter.StatusError,
-			})
-		}
+		a.update(reporter.Update{
+			Message: fmt.Sprintf("error: %v", safeout.String(err.Error())),
+			Status:  reporter.StatusError,
+		})
 
 		return err
 	})
@@ -188,6 +246,11 @@ func (a *nodeTracker) trackEventsWithRetry(actorIDCh chan string) error {
 
 func (a *nodeTracker) runPostCheckWithRetry(preActionBootID string) error {
 	return retry.Constant(a.tracker.timeout).RetryWithContext(a.ctx, func(ctx context.Context) error {
+		// bound a single attempt: the post check talks to the node over the same connection the
+		// event stream used, so it can block indefinitely for the same reason
+		ctx, cancel := context.WithTimeout(ctx, postCheckTimeout)
+		defer cancel()
+
 		// retryable function
 		err := func() error {
 			err := a.tracker.postCheckFn(ctx, a.cli, a.node, preActionBootID)
@@ -204,6 +267,15 @@ func (a *nodeTracker) runPostCheckWithRetry(preActionBootID string) error {
 		}()
 
 		// handle retryable errors
+		if errors.Is(err, context.DeadlineExceeded) || client.StatusCode(err) == codes.DeadlineExceeded {
+			a.update(reporter.Update{
+				Message: fmt.Sprintf("post check stuck for %s, retrying...", postCheckTimeout),
+				Status:  reporter.StatusRunning,
+			})
+
+			return retry.ExpectedError(err)
+		}
+
 		statusCode := client.StatusCode(err)
 		if errors.Is(err, io.EOF) || statusCode == codes.Unavailable || statusCode == codes.Canceled {
 			a.update(reporter.Update{
@@ -218,14 +290,20 @@ func (a *nodeTracker) runPostCheckWithRetry(preActionBootID string) error {
 	})
 }
 
-func (a *nodeTracker) handleEvents(eventCh chan client.EventResult, actorID string) error {
+func (a *nodeTracker) handleEvents(ctx context.Context, eventCh chan client.EventResult, actorID string, lastEventID *string, progress func()) error {
 	for {
 		var eventResult client.EventResult
 
 		select {
 		case eventResult = <-eventCh:
-		case <-a.ctx.Done():
-			return a.ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		progress()
+
+		if eventResult.Event.ID != "" {
+			*lastEventID = eventResult.Event.ID
 		}
 
 		if a.tracker.expectedEventFn(eventResult) {

--- a/pkg/machinery/client/dialer/proxy.go
+++ b/pkg/machinery/client/dialer/proxy.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 
 	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/net/proxy"
@@ -262,15 +263,37 @@ func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) erro
 	return nil
 }
 
+// TCP keepalive settings for the Talos API client connections.
+//
+// Most long-running Talos API calls are server-streaming (e.g. `Events`), so the client sends
+// nothing at all once the request is on the wire. A peer which goes away without closing the
+// connection - a node kexec'ed into a new kernel by an upgrade is the common case - is therefore
+// invisible at the HTTP/2 level: it produces silence, not an error, and the connection stays
+// `READY` forever.
+//
+// TCP keepalives probe the connection from below HTTP/2, so unlike gRPC keepalive pings they are
+// never seen by the server and can't trip its keepalive enforcement policy on a connection which
+// is idle but perfectly valid (e.g. while the node is pulling an image).
+//
+// Only `Idle` and `Interval` are set: those are the knobs supported across the platforms
+// `talosctl` runs on, while the probe count is not (it is unavailable on OpenBSD and on Windows
+// releases before 10 1709). Leaving the count at the OS default (8-10 probes) puts the detection
+// time at around two minutes.
+const (
+	tcpKeepaliveIdle     = 30 * time.Second
+	tcpKeepaliveInterval = 10 * time.Second
+)
+
 // NetDialerWithTCPKeepalive returns a net.Dialer that enables TCP keepalives on
-// the underlying connection with OS default values for keepalive parameters.
+// the underlying connection to detect peers which went away without closing the connection.
 func NetDialerWithTCPKeepalive() *net.Dialer {
 	return &net.Dialer{
 		KeepAliveConfig: net.KeepAliveConfig{
 			Enable:   true,
-			Idle:     -1,
-			Count:    -1,
-			Interval: -1,
+			Idle:     tcpKeepaliveIdle,
+			Interval: tcpKeepaliveInterval,
+			// not set: unsupported on some platforms, so the OS default applies
+			Count: -1,
 		},
 	}
 }


### PR DESCRIPTION
Fixes #14242

Two separate fixes:

* enforce more tight TCP keep-alive settings by default
* add a user-space fallback - if the `Events` API doesn't return any events for a timeout, restart event streaming
