### PR TITLE
[DO-NOT-MERGE/for discussion only]feat: add opt-in static networking for QEMU

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -5,15 +5,19 @@
 package makers
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/netip"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-blockdevice/v2/encryption"
 	"github.com/siderolabs/go-procfs/procfs"
@@ -28,6 +32,7 @@ import (
 	configbase "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
@@ -247,6 +252,9 @@ func (m *Qemu) AddExtraProvisionOpts() error {
 	})
 
 	externalKubernetesEndpoint := m.Provisioner.GetExternalKubernetesControlPlaneEndpoint(m.ClusterRequest.Network, m.Ops.ControlPlanePort)
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		externalKubernetesEndpoint = m.directKubernetesEndpoint()
+	}
 
 	// full-CLOS uses the BGP-advertised anycast VIP as the k8s endpoint (reachable via the host zebra
 	// route), not the provisioner's host-side load balancer.
@@ -340,6 +348,9 @@ func (m *Qemu) ModifyClusterRequest() error {
 	m.ClusterRequest.Network.ImageCacheTLSCertFile = m.EOps.ImageCacheTLSCertFile
 	m.ClusterRequest.Network.ImageCacheTLSKeyFile = m.EOps.ImageCacheTLSKeyFile
 	m.ClusterRequest.Network.ImageCachePort = m.EOps.ImageCachePort
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		m.ClusterRequest.Network.NoDHCP = true
+	}
 
 	m.ClusterRequest.KernelPath = m.EOps.NodeVmlinuzPath
 	m.ClusterRequest.InitramfsPath = m.EOps.NodeInitramfsPath
@@ -394,6 +405,10 @@ func (m *Qemu) ModifyNodes() error {
 		return err
 	}
 
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		m.InClusterEndpoint = m.directKubernetesEndpoint()
+	}
+
 	for i := range m.ClusterRequest.Nodes {
 		node := &m.ClusterRequest.Nodes[i]
 
@@ -407,9 +422,120 @@ func (m *Qemu) ModifyNodes() error {
 		node.SkipInjectingConfig = m.Ops.SkipInjectingConfig
 		node.BadRTC = m.EOps.BadRTC
 		node.ExtraKernelArgs = extraKernelArgs
+
+		if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+			if err = m.configureStaticIPv4(i, node); err != nil {
+				return err
+			}
+		}
 	}
 
 	m.ClusterRequest.SiderolinkRequest = m.SideroLinkBuilder.SiderolinkRequest()
+
+	return nil
+}
+
+func (m *Qemu) directKubernetesEndpoint() string {
+	controlPlane := m.ClusterRequest.Nodes.ControlPlaneNodes()[0]
+
+	return "https://" + nethelpers.JoinHostPort(firstIPv4(controlPlane.IPs).String(), m.Ops.ControlPlanePort)
+}
+
+// configureStaticIPv4 bypasses the host-side DHCP server for environments where
+// macOS endpoint security prevents broadcast DHCP packets from reaching the
+// talosctl child process. It is deliberately opt-in and leaves the normal QEMU
+// networking path unchanged.
+func (m *Qemu) configureStaticIPv4(nodeIndex int, node *provision.NodeRequest) error {
+	var (
+		nodeIP     netip.Addr
+		nodePrefix netip.Prefix
+		gateway    netip.Addr
+		nameserver netip.Addr
+	)
+
+	for i, ip := range node.IPs {
+		if ip.Is4() {
+			nodeIP = ip
+			nodePrefix = netip.PrefixFrom(ip, m.Cidrs[i].Bits())
+			gateway = m.GatewayIPs[i]
+
+			break
+		}
+	}
+
+	if !nodeIP.IsValid() {
+		return fmt.Errorf("TALOS_QEMU_STATIC_IP requires an IPv4 cluster network")
+	}
+
+	for _, candidate := range m.ClusterRequest.Network.Nameservers {
+		if candidate.Is4() {
+			nameserver = candidate
+
+			break
+		}
+	}
+
+	if !nameserver.IsValid() {
+		nameserver = gateway
+	}
+
+	link := networkcfg.NewLinkConfigV1Alpha1("net0")
+	link.LinkAddresses = []networkcfg.AddressConfig{{AddressAddress: nodePrefix}}
+	link.LinkRoutes = []networkcfg.RouteConfig{{RouteGateway: metacfg.Addr{Addr: gateway}}}
+
+	alias := networkcfg.NewLinkAliasConfigV1Alpha1("net0")
+	alias.Selector = networkcfg.LinkSelector{
+		Match: cel.MustExpression(cel.ParseBooleanExpression(`link.driver == "virtio_net"`, celenv.LinkLocator())),
+	}
+
+	resolver := networkcfg.NewResolverConfigV1Alpha1()
+	resolver.ResolverNameservers = []networkcfg.NameserverConfig{{Address: metacfg.Addr{Addr: nameserver}}}
+
+	// virtio_net is a module in recent Talos kernels, so the management NIC does
+	// not exist while Linux's built-in ip= autoconfiguration runs. Feed Talos a
+	// compact, partial early config instead: once udev loads the NIC driver, the
+	// normal network controllers apply the address before maintenance mode starts.
+	earlyConfig, err := container.New(alias, link, resolver)
+	if err != nil {
+		return fmt.Errorf("building early static network config for node %d: %w", nodeIndex, err)
+	}
+
+	earlyConfigBytes, err := earlyConfig.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+	if err != nil {
+		return fmt.Errorf("encoding early static network config for node %d: %w", nodeIndex, err)
+	}
+
+	var compressed bytes.Buffer
+
+	zencoder, err := zstd.NewWriter(&compressed)
+	if err != nil {
+		return fmt.Errorf("creating early static network config encoder for node %d: %w", nodeIndex, err)
+	}
+
+	if _, err = zencoder.Write(earlyConfigBytes); err != nil {
+		return fmt.Errorf("compressing early static network config for node %d: %w", nodeIndex, err)
+	}
+
+	if err = zencoder.Close(); err != nil {
+		return fmt.Errorf("closing early static network config encoder for node %d: %w", nodeIndex, err)
+	}
+
+	node.SDStubKernelArgs = procfs.NewCmdline("")
+	node.SDStubKernelArgs.Append(constants.KernelParamConfigEarly, base64.StdEncoding.EncodeToString(compressed.Bytes()))
+
+	ctr, err := container.New(link)
+	if err != nil {
+		return fmt.Errorf("building static network config for node %d: %w", nodeIndex, err)
+	}
+
+	if m.PerNodePatches == nil {
+		m.PerNodePatches = map[int][]configpatcher.Patch{}
+	}
+
+	m.PerNodePatches[nodeIndex] = append(
+		m.PerNodePatches[nodeIndex],
+		configpatcher.NewStrategicMergePatch(ctr),
+	)
 
 	return nil
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
@@ -5,10 +5,15 @@
 package makers_test
 
 import (
+	"bytes"
+	"encoding/base64"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
+	"github.com/siderolabs/go-procfs/procfs"
 	sideronet "github.com/siderolabs/net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +43,71 @@ func TestQemuMaker_MachineConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assertConfigDefaultness(t, cOps, *m.Maker, nil)
+}
+
+func TestQemuMaker_StaticIP(t *testing.T) {
+	t.Setenv("TALOS_QEMU_STATIC_IP", "1")
+
+	cOps := clusterops.GetCommon()
+	cOps.NetworkCIDR = "192.168.200.0/24"
+	rootOps := *cOps.RootOps
+	rootOps.ClusterName = "talos-default"
+	cOps.RootOps = &rootOps
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    clusterops.GetQemu(),
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	clusterConfigs, err := m.GetClusterConfigs()
+	require.NoError(t, err)
+
+	controlPlane := clusterConfigs.ClusterRequest.Nodes[0]
+	worker := clusterConfigs.ClusterRequest.Nodes[1]
+
+	controlPlaneEarlyConfig := decodeEarlyConfig(t, controlPlane.SDStubKernelArgs)
+	workerEarlyConfig := decodeEarlyConfig(t, worker.SDStubKernelArgs)
+	assert.Contains(t, controlPlaneEarlyConfig, "kind: LinkAliasConfig\nname: net0")
+	assert.Contains(t, controlPlaneEarlyConfig, "address: 192.168.200.2/24")
+	assert.Contains(t, controlPlaneEarlyConfig, "gateway: 192.168.200.1")
+	assert.Contains(t, workerEarlyConfig, "address: 192.168.200.3/24")
+	assert.NotContains(t, controlPlane.SDStubKernelArgs.String(), "ip=")
+
+	controlPlaneConfig, err := controlPlane.Config.EncodeString()
+	require.NoError(t, err)
+	assert.Contains(t, controlPlaneConfig, "endpoint: https://192.168.200.2:6443")
+	assert.Contains(t, controlPlaneConfig, "kind: LinkConfig\nname: net0")
+	assert.Contains(t, controlPlaneConfig, "address: 192.168.200.2/24")
+	assert.Contains(t, controlPlaneConfig, "gateway: 192.168.200.1")
+	assert.NotContains(t, controlPlaneConfig, "kind: DHCPv4Config")
+
+	workerConfig, err := worker.Config.EncodeString()
+	require.NoError(t, err)
+	assert.Contains(t, workerConfig, "address: 192.168.200.3/24")
+}
+
+func decodeEarlyConfig(t *testing.T, cmdline *procfs.Cmdline) string {
+	t.Helper()
+	require.NotNil(t, cmdline)
+
+	parameter := cmdline.Get(constants.KernelParamConfigEarly)
+	require.NotNil(t, parameter)
+	value := parameter.First()
+	require.NotNil(t, value)
+
+	compressed, err := base64.StdEncoding.DecodeString(*value)
+	require.NoError(t, err)
+
+	decoder, err := zstd.NewReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	t.Cleanup(decoder.Close)
+
+	decoded, err := io.ReadAll(decoder)
+	require.NoError(t, err)
+
+	return string(decoded)
 }
 
 func TestQemuMaker_RegistryAuth(t *testing.T) {


### PR DESCRIPTION
## What?

Add an opt-in static networking path for local QEMU clusters, enabled with `TALOS_QEMU_STATIC_IP=1`.

When enabled, this change:

- disables DHCP for the QEMU management network;
- assigns each node its already allocated address and default route through a small, compressed `talos.config.early` document;
- persists the same static address in the full machine configuration; and
- uses the first control-plane node directly for the Kubernetes endpoint instead of the host-side load balancer.

The existing QEMU behavior is unchanged unless the environment variable is set. I used an environment variable for this draft to avoid committing to a public CLI interface as it's a **hack only meant for discussion.**

## Why?

On my managed macOS machine, `talosctl cluster create qemu` consistently stalls while applying configuration. Packet captures on the VM bridge show DHCP Discover packets from both guests, but no DHCP Offer is returned. The generated host firewall rules explicitly permit traffic within the QEMU subnet, and changing the CIDR does not help.

The result is that the nodes never receive their allocated addresses and the Talos API at the first control-plane address cannot be reached. Host-side helper services such as the load balancer are also unreliable in this environment, which is why this path uses the control-plane address directly.

An initial workaround used the Linux `ip=` kernel argument. That worked with a v1.14 image on this machine, but it is not robust: with the current arm64 image, `virtio_net` is loaded as a module after the kernel's built-in IP autoconfiguration. The kernel waited 120 seconds, selected `bond0`, and the real QEMU interface (`enp0s6` in that build) appeared only after userspace started.

Using `talos.config.early` avoids depending on PCI-derived interface names or on the NIC being available during kernel IP autoconfiguration. In an end-to-end test from current `main`, the real NIC appeared at 1.3 seconds, the static address was applied at 2.4 seconds, the full machine configuration was accepted at 6.5 seconds, and both the control-plane and worker nodes reached Kubernetes `Ready`.

I am opening this as a draft as this is not meant to be merged, simply for discussion.

<details><summary>Initial working patch tested on 1.14.0 tweaked in this PR for main</summary>

```diff
diff --git i/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go w/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
index 9bf4fb1..972b646 100644
--- i/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
+++ w/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -223,6 +225,9 @@ func (m *Qemu) AddExtraProvisionOpts() error {
 	})
 
 	externalKubernetesEndpoint := m.Provisioner.GetExternalKubernetesControlPlaneEndpoint(m.ClusterRequest.Network, m.Ops.ControlPlanePort)
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		externalKubernetesEndpoint = m.directKubernetesEndpoint()
+	}
 
 	// full-CLOS uses the BGP-advertised anycast VIP as the k8s endpoint (reachable via the host zebra
 	// route), not the provisioner's host-side load balancer.
@@ -316,6 +321,9 @@ func (m *Qemu) ModifyClusterRequest() error {
 	m.ClusterRequest.Network.ImageCacheTLSCertFile = m.EOps.ImageCacheTLSCertFile
 	m.ClusterRequest.Network.ImageCacheTLSKeyFile = m.EOps.ImageCacheTLSKeyFile
 	m.ClusterRequest.Network.ImageCachePort = m.EOps.ImageCachePort
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		m.ClusterRequest.Network.NoDHCP = true
+	}
 
 	m.ClusterRequest.KernelPath = m.EOps.NodeVmlinuzPath
 	m.ClusterRequest.InitramfsPath = m.EOps.NodeInitramfsPath
@@ -370,6 +378,10 @@ func (m *Qemu) ModifyNodes() error {
 		return err
 	}
 
+	if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+		m.InClusterEndpoint = m.directKubernetesEndpoint()
+	}
+
 	for i := range m.ClusterRequest.Nodes {
 		node := &m.ClusterRequest.Nodes[i]
 
@@ -383,6 +395,12 @@ func (m *Qemu) ModifyNodes() error {
 		node.SkipInjectingConfig = m.Ops.SkipInjectingConfig
 		node.BadRTC = m.EOps.BadRTC
 		node.ExtraKernelArgs = extraKernelArgs
+
+		if os.Getenv("TALOS_QEMU_STATIC_IP") == "1" {
+			if err = m.configureStaticIPv4(i, node); err != nil {
+				return err
+			}
+		}
 	}
 
 	m.ClusterRequest.SiderolinkRequest = m.SideroLinkBuilder.SiderolinkRequest()
@@ -390,6 +408,84 @@ func (m *Qemu) ModifyNodes() error {
 	return nil
 }
 
+func (m *Qemu) directKubernetesEndpoint() string {
+	controlPlane := m.ClusterRequest.Nodes.ControlPlaneNodes()[0]
+
+	return "https://" + nethelpers.JoinHostPort(firstIPv4(controlPlane.IPs).String(), m.Ops.ControlPlanePort)
+}
+
+// configureStaticIPv4 bypasses the host-side DHCP server for environments where
+// macOS endpoint security prevents broadcast DHCP packets from reaching the
+// talosctl child process. It is deliberately opt-in and leaves the normal QEMU
+// networking path unchanged.
+func (m *Qemu) configureStaticIPv4(nodeIndex int, node *provision.NodeRequest) error {
+	var (
+		nodeIP     netip.Addr
+		nodePrefix netip.Prefix
+		gateway    netip.Addr
+		nameserver netip.Addr
+	)
+
+	for i, ip := range node.IPs {
+		if ip.Is4() {
+			nodeIP = ip
+			nodePrefix = netip.PrefixFrom(ip, m.Cidrs[i].Bits())
+			gateway = m.GatewayIPs[i]
+
+			break
+		}
+	}
+
+	if !nodeIP.IsValid() {
+		return fmt.Errorf("TALOS_QEMU_STATIC_IP requires an IPv4 cluster network")
+	}
+
+	for _, candidate := range m.ClusterRequest.Network.Nameservers {
+		if candidate.Is4() {
+			nameserver = candidate
+
+			break
+		}
+	}
+
+	if !nameserver.IsValid() {
+		nameserver = gateway
+	}
+
+	mask := net.IP(net.CIDRMask(nodePrefix.Bits(), 32)).String()
+	staticIPArg := fmt.Sprintf(
+		"%s::%s:%s:%s:enp0s5:none:%s",
+		nodeIP,
+		gateway,
+		mask,
+		node.Name,
+		nameserver,
+	)
+
+	node.SDStubKernelArgs = procfs.NewCmdline("")
+	node.SDStubKernelArgs.Append("ip", staticIPArg)
+
+	link := networkcfg.NewLinkConfigV1Alpha1("net0")
+	link.LinkAddresses = []networkcfg.AddressConfig{{AddressAddress: nodePrefix}}
+	link.LinkRoutes = []networkcfg.RouteConfig{{RouteGateway: metacfg.Addr{Addr: gateway}}}
+
+	ctr, err := container.New(link)
+	if err != nil {
+		return fmt.Errorf("building static network config for node %d: %w", nodeIndex, err)
+	}
+
+	if m.PerNodePatches == nil {
+		m.PerNodePatches = map[int][]configpatcher.Patch{}
+	}
+
+	m.PerNodePatches[nodeIndex] = append(
+		m.PerNodePatches[nodeIndex],
+		configpatcher.NewStrategicMergePatch(ctr),
+	)
+
+	return nil
+}
+
 func (m *Qemu) addDiskEncryptionPatches() error {
 	var diskEncryptionPatches []configpatcher.Patch
 
diff --git i/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go w/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
index bcfacbc..8df6945 100644
--- i/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
+++ w/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/configmaker/internal/makers/qemu_test.go
@@ -40,6 +40,52 @@ func TestQemuMaker_MachineConfig(t *testing.T) {
 	assertConfigDefaultness(t, cOps, *m.Maker, nil)
 }
 
+func TestQemuMaker_StaticIP(t *testing.T) {
+	t.Setenv("TALOS_QEMU_STATIC_IP", "1")
+
+	cOps := clusterops.GetCommon()
+	cOps.NetworkCIDR = "192.168.200.0/24"
+	rootOps := *cOps.RootOps
+	rootOps.ClusterName = "talos-default"
+	cOps.RootOps = &rootOps
+
+	m, err := makers.NewQemu(makers.MakerOptions[clusterops.Qemu]{
+		ExtraOps:    clusterops.GetQemu(),
+		CommonOps:   cOps,
+		Provisioner: testProvisioner{},
+	})
+	require.NoError(t, err)
+
+	clusterConfigs, err := m.GetClusterConfigs()
+	require.NoError(t, err)
+
+	controlPlane := clusterConfigs.ClusterRequest.Nodes[0]
+	worker := clusterConfigs.ClusterRequest.Nodes[1]
+
+	require.NotNil(t, controlPlane.SDStubKernelArgs)
+	require.NotNil(t, worker.SDStubKernelArgs)
+	assert.Equal(t,
+		"ip=192.168.200.2::192.168.200.1:255.255.255.0:talos-default-controlplane-1:enp0s5:none:192.168.200.1",
+		controlPlane.SDStubKernelArgs.String(),
+	)
+	assert.Equal(t,
+		"ip=192.168.200.3::192.168.200.1:255.255.255.0:talos-default-worker-1:enp0s5:none:192.168.200.1",
+		worker.SDStubKernelArgs.String(),
+	)
+
+	controlPlaneConfig, err := controlPlane.Config.EncodeString()
+	require.NoError(t, err)
+	assert.Contains(t, controlPlaneConfig, "endpoint: https://192.168.200.2:6443")
+	assert.Contains(t, controlPlaneConfig, "kind: LinkConfig\nname: net0")
+	assert.Contains(t, controlPlaneConfig, "address: 192.168.200.2/24")
+	assert.Contains(t, controlPlaneConfig, "gateway: 192.168.200.1")
+	assert.NotContains(t, controlPlaneConfig, "kind: DHCPv4Config")
+
+	workerConfig, err := worker.Config.EncodeString()
+	require.NoError(t, err)
+	assert.Contains(t, workerConfig, "address: 192.168.200.3/24")
+}
+
 func TestQemuMaker_RegistryAuth(t *testing.T) {
 	cOps := clusterops.GetCommon()
 	qOps := clusterops.GetQemu()
```

</details>


Technical details:
* `Darwin 25.6.0 Darwin Kernel Version 25.6.0: Fri Jul 31 19:18:49 PDT 2026; root:xnu-12377.161.14~5/RELEASE_ARM64_T6000 arm64 arm Darwin`
* Apple M1 Max 64 GB running Tahoe `26.6.2`
* QEMU emulator version 11.1.1