### PR TITLE
fix: restrict generated configuration file permissions

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_dev.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 	"github.com/siderolabs/talos/pkg/provision/access"
 	"github.com/siderolabs/talos/pkg/provision/providers/remote"
 )
@@ -161,6 +162,12 @@ func mergeKubeconfig(ctx context.Context, clusterAccess *access.Adapter) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error merging kubeconfig: %w", err)
+	}
+
+	// restrict the mode before the merged kubeconfig is written back:
+	// clientcmd keeps the mode of an already existing file
+	if err = fileutils.RestrictSecretMode(kubeconfigPath); err != nil {
+		return err
 	}
 
 	return merger.Write(kubeconfigPath)

--- a/cmd/talosctl/cmd/mgmt/cluster/create/create_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/create_qemu.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 	"github.com/siderolabs/talos/pkg/provision"
 )
 
@@ -145,7 +146,7 @@ func writeMachineconfig(clusterConfigs clusterops.ClusterConfigs, cOps clusterop
 	}
 
 	fullFilePath := filepath.Join(".", "machineconfig.yaml")
-	if err = os.WriteFile(fullFilePath, cfgBytes, 0o644); err != nil {
+	if err = fileutils.WriteSecret(fullFilePath, cfgBytes); err != nil {
 		return err
 	}
 

--- a/cmd/talosctl/cmd/mgmt/gen/ca.go
+++ b/cmd/talosctl/cmd/mgmt/gen/ca.go
@@ -7,13 +7,13 @@ package gen
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/siderolabs/crypto/x509"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genCACmdFlags struct {
@@ -49,15 +49,15 @@ var genCACmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(caCertFile, ca.CrtPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(caCertFile, ca.CrtPEM); err != nil {
 			return fmt.Errorf("error writing CA certificate: %w", err)
 		}
 
-		if err := os.WriteFile(caHashFile, []byte(x509.Hash(ca.Crt)), 0o600); err != nil {
+		if err := fileutils.WriteSecret(caHashFile, []byte(x509.Hash(ca.Crt))); err != nil {
 			return fmt.Errorf("error writing certificate hash: %w", err)
 		}
 
-		if err := os.WriteFile(caKeyFile, ca.KeyPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(caKeyFile, ca.KeyPEM); err != nil {
 			return fmt.Errorf("error writing key: %w", err)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/gen/config.go
+++ b/cmd/talosctl/cmd/mgmt/gen/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 const (
@@ -304,7 +305,7 @@ func writeConfigBundle(configBundle *bundle.Bundle, outputPaths configOutputPath
 			return err
 		}
 
-		if err = writeToDestination(data, outputPaths.controlPlane, 0o644); err != nil {
+		if err = writeToDestination(data, outputPaths.controlPlane); err != nil {
 			return err
 		}
 	}
@@ -315,7 +316,7 @@ func writeConfigBundle(configBundle *bundle.Bundle, outputPaths configOutputPath
 			return err
 		}
 
-		if err = writeToDestination(data, outputPaths.worker, 0o644); err != nil {
+		if err = writeToDestination(data, outputPaths.worker); err != nil {
 			return err
 		}
 	}
@@ -326,7 +327,7 @@ func writeConfigBundle(configBundle *bundle.Bundle, outputPaths configOutputPath
 			return fmt.Errorf("failed to marshal config: %+v", err)
 		}
 
-		if err = writeToDestination(data, outputPaths.talosconfig, 0o644); err != nil {
+		if err = writeToDestination(data, outputPaths.talosconfig); err != nil {
 			return err
 		}
 	}
@@ -334,7 +335,7 @@ func writeConfigBundle(configBundle *bundle.Bundle, outputPaths configOutputPath
 	return nil
 }
 
-func writeToDestination(data []byte, destination string, permissions os.FileMode) error {
+func writeToDestination(data []byte, destination string) error {
 	if destination == stdoutOutput {
 		_, err := os.Stdout.Write(data)
 
@@ -348,11 +349,11 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 	parentDir := filepath.Dir(destination)
 
 	// Create dir path, ignoring "already exists" messages
-	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(parentDir, fileutils.SecretDirMode); err != nil {
 		return fmt.Errorf("failed to create output dir: %w", err)
 	}
 
-	err := os.WriteFile(destination, data, permissions)
+	err := fileutils.WriteSecret(destination, data)
 
 	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
 

--- a/cmd/talosctl/cmd/mgmt/gen/crt.go
+++ b/cmd/talosctl/cmd/mgmt/gen/crt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genCrtCmdFlags struct {
@@ -93,7 +94,7 @@ var genCrtCmd = &cobra.Command{
 			return err
 		}
 
-		if err = os.WriteFile(certFile, signedCrt.X509CertificatePEM, 0o600); err != nil {
+		if err = fileutils.WriteSecret(certFile, signedCrt.X509CertificatePEM); err != nil {
 			return fmt.Errorf("error writing certificate: %s", err)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/gen/csr.go
+++ b/cmd/talosctl/cmd/mgmt/gen/csr.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
@@ -77,7 +78,7 @@ var genCSRCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(csrFile, csr.X509CertificateRequestPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(csrFile, csr.X509CertificateRequestPEM); err != nil {
 			return fmt.Errorf("error writing CSR: %s", err)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/gen/key.go
+++ b/cmd/talosctl/cmd/mgmt/gen/key.go
@@ -6,12 +6,12 @@ package gen
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/siderolabs/crypto/x509"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genKeyCmdFlags struct {
@@ -36,7 +36,7 @@ var genKeyCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(keyFile, key.PrivateKeyPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(keyFile, key.PrivateKeyPEM); err != nil {
 			return fmt.Errorf("error writing key: %w", err)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/gen/keypair.go
+++ b/cmd/talosctl/cmd/mgmt/gen/keypair.go
@@ -7,12 +7,12 @@ package gen
 import (
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/siderolabs/crypto/x509"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/cli"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genKeypairCmdFlags struct {
@@ -54,11 +54,11 @@ var genKeypairCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(certFile, ca.CrtPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(certFile, ca.CrtPEM); err != nil {
 			return fmt.Errorf("error writing certificate: %s", err)
 		}
 
-		if err := os.WriteFile(keyFile, ca.KeyPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(keyFile, ca.KeyPEM); err != nil {
 			return fmt.Errorf("error writing key: %s", err)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/gen/secrets.go
+++ b/cmd/talosctl/cmd/mgmt/gen/secrets.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genSecretsCmdFlags struct {
@@ -92,7 +93,7 @@ func writeSecretsBundleToFile(bundle *secrets.Bundle) error {
 		return err
 	}
 
-	return os.WriteFile(genSecretsCmdFlags.outputFile, bundleBytes, 0o600)
+	return fileutils.WriteSecret(genSecretsCmdFlags.outputFile, bundleBytes)
 }
 
 func init() {

--- a/cmd/talosctl/cmd/mgmt/gen/secureboot.go
+++ b/cmd/talosctl/cmd/mgmt/gen/secureboot.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/siderolabs/talos/pkg/imager/profile"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var genSecurebootCmdFlags struct {
@@ -85,20 +85,20 @@ var genSecurebootDatabaseCmd = &cobra.Command{
 	},
 }
 
-func checkedWrite(path string, data []byte, perm fs.FileMode) error { //nolint:unparam
+func checkedWrite(path string, data []byte) error {
 	if err := validateFileExists(path); err != nil {
 		return err
 	}
 
 	if dirname := filepath.Dir(path); dirname != "." {
-		if err := os.MkdirAll(dirname, 0o700); err != nil {
+		if err := os.MkdirAll(dirname, fileutils.SecretDirMode); err != nil {
 			return err
 		}
 	}
 
 	fmt.Fprintf(os.Stderr, "writing %s\n", path)
 
-	return os.WriteFile(path, data, perm)
+	return fileutils.WriteSecret(path, data)
 }
 
 func generateSigningCerts(path, prefix, commonName string, rsaBits int, outputCert bool) error {
@@ -119,7 +119,7 @@ func generateSigningCerts(path, prefix, commonName string, rsaBits int, outputCe
 	}
 
 	if outputCert {
-		if err = checkedWrite(filepath.Join(path, prefix+"-signing-cert.pem"), signingKey.CrtPEM, 0o600); err != nil {
+		if err = checkedWrite(filepath.Join(path, prefix+"-signing-cert.pem"), signingKey.CrtPEM); err != nil {
 			return err
 		}
 
@@ -128,7 +128,7 @@ func generateSigningCerts(path, prefix, commonName string, rsaBits int, outputCe
 		}
 	}
 
-	return checkedWrite(filepath.Join(path, prefix+"-signing-key.pem"), signingKey.KeyPEM, 0o600)
+	return checkedWrite(filepath.Join(path, prefix+"-signing-key.pem"), signingKey.KeyPEM)
 }
 
 func saveAsDER(file string, pem []byte) error {
@@ -137,7 +137,7 @@ func saveAsDER(file string, pem []byte) error {
 		return err
 	}
 
-	return checkedWrite(file, publicKeyDER, 0o600)
+	return checkedWrite(file, publicKeyDER)
 }
 
 // generateSecureBootDatabase generates a UEFI database to enroll the signing certificate.
@@ -168,7 +168,7 @@ func generateSecureBootDatabase(ctx context.Context, path, enrolledCertificatePa
 
 	// output all files with sd-boot conventional names for auto-enrolment
 	for _, entry := range db {
-		if err = checkedWrite(filepath.Join(path, entry.Name), entry.Contents, 0o600); err != nil {
+		if err = checkedWrite(filepath.Join(path, entry.Name), entry.Contents); err != nil {
 			return err
 		}
 	}

--- a/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
+++ b/cmd/talosctl/cmd/mgmt/machineconfig/patch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 var patchCmdFlags struct {
@@ -56,11 +57,11 @@ var patchCmd = &cobra.Command{
 		parentDir := filepath.Dir(patchCmdFlags.output)
 
 		// Create dir path, ignoring "already exists" messages
-		if err := os.MkdirAll(parentDir, os.ModePerm); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(parentDir, fileutils.SecretDirMode); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create output dir: %w", err)
 		}
 
-		return os.WriteFile(patchCmdFlags.output, patchedData, 0o644)
+		return fileutils.WriteSecret(patchCmdFlags.output, patchedData)
 	},
 }
 

--- a/cmd/talosctl/cmd/talos/image.go
+++ b/cmd/talosctl/cmd/talos/image.go
@@ -53,6 +53,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 	"github.com/siderolabs/talos/pkg/machinery/version"
 	"github.com/siderolabs/talos/pkg/reporter"
 )
@@ -1032,7 +1033,7 @@ var imageCacheCertGenCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(imageCacheCertGenCmdFlags.tlsKeyFile, keyPEM, 0o600); err != nil {
+		if err := fileutils.WriteSecret(imageCacheCertGenCmdFlags.tlsKeyFile, keyPEM); err != nil {
 			return err
 		}
 

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/safeout"
 	taloskubeconfig "github.com/siderolabs/talos/pkg/kubeconfig"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 const stdoutOutput = "-"
@@ -136,7 +137,7 @@ If merge flag is false and [local-path] is "-", config will be written to stdout
 			return err
 		}
 
-		return os.WriteFile(localPath, data, 0o600)
+		return fileutils.WriteSecret(localPath, data)
 	},
 }
 
@@ -165,6 +166,12 @@ func mergeKubeconfig(config *clientcmdapi.Config, localPath string) error {
 		},
 	})
 	if err != nil {
+		return err
+	}
+
+	// restrict the mode before the merged kubeconfig is written back:
+	// clientcmd keeps the mode of an already existing file
+	if err = fileutils.RestrictSecretMode(localPath); err != nil {
 		return err
 	}
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -222,6 +222,17 @@ Note that `[debug]` `level`, `format` and `log_trace_id` stay at the top level, 
 derived from the `grpc` address: if the `grpc` address is customized, the `ttrpc` plugin address has to be set explicitly.
 """
 
+    [notes.secret_file_permissions]
+        title = "Permissions of the Generated Files"
+        description = """\
+`talosctl` now writes every file which might contain secrets with `0600` permissions (owner read/write only),
+and it restricts the permissions of the files it overwrites as well.
+
+This affects the machine configuration (`talosctl gen config`, `talosctl machineconfig patch`,
+`talosctl cluster create --skip-injecting-config`), `talosconfig` and `kubeconfig`.
+"""
+
+
     [notes.nfs_external_volumes]
         title = "NFS External Volumes"
         description = """\

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -184,6 +184,40 @@ func (suite *GenSuite) TestGenConfigPatchStrategic() {
 	}
 }
 
+// TestGenConfigPermissions verifies that generated configs are not readable by group/others.
+func (suite *GenSuite) TestGenConfigPermissions() {
+	configNames := []string{"controlplane.yaml", "worker.yaml", "talosconfig"}
+
+	suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile("generating PKI and tokens")))
+
+	for _, configName := range configNames {
+		st, err := os.Stat(configName)
+		suite.Require().NoError(err)
+
+		suite.Assert().Equal(os.FileMode(0o600), st.Mode().Perm(), "checking %q", configName)
+	}
+
+	// overwriting configs left over by an older version of talosctl should restrict the mode as well
+	for _, configName := range configNames {
+		suite.Require().NoError(os.Chmod(configName, 0o644))
+	}
+
+	suite.RunCLI([]string{"gen", "config", "--force", "foo", "https://192.168.0.1:6443"},
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile("generating PKI and tokens")))
+
+	for _, configName := range configNames {
+		st, err := os.Stat(configName)
+		suite.Require().NoError(err)
+
+		suite.Assert().Equal(os.FileMode(0o600), st.Mode().Perm(), "checking %q", configName)
+	}
+}
+
 // TestSecrets ...
 func (suite *GenSuite) TestSecrets() {
 	suite.RunCLI([]string{"gen", "secrets"}, base.StdoutEmpty())

--- a/internal/integration/cli/machineconfig.go
+++ b/internal/integration/cli/machineconfig.go
@@ -151,6 +151,12 @@ func (suite *MachineConfigSuite) TestPatchWriteToFile() {
 	suite.Assert().NoError(err)
 
 	suite.Assert().Contains(string(outputBytes), "clusterName: replaced")
+
+	// the patched machine config contains secrets, so it should not be readable by group/others
+	st, err := os.Stat(outputFile)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(os.FileMode(0o600), st.Mode().Perm())
 }
 
 func init() {

--- a/pkg/machinery/client/config/config.go
+++ b/pkg/machinery/client/config/config.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/siderolabs/crypto/x509"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 // Config represents the client configuration file (talosconfig).
@@ -181,11 +183,11 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 
-	if err = os.MkdirAll(filepath.Dir(c.path.Path), 0o700); err != nil {
+	if err = os.MkdirAll(filepath.Dir(c.path.Path), fileutils.SecretDirMode); err != nil {
 		return err
 	}
 
-	return os.WriteFile(c.path.Path, configBytes, 0o600)
+	return fileutils.WriteSecret(c.path.Path, configBytes)
 }
 
 // Bytes gets yaml encoded config data.

--- a/pkg/machinery/config/bundle/bundle.go
+++ b/pkg/machinery/config/bundle/bundle.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 )
 
 // Bundle defines a set of machine configuration files.
@@ -187,7 +188,7 @@ func (bundle *Bundle) Write(outputDir string, commentsFlags encoder.CommentsFlag
 			return err
 		}
 
-		if err = os.WriteFile(fullFilePath, bytes, 0o644); err != nil {
+		if err = fileutils.WriteSecret(fullFilePath, bytes); err != nil {
 			return err
 		}
 

--- a/pkg/machinery/fileutils/fileutils.go
+++ b/pkg/machinery/fileutils/fileutils.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package fileutils provides helpers for handling files which contain secrets.
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+const (
+	// SecretFileMode is the mode of the files which contain secrets: machine configuration,
+	// talosconfig, kubeconfig, secrets bundle, private keys, etc.
+	SecretFileMode os.FileMode = 0o600
+
+	// SecretDirMode is the mode of the directories which contain files with secrets.
+	SecretDirMode os.FileMode = 0o700
+)
+
+// WriteSecret writes the data to the file at path with SecretFileMode.
+//
+// Unlike os.WriteFile, it also restricts the mode of an already existing file.
+func WriteSecret(path string, data []byte) error {
+	if err := RestrictSecretMode(path); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, SecretFileMode)
+}
+
+// RestrictSecretMode restricts the mode of an existing file at path to SecretFileMode,
+// missing files are ignored.
+//
+// It should be called before writing the file, so that the contents are never exposed:
+// os.WriteFile (and most other writers) keep the mode of an already existing file.
+func RestrictSecretMode(path string) error {
+	if err := os.Chmod(path, SecretFileMode); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/machinery/fileutils/fileutils_test.go
+++ b/pkg/machinery/fileutils/fileutils_test.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package fileutils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
+)
+
+func TestWriteSecret(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "secret.yaml")
+
+	require.NoError(t, fileutils.WriteSecret(path, []byte("foo")))
+
+	assertContentsAndMode(t, path, "foo")
+
+	// overwriting a file which is readable by everyone should restrict the mode
+	require.NoError(t, os.Chmod(path, 0o644))
+	require.NoError(t, fileutils.WriteSecret(path, []byte("bar")))
+
+	assertContentsAndMode(t, path, "bar")
+}
+
+func TestRestrictSecretMode(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "secret.yaml")
+
+	// missing files are ignored
+	require.NoError(t, fileutils.RestrictSecretMode(path))
+
+	require.NoError(t, os.WriteFile(path, []byte("foo"), 0o644))
+	require.NoError(t, fileutils.RestrictSecretMode(path))
+
+	assertContentsAndMode(t, path, "foo")
+}
+
+func assertContentsAndMode(t *testing.T, path, expected string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(contents))
+
+	st, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, fileutils.SecretFileMode, st.Mode().Perm())
+}

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/fileutils"
 	"github.com/siderolabs/talos/pkg/machinery/kernel"
 	"github.com/siderolabs/talos/pkg/provision"
 	"github.com/siderolabs/talos/pkg/provision/providers/vm"
@@ -267,7 +268,12 @@ func (p *provisioner) createNode(ctx context.Context, state *provision.State, cl
 		return provision.NodeInfo{}, err
 	}
 
-	launchConfigFile, err := os.Create(state.GetRelativePath(fmt.Sprintf("%s.config", nodeReq.Name)))
+	// the launch config embeds the machine config, so keep it owner-only
+	launchConfigFile, err := os.OpenFile(
+		state.GetRelativePath(fmt.Sprintf("%s.config", nodeReq.Name)),
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		fileutils.SecretFileMode,
+	)
 	if err != nil {
 		return provision.NodeInfo{}, err
 	}
@@ -410,7 +416,7 @@ func (p *provisioner) createMetalConfigISO(ctx context.Context, state *provision
 
 	defer os.RemoveAll(tmpDir) //nolint:errcheck
 
-	if err = os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(config), 0o644); err != nil {
+	if err = fileutils.WriteSecret(filepath.Join(tmpDir, "config.yaml"), []byte(config)); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
# Pull Request

## What? (description)

Write generated machine configs and `talosconfig` with `0600` permissions. 
Overwriting an existing file fixes its mode too

## Why? (reasoning)

Repro on Linux with a normal `umask 022`:

```sh
talosctl gen config test https://10.0.0.1:6443
stat -c '%n %a' controlplane.yaml worker.yaml talosconfig
```

All three files were `0644`, even though they contain cluster credentials and private keys. 
Pretty easy to hit, this makes them `0600`

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
