### PR TITLE
fix: notify about link alias changes

### DIFF
--- a/api/resource/definitions/network/network.proto
+++ b/api/resource/definitions/network/network.proto
@@ -344,7 +344,7 @@ message LinkAliasSpecSpec {
   string alias = 1;
 }
 
-// LinkRefreshSpec describes status of rendered secrets.
+// LinkRefreshSpec is used to force refresh LinkStatus on link changes.
 message LinkRefreshSpec {
   int64 generation = 1;
 }

--- a/internal/app/machined/pkg/controllers/network/link_alias_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_alias_spec.go
@@ -38,7 +38,12 @@ func (ctrl *LinkAliasSpecController) Inputs() []controller.Input {
 
 // Outputs implements controller.Controller interface.
 func (ctrl *LinkAliasSpecController) Outputs() []controller.Output {
-	return nil
+	return []controller.Output{
+		{
+			Type: network.LinkRefreshType,
+			Kind: controller.OutputShared,
+		},
+	}
 }
 
 // Run implements controller.Controller interface.
@@ -102,7 +107,10 @@ func (ctrl *LinkAliasSpecController) Run(ctx context.Context, r controller.Runti
 		}
 
 		// loop over links and make reconcile decision
-		var multiErr *multierror.Error
+		var (
+			multiErr *multierror.Error
+			changed  bool
+		)
 
 		for _, link := range links {
 			if link.Attributes == nil {
@@ -137,6 +145,8 @@ func (ctrl *LinkAliasSpecController) Run(ctx context.Context, r controller.Runti
 					},
 				}); err != nil {
 					multiErr = multierror.Append(multiErr, fmt.Errorf("error removing alias %q from link %q: %w", currentAlias, link.Attributes.Name, err))
+				} else {
+					changed = true
 				}
 			} else if shouldHaveAlias && currentAlias != expectedAlias {
 				// should have alias, but doesn't have it or it's different - set it
@@ -153,7 +163,21 @@ func (ctrl *LinkAliasSpecController) Run(ctx context.Context, r controller.Runti
 					},
 				}); err != nil {
 					multiErr = multierror.Append(multiErr, fmt.Errorf("error setting alias %q on link %q: %w", expectedAlias, link.Attributes.Name, err))
+				} else {
+					changed = true
 				}
+			}
+		}
+
+		// the kernel sends no RTM_NEWLINK for an IFLA_IFALIAS-only change, so LinkStatusController
+		// would never learn about the new alias, so we bump the LinkRefresh resource to trigger a refresh of all links
+		if changed {
+			if err = safe.WriterModify(ctx, r, network.NewLinkRefresh(network.NamespaceName, network.LinkRefreshAliases), func(r *network.LinkRefresh) error {
+				r.TypedSpec().Bump()
+
+				return nil
+			}); err != nil {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("error bumping link refresh: %w", err))
 			}
 		}
 

--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -879,7 +879,7 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 				logger.Info("reconfigured wireguard link", zap.Int("peers", len(link.TypedSpec().Wireguard.Peers)))
 
 				// notify link status controller, as wireguard updates can't be watched via netlink API
-				if err = safe.WriterModify[*network.LinkRefresh](ctx, r, network.NewLinkRefresh(network.NamespaceName, network.LinkKindWireguard), func(r *network.LinkRefresh) error {
+				if err = safe.WriterModify[*network.LinkRefresh](ctx, r, network.NewLinkRefresh(network.NamespaceName, network.LinkRefreshWireguard), func(r *network.LinkRefresh) error {
 					r.TypedSpec().Bump()
 
 					return nil

--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -69,6 +69,14 @@ func (ctrl *LinkStatusController) Run(ctx context.Context, r controller.Runtime,
 				Type:      network.LinkSpecType,
 				Kind:      controller.InputStrong,
 			},
+			{
+				// link changes which the kernel doesn't announce over netlink:
+				// * Wireguard settings
+				// * link alias changes
+				Namespace: network.NamespaceName,
+				Type:      network.LinkRefreshType,
+				Kind:      controller.InputWeak,
+			},
 		},
 	); err != nil {
 		return err

--- a/pkg/machinery/api/resource/definitions/network/network.pb.go
+++ b/pkg/machinery/api/resource/definitions/network/network.pb.go
@@ -2480,7 +2480,7 @@ func (x *LinkAliasSpecSpec) GetAlias() string {
 	return ""
 }
 
-// LinkRefreshSpec describes status of rendered secrets.
+// LinkRefreshSpec is used to force refresh LinkStatus on link changes.
 type LinkRefreshSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Generation    int64                  `protobuf:"varint,1,opt,name=generation,proto3" json:"generation,omitempty"`

--- a/pkg/machinery/resources/network/link_refresh.go
+++ b/pkg/machinery/resources/network/link_refresh.go
@@ -18,14 +18,18 @@ const LinkRefreshType = resource.Type("LinkRefreshes.net.talos.dev")
 
 // LinkRefresh resource is used to communicate link changes which can't be subscribed to via netlink.
 //
-// The only usecase for now is the Wireguards, as there's no way subscribe to wireguard updates
-// via the netlink API.
-//
-// Whenever Wireguard interface is updated, LinkRefresh resource is modified to trigger a reconcile
-// loop in the LinkStatusController.
+// There are two specific use cases for this resource:
+// - Wireguard configuration changes
+// - link alias changes.
 type LinkRefresh = typed.Resource[LinkRefreshSpec, LinkRefreshExtension]
 
-// LinkRefreshSpec describes status of rendered secrets.
+// Constants for the link refreshes.
+const (
+	LinkRefreshAliases   resource.ID = "link-aliases"
+	LinkRefreshWireguard resource.ID = "wireguard"
+)
+
+// LinkRefreshSpec is used to force refresh LinkStatus on link changes.
 //
 //gotagsrewrite:gen
 type LinkRefreshSpec struct {

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -10624,7 +10624,7 @@ LinkAliasSpecSpec describes status of rendered secrets.
 <a name="talos.resource.definitions.network.LinkRefreshSpec"></a>
 
 ### LinkRefreshSpec
-LinkRefreshSpec describes status of rendered secrets.
+LinkRefreshSpec is used to force refresh LinkStatus on link changes.
 
 
 | Field | Type | Label | Description |


### PR DESCRIPTION
The problem is that Linux kernel doesn't emit netlink notification for pure alias changes, so this doesn't wake up the LinkStatus controller.

Under regular boot timing, the LinkStatus controller would be woken up by an unrelated netlink notification and reconcile aliases, but it might be never woken up with different timing.

In our cluster create case, the `net0` alias is created, and the rest of the network config is driven from it, so it the alias notification is lost, the machine boots up with no networking configured.

This showed up in unrelated work, but it was a rare flake in the CI as well.
