### PR TITLE
fix: add missing NFS patches for extension tests

### DIFF
--- a/hack/test/patches/extensions.yaml
+++ b/hack/test/patches/extensions.yaml
@@ -182,3 +182,27 @@ contents: |
   frun 10%
   fcull 7%
   fstop 3%
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nfsd
+---
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: nfs
+volumeType: directory
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: exports
+mode: 0o644
+contents: |
+  /var/mnt/nfs 172.20.1.0/24(rw,sync,no_subtree_check,fsid=0)
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: netconfig
+mode: 0o644
+contents: |
+  udp        tpi_clts      v     inet     udp     -       -
+  tcp        tpi_cots_ord  v     inet     tcp     -       -


### PR DESCRIPTION
https://github.com/siderolabs/extensions/pull/1237 adds an NFS server extension, but no matching `KernelModuleConfig`, user volume, nor etc configs were added to `hack/test/patches/extensions.yaml`, causing the integration-extensions job to get stuck indefinitely on:
```
ext-nfs-server starting. [ 1188.981434] [talos] task startAllServices (1/1): service "ext-nfs-server" to be up/finished
```

https://github.com/siderolabs/talos/actions/runs/34146893466/job/101855719558

Just to confirm, `pkgs` builds `nfsd` with `m`: https://github.com/siderolabs/pkgs/blob/977b61fb151992e74cbd89a4dcd921f91dc30ac8/kernel/build/config-amd64#L6812-L6813