### PR TITLE
fix: bump history max cap to 1536

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -55,7 +55,7 @@ func NewState() (*State, error) {
 		func(ns string) state.CoreState {
 			return inmem.NewStateWithOptions(
 				inmem.WithHistoryInitialCapacity(8),
-				inmem.WithHistoryMaxCapacity(1024),
+				inmem.WithHistoryMaxCapacity(1536),
 				inmem.WithHistoryGap(4),
 			)(ns)
 		},


### PR DESCRIPTION
Fix history max capacity to fix flood of events from builtin kernel modules

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
