### PR TITLE
feat: add NixOS OVMF search path

### DIFF
--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -134,6 +134,7 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
 			"/usr/share/qemu",
 			"/usr/share/ovmf/x64",      // Arch Linux
 			"/opt/homebrew/share/qemu", // Darwin
+			"/run/libvirt/nix-ovmf/",   // NixOS
 		}
 
 		// Secure boot enabled firmware files


### PR DESCRIPTION
On NixOS /run/libvirt/nix-ovmf/*.fd is symlinked to their "current" active versions.

By adding this search path, we don't need to explicitly pass this as a flag

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
On NixOS /run/libvirt/nix-ovmf/*.fd is symlinked to their "current" active versions.

## Why? (reasoning)

By adding this search path, we don't need to explicitly pass this as a flag
## Acceptance

talosctl builds normally
Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
