### PR TITLE
fix: drop logical links if they no longer declare as logical

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -340,25 +340,36 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 	switch link.Metadata().Phase() {
 	case resource.PhaseTearingDown:
 		// TODO: should we bring link down if it's physical and the spec was torn down?
-		if link.TypedSpec().Logical {
-			existing := findLink(*links, link.TypedSpec().Name, false) // logical links don't have aliases
+		existing := findLink(*links, link.TypedSpec().Name, false) // logical links don't have aliases
 
-			deleteLink := existing != nil
+		deleteLink := existing != nil
+		if deleteLink {
+			var existingKind string
 
-			if deleteLink {
-				if err := conn.Link.Delete(existing.Index); err != nil {
-					return fmt.Errorf("error deleting link %q: %w", link.TypedSpec().Name, err)
-				}
+			if existing.Attributes != nil && existing.Attributes.Info != nil {
+				existingKind = existing.Attributes.Info.Kind
+			}
 
-				logger.Info("deleted link", zap.String("name", existing.Attributes.Name))
+			// this check mirrors exactly LinkStatus.Physical() method, but expressed in Linux netlink data
+			if existingKind == "" && existing.Type == uint16(nethelpers.LinkEther) {
+				// don't ever try to deleted physical links
+				deleteLink = false
+			}
+		}
 
-				// refresh links as the link list got changed
-				var err error
+		if deleteLink {
+			if err := conn.Link.Delete(existing.Index); err != nil {
+				return fmt.Errorf("error deleting link %q: %w", link.TypedSpec().Name, err)
+			}
 
-				*links, err = conn.Link.List()
-				if err != nil {
-					return fmt.Errorf("error listing links: %w", err)
-				}
+			logger.Info("deleted link", zap.String("name", existing.Attributes.Name))
+
+			// refresh links as the link list got changed
+			var err error
+
+			*links, err = conn.Link.List()
+			if err != nil {
+				return fmt.Errorf("error listing links: %w", err)
 			}
 		}
 

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -131,6 +131,7 @@ func (suite *LinkSpecSuite) TestDummy() {
 	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), dummy.Metadata()))
 
 	ctest.AssertNoResource[*network.LinkSpec](suite, dummyInterface)
+	ctest.AssertNoResource[*network.LinkStatus](suite, dummyInterface)
 }
 
 func (suite *LinkSpecSuite) TestDummyWithMAC() {
@@ -161,6 +162,41 @@ func (suite *LinkSpecSuite) TestDummyWithMAC() {
 	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), dummy.Metadata()))
 
 	ctest.AssertNoResource[*network.LinkSpec](suite, dummyInterface)
+	ctest.AssertNoResource[*network.LinkStatus](suite, dummyInterface)
+}
+
+func (suite *LinkSpecSuite) TestDummyDropsLogical() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	dummy := network.NewLinkSpec(network.NamespaceName, dummyInterface)
+	*dummy.TypedSpec() = network.LinkSpecSpec{
+		Name:        dummyInterface,
+		Type:        nethelpers.LinkEther,
+		Kind:        "dummy",
+		MTU:         1400,
+		Up:          true,
+		Logical:     true,
+		ConfigLayer: network.ConfigDefault,
+	}
+
+	suite.Create(dummy)
+
+	ctest.AssertResource(suite, dummyInterface, func(r *network.LinkStatus, asrt *assert.Assertions) {
+		asrt.Equal("dummy", r.TypedSpec().Kind)
+	})
+
+	// drop logical flag, it doesn't matter once the link is created
+	ctest.UpdateWithConflicts(suite, dummy, func(r *network.LinkSpec) error {
+		r.TypedSpec().Logical = false
+
+		return nil
+	})
+
+	suite.Require().NoError(suite.State().TeardownAndDestroy(suite.Ctx(), dummy.Metadata()))
+
+	ctest.AssertNoResource[*network.LinkSpec](suite, dummyInterface)
+	// the link should be deleted even if it's not logical anymore
+	ctest.AssertNoResource[*network.LinkStatus](suite, dummyInterface)
 }
 
 func (suite *LinkSpecSuite) TestVeth() {


### PR DESCRIPTION
By the time the link is up to be deleted, it might lose its logical status. This happens due to link merge process - the link will be created only when it is declared as logical, but other parties might inject partial merged configs (e.g. DHCP issuing MTU data), so once the main part is dropped (as machine config drops the link), the logical might flip to "false" on merge.

Dervice logical status from the actual link data in the Linux kernel instead of spec (spec is used in created path though).

The integration test will come via another PR.
