### PR TITLE
fix: #14263 empty searchDomains is dropped on merge

### DIFF
--- a/internal/app/machined/pkg/controllers/network/resolver_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_config_test.go
@@ -230,7 +230,7 @@ func (suite *ResolverConfigSuite) TestMachineConfigurationNewStyle() {
 		},
 	}
 	rc.ResolverSearchDomains = networkcfg.SearchDomainsConfig{
-		SearchDomains: []string{"example.com", "example.org"},
+		SearchDomains: networkcfg.SearchDomainList{"example.com", "example.org"},
 	}
 
 	ctr, err := container.New(rc)
@@ -270,7 +270,7 @@ func (suite *ResolverConfigSuite) TestMachineConfigurationEmptySearchDomains() {
 	rc := networkcfg.NewResolverConfigV1Alpha1()
 	// explicit empty search domains (domains: []): no nameservers, override to clear
 	rc.ResolverSearchDomains = networkcfg.SearchDomainsConfig{
-		SearchDomains: []string{},
+		SearchDomains: networkcfg.SearchDomainList{},
 	}
 
 	ctr, err := container.New(rc)

--- a/pkg/machinery/config/types/network/network_doc.go
+++ b/pkg/machinery/config/types/network/network_doc.go
@@ -2009,7 +2009,7 @@ func (SearchDomainsConfig) Doc() *encoder.Doc {
 		Fields: []encoder.Doc{
 			{
 				Name:        "domains",
-				Type:        "[]string",
+				Type:        "SearchDomainList",
 				Note:        "",
 				Description: "A list of search domains to be used for DNS resolution.\n\nSearch domains are appended to unqualified domain names during DNS resolution.\nFor example, if \"example.com\" is a search domain and a user tries to resolve\n\"host\", the system will attempt to resolve \"host.example.com\".\n\nIf set, this overrides any search domains obtained via DHCP or platform configuration.\nAn empty list (`domains: []`) clears search domains obtained from DHCP or platform,\nwhile leaving this field unset inherits them.\nThe default configuration derives the search domain from the hostname FQDN.",
 				Comments:    [3]string{"" /* encoder.HeadComment */, "A list of search domains to be used for DNS resolution." /* encoder.LineComment */, "" /* encoder.FootComment */},

--- a/pkg/machinery/config/types/network/resolver.go
+++ b/pkg/machinery/config/types/network/resolver.go
@@ -140,13 +140,32 @@ type SearchDomainsConfig struct {
 	//     An empty list (`domains: []`) clears search domains obtained from DHCP or platform,
 	//     while leaving this field unset inherits them.
 	//     The default configuration derives the search domain from the hostname FQDN.
-	SearchDomains []string `yaml:"domains,omitempty"`
+	//   schema:
+	//     type: array
+	//     items:
+	//       type: string
+	SearchDomains SearchDomainList `yaml:"domains,omitempty" talos:"omitonlyifnil" merge:"replace"`
 	//   description: |
 	//     Disable default search domain configuration from hostname FQDN.
 	//
 	//     When set to true, the system will not derive search domains from the hostname FQDN.
 	//     This allows for a custom configuration of search domains without any defaults.
 	SearchDisableDefault *bool `yaml:"disableDefault,omitempty"`
+}
+
+// SearchDomainList is a list of DNS search domains.
+//
+// A nil list means that search domains are not configured (and are inherited from
+// other configuration layers), while an explicitly empty list clears search domains
+// obtained from DHCP or platform.
+type SearchDomainList []string
+
+// IsZero implements yaml.IsZeroer.
+//
+// Only a nil list is considered zero, so that an explicitly empty list survives
+// encoding with the `omitempty` tag instead of being dropped.
+func (l SearchDomainList) IsZero() bool {
+	return l == nil
 }
 
 // HostDNSConfig represents host DNS configuration.
@@ -192,7 +211,7 @@ func exampleResolverConfigV1Alpha1() *ResolverConfigV1Alpha1 {
 		},
 	}
 	cfg.ResolverSearchDomains = SearchDomainsConfig{
-		SearchDomains: []string{"example.com"},
+		SearchDomains: SearchDomainList{"example.com"},
 	}
 
 	return cfg
@@ -363,7 +382,7 @@ func (s *ResolverConfigV1Alpha1) SearchDomains() optional.Optional[[]string] {
 		return optional.None[[]string]()
 	}
 
-	return optional.Some(slices.Clone(s.ResolverSearchDomains.SearchDomains))
+	return optional.Some([]string(slices.Clone(s.ResolverSearchDomains.SearchDomains)))
 }
 
 // DisableSearchDomain implements NetworkResolverConfig interface.

--- a/pkg/machinery/config/types/network/resolver_test.go
+++ b/pkg/machinery/config/types/network/resolver_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
+	"github.com/siderolabs/talos/pkg/machinery/config/merge"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
@@ -25,6 +26,9 @@ var expectedResolverConfigDocument []byte
 
 //go:embed testdata/resolverconfig_with_hostdns.yaml
 var expectedResolverConfigDocumentWithHostDNS []byte
+
+//go:embed testdata/resolverconfig_empty_search_domains.yaml
+var expectedResolverConfigDocumentEmptySearchDomains []byte
 
 func TestResolverConfigMarshalStability(t *testing.T) {
 	t.Parallel()
@@ -41,7 +45,7 @@ func TestResolverConfigMarshalStability(t *testing.T) {
 		},
 	}
 	cfg.ResolverSearchDomains = network.SearchDomainsConfig{
-		SearchDomains:        []string{"example.org", "example.com"},
+		SearchDomains:        network.SearchDomainList{"example.org", "example.com"},
 		SearchDisableDefault: new(false),
 	}
 
@@ -76,6 +80,125 @@ func TestResolverConfigMarshalStabilityWithHostDNS(t *testing.T) {
 	assert.Equal(t, expectedResolverConfigDocumentWithHostDNS, marshaled)
 }
 
+// TestResolverConfigMarshalStabilityEmptySearchDomains asserts that an explicitly empty
+// list of search domains survives encoding.
+//
+// An empty list clears search domains obtained from DHCP or platform, so dropping it on
+// encoding (as `omitempty` would) makes it impossible to persist.
+func TestResolverConfigMarshalStabilityEmptySearchDomains(t *testing.T) {
+	t.Parallel()
+
+	cfg := network.NewResolverConfigV1Alpha1()
+	cfg.ResolverSearchDomains = network.SearchDomainsConfig{
+		SearchDomains:        network.SearchDomainList{},
+		SearchDisableDefault: new(true),
+	}
+
+	marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsDisabled)).Encode()
+	require.NoError(t, err)
+
+	t.Log(string(marshaled))
+
+	assert.Equal(t, expectedResolverConfigDocumentEmptySearchDomains, marshaled)
+
+	// the encoder takes a different code path when comments are enabled, so cover it as well
+	marshaledWithComments, err := encoder.NewEncoder(cfg, encoder.WithComments(encoder.CommentsAll)).Encode()
+	require.NoError(t, err)
+
+	t.Log(string(marshaledWithComments))
+
+	assert.Contains(t, string(marshaledWithComments), "domains: []")
+}
+
+// TestResolverConfigMarshalUnsetSearchDomains asserts that an unset list of search domains
+// is not encoded, as that would turn "inherit" into "clear" on the next write.
+func TestResolverConfigMarshalUnsetSearchDomains(t *testing.T) {
+	t.Parallel()
+
+	cfg := network.NewResolverConfigV1Alpha1()
+	cfg.ResolverSearchDomains = network.SearchDomainsConfig{
+		SearchDisableDefault: new(true),
+	}
+
+	for _, comments := range []encoder.CommentsFlags{encoder.CommentsDisabled, encoder.CommentsAll} {
+		marshaled, err := encoder.NewEncoder(cfg, encoder.WithComments(comments)).Encode()
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(marshaled), "domains:")
+	}
+}
+
+func TestResolverConfigUnmarshalEmptySearchDomains(t *testing.T) {
+	t.Parallel()
+
+	provider, err := configloader.NewFromBytes(expectedResolverConfigDocumentEmptySearchDomains)
+	require.NoError(t, err)
+
+	docs := provider.Documents()
+	require.Len(t, docs, 1)
+
+	assert.Equal(t, &network.ResolverConfigV1Alpha1{
+		Meta: meta.Meta{
+			MetaAPIVersion: "v1alpha1",
+			MetaKind:       network.ResolverKind,
+		},
+		ResolverSearchDomains: network.SearchDomainsConfig{
+			SearchDomains:        network.SearchDomainList{},
+			SearchDisableDefault: new(true),
+		},
+	}, docs[0])
+
+	searchDomains := provider.NetworkResolverConfig().SearchDomains()
+	assert.True(t, searchDomains.IsPresent())
+	assert.Empty(t, searchDomains.ValueOrZero())
+}
+
+// TestResolverConfigMergeSearchDomains asserts that a strategic merge patch replaces the
+// list of search domains instead of appending to it, so that `domains: []` clears it.
+func TestResolverConfigMergeSearchDomains(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		left     network.SearchDomainList
+		right    network.SearchDomainList
+		expected network.SearchDomainList
+	}{
+		{
+			name:     "clear",
+			left:     network.SearchDomainList{"example.org"},
+			right:    network.SearchDomainList{},
+			expected: network.SearchDomainList{},
+		},
+		{
+			name:     "replace",
+			left:     network.SearchDomainList{"example.org"},
+			right:    network.SearchDomainList{"example.com"},
+			expected: network.SearchDomainList{"example.com"},
+		},
+		{
+			name:     "unset keeps left",
+			left:     network.SearchDomainList{"example.org"},
+			right:    nil,
+			expected: network.SearchDomainList{"example.org"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			left := network.NewResolverConfigV1Alpha1()
+			left.ResolverSearchDomains.SearchDomains = test.left
+
+			right := network.NewResolverConfigV1Alpha1()
+			right.ResolverSearchDomains.SearchDomains = test.right
+
+			require.NoError(t, merge.Merge(left, right))
+
+			assert.Equal(t, test.expected, left.ResolverSearchDomains.SearchDomains)
+		})
+	}
+}
+
 func TestResolverConfigUnmarshal(t *testing.T) {
 	t.Parallel()
 
@@ -101,7 +224,7 @@ func TestResolverConfigUnmarshal(t *testing.T) {
 			},
 		},
 		ResolverSearchDomains: network.SearchDomainsConfig{
-			SearchDomains:        []string{"example.org", "example.com"},
+			SearchDomains:        network.SearchDomainList{"example.org", "example.com"},
 			SearchDisableDefault: new(false),
 		},
 	}, docs[0])

--- a/pkg/machinery/config/types/network/testdata/resolverconfig_empty_search_domains.yaml
+++ b/pkg/machinery/config/types/network/testdata/resolverconfig_empty_search_domains.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1alpha1
+kind: ResolverConfig
+searchDomains:
+    domains: []
+    disableDefault: true

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_network_bridge_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_network_bridge_test.go
@@ -301,7 +301,7 @@ func TestResolverBridging(t *testing.T) {
 					},
 				}
 				rc.ResolverSearchDomains = network.SearchDomainsConfig{
-					SearchDomains:        []string{"universe.com", "galaxy.org"},
+					SearchDomains:        network.SearchDomainList{"universe.com", "galaxy.org"},
 					SearchDisableDefault: new(true),
 				}
 

--- a/website/content/v1.15/reference/configuration/network/resolverconfig.md
+++ b/website/content/v1.15/reference/configuration/network/resolverconfig.md
@@ -118,7 +118,7 @@ SearchDomainsConfig represents search domains configuration.
 
 | Field | Type | Description | Value(s) |
 |-------|------|-------------|----------|
-|`domains` |[]string |A list of search domains to be used for DNS resolution.<br><br>Search domains are appended to unqualified domain names during DNS resolution.<br>For example, if "example.com" is a search domain and a user tries to resolve<br>"host", the system will attempt to resolve "host.example.com".<br><br>If set, this overrides any search domains obtained via DHCP or platform configuration.<br>An empty list (`domains: []`) clears search domains obtained from DHCP or platform,<br>while leaving this field unset inherits them.<br>The default configuration derives the search domain from the hostname FQDN.  | |
+|`domains` |SearchDomainList |A list of search domains to be used for DNS resolution.<br><br>Search domains are appended to unqualified domain names during DNS resolution.<br>For example, if "example.com" is a search domain and a user tries to resolve<br>"host", the system will attempt to resolve "host.example.com".<br><br>If set, this overrides any search domains obtained via DHCP or platform configuration.<br>An empty list (`domains: []`) clears search domains obtained from DHCP or platform,<br>while leaving this field unset inherits them.<br>The default configuration derives the search domain from the hostname FQDN.  | |
 |`disableDefault` |bool |Disable default search domain configuration from hostname FQDN.<br><br>When set to true, the system will not derive search domains from the hostname FQDN.<br>This allows for a custom configuration of search domains without any defaults.  | |
 
 


### PR DESCRIPTION
Resolves https://github.com/siderolabs/talos/issues/14263

We now preserve the distinction between unset and empty search domain lists. Providing an empty `domains: []` in a machine config patch will now correctly clear the values.
