### PR TITLE
feat: Control verbosity of kube-network-policies sidecar container

### DIFF
--- a/api/resource/definitions/k8s/k8s.proto
+++ b/api/resource/definitions/k8s/k8s.proto
@@ -96,6 +96,7 @@ message BootstrapManifestsConfigSpec {
   google.protobuf.Struct proxy_config = 27;
   Resources proxy_resources = 28;
   string proxy_config_checksum = 29;
+  bool flannel_kube_network_policies_verbose = 30;
 }
 
 // ConfigStatusSpec describes status of rendered secrets.

--- a/internal/app/machined/pkg/controllers/k8s/control_plane.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane.go
@@ -475,6 +475,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					res.TypedSpec().FlannelKubeServiceHost = flannelKubeServiceHost
 					res.TypedSpec().FlannelKubeServicePort = flannelKubeServicePort
 					res.TypedSpec().FlannelKubeNetworkPoliciesEnabled = k8sFlannelCNIConfig.KubeNetworkPoliciesEnabled()
+					res.TypedSpec().FlannelKubeNetworkPoliciesVerbose = k8sFlannelCNIConfig.KubeNetworkPoliciesVerbose()
 					res.TypedSpec().FlannelKubeNetworkPoliciesImage = images.KubeNetworkPolicies().String()
 					res.TypedSpec().CNIName = constants.FlannelCNI
 				} else {
@@ -489,6 +490,7 @@ func NewControlPlaneBootstrapManifestsController() *ControlPlaneBootstrapManifes
 					res.TypedSpec().FlannelKubeServiceHost = ""
 					res.TypedSpec().FlannelKubeServicePort = ""
 					res.TypedSpec().FlannelKubeNetworkPoliciesEnabled = false
+					res.TypedSpec().FlannelKubeNetworkPoliciesVerbose = true
 					res.TypedSpec().FlannelKubeNetworkPoliciesImage = ""
 					res.TypedSpec().CNIName = constants.NoneCNI
 				}

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/flannel.go
@@ -311,13 +311,18 @@ func FlannelDaemonSetTemplate(spec *k8s.BootstrapManifestsConfigSpec) (runtime.O
 	}
 
 	if spec.FlannelKubeNetworkPoliciesEnabled {
+		verbosity := "--v=0"
+		if spec.FlannelKubeNetworkPoliciesVerbose {
+			verbosity = "--v=2"
+		}
+
 		containers = append(containers, corev1.Container{
 			Name:  "kube-network-policies",
 			Image: spec.FlannelKubeNetworkPoliciesImage,
 			Command: []string{
 				"/bin/netpol",
 				"--hostname-override=$(MY_NODE_NAME)",
-				"--v=2",
+				verbosity,
 			},
 			Env: []corev1.EnvVar{
 				{

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/k8stemplates_test.go
@@ -542,6 +542,32 @@ func TestTemplates(t *testing.T) {
 					},
 					FlannelKubeNetworkPoliciesEnabled: true,
 					FlannelKubeNetworkPoliciesImage:   "registry.k8s.io/networking/kube-network-policies:v0.7.0",
+					FlannelKubeNetworkPoliciesVerbose: true,
+				})
+				require.NoError(t, err)
+
+				return spec
+			},
+		},
+		{
+			name: "flannel-daemonset-with-network-policies-non-verbose",
+			obj: func() runtime.Object {
+				spec, err := k8stemplates.FlannelDaemonSetTemplate(&k8s.BootstrapManifestsConfigSpec{
+					FlannelImage:     "quay.io/coreos/flannel:v0.14.0",
+					FlannelExtraArgs: []string{"--foo=bar"},
+					FlannelResources: k8s.Resources{
+						Requests: map[string]string{
+							"cpu":    "100m",
+							"memory": "50Mi",
+						},
+						Limits: map[string]string{
+							"cpu":    "200m",
+							"memory": "100Mi",
+						},
+					},
+					FlannelKubeNetworkPoliciesEnabled: true,
+					FlannelKubeNetworkPoliciesImage:   "registry.k8s.io/networking/kube-network-policies:v0.7.0",
+					FlannelKubeNetworkPoliciesVerbose: false,
 				})
 				require.NoError(t, err)
 

--- a/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-daemonset-with-network-policies-non-verbose.yaml
+++ b/internal/app/machined/pkg/controllers/k8s/internal/k8stemplates/testdata/flannel-daemonset-with-network-policies-non-verbose.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: flannel
+    tier: node
+  name: kube-flannel
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: flannel
+      tier: node
+  template:
+    metadata:
+      labels:
+        k8s-app: flannel
+        tier: node
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        - --foo=bar
+        command:
+        - /opt/bin/flanneld
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
+        - name: GOMEMLIMIT
+          value: "99614720"
+        image: quay.io/coreos/flannel:v0.14.0
+        name: kube-flannel
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+        volumeMounts:
+        - mountPath: /run/flannel
+          name: run
+        - mountPath: /etc/kube-flannel/
+          name: flannel-cfg
+      - command:
+        - /bin/netpol
+        - --hostname-override=$(MY_NODE_NAME)
+        - --v=0
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.k8s.io/networking/kube-network-policies:v0.7.0
+        name: kube-network-policies
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+      hostNetwork: true
+      initContainers:
+      - args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        command:
+        - cp
+        image: quay.io/coreos/flannel:v0.14.0
+        name: install-config
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/cni/net.d
+          name: cni
+        - mountPath: /etc/kube-flannel/
+          name: flannel-cfg
+      priorityClassName: system-node-critical
+      serviceAccountName: flannel
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /run/flannel
+        name: run
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni
+      - configMap:
+          name: kube-flannel-cfg
+        name: flannel-cfg
+      - hostPath:
+          path: /usr/lib/modules
+        name: lib-modules
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0

--- a/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s.pb.go
@@ -553,6 +553,7 @@ type BootstrapManifestsConfigSpec struct {
 	ProxyConfig                       *structpb.Struct       `protobuf:"bytes,27,opt,name=proxy_config,json=proxyConfig,proto3" json:"proxy_config,omitempty"`
 	ProxyResources                    *Resources             `protobuf:"bytes,28,opt,name=proxy_resources,json=proxyResources,proto3" json:"proxy_resources,omitempty"`
 	ProxyConfigChecksum               string                 `protobuf:"bytes,29,opt,name=proxy_config_checksum,json=proxyConfigChecksum,proto3" json:"proxy_config_checksum,omitempty"`
+	FlannelKubeNetworkPoliciesVerbose bool                   `protobuf:"varint,30,opt,name=flannel_kube_network_policies_verbose,json=flannelKubeNetworkPoliciesVerbose,proto3" json:"flannel_kube_network_policies_verbose,omitempty"`
 	unknownFields                     protoimpl.UnknownFields
 	sizeCache                         protoimpl.SizeCache
 }
@@ -781,6 +782,13 @@ func (x *BootstrapManifestsConfigSpec) GetProxyConfigChecksum() string {
 		return x.ProxyConfigChecksum
 	}
 	return ""
+}
+
+func (x *BootstrapManifestsConfigSpec) GetFlannelKubeNetworkPoliciesVerbose() bool {
+	if x != nil {
+		return x.FlannelKubeNetworkPoliciesVerbose
+	}
+	return false
 }
 
 // ConfigStatusSpec describes status of rendered secrets.
@@ -2732,7 +2740,7 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\awebhook\x18\x03 \x01(\v2\x17.google.protobuf.StructR\awebhook\"\x85\x01\n" +
 	"\x17AuthorizationConfigSpec\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12T\n" +
-	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\xb2\v\n" +
+	"\x06config\x18\x02 \x03(\v2<.talos.resource.definitions.k8s.AuthorizationAuthorizersSpecR\x06config\"\x84\f\n" +
 	"\x1cBootstrapManifestsConfigSpec\x12\x16\n" +
 	"\x06server\x18\x01 \x01(\tR\x06server\x12%\n" +
 	"\x0ecluster_domain\x18\x02 \x01(\tR\rclusterDomain\x12\x1c\n" +
@@ -2765,7 +2773,8 @@ const file_resource_definitions_k8s_k8s_proto_rawDesc = "" +
 	"\x1cflannel_backend_extra_config\x18\x1a \x01(\v2\x17.google.protobuf.StructR\x19flannelBackendExtraConfig\x12:\n" +
 	"\fproxy_config\x18\x1b \x01(\v2\x17.google.protobuf.StructR\vproxyConfig\x12R\n" +
 	"\x0fproxy_resources\x18\x1c \x01(\v2).talos.resource.definitions.k8s.ResourcesR\x0eproxyResources\x122\n" +
-	"\x15proxy_config_checksum\x18\x1d \x01(\tR\x13proxyConfigChecksum\"B\n" +
+	"\x15proxy_config_checksum\x18\x1d \x01(\tR\x13proxyConfigChecksum\x12P\n" +
+	"%flannel_kube_network_policies_verbose\x18\x1e \x01(\bR!flannelKubeNetworkPoliciesVerbose\"B\n" +
 	"\x10ConfigStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\"\x83\a\n" +

--- a/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/k8s/k8s_vtproto.pb.go
@@ -565,6 +565,18 @@ func (m *BootstrapManifestsConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.FlannelKubeNetworkPoliciesVerbose {
+		i--
+		if m.FlannelKubeNetworkPoliciesVerbose {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xf0
+	}
 	if len(m.ProxyConfigChecksum) > 0 {
 		i -= len(m.ProxyConfigChecksum)
 		copy(dAtA[i:], m.ProxyConfigChecksum)
@@ -3166,6 +3178,9 @@ func (m *BootstrapManifestsConfigSpec) SizeVT() (n int) {
 	l = len(m.ProxyConfigChecksum)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FlannelKubeNetworkPoliciesVerbose {
+		n += 3
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6202,6 +6217,26 @@ func (m *BootstrapManifestsConfigSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.ProxyConfigChecksum = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 30:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FlannelKubeNetworkPoliciesVerbose", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.FlannelKubeNetworkPoliciesVerbose = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/config/config/k8s.go
+++ b/pkg/machinery/config/config/k8s.go
@@ -115,6 +115,7 @@ type K8sFlannelCNIConfig interface {
 	Resources() Resources
 	ExtraArgs() []string
 	KubeNetworkPoliciesEnabled() bool
+	KubeNetworkPoliciesVerbose() bool
 }
 
 // K8sAdmissionControlPluginConfig defines the configuration options for kube-apiserver admission control plugins.

--- a/pkg/machinery/config/schemas/config.schema.json
+++ b/pkg/machinery/config/schemas/config.schema.json
@@ -2785,6 +2785,13 @@
           "description": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.\n",
           "markdownDescription": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
           "x-intellij-html-description": "\u003cp\u003eDeploys kube-network-policies along with Flannel.\u003c/p\u003e\n\n\u003cp\u003eThis enables Kubernetes Network Policies support in the cluster.\u003c/p\u003e\n"
+        },
+        "kubeNetworkPoliciesVerbose": {
+          "type": "boolean",
+          "title": "kubeNetworkPoliciesVerbose",
+          "description": "Enables verbose logging for kube-network-policies.\n\nThis enables verbose logging for the kube-network-policies container.\n",
+          "markdownDescription": "Enables verbose logging for kube-network-policies.\n\nThis enables verbose logging for the kube-network-policies container.",
+          "x-intellij-html-description": "\u003cp\u003eEnables verbose logging for kube-network-policies.\u003c/p\u003e\n\n\u003cp\u003eThis enables verbose logging for the kube-network-policies container.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,

--- a/pkg/machinery/config/types/k8s/deep_copy.generated.go
+++ b/pkg/machinery/config/types/k8s/deep_copy.generated.go
@@ -225,6 +225,10 @@ func (o *KubeFlannelCNIConfigV1Alpha1) DeepCopy() *KubeFlannelCNIConfigV1Alpha1 
 		cp.FlannelKubeNetworkPoliciesEnabled = new(bool)
 		*cp.FlannelKubeNetworkPoliciesEnabled = *o.FlannelKubeNetworkPoliciesEnabled
 	}
+	if o.FlannelKubeNetworkPoliciesVerbose != nil {
+		cp.FlannelKubeNetworkPoliciesVerbose = new(bool)
+		*cp.FlannelKubeNetworkPoliciesVerbose = *o.FlannelKubeNetworkPoliciesVerbose
+	}
 	return &cp
 }
 

--- a/pkg/machinery/config/types/k8s/flannel.go
+++ b/pkg/machinery/config/types/k8s/flannel.go
@@ -96,6 +96,11 @@ type KubeFlannelCNIConfigV1Alpha1 struct {
 	//
 	//     This enables Kubernetes Network Policies support in the cluster.
 	FlannelKubeNetworkPoliciesEnabled *bool `yaml:"kubeNetworkPoliciesEnabled,omitempty"`
+	//   description: |
+	//     Enables verbose logging for kube-network-policies.
+	//
+	//     This enables verbose logging for the kube-network-policies container.
+	FlannelKubeNetworkPoliciesVerbose *bool `yaml:"kubeNetworkPoliciesVerbose,omitempty"`
 }
 
 // NewKubeFlannelCNIConfigV1Alpha1 creates a new KubeFlannelCNIConfig config document.
@@ -192,6 +197,15 @@ func (s *KubeFlannelCNIConfigV1Alpha1) ExtraArgs() []string {
 // KubeNetworkPoliciesEnabled implements config.K8sFlannelCNIConfig interface.
 func (s *KubeFlannelCNIConfigV1Alpha1) KubeNetworkPoliciesEnabled() bool {
 	return pointer.SafeDeref(s.FlannelKubeNetworkPoliciesEnabled)
+}
+
+// KubeNetworkPoliciesVerbose implements config.K8sFlannelCNIConfig interface.
+func (s *KubeFlannelCNIConfigV1Alpha1) KubeNetworkPoliciesVerbose() bool {
+	if s.FlannelKubeNetworkPoliciesVerbose == nil {
+		return true
+	}
+
+	return *s.FlannelKubeNetworkPoliciesVerbose
 }
 
 // ControlplaneOnlyDocument implements container.ControlplaneOnlyConfig interface.

--- a/pkg/machinery/config/types/k8s/k8s_doc.go
+++ b/pkg/machinery/config/types/k8s/k8s_doc.go
@@ -589,6 +589,13 @@ func (KubeFlannelCNIConfigV1Alpha1) Doc() *encoder.Doc {
 				Description: "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "Deploys kube-network-policies along with Flannel." /* encoder.LineComment */, "" /* encoder.FootComment */},
 			},
+			{
+				Name:        "kubeNetworkPoliciesVerbose",
+				Type:        "bool",
+				Note:        "",
+				Description: "Enables verbose logging for kube-network-policies.\n\nThis enables verbose logging for the kube-network-policies container.",
+				Comments:    [3]string{"" /* encoder.HeadComment */, "Enables verbose logging for kube-network-policies." /* encoder.LineComment */, "" /* encoder.FootComment */},
+			},
 		},
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
@@ -65,3 +65,12 @@ func (c *FlannelCNIConfig) ExtraArgs() []string {
 func (c *FlannelCNIConfig) KubeNetworkPoliciesEnabled() bool {
 	return pointer.SafeDeref(c.FlannelKubeNetworkPoliciesEnabled)
 }
+
+// KubeNetworkPoliciesVerbose implements the config.K8sFlannelCNIConfig interface.
+func (c *FlannelCNIConfig) KubeNetworkPoliciesVerbose() bool {
+	if c.FlannelKubeNetworkPoliciesVerbose == nil {
+		return true
+	}
+
+	return *c.FlannelKubeNetworkPoliciesVerbose
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_cniconfig.go
@@ -68,9 +68,5 @@ func (c *FlannelCNIConfig) KubeNetworkPoliciesEnabled() bool {
 
 // KubeNetworkPoliciesVerbose implements the config.K8sFlannelCNIConfig interface.
 func (c *FlannelCNIConfig) KubeNetworkPoliciesVerbose() bool {
-	if c.FlannelKubeNetworkPoliciesVerbose == nil {
-		return true
-	}
-
-	return *c.FlannelKubeNetworkPoliciesVerbose
+	return true
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1313,6 +1313,11 @@ type FlannelCNIConfig struct {
 	//
 	//     This enables Kubernetes Network Policies support in the cluster.
 	FlannelKubeNetworkPoliciesEnabled *bool `yaml:"kubeNetworkPoliciesEnabled,omitempty"`
+	//   description: |
+	//     Enables verbose logging for kube-network-policies.
+	//
+	//     This enables verbose logging for the kube-network-policies container.
+	FlannelKubeNetworkPoliciesVerbose *bool `yaml:"kubeNetworkPoliciesVerbose,omitempty"`
 }
 
 var _ config.ExternalCloudProvider = (*ExternalCloudProviderConfig)(nil)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1313,11 +1313,6 @@ type FlannelCNIConfig struct {
 	//
 	//     This enables Kubernetes Network Policies support in the cluster.
 	FlannelKubeNetworkPoliciesEnabled *bool `yaml:"kubeNetworkPoliciesEnabled,omitempty"`
-	//   description: |
-	//     Enables verbose logging for kube-network-policies.
-	//
-	//     This enables verbose logging for the kube-network-policies container.
-	FlannelKubeNetworkPoliciesVerbose *bool `yaml:"kubeNetworkPoliciesVerbose,omitempty"`
 }
 
 var _ config.ExternalCloudProvider = (*ExternalCloudProviderConfig)(nil)

--- a/pkg/machinery/resources/k8s/manifests_config.go
+++ b/pkg/machinery/resources/k8s/manifests_config.go
@@ -52,6 +52,7 @@ type BootstrapManifestsConfigSpec struct {
 	FlannelKubeServicePort            string         `yaml:"flannelKubeServicePort" protobuf:"18"`
 	FlannelKubeNetworkPoliciesEnabled bool           `yaml:"flannelKubeNetworkPoliciesEnabled" protobuf:"19"`
 	FlannelKubeNetworkPoliciesImage   string         `yaml:"flannelKubeNetworkPoliciesImage" protobuf:"20"`
+	FlannelKubeNetworkPoliciesVerbose bool           `yaml:"flannelKubeNetworkPoliciesVerbose" protobuf:"30"`
 	FlannelBackendType                string         `yaml:"flannelBackendType" protobuf:"23"`
 	FlannelBackendPort                uint16         `yaml:"flannelBackendPort" protobuf:"24"`
 	FlannelBackendMTU                 uint32         `yaml:"flannelBackendMTU" protobuf:"22"`

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -8513,6 +8513,7 @@ BootstrapManifestsConfigSpec is configuration for bootstrap manifests.
 | flannel_kube_service_host | [string](#string) |  |  |
 | flannel_kube_service_port | [string](#string) |  |  |
 | flannel_kube_network_policies_enabled | [bool](#bool) |  |  |
+| flannel_kube_network_policies_verbose | [bool](#bool) |  |  |
 | flannel_kube_network_policies_image | [string](#string) |  |  |
 | cni_name | [string](#string) |  |  |
 | flannel_backend_mtu | [uint32](#uint32) |  |  |

--- a/website/content/v1.15/reference/configuration/kubernetes/kubeflannelcniconfig.md
+++ b/website/content/v1.15/reference/configuration/kubernetes/kubeflannelcniconfig.md
@@ -38,6 +38,7 @@ extraArgs:
     - --iface-can-reach=192.168.1.1
 {{< /highlight >}}</details> | |
 |`kubeNetworkPoliciesEnabled` |bool |Deploys kube-network-policies along with Flannel.<br><br>This enables Kubernetes Network Policies support in the cluster.  | |
+|`kubeNetworkPoliciesVerbose` |bool |Enables verbose logging for kube-network-policies.<br><br>This enables verbose logging for the kube-network-policies container.  | |
 
 
 

--- a/website/content/v1.15/schemas/config.schema.json
+++ b/website/content/v1.15/schemas/config.schema.json
@@ -2785,6 +2785,13 @@
           "description": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.\n",
           "markdownDescription": "Deploys kube-network-policies along with Flannel.\n\nThis enables Kubernetes Network Policies support in the cluster.",
           "x-intellij-html-description": "\u003cp\u003eDeploys kube-network-policies along with Flannel.\u003c/p\u003e\n\n\u003cp\u003eThis enables Kubernetes Network Policies support in the cluster.\u003c/p\u003e\n"
+        },
+        "kubeNetworkPoliciesVerbose": {
+          "type": "boolean",
+          "title": "kubeNetworkPoliciesVerbose",
+          "description": "Enables verbose logging for kube-network-policies.\n\nThis enables verbose logging for the kube-network-policies container.\n",
+          "markdownDescription": "Enables verbose logging for kube-network-policies.\n\nThis enables verbose logging for the kube-network-policies container.",
+          "x-intellij-html-description": "\u003cp\u003eEnables verbose logging for kube-network-policies.\u003c/p\u003e\n\n\u003cp\u003eThis enables verbose logging for the kube-network-policies container.\u003c/p\u003e\n"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Added a new flag kubeNetworkPoliciesVerbose to KubeFlannelCNIConfigV1Alpha1 to control verbosity of kube-network-policies sidecar container.

## Why? (reasoning)

By default when network policies are enabled for flannel, it logs each and every packet flooding the logs overwhelming log collectors like Promtail.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
