### PR TITLE
fix: tighten the validation of v1alpha1 configs vs. migration

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -1269,6 +1269,11 @@ func (s *Server) Kubeconfig(empty *emptypb.Empty, obj machine.MachineService_Kub
 		return status.Error(codes.FailedPrecondition, "k8s API server CA config is not set")
 	}
 
+	k8sClusterConfig := s.Controller.Runtime().Config().K8sClusterConfig()
+	if k8sClusterConfig == nil {
+		return status.Error(codes.FailedPrecondition, "cluster name and endpoint are not configured (.cluster.controlPlane.endpoint or KubeClusterConfig document)")
+	}
+
 	if err := kubeconfig.GenerateAdmin(
 		struct {
 			configconfig.ClusterConfig
@@ -1277,7 +1282,7 @@ func (s *Server) Kubeconfig(empty *emptypb.Empty, obj machine.MachineService_Kub
 		}{
 			ClusterConfig:        s.Controller.Runtime().Config().Cluster(),
 			K8sAPIServerCAConfig: k8sCAConfig,
-			K8sClusterConfig:     s.Controller.Runtime().Config().K8sClusterConfig(),
+			K8sClusterConfig:     k8sClusterConfig,
 		},
 		&b,
 	); err != nil {
@@ -2412,7 +2417,12 @@ func (s *Server) GenerateClientConfiguration(ctx context.Context, in *machine.Ge
 	}
 
 	// make a nice context name
-	contextName := s.Controller.Runtime().Config().K8sClusterConfig().ClusterName()
+	k8sClusterConfig := s.Controller.Runtime().Config().K8sClusterConfig()
+	if k8sClusterConfig == nil {
+		return nil, status.Error(codes.FailedPrecondition, "cluster name and endpoint are not configured (.cluster.controlPlane.endpoint or KubeClusterConfig document)")
+	}
+
+	contextName := k8sClusterConfig.ClusterName()
 	if r := roles.Strings(); len(r) == 1 {
 		contextName = strings.TrimPrefix(r[0], role.Prefix) + "@" + contextName
 	}

--- a/pkg/machinery/config/container/validate.go
+++ b/pkg/machinery/config/container/validate.go
@@ -18,6 +18,7 @@ import (
 	configconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/validation"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 )
@@ -106,8 +107,12 @@ func (container *Container) validate(mode validation.RuntimeMode, opt ...validat
 		}
 	}
 
-	if err := container.validateContainer(mode); err != nil {
-		multiErr = multierror.Append(multiErr, err)
+	containerWarnings, containerErr := container.validateContainer(mode)
+
+	warnings = append(warnings, containerWarnings...)
+
+	if containerErr != nil {
+		multiErr = multierror.Append(multiErr, containerErr)
 	}
 
 	return warnings, multiErr.ErrorOrNil()
@@ -204,9 +209,14 @@ func (container *Container) runtimeValidateContainer(ctx context.Context, st sta
 //
 // This validation is used to do validation which only makes sense for the full configuration (vs. individual documents).
 //
+// The method returns warnings and fatal errors (as multierror).
+//
 //nolint:gocyclo,cyclop
-func (container *Container) validateContainer(mode validation.RuntimeMode) error {
-	var errs error
+func (container *Container) validateContainer(mode validation.RuntimeMode) ([]string, error) {
+	var (
+		warnings []string
+		errs     error
+	)
 
 	if mode.InContainer() {
 		// in container mode, HostDNS must be enabled and forward KubeDNS to host must be enabled as well
@@ -293,6 +303,38 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 				errs = multierror.Append(errs, fmt.Errorf("etcd encryption config is required for control plane machines running kube-apiserver"))
 			}
 		}
+
+		// the legacy .machine.nodeLabels/.machine.nodeTaints are amended with the control plane role
+		// label and taint for control plane machines, while the KubeNodeConfig document is used as-is,
+		// so warn if the control plane role label is missing after the migration
+		//
+		// the taint is not checked, as skipping it is a valid way to allow scheduling on control planes
+		if nodeConfigs := findMatchingDocs[configconfig.K8sNodeConfig](container.documents); len(nodeConfigs) > 0 {
+			nodeConfig := nodeConfigs[0]
+
+			_, hasControlPlaneLabel := nodeConfig.Labels()[constants.LabelNodeRoleControlPlane]
+
+			// if the node is not registered in Kubernetes, the labels and taints are not used at all
+			if !hasControlPlaneLabel && !nodeConfig.SkipNodeRegistration() {
+				warnings = append(warnings, fmt.Sprintf(
+					"KubeNodeConfig document should set the %q node label on control plane machines "+
+						"(and, unless scheduling on control planes is allowed, the %q taint): "+
+						"unlike .machine.nodeLabels/.machine.nodeTaints, the document contents are used as-is",
+					constants.LabelNodeRoleControlPlane,
+					constants.LabelNodeRoleControlPlane+": "+constants.TaintEffectNoSchedule,
+				))
+			}
+		}
+	}
+
+	// if Kubernetes is configured for this machine (there is a Kubernetes CA), the cluster name and
+	// endpoint are required: they might be provided either by the legacy .cluster.controlPlane.endpoint
+	// or by the KubeClusterConfig document, so this is a cross-document check
+	//
+	// configs generated with Kubernetes disabled have neither, so they are not affected
+	if container.K8sAPIServerCAConfig() != nil && container.K8sClusterConfig() == nil {
+		errs = multierror.Append(errs, fmt.Errorf("cluster name and endpoint are required when Kubernetes is configured: "+
+			"either .cluster.clusterName/.cluster.controlPlane.endpoint or the KubeClusterConfig document"))
 	}
 
 	controlplaneDocs := findMatchingDocs[ControlplaneOnlyConfig](container.documents)
@@ -313,7 +355,7 @@ func (container *Container) validateContainer(mode validation.RuntimeMode) error
 		)
 	}
 
-	return errs
+	return warnings, errs
 }
 
 // Validate is the legacy validation method.

--- a/pkg/machinery/config/container/validate_test.go
+++ b/pkg/machinery/config/container/validate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/xtesting/must"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/config"
@@ -299,12 +300,45 @@ func TestValidateContainer(t *testing.T) {
 
 	apiServerCAConfig := k8s.NewKubeAPIServerCAConfigV1Alpha1()
 
+	// the cluster endpoint was migrated out of the v1alpha1 config
+	v1alpha1CfgControlplaneNoEndpoint := v1alpha1CfgControlplane.DeepCopy()
+	v1alpha1CfgControlplaneNoEndpoint.ClusterConfig.ControlPlane = nil //nolint:staticcheck // testing legacy features
+
+	kubeClusterConfig := k8s.NewKubeClusterConfigV1Alpha1()
+	kubeClusterConfig.ClusterNameConfig = "test-cluster"
+	kubeClusterConfig.ClusterEndpointConfig = meta.URL{URL: must.Value(url.Parse("https://localhost:6443"))(t)}
+
+	// .machine.nodeLabels migrated to the KubeNodeConfig document as-is, without the control plane role label
+	kubeNodeConfig := k8s.NewKubeNodeConfigV1Alpha1()
+	kubeNodeConfig.LabelsConfig = map[string]string{
+		"rack": "r13a25",
+	}
+
+	kubeNodeConfigControlplane := k8s.NewKubeNodeConfigV1Alpha1()
+	kubeNodeConfigControlplane.LabelsConfig = map[string]string{
+		constants.LabelNodeRoleControlPlane: "",
+	}
+	kubeNodeConfigControlplane.TaintsConfig = map[string]string{
+		constants.LabelNodeRoleControlPlane: constants.TaintEffectNoSchedule,
+	}
+
+	kubeNodeConfigStandalone := k8s.NewKubeNodeConfigV1Alpha1()
+	kubeNodeConfigStandalone.SkipNodeRegistrationConfig = new(true)
+
+	encryptedDNSWarning := "all configured nameservers use encrypted DNS (DoT or DoH): validating certificates requires a correct system clock, " +
+		"so boot may stall when NTP servers are configured by hostname; consider keeping at least one plain-DNS fallback or configuring NTP servers by IP address"
+
+	controlPlaneLabelWarning := "KubeNodeConfig document should set the \"node-role.kubernetes.io/control-plane\" node label on control plane machines " +
+		"(and, unless scheduling on control planes is allowed, the \"node-role.kubernetes.io/control-plane: NoSchedule\" taint): " +
+		"unlike .machine.nodeLabels/.machine.nodeTaints, the document contents are used as-is"
+
 	for _, tt := range []struct {
 		name        string
 		documents   []config.Document
 		inContainer bool
 
-		expectedError string
+		expectedWarnings []string
+		expectedError    string
 	}{
 		{
 			name: "empty !container",
@@ -350,13 +384,15 @@ func TestValidateContainer(t *testing.T) {
 			inContainer: true,
 		},
 		{
-			name:          "DoT without hostDNS",
-			documents:     []config.Document{resolverConfigDoT},
-			expectedError: "1 error occurred:\n\t* hostDNS must be enabled when using non-default DNS protocols\n\n",
+			name:             "DoT without hostDNS",
+			documents:        []config.Document{resolverConfigDoT},
+			expectedWarnings: []string{encryptedDNSWarning},
+			expectedError:    "1 error occurred:\n\t* hostDNS must be enabled when using non-default DNS protocols\n\n",
 		},
 		{
-			name:      "DoT with hostDNS",
-			documents: []config.Document{resolverConfigDoT, v1alpha1CfgHostDNS},
+			name:             "DoT with hostDNS",
+			documents:        []config.Document{resolverConfigDoT, v1alpha1CfgHostDNS},
+			expectedWarnings: []string{encryptedDNSWarning},
 		},
 		{
 			name:      "controlplane doc only",
@@ -393,6 +429,40 @@ func TestValidateContainer(t *testing.T) {
 
 			expectedError: "1 error occurred:\n\t* etcd encryption config is required for control plane machines running kube-apiserver\n\n",
 		},
+		{
+			// the cluster endpoint was removed from the v1alpha1 config, but the KubeClusterConfig
+			// document was not added: Kubernetes is configured, but there is no way to reach it
+			name:      "api-server CA without cluster endpoint",
+			documents: []config.Document{v1alpha1CfgControlplaneNoEndpoint, apiServerCAConfig, kubeEtcdEncryptionConfig},
+
+			expectedError: "1 error occurred:\n\t* cluster name and endpoint are required when Kubernetes is configured: " +
+				"either .cluster.clusterName/.cluster.controlPlane.endpoint or the KubeClusterConfig document\n\n",
+		},
+		{
+			name:      "api-server CA with migrated cluster endpoint",
+			documents: []config.Document{v1alpha1CfgControlplaneNoEndpoint, apiServerCAConfig, kubeEtcdEncryptionConfig, kubeClusterConfig},
+		},
+		{
+			// the control plane role label is not synthesized for the KubeNodeConfig document
+			name:      "node config without control plane role label",
+			documents: []config.Document{v1alpha1CfgControlplane, kubeNodeConfig},
+
+			expectedWarnings: []string{controlPlaneLabelWarning},
+		},
+		{
+			name:      "node config with control plane role label",
+			documents: []config.Document{v1alpha1CfgControlplane, kubeNodeConfigControlplane},
+		},
+		{
+			// the node is not registered in Kubernetes, so the labels and taints are not used
+			name:      "node config with skipped node registration",
+			documents: []config.Document{v1alpha1CfgControlplane, kubeNodeConfigStandalone},
+		},
+		{
+			// worker machines never get the control plane role label
+			name:      "node config without control plane role label on a worker",
+			documents: []config.Document{v1alpha1Cfg, kubeNodeConfig},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -400,7 +470,9 @@ func TestValidateContainer(t *testing.T) {
 			ctr, err := container.New(tt.documents...)
 			require.NoError(t, err)
 
-			_, err = ctr.ValidateAsClient(validationMode{inContainer: tt.inContainer})
+			warnings, err := ctr.ValidateAsClient(validationMode{inContainer: tt.inContainer})
+
+			assert.Equal(t, tt.expectedWarnings, warnings)
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)

--- a/pkg/machinery/config/generate/secrets/bundle.go
+++ b/pkg/machinery/config/generate/secrets/bundle.go
@@ -198,13 +198,34 @@ type etcdEncryptionConfigProvider struct {
 }
 
 // NewBundleFromConfig creates secrets bundle using existing config.
+//
+//nolint:gocyclo
 func NewBundleFromConfig(clock Clock, c config.Config) (*Bundle, error) {
-	certs := &Certs{
-		K8s:               c.K8sAPIServerCAConfig().IssuingCA(),
-		K8sAggregator:     c.K8sAggregatorCAConfig().IssuingCA(),
-		K8sServiceAccount: c.K8sServiceAccountConfig().IssuingKey(),
-		Etcd:              c.Cluster().Etcd().CA(),
-		OS:                c.Machine().Security().IssuingCA(),
+	// the secrets might be missing from the config (e.g. a worker config, or a config
+	// which keeps them in the multi-doc documents which are not present), so each accessor is
+	// checked for nil before use
+	certs := &Certs{}
+
+	if clusterConfig := c.Cluster(); clusterConfig != nil {
+		if etcdCA := clusterConfig.Etcd(); etcdCA != nil {
+			certs.Etcd = etcdCA.CA()
+		}
+	}
+
+	if machineConfig := c.Machine(); machineConfig != nil {
+		certs.OS = machineConfig.Security().IssuingCA()
+	}
+
+	if apiServerCA := c.K8sAPIServerCAConfig(); apiServerCA != nil {
+		certs.K8s = apiServerCA.IssuingCA()
+	}
+
+	if aggregatorCA := c.K8sAggregatorCAConfig(); aggregatorCA != nil {
+		certs.K8sAggregator = aggregatorCA.IssuingCA()
+	}
+
+	if serviceAccount := c.K8sServiceAccountConfig(); serviceAccount != nil {
+		certs.K8sServiceAccount = serviceAccount.IssuingKey()
 	}
 
 	cluster := &Cluster{}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -61,8 +61,15 @@ func (c *ClusterConfig) Scheduler() *SchedulerConfig {
 	return c.SchedulerConfig
 }
 
-// Endpoint implements the config.ClusterConfig interface.
+// Endpoint returns the Kubernetes API endpoint as set in the v1alpha1 config.
+//
+// It returns nil if the endpoint is not set in the v1alpha1 config: e.g. when the cluster
+// endpoint was migrated to the KubeClusterConfig document.
 func (c *ClusterConfig) Endpoint() *url.URL {
+	if c.ControlPlane == nil || c.ControlPlane.Endpoint == nil {
+		return nil
+	}
+
 	return c.ControlPlane.Endpoint.URL
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_k8s_bridge.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_k8s_bridge.go
@@ -327,8 +327,18 @@ func (c *Config) K8sServiceAccountConfig() config.K8sServiceAccountConfig {
 		return nil
 	}
 
+	endpoint := c.ClusterConfig.Endpoint()
+	if endpoint == nil {
+		// the legacy service account config derives the issuer URL and the API audiences from the
+		// cluster endpoint, so it is not usable without it (e.g. when the cluster endpoint was
+		// migrated to the KubeClusterConfig document, but the service account was not)
+		//
+		// this combination is rejected by the config validation
+		return nil
+	}
+
 	return serviceAccountShim{
-		endpoint: c.ClusterConfig.Endpoint(),
+		endpoint: endpoint,
 		key:      c.ClusterConfig.ClusterServiceAccount,
 	}
 }
@@ -382,7 +392,8 @@ func (s serviceAccountShim) APIAudiences() []string {
 
 // K8sClusterConfig implements the config.Config interface.
 func (c *Config) K8sClusterConfig() config.K8sClusterConfig {
-	if c.ClusterConfig == nil || c.ClusterConfig.ControlPlane == nil {
+	// if the endpoint is missing, assume it's not set (multi-doc should provide it)
+	if c.ClusterConfig == nil || c.ClusterConfig.Endpoint() == nil {
 		return nil
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_k8s_bridge_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_k8s_bridge_test.go
@@ -1089,6 +1089,35 @@ func TestKubeServiceAccountBridge(t *testing.T) {
 			expectNil: true,
 		},
 		{
+			// the cluster endpoint was migrated to the KubeClusterConfig document, but the service
+			// account was left in the v1alpha1 config: the legacy service account config derives the
+			// issuer URL from the cluster endpoint, so it is not usable (and this combination is
+			// rejected by the config validation)
+			name: "v1alpha1 service account without cluster endpoint",
+
+			cfg: func(t *testing.T) config.Config {
+				cc := k8s.NewKubeClusterConfigV1Alpha1()
+				cc.ClusterNameConfig = "test-cluster"
+				cc.ClusterEndpointConfig = meta.URL{URL: endpoint}
+
+				c, err := container.New(
+					&v1alpha1.Config{
+						ClusterConfig: &v1alpha1.ClusterConfig{
+							ClusterServiceAccount: &x509.PEMEncodedKey{
+								Key: sa.KeyPEM,
+							},
+						},
+					},
+					cc,
+				)
+				require.NoError(t, err)
+
+				return c
+			},
+
+			expectNil: true,
+		},
+		{
 			name: "v1alpha1 with service account",
 
 			cfg: func(*testing.T) config.Config {
@@ -1938,6 +1967,24 @@ func TestKubeClusterConfigBridge(t *testing.T) {
 
 			expectClusterName:     "test-cluster",
 			expectClusterEndpoint: endpoint,
+		},
+		{
+			// the endpoint is required, as it's the only way to reach the cluster; this combination
+			// is rejected by the config validation
+			name: "v1alpha1 without cluster endpoint",
+
+			cfg: func(*testing.T) config.Config {
+				return container.NewV1Alpha1(&v1alpha1.Config{
+					ClusterConfig: &v1alpha1.ClusterConfig{
+						ClusterName: "test-cluster",
+						ControlPlane: &v1alpha1.ControlPlaneConfig{
+							LocalAPIServerPort: 7443,
+						},
+					},
+				})
+			},
+
+			expectNil: true,
 		},
 		{
 			name: "new style",

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -406,12 +406,21 @@ func (c *ClusterConfig) Validate(isControlPlane bool) error {
 
 	if c.ControlPlane != nil {
 		if c.ControlPlane.Endpoint == nil {
-			return errors.New("cluster controlplane endpoint is required")
+			return errors.New("cluster controlplane endpoint is required (.cluster.controlPlane.endpoint); " +
+				"when the endpoint is migrated to the KubeClusterConfig document, the whole .cluster.controlPlane section should be removed " +
+				"(.cluster.controlPlane.localAPIServerPort is migrated to the KubeAPIServerConfig document)")
 		}
 
 		if err := sideronet.ValidateEndpointURI(c.ControlPlane.Endpoint.URL.String()); err != nil {
 			result = multierror.Append(result, fmt.Errorf("invalid controlplane endpoint: %w", err))
 		}
+	}
+
+	// the legacy service account config derives the issuer URL and the API audiences from the cluster
+	// endpoint, so it has no meaning without the endpoint being set in the same document
+	if c.ClusterServiceAccount != nil && c.Endpoint() == nil {
+		result = multierror.Append(result, errors.New(".cluster.serviceAccount requires the cluster endpoint to be set in the same document (.cluster.controlPlane.endpoint); "+
+			"when the cluster endpoint is migrated to the KubeClusterConfig document, .cluster.serviceAccount should be migrated to the KubeServiceAccountConfig document as well"))
 	}
 
 	if c.ClusterNetwork != nil && c.ClusterNetwork.DNSDomain != "" && !isValidDNSName(c.ClusterNetwork.DNSDomain) {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -2033,6 +2033,75 @@ func TestValidate(t *testing.T) {
 			},
 			expectedError: "1 error occurred:\n\t* feature hostDNS.forwardKubeDNSToHost requires hostDNS.enabled to be true (.machine.features.hostDNS)\n\n",
 		},
+		{
+			// the cluster endpoint was migrated to the KubeClusterConfig document, but the service
+			// account was left in the v1alpha1 config: the legacy service account config derives the
+			// issuer URL and the API audiences from the cluster endpoint, so this combination has no meaning
+			name: "ServiceAccountWithoutClusterEndpoint",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+					MachineCA: &x509.PEMEncodedCertificateAndKey{
+						Crt: []byte("foo"),
+						Key: []byte("bar"),
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ClusterServiceAccount: &x509.PEMEncodedKey{
+						Key: []byte("foo"),
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* .cluster.serviceAccount requires the cluster endpoint to be set in the same document (.cluster.controlPlane.endpoint); " +
+				"when the cluster endpoint is migrated to the KubeClusterConfig document, .cluster.serviceAccount should be migrated to the KubeServiceAccountConfig document as well\n\n",
+		},
+		{
+			name: "ServiceAccountWithClusterEndpoint",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+					MachineCA: &x509.PEMEncodedCertificateAndKey{
+						Crt: []byte("foo"),
+						Key: []byte("bar"),
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ClusterServiceAccount: &x509.PEMEncodedKey{
+						Key: []byte("foo"),
+					},
+				},
+			},
+		},
+		{
+			// .cluster.controlPlane is present, but the endpoint was migrated to the KubeClusterConfig
+			// document: the whole section should have been removed
+			name: "ControlPlaneWithoutEndpoint",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+					MachineCA: &x509.PEMEncodedCertificateAndKey{
+						Crt: []byte("foo"),
+						Key: []byte("bar"),
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						LocalAPIServerPort: 7443,
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* cluster controlplane endpoint is required (.cluster.controlPlane.endpoint); " +
+				"when the endpoint is migrated to the KubeClusterConfig document, the whole .cluster.controlPlane section should be removed " +
+				"(.cluster.controlPlane.localAPIServerPort is migrated to the KubeAPIServerConfig document)\n\n",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
When migrating to new multi-doc config, some documents naturally changed its meaning, and some were expanded.

If the machine config is generated with 1.14 contract, it is correct, but if someone tries to gradually replace old pre-1.14 config with new one, they might hit a case when Talos can't produce a valid configuration anymore, one such example is in #14338.

Do more validation across the machine configuration to ensure that we are not producing an input which will later make controllers panic.

Fixes #14338
