### PR TITLE
test: add a way to provision extra DHCP entries in the test

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -79,6 +79,8 @@ func NewQemu(ops MakerOptions[clusterops.Qemu]) (Qemu, error) {
 }
 
 // InitExtra implements ExtraOptionsProvider.
+//
+//nolint:gocyclo
 func (m *Qemu) InitExtra() error {
 	if m.EOps.UseVIP {
 		vip, err := sideronet.NthIPInNetwork(m.Cidrs[0], vipOffset)
@@ -118,6 +120,26 @@ func (m *Qemu) InitExtra() error {
 		if err := m.initBGPCLOS(); err != nil {
 			return err
 		}
+	}
+
+	for extraIPs := range m.EOps.ExtraDHCPRecordsCount {
+		// start with .100 IP: .50 is the VIP
+		const extraDHCPRecordOffset = 100
+
+		ip, err := sideronet.NthIPInNetwork(m.Cidrs[0], extraDHCPRecordOffset+extraIPs)
+		if err != nil {
+			return err
+		}
+
+		m.ClusterRequest.Network.ExtraDHCPRecords = append(
+			m.ClusterRequest.Network.ExtraDHCPRecords,
+			provision.DHCPRecord{
+				MAC:     fmt.Sprintf("52:54:00:00:%02x:%02x", extraIPs, extraIPs),
+				IP:      netip.PrefixFrom(ip, m.Cidrs[0].Bits()),
+				Gateway: m.GatewayIPs[0],
+				Name:    fmt.Sprintf("extra-%d", extraIPs),
+			},
+		)
 	}
 
 	return nil

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go
@@ -162,6 +162,12 @@ type Qemu struct {
 	// "example.com" or "registry.example.com:5000"), and the value is the HTTPAuth
 	// containing the username and password for that endpoint.
 	DownloadHTTPAuth map[string]HTTPAuth
+
+	// ExtraDHCPRecordsCount is a numer of extra DHCP records to be added to the DHCP server
+	// database.
+	//
+	// They can be used to ensure predictable IPs for extra MACs exposed on the QEMU virtual network.
+	ExtraDHCPRecordsCount int
 }
 
 // HTTPAuth represents basic authentication credentials for downloading boot assets.

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -330,6 +330,9 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 				return err
 			}
 
+			// for dev mode, provision extra DHCP records for host-exposed workloads in the cluster
+			qOps.ExtraDHCPRecordsCount = 50
+
 			return createDevCluster(cmd.Context(), cOps, qOps)
 		},
 	}

--- a/internal/integration/api/network-config.go
+++ b/internal/integration/api/network-config.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"net"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -553,6 +554,59 @@ func (suite *NetworkConfigSuite) TestMacVLANConfig() {
 	for _, dummyName := range dummyNames {
 		rtestutils.AssertNoResource[*networkres.LinkStatus](nodeCtx, suite.T(), suite.Client.COSI, dummyName)
 	}
+}
+
+// TestMacVLANWithDHCP tests creation of macvlan interfaces with DHCP.
+func (suite *NetworkConfigSuite) TestMacVLANWithDHCP() {
+	if suite.Cluster == nil || suite.Cluster.Provisioner() != base.ProvisionerQEMU {
+		suite.T().Skip("skipping if cluster is not qemu")
+	}
+
+	if len(suite.Cluster.Info().Network.ExtraDHCPRecords) == 0 {
+		suite.T().Skip("skipping if no extra DHCP records are configured")
+	}
+
+	dhcpRecord := suite.Cluster.Info().Network.ExtraDHCPRecords[0]
+
+	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)
+	nodeCtx := client.WithNode(suite.ctx, node)
+
+	suite.T().Logf("testing on node %q", node)
+
+	suffix := rand.IntN(10000)
+
+	macvlanName := fmt.Sprintf("mvlan%d", suffix)
+
+	macAddress, err := net.ParseMAC(dhcpRecord.MAC)
+	suite.Require().NoError(err)
+
+	macvlan := network.NewMacVLANConfigV1Alpha1(macvlanName)
+	macvlan.MacVLANParent = "net0"
+	macvlan.MacVLANMode = new(nethelpers.MacvlanModeBridge)
+	macvlan.HardwareAddressConfig = nethelpers.HardwareAddr(macAddress)
+	macvlan.LinkUp = new(true)
+
+	dhcp4 := network.NewDHCPv4ConfigV1Alpha1(macvlanName)
+	dhcp4.ConfigIgnoreHostname = new(true)
+	dhcp4.ConfigIgnoreRoutes = new(true)
+
+	addressID := macvlanName + "/" + dhcpRecord.IP.String()
+
+	suite.PatchMachineConfig(nodeCtx, macvlan, dhcp4)
+
+	// DHCP runs, assigning the expected IP address to the macvlan interface
+	rtestutils.AssertResource(
+		nodeCtx, suite.T(), suite.Client.COSI, addressID,
+		func(address *networkres.AddressStatus, asrt *assert.Assertions) {
+			asrt.Equal(macvlanName, address.TypedSpec().LinkName)
+		},
+	)
+
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.MacVLANKind, macvlanName)
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, network.DHCPv4Kind, macvlanName)
+
+	rtestutils.AssertNoResource[*networkres.AddressStatus](nodeCtx, suite.T(), suite.Client.COSI, addressID)
+	rtestutils.AssertNoResource[*networkres.LinkStatus](nodeCtx, suite.T(), suite.Client.COSI, macvlanName)
 }
 
 // TestVXLANConfig tests creation of vxlan interfaces.

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/provision"
+	"github.com/siderolabs/talos/pkg/provision/providers/vm"
 )
 
 // Create Talos cluster as a set of qemu VMs.
@@ -132,6 +133,19 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		}
 	}
 
+	for _, extraDHCPRecord := range request.Network.ExtraDHCPRecords {
+		if err = vm.DumpIPAMRecord(statePath, vm.IPAMRecord{
+			IP:       extraDHCPRecord.IP.Addr(),
+			Netmask:  byte(extraDHCPRecord.IP.Bits()),
+			Gateway:  extraDHCPRecord.Gateway,
+			MAC:      extraDHCPRecord.MAC,
+			Hostname: extraDHCPRecord.Name,
+			MTU:      request.Network.MTU,
+		}); err != nil {
+			return nil, fmt.Errorf("error dumping extra IPAM record: %w", err)
+		}
+	}
+
 	var nodeInfo []provision.NodeInfo //nolint:prealloc // this is created by p.createNodes
 
 	fmt.Fprintln(options.LogWriter, "creating controlplane nodes")
@@ -183,6 +197,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 			NoMasqueradeCIDRs: request.Network.NoMasqueradeCIDRs,
 			GatewayAddrs:      request.Network.GatewayAddrs,
 			MTU:               request.Network.MTU,
+			ExtraDHCPRecords:  request.Network.ExtraDHCPRecords,
 		},
 		Nodes:              nodeInfo,
 		ExtraNodes:         pxeNodeInfo,

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -83,6 +83,11 @@ type NetworkRequest struct {
 	// on a BGP-advertised loopback instead.
 	NoDHCP bool
 
+	// ExtraDHCPRecords adds additional DHCP records to the DHCP server configuration.
+	//
+	// Records for the nodes will be added automatically, so this is only needed for specific tests.
+	ExtraDHCPRecords []DHCPRecord
+
 	LoadBalancerPorts []int
 
 	// CNI-specific parameters.
@@ -109,6 +114,14 @@ type NetworkRequest struct {
 	ImageCacheTLSCertFile string
 	ImageCacheTLSKeyFile  string
 	ImageCachePort        uint16
+}
+
+// DHCPRecord describes a DHCP record to be added to the DHCP server configuration.
+type DHCPRecord struct {
+	MAC     string
+	IP      netip.Prefix
+	Gateway netip.Addr
+	Name    string
 }
 
 // NodeRequests is a list of NodeRequest.

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -43,6 +43,7 @@ type NetworkInfo struct {
 	GatewayAddrs      []netip.Addr
 	MTU               int
 	NoMasqueradeCIDRs []netip.Prefix
+	ExtraDHCPRecords  []DHCPRecord
 }
 
 // NodeInfo describes a node.


### PR DESCRIPTION
In dev environment, add extra DHCP entries at fixed IPs/MACs.

Use them in the test for MacVLAN link with DHCP as a testbed.

Depends on #14325 as a fix.