### PR TITLE
Fix dry-run confirmation of try-mode config

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -202,10 +202,6 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 
 	var modeDetails string
 
-	if in.Mode != machine.ApplyConfigurationRequest_TRY {
-		s.Controller.Runtime().CancelConfigRollbackTimeout()
-	}
-
 	cfgProvider, err := configloader.NewFromBytes(in.GetData())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -273,6 +269,10 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 				},
 			},
 		}, nil
+	}
+
+	if in.Mode != machine.ApplyConfigurationRequest_TRY {
+		s.Controller.Runtime().CancelConfigRollbackTimeout()
 	}
 
 	log.Printf("apply config request: mode %s", strings.ToLower(mode))

--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -619,6 +619,14 @@ func (suite *ApplyConfigSuite) TestApplyTry() {
 
 	suite.Assert().Truef(assertDummyInterface(provider), "dummy interface wasn't found")
 
+	// A dry run must not confirm the pending try-mode configuration.
+	_, err = suite.Client.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
+		Data:   suite.PatchV1Alpha1Config(provider, func(*v1alpha1.Config) {}),
+		Mode:   machineapi.ApplyConfigurationRequest_AUTO,
+		DryRun: true,
+	})
+	suite.Require().NoError(err)
+
 	rtestutils.AssertResource(nodeCtx, suite.T(), suite.Client.COSI, mc.ActiveID, func(r *mc.MachineConfig, asrt *assert.Assertions) {
 		asrt.False(assertDummyInterface(r.Provider()))
 	})


### PR DESCRIPTION
## Summary

- keep `--mode=try` rollback timers intact for dry-run requests
- cancel an existing rollback only after configuration parsing, validation, and dry-run handling succeed
- extend the apply-config integration test to cover a dry run during a try-mode window

Fixes #14343

## Validation

- `go test -tags=integration_api -run '^$' ./internal/integration/api`
- `go test -run '^$' ./internal/app/machined/internal/server/v1alpha1`
- `gofmt` and `git diff --check`

This change was prepared with AI assistance and reviewed against the repository contribution guidance.
