### PR TITLE
test: skip the macvlan DHCP test on full-CLOS clusters

### DIFF
--- a/internal/integration/api/network-config.go
+++ b/internal/integration/api/network-config.go
@@ -566,6 +566,12 @@ func (suite *NetworkConfigSuite) TestMacVLANWithDHCP() {
 		suite.T().Skip("skipping if no extra DHCP records are configured")
 	}
 
+	if suite.BGPCLOSEnabled {
+		// A full-CLOS node has no net0 to parent the macvlan on: it reaches the cluster over its
+		// fabric uplinks and a BGP-advertised loopback, and the DHCP server is not on that path.
+		suite.T().Skip("skipping macvlan DHCP test on a full-CLOS cluster")
+	}
+
 	dhcpRecord := suite.Cluster.Info().Network.ExtraDHCPRecords[0]
 
 	node := suite.RandomDiscoveredNodeInternalIP(machine.TypeWorker)


### PR DESCRIPTION
The test parents its macvlan on net0, but a full-CLOS node has no net0 at all: it reaches the cluster over fabric uplinks and a BGP-advertised loopback. The link is therefore never created, the DHCP operator never passes its RequireUp gate, and the test waits out its thirty seconds for an address that was never requested.

Reproduced on QEMU with --with-bgp-clos: 15 of 15 runs failed at exactly 30.00s, the provisioner's DHCP server logged no requests at all, and BGP sessions were untouched throughout. Repointing the parent at a fabric uplink is not a fix either: the link then comes up and a DISCOVER is sent, but a full-CLOS node has no path to the management-bridge DHCP server, so no address arrives.

e2e-bgp-clos has failed this test since it was added.