### PR TITLE
feat: report MDArrayStatus for MD arrays with no RAIDArrayConfig

### DIFF
--- a/api/resource/definitions/storage/storage.proto
+++ b/api/resource/definitions/storage/storage.proto
@@ -271,6 +271,12 @@ message MDArrayStatusSpec {
   string array_state = 10;
   // SyncAction is the current sysfs sync_action value.
   string sync_action = 11;
+  // Unmanaged is true when this array has no backing MDArraySpec.
+  //
+  // Unmanaged arrays are reported for visibility only: they are discovered
+  // on disk (e.g. assembled by the kernel/udev before Talos ever wrote a
+  // RAIDArrayConfig for them), and are never reconciled or self-healed.
+  bool unmanaged = 12;
 }
 
 // MDRefreshRequestSpec is the spec for MDRefreshRequest.

--- a/internal/app/machined/pkg/controllers/storage/md_array_reconcile.go
+++ b/internal/app/machined/pkg/controllers/storage/md_array_reconcile.go
@@ -38,6 +38,7 @@ type MDProvisioner interface {
 	Grow(ctx context.Context, device string, raidDevices int) error
 	DetailDevice(ctx context.Context, device string) (md.Detail, error)
 	FindDeviceByMember(member string) (string, error)
+	ListArrays() ([]string, error)
 	IsSyncing(device string) (bool, error)
 	ArrayStateForDevice(device string) (string, error)
 	SyncActionForDevice(device string) (md.SyncAction, error)
@@ -127,23 +128,37 @@ func (ctrl *MDArrayReconcileController) reconcile(ctx context.Context, r control
 
 	var reconcileErrs error
 
+	claimed := map[string]struct{}{}
+	specIDs := map[string]struct{}{}
+
 	for spec := range specs.All() {
-		status, err := ctrl.reconcileArray(ctx, logger, spec.Metadata().ID(), spec.TypedSpec())
+		id := spec.Metadata().ID()
+		specIDs[id] = struct{}{}
+
+		status, device, err := ctrl.reconcileArray(ctx, logger, id, spec.TypedSpec())
 		if err != nil {
 			if errors.Is(err, md.ErrResync) {
-				logger.Debug("MD array is syncing; waiting for monitor refresh", zap.String("array", spec.Metadata().ID()), zap.Error(err))
+				logger.Debug("MD array is syncing; waiting for monitor refresh", zap.String("array", id), zap.Error(err))
 			} else {
-				reconcileErrs = errors.Join(reconcileErrs, fmt.Errorf("reconcile array %q: %w", spec.Metadata().ID(), err))
+				reconcileErrs = errors.Join(reconcileErrs, fmt.Errorf("reconcile array %q: %w", id, err))
 			}
 		}
 
-		if err := safe.WriterModify(ctx, r, storage.NewMDArrayStatus(storage.NamespaceName, spec.Metadata().ID()), func(s *storage.MDArrayStatus) error {
+		if device != "" {
+			claimed[device] = struct{}{}
+		}
+
+		if err := safe.WriterModify(ctx, r, storage.NewMDArrayStatus(storage.NamespaceName, id), func(s *storage.MDArrayStatus) error {
 			*s.TypedSpec() = *status
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("modify MDArrayStatus %q: %w", spec.Metadata().ID(), err)
+			return fmt.Errorf("modify MDArrayStatus %q: %w", id, err)
 		}
+	}
+
+	if err := ctrl.reportUnmanagedArrays(ctx, r, logger, claimed, specIDs); err != nil {
+		return err
 	}
 
 	if err := safe.CleanupOutputs[*storage.MDArrayStatus](ctx, r); err != nil {
@@ -157,12 +172,68 @@ func (ctrl *MDArrayReconcileController) reconcile(ctx context.Context, r control
 	return nil
 }
 
-func (ctrl *MDArrayReconcileController) reconcileArray(ctx context.Context, logger *zap.Logger, name string, spec *storage.MDArraySpecSpec) (*storage.MDArrayStatusSpec, error) {
+// reportUnmanagedArrays reports MDArrayStatus for MD arrays present on the box which have
+// no matching MDArraySpec (and therefore no RAIDArrayConfig), e.g. a boot mirror assembled
+// before Talos ever wrote a machine config for it. These are observed only: no Create/Add/
+// Grow is ever issued for them, and only raid1 arrays are reported, since that is the only
+// level MDArrayStatusSpec.Level can represent today.
+func (ctrl *MDArrayReconcileController) reportUnmanagedArrays(ctx context.Context, r controller.Runtime, logger *zap.Logger, claimed, specIDs map[string]struct{}) error {
+	arrays, err := ctrl.MD.ListArrays()
+	if err != nil {
+		return fmt.Errorf("list MD arrays: %w", err)
+	}
+
+	for _, device := range arrays {
+		if _, ok := claimed[device]; ok {
+			continue
+		}
+
+		id := filepath.Base(device)
+		if _, ok := specIDs[id]; ok {
+			continue
+		}
+
+		detail, err := ctrl.MD.DetailDevice(ctx, device)
+		if err != nil {
+			// e.g. an assembled-but-not-yet-running array; nothing trustworthy to report
+			// until it can be queried (MDLastResortController will run it if it's stuck).
+			continue
+		}
+
+		if detail.Level != "" && detail.Level != "raid1" {
+			// storage.MDLevel only models raid1 today: report nothing rather than mislabel
+			// the level of an array Talos doesn't actually know how to represent.
+			logger.Debug("skipping unmanaged array with unsupported level",
+				zap.String("device", device), zap.String("level", detail.Level))
+
+			continue
+		}
+
+		status := &storage.MDArrayStatusSpec{Level: storage.MDLevelRAID1, Device: device, Unmanaged: true}
+
+		ctrl.updateObservedStatus(ctx, device, status)
+		markReadyIfIdle(status)
+
+		if err := safe.WriterModify(ctx, r, storage.NewMDArrayStatus(storage.NamespaceName, id), func(s *storage.MDArrayStatus) error {
+			*s.TypedSpec() = *status
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("modify MDArrayStatus %q: %w", id, err)
+		}
+	}
+
+	return nil
+}
+
+func (ctrl *MDArrayReconcileController) reconcileArray(ctx context.Context, logger *zap.Logger, name string, spec *storage.MDArraySpecSpec) (*storage.MDArrayStatusSpec, string, error) {
 	status := mdArrayStatusForSpec(name, spec)
 
 	diskPaths, err := ctrl.matchMembers(ctx, &spec.VolumeSelector)
 	if err != nil {
-		return statusWithError(status, fmt.Errorf("match disks: %w", err))
+		errStatus, wrapErr := statusWithError(status, fmt.Errorf("match disks: %w", err))
+
+		return errStatus, "", wrapErr
 	}
 
 	status.Members = diskPaths
@@ -176,12 +247,14 @@ func (ctrl *MDArrayReconcileController) reconcileArray(ctx context.Context, logg
 		status.Status = storage.MDArrayPhaseWaiting
 		status.Error = waitingForMembersError(diskPaths)
 
-		return status, nil
+		return status, "", nil
 	}
 
 	device, err := ctrl.findExistingDevice(diskPaths)
 	if err != nil {
-		return statusWithError(status, fmt.Errorf("find existing MD device: %w", err))
+		errStatus, wrapErr := statusWithError(status, fmt.Errorf("find existing MD device: %w", err))
+
+		return errStatus, "", wrapErr
 	}
 
 	if device == "" {
@@ -199,13 +272,13 @@ func (ctrl *MDArrayReconcileController) reconcileArray(ctx context.Context, logg
 
 		status.Error = provisioningError(err)
 
-		return status, err
+		return status, device, err
 	}
 
 	ctrl.updateObservedStatus(ctx, device, status)
 	markReadyIfIdle(status)
 
-	return status, nil
+	return status, device, nil
 }
 
 func mdArrayStatusForSpec(name string, spec *storage.MDArraySpecSpec) *storage.MDArrayStatusSpec {
@@ -236,12 +309,14 @@ func (ctrl *MDArrayReconcileController) createArray(
 	spec *storage.MDArraySpecSpec,
 	members []string,
 	status *storage.MDArrayStatusSpec,
-) (*storage.MDArrayStatusSpec, error) {
+) (*storage.MDArrayStatusSpec, string, error) {
 	logger.Info("creating MD array", zap.String("array", name), zap.Strings("members", members))
 
 	device, err := ctrl.MD.Create(ctx, name, md.CreateOptions{Level: spec.Level.Mdadm(), Metadata: spec.Metadata.Mdadm(), RaidDevices: len(members), Devices: members})
 	if err != nil && !errors.Is(err, md.ErrExists) {
-		return statusWithError(status, fmt.Errorf("create: %w", err))
+		errStatus, wrapErr := statusWithError(status, fmt.Errorf("create: %w", err))
+
+		return errStatus, "", wrapErr
 	}
 
 	if device == "" {
@@ -249,7 +324,9 @@ func (ctrl *MDArrayReconcileController) createArray(
 
 		device, findErr = ctrl.findExistingDevice(members)
 		if findErr != nil {
-			return statusWithError(status, fmt.Errorf("find existing MD device: %w", findErr))
+			errStatus, wrapErr := statusWithError(status, fmt.Errorf("find existing MD device: %w", findErr))
+
+			return errStatus, "", wrapErr
 		}
 	}
 
@@ -257,13 +334,13 @@ func (ctrl *MDArrayReconcileController) createArray(
 		status.Status = storage.MDArrayPhaseError
 		status.Error = "array reported as existing but device could not be resolved (may be inactive)"
 
-		return status, nil
+		return status, "", nil
 	}
 
 	ctrl.updateObservedStatus(ctx, device, status)
 	markReadyIfIdle(status)
 
-	return status, nil
+	return status, device, nil
 }
 
 func (ctrl *MDArrayReconcileController) reconcileExistingArray(ctx context.Context, logger *zap.Logger, name, device string, desiredMembers []string) error {

--- a/internal/app/machined/pkg/controllers/storage/md_array_reconcile_test.go
+++ b/internal/app/machined/pkg/controllers/storage/md_array_reconcile_test.go
@@ -35,6 +35,8 @@ type fakeMDProvisioner struct {
 	details map[string]md.Detail
 	// syncAction maps md node -> current sync action (default idle).
 	syncAction map[string]md.SyncAction
+	// arrays is returned by ListArrays, simulating every MD device present on the box.
+	arrays []string
 
 	// createNode is the node Create returns; createErr overrides success.
 	createNode string
@@ -141,6 +143,13 @@ func (f *fakeMDProvisioner) ArrayStateForDevice(string) (string, error) {
 	return "clean", nil
 }
 
+func (f *fakeMDProvisioner) ListArrays() ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.arrays...), nil
+}
+
 func (f *fakeMDProvisioner) SyncActionForDevice(device string) (md.SyncAction, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -192,6 +201,7 @@ func (f *fakeMDProvisioner) reset() {
 	f.findByMember = map[string]string{}
 	f.details = map[string]md.Detail{}
 	f.syncAction = map[string]md.SyncAction{}
+	f.arrays = nil
 	f.createNode = "/dev/md0"
 	f.createErr = nil
 	f.creates = map[string][]string{}
@@ -357,6 +367,74 @@ func (suite *MDArrayReconcileSuite) TestReportsSyncActionAsRebuilding() {
 		asrt.Equal(storageres.MDArrayPhaseRebuilding, status.TypedSpec().Status)
 		asrt.Equal(string(md.SyncActionRecover), status.TypedSpec().SyncAction)
 	})
+}
+
+func (suite *MDArrayReconcileSuite) TestReportsUnmanagedDiscoveredArray() {
+	suite.md.details["/dev/md127"] = md.Detail{
+		Level:       "raid1",
+		RaidDevices: 2,
+		Members:     []string{"/dev/nvme0n1", "/dev/nvme1n1"},
+		UUID:        "1234-uuid",
+		Name:        "talos:boot",
+	}
+	suite.md.arrays = []string{"/dev/md127"}
+
+	// no MDArraySpec exists for this array; creating an unrelated disk just gives the
+	// controller an input event to react to.
+	createDisk(&suite.DefaultSuite, "nvme0n1", "/dev/nvme0n1", "nvme")
+
+	ctest.AssertResource(suite, "md127", func(status *storageres.MDArrayStatus, asrt *assert.Assertions) {
+		asrt.True(status.TypedSpec().Unmanaged)
+		asrt.Equal("/dev/md127", status.TypedSpec().Device)
+		asrt.Equal([]string{"/dev/nvme0n1", "/dev/nvme1n1"}, status.TypedSpec().Members)
+		asrt.Equal(storageres.MDArrayPhaseReady, status.TypedSpec().Status)
+	})
+
+	_, created := suite.md.created("md127")
+	suite.Assert().False(created, "an unmanaged array must never be provisioned")
+	suite.Assert().Empty(suite.md.added("/dev/md127"), "an unmanaged array must never be reconciled")
+
+	_, grown := suite.md.grown("/dev/md127")
+	suite.Assert().False(grown, "an unmanaged array must never be grown")
+}
+
+func (suite *MDArrayReconcileSuite) TestSkipsUnmanagedArrayWithUnsupportedLevel() {
+	suite.md.details["/dev/md127"] = md.Detail{
+		Level:       "raid5",
+		RaidDevices: 3,
+		Members:     []string{"/dev/nvme0n1", "/dev/nvme1n1", "/dev/nvme2n1"},
+	}
+	suite.md.arrays = []string{"/dev/md127"}
+
+	createDisk(&suite.DefaultSuite, "nvme0n1", "/dev/nvme0n1", "nvme")
+
+	ctest.AssertNoResource[*storageres.MDArrayStatus](suite, "md127")
+}
+
+func (suite *MDArrayReconcileSuite) TestSkipsUnmanagedArrayNotYetQueryable() {
+	// "/dev/md127" is present per ListArrays but has no matching entry in details, so
+	// DetailDevice fails, e.g. an array udev hasn't run yet.
+	suite.md.arrays = []string{"/dev/md127"}
+
+	createDisk(&suite.DefaultSuite, "nvme0n1", "/dev/nvme0n1", "nvme")
+
+	ctest.AssertNoResource[*storageres.MDArrayStatus](suite, "md127")
+}
+
+func (suite *MDArrayReconcileSuite) TestManagedArrayIsNotReportedUnmanaged() {
+	createDisk(&suite.DefaultSuite, "nvme0n1", "/dev/nvme0n1", "nvme")
+	createDisk(&suite.DefaultSuite, "nvme1n1", "/dev/nvme1n1", "nvme")
+
+	suite.md.arrays = []string{suite.md.createNode}
+
+	suite.createArraySpec("data", `disk.transport == "nvme"`)
+
+	ctest.AssertResource(suite, "data", func(status *storageres.MDArrayStatus, asrt *assert.Assertions) {
+		asrt.False(status.TypedSpec().Unmanaged)
+		asrt.Equal(storageres.MDArrayPhaseReady, status.TypedSpec().Status)
+	})
+
+	ctest.AssertNoResource[*storageres.MDArrayStatus](suite, "md0")
 }
 
 func TestMDArrayReconcileSuite(t *testing.T) {

--- a/internal/integration/api/storage.go
+++ b/internal/integration/api/storage.go
@@ -1416,6 +1416,37 @@ func (suite *StorageSuite) TestRAIDArrayGrow_RAID1() {
 	}, raidAssertTimeout, raidAssertInterval, "MD array status was not grown for %q", raidName)
 }
 
+// TestRAIDArrayUnmanaged_RAID1 provisions a raid1 array via a RAIDArrayConfig, then
+// removes the config document while leaving the array itself running. Talos never
+// stops an array just because its config disappeared (only an explicit MDDestroy
+// does that), so this reproduces, on a real node, the exact state an image-based
+// deployment is in from its very first boot: an assembled MD array with no
+// MDArraySpec. It verifies MDArrayReconcileController's discovery pass reports the
+// array as Unmanaged, keyed by its kernel device name, and that the old
+// spec-keyed MDArrayStatus is gone.
+func (suite *StorageSuite) TestRAIDArrayUnmanaged_RAID1() {
+	const raidName = "mdunmanaged"
+
+	nodeCtx, _, userDisks, teardown := suite.provisionRAID1Mirror(raidName, 2)
+	defer teardown()
+
+	memberDisks := userDisks[:2]
+
+	devName, ok := suite.raidArrayDevName(nodeCtx, raidName)
+	suite.Require().True(ok, "MD array %q device name not found", raidName)
+
+	suite.T().Logf("removing RAIDArrayConfig %q, leaving array %q running", raidName, devName)
+
+	suite.RemoveMachineConfigDocumentsByName(nodeCtx, storagecfg.RAIDArrayConfigKind, raidName)
+
+	suite.Require().Eventually(func() bool {
+		return suite.mdArrayStatusIsUnmanaged(nodeCtx, devName, memberDisks)
+	}, raidAssertTimeout, raidAssertInterval, "MD array %q was not reported as unmanaged after its config was removed", raidName)
+
+	_, err := safe.StateGetByID[*storageres.MDArrayStatus](nodeCtx, suite.Client.COSI, raidName)
+	suite.Require().True(state.IsNotFoundError(err), "expected MDArrayStatus %q to be gone, got: %v", raidName, err)
+}
+
 // TestRAIDArrayUserVolumeDisk provisions a disk-backed (whole-device) UserVolume
 // on top of a raid1 array and verifies it comes up Ready and mounted.
 func (suite *StorageSuite) TestRAIDArrayUserVolumeDisk_RAID1() {
@@ -1520,6 +1551,33 @@ func (suite *StorageSuite) mdArrayStatusMatches(ctx context.Context, name, devic
 
 	if len(mismatches) > 0 {
 		suite.T().Logf("MD array %q not matching yet: %s", name, strings.Join(mismatches, "; "))
+
+		return false
+	}
+
+	return true
+}
+
+// mdArrayStatusIsUnmanaged reports whether devName carries an MDArrayStatus marked
+// Unmanaged with exactly the expected members.
+func (suite *StorageSuite) mdArrayStatusIsUnmanaged(ctx context.Context, devName string, members []string) bool {
+	status, err := safe.StateGetByID[*storageres.MDArrayStatus](ctx, suite.Client.COSI, devName)
+	if err != nil {
+		suite.T().Logf("MD array %q: unmanaged status not found yet: %v", devName, err)
+
+		return false
+	}
+
+	spec := status.TypedSpec()
+
+	if !spec.Unmanaged {
+		suite.T().Logf("MD array %q: not yet reported unmanaged", devName)
+
+		return false
+	}
+
+	if !sameStringSet(spec.Members, members) {
+		suite.T().Logf("MD array %q: members got %v, want %v", devName, spec.Members, members)
 
 		return false
 	}

--- a/internal/pkg/md/array.go
+++ b/internal/pkg/md/array.go
@@ -146,6 +146,36 @@ func InactiveArrays() ([]string, error) {
 	return inactive, nil
 }
 
+// ListArrays returns the /dev/mdN device paths for all present MD arrays, regardless of state.
+func (*MD) ListArrays() ([]string, error) {
+	return ListArrays()
+}
+
+// ListArrays returns the /dev/mdN device paths for all present MD arrays, regardless of state.
+func ListArrays() ([]string, error) {
+	entries, err := os.ReadDir(sysBlockDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", sysBlockDir, err)
+	}
+
+	var arrays []string
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "md") {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(sysBlockDir, name, "md")); err != nil {
+			continue
+		}
+
+		arrays = append(arrays, filepath.Join("/dev", name))
+	}
+
+	return arrays, nil
+}
+
 // ArrayStateForDevice returns the current array state for an MD device.
 func (*MD) ArrayStateForDevice(device string) (string, error) {
 	return ArrayStateForDevice(device)

--- a/internal/pkg/md/array_test.go
+++ b/internal/pkg/md/array_test.go
@@ -50,6 +50,11 @@ func TestSysfsHelpers(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sysBlockDir, "md0", "md", "array_state"), []byte("inactive\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(sysBlockDir, "md0", "md", "sync_action"), []byte("resync\n"), 0o644))
 
+	// a second, active array: InactiveArrays must skip it, but ListArrays reports every
+	// present array regardless of state.
+	require.NoError(t, os.MkdirAll(filepath.Join(sysBlockDir, "md1", "md"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sysBlockDir, "md1", "md", "array_state"), []byte("clean\n"), 0o644))
+
 	dev, err := FindDeviceByMember("/dev/sda")
 	require.NoError(t, err)
 	assert.Equal(t, "/dev/md0", dev)
@@ -57,6 +62,10 @@ func TestSysfsHelpers(t *testing.T) {
 	inactive, err := InactiveArrays()
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/dev/md0"}, inactive)
+
+	arrays, err := ListArrays()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/dev/md0", "/dev/md1"}, arrays)
 
 	state, err := ArrayStateForDevice("/dev/md0")
 	require.NoError(t, err)

--- a/pkg/machinery/api/resource/definitions/storage/storage.pb.go
+++ b/pkg/machinery/api/resource/definitions/storage/storage.pb.go
@@ -1285,7 +1285,13 @@ type MDArrayStatusSpec struct {
 	// ArrayState is the current sysfs array_state value.
 	ArrayState string `protobuf:"bytes,10,opt,name=array_state,json=arrayState,proto3" json:"array_state,omitempty"`
 	// SyncAction is the current sysfs sync_action value.
-	SyncAction    string `protobuf:"bytes,11,opt,name=sync_action,json=syncAction,proto3" json:"sync_action,omitempty"`
+	SyncAction string `protobuf:"bytes,11,opt,name=sync_action,json=syncAction,proto3" json:"sync_action,omitempty"`
+	// Unmanaged is true when this array has no backing MDArraySpec.
+	//
+	// Unmanaged arrays are reported for visibility only: they are discovered
+	// on disk (e.g. assembled by the kernel/udev before Talos ever wrote a
+	// RAIDArrayConfig for them), and are never reconciled or self-healed.
+	Unmanaged     bool `protobuf:"varint,12,opt,name=unmanaged,proto3" json:"unmanaged,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1395,6 +1401,13 @@ func (x *MDArrayStatusSpec) GetSyncAction() string {
 		return x.SyncAction
 	}
 	return ""
+}
+
+func (x *MDArrayStatusSpec) GetUnmanaged() bool {
+	if x != nil {
+		return x.Unmanaged
+	}
+	return false
 }
 
 // MDRefreshRequestSpec is the spec for MDRefreshRequest.
@@ -1577,7 +1590,7 @@ const file_resource_definitions_storage_storage_proto_rawDesc = "" +
 	"\x0fMDArraySpecSpec\x12F\n" +
 	"\x05level\x18\x01 \x01(\x0e20.talos.resource.definitions.enums.StorageMDLevelR\x05level\x12N\n" +
 	"\x0fvolume_selector\x18\x02 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\x0evolumeSelector\x12O\n" +
-	"\bmetadata\x18\x03 \x01(\x0e23.talos.resource.definitions.enums.StorageMDMetadataR\bmetadata\"\x9b\x03\n" +
+	"\bmetadata\x18\x03 \x01(\x0e23.talos.resource.definitions.enums.StorageMDMetadataR\bmetadata\"\xb9\x03\n" +
 	"\x11MDArrayStatusSpec\x12F\n" +
 	"\x05level\x18\x01 \x01(\x0e20.talos.resource.definitions.enums.StorageMDLevelR\x05level\x12\x16\n" +
 	"\x06device\x18\x02 \x01(\tR\x06device\x12\x18\n" +
@@ -1592,7 +1605,8 @@ const file_resource_definitions_storage_storage_proto_rawDesc = "" +
 	" \x01(\tR\n" +
 	"arrayState\x12\x1f\n" +
 	"\vsync_action\x18\v \x01(\tR\n" +
-	"syncAction\"0\n" +
+	"syncAction\x12\x1c\n" +
+	"\tunmanaged\x18\f \x01(\bR\tunmanaged\"0\n" +
 	"\x14MDRefreshRequestSpec\x12\x18\n" +
 	"\arequest\x18\x01 \x01(\x03R\arequestBx\n" +
 	"*dev.talos.api.resource.definitions.storageZJgithub.com/siderolabs/talos/pkg/machinery/api/resource/definitions/storageb\x06proto3"

--- a/pkg/machinery/api/resource/definitions/storage/storage_vtproto.pb.go
+++ b/pkg/machinery/api/resource/definitions/storage/storage_vtproto.pb.go
@@ -1133,6 +1133,16 @@ func (m *MDArrayStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Unmanaged {
+		i--
+		if m.Unmanaged {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x60
+	}
 	if len(m.SyncAction) > 0 {
 		i -= len(m.SyncAction)
 		copy(dAtA[i:], m.SyncAction)
@@ -1791,6 +1801,9 @@ func (m *MDArrayStatusSpec) SizeVT() (n int) {
 	l = len(m.SyncAction)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Unmanaged {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5718,6 +5731,26 @@ func (m *MDArrayStatusSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.SyncAction = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Unmanaged", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Unmanaged = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/machinery/resources/storage/md_array_status.go
+++ b/pkg/machinery/resources/storage/md_array_status.go
@@ -45,6 +45,12 @@ type MDArrayStatusSpec struct {
 	ArrayState string `yaml:"arrayState,omitempty" protobuf:"10"`
 	// SyncAction is the current sysfs sync_action value.
 	SyncAction string `yaml:"syncAction,omitempty" protobuf:"11"`
+	// Unmanaged is true when this array has no backing MDArraySpec.
+	//
+	// Unmanaged arrays are reported for visibility only: they are discovered
+	// on disk (e.g. assembled by the kernel/udev before Talos ever wrote a
+	// RAIDArrayConfig for them), and are never reconciled or self-healed.
+	Unmanaged bool `yaml:"unmanaged,omitempty" protobuf:"12"`
 }
 
 // NewMDArrayStatus initializes an MDArrayStatus resource.
@@ -68,6 +74,7 @@ func (MDArrayStatusExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 			{Name: "Status", JSONPath: "{.status}"},
 			{Name: "Sync", JSONPath: "{.syncAction}"},
 			{Name: "Device", JSONPath: "{.device}"},
+			{Name: "Unmanaged", JSONPath: "{.unmanaged}"},
 		},
 	}
 }

--- a/website/content/v1.15/reference/api.md
+++ b/website/content/v1.15/reference/api.md
@@ -12405,6 +12405,7 @@ MDArrayStatusSpec is the spec for MDArrayStatus resource.
 | metadata | [string](#string) |  | Metadata is the MD metadata format/version. |
 | array_state | [string](#string) |  | ArrayState is the current sysfs array_state value. |
 | sync_action | [string](#string) |  | SyncAction is the current sysfs sync_action value. |
+| unmanaged | [bool](#bool) |  | Unmanaged is true when this array has no backing MDArraySpec.<br><br>Unmanaged arrays are reported for visibility only: they are discovered on disk (e.g. assembled by the kernel/udev before Talos ever wrote a RAIDArrayConfig for them), and are never reconciled or self-healed. |
 
 
 


### PR DESCRIPTION
## What? (description)

`MDArrayReconcileController` only produces an `MDArrayStatus` for arrays that
have a matching `MDArraySpec` (i.e. a `RAIDArrayConfig` document). On an
image-based deployment — writing a disk image onto a pre-built mdadm mirror —
the array exists and is assembled before Talos ever writes such a document, so
it never gets a status at all: `talosctl get mdarraystatus` is empty and the
only way to check the array's health is to read `/proc/mdstat` on the node.

This adds a read-only pass to `MDArrayReconcileController` that lists every MD
array present on the box (`md.ListArrays`, new) and reports an `MDArrayStatus`
for any array not already claimed by a spec, marked `Unmanaged: true`. It never
calls `Create`/`Add`/`Grow`; it only reuses the existing
`DetailDevice`/`ArrayStateForDevice`/`SyncActionForDevice` observation path
that spec-backed arrays already use. Only `raid1` is reported, since
`MDArrayStatusSpec.Level` can't represent anything else today, and an array
that can't be queried yet is skipped rather than reported with
empty/misleading fields.

Also adds `TestRAIDArrayUnmanaged_RAID1` to the QEMU acceptance suite. There's
no client-facing way to create an MD array outside the reconciler, so there's
no direct way to provision a "pre-built, never configured" array through the
API. Instead the test provisions via `RAIDArrayConfig` and then removes the
config document while leaving the array running — Talos never stops an array
just because its config disappeared, so this reaches the same state (an
assembled array with no `MDArraySpec`) an image-based deployment starts in
from its first boot, and exercises the real discovery pass end to end.
Verified passing against a real QEMU cluster.

## Why? (reasoning)

This is gap 1 from #14337 ("status for discovered arrays, spec-backed or
not") — I provision Talos on bare metal by writing a disk image onto an
mdadm mirror built ahead of time, and had no way to monitor that mirror's
health without a document I can't meaningfully author (the array's identity
isn't known until provisioning time, and the document could never be
load-bearing for assembly anyway, since it would live on the very array it
describes). Gap 2 from that discussion (self-healing / hot-replace) is
intentionally left for a follow-up, pending the maintainers' input on the
open questions there.

## Acceptance

- [x] you linked an issue (if applicable) — #14337
- [x] you included tests (if applicable) — unit tests in
      `internal/pkg/md` and `internal/app/machined/pkg/controllers/storage`,
      plus `TestRAIDArrayUnmanaged_RAID1` in the QEMU acceptance suite
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

Note on the last two boxes: I ran targeted `go test` against the two touched
packages and `golangci-lint` against just the changed files (both clean),
rather than the full whole-repo Docker-based `make lint`/`make unit-tests`
targets, given the scope of the change.