### PR TITLE
fix: do not panic validating a null machine.network.interfaces entry

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -150,6 +150,14 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 		}
 	case machine.TypeWorker:
 		for _, d := range c.Machine().Network().Devices() {
+			// Devices() maps each *Device into the config.Device interface, so a
+			// null entry arrives as a non-nil interface holding a nil pointer and
+			// d == nil does not catch it. The interfaces loop further down reports
+			// the null itself.
+			if dev, ok := d.(*Device); ok && dev == nil {
+				continue
+			}
+
 			if d.VIPConfig() != nil {
 				result = multierror.Append(result, errors.New("virtual (shared) IP is not allowed on non-controlplane nodes"))
 			}
@@ -184,7 +192,13 @@ func (c *Config) Validate(mode validation.RuntimeMode, options ...validation.Opt
 	if c.MachineConfig.MachineNetwork != nil {
 		allSecondaryInterfaces := map[string]string{}
 
-		for _, device := range c.MachineConfig.MachineNetwork.NetworkInterfaces {
+		for i, device := range c.MachineConfig.MachineNetwork.NetworkInterfaces {
+			if device == nil {
+				result = multierror.Append(result, fmt.Errorf("machine.network.interfaces[%d] is null", i))
+
+				continue
+			}
+
 			if device.Bond() != nil && device.Bridge() != nil {
 				result = multierror.Append(result, fmt.Errorf("interface has both bridge and bond sections set %q: %w", device.Interface(), ErrMutuallyExclusive))
 			}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -2348,3 +2348,37 @@ func TestValidateKubernetesVersions(t *testing.T) {
 		})
 	}
 }
+
+// A null entry in a YAML sequence unmarshals to a nil element. The loop over
+// machine.disks already reports that, and ValidateNetworkDevices guards for it,
+// but the loop that cross-checks bonds and bridges runs first.
+func TestValidateNullNetworkInterface(t *testing.T) {
+	t.Parallel()
+
+	endpointURL, err := url.Parse("https://localhost:6443/")
+	require.NoError(t, err)
+
+	config := &v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineType: "worker",
+			MachineCA: &x509.PEMEncodedCertificateAndKey{
+				Crt: []byte("foo"),
+			},
+			MachineNetwork: &v1alpha1.NetworkConfig{
+				NetworkInterfaces: v1alpha1.NetworkDeviceList{nil},
+			},
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					endpointURL,
+				},
+			},
+		},
+	}
+
+	_, errs := config.Validate(runtimeMode{false}, validation.WithLocal())
+	require.Error(t, errs)
+	assert.Contains(t, errs.Error(), "machine.network.interfaces[0] is null")
+}


### PR DESCRIPTION
A null entry in a YAML sequence unmarshals to a nil element, so a machine config like

```yaml
machine:
  network:
    interfaces:
      - null
```

reaches validation with a nil `*Device` in `NetworkInterfaces`. The loop over `machine.disks` already handles exactly this and reports `machine.disks[i] is null`, and `ValidateNetworkDevices` guards its argument with `if d == nil`. The two loops over `machine.network.interfaces` that run before it do not, so validating such a config segfaults rather than rejecting it.

Worth calling out for review: the first of those loops is not fixed by a plain nil check. `Devices()` is

```go
return xslices.Map(n.NetworkInterfaces, func(d *Device) config.Device { return d })
```

so a null entry arrives as a non-nil `config.Device` interface holding a nil `*Device`, and `d == nil` is false for it. I found that the hard way: adding the obvious check left the panic in place, one frame further along in `(*Device).VIPConfig`. The guard here type-asserts back to the concrete pointer instead.

That same trap applies to the other three callers of `Devices()` (`k8s/nodeip_config.go`, `network/device_config.go`, `etcd/config.go`), though those only run against a config that has already passed validation, so this change closes the reachable path. If you would rather have `Devices()` skip nil entries at the source I am happy to redo it that way; I kept the change inside the validator because filtering there would shift the index that `device_config.go` uses.

Verification: a new test in `v1alpha1_validation_test.go` validates a worker config whose only interface is null. It panics with a nil pointer dereference on main and now returns `machine.network.interfaces[0] is null`. `go test ./config/...` in `pkg/machinery` is identical against main, no failures either side.
