### PR TITLE
fix: make --insecure reachable for talosctl meta subcommands

### DIFF
--- a/cmd/talosctl/cmd/talos/meta.go
+++ b/cmd/talosctl/cmd/talos/meta.go
@@ -107,7 +107,7 @@ var metaDeleteCmd = &cobra.Command{
 }
 
 func init() {
-	metaCmdFlags.InsecureFlags.AddFlags(metaCmd)
+	metaCmdFlags.InsecureFlags.AddPersistentFlags(metaCmd)
 
 	metaCmd.AddCommand(metaWriteCmd)
 	metaCmd.AddCommand(metaDeleteCmd)

--- a/cmd/talosctl/pkg/talos/global/insecure.go
+++ b/cmd/talosctl/pkg/talos/global/insecure.go
@@ -4,7 +4,10 @@
 
 package global
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
 
 // InsecureFlags is a mix-in args struct for commands that support the --insecure flag.
 type InsecureFlags struct {
@@ -14,8 +17,20 @@ type InsecureFlags struct {
 
 // AddFlags adds the InsecureFlags flags to the given command.
 func (a *InsecureFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&a.Insecure, "insecure", "i", false, "use the insecure (encrypted with no auth) maintenance service")
-	cmd.Flags().StringSliceVar(&a.CertFingerprints, "cert-fingerprint", nil, "list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)")
+	a.addFlags(cmd.Flags())
+}
+
+// AddPersistentFlags adds the InsecureFlags flags to the given command and to its subcommands.
+//
+// Use it on a command that groups subcommands instead of running itself: cobra merges a parent's
+// persistent flags into its subcommands, but not its local ones.
+func (a *InsecureFlags) AddPersistentFlags(cmd *cobra.Command) {
+	a.addFlags(cmd.PersistentFlags())
+}
+
+func (a *InsecureFlags) addFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&a.Insecure, "insecure", "i", false, "use the insecure (encrypted with no auth) maintenance service")
+	flags.StringSliceVar(&a.CertFingerprints, "cert-fingerprint", nil, "list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)")
 }
 
 // GetInsecureFlag returns the value of the --insecure flag.

--- a/website/content/v1.15/reference/cli.md
+++ b/website/content/v1.15/reference/cli.md
@@ -2856,9 +2856,11 @@ talosctl meta delete key [flags]
 ### Options inherited from parent commands
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2885,9 +2887,11 @@ talosctl meta write key value [flags]
 ### Options inherited from parent commands
 
 ```
+      --cert-fingerprint strings   list of server certificate fingerprints to accept (defaults to no check, only used with --insecure flag)
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
+  -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order


### PR DESCRIPTION
# Pull Request

## What? (description)

`InsecureFlags` gets an `AddPersistentFlags`, and `talosctl meta` switches to it, so `meta write` and `meta delete` see `--insecure` and `--cert-fingerprint` again. Tests cover parsing both flags on the two subcommands, plus a walk over the command tree that fails if a command which runs nothing carries `--insecure` as a local flag.

## Why? (reasoning)

Fixes #14346

Since v1.14.0 `talosctl meta write --insecure` fails with `unknown flag: --insecure`. #13500 replaced `metaCmd.PersistentFlags()` with `InsecureFlags.AddFlags(metaCmd)`, and that one registers in the local flag set. Cobra merges a parent's persistent flags into a child, not its local ones, and `metaCmd` is `Args: cobra.NoArgs` with no `RunE`, so the flag had nowhere to land. `talosctl meta --help` still listed it.

Writing a META key goes over the maintenance service, before a machine config exists, so there is no other route to that operation.

`wipe` registers the mix-in on the subcommands that run and works. Persistent flags on the parent keep both `meta write --insecure` and `meta --insecure write` working, the same as v1.13.7.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

Conform passes everything except the GPG identity check, which wants the signing key to belong to a siderolabs org member. The CLI reference was regenerated with the same generator the docs target runs, and it reproduces the committed file byte for byte on a clean tree.

> See `make help` for a description of the available targets.
