### PR TITLE
chore: support correctly various disk types for the system disk

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common.go
@@ -285,7 +285,7 @@ func (m *Maker[T]) applyOmniConfigs() error {
 //nolint:gocyclo
 func (m *Maker[T]) finalizeMachineConfigs() (*bundle.Bundle, error) {
 	// These options needs to be generated after the implementing maker has made changes to the cluster request.
-	provisionGenOps, provisionBundleOps := m.Provisioner.GenOptions(m.ClusterRequest.Network, m.VersionContract)
+	provisionGenOps, provisionBundleOps := m.Provisioner.GenOptions(m.ClusterRequest, m.VersionContract)
 	m.GenOps = slices.Concat(m.GenOps, provisionGenOps)
 	m.ConfigBundleOps = slices.Concat(m.ConfigBundleOps, provisionBundleOps)
 	m.GenOps = slices.Concat(m.GenOps, []generate.Option{generate.WithEndpointList(m.Endpoints)})

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/common_test.go
@@ -27,7 +27,7 @@ type testProvisioner struct {
 	provision.Provisioner
 }
 
-func (p testProvisioner) GenOptions(r provision.NetworkRequest, _ *config.VersionContract) ([]generate.Option, []bundle.Option) {
+func (p testProvisioner) GenOptions(r provision.ClusterRequest, _ *config.VersionContract) ([]generate.Option, []bundle.Option) {
 	return []generate.Option{func(o *generate.Options) error { return nil }}, nil
 }
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -141,7 +141,8 @@ func addTalosVersionFlag(flagset *pflag.FlagSet, bind *string, description strin
 
 func addDisksFlag(flagset *pflag.FlagSet, bind *flags.Disks) {
 	flagset.Var(bind, disksFlagName,
-		`list of disks to create in format "<driver1>:<size1>" (disks after the first one are added only to worker machines)`)
+		`list of disks to create in format "<driver1>:<size1>", drivers: virtio, ide, ahci, scsi, nvme, megaraid, usb, virtiofs `+
+			`(disks after the first one are added only to worker machines)`)
 }
 
 // selectProvisioner returns the qemu provisioner by default, or the remote

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -24,6 +24,7 @@ import (
 
 type legacyOps struct {
 	clusterDiskSize   int
+	clusterDiskDriver string
 	extraDisks        int
 	extraDiskSize     int
 	extraDisksDrivers []string
@@ -46,6 +47,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		preallocateDisksFlag            = "disk-preallocate"
 		clusterUserVolumesFlag          = "user-volumes"
 		clusterDiskSizeFlag             = "disk"
+		clusterDiskDriverFlag           = "disk-driver"
 		primaryDisksFlag                = "primary-disks"
 		diskBlockSizeFlag               = "disk-block-size"
 		useVIPFlag                      = "use-vip"
@@ -286,7 +288,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 			}
 
 			var disks strings.Builder
-			fmt.Fprintf(&disks, "virtio:%d", legacyOps.clusterDiskSize)
+			fmt.Fprintf(&disks, "%s:%d", legacyOps.clusterDiskDriver, legacyOps.clusterDiskSize)
 
 			for i := range legacyOps.extraDisks {
 				driver := "ide"
@@ -327,9 +329,11 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 		},
 	}
 	createCmd.Flags().IntVar(&legacyOps.clusterDiskSize, clusterDiskSizeFlag, 6*1024, "default limit on disk size in MB (each VM)")
+	createCmd.Flags().StringVar(&legacyOps.clusterDiskDriver, clusterDiskDriverFlag, "virtio",
+		"driver for the primary (system) disks (virtio, ide, ahci, scsi, nvme, megaraid, usb)")
 	createCmd.Flags().IntVar(&qOps.PrimaryDisks, primaryDisksFlag, qOps.PrimaryDisks, "number of primary disks to create for each VM (each sized by --disk)")
 	createCmd.Flags().IntVar(&legacyOps.extraDisks, extraDisksFlag, 0, "number of extra disks to create for each worker VM")
-	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksDrivers, extraDisksDriversFlag, nil, "driver for each extra disk (virtio, ide, ahci, scsi, nvme, megaraid)")
+	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksDrivers, extraDisksDriversFlag, nil, "driver for each extra disk (virtio, ide, ahci, scsi, nvme, megaraid, usb, virtiofs)")
 	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksTags, extraDisksTagsFlag, nil, "tags for each extra disk (only used by virtiofs)")
 	createCmd.Flags().StringSliceVar(&legacyOps.extraDisksSerials, extraDisksSerialsFlag, nil, "serials for each extra disk")
 	createCmd.Flags().IntVar(&legacyOps.extraDiskSize, extraDiskSizeFlag, 5*1024, "default limit on disk size in MB (each VM)")

--- a/cmd/talosctl/cmd/mgmt/cluster/create/flags/disks.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/flags/disks.go
@@ -25,7 +25,7 @@ type DiskRequest struct {
 var tagDrivers = []string{"virtiofs"}
 
 // Drivers that support serial option.
-var serialDrivers = []string{"virtio"}
+var serialDrivers = []string{"virtio", "usb"}
 
 // ParseDisksFlag parses the disks flag into a slice of DiskRequests.
 func ParseDisksFlag(disks []string) ([]DiskRequest, error) {

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -350,6 +350,7 @@ function create_cluster {
     --controlplanes="${QEMU_CONTROLPLANES:-3}" \
     --workers="${QEMU_WORKERS:-2}" \
     --disk="${QEMU_SYSTEM_DISK_SIZE:-15360}" \
+    --disk-driver="${QEMU_SYSTEM_DISK_DRIVER:-virtio}" \
     --primary-disks="${QEMU_SYSTEM_DISKS:-1}" \
     --extra-disks="${QEMU_EXTRA_DISKS:-0}" \
     --extra-disks-size="${QEMU_EXTRA_DISKS_SIZE:-6144}" \

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -938,7 +938,7 @@ func (suite *BaseSuite) setupCluster(options clusterOptions) {
 		suite.Require().NoError(err)
 	}
 
-	genOptions, bundleOptions := suite.provisioner.GenOptions(request.Network, versionContract)
+	genOptions, bundleOptions := suite.provisioner.GenOptions(request, versionContract)
 
 	for _, registryMirror := range DefaultSettings.RegistryMirrors {
 		parts := strings.Split(registryMirror, "=")

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -87,7 +87,7 @@ func (p *provisioner) Close() error {
 }
 
 // GenOptions provides a list of additional config generate options.
-func (p *provisioner) GenOptions(networkReq provision.NetworkRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
+func (p *provisioner) GenOptions(_ provision.ClusterRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
 	var genOptions []generate.Option
 
 	if contract.HostDNSEnabled() {

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -36,6 +36,9 @@ const (
 	// qemuStartupGracePeriod separates "QEMU never came up" from "the VM ran and then died": a
 	// process which exits with an error this soon after being started never got to run the VM.
 	qemuStartupGracePeriod = 5 * time.Second
+
+	// xhciID is the QEMU id of the single xHCI controller shared by the USB disks and the USB boot stick.
+	xhciID = "xhci"
 )
 
 // LaunchConfig is passed in to the Launch function over stdin.
@@ -197,8 +200,8 @@ func launchVM(config *LaunchConfig) error {
 	}
 
 	var (
-		scsiAttached, ahciAttached, nvmeAttached, megaraidAttached, virtiofsAttached bool
-		ahciBus                                                                      int
+		scsiAttached, ahciAttached, nvmeAttached, megaraidAttached, virtiofsAttached, xhciAttached bool
+		ahciBus                                                                                    int
 	)
 
 	for i, disk := range config.DiskPaths {
@@ -280,6 +283,18 @@ func launchVM(config *LaunchConfig) error {
 				args,
 				"-drive", fmt.Sprintf("id=scsi%d,format=raw,if=none,file=%s,discard=unmap,cache=unsafe", i, disk),
 				"-device", fmt.Sprintf("scsi-hd,drive=scsi%d,bus=scsi1.0,channel=0,scsi-id=%d,lun=0,logical_block_size=%d,physical_block_size=%d", i, i, blockSize, blockSize),
+			)
+
+		case "usb":
+			if !xhciAttached {
+				args = append(args, "-device", "nec-usb-xhci,id="+xhciID)
+				xhciAttached = true
+			}
+
+			args = append(
+				args,
+				"-drive", fmt.Sprintf("id=usb%d,format=raw,if=none,file=%s,discard=unmap,cache=unsafe", i, disk),
+				"-device", fmt.Sprintf("usb-storage,bus=%s.0,drive=usb%d,logical_block_size=%d,physical_block_size=%d%s", xhciID, i, blockSize, blockSize, serial),
 			)
 
 		case "virtiofs":
@@ -417,11 +432,14 @@ func launchVM(config *LaunchConfig) error {
 				fmt.Sprintf("id=cdrom0,file=%s,media=cdrom", config.ISOPath),
 			)
 		case config.USBPath != "" && !skipBootloader:
+			if !xhciAttached {
+				args = append(args, "-device", "nec-usb-xhci,id="+xhciID)
+			}
+
 			args = append(
 				args,
 				"-drive", fmt.Sprintf("if=none,id=stick,format=raw,read-only=on,file=%s", config.USBPath),
-				"-device", "nec-usb-xhci,id=xhci",
-				"-device", "usb-storage,bus=xhci.0,drive=stick,removable=on",
+				"-device", fmt.Sprintf("usb-storage,bus=%s.0,drive=stick,removable=on", xhciID),
 			)
 		case config.UKIPath != "":
 			args = append(

--- a/pkg/provision/providers/qemu/qemu.go
+++ b/pkg/provision/providers/qemu/qemu.go
@@ -47,7 +47,9 @@ func (p *provisioner) Close() error {
 // GenOptions provides a list of additional config generate options.
 //
 //nolint:gocyclo
-func (p *provisioner) GenOptions(networkReq provision.NetworkRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
+func (p *provisioner) GenOptions(clusterReq provision.ClusterRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
+	networkReq := clusterReq.Network
+
 	hasIPv4 := false
 	hasIPv6 := false
 
@@ -60,7 +62,7 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest, contract *
 	}
 
 	genOpts := []generate.Option{
-		generate.WithInstallDisk("/dev/vda"),
+		generate.WithInstallDisk(clusterReq.InstallDiskPath()),
 	}
 
 	var bundleOpts []bundle.Option

--- a/pkg/provision/providers/remote/remote.go
+++ b/pkg/provision/providers/remote/remote.go
@@ -317,7 +317,9 @@ func resolveLogWriter(opts []provision.Option) io.Writer {
 // in-process QEMU provisioner expects.
 //
 //nolint:gocyclo
-func (p *Provisioner) GenOptions(networkReq provision.NetworkRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
+func (p *Provisioner) GenOptions(clusterReq provision.ClusterRequest, contract *config.VersionContract) ([]generate.Option, []bundle.Option) {
+	networkReq := clusterReq.Network
+
 	hasIPv4 := false
 	hasIPv6 := false
 
@@ -330,7 +332,7 @@ func (p *Provisioner) GenOptions(networkReq provision.NetworkRequest, contract *
 	}
 
 	genOpts := []generate.Option{
-		generate.WithInstallDisk("/dev/vda"),
+		generate.WithInstallDisk(clusterReq.InstallDiskPath()),
 	}
 
 	var bundleOpts []bundle.Option

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -27,7 +27,7 @@ type Provisioner interface {
 
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
 
-	GenOptions(NetworkRequest, *config.VersionContract) ([]generate.Option, []bundle.Option)
+	GenOptions(ClusterRequest, *config.VersionContract) ([]generate.Option, []bundle.Option)
 
 	GetInClusterKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string
 	GetExternalKubernetesControlPlaneEndpoint(req NetworkRequest, controlPlanePort int) string

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/provision"
@@ -34,4 +35,49 @@ func TestHTTPProbeRequestNormalize(t *testing.T) {
 	normalized, err = request.Normalize()
 	require.NoError(t, err)
 	require.Equal(t, provision.HTTPProbeMaxTimeout, normalized.Timeout)
+}
+
+func TestClusterRequestInstallDiskPath(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		disks    []*provision.Disk
+		expected string
+	}{
+		{
+			name:     "no disks",
+			expected: "/dev/vda",
+		},
+		{
+			name:     "virtio",
+			disks:    []*provision.Disk{{Driver: "virtio"}, {Driver: "usb"}},
+			expected: "/dev/vda",
+		},
+		{
+			name:     "usb",
+			disks:    []*provision.Disk{{Driver: "usb"}, {Driver: "virtio"}},
+			expected: "/dev/sda",
+		},
+		{
+			name:     "nvme",
+			disks:    []*provision.Disk{{Driver: "nvme"}},
+			expected: "/dev/nvme0n1",
+		},
+		{
+			name:     "unknown driver",
+			disks:    []*provision.Disk{{Driver: "virtiofs"}},
+			expected: "/dev/vda",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := provision.ClusterRequest{
+				Nodes: provision.NodeRequests{{Disks: test.disks}},
+			}
+
+			assert.Equal(t, test.expected, req.InstallDiskPath())
+		})
+	}
 }

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -183,7 +183,7 @@ type Disk struct {
 	SkipPreallocate bool
 	// Driver for the disk.
 	//
-	// Supported types: "virtio", "ide", "ahci", "scsi", "nvme", "megaraid", "virtiofs" (special).
+	// Supported types: "virtio", "ide", "ahci", "scsi", "nvme", "megaraid", "usb", "virtiofs" (special).
 	Driver string
 	// Block size for the disk, defaults to 512 if not set.
 	BlockSize uint
@@ -289,4 +289,38 @@ func (sr *SiderolinkRequest) GetAddr(u *uuid.UUID) (netip.Addr, bool) {
 type SiderolinkBind struct {
 	UUID uuid.UUID
 	Addr netip.Addr
+}
+
+// defaultInstallDiskPath is the guest path of the primary disk for the drivers which don't override it.
+const defaultInstallDiskPath = "/dev/vda"
+
+// installDiskPaths maps a disk driver to the guest device path the kernel gives to the first such disk.
+//
+//nolint:goconst
+var installDiskPaths = map[string]string{
+	"virtio":   "/dev/vda",
+	"ide":      "/dev/sda",
+	"ahci":     "/dev/sda",
+	"scsi":     "/dev/sda",
+	"megaraid": "/dev/sda",
+	"usb":      "/dev/sda",
+	"nvme":     "/dev/nvme0n1",
+}
+
+// InstallDiskPath returns the guest device path Talos should be installed to, derived from the
+// driver of the primary disk of the first node.
+//
+// Note: with a mix of drivers which share the same device name prefix (e.g. a "usb" primary disk and
+// a "scsi" extra disk) the kernel assigns the names in probe order, so the path is only reliable when
+// the primary disk is the only one of its kind.
+func (reqs *ClusterRequest) InstallDiskPath() string {
+	if len(reqs.Nodes) == 0 || len(reqs.Nodes[0].Disks) == 0 {
+		return defaultInstallDiskPath
+	}
+
+	if path, ok := installDiskPaths[reqs.Nodes[0].Disks[0].Driver]; ok {
+		return path
+	}
+
+	return defaultInstallDiskPath
 }

--- a/website/content/v1.15/reference/cli.md
+++ b/website/content/v1.15/reference/cli.md
@@ -149,6 +149,7 @@ talosctl cluster create dev [flags]
       --disable-dhcp-hostname                    skip announcing hostname via DHCP
       --disk int                                 default limit on disk size in MB (each VM) (default 6144)
       --disk-block-size uint                     disk block size (default 512)
+      --disk-driver string                       driver for the primary (system) disks (virtio, ide, ahci, scsi, nvme, megaraid, usb) (default "virtio")
       --disk-encryption-key-types stringArray    encryption key types to use for disk encryption (uuid, kms) (default [uuid])
       --disk-image-path string                   disk image to use
       --disk-preallocate                         whether disk space should be preallocated (default true)
@@ -159,7 +160,7 @@ talosctl cluster create dev [flags]
       --endpoint string                          use endpoint instead of provider defaults
       --extra-boot-kernel-args string            add extra kernel args to the initial boot from vmlinuz and initramfs
       --extra-disks int                          number of extra disks to create for each worker VM
-      --extra-disks-drivers strings              driver for each extra disk (virtio, ide, ahci, scsi, nvme, megaraid)
+      --extra-disks-drivers strings              driver for each extra disk (virtio, ide, ahci, scsi, nvme, megaraid, usb, virtiofs)
       --extra-disks-on-controlplanes             attach the extra disks to controlplane machines as well (by default they are attached only to workers)
       --extra-disks-serials strings              serials for each extra disk
       --extra-disks-size int                     default limit on disk size in MB (each VM) (default 5120)
@@ -315,7 +316,7 @@ talosctl cluster create qemu [flags]
       --controlplanes int                        the number of controlplanes to create (default 1)
       --cpus-controlplanes string                the share of CPUs as fraction for each control plane/VM (default "2.0")
       --cpus-workers string                      the share of CPUs as fraction for each worker/VM (default "2.0")
-      --disks disks                              list of disks to create in format "<driver1>:<size1>" (disks after the first one are added only to worker machines) (default virtio:10GiB,virtio:6GiB)
+      --disks disks                              list of disks to create in format "<driver1>:<size1>", drivers: virtio, ide, ahci, scsi, nvme, megaraid, usb, virtiofs (disks after the first one are added only to worker machines) (default virtio:10GiB,virtio:6GiB)
   -h, --help                                     help for qemu
       --image-factory-auth string                username:password for authenticating with the Image Factory
       --image-factory-url string                 Image Factory url (default "https://factory.talos.dev/")


### PR DESCRIPTION
This wires properly system disk device driver, and adds support for emulated USB disks for the system disk. (This is separate from the `--usb-path` directive which is meant for ISO-on-USB case).

This just improves test harness, the fix for USB settle is coming in a separate PR.

Part of #14260
