### PR TITLE
feat: talosctl `--config-patch*` autocompletion

### DIFF
--- a/cmd/talosctl/cmd/common/completion.go
+++ b/cmd/talosctl/cmd/common/completion.go
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CompleteConfigPatch completes the value of a flag which accepts the `@file` config patch syntax.
+func CompleteConfigPatch(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if toComplete != "" && !strings.HasPrefix(toComplete, "@") {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	dir, base := splitPathPrefix(strings.TrimPrefix(toComplete, "@"))
+
+	completions, hasDir := configPatchCandidates(dir, base)
+
+	directive := cobra.ShellCompDirectiveNoFileComp
+
+	if hasDir {
+		directive |= cobra.ShellCompDirectiveNoSpace
+	}
+
+	return completions, directive
+}
+
+// splitPathPrefix splits path into the directory prefix as typed and the basename prefix.
+func splitPathPrefix(path string) (dir, base string) {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[:idx+1], path[idx+1:]
+	}
+
+	return "", path
+}
+
+// configPatchCandidates lists the entries of dir whose name starts with base, `@`-prefixed.
+func configPatchCandidates(dir, base string) (completions []string, hasDir bool) {
+	readDir := dir
+
+	if readDir == "" {
+		readDir = "."
+	}
+
+	entries, err := os.ReadDir(readDir)
+	if err != nil {
+		return nil, false
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+
+		if !strings.HasPrefix(name, base) {
+			continue
+		}
+
+		// hidden entries are only offered when explicitly asked for, as the shells do
+		if strings.HasPrefix(name, ".") && !strings.HasPrefix(base, ".") {
+			continue
+		}
+
+		if isDir(readDir, entry) {
+			hasDir = true
+
+			completions = append(completions, "@"+dir+name+"/")
+
+			continue
+		}
+
+		completions = append(completions, "@"+dir+name)
+	}
+
+	return completions, hasDir
+}
+
+// isDir resolves symlinks, so that a symlinked directory can be descended into as well.
+func isDir(readDir string, entry os.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(readDir, entry.Name()))
+
+	return err == nil && info.IsDir()
+}

--- a/cmd/talosctl/cmd/common/completion_test.go
+++ b/cmd/talosctl/cmd/common/completion_test.go
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
+)
+
+// setupPatchDir creates a directory with a fixed set of entries to complete against.
+func setupPatchDir(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+
+	for _, name := range []string{"custom-config.yaml", "custom-other.yml", "patch.json", "notes.txt", ".hidden.yaml"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), nil, 0o644))
+	}
+
+	require.NoError(t, os.Mkdir(filepath.Join(root, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "inner.yaml"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "subnet.yaml"), nil, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "secrets"), 0o755))
+
+	return root
+}
+
+// Note: no t.Parallel, as t.Chdir is incompatible with it.
+func TestCompleteConfigPatch(t *testing.T) {
+	root := setupPatchDir(t)
+
+	for _, test := range []struct {
+		name       string
+		toComplete string
+		expected   []string
+		directive  cobra.ShellCompDirective
+	}{
+		{
+			name:       "prefix match",
+			toComplete: "@cu",
+			expected:   []string{"@custom-config.yaml", "@custom-other.yml"},
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:       "files and directories",
+			toComplete: "@sub",
+			expected:   []string{"@sub/", "@subnet.yaml"},
+			directive:  cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			name:       "dot slash prefix is preserved",
+			toComplete: "@./cu",
+			expected:   []string{"@./custom-config.yaml", "@./custom-other.yml"},
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:       "inside a directory",
+			toComplete: "@sub/",
+			expected:   []string{"@sub/inner.yaml"},
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:       "missing directory",
+			toComplete: "@nope/",
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:       "hidden entries are skipped",
+			toComplete: "@",
+			expected: []string{
+				"@notes.txt", "@patch.json", "@secrets/", "@custom-config.yaml", "@custom-other.yml", "@sub/", "@subnet.yaml",
+			},
+			directive: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			name:       "hidden entries when asked for",
+			toComplete: "@.",
+			expected:   []string{"@.hidden.yaml"},
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:       "empty input",
+			toComplete: "",
+			expected: []string{
+				"@notes.txt", "@patch.json", "@secrets/", "@custom-config.yaml", "@custom-other.yml", "@sub/", "@subnet.yaml",
+			},
+			directive: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			name:       "bare filename is left to the shell",
+			toComplete: "sma",
+			directive:  cobra.ShellCompDirectiveDefault,
+		},
+		{
+			name:       "inline patch is left to the shell",
+			toComplete: "machine:\n  network: {}",
+			directive:  cobra.ShellCompDirectiveDefault,
+		},
+		{
+			name:       "tilde is not expanded",
+			toComplete: "@~/",
+			directive:  cobra.ShellCompDirectiveNoFileComp,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Chdir(root)
+
+			completions, directive := common.CompleteConfigPatch(nil, nil, test.toComplete)
+
+			assert.ElementsMatch(t, test.expected, completions)
+			assert.Equal(t, test.directive, directive)
+		})
+	}
+}
+
+func TestCompleteConfigPatchAbsolutePath(t *testing.T) {
+	root := setupPatchDir(t)
+
+	completions, directive := common.CompleteConfigPatch(nil, nil, "@"+filepath.Join(root, "cu"))
+
+	assert.ElementsMatch(t, []string{
+		"@" + filepath.Join(root, "custom-config.yaml"),
+		"@" + filepath.Join(root, "custom-other.yml"),
+	}, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+// Note: no t.Parallel, as t.Chdir is incompatible with it.
+func TestCompleteConfigPatchSymlinkedDir(t *testing.T) {
+	root := setupPatchDir(t)
+
+	require.NoError(t, os.Symlink(filepath.Join(root, "sub"), filepath.Join(root, "linked")))
+
+	t.Chdir(root)
+
+	completions, directive := common.CompleteConfigPatch(nil, nil, "@link")
+
+	assert.Equal(t, []string{"@linked/"}, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace, directive)
+}

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/siderolabs/talos/cmd/talosctl/cmd/common"
 	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/clusterops"
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create/flags"
@@ -153,6 +154,15 @@ func selectProvisioner(ctx context.Context, _ clusterops.Common) (provision.Prov
 	}
 
 	return providers.Factory(ctx, providers.QemuProviderName)
+}
+
+// registerConfigPatchCompletions enables `@file` path completion for the given config patch flags.
+//
+// It has to be called after the flags have been added to the command.
+func registerConfigPatchCompletions(cmd *cobra.Command, flagNames ...string) {
+	for _, flagName := range flagNames {
+		cli.Should(cmd.RegisterFlagCompletionFunc(flagName, common.CompleteConfigPatch))
+	}
 }
 
 func addOmniJoinTokenFlag(cmd *cobra.Command, bindAPIEndpoint *string, cfgPatchAllFlagName, cfgPatchWorkersFlagName, cfgPatchCPsFlagName string) {

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go
@@ -354,6 +354,7 @@ func getCreateCmd(cmdName string, hidden bool) *cobra.Command {
 	createCmd.Flags().AddFlagSet(getCommonFlags())
 	createCmd.Flags().AddFlagSet(getQemuFlags())
 	addOmniJoinTokenFlag(createCmd, &cOps.OmniAPIEndpoint, configPatchFlag, configPatchWorkerFlag, configPatchControlPlaneFlag)
+	registerConfigPatchCompletions(createCmd, configPatchFlag, configPatchControlPlaneFlag, configPatchWorkerFlag)
 
 	createCmd.MarkFlagsMutuallyExclusive(tpmEnabledFlag, tpm2EnabledFlag)
 

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_docker.go
@@ -74,6 +74,7 @@ func init() {
 
 	createDockerCmd.Flags().AddFlagSet(getDockerFlags())
 	createDockerCmd.Flags().AddFlagSet(commonFlags)
+	registerConfigPatchCompletions(createDockerCmd, configPatchFlagName, configPatchControlPlaneFlagName, configPatchWorkerFlagName)
 
 	createCmd.AddCommand(createDockerCmd)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/cmd_qemu.go
@@ -77,6 +77,7 @@ func init() {
 	createQemuCmd.Flags().AddFlagSet(commonFlags)
 	createQemuCmd.Flags().AddFlagSet(getQemuFlags())
 	addOmniJoinTokenFlag(createQemuCmd, &cOps.OmniAPIEndpoint, configPatchFlagName, configPatchWorkerFlagName, configPatchControlPlaneFlagName)
+	registerConfigPatchCompletions(createQemuCmd, configPatchFlagName, configPatchControlPlaneFlagName, configPatchWorkerFlagName)
 
 	createCmd.AddCommand(createQemuCmd)
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/completion_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/completion_test.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package create_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+
+	clustercmd "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster"
+	_ "github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/cluster/create"
+)
+
+// TestConfigPatchFlagsHaveCompletion makes sure that every config patch flag of every cluster
+// command offers `@file` completion, so that a newly added command cannot silently miss it.
+func TestConfigPatchFlagsHaveCompletion(t *testing.T) {
+	var walk func(cmd *cobra.Command, path string)
+
+	walk = func(cmd *cobra.Command, path string) {
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			if !strings.HasPrefix(flag.Name, "config-patch") {
+				return
+			}
+
+			_, ok := cmd.GetFlagCompletionFunc(flag.Name)
+
+			assert.True(t, ok, "%s: --%s has no completion function registered", path, flag.Name)
+		})
+
+		for _, sub := range cmd.Commands() {
+			walk(sub, path+" "+sub.Name())
+		}
+	}
+
+	walk(clustercmd.Cmd, clustercmd.Cmd.Name())
+}


### PR DESCRIPTION
Adds talosctl support for `--config-patch*` option `@<path>` autocompletion.

---

To test manually against Bash/Zsh:
```sh
go build -o /tmp/ptbin/talosctl ./cmd/talosctl
export PATH=/tmp/ptbin:$PATH

mkdir -p /tmp/pt/sub /tmp/pt/secrets && cd /tmp/pt
touch smart-config.yaml smart-other.yaml notes.txt sub/inner.yaml

# bash
source /usr/share/bash-completion/bash_completion
source <(talosctl completion bash)

# zsh (compinit must run before sourcing: the script calls compdef)
autoload -Uz compinit && compinit -u
source <(talosctl completion zsh)
```

Then input:
```sh
talosctl cluster create dev --config-patch @sma
```

And hit `TAB`.  Should autocomplete to the nearest matches, `@smart-`, and on the subsequent `TAB` hits, show the matching candidates:
```sh
majabojarska@fw13:/tmp/pt$ talosctl cluster create dev --config-patch @smart-
@smart-config.yaml  @smart-other.yaml
```